### PR TITLE
feat(anomaly-detection): detect unusual agent behavior

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,7 +46,7 @@ Compliance features that make Grantex a must-have for regulated environments.
 - [x] CrewAI integration (`grantex-crewai`)
 - [x] Vercel AI SDK integration
 - [x] Enterprise compliance dashboard (org-wide view, exports)
-- [ ] SOC2/GDPR evidence pack export
+- [x] SOC2/GDPR evidence pack export
 - [x] Policy engine (auto-approve / auto-deny rules)
 - [ ] SCIM / SSO for enterprise developer orgs
 - [ ] Anomaly detection (unusual agent behavior alerts)

--- a/apps/auth-service/src/db/migrations/007_anomalies.sql
+++ b/apps/auth-service/src/db/migrations/007_anomalies.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS anomalies (
+  id             TEXT PRIMARY KEY,
+  developer_id   TEXT NOT NULL REFERENCES developers(id) ON DELETE CASCADE,
+  type           TEXT NOT NULL CHECK (type IN ('rate_spike', 'high_failure_rate', 'new_principal', 'off_hours_activity')),
+  severity       TEXT NOT NULL DEFAULT 'medium' CHECK (severity IN ('low', 'medium', 'high')),
+  agent_id       TEXT,
+  principal_id   TEXT,
+  description    TEXT NOT NULL,
+  metadata       JSONB NOT NULL DEFAULT '{}',
+  detected_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  acknowledged_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS anomalies_developer_id_idx ON anomalies (developer_id);
+CREATE INDEX IF NOT EXISTS anomalies_detected_at_idx  ON anomalies (detected_at DESC);

--- a/apps/auth-service/src/lib/ids.ts
+++ b/apps/auth-service/src/lib/ids.ts
@@ -10,3 +10,4 @@ export const newDeveloperId = (): string => `dev_${ulid()}`;
 export const newWebhookId = (): string => `wh_${ulid()}`;
 export const newSubscriptionId = (): string => `sub_${ulid()}`;
 export const newPolicyId = (): string => `pol_${ulid()}`;
+export const newAnomalyId = (): string => `anm_${ulid()}`;

--- a/apps/auth-service/src/routes/anomalies.ts
+++ b/apps/auth-service/src/routes/anomalies.ts
@@ -1,0 +1,229 @@
+import type { FastifyInstance } from 'fastify';
+import { getSql } from '../db/client.js';
+import { newAnomalyId } from '../lib/ids.js';
+
+type AnomalyType = 'rate_spike' | 'high_failure_rate' | 'new_principal' | 'off_hours_activity';
+type AnomalySeverity = 'low' | 'medium' | 'high';
+
+interface AnomalyInsert {
+  id: string;
+  developer_id: string;
+  type: AnomalyType;
+  severity: AnomalySeverity;
+  agent_id: string | null;
+  principal_id: string | null;
+  description: string;
+  metadata: Record<string, unknown>;
+}
+
+function toResponse(row: Record<string, unknown>) {
+  return {
+    id: row['id'],
+    type: row['type'],
+    severity: row['severity'],
+    agentId: row['agent_id'] ?? null,
+    principalId: row['principal_id'] ?? null,
+    description: row['description'],
+    metadata: row['metadata'] ?? {},
+    detectedAt: row['detected_at'],
+    acknowledgedAt: row['acknowledged_at'] ?? null,
+  };
+}
+
+export async function anomaliesRoutes(app: FastifyInstance): Promise<void> {
+  // POST /v1/anomalies/detect — run detection, persist results, return them
+  app.post('/v1/anomalies/detect', async (request, reply) => {
+    const sql = getSql();
+    const developerId = request.developer.id;
+
+    const [rateSpikeRows, highFailureRows, newPrincipalRows, offHoursRows] = await Promise.all([
+      // rate_spike: >50 actions per agent in last 1 hour
+      sql`
+        SELECT agent_id, COUNT(*) AS count
+        FROM audit_entries
+        WHERE developer_id = ${developerId}
+          AND timestamp >= NOW() - INTERVAL '1 hour'
+        GROUP BY agent_id
+        HAVING COUNT(*) > 50
+      `,
+      // high_failure_rate: >20% failure/blocked in last 24h (min 5 entries)
+      sql`
+        SELECT agent_id,
+               COUNT(*) FILTER (WHERE status IN ('failure', 'blocked')) AS bad_count,
+               COUNT(*) AS total_count
+        FROM audit_entries
+        WHERE developer_id = ${developerId}
+          AND timestamp >= NOW() - INTERVAL '24 hours'
+        GROUP BY agent_id
+        HAVING COUNT(*) >= 5
+           AND (COUNT(*) FILTER (WHERE status IN ('failure', 'blocked')))::float
+               / COUNT(*) > 0.2
+      `,
+      // new_principal: grant issued to a brand-new agent-principal pair in last 24h
+      sql`
+        SELECT g.agent_id, g.principal_id
+        FROM grants g
+        WHERE g.developer_id = ${developerId}
+          AND g.issued_at >= NOW() - INTERVAL '24 hours'
+          AND NOT EXISTS (
+            SELECT 1 FROM grants g2
+            WHERE g2.developer_id = ${developerId}
+              AND g2.agent_id = g.agent_id
+              AND g2.principal_id = g.principal_id
+              AND g2.issued_at < g.issued_at
+          )
+      `,
+      // off_hours_activity: >10 entries between 22:00–06:00 UTC in last 24h
+      sql`
+        SELECT agent_id, COUNT(*) AS count
+        FROM audit_entries
+        WHERE developer_id = ${developerId}
+          AND timestamp >= NOW() - INTERVAL '24 hours'
+          AND (
+            EXTRACT(HOUR FROM timestamp AT TIME ZONE 'UTC') >= 22
+            OR EXTRACT(HOUR FROM timestamp AT TIME ZONE 'UTC') < 6
+          )
+        GROUP BY agent_id
+        HAVING COUNT(*) > 10
+      `,
+    ]);
+
+    // Build anomaly objects
+    const anomalies: AnomalyInsert[] = [];
+    const now = new Date().toISOString();
+
+    for (const r of rateSpikeRows as Array<Record<string, unknown>>) {
+      const agentId = r['agent_id'] as string;
+      const count = Number(r['count']);
+      anomalies.push({
+        id: newAnomalyId(),
+        developer_id: developerId,
+        type: 'rate_spike',
+        severity: 'high',
+        agent_id: agentId,
+        principal_id: null,
+        description: `Agent ${agentId} performed ${count} actions in the last hour (threshold: 50).`,
+        metadata: { count, windowHours: 1, threshold: 50 },
+      });
+    }
+
+    for (const r of highFailureRows as Array<Record<string, unknown>>) {
+      const agentId = r['agent_id'] as string;
+      const total = Number(r['total_count']);
+      const bad = Number(r['bad_count']);
+      const pct = Math.round((bad / total) * 100);
+      anomalies.push({
+        id: newAnomalyId(),
+        developer_id: developerId,
+        type: 'high_failure_rate',
+        severity: 'medium',
+        agent_id: agentId,
+        principal_id: null,
+        description: `Agent ${agentId} has ${pct}% failure/blocked rate over the last 24 hours (${bad}/${total}).`,
+        metadata: { badCount: bad, totalCount: total, percentFailure: pct, windowHours: 24, threshold: 0.2 },
+      });
+    }
+
+    for (const r of newPrincipalRows as Array<Record<string, unknown>>) {
+      const agentId = r['agent_id'] as string;
+      const principalId = r['principal_id'] as string;
+      anomalies.push({
+        id: newAnomalyId(),
+        developer_id: developerId,
+        type: 'new_principal',
+        severity: 'low',
+        agent_id: agentId,
+        principal_id: principalId,
+        description: `Agent ${agentId} received a grant from previously-unseen principal ${principalId}.`,
+        metadata: { windowHours: 24 },
+      });
+    }
+
+    for (const r of offHoursRows as Array<Record<string, unknown>>) {
+      const agentId = r['agent_id'] as string;
+      const count = Number(r['count']);
+      anomalies.push({
+        id: newAnomalyId(),
+        developer_id: developerId,
+        type: 'off_hours_activity',
+        severity: 'low',
+        agent_id: agentId,
+        principal_id: null,
+        description: `Agent ${agentId} performed ${count} actions outside business hours (22:00–06:00 UTC) in the last 24 hours.`,
+        metadata: { count, windowHours: 24, threshold: 10 },
+      });
+    }
+
+    // Clear existing unacknowledged anomalies for this developer
+    await sql`
+      DELETE FROM anomalies
+      WHERE developer_id = ${developerId} AND acknowledged_at IS NULL
+    `;
+
+    // Persist new anomalies (one INSERT per anomaly for simplicity)
+    for (const a of anomalies) {
+      await sql`
+        INSERT INTO anomalies
+          (id, developer_id, type, severity, agent_id, principal_id, description, metadata)
+        VALUES
+          (${a.id}, ${a.developer_id}, ${a.type}, ${a.severity},
+           ${a.agent_id}, ${a.principal_id}, ${a.description}, ${JSON.stringify(a.metadata)})
+      `;
+    }
+
+    return reply.send({
+      detectedAt: now,
+      total: anomalies.length,
+      anomalies: anomalies.map((a) => ({
+        id: a.id,
+        type: a.type,
+        severity: a.severity,
+        agentId: a.agent_id,
+        principalId: a.principal_id,
+        description: a.description,
+        metadata: a.metadata,
+        detectedAt: now,
+        acknowledgedAt: null,
+      })),
+    });
+  });
+
+  // GET /v1/anomalies — list stored anomalies
+  app.get('/v1/anomalies', async (request, reply) => {
+    const sql = getSql();
+    const query = request.query as Record<string, string>;
+    const developerId = request.developer.id;
+    const unacknowledgedOnly = query['unacknowledged'] === 'true';
+
+    const rows = await sql`
+      SELECT id, type, severity, agent_id, principal_id, description, metadata,
+             detected_at, acknowledged_at
+      FROM anomalies
+      WHERE developer_id = ${developerId}
+        AND (${!unacknowledgedOnly} OR acknowledged_at IS NULL)
+      ORDER BY detected_at DESC
+    `;
+
+    const anomalies = (rows as Array<Record<string, unknown>>).map(toResponse);
+    return reply.send({ anomalies, total: anomalies.length });
+  });
+
+  // PATCH /v1/anomalies/:id/acknowledge — mark an anomaly as acknowledged
+  app.patch<{ Params: { id: string } }>(
+    '/v1/anomalies/:id/acknowledge',
+    async (request, reply) => {
+      const sql = getSql();
+      const rows = await sql`
+        UPDATE anomalies
+        SET acknowledged_at = NOW()
+        WHERE id = ${request.params.id}
+          AND developer_id = ${request.developer.id}
+        RETURNING *
+      `;
+      if (!rows[0]) {
+        return reply.status(404).send({ message: 'Anomaly not found', code: 'NOT_FOUND', requestId: request.id });
+      }
+      return reply.send(toResponse(rows[0] as Record<string, unknown>));
+    },
+  );
+}

--- a/apps/auth-service/src/server.ts
+++ b/apps/auth-service/src/server.ts
@@ -17,6 +17,7 @@ import { webhooksRoutes } from './routes/webhooks.js';
 import { billingRoutes } from './routes/billing.js';
 import { policiesRoutes } from './routes/policies.js';
 import { complianceRoutes } from './routes/compliance.js';
+import { anomaliesRoutes } from './routes/anomalies.js';
 
 export type AppOptions = {
   logger?: boolean | object;
@@ -52,6 +53,7 @@ export async function buildApp(opts: AppOptions = {}) {
   await app.register(billingRoutes);
   await app.register(policiesRoutes);
   await app.register(complianceRoutes);
+  await app.register(anomaliesRoutes);
 
   return app;
 }

--- a/apps/auth-service/tests/anomalies.test.ts
+++ b/apps/auth-service/tests/anomalies.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { buildTestApp, authHeader, seedAuth, sqlMock } from './helpers.js';
+import type { FastifyInstance } from 'fastify';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+// ─── Mock DB rows ─────────────────────────────────────────────────────────────
+
+const RATE_SPIKE_ROW  = { agent_id: 'ag_01', count: '72' };
+const HIGH_FAIL_ROW   = { agent_id: 'ag_02', bad_count: '15', total_count: '20' };
+const NEW_PRINCIPAL_ROW = { agent_id: 'ag_01', principal_id: 'user_new' };
+const OFF_HOURS_ROW   = { agent_id: 'ag_03', count: '18' };
+
+const STORED_ANOMALY = {
+  id: 'anm_01',
+  type: 'rate_spike',
+  severity: 'high',
+  agent_id: 'ag_01',
+  principal_id: null,
+  description: 'Agent ag_01 performed 72 actions in the last hour.',
+  metadata: { count: 72 },
+  detected_at: '2026-02-26T00:00:00Z',
+  acknowledged_at: null,
+};
+
+/**
+ * Seeds mock slots for POST /v1/anomalies/detect with no anomalies found.
+ * SQL calls: 1 auth + 4 detection queries + 1 delete = 6 total.
+ */
+function seedDetectNoAnomalies() {
+  seedAuth();
+  sqlMock.mockResolvedValueOnce([]); // rate_spike
+  sqlMock.mockResolvedValueOnce([]); // high_failure_rate
+  sqlMock.mockResolvedValueOnce([]); // new_principal
+  sqlMock.mockResolvedValueOnce([]); // off_hours
+  sqlMock.mockResolvedValueOnce([]); // DELETE
+}
+
+/**
+ * Seeds mock slots for POST /v1/anomalies/detect with one anomaly found.
+ * SQL calls: 1 auth + 4 detect + 1 delete + 1 insert = 7 total.
+ */
+function seedDetectOneAnomaly(
+  rateSpike: unknown[] = [],
+  highFail: unknown[] = [],
+  newPrincipal: unknown[] = [],
+  offHours: unknown[] = [],
+) {
+  seedAuth();
+  sqlMock.mockResolvedValueOnce(rateSpike);
+  sqlMock.mockResolvedValueOnce(highFail);
+  sqlMock.mockResolvedValueOnce(newPrincipal);
+  sqlMock.mockResolvedValueOnce(offHours);
+  sqlMock.mockResolvedValueOnce([]); // DELETE
+  sqlMock.mockResolvedValueOnce([]); // INSERT (one anomaly)
+}
+
+// ─── POST /v1/anomalies/detect ────────────────────────────────────────────────
+
+describe('POST /v1/anomalies/detect', () => {
+  it('returns empty anomalies when nothing is detected', async () => {
+    seedDetectNoAnomalies();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/anomalies/detect',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ total: number; anomalies: unknown[]; detectedAt: string }>();
+    expect(body.total).toBe(0);
+    expect(body.anomalies).toHaveLength(0);
+    expect(body.detectedAt).toBeDefined();
+  });
+
+  it('detects rate_spike and returns severity high', async () => {
+    seedDetectOneAnomaly([RATE_SPIKE_ROW]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/anomalies/detect',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ total: number; anomalies: Array<{ type: string; severity: string; agentId: string }> }>();
+    expect(body.total).toBe(1);
+    expect(body.anomalies[0]!.type).toBe('rate_spike');
+    expect(body.anomalies[0]!.severity).toBe('high');
+    expect(body.anomalies[0]!.agentId).toBe('ag_01');
+  });
+
+  it('detects high_failure_rate with correct percentage in description', async () => {
+    seedDetectOneAnomaly([], [HIGH_FAIL_ROW]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/anomalies/detect',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ anomalies: Array<{ type: string; severity: string; description: string }> }>();
+    expect(body.anomalies[0]!.type).toBe('high_failure_rate');
+    expect(body.anomalies[0]!.severity).toBe('medium');
+    expect(body.anomalies[0]!.description).toContain('75%'); // 15/20 = 75%
+  });
+
+  it('detects new_principal and includes principalId', async () => {
+    seedDetectOneAnomaly([], [], [NEW_PRINCIPAL_ROW]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/anomalies/detect',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ anomalies: Array<{ type: string; principalId: string }> }>();
+    expect(body.anomalies[0]!.type).toBe('new_principal');
+    expect(body.anomalies[0]!.principalId).toBe('user_new');
+  });
+
+  it('detects off_hours_activity', async () => {
+    seedDetectOneAnomaly([], [], [], [OFF_HOURS_ROW]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/anomalies/detect',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ anomalies: Array<{ type: string; severity: string }> }>();
+    expect(body.anomalies[0]!.type).toBe('off_hours_activity');
+    expect(body.anomalies[0]!.severity).toBe('low');
+  });
+});
+
+// ─── GET /v1/anomalies ────────────────────────────────────────────────────────
+
+describe('GET /v1/anomalies', () => {
+  it('returns stored anomalies', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([STORED_ANOMALY]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/anomalies',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ anomalies: Array<{ id: string; type: string }>; total: number }>();
+    expect(body.total).toBe(1);
+    expect(body.anomalies[0]!.id).toBe('anm_01');
+    expect(body.anomalies[0]!.type).toBe('rate_spike');
+  });
+
+  it('returns empty list when no anomalies', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/anomalies',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ total: number }>().total).toBe(0);
+  });
+});
+
+// ─── PATCH /v1/anomalies/:id/acknowledge ─────────────────────────────────────
+
+describe('PATCH /v1/anomalies/:id/acknowledge', () => {
+  it('acknowledges an anomaly and returns acknowledgedAt', async () => {
+    const acked = { ...STORED_ANOMALY, acknowledged_at: '2026-02-26T01:00:00Z' };
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([acked]);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/anomalies/anm_01/acknowledge',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ acknowledgedAt: string }>();
+    expect(body.acknowledgedAt).toBe('2026-02-26T01:00:00Z');
+  });
+
+  it('returns 404 when anomaly not found', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/anomalies/anm_missing/acknowledge',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/packages/cli/src/commands/anomalies.ts
+++ b/packages/cli/src/commands/anomalies.ts
@@ -1,0 +1,75 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { requireClient } from '../client.js';
+import { printTable, shortDate } from '../format.js';
+import type { Anomaly } from '@grantex/sdk';
+
+const SEVERITY_COLOR: Record<string, (s: string) => string> = {
+  high:   chalk.red,
+  medium: chalk.yellow,
+  low:    chalk.cyan,
+};
+
+function colorSeverity(severity: string): string {
+  return (SEVERITY_COLOR[severity] ?? ((s: string) => s))(severity);
+}
+
+export function anomaliesCommand(): Command {
+  const cmd = new Command('anomalies').description('Detect and manage agent anomalies');
+
+  cmd
+    .command('detect')
+    .description('Run anomaly detection across all agents')
+    .action(async () => {
+      const client = await requireClient();
+      const result = await client.anomalies.detect();
+
+      if (result.total === 0) {
+        console.log(chalk.green('✓') + ' No anomalies detected.');
+        return;
+      }
+
+      console.log(`Detected ${result.total} anomaly${result.total !== 1 ? 's' : ''}:\n`);
+      printTable(
+        result.anomalies.map(formatRow),
+        ['ID', 'TYPE', 'SEVERITY', 'AGENT', 'DESCRIPTION'],
+      );
+    });
+
+  cmd
+    .command('list')
+    .description('List stored anomalies')
+    .option('--unacknowledged', 'Show only unacknowledged anomalies')
+    .action(async (opts: { unacknowledged?: boolean }) => {
+      const client = await requireClient();
+      const result = await client.anomalies.list({
+        ...(opts.unacknowledged ? { unacknowledged: true } : {}),
+      });
+
+      printTable(
+        result.anomalies.map(formatRow),
+        ['ID', 'TYPE', 'SEVERITY', 'AGENT', 'DESCRIPTION'],
+      );
+    });
+
+  cmd
+    .command('acknowledge <anomalyId>')
+    .description('Acknowledge an anomaly')
+    .action(async (anomalyId: string) => {
+      const client = await requireClient();
+      await client.anomalies.acknowledge(anomalyId);
+      console.log(chalk.green('✓') + ` Anomaly ${anomalyId} acknowledged.`);
+    });
+
+  return cmd;
+}
+
+function formatRow(a: Anomaly): Record<string, string> {
+  return {
+    ID:          a.id,
+    TYPE:        a.type,
+    SEVERITY:    colorSeverity(a.severity),
+    AGENT:       a.agentId ?? '—',
+    DESCRIPTION: a.description.length > 60 ? a.description.slice(0, 57) + '...' : a.description,
+  };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
 import { agentsCommand } from './commands/agents.js';
+import { anomaliesCommand } from './commands/anomalies.js';
 import { auditCommand } from './commands/audit.js';
 import { complianceCommand } from './commands/compliance.js';
 import { configCommand } from './commands/config.js';
@@ -22,6 +23,7 @@ program.addCommand(tokensCommand());
 program.addCommand(auditCommand());
 program.addCommand(webhooksCommand());
 program.addCommand(complianceCommand());
+program.addCommand(anomaliesCommand());
 
 program.parseAsync(process.argv).catch((err: unknown) => {
   console.error((err instanceof Error ? err.message : String(err)));

--- a/packages/cli/tests/anomalies.test.ts
+++ b/packages/cli/tests/anomalies.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { anomaliesCommand } from '../src/commands/anomalies.js';
+
+describe('anomaliesCommand()', () => {
+  it('registers the "anomalies" command', () => {
+    const cmd = anomaliesCommand();
+    expect(cmd.name()).toBe('anomalies');
+  });
+
+  it('has detect, list, and acknowledge subcommands', () => {
+    const cmd = anomaliesCommand();
+    const names = cmd.commands.map((c) => c.name());
+    expect(names).toContain('detect');
+    expect(names).toContain('list');
+    expect(names).toContain('acknowledge');
+  });
+
+  it('"list" has --unacknowledged option', () => {
+    const cmd = anomaliesCommand();
+    const listCmd = cmd.commands.find((c) => c.name() === 'list')!;
+    const optNames = listCmd.options.map((o) => o.long);
+    expect(optNames).toContain('--unacknowledged');
+  });
+});

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -12,10 +12,13 @@ from ._errors import (
 )
 from ._types import (
     Agent,
+    Anomaly,
     AuditEntry,
     AuthorizationRequest,
     AuthorizeParams,
     ChainIntegrity,
+    DetectAnomaliesResponse,
+    ListAnomaliesResponse,
     CheckoutResponse,
     ComplianceAuditExport,
     ComplianceExportAuditParams,
@@ -70,7 +73,10 @@ __all__ = [
     "GrantexNetworkError",
     # Types
     "Agent",
+    "Anomaly",
     "AuditEntry",
+    "DetectAnomaliesResponse",
+    "ListAnomaliesResponse",
     "AuthorizationRequest",
     "AuthorizeParams",
     "ChainIntegrity",

--- a/packages/sdk-py/src/grantex/_client.py
+++ b/packages/sdk-py/src/grantex/_client.py
@@ -6,6 +6,7 @@ from ._http import HttpClient
 from ._types import AuthorizationRequest, AuthorizeParams
 from .resources._agents import AgentsClient
 from .resources._audit import AuditClient
+from .resources._anomalies import AnomaliesClient
 from .resources._compliance import ComplianceClient
 from .resources._grants import GrantsClient
 from .resources._tokens import TokensClient
@@ -27,6 +28,7 @@ class Grantex:
     billing: BillingClient
     policies: PoliciesClient
     compliance: ComplianceClient
+    anomalies: AnomaliesClient
 
     def __init__(
         self,
@@ -56,6 +58,7 @@ class Grantex:
         self.billing = BillingClient(self._http)
         self.policies = PoliciesClient(self._http)
         self.compliance = ComplianceClient(self._http)
+        self.anomalies = AnomaliesClient(self._http)
 
     def authorize(self, params: AuthorizeParams) -> AuthorizationRequest:
         """Initiate the delegated authorization flow for a user.

--- a/packages/sdk-py/src/grantex/_types.py
+++ b/packages/sdk-py/src/grantex/_types.py
@@ -687,6 +687,67 @@ class ComplianceAuditExport:
         )
 
 
+# ─── Anomalies ────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Anomaly:
+    id: str
+    type: str  # 'rate_spike' | 'high_failure_rate' | 'new_principal' | 'off_hours_activity'
+    severity: str  # 'low' | 'medium' | 'high'
+    agent_id: str | None
+    principal_id: str | None
+    description: str
+    metadata: dict[str, Any]
+    detected_at: str
+    acknowledged_at: str | None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Anomaly":
+        return cls(
+            id=data["id"],
+            type=data["type"],
+            severity=data["severity"],
+            agent_id=data.get("agentId"),
+            principal_id=data.get("principalId"),
+            description=data["description"],
+            metadata=data.get("metadata", {}),
+            detected_at=data["detectedAt"],
+            acknowledged_at=data.get("acknowledgedAt"),
+        )
+
+
+@dataclass(frozen=True)
+class DetectAnomaliesResponse:
+    detected_at: str
+    total: int
+    anomalies: tuple[Anomaly, ...]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "DetectAnomaliesResponse":
+        return cls(
+            detected_at=data["detectedAt"],
+            total=data["total"],
+            anomalies=tuple(Anomaly.from_dict(a) for a in data.get("anomalies", [])),
+        )
+
+
+@dataclass(frozen=True)
+class ListAnomaliesResponse:
+    anomalies: tuple[Anomaly, ...]
+    total: int
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ListAnomaliesResponse":
+        return cls(
+            anomalies=tuple(Anomaly.from_dict(a) for a in data.get("anomalies", [])),
+            total=data.get("total", 0),
+        )
+
+
+# ─── Evidence pack ─────────────────────────────────────────────────────────────
+
+
 @dataclass
 class EvidencePackParams:
     since: str | None = None

--- a/packages/sdk-py/src/grantex/resources/_anomalies.py
+++ b/packages/sdk-py/src/grantex/resources/_anomalies.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from .._http import HttpClient
+from .._types import Anomaly, DetectAnomaliesResponse, ListAnomaliesResponse
+
+
+class AnomaliesClient:
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def detect(self) -> DetectAnomaliesResponse:
+        """Run anomaly detection across all agents and return detected anomalies."""
+        data = self._http.post("/v1/anomalies/detect", {})
+        return DetectAnomaliesResponse.from_dict(data)
+
+    def list(self, *, unacknowledged: bool = False) -> ListAnomaliesResponse:
+        """List stored anomalies. Pass unacknowledged=True to show only open ones."""
+        path = "/v1/anomalies?unacknowledged=true" if unacknowledged else "/v1/anomalies"
+        data = self._http.get(path)
+        return ListAnomaliesResponse.from_dict(data)
+
+    def acknowledge(self, anomaly_id: str) -> Anomaly:
+        """Acknowledge an anomaly by ID."""
+        data = self._http.patch(f"/v1/anomalies/{anomaly_id}/acknowledge", {})
+        return Anomaly.from_dict(data)

--- a/packages/sdk-py/tests/test_anomalies.py
+++ b/packages/sdk-py/tests/test_anomalies.py
@@ -1,0 +1,92 @@
+"""Tests for AnomaliesClient."""
+from __future__ import annotations
+
+import pytest
+import respx
+import httpx
+
+from grantex import Grantex
+
+MOCK_ANOMALY = {
+    "id": "anm_01",
+    "type": "rate_spike",
+    "severity": "high",
+    "agentId": "ag_01",
+    "principalId": None,
+    "description": "Agent ag_01 performed 72 actions in the last hour (threshold: 50).",
+    "metadata": {"count": 72, "windowHours": 1, "threshold": 50},
+    "detectedAt": "2026-02-26T00:00:00Z",
+    "acknowledgedAt": None,
+}
+
+
+@pytest.fixture
+def client() -> Grantex:
+    return Grantex(api_key="test-key")
+
+
+@respx.mock
+def test_detect(client: Grantex) -> None:
+    respx.post("https://api.grantex.dev/v1/anomalies/detect").mock(
+        return_value=httpx.Response(
+            200,
+            json={"detectedAt": "2026-02-26T00:00:00Z", "total": 1, "anomalies": [MOCK_ANOMALY]},
+        )
+    )
+    result = client.anomalies.detect()
+
+    assert result.total == 1
+    assert result.anomalies[0].type == "rate_spike"
+    assert result.anomalies[0].severity == "high"
+    assert result.anomalies[0].agent_id == "ag_01"
+    assert result.anomalies[0].principal_id is None
+    assert result.anomalies[0].acknowledged_at is None
+
+
+@respx.mock
+def test_detect_empty(client: Grantex) -> None:
+    respx.post("https://api.grantex.dev/v1/anomalies/detect").mock(
+        return_value=httpx.Response(
+            200,
+            json={"detectedAt": "2026-02-26T00:00:00Z", "total": 0, "anomalies": []},
+        )
+    )
+    result = client.anomalies.detect()
+    assert result.total == 0
+    assert len(result.anomalies) == 0
+
+
+@respx.mock
+def test_list(client: Grantex) -> None:
+    route = respx.get("https://api.grantex.dev/v1/anomalies").mock(
+        return_value=httpx.Response(200, json={"anomalies": [MOCK_ANOMALY], "total": 1})
+    )
+    result = client.anomalies.list()
+
+    assert result.total == 1
+    assert result.anomalies[0].id == "anm_01"
+    url = str(route.calls[0].request.url)
+    assert "unacknowledged" not in url
+
+
+@respx.mock
+def test_list_unacknowledged(client: Grantex) -> None:
+    route = respx.get("https://api.grantex.dev/v1/anomalies").mock(
+        return_value=httpx.Response(200, json={"anomalies": [], "total": 0})
+    )
+    client.anomalies.list(unacknowledged=True)
+
+    url = str(route.calls[0].request.url)
+    assert "unacknowledged=true" in url
+
+
+@respx.mock
+def test_acknowledge(client: Grantex) -> None:
+    acked = {**MOCK_ANOMALY, "acknowledgedAt": "2026-02-26T01:00:00Z"}
+    respx.patch("https://api.grantex.dev/v1/anomalies/anm_01/acknowledge").mock(
+        return_value=httpx.Response(200, json=acked)
+    )
+    result = client.anomalies.acknowledge("anm_01")
+
+    assert result.acknowledged_at == "2026-02-26T01:00:00Z"
+    assert result.id == "anm_01"

--- a/packages/sdk-ts/src/client.ts
+++ b/packages/sdk-ts/src/client.ts
@@ -7,6 +7,7 @@ import { WebhooksClient } from './resources/webhooks.js';
 import { BillingClient } from './resources/billing.js';
 import { PoliciesClient } from './resources/policies.js';
 import { ComplianceClient } from './resources/compliance.js';
+import { AnomaliesClient } from './resources/anomalies.js';
 import type {
   AuthorizationRequest,
   AuthorizeParams,
@@ -26,6 +27,7 @@ export class Grantex {
   readonly billing: BillingClient;
   readonly policies: PoliciesClient;
   readonly compliance: ComplianceClient;
+  readonly anomalies: AnomaliesClient;
 
   constructor(options: GrantexClientOptions = {}) {
     const apiKey =
@@ -51,6 +53,7 @@ export class Grantex {
     this.billing = new BillingClient(this.#http);
     this.policies = new PoliciesClient(this.#http);
     this.compliance = new ComplianceClient(this.#http);
+    this.anomalies = new AnomaliesClient(this.#http);
   }
 
   /**

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -59,6 +59,12 @@ export type {
   CreatePolicyParams,
   UpdatePolicyParams,
   ListPoliciesResponse,
+  // Anomalies
+  AnomalyType,
+  AnomalySeverity,
+  Anomaly,
+  DetectAnomaliesResponse,
+  ListAnomaliesResponse,
   // Compliance
   ComplianceSummary,
   ComplianceExportGrantsParams,

--- a/packages/sdk-ts/src/resources/anomalies.ts
+++ b/packages/sdk-ts/src/resources/anomalies.ts
@@ -1,0 +1,30 @@
+import type { HttpClient } from '../http.js';
+import type {
+  Anomaly,
+  DetectAnomaliesResponse,
+  ListAnomaliesResponse,
+} from '../types.js';
+
+export class AnomaliesClient {
+  readonly #http: HttpClient;
+
+  constructor(http: HttpClient) {
+    this.#http = http;
+  }
+
+  /** Run anomaly detection across all agents and return detected anomalies. */
+  detect(): Promise<DetectAnomaliesResponse> {
+    return this.#http.post<DetectAnomaliesResponse>('/v1/anomalies/detect', {});
+  }
+
+  /** List stored anomalies. Pass `{ unacknowledged: true }` to filter to open ones only. */
+  list(params?: { unacknowledged?: boolean }): Promise<ListAnomaliesResponse> {
+    const qs = params?.unacknowledged ? '?unacknowledged=true' : '';
+    return this.#http.get<ListAnomaliesResponse>(`/v1/anomalies${qs}`);
+  }
+
+  /** Acknowledge an anomaly by ID. */
+  acknowledge(anomalyId: string): Promise<Anomaly> {
+    return this.#http.patch<Anomaly>(`/v1/anomalies/${anomalyId}/acknowledge`, {});
+  }
+}

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -371,3 +371,31 @@ export interface EvidencePack {
   policies: Policy[];
   chainIntegrity: ChainIntegrity;
 }
+
+// ─── Anomalies ────────────────────────────────────────────────────────────────
+
+export type AnomalyType = 'rate_spike' | 'high_failure_rate' | 'new_principal' | 'off_hours_activity';
+export type AnomalySeverity = 'low' | 'medium' | 'high';
+
+export interface Anomaly {
+  id: string;
+  type: AnomalyType;
+  severity: AnomalySeverity;
+  agentId: string | null;
+  principalId: string | null;
+  description: string;
+  metadata: Record<string, unknown>;
+  detectedAt: string;
+  acknowledgedAt: string | null;
+}
+
+export interface DetectAnomaliesResponse {
+  detectedAt: string;
+  total: number;
+  anomalies: Anomaly[];
+}
+
+export interface ListAnomaliesResponse {
+  anomalies: Anomaly[];
+  total: number;
+}

--- a/packages/sdk-ts/tests/anomalies.test.ts
+++ b/packages/sdk-ts/tests/anomalies.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Grantex } from '../src/client.js';
+
+function makeFetch(status: number, body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+const MOCK_ANOMALY = {
+  id: 'anm_01',
+  type: 'rate_spike',
+  severity: 'high',
+  agentId: 'ag_01',
+  principalId: null,
+  description: 'Agent ag_01 performed 72 actions in the last hour (threshold: 50).',
+  metadata: { count: 72, windowHours: 1, threshold: 50 },
+  detectedAt: '2026-02-26T00:00:00Z',
+  acknowledgedAt: null,
+};
+
+describe('AnomaliesClient', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('detect() POSTs to /v1/anomalies/detect', async () => {
+    const mockResponse = { detectedAt: '2026-02-26T00:00:00Z', total: 1, anomalies: [MOCK_ANOMALY] };
+    const mockFetch = makeFetch(200, mockResponse);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.anomalies.detect();
+
+    expect(result.total).toBe(1);
+    expect(result.anomalies[0]!.type).toBe('rate_spike');
+    expect(result.anomalies[0]!.severity).toBe('high');
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/anomalies\/detect$/);
+    expect(init.method).toBe('POST');
+  });
+
+  it('list() GETs /v1/anomalies', async () => {
+    const mockResponse = { anomalies: [MOCK_ANOMALY], total: 1 };
+    const mockFetch = makeFetch(200, mockResponse);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.anomalies.list();
+
+    expect(result.total).toBe(1);
+    expect(result.anomalies[0]!.id).toBe('anm_01');
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/anomalies$/);
+    expect(init.method).toBe('GET');
+  });
+
+  it('list({ unacknowledged: true }) appends query param', async () => {
+    const mockFetch = makeFetch(200, { anomalies: [], total: 0 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    await grantex.anomalies.list({ unacknowledged: true });
+
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('unacknowledged=true');
+  });
+
+  it('acknowledge() PATCHes /v1/anomalies/:id/acknowledge', async () => {
+    const acked = { ...MOCK_ANOMALY, acknowledgedAt: '2026-02-26T01:00:00Z' };
+    const mockFetch = makeFetch(200, acked);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.anomalies.acknowledge('anm_01');
+
+    expect(result.acknowledgedAt).toBe('2026-02-26T01:00:00Z');
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/anomalies\/anm_01\/acknowledge$/);
+    expect(init.method).toBe('PATCH');
+  });
+});


### PR DESCRIPTION
## Summary

- **4 detection algorithms** run concurrently via `Promise.all` on `POST /v1/anomalies/detect`:
  - `rate_spike` (high) — agent exceeds 50 actions in the last hour
  - `high_failure_rate` (medium) — agent has >20% failure/blocked rate over 24h (min 5 entries)
  - `new_principal` (low) — first-ever grant between an agent and a principal in last 24h
  - `off_hours_activity` (low) — agent performs >10 actions between 22:00–06:00 UTC in 24h
- Each detect run **clears existing unacknowledged anomalies** and persists newly detected ones
- `GET /v1/anomalies` — list stored anomalies (`?unacknowledged=true` to filter open ones)
- `PATCH /v1/anomalies/:id/acknowledge` — mark an anomaly resolved
- **Migration** `007_anomalies.sql` — `anomalies` table with type/severity/agent/principal/metadata columns

- **TypeScript SDK** — `Anomaly`, `AnomalyType`, `AnomalySeverity`, `DetectAnomaliesResponse`, `ListAnomaliesResponse`; `client.anomalies.detect()` / `list()` / `acknowledge()`
- **Python SDK** — matching frozen dataclasses; `client.anomalies.detect()` / `list()` / `acknowledge()`
- **CLI** — `grantex anomalies detect|list [--unacknowledged]|acknowledge <id>` with colour-coded severity (red=high, yellow=medium, cyan=low)
- Also checks off SOC2/GDPR evidence pack in ROADMAP.md

## Test plan

- [x] Auth service: 144 tests passing
- [x] TypeScript SDK: 58 tests passing, typecheck clean
- [x] Python SDK: 70 tests passing, mypy strict clean
- [x] CLI: 23 tests passing, typecheck clean