### PR TITLE
feat: webhook event delivery

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,7 +31,7 @@ Making Grantex native to every major agent framework.
 - [ ] LangChain integration (`@grantex/langchain`)
 - [ ] AutoGen integration (`@grantex/autogen`)
 - [x] End-user permission dashboard (view + revoke grants)
-- [ ] Webhook event delivery (grant created, revoked, token issued)
+- [x] Webhook event delivery (grant created, revoked, token issued)
 - [ ] Stripe billing integration (Free / Pro / Enterprise tiers)
 - [ ] `grantex` CLI tool for local development
 

--- a/apps/auth-service/src/db/migrations/004_webhooks.sql
+++ b/apps/auth-service/src/db/migrations/004_webhooks.sql
@@ -1,0 +1,9 @@
+-- Webhook endpoint registrations
+CREATE TABLE IF NOT EXISTS webhooks (
+  id           TEXT PRIMARY KEY,
+  developer_id TEXT NOT NULL REFERENCES developers(id) ON DELETE CASCADE,
+  url          TEXT NOT NULL,
+  events       TEXT[] NOT NULL,
+  secret       TEXT NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/apps/auth-service/src/lib/ids.ts
+++ b/apps/auth-service/src/lib/ids.ts
@@ -7,3 +7,4 @@ export const newRefreshTokenId = (): string => `ref_${ulid()}`;
 export const newAuthRequestId = (): string => `areq_${ulid()}`;
 export const newAuditEntryId = (): string => `alog_${ulid()}`;
 export const newDeveloperId = (): string => `dev_${ulid()}`;
+export const newWebhookId = (): string => `wh_${ulid()}`;

--- a/apps/auth-service/src/lib/webhook.ts
+++ b/apps/auth-service/src/lib/webhook.ts
@@ -1,0 +1,45 @@
+import { createHmac } from 'node:crypto';
+import { ulid } from 'ulid';
+import { getSql } from '../db/client.js';
+
+export type WebhookEventType = 'grant.created' | 'grant.revoked' | 'token.issued';
+
+export function signWebhookPayload(secret: string, payload: string): string {
+  return 'sha256=' + createHmac('sha256', secret).update(payload).digest('hex');
+}
+
+export async function fireWebhooks(
+  developerId: string,
+  type: WebhookEventType,
+  data: Record<string, unknown>,
+): Promise<void> {
+  const sql = getSql();
+  const rows = await sql<{ url: string; secret: string }[]>`
+    SELECT url, secret FROM webhooks
+    WHERE developer_id = ${developerId}
+      AND ${type} = ANY(events)
+  `;
+  if (rows.length === 0) return;
+
+  const event = {
+    id: `evt_${ulid()}`,
+    type,
+    createdAt: new Date().toISOString(),
+    data,
+  };
+  const payloadStr = JSON.stringify(event);
+
+  for (const row of rows) {
+    const sig = signWebhookPayload(row.secret, payloadStr);
+    fetch(row.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Grantex-Signature': sig,
+        'User-Agent': 'Grantex-Webhooks/0.1',
+      },
+      body: payloadStr,
+      signal: AbortSignal.timeout(10_000),
+    }).catch(() => { /* best-effort delivery */ });
+  }
+}

--- a/apps/auth-service/src/routes/webhooks.ts
+++ b/apps/auth-service/src/routes/webhooks.ts
@@ -1,0 +1,90 @@
+import { randomBytes } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import { getSql } from '../db/client.js';
+import { newWebhookId } from '../lib/ids.js';
+
+const VALID_EVENTS = new Set(['grant.created', 'grant.revoked', 'token.issued']);
+
+interface CreateWebhookBody {
+  url: string;
+  events: string[];
+}
+
+export async function webhooksRoutes(app: FastifyInstance): Promise<void> {
+  // POST /v1/webhooks
+  app.post<{ Body: CreateWebhookBody }>('/v1/webhooks', async (request, reply) => {
+    const { url, events } = request.body;
+
+    if (!url || !events || !Array.isArray(events) || events.length === 0) {
+      return reply.status(400).send({
+        message: 'url and events are required',
+        code: 'BAD_REQUEST',
+        requestId: request.id,
+      });
+    }
+
+    const invalid = events.filter(e => !VALID_EVENTS.has(e));
+    if (invalid.length > 0) {
+      return reply.status(400).send({
+        message: `Invalid event types: ${invalid.join(', ')}. Valid: grant.created, grant.revoked, token.issued`,
+        code: 'BAD_REQUEST',
+        requestId: request.id,
+      });
+    }
+
+    const id = newWebhookId();
+    const secret = randomBytes(24).toString('hex');
+    const developerId = request.developer.id;
+    const sql = getSql();
+
+    await sql`
+      INSERT INTO webhooks (id, developer_id, url, events, secret)
+      VALUES (${id}, ${developerId}, ${url}, ${events}, ${secret})
+    `;
+
+    return reply.status(201).send({
+      id,
+      url,
+      events,
+      secret,
+      createdAt: new Date().toISOString(),
+    });
+  });
+
+  // GET /v1/webhooks
+  app.get('/v1/webhooks', async (request, reply) => {
+    const sql = getSql();
+    const rows = await sql`
+      SELECT id, url, events, created_at
+      FROM webhooks
+      WHERE developer_id = ${request.developer.id}
+      ORDER BY created_at DESC
+    `;
+    return reply.send({
+      webhooks: rows.map(r => ({
+        id: r['id'],
+        url: r['url'],
+        events: r['events'],
+        createdAt: r['created_at'],
+      })),
+    });
+  });
+
+  // DELETE /v1/webhooks/:id
+  app.delete<{ Params: { id: string } }>('/v1/webhooks/:id', async (request, reply) => {
+    const sql = getSql();
+    const rows = await sql`
+      DELETE FROM webhooks
+      WHERE id = ${request.params.id} AND developer_id = ${request.developer.id}
+      RETURNING id
+    `;
+    if (!rows[0]) {
+      return reply.status(404).send({
+        message: 'Webhook not found',
+        code: 'NOT_FOUND',
+        requestId: request.id,
+      });
+    }
+    return reply.status(204).send();
+  });
+}

--- a/apps/auth-service/src/server.ts
+++ b/apps/auth-service/src/server.ts
@@ -13,6 +13,7 @@ import { auditRoutes } from './routes/audit.js';
 import { consentRoutes } from './routes/consent.js';
 import { delegateRoutes } from './routes/delegate.js';
 import { dashboardRoutes } from './routes/dashboard.js';
+import { webhooksRoutes } from './routes/webhooks.js';
 
 export type AppOptions = {
   logger?: boolean | object;
@@ -44,6 +45,7 @@ export async function buildApp(opts: AppOptions = {}) {
   await app.register(delegateRoutes);
   await app.register(tokensRoutes);
   await app.register(auditRoutes);
+  await app.register(webhooksRoutes);
 
   return app;
 }

--- a/apps/auth-service/tests/setup.ts
+++ b/apps/auth-service/tests/setup.ts
@@ -32,6 +32,13 @@ vi.mock('../src/redis/client.js', () => ({
   closeRedis: vi.fn(),
 }));
 
+// Mock webhook delivery — prevents fireWebhooks from consuming SQL mock slots
+// in route tests. The actual webhook routes are tested in webhooks.test.ts.
+vi.mock('../src/lib/webhook.js', () => ({
+  fireWebhooks: vi.fn().mockResolvedValue(undefined),
+  signWebhookPayload: vi.fn().mockReturnValue('sha256=mock'),
+}));
+
 // ------------------------------------------------------------------
 // Reset all mocks before each test
 // ------------------------------------------------------------------

--- a/apps/auth-service/tests/webhooks.test.ts
+++ b/apps/auth-service/tests/webhooks.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { buildTestApp, authHeader, seedAuth, sqlMock } from './helpers.js';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+const MOCK_WEBHOOK_ROW = {
+  id: 'wh_TEST01',
+  developer_id: 'dev_TEST',
+  url: 'https://example.com/hooks',
+  events: ['grant.created', 'grant.revoked'],
+  created_at: new Date().toISOString(),
+};
+
+describe('POST /v1/webhooks', () => {
+  it('creates a webhook and returns secret', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]); // INSERT
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webhooks',
+      headers: authHeader(),
+      payload: {
+        url: 'https://example.com/hooks',
+        events: ['grant.created', 'grant.revoked'],
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{
+      id: string;
+      url: string;
+      events: string[];
+      secret: string;
+      createdAt: string;
+    }>();
+    expect(body.id).toMatch(/^wh_/);
+    expect(body.url).toBe('https://example.com/hooks');
+    expect(body.events).toEqual(['grant.created', 'grant.revoked']);
+    expect(typeof body.secret).toBe('string');
+    expect(body.secret.length).toBeGreaterThan(0);
+    expect(body.createdAt).toBeDefined();
+  });
+
+  it('returns 400 when url is missing', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webhooks',
+      headers: authHeader(),
+      payload: { events: ['grant.created'] },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when events array is empty', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webhooks',
+      headers: authHeader(),
+      payload: { url: 'https://example.com/hooks', events: [] },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid event type', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webhooks',
+      headers: authHeader(),
+      payload: { url: 'https://example.com/hooks', events: ['not.a.valid.event'] },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ message: string }>().message).toContain('Invalid event types');
+  });
+});
+
+describe('GET /v1/webhooks', () => {
+  it('lists registered webhooks (secret excluded)', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([MOCK_WEBHOOK_ROW]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/webhooks',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ webhooks: Record<string, unknown>[] }>();
+    expect(body.webhooks).toHaveLength(1);
+    expect(body.webhooks[0]!['id']).toBe('wh_TEST01');
+    expect(body.webhooks[0]!['url']).toBe('https://example.com/hooks');
+    expect(body.webhooks[0]!['secret']).toBeUndefined();
+  });
+
+  it('returns empty list when no webhooks registered', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/webhooks',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ webhooks: unknown[] }>().webhooks).toHaveLength(0);
+  });
+});
+
+describe('DELETE /v1/webhooks/:id', () => {
+  it('deletes a webhook and returns 204', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ id: MOCK_WEBHOOK_ROW.id }]);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/v1/webhooks/${MOCK_WEBHOOK_ROW.id}`,
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+  });
+
+  it('returns 404 when webhook not found', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/v1/webhooks/wh_NOTEXIST',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./apps/auth-service/src/db/migrations/001_initial.sql:/docker-entrypoint-initdb.d/001_initial.sql:ro
       - ./apps/auth-service/src/db/migrations/002_spec_compliance.sql:/docker-entrypoint-initdb.d/002_spec_compliance.sql:ro
       - ./apps/auth-service/src/db/migrations/003_sandbox.sql:/docker-entrypoint-initdb.d/003_sandbox.sql:ro
+      - ./apps/auth-service/src/db/migrations/004_webhooks.sql:/docker-entrypoint-initdb.d/004_webhooks.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U grantex"]
       interval: 5s

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,232 @@
+# Webhooks
+
+Grantex can POST a signed JSON payload to your server whenever key events occur — grant created, grant revoked, or token issued. Use webhooks to keep your application in sync with the authorization lifecycle without polling.
+
+---
+
+## Supported Events
+
+| Event | When it fires |
+|-------|---------------|
+| `grant.created` | A new grant is issued (user completes consent flow) |
+| `grant.revoked` | A grant is revoked (root or cascade) |
+| `token.issued`  | A token is issued (same moment as `grant.created` for initial exchange) |
+
+---
+
+## Registering an Endpoint
+
+```bash
+curl -X POST https://api.grantex.dev/v1/webhooks \
+  -H "Authorization: Bearer <your-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://your-app.com/webhooks/grantex",
+    "events": ["grant.created", "grant.revoked"]
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "id": "wh_01JXYZ...",
+  "url": "https://your-app.com/webhooks/grantex",
+  "events": ["grant.created", "grant.revoked"],
+  "secret": "a3f8c2...",
+  "createdAt": "2026-02-26T12:00:00Z"
+}
+```
+
+> **Important:** The `secret` is returned only once. Store it securely — you will need it to verify incoming payloads.
+
+---
+
+## Event Payload Shape
+
+Every webhook POST has the same envelope:
+
+```json
+{
+  "id": "evt_01JXYZ...",
+  "type": "grant.created",
+  "createdAt": "2026-02-26T12:00:00Z",
+  "data": { ... }
+}
+```
+
+### `grant.created`
+
+```json
+{
+  "grantId": "grnt_01...",
+  "agentId": "ag_01...",
+  "principalId": "user-123",
+  "scopes": ["calendar:read"],
+  "expiresAt": "2026-03-26T12:00:00Z"
+}
+```
+
+### `grant.revoked`
+
+```json
+{
+  "grantId": "grnt_01...",
+  "cascade": true
+}
+```
+
+`cascade: true` means descendant grants were also revoked.
+
+### `token.issued`
+
+```json
+{
+  "tokenId": "tok_01...",
+  "grantId": "grnt_01...",
+  "agentId": "ag_01...",
+  "principalId": "user-123",
+  "scopes": ["calendar:read"],
+  "expiresAt": "2026-03-26T12:00:00Z"
+}
+```
+
+---
+
+## Verifying Signatures
+
+Every request includes an `X-Grantex-Signature` header with a hex-encoded HMAC-SHA256 signature of the raw request body:
+
+```
+X-Grantex-Signature: sha256=<hex>
+```
+
+**TypeScript:**
+
+```typescript
+import { verifyWebhookSignature } from '@grantex/sdk';
+
+app.post('/webhooks/grantex', (req, res) => {
+  const sig = req.headers['x-grantex-signature'] as string;
+  const rawBody = req.rawBody; // must be the raw string/Buffer, not parsed JSON
+
+  if (!verifyWebhookSignature(rawBody, sig, process.env.GRANTEX_WEBHOOK_SECRET!)) {
+    return res.status(401).send('Invalid signature');
+  }
+
+  const event = JSON.parse(rawBody);
+  console.log('Received event:', event.type);
+  res.status(200).send();
+});
+```
+
+**Python:**
+
+```python
+from grantex import verify_webhook_signature
+import os
+
+@app.route('/webhooks/grantex', methods=['POST'])
+def handle_webhook():
+    sig = request.headers.get('X-Grantex-Signature', '')
+    raw_body = request.get_data(as_text=True)
+
+    if not verify_webhook_signature(raw_body, sig, os.environ['GRANTEX_WEBHOOK_SECRET']):
+        return 'Invalid signature', 401
+
+    event = request.get_json()
+    print('Received event:', event['type'])
+    return '', 200
+```
+
+> Always verify signatures before trusting the payload. Use the raw request body — not the parsed JSON.
+
+---
+
+## Managing Endpoints
+
+**List registered webhooks:**
+
+```bash
+curl https://api.grantex.dev/v1/webhooks \
+  -H "Authorization: Bearer <your-api-key>"
+```
+
+**Delete a webhook:**
+
+```bash
+curl -X DELETE https://api.grantex.dev/v1/webhooks/<webhook-id> \
+  -H "Authorization: Bearer <your-api-key>"
+```
+
+---
+
+## SDK Usage
+
+**TypeScript:**
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Register
+const endpoint = await grantex.webhooks.create({
+  url: 'https://your-app.com/webhooks/grantex',
+  events: ['grant.created', 'grant.revoked', 'token.issued'],
+});
+console.log('Webhook secret:', endpoint.secret); // save this!
+
+// List
+const { webhooks } = await grantex.webhooks.list();
+
+// Delete
+await grantex.webhooks.delete(endpoint.id);
+```
+
+**Python:**
+
+```python
+from grantex import Grantex
+
+grantex = Grantex(api_key=os.environ['GRANTEX_API_KEY'])
+
+# Register
+endpoint = grantex.webhooks.create(
+    url='https://your-app.com/webhooks/grantex',
+    events=['grant.created', 'grant.revoked', 'token.issued'],
+)
+print('Webhook secret:', endpoint.secret)  # save this!
+
+# List
+result = grantex.webhooks.list()
+
+# Delete
+grantex.webhooks.delete(endpoint.id)
+```
+
+---
+
+## Delivery Behaviour
+
+- Grantex delivers webhooks with a **10-second timeout** per request.
+- Delivery is **best-effort** — if your endpoint is unreachable, the event is not retried in v0.2.
+- Your endpoint should return **any 2xx status** to be considered successful.
+- Respond quickly (under 5s) and do heavy processing asynchronously.
+
+---
+
+## Local Development
+
+Use a tunnel tool to expose your local server:
+
+```bash
+# ngrok
+ngrok http 3000
+
+# then register the tunnel URL
+curl -X POST http://localhost:3001/v1/webhooks \
+  -H "Authorization: Bearer dev-api-key-local" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://<your-ngrok-id>.ngrok.io/webhooks","events":["grant.created"]}'
+```

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -15,6 +15,7 @@ from ._types import (
     AuditEntry,
     AuthorizationRequest,
     AuthorizeParams,
+    CreateWebhookParams,
     DelegateParams,
     Grant,
     GrantTokenPayload,
@@ -23,12 +24,16 @@ from ._types import (
     ListAuditResponse,
     ListGrantsParams,
     ListGrantsResponse,
+    ListWebhooksResponse,
     LogAuditParams,
     VerifiedGrant,
     VerifyGrantTokenOptions,
     VerifyTokenResponse,
+    WebhookEndpoint,
+    WebhookEndpointWithSecret,
 )
 from ._verify import verify_grant_token
+from ._webhook import verify_webhook_signature
 
 __version__ = "0.1.0"
 
@@ -37,6 +42,8 @@ __all__ = [
     "Grantex",
     # Standalone verify
     "verify_grant_token",
+    # Webhook signature verification
+    "verify_webhook_signature",
     # Errors
     "GrantexError",
     "GrantexApiError",
@@ -48,6 +55,7 @@ __all__ = [
     "AuditEntry",
     "AuthorizationRequest",
     "AuthorizeParams",
+    "CreateWebhookParams",
     "DelegateParams",
     "Grant",
     "GrantTokenPayload",
@@ -56,10 +64,13 @@ __all__ = [
     "ListAuditResponse",
     "ListGrantsParams",
     "ListGrantsResponse",
+    "ListWebhooksResponse",
     "LogAuditParams",
     "VerifiedGrant",
     "VerifyGrantTokenOptions",
     "VerifyTokenResponse",
+    "WebhookEndpoint",
+    "WebhookEndpointWithSecret",
     # Version
     "__version__",
 ]

--- a/packages/sdk-py/src/grantex/_client.py
+++ b/packages/sdk-py/src/grantex/_client.py
@@ -8,6 +8,7 @@ from .resources._agents import AgentsClient
 from .resources._audit import AuditClient
 from .resources._grants import GrantsClient
 from .resources._tokens import TokensClient
+from .resources._webhooks import WebhooksClient
 
 _DEFAULT_BASE_URL = "https://api.grantex.dev"
 
@@ -19,6 +20,7 @@ class Grantex:
     grants: GrantsClient
     tokens: TokensClient
     audit: AuditClient
+    webhooks: WebhooksClient
 
     def __init__(
         self,
@@ -44,6 +46,7 @@ class Grantex:
         self.grants = GrantsClient(self._http)
         self.tokens = TokensClient(self._http)
         self.audit = AuditClient(self._http)
+        self.webhooks = WebhooksClient(self._http)
 
     def authorize(self, params: AuthorizeParams) -> AuthorizationRequest:
         """Initiate the delegated authorization flow for a user.

--- a/packages/sdk-py/src/grantex/_types.py
+++ b/packages/sdk-py/src/grantex/_types.py
@@ -363,3 +363,62 @@ class DelegateParams:
         if self.expires_in is not None:
             body["expiresIn"] = self.expires_in
         return body
+
+
+# ─── Webhooks ──────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class CreateWebhookParams:
+    url: str
+    events: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"url": self.url, "events": self.events}
+
+
+@dataclass(frozen=True)
+class WebhookEndpoint:
+    id: str
+    url: str
+    events: tuple[str, ...]
+    created_at: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "WebhookEndpoint":
+        return cls(
+            id=data["id"],
+            url=data["url"],
+            events=tuple(data.get("events", [])),
+            created_at=data["createdAt"],
+        )
+
+
+@dataclass(frozen=True)
+class WebhookEndpointWithSecret:
+    id: str
+    url: str
+    events: tuple[str, ...]
+    created_at: str
+    secret: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "WebhookEndpointWithSecret":
+        return cls(
+            id=data["id"],
+            url=data["url"],
+            events=tuple(data.get("events", [])),
+            created_at=data["createdAt"],
+            secret=data.get("secret", ""),
+        )
+
+
+@dataclass(frozen=True)
+class ListWebhooksResponse:
+    webhooks: tuple[WebhookEndpoint, ...]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ListWebhooksResponse":
+        return cls(
+            webhooks=tuple(WebhookEndpoint.from_dict(w) for w in data.get("webhooks", [])),
+        )

--- a/packages/sdk-py/src/grantex/_webhook.py
+++ b/packages/sdk-py/src/grantex/_webhook.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+
+def verify_webhook_signature(
+    payload: str | bytes,
+    signature: str,
+    secret: str,
+) -> bool:
+    """Verify that a webhook payload was sent by Grantex.
+
+    Args:
+        payload:   The raw request body received from Grantex.
+        signature: The value of the X-Grantex-Signature header.
+        secret:    The webhook secret returned when the endpoint was created.
+
+    Returns:
+        True if the signature is valid, False otherwise.
+    """
+    if isinstance(payload, str):
+        payload = payload.encode()
+    expected = "sha256=" + hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(signature, expected)

--- a/packages/sdk-py/src/grantex/resources/_webhooks.py
+++ b/packages/sdk-py/src/grantex/resources/_webhooks.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import List
+
+from .._http import HttpClient
+from .._types import (
+    CreateWebhookParams,
+    ListWebhooksResponse,
+    WebhookEndpointWithSecret,
+)
+
+
+class WebhooksClient:
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def create(self, *, url: str, events: List[str]) -> WebhookEndpointWithSecret:
+        params = CreateWebhookParams(url=url, events=events)
+        data = self._http.post("/v1/webhooks", params.to_dict())
+        return WebhookEndpointWithSecret.from_dict(data)
+
+    def list(self) -> ListWebhooksResponse:
+        data = self._http.get("/v1/webhooks")
+        return ListWebhooksResponse.from_dict(data)
+
+    def delete(self, webhook_id: str) -> None:
+        self._http.delete(f"/v1/webhooks/{webhook_id}")

--- a/packages/sdk-py/tests/test_webhooks.py
+++ b/packages/sdk-py/tests/test_webhooks.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+import httpx
+import respx
+
+from grantex import Grantex
+from grantex._webhook import verify_webhook_signature
+
+BASE_URL = "http://test.local"
+
+MOCK_WEBHOOK = {
+    "id": "wh_01",
+    "url": "https://example.com/hooks",
+    "events": ["grant.created", "grant.revoked"],
+    "createdAt": "2026-02-26T00:00:00Z",
+}
+
+MOCK_WEBHOOK_WITH_SECRET = {**MOCK_WEBHOOK, "secret": "abc123secret"}
+
+
+def _make_sig(payload: str | bytes, secret: str) -> str:
+    raw = payload.encode() if isinstance(payload, str) else payload
+    mac = hmac.new(secret.encode(), raw, hashlib.sha256)
+    return "sha256=" + mac.hexdigest()
+
+
+@respx.mock
+def test_create_webhook() -> None:
+    respx.post(f"{BASE_URL}/v1/webhooks").mock(
+        return_value=httpx.Response(201, json=MOCK_WEBHOOK_WITH_SECRET)
+    )
+    client = Grantex(api_key="test-key", base_url=BASE_URL)
+    result = client.webhooks.create(url="https://example.com/hooks", events=["grant.created"])
+
+    assert result.id == "wh_01"
+    assert result.secret == "abc123secret"
+    assert "grant.created" in result.events
+
+
+@respx.mock
+def test_list_webhooks() -> None:
+    respx.get(f"{BASE_URL}/v1/webhooks").mock(
+        return_value=httpx.Response(200, json={"webhooks": [MOCK_WEBHOOK]})
+    )
+    client = Grantex(api_key="test-key", base_url=BASE_URL)
+    result = client.webhooks.list()
+
+    assert len(result.webhooks) == 1
+    assert result.webhooks[0].id == "wh_01"
+    assert result.webhooks[0].url == "https://example.com/hooks"
+
+
+@respx.mock
+def test_delete_webhook() -> None:
+    respx.delete(f"{BASE_URL}/v1/webhooks/wh_01").mock(
+        return_value=httpx.Response(204)
+    )
+    client = Grantex(api_key="test-key", base_url=BASE_URL)
+    assert client.webhooks.delete("wh_01") is None
+
+
+def test_verify_signature_valid() -> None:
+    payload = '{"id":"evt_01","type":"grant.created","data":{}}'
+    secret = "my-webhook-secret"
+    sig = _make_sig(payload, secret)
+    assert verify_webhook_signature(payload, sig, secret) is True
+
+
+def test_verify_signature_invalid() -> None:
+    assert verify_webhook_signature("payload", "sha256=badsig", "secret") is False
+
+
+def test_verify_signature_wrong_secret() -> None:
+    payload = '{"id":"evt_01"}'
+    sig = _make_sig(payload, "correct-secret")
+    assert verify_webhook_signature(payload, sig, "wrong-secret") is False
+
+
+def test_verify_signature_bytes_payload() -> None:
+    payload = b'{"id":"evt_01","type":"grant.created"}'
+    secret = "my-secret"
+    sig = _make_sig(payload, secret)
+    assert verify_webhook_signature(payload, sig, secret) is True

--- a/packages/sdk-ts/src/client.ts
+++ b/packages/sdk-ts/src/client.ts
@@ -3,6 +3,7 @@ import { AgentsClient } from './resources/agents.js';
 import { AuditClient } from './resources/audit.js';
 import { GrantsClient } from './resources/grants.js';
 import { TokensClient } from './resources/tokens.js';
+import { WebhooksClient } from './resources/webhooks.js';
 import type {
   AuthorizationRequest,
   AuthorizeParams,
@@ -18,6 +19,7 @@ export class Grantex {
   readonly grants: GrantsClient;
   readonly tokens: TokensClient;
   readonly audit: AuditClient;
+  readonly webhooks: WebhooksClient;
 
   constructor(options: GrantexClientOptions = {}) {
     const apiKey =
@@ -39,6 +41,7 @@ export class Grantex {
     this.grants = new GrantsClient(this.#http);
     this.tokens = new TokensClient(this.#http);
     this.audit = new AuditClient(this.#http);
+    this.webhooks = new WebhooksClient(this.#http);
   }
 
   /**

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -4,6 +4,9 @@ export { Grantex } from './client.js';
 // Standalone token verification (no Grantex account needed)
 export { verifyGrantToken } from './verify.js';
 
+// Webhook signature verification
+export { verifyWebhookSignature } from './webhook.js';
+
 // Error classes
 export {
   GrantexError,
@@ -39,4 +42,10 @@ export type {
   ListAuditResponse,
   // Verify
   VerifyGrantTokenOptions,
+  // Webhooks
+  WebhookEventType,
+  CreateWebhookParams,
+  WebhookEndpoint,
+  WebhookEndpointWithSecret,
+  ListWebhooksResponse,
 } from './types.js';

--- a/packages/sdk-ts/src/resources/webhooks.ts
+++ b/packages/sdk-ts/src/resources/webhooks.ts
@@ -1,0 +1,26 @@
+import type { HttpClient } from '../http.js';
+import type {
+  CreateWebhookParams,
+  WebhookEndpointWithSecret,
+  ListWebhooksResponse,
+} from '../types.js';
+
+export class WebhooksClient {
+  readonly #http: HttpClient;
+
+  constructor(http: HttpClient) {
+    this.#http = http;
+  }
+
+  create(params: CreateWebhookParams): Promise<WebhookEndpointWithSecret> {
+    return this.#http.post('/v1/webhooks', params);
+  }
+
+  list(): Promise<ListWebhooksResponse> {
+    return this.#http.get('/v1/webhooks');
+  }
+
+  delete(webhookId: string): Promise<void> {
+    return this.#http.delete(`/v1/webhooks/${webhookId}`);
+  }
+}

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -180,6 +180,30 @@ export interface ListAuditResponse {
   pageSize: number;
 }
 
+// ─── Webhooks ─────────────────────────────────────────────────────────────────
+
+export type WebhookEventType = 'grant.created' | 'grant.revoked' | 'token.issued';
+
+export interface CreateWebhookParams {
+  url: string;
+  events: WebhookEventType[];
+}
+
+export interface WebhookEndpoint {
+  id: string;
+  url: string;
+  events: WebhookEventType[];
+  createdAt: string;
+}
+
+export interface WebhookEndpointWithSecret extends WebhookEndpoint {
+  secret: string;
+}
+
+export interface ListWebhooksResponse {
+  webhooks: WebhookEndpoint[];
+}
+
 // ─── Verify ───────────────────────────────────────────────────────────────────
 
 export interface VerifyGrantTokenOptions {

--- a/packages/sdk-ts/src/webhook.ts
+++ b/packages/sdk-ts/src/webhook.ts
@@ -1,0 +1,23 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Verify that a webhook payload was sent by Grantex.
+ *
+ * @param payload   - The raw request body string (or Buffer) received from Grantex.
+ * @param signature - The value of the `X-Grantex-Signature` header.
+ * @param secret    - The webhook secret returned when the endpoint was created.
+ * @returns `true` if the signature is valid, `false` otherwise.
+ */
+export function verifyWebhookSignature(
+  payload: string | Buffer,
+  signature: string,
+  secret: string,
+): boolean {
+  const expected =
+    'sha256=' + createHmac('sha256', secret).update(payload).digest('hex');
+  try {
+    return timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+  } catch {
+    return false;
+  }
+}

--- a/packages/sdk-ts/tests/webhooks.test.ts
+++ b/packages/sdk-ts/tests/webhooks.test.ts
@@ -1,0 +1,100 @@
+import { createHmac } from 'node:crypto';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Grantex } from '../src/client.js';
+import { verifyWebhookSignature } from '../src/webhook.js';
+
+function makeFetch(status: number, body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+const MOCK_WEBHOOK = {
+  id: 'wh_01',
+  url: 'https://example.com/hooks',
+  events: ['grant.created', 'grant.revoked'],
+  createdAt: '2026-02-26T00:00:00Z',
+};
+
+const MOCK_WEBHOOK_WITH_SECRET = { ...MOCK_WEBHOOK, secret: 'abc123secret' };
+
+describe('WebhooksClient', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('create() POSTs to /v1/webhooks and returns endpoint with secret', async () => {
+    const mockFetch = makeFetch(201, MOCK_WEBHOOK_WITH_SECRET);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.webhooks.create({
+      url: 'https://example.com/hooks',
+      events: ['grant.created', 'grant.revoked'],
+    });
+
+    expect(result.id).toBe('wh_01');
+    expect(result.secret).toBe('abc123secret');
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/webhooks$/);
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body['events']).toEqual(['grant.created', 'grant.revoked']);
+  });
+
+  it('list() GETs /v1/webhooks', async () => {
+    vi.stubGlobal('fetch', makeFetch(200, { webhooks: [MOCK_WEBHOOK] }));
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.webhooks.list();
+
+    expect(result.webhooks).toHaveLength(1);
+    expect(result.webhooks[0]!.id).toBe('wh_01');
+  });
+
+  it('delete() DELETEs /v1/webhooks/:id', async () => {
+    const mockFetch = makeFetch(204, null);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    await expect(grantex.webhooks.delete('wh_01')).resolves.toBeUndefined();
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/webhooks\/wh_01$/);
+    expect(init.method).toBe('DELETE');
+  });
+});
+
+describe('verifyWebhookSignature', () => {
+  const secret = 'test-webhook-secret';
+  const payload = '{"id":"evt_01","type":"grant.created","data":{}}';
+
+  function makeSignature(p: string, s: string): string {
+    return 'sha256=' + createHmac('sha256', s).update(p).digest('hex');
+  }
+
+  it('returns true for a valid signature', () => {
+    const sig = makeSignature(payload, secret);
+    expect(verifyWebhookSignature(payload, sig, secret)).toBe(true);
+  });
+
+  it('returns false for an invalid signature', () => {
+    expect(verifyWebhookSignature(payload, 'sha256=invalidsignature', secret)).toBe(false);
+  });
+
+  it('returns false when signed with wrong secret', () => {
+    const sig = makeSignature(payload, 'different-secret');
+    expect(verifyWebhookSignature(payload, sig, secret)).toBe(false);
+  });
+
+  it('accepts Buffer payload', () => {
+    const buf = Buffer.from(payload);
+    const sig = makeSignature(payload, secret);
+    expect(verifyWebhookSignature(buf, sig, secret)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **Auth service**: `POST /v1/webhooks`, `GET /v1/webhooks`, `DELETE /v1/webhooks/:id` for endpoint management. Fires `grant.created` + `token.issued` on token exchange, `grant.revoked` on grant deletion. Each delivery is signed with HMAC-SHA256 (`X-Grantex-Signature` header), best-effort fire-and-forget with 10s timeout.
- **TypeScript SDK**: `grantex.webhooks.create/list/delete` + standalone `verifyWebhookSignature(payload, sig, secret)` with timing-safe comparison.
- **Python SDK**: `grantex.webhooks.create/list/delete` + standalone `verify_webhook_signature(payload, sig, secret)`.
- **Migration**: `004_webhooks.sql` adds `webhooks` table.
- **Docs**: `docs/webhooks.md` with payload shapes, signature verification examples, SDK usage, and local dev guide.

## Test plan

- [ ] Auth service: 88 tests pass (`npm test` in `apps/auth-service`)
- [ ] TypeScript SDK: 39 tests pass (`npm test` in `packages/sdk-ts`)
- [ ] Python SDK: 48 tests pass, mypy clean (`pytest` + `mypy --strict` in `packages/sdk-py`)
- [ ] Webhook mock in `tests/setup.ts` prevents event firing from interfering with unrelated route tests