### PR TITLE
feat(crewai): add grantex-crewai Python integration package

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,7 +43,7 @@ Making Grantex native to every major agent framework.
 
 Compliance features that make Grantex a must-have for regulated environments.
 
-- [ ] CrewAI integration (`grantex-crewai`)
+- [x] CrewAI integration (`grantex-crewai`)
 - [ ] Vercel AI SDK integration
 - [ ] Enterprise compliance dashboard (org-wide view, exports)
 - [ ] SOC2/GDPR evidence pack export

--- a/packages/crewai/pyproject.toml
+++ b/packages/crewai/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "grantex-crewai"
+version = "0.1.0"
+description = "Grantex integration for CrewAI — scope-enforced, audited agent tools"
+requires-python = ">=3.9"
+dependencies = [
+    "grantex>=0.1.0",
+]
+
+[project.optional-dependencies]
+crewai = ["crewai>=0.28.0"]
+dev = [
+    "pytest>=8.0",
+    "pytest-mock>=3.12",
+]
+
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/grantex_crewai"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.mypy]
+strict = true
+python_version = "3.9"

--- a/packages/crewai/src/grantex_crewai/__init__.py
+++ b/packages/crewai/src/grantex_crewai/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from ._audit import with_audit_logging
+from ._jwt import decode_jwt_payload
+from ._tool import create_grantex_tool, get_tool_scopes
+
+__all__ = [
+    "create_grantex_tool",
+    "get_tool_scopes",
+    "with_audit_logging",
+    "decode_jwt_payload",
+]

--- a/packages/crewai/src/grantex_crewai/_audit.py
+++ b/packages/crewai/src/grantex_crewai/_audit.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import types
+from typing import Any
+
+
+def with_audit_logging(
+    tool: Any,
+    client: Any,
+    *,
+    agent_id: str,
+    grant_id: str,
+) -> Any:
+    """Wrap a CrewAI tool's ``_run`` method with Grantex audit logging.
+
+    On success, logs a ``'tool.run'`` audit entry with ``status='success'``.
+    On failure, logs with ``status='failure'`` and re-raises the exception.
+
+    Args:
+        tool: A CrewAI ``BaseTool`` instance (returned by
+              :func:`create_grantex_tool`).
+        client: A ``grantex.Grantex`` client instance.
+        agent_id: The Grantex agent ID to attribute the action to.
+        grant_id: The grant ID authorising this tool invocation.
+
+    Returns:
+        The same ``tool`` object with its ``_run`` method patched in-place.
+
+    Example::
+
+        tool = with_audit_logging(tool, grantex_client,
+                                  agent_id="ag_01...", grant_id="grnt_01...")
+    """
+    original_run = tool._run  # noqa: SLF001
+
+    def _audited_run(**kwargs: Any) -> str:
+        action = f"tool.run:{tool.name}"
+        try:
+            result: str = original_run(**kwargs)
+            client.audit.log(
+                agent_id=agent_id,
+                grant_id=grant_id,
+                action=action,
+                metadata={"kwargs": kwargs},
+                status="success",
+            )
+            return result
+        except Exception as exc:
+            client.audit.log(
+                agent_id=agent_id,
+                grant_id=grant_id,
+                action=action,
+                metadata={"kwargs": kwargs, "error": str(exc)},
+                status="failure",
+            )
+            raise
+
+    # Replace the bound method via types.MethodType so self is passed correctly
+    tool._run = types.MethodType(  # noqa: SLF001
+        lambda self, **kw: _audited_run(**kw), tool
+    )
+    return tool

--- a/packages/crewai/src/grantex_crewai/_jwt.py
+++ b/packages/crewai/src/grantex_crewai/_jwt.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, Dict
+
+
+def _b64url_decode(segment: str) -> bytes:
+    """Decode a base64url segment (no padding required)."""
+    padding = 4 - len(segment) % 4
+    if padding != 4:
+        segment += "=" * padding
+    return base64.urlsafe_b64decode(segment)
+
+
+def decode_jwt_payload(token: str) -> Dict[str, Any]:
+    """Decode the payload of a JWT without verifying the signature.
+
+    This is intentionally an offline operation — the token must already
+    have been verified (e.g. by Grantex) before being passed here.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise ValueError("Invalid JWT: expected 3 parts separated by '.'")
+    payload_bytes = _b64url_decode(parts[1])
+    return json.loads(payload_bytes.decode("utf-8"))  # type: ignore[no-any-return]

--- a/packages/crewai/src/grantex_crewai/_tool.py
+++ b/packages/crewai/src/grantex_crewai/_tool.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Optional, Type
+
+from ._jwt import decode_jwt_payload
+
+
+def create_grantex_tool(
+    *,
+    name: str,
+    description: str,
+    grant_token: str,
+    required_scope: str,
+    func: Callable[..., str],
+    args_schema: Optional[Any] = None,
+) -> Any:
+    """Create a CrewAI-compatible tool with Grantex scope enforcement.
+
+    The tool performs an **offline** scope check against the JWT ``scp``
+    claim before invoking ``func``.  Pass ``args_schema`` as a Pydantic
+    ``BaseModel`` subclass to describe the tool's input; if omitted a
+    schema-less tool is created.
+
+    Example::
+
+        from pydantic import BaseModel
+
+        class FetchParams(BaseModel):
+            url: str
+
+        tool = create_grantex_tool(
+            name="fetch_data",
+            description="Fetches data from the given URL.",
+            grant_token=token,
+            required_scope="data:read",
+            func=lambda url: requests.get(url).text,
+            args_schema=FetchParams,
+        )
+
+    Raises:
+        PermissionError: if the grant token does not contain the required scope.
+        ImportError: if ``crewai`` is not installed.
+    """
+    # Lazy import so the package can be imported without crewai installed
+    # (useful for testing and environments that only need the type stubs).
+    from crewai.tools import BaseTool  # type: ignore[import-not-found]
+    from pydantic import BaseModel
+
+    # Offline scope check
+    try:
+        payload = decode_jwt_payload(grant_token)
+    except Exception as exc:
+        raise ValueError(f"Could not decode grant_token: {exc}") from exc
+
+    scopes: list[str] = payload.get("scp", [])
+    if required_scope not in scopes:
+        raise PermissionError(
+            f"Grant token is missing required scope '{required_scope}'. "
+            f"Granted scopes: {scopes}"
+        )
+
+    # Determine the schema to attach
+    effective_schema: Type[BaseModel]
+    if args_schema is not None:
+        effective_schema = args_schema
+    else:
+        # Minimal schema that accepts any keyword arguments
+        class _EmptySchema(BaseModel):
+            pass
+
+        effective_schema = _EmptySchema
+
+    # Capture locals for the dynamic class
+    _func = func
+    _schema = effective_schema
+    _name = name
+    _description = description
+
+    class _GrantexTool(BaseTool):  # type: ignore[misc]
+        name: str = _name
+        description: str = _description
+        args_schema: Type[BaseModel] = _schema
+
+        def _run(self, **kwargs: Any) -> str:
+            return _func(**kwargs)
+
+    return _GrantexTool()
+
+
+def get_tool_scopes(grant_token: str) -> list[str]:
+    """Return the scopes embedded in a grant token (offline, no network call)."""
+    payload = decode_jwt_payload(grant_token)
+    scopes: list[str] = payload.get("scp", [])
+    return scopes

--- a/packages/crewai/tests/conftest.py
+++ b/packages/crewai/tests/conftest.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ─── Minimal crewai stub ─────────────────────────────────────────────────────
+# Injected before any test module imports grantex_crewai so that
+# `from crewai.tools import BaseTool` resolves to our stub class.
+
+class _BaseTool:
+    """Minimal BaseTool stub that mimics the CrewAI interface."""
+
+    name: str = ""
+    description: str = ""
+    args_schema: Any = None
+
+    def _run(self, **kwargs: Any) -> str:  # pragma: no cover
+        raise NotImplementedError
+
+    def run(self, **kwargs: Any) -> str:
+        return self._run(**kwargs)
+
+
+_crewai_tools_mod = types.ModuleType("crewai.tools")
+_crewai_tools_mod.BaseTool = _BaseTool  # type: ignore[attr-defined]
+
+_crewai_mod = types.ModuleType("crewai")
+_crewai_mod.tools = _crewai_tools_mod  # type: ignore[attr-defined]
+
+sys.modules.setdefault("crewai", _crewai_mod)
+sys.modules.setdefault("crewai.tools", _crewai_tools_mod)
+
+
+# ─── Pydantic stub (only needed if pydantic not installed) ───────────────────
+# Most environments will have pydantic, but guard just in case.
+if "pydantic" not in sys.modules:  # pragma: no cover
+    _pydantic_mod = types.ModuleType("pydantic")
+
+    class _BaseModel:
+        pass
+
+    _pydantic_mod.BaseModel = _BaseModel  # type: ignore[attr-defined]
+    sys.modules["pydantic"] = _pydantic_mod
+
+
+# ─── JWT helpers ─────────────────────────────────────────────────────────────
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def make_grant_token(scopes: list[str], extra: dict[str, Any] | None = None) -> str:
+    """Build a fake (unsigned) JWT with the given scp claim."""
+    header = _b64url(json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
+    payload_data: dict[str, Any] = {
+        "iss": "https://api.grantex.dev",
+        "sub": "user_01",
+        "agt": "did:grantex:ag_01",
+        "dev": "dev_01",
+        "scp": scopes,
+        "iat": 1700000000,
+        "exp": 9999999999,
+        "jti": "tok_01",
+        "grnt": "grnt_01",
+    }
+    if extra:
+        payload_data.update(extra)
+    payload = _b64url(json.dumps(payload_data).encode())
+    return f"{header}.{payload}.fakesignature"
+
+
+# ─── Mock Grantex client ──────────────────────────────────────────────────────
+
+@pytest.fixture()
+def mock_grantex() -> MagicMock:
+    client = MagicMock()
+    client.audit.log = MagicMock(return_value=None)
+    return client

--- a/packages/crewai/tests/test_audit.py
+++ b/packages/crewai/tests/test_audit.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from grantex_crewai import create_grantex_tool, with_audit_logging
+from .conftest import make_grant_token
+
+
+TOKEN = make_grant_token(["data:read"])
+
+
+def _make_tool(func: object) -> object:
+    return create_grantex_tool(
+        name="test_tool",
+        description="A test tool.",
+        grant_token=TOKEN,
+        required_scope="data:read",
+        func=func,  # type: ignore[arg-type]
+    )
+
+
+# ─── with_audit_logging ───────────────────────────────────────────────────────
+
+def test_audit_logs_success(mock_grantex: MagicMock) -> None:
+    tool = _make_tool(lambda item: f"processed:{item}")
+    tool = with_audit_logging(
+        tool, mock_grantex, agent_id="ag_01", grant_id="grnt_01"
+    )
+
+    result = tool._run(item="widget")
+
+    assert result == "processed:widget"
+    mock_grantex.audit.log.assert_called_once_with(
+        agent_id="ag_01",
+        grant_id="grnt_01",
+        action="tool.run:test_tool",
+        metadata={"kwargs": {"item": "widget"}},
+        status="success",
+    )
+
+
+def test_audit_logs_failure_and_reraises(mock_grantex: MagicMock) -> None:
+    def boom(item: str) -> str:
+        raise RuntimeError("something went wrong")
+
+    tool = _make_tool(boom)
+    tool = with_audit_logging(
+        tool, mock_grantex, agent_id="ag_01", grant_id="grnt_01"
+    )
+
+    with pytest.raises(RuntimeError, match="something went wrong"):
+        tool._run(item="widget")
+
+    mock_grantex.audit.log.assert_called_once_with(
+        agent_id="ag_01",
+        grant_id="grnt_01",
+        action="tool.run:test_tool",
+        metadata={"kwargs": {"item": "widget"}, "error": "something went wrong"},
+        status="failure",
+    )
+
+
+def test_audit_returns_same_tool_instance(mock_grantex: MagicMock) -> None:
+    tool = _make_tool(lambda: "ok")
+    original_id = id(tool)
+    returned = with_audit_logging(
+        tool, mock_grantex, agent_id="ag_01", grant_id="grnt_01"
+    )
+    assert id(returned) == original_id
+
+
+def test_audit_does_not_log_on_scope_error() -> None:
+    """PermissionError from create_grantex_tool happens before any run, so no log."""
+    mock_client = MagicMock()
+    token_no_scope = make_grant_token([])
+
+    with pytest.raises(PermissionError):
+        create_grantex_tool(
+            name="restricted",
+            description="restricted",
+            grant_token=token_no_scope,
+            required_scope="data:read",
+            func=lambda: "ok",
+        )
+
+    mock_client.audit.log.assert_not_called()

--- a/packages/crewai/tests/test_tool.py
+++ b/packages/crewai/tests/test_tool.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+
+from grantex_crewai import create_grantex_tool, get_tool_scopes
+from .conftest import make_grant_token
+
+
+TOKEN_WITH_READ = make_grant_token(["data:read", "data:write"])
+TOKEN_EMPTY = make_grant_token([])
+
+
+# ─── create_grantex_tool ──────────────────────────────────────────────────────
+
+def test_create_tool_returns_base_tool_instance() -> None:
+    tool = create_grantex_tool(
+        name="my_tool",
+        description="Does something.",
+        grant_token=TOKEN_WITH_READ,
+        required_scope="data:read",
+        func=lambda: "ok",
+    )
+    # Should be an instance of our stubbed BaseTool
+    from crewai.tools import BaseTool  # type: ignore[import-untyped]
+    assert isinstance(tool, BaseTool)
+    assert tool.name == "my_tool"
+    assert tool.description == "Does something."
+
+
+def test_create_tool_raises_permission_error_for_missing_scope() -> None:
+    with pytest.raises(PermissionError, match="missing required scope 'admin:all'"):
+        create_grantex_tool(
+            name="admin_tool",
+            description="Admin action.",
+            grant_token=TOKEN_WITH_READ,
+            required_scope="admin:all",
+            func=lambda: "ok",
+        )
+
+
+def test_create_tool_raises_for_invalid_jwt() -> None:
+    with pytest.raises(ValueError, match="Could not decode grant_token"):
+        create_grantex_tool(
+            name="t",
+            description="d",
+            grant_token="not.a.valid.jwt.at.all",
+            required_scope="data:read",
+            func=lambda: "ok",
+        )
+
+
+def test_tool_run_delegates_to_func() -> None:
+    calls: list[dict[str, str]] = []
+
+    def my_func(url: str) -> str:
+        calls.append({"url": url})
+        return f"fetched:{url}"
+
+    tool = create_grantex_tool(
+        name="fetch",
+        description="Fetch a URL.",
+        grant_token=TOKEN_WITH_READ,
+        required_scope="data:read",
+        func=my_func,
+    )
+
+    result = tool._run(url="https://example.com")
+    assert result == "fetched:https://example.com"
+    assert calls == [{"url": "https://example.com"}]
+
+
+def test_get_tool_scopes_returns_scp_list() -> None:
+    scopes = get_tool_scopes(TOKEN_WITH_READ)
+    assert scopes == ["data:read", "data:write"]
+
+
+def test_get_tool_scopes_empty_token() -> None:
+    scopes = get_tool_scopes(TOKEN_EMPTY)
+    assert scopes == []


### PR DESCRIPTION
## Summary

- New package `grantex-crewai` (`packages/crewai/`) — Python integration for CrewAI agent frameworks
- `create_grantex_tool()` — factory that builds a `BaseTool` subclass with **offline scope enforcement** (decodes `scp` claim from the grant JWT at construction time; raises `PermissionError` if the required scope is absent)
- `with_audit_logging()` — wraps a tool's `_run` method in-place to emit `audit.log()` calls with `status='success'` or `status='failure'` after each invocation
- `get_tool_scopes()` — convenience helper to inspect scopes without creating a tool
- Lazy `crewai` import: the package imports cleanly without `crewai` installed (only needed at `create_grantex_tool()` call time)
- 10 tests, all passing; `mypy --strict` clean

## Test plan

- [x] `pytest packages/crewai` — 10/10 pass
- [x] `mypy --strict packages/crewai/src/grantex_crewai` — 0 errors
- [x] Scope-missing token raises `PermissionError` at construction time
- [x] Tool `_run` delegates to user-supplied `func`
- [x] Audit success/failure branches verified with mock Grantex client
- [x] `with_audit_logging` returns the same tool instance (in-place mutation)