### PR TITLE
fix: align auth service and SDKs to SPEC §5,§7,§8,§10

### DIFF
--- a/apps/auth-service/src/routes/audit.ts
+++ b/apps/auth-service/src/routes/audit.ts
@@ -13,8 +13,8 @@ interface AuditLogBody {
 }
 
 export async function auditRoutes(app: FastifyInstance): Promise<void> {
-  // POST /v1/audit
-  app.post<{ Body: AuditLogBody }>('/v1/audit', async (request, reply) => {
+  // POST /v1/audit/log
+  app.post<{ Body: AuditLogBody }>('/v1/audit/log', async (request, reply) => {
     const { agentId, agentDid, grantId, principalId, action, metadata = {} } = request.body;
 
     if (!agentId || !agentDid || !grantId || !principalId || !action) {
@@ -66,8 +66,8 @@ export async function auditRoutes(app: FastifyInstance): Promise<void> {
     return reply.status(201).send(toAuditResponse(rows[0]!));
   });
 
-  // GET /v1/audit
-  app.get('/v1/audit', async (request, reply) => {
+  // GET /v1/audit/entries
+  app.get('/v1/audit/entries', async (request, reply) => {
     const sql = getSql();
     const query = request.query as Record<string, string>;
     const developerId = request.developer.id;

--- a/apps/auth-service/src/routes/authorize.ts
+++ b/apps/auth-service/src/routes/authorize.ts
@@ -54,7 +54,7 @@ export async function authorizeRoutes(app: FastifyInstance): Promise<void> {
     const consentUrl = `${config.jwtIssuer}/consent?req=${id}`;
 
     return reply.status(201).send({
-      requestId: id,
+      authRequestId: id,
       consentUrl,
       expiresAt: expiresAt.toISOString(),
     });

--- a/apps/auth-service/src/routes/token.ts
+++ b/apps/auth-service/src/routes/token.ts
@@ -103,9 +103,9 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
     });
 
     return reply.status(201).send({
-      accessToken: jwt,
-      tokenType: 'Bearer',
-      expiresIn: expiresSeconds,
+      grantToken: jwt,
+      expiresAt: expiresAt.toISOString(),
+      scopes: authReq['scopes'] as string[],
       refreshToken: refreshId,
       grantId,
     });

--- a/apps/auth-service/src/routes/tokens.ts
+++ b/apps/auth-service/src/routes/tokens.ts
@@ -4,8 +4,8 @@ import { getRedis } from '../redis/client.js';
 import { decodeTokenClaims } from '../lib/crypto.js';
 
 export async function tokensRoutes(app: FastifyInstance): Promise<void> {
-  // POST /v1/tokens/introspect
-  app.post<{ Body: { token: string } }>('/v1/tokens/introspect', async (request, reply) => {
+  // POST /v1/tokens/verify
+  app.post<{ Body: { token: string } }>('/v1/tokens/verify', async (request, reply) => {
     const { token } = request.body;
     if (!token) {
       return reply.status(400).send({ message: 'token is required', code: 'BAD_REQUEST', requestId: request.id });
@@ -15,13 +15,13 @@ export async function tokensRoutes(app: FastifyInstance): Promise<void> {
     try {
       claims = decodeTokenClaims(token);
     } catch {
-      return reply.send({ active: false });
+      return reply.send({ valid: false });
     }
 
     const jti = claims['jti'] as string | undefined;
     const gid = (claims['gid'] ?? claims['jti']) as string | undefined;
 
-    if (!jti) return reply.send({ active: false });
+    if (!jti) return reply.send({ valid: false });
 
     // Redis check first
     const redis = getRedis();
@@ -31,7 +31,7 @@ export async function tokensRoutes(app: FastifyInstance): Promise<void> {
     ]);
 
     if (tokenRevoked || grantRevoked) {
-      return reply.send({ active: false });
+      return reply.send({ valid: false });
     }
 
     // DB check
@@ -44,38 +44,34 @@ export async function tokensRoutes(app: FastifyInstance): Promise<void> {
     `;
 
     const row = rows[0];
-    if (!row) return reply.send({ active: false });
+    if (!row) return reply.send({ valid: false });
 
     if (row['is_revoked'] as boolean) {
       // Write-back to Redis
       const expiresAt = new Date(row['expires_at'] as string);
       const ttl = Math.max(1, Math.floor((expiresAt.getTime() - Date.now()) / 1000));
       await redis.set(`revoked:tok:${jti}`, '1', 'EX', ttl);
-      return reply.send({ active: false });
+      return reply.send({ valid: false });
     }
 
-    if (row['grant_status'] !== 'active') return reply.send({ active: false });
+    if (row['grant_status'] !== 'active') return reply.send({ valid: false });
 
     const expiresAt = new Date(row['expires_at'] as string);
-    if (expiresAt < new Date()) return reply.send({ active: false });
+    if (expiresAt < new Date()) return reply.send({ valid: false });
 
     return reply.send({
-      active: true,
-      sub: claims['sub'],
-      agt: claims['agt'],
-      dev: claims['dev'],
-      scp: claims['scp'],
-      iss: claims['iss'],
-      jti,
-      exp: claims['exp'],
-      iat: claims['iat'],
-      ...(claims['gid'] !== undefined ? { gid: claims['gid'] } : {}),
+      valid: true,
+      grantId: gid,
+      scopes: claims['scp'],
+      principal: claims['sub'],
+      agent: claims['agt'],
+      expiresAt: new Date((claims['exp'] as number) * 1000).toISOString(),
     });
   });
 
-  // DELETE /v1/tokens/:jti  (revoke token)
-  app.delete<{ Params: { jti: string } }>('/v1/tokens/:jti', async (request, reply) => {
-    const { jti } = request.params;
+  // POST /v1/tokens/revoke
+  app.post<{ Body: { jti: string } }>('/v1/tokens/revoke', async (request, reply) => {
+    const { jti } = request.body;
     const sql = getSql();
 
     const rows = await sql`

--- a/apps/auth-service/tests/audit.test.ts
+++ b/apps/auth-service/tests/audit.test.ts
@@ -23,7 +23,7 @@ const auditEntry = {
   timestamp: new Date().toISOString(),
 };
 
-describe('POST /v1/audit', () => {
+describe('POST /v1/audit/log', () => {
   it('creates an audit entry with hash', async () => {
     seedAuth();
     // Previous hash query
@@ -33,7 +33,7 @@ describe('POST /v1/audit', () => {
 
     const res = await app.inject({
       method: 'POST',
-      url: '/v1/audit',
+      url: '/v1/audit/log',
       headers: authHeader(),
       payload: {
         agentId: TEST_AGENT.id,
@@ -66,7 +66,7 @@ describe('POST /v1/audit', () => {
 
     const res = await app.inject({
       method: 'POST',
-      url: '/v1/audit',
+      url: '/v1/audit/log',
       headers: authHeader(),
       payload: {
         agentId: TEST_AGENT.id,
@@ -87,7 +87,7 @@ describe('POST /v1/audit', () => {
 
     const res = await app.inject({
       method: 'POST',
-      url: '/v1/audit',
+      url: '/v1/audit/log',
       headers: authHeader(),
       payload: { agentId: TEST_AGENT.id }, // missing other required fields
     });
@@ -96,14 +96,14 @@ describe('POST /v1/audit', () => {
   });
 });
 
-describe('GET /v1/audit', () => {
+describe('GET /v1/audit/entries', () => {
   it('returns audit entries', async () => {
     seedAuth();
     sqlMock.mockResolvedValueOnce([auditEntry]);
 
     const res = await app.inject({
       method: 'GET',
-      url: '/v1/audit',
+      url: '/v1/audit/entries',
       headers: authHeader(),
     });
 
@@ -119,7 +119,7 @@ describe('GET /v1/audit', () => {
 
     const res = await app.inject({
       method: 'GET',
-      url: `/v1/audit?agentId=${TEST_AGENT.id}&action=invoke`,
+      url: `/v1/audit/entries?agentId=${TEST_AGENT.id}&action=invoke`,
       headers: authHeader(),
     });
 

--- a/apps/auth-service/tests/authorize.test.ts
+++ b/apps/auth-service/tests/authorize.test.ts
@@ -29,8 +29,8 @@ describe('POST /v1/authorize', () => {
     });
 
     expect(res.statusCode).toBe(201);
-    const body = res.json<{ requestId: string; consentUrl: string; expiresAt: string }>();
-    expect(body.requestId).toBeDefined();
+    const body = res.json<{ authRequestId: string; consentUrl: string; expiresAt: string }>();
+    expect(body.authRequestId).toBeDefined();
     expect(body.consentUrl).toContain('/consent?req=');
     expect(body.expiresAt).toBeDefined();
   });

--- a/apps/auth-service/tests/token.test.ts
+++ b/apps/auth-service/tests/token.test.ts
@@ -44,21 +44,21 @@ describe('POST /v1/token', () => {
 
     expect(res.statusCode).toBe(201);
     const body = res.json<{
-      accessToken: string;
-      tokenType: string;
-      expiresIn: number;
+      grantToken: string;
+      expiresAt: string;
+      scopes: string[];
       refreshToken: string;
       grantId: string;
     }>();
 
-    expect(body.tokenType).toBe('Bearer');
-    expect(body.expiresIn).toBe(86400);
-    expect(typeof body.accessToken).toBe('string');
+    expect(typeof body.grantToken).toBe('string');
+    expect(body.expiresAt).toBeDefined();
+    expect(body.scopes).toEqual(['read', 'write']);
     expect(typeof body.refreshToken).toBe('string');
     expect(typeof body.grantId).toBe('string');
 
     // Verify JWT structure
-    const claims = decodeJwt(body.accessToken);
+    const claims = decodeJwt(body.grantToken);
     expect(claims.sub).toBe('user_123');
     expect(claims['agt']).toBe(TEST_AGENT.did);
     expect(claims['dev']).toBe(TEST_DEVELOPER.id);

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -17,16 +17,15 @@ from ._types import (
     AuthorizeParams,
     Grant,
     GrantTokenPayload,
-    IntrospectTokenResponse,
     ListAgentsResponse,
     ListAuditParams,
     ListAuditResponse,
     ListGrantsParams,
     ListGrantsResponse,
     LogAuditParams,
-    RevokeTokenResponse,
     VerifiedGrant,
     VerifyGrantTokenOptions,
+    VerifyTokenResponse,
 )
 from ._verify import verify_grant_token
 
@@ -50,16 +49,15 @@ __all__ = [
     "AuthorizeParams",
     "Grant",
     "GrantTokenPayload",
-    "IntrospectTokenResponse",
     "ListAgentsResponse",
     "ListAuditParams",
     "ListAuditResponse",
     "ListGrantsParams",
     "ListGrantsResponse",
     "LogAuditParams",
-    "RevokeTokenResponse",
     "VerifiedGrant",
     "VerifyGrantTokenOptions",
+    "VerifyTokenResponse",
     # Version
     "__version__",
 ]

--- a/packages/sdk-py/src/grantex/_types.py
+++ b/packages/sdk-py/src/grantex/_types.py
@@ -90,7 +90,7 @@ class AuthorizationRequest:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> AuthorizationRequest:
         return cls(
-            request_id=data["requestId"],
+            request_id=data["authRequestId"],
             consent_url=data["consentUrl"],
             agent_id=data["agentId"],
             principal_id=data["principalId"],
@@ -190,41 +190,25 @@ class VerifiedGrant:
 
 
 @dataclass(frozen=True)
-class IntrospectTokenResponse:
-    active: bool
-    token_id: str | None
+class VerifyTokenResponse:
+    valid: bool
     grant_id: str | None
-    principal_id: str | None
-    agent_did: str | None
-    developer_id: str | None
     scopes: tuple[str, ...] | None
-    issued_at: int | None
-    expires_at: int | None
+    principal: str | None
+    agent: str | None
+    expires_at: str | None
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> IntrospectTokenResponse:
+    def from_dict(cls, data: dict[str, Any]) -> VerifyTokenResponse:
         raw_scopes = data.get("scopes")
         return cls(
-            active=data["active"],
-            token_id=data.get("tokenId"),
+            valid=data["valid"],
             grant_id=data.get("grantId"),
-            principal_id=data.get("principalId"),
-            agent_did=data.get("agentDid"),
-            developer_id=data.get("developerId"),
             scopes=tuple(raw_scopes) if raw_scopes is not None else None,
-            issued_at=data.get("issuedAt"),
+            principal=data.get("principal"),
+            agent=data.get("agent"),
             expires_at=data.get("expiresAt"),
         )
-
-
-@dataclass(frozen=True)
-class RevokeTokenResponse:
-    revoked: bool
-    token_id: str
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> RevokeTokenResponse:
-        return cls(revoked=data["revoked"], token_id=data["tokenId"])
 
 
 # ─── Audit ────────────────────────────────────────────────────────────────────

--- a/packages/sdk-py/src/grantex/resources/_tokens.py
+++ b/packages/sdk-py/src/grantex/resources/_tokens.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
 from .._http import HttpClient
-from .._types import IntrospectTokenResponse, RevokeTokenResponse
+from .._types import VerifyTokenResponse
 
 
 class TokensClient:
     def __init__(self, http: HttpClient) -> None:
         self._http = http
 
-    def introspect(self, token: str) -> IntrospectTokenResponse:
-        data = self._http.post("/v1/tokens/introspect", {"token": token})
-        return IntrospectTokenResponse.from_dict(data)
+    def verify(self, token: str) -> VerifyTokenResponse:
+        data = self._http.post("/v1/tokens/verify", {"token": token})
+        return VerifyTokenResponse.from_dict(data)
 
-    def revoke(self, token_id: str) -> RevokeTokenResponse:
-        data = self._http.delete(f"/v1/tokens/{token_id}")
-        return RevokeTokenResponse.from_dict(data)
+    def revoke(self, token_id: str) -> None:
+        self._http.post("/v1/tokens/revoke", {"jti": token_id})
+        return None

--- a/packages/sdk-py/tests/conftest.py
+++ b/packages/sdk-py/tests/conftest.py
@@ -55,7 +55,7 @@ MOCK_JWT_PAYLOAD: dict = {
 }
 
 MOCK_AUTHORIZATION_REQUEST: dict = {
-    "requestId": "req_01HXYZ",
+    "authRequestId": "req_01HXYZ",
     "consentUrl": "https://consent.grantex.dev/authorize?req=eyJ",
     "agentId": "ag_01HXYZ123abc",
     "principalId": "user_abc123",

--- a/packages/sdk-py/tests/test_tokens.py
+++ b/packages/sdk-py/tests/test_tokens.py
@@ -14,29 +14,27 @@ def client() -> Grantex:
 
 
 @respx.mock
-def test_introspect(client: Grantex) -> None:
+def test_verify(client: Grantex) -> None:
     payload = {
-        "active": True,
-        "tokenId": "tok_01HXYZ",
+        "valid": True,
         "grantId": "grant_01HXYZ",
-        "principalId": "user_abc123",
-        "agentDid": "did:grantex:ag_01HXYZ123abc",
-        "developerId": "org_test",
         "scopes": ["calendar:read"],
-        "issuedAt": 1709000000,
-        "expiresAt": 9999999999,
+        "principal": "user_abc123",
+        "agent": "did:grantex:ag_01HXYZ123abc",
+        "expiresAt": "2024-01-02T00:00:00Z",
     }
     import json
 
-    route = respx.post("https://api.grantex.dev/v1/tokens/introspect").mock(
+    route = respx.post("https://api.grantex.dev/v1/tokens/verify").mock(
         return_value=httpx.Response(200, json=payload)
     )
-    response = client.tokens.introspect("my.jwt.token")
+    response = client.tokens.verify("my.jwt.token")
 
-    assert response.active is True
-    assert response.token_id == "tok_01HXYZ"
+    assert response.valid is True
     assert response.grant_id == "grant_01HXYZ"
     assert response.scopes == ("calendar:read",)
+    assert response.principal == "user_abc123"
+    assert response.agent == "did:grantex:ag_01HXYZ123abc"
 
     body = json.loads(route.calls[0].request.content)
     assert body["token"] == "my.jwt.token"
@@ -44,20 +42,18 @@ def test_introspect(client: Grantex) -> None:
 
 @respx.mock
 def test_revoke(client: Grantex) -> None:
-    respx.delete("https://api.grantex.dev/v1/tokens/tok_01HXYZ").mock(
-        return_value=httpx.Response(200, json={"revoked": True, "tokenId": "tok_01HXYZ"})
+    respx.post("https://api.grantex.dev/v1/tokens/revoke").mock(
+        return_value=httpx.Response(204)
     )
     response = client.tokens.revoke("tok_01HXYZ")
-    assert response.revoked is True
-    assert response.token_id == "tok_01HXYZ"
+    assert response is None
 
 
 @respx.mock
-def test_introspect_inactive_token(client: Grantex) -> None:
-    respx.post("https://api.grantex.dev/v1/tokens/introspect").mock(
-        return_value=httpx.Response(200, json={"active": False})
+def test_verify_inactive_token(client: Grantex) -> None:
+    respx.post("https://api.grantex.dev/v1/tokens/verify").mock(
+        return_value=httpx.Response(200, json={"valid": False})
     )
-    response = client.tokens.introspect("expired.jwt.token")
-    assert response.active is False
-    assert response.token_id is None
+    response = client.tokens.verify("expired.jwt.token")
+    assert response.valid is False
     assert response.scopes is None

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -30,8 +30,7 @@ export type {
   ListGrantsResponse,
   VerifiedGrant,
   // Tokens
-  IntrospectTokenResponse,
-  RevokeTokenResponse,
+  VerifyTokenResponse,
   // Audit
   LogAuditParams,
   AuditEntry,

--- a/packages/sdk-ts/src/resources/tokens.ts
+++ b/packages/sdk-ts/src/resources/tokens.ts
@@ -1,5 +1,5 @@
 import type { HttpClient } from '../http.js';
-import type { IntrospectTokenResponse, RevokeTokenResponse } from '../types.js';
+import type { VerifyTokenResponse } from '../types.js';
 
 export class TokensClient {
   readonly #http: HttpClient;
@@ -8,13 +8,13 @@ export class TokensClient {
     this.#http = http;
   }
 
-  introspect(token: string): Promise<IntrospectTokenResponse> {
-    return this.#http.post<IntrospectTokenResponse>('/v1/tokens/introspect', {
+  verify(token: string): Promise<VerifyTokenResponse> {
+    return this.#http.post<VerifyTokenResponse>('/v1/tokens/verify', {
       token,
     });
   }
 
-  revoke(tokenId: string): Promise<RevokeTokenResponse> {
-    return this.#http.delete<RevokeTokenResponse>(`/v1/tokens/${tokenId}`);
+  revoke(tokenId: string): Promise<void> {
+    return this.#http.post<void>('/v1/tokens/revoke', { jti: tokenId });
   }
 }

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -54,7 +54,7 @@ export interface AuthorizeParams {
 }
 
 export interface AuthorizationRequest {
-  requestId: string;
+  authRequestId: string;
   consentUrl: string;
   agentId: string;
   principalId: string;
@@ -116,21 +116,13 @@ export interface VerifiedGrant {
 
 // ─── Tokens ───────────────────────────────────────────────────────────────────
 
-export interface IntrospectTokenResponse {
-  active: boolean;
-  tokenId?: string;
+export interface VerifyTokenResponse {
+  valid: boolean;
   grantId?: string;
-  principalId?: string;
-  agentDid?: string;
-  developerId?: string;
   scopes?: string[];
-  issuedAt?: number;
-  expiresAt?: number;
-}
-
-export interface RevokeTokenResponse {
-  revoked: boolean;
-  tokenId: string;
+  principal?: string;
+  agent?: string;
+  expiresAt?: string;
 }
 
 // ─── Audit ────────────────────────────────────────────────────────────────────

--- a/packages/sdk-ts/tests/client.test.ts
+++ b/packages/sdk-ts/tests/client.test.ts
@@ -41,7 +41,7 @@ describe('Grantex client', () => {
   describe('authorize()', () => {
     it('maps userId → principalId in request body', async () => {
       const mockFetch = makeFetch(200, {
-        requestId: 'req_1',
+        authRequestId: 'req_1',
         consentUrl: 'https://consent.grantex.dev/authorize?req=abc',
         agentId: 'ag_1',
         principalId: 'principal_abc',


### PR DESCRIPTION
## Summary

- **authorize**: `requestId` → `authRequestId` in response (SPEC §5)
- **token**: `accessToken`/`tokenType`/`expiresIn` → `grantToken`/`expiresAt`/`scopes` (SPEC §7)
- **tokens**: `/v1/tokens/introspect` → `/v1/tokens/verify`; `active` → `valid`; response reshaped to `{ valid, grantId, scopes, principal, agent, expiresAt }`; `DELETE /v1/tokens/:jti` → `POST /v1/tokens/revoke` with body `{ jti }` (SPEC §8)
- **audit**: `POST /v1/audit` → `/v1/audit/log`; `GET /v1/audit` → `/v1/audit/entries` (SPEC §10)
- **sdk-ts**: `introspect()` → `verify()`; `revoke()` uses POST; `IntrospectTokenResponse`/`RevokeTokenResponse` replaced by `VerifyTokenResponse`
- **sdk-py**: same renames; `VerifyTokenResponse` with `valid`/`principal`/`agent` fields; `revoke()` returns `None`

## Test plan

- [x] `apps/auth-service`: 73/73 tests pass, 0 typecheck errors
- [x] `packages/sdk-ts`: 31/31 tests pass, 0 typecheck errors
- [x] `packages/sdk-py`: 40/40 tests pass, 0 mypy errors