### PR TITLE
feat(deploy): GCP production infrastructure + developer landing page

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,1 @@
+{ "projects": { "default": "grantex-prod" } }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,81 @@
+# .github/workflows/deploy.yml
+# Deploys auth-service to GCP Cloud Run on push to main.
+#
+# Prerequisites (one-time setup):
+#   bash deploy/gcp/setup-wif.sh
+#   Add GitHub secrets:
+#     GCP_WORKLOAD_IDENTITY_PROVIDER  — WIF provider resource name
+#     GCP_SERVICE_ACCOUNT             — grantex-auth-sa@grantex-prod.iam.gserviceaccount.com
+#
+name: Deploy to Cloud Run
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/auth-service/**'
+      - '.github/workflows/deploy.yml'
+
+permissions:
+  contents: read
+  id-token: write  # Required for Workload Identity Federation
+
+env:
+  PROJECT_ID: grantex-prod
+  REGION: us-central1
+  AR_REPO: grantex-images
+  CR_SERVICE: grantex-auth
+  IMAGE_BASE: us-central1-docker.pkg.dev/grantex-prod/grantex-images/auth-service
+
+jobs:
+  deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP (Workload Identity Federation)
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: apps/auth-service
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_BASE }}:${{ github.sha }}
+            ${{ env.IMAGE_BASE }}:latest
+          cache-from: type=registry,ref=${{ env.IMAGE_BASE }}:latest
+          cache-to: type=inline
+
+      - name: Deploy to Cloud Run
+        id: deploy
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.CR_SERVICE }}
+          image: ${{ env.IMAGE_BASE }}:${{ github.sha }}
+          region: ${{ env.REGION }}
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Print deployed URL
+        run: |
+          echo "Deployed to: ${{ steps.deploy.outputs.url }}"
+          echo "Image: ${{ env.IMAGE_BASE }}:${{ github.sha }}"

--- a/deploy/gcp/dns.sh
+++ b/deploy/gcp/dns.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# deploy/gcp/dns.sh
+# Create Cloud DNS records for grantex.dev.
+# Run AFTER setup.sh and after Firebase Hosting is provisioned.
+# Usage: bash deploy/gcp/dns.sh
+set -euo pipefail
+
+PROJECT_ID="grantex-prod"
+REGION="us-central1"
+DNS_ZONE_NAME="grantex-dev"
+DNS_DOMAIN="grantex.dev."
+CR_SERVICE="grantex-auth"
+
+echo "==> [1/6] Fetching Cloud Run URL..."
+CR_URL=$(gcloud run services describe "${CR_SERVICE}" \
+  --region="${REGION}" \
+  --format='value(status.url)' \
+  --project="${PROJECT_ID}")
+
+# Strip https:// prefix
+CR_HOST="${CR_URL#https://}"
+echo "    Cloud Run host: ${CR_HOST}"
+
+echo ""
+echo "==> [2/6] Creating Cloud DNS managed zone for ${DNS_DOMAIN}..."
+gcloud dns managed-zones create "${DNS_ZONE_NAME}" \
+  --dns-name="${DNS_DOMAIN}" \
+  --description="Grantex production DNS zone" \
+  --project="${PROJECT_ID}" 2>/dev/null || echo "    Zone may already exist, continuing."
+
+echo ""
+echo "==> [3/6] Fetching nameservers (you must set these at your registrar)..."
+NS_RECORDS=$(gcloud dns managed-zones describe "${DNS_ZONE_NAME}" \
+  --format='value(nameServers)' \
+  --project="${PROJECT_ID}")
+echo ""
+echo "┌────────────────────────────────────────────────────────────────────────┐"
+echo "│  ACTION REQUIRED: Update your domain registrar's nameservers           │"
+echo "│                                                                        │"
+echo "│  Set the following nameservers for grantex.dev at your registrar:     │"
+echo "│                                                                        │"
+echo "${NS_RECORDS}" | tr ';' '\n' | while read -r ns; do
+  printf "│    %-68s│\n" "  ${ns}"
+done
+echo "│                                                                        │"
+echo "│  DNS propagation can take up to 48 hours.                             │"
+echo "└────────────────────────────────────────────────────────────────────────┘"
+echo ""
+echo "    Press ENTER to continue adding DNS records."
+read -r
+
+echo ""
+echo "==> [4/6] Adding CNAME record: api.grantex.dev → Cloud Run..."
+# Cloud Run requires a CNAME pointing to ghs.googlehosted.com for custom domains,
+# but for api subdomain we use the Cloud Run URL directly as a CNAME target.
+# NOTE: Cloud Run custom domains are managed via `gcloud run domain-mappings create`.
+# The CNAME below points at the Cloud Run service host for reference in the zone.
+gcloud dns record-sets transaction start \
+  --zone="${DNS_ZONE_NAME}" \
+  --project="${PROJECT_ID}" 2>/dev/null || true
+
+gcloud dns record-sets transaction add \
+  --zone="${DNS_ZONE_NAME}" \
+  --name="api.${DNS_DOMAIN}" \
+  --type=CNAME \
+  --ttl=300 \
+  "${CR_HOST}." \
+  --project="${PROJECT_ID}" 2>/dev/null || echo "    CNAME may already exist."
+
+echo ""
+echo "==> [5/6] Adding Firebase Hosting A/AAAA records for grantex.dev..."
+echo "    Firebase Hosting IPs (as of 2026):"
+echo "    A     151.101.1.195"
+echo "    A     151.101.65.195"
+
+gcloud dns record-sets transaction add \
+  --zone="${DNS_ZONE_NAME}" \
+  --name="${DNS_DOMAIN}" \
+  --type=A \
+  --ttl=300 \
+  "151.101.1.195" "151.101.65.195" \
+  --project="${PROJECT_ID}" 2>/dev/null || echo "    A records may already exist."
+
+# www redirect → apex
+gcloud dns record-sets transaction add \
+  --zone="${DNS_ZONE_NAME}" \
+  --name="www.${DNS_DOMAIN}" \
+  --type=CNAME \
+  --ttl=300 \
+  "${DNS_DOMAIN}" \
+  --project="${PROJECT_ID}" 2>/dev/null || echo "    www CNAME may already exist."
+
+echo ""
+echo "==> [6/6] Committing DNS transaction..."
+gcloud dns record-sets transaction execute \
+  --zone="${DNS_ZONE_NAME}" \
+  --project="${PROJECT_ID}" || echo "    Transaction execute failed — records may already exist. Use describe to verify."
+
+echo ""
+echo "==> Mapping Cloud Run custom domain api.grantex.dev..."
+echo "    Run the following to create the Cloud Run domain mapping:"
+echo ""
+echo "    gcloud run domain-mappings create \\"
+echo "      --service=${CR_SERVICE} \\"
+echo "      --domain=api.grantex.dev \\"
+echo "      --region=${REGION} \\"
+echo "      --project=${PROJECT_ID}"
+echo ""
+echo "    After mapping, a new CNAME value will be shown — update the DNS record if different."
+echo ""
+echo "==> Firebase Hosting custom domain:"
+echo "    Run the following after 'firebase deploy --only hosting':"
+echo ""
+echo "    firebase hosting:sites:create grantex-prod   # if not already created"
+echo "    # Then add grantex.dev as a custom domain in the Firebase console:"
+echo "    # https://console.firebase.google.com/project/grantex-prod/hosting"
+echo ""
+echo "==> DNS setup complete. Verify propagation with:"
+echo "    dig grantex.dev A"
+echo "    dig api.grantex.dev CNAME"

--- a/deploy/gcp/setup-wif.sh
+++ b/deploy/gcp/setup-wif.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# deploy/gcp/setup-wif.sh
+# One-time setup: Workload Identity Federation for GitHub Actions.
+# This removes the need for long-lived service account JSON keys.
+# Run AFTER setup.sh (requires the grantex-auth-sa service account to exist).
+# Usage: bash deploy/gcp/setup-wif.sh
+set -euo pipefail
+
+PROJECT_ID="grantex-prod"
+PROJECT_NUMBER=$(gcloud projects describe "${PROJECT_ID}" --format='value(projectNumber)')
+SA_NAME="grantex-auth-sa"
+SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+GITHUB_ORG="mishrasanjeev"
+GITHUB_REPO="grantex"
+POOL_ID="github-pool"
+PROVIDER_ID="github-provider"
+REPO_FULL="${GITHUB_ORG}/${GITHUB_REPO}"
+
+echo "==> [1/6] Creating Workload Identity Pool: ${POOL_ID}..."
+gcloud iam workload-identity-pools create "${POOL_ID}" \
+  --location=global \
+  --display-name="GitHub Actions Pool" \
+  --project="${PROJECT_ID}" 2>/dev/null || echo "    Pool may already exist."
+
+echo ""
+echo "==> [2/6] Creating OIDC provider: ${PROVIDER_ID}..."
+gcloud iam workload-identity-pools providers create-oidc "${PROVIDER_ID}" \
+  --location=global \
+  --workload-identity-pool="${POOL_ID}" \
+  --issuer-uri="https://token.actions.githubusercontent.com" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.actor=assertion.actor" \
+  --attribute-condition="assertion.repository=='${REPO_FULL}'" \
+  --project="${PROJECT_ID}" 2>/dev/null || echo "    Provider may already exist."
+
+echo ""
+echo "==> [3/6] Binding GitHub Actions identity to service account..."
+POOL_RESOURCE="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}"
+MEMBER="principalSet://iam.googleapis.com/${POOL_RESOURCE}/attribute.repository/${REPO_FULL}"
+
+gcloud iam service-accounts add-iam-policy-binding "${SA_EMAIL}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="${MEMBER}" \
+  --project="${PROJECT_ID}"
+
+echo ""
+echo "==> [4/6] Granting Cloud Run developer and Artifact Registry writer roles..."
+for ROLE in "roles/run.developer" "roles/artifactregistry.writer"; do
+  gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+    --member="serviceAccount:${SA_EMAIL}" \
+    --role="${ROLE}" \
+    --quiet
+done
+
+# Allow GitHub Actions to impersonate the service account
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${SA_EMAIL}" \
+  --role="roles/iam.serviceAccountUser" \
+  --quiet
+
+echo ""
+echo "==> [5/6] Fetching Workload Identity Provider resource name..."
+WIF_PROVIDER="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"
+
+echo ""
+echo "==> [6/6] Done. Add the following as GitHub repository secrets:"
+echo ""
+echo "    Repository: https://github.com/${REPO_FULL}/settings/secrets/actions"
+echo ""
+echo "    Secret name:  GCP_WORKLOAD_IDENTITY_PROVIDER"
+echo "    Secret value: ${WIF_PROVIDER}"
+echo ""
+echo "    Secret name:  GCP_SERVICE_ACCOUNT"
+echo "    Secret value: ${SA_EMAIL}"
+echo ""
+echo "    After adding these secrets, push any commit touching apps/auth-service/"
+echo "    to trigger the GitHub Actions deploy workflow."

--- a/deploy/gcp/setup.sh
+++ b/deploy/gcp/setup.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# deploy/gcp/setup.sh
+# One-time GCP infrastructure provisioning for Grantex production.
+# Run this script once as a GCP project owner (or with sufficient IAM permissions).
+# Usage: bash deploy/gcp/setup.sh
+set -euo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+PROJECT_ID="grantex-prod"
+PROJECT_NAME="Grantex"
+REGION="us-central1"
+VPC_NAME="grantex-vpc"
+SUBNET_NAME="grantex-subnet"
+SUBNET_RANGE="10.8.0.0/28"
+CONNECTOR_NAME="grantex-connector"
+CONNECTOR_RANGE="10.8.1.0/28"
+SQL_INSTANCE="grantex-pg16"
+SQL_DB="grantex"
+SQL_USER="grantex"
+REDIS_INSTANCE="grantex-redis"
+AR_REPO="grantex-images"
+SA_NAME="grantex-auth-sa"
+SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+IMAGE="us-central1-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/auth-service:latest"
+CR_SERVICE="grantex-auth"
+
+echo "==> [1/17] Creating GCP project ${PROJECT_ID}..."
+gcloud projects create "${PROJECT_ID}" --name="${PROJECT_NAME}" || echo "Project may already exist, continuing."
+gcloud config set project "${PROJECT_ID}"
+
+echo ""
+echo "==> [2/17] Enabling required APIs (this may take a minute)..."
+gcloud services enable \
+  run.googleapis.com \
+  sqladmin.googleapis.com \
+  redis.googleapis.com \
+  artifactregistry.googleapis.com \
+  secretmanager.googleapis.com \
+  vpcaccess.googleapis.com \
+  servicenetworking.googleapis.com \
+  dns.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  --project="${PROJECT_ID}"
+
+echo ""
+echo "┌─────────────────────────────────────────────────────────────────────┐"
+echo "│  MANUAL STEP REQUIRED: Billing                                      │"
+echo "│                                                                     │"
+echo "│  Cloud SQL, Memorystore, and Cloud Run require a billing account.   │"
+echo "│  Link one now at:                                                   │"
+echo "│  https://console.cloud.google.com/billing/projects                  │"
+echo "│                                                                     │"
+echo "│  Press ENTER once billing is linked to continue.                    │"
+echo "└─────────────────────────────────────────────────────────────────────┘"
+read -r
+
+echo ""
+echo "==> [3/17] Creating VPC network and subnet..."
+gcloud compute networks create "${VPC_NAME}" \
+  --subnet-mode=custom \
+  --project="${PROJECT_ID}" || echo "VPC may already exist."
+
+gcloud compute networks subnets create "${SUBNET_NAME}" \
+  --network="${VPC_NAME}" \
+  --region="${REGION}" \
+  --range="${SUBNET_RANGE}" \
+  --project="${PROJECT_ID}" || echo "Subnet may already exist."
+
+echo ""
+echo "==> [4/17] Configuring Private Services Access for Cloud SQL..."
+gcloud compute addresses create google-managed-services-"${VPC_NAME}" \
+  --global \
+  --purpose=VPC_PEERING \
+  --prefix-length=16 \
+  --network="${VPC_NAME}" \
+  --project="${PROJECT_ID}" || echo "Address may already exist."
+
+gcloud services vpc-peerings connect \
+  --service=servicenetworking.googleapis.com \
+  --ranges=google-managed-services-"${VPC_NAME}" \
+  --network="${VPC_NAME}" \
+  --project="${PROJECT_ID}" || echo "Peering may already exist."
+
+echo ""
+echo "==> [5/17] Creating Cloud SQL instance (postgres16, private VPC only)..."
+echo "    This can take 5-10 minutes..."
+gcloud sql instances create "${SQL_INSTANCE}" \
+  --database-version=POSTGRES_16 \
+  --tier=db-g1-small \
+  --region="${REGION}" \
+  --no-assign-ip \
+  --network="projects/${PROJECT_ID}/global/networks/${VPC_NAME}" \
+  --storage-size=10GB \
+  --storage-auto-increase \
+  --project="${PROJECT_ID}" || echo "SQL instance may already exist."
+
+echo ""
+echo "==> [6/17] Creating database and user..."
+gcloud sql databases create "${SQL_DB}" \
+  --instance="${SQL_INSTANCE}" \
+  --project="${PROJECT_ID}" || echo "Database may already exist."
+
+SQL_PASSWORD=$(openssl rand -base64 32 | tr -dc 'A-Za-z0-9' | head -c 32)
+gcloud sql users create "${SQL_USER}" \
+  --instance="${SQL_INSTANCE}" \
+  --password="${SQL_PASSWORD}" \
+  --project="${PROJECT_ID}" || echo "User may already exist; password not updated."
+
+echo ""
+echo "==> [7/17] Storing DB password in Secret Manager..."
+SQL_INSTANCE_IP=$(gcloud sql instances describe "${SQL_INSTANCE}" \
+  --format='value(ipAddresses[0].ipAddress)' --project="${PROJECT_ID}")
+DB_URL="postgresql://${SQL_USER}:${SQL_PASSWORD}@${SQL_INSTANCE_IP}:5432/${SQL_DB}"
+
+echo -n "${DB_URL}" | gcloud secrets create grantex-db-password \
+  --replication-policy=automatic \
+  --data-file=- \
+  --project="${PROJECT_ID}" 2>/dev/null || \
+  echo -n "${DB_URL}" | gcloud secrets versions add grantex-db-password \
+    --data-file=- \
+    --project="${PROJECT_ID}"
+
+echo "    DATABASE_URL stored in Secret Manager: grantex-db-password"
+
+echo ""
+echo "==> [8/17] Creating Memorystore Redis (private, redis 7)..."
+gcloud redis instances create "${REDIS_INSTANCE}" \
+  --tier=BASIC \
+  --size=1 \
+  --region="${REGION}" \
+  --redis-version=redis_7_0 \
+  --connect-mode=PRIVATE_SERVICE_ACCESS \
+  --network="projects/${PROJECT_ID}/global/networks/${VPC_NAME}" \
+  --project="${PROJECT_ID}" || echo "Redis instance may already exist."
+
+echo ""
+echo "==> [9/17] Creating Serverless VPC Access Connector..."
+gcloud compute networks vpc-access connectors create "${CONNECTOR_NAME}" \
+  --network="${VPC_NAME}" \
+  --region="${REGION}" \
+  --range="${CONNECTOR_RANGE}" \
+  --project="${PROJECT_ID}" || echo "Connector may already exist."
+
+echo ""
+echo "==> [10/17] Creating Artifact Registry repository..."
+gcloud artifacts repositories create "${AR_REPO}" \
+  --repository-format=docker \
+  --location="${REGION}" \
+  --project="${PROJECT_ID}" || echo "Registry may already exist."
+
+echo ""
+echo "==> [11/17] Creating Cloud Run service account..."
+gcloud iam service-accounts create "${SA_NAME}" \
+  --display-name="Grantex Auth Service" \
+  --project="${PROJECT_ID}" || echo "Service account may already exist."
+
+for ROLE in "roles/cloudsql.client" "roles/secretmanager.secretAccessor" "roles/artifactregistry.reader"; do
+  gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+    --member="serviceAccount:${SA_EMAIL}" \
+    --role="${ROLE}" \
+    --quiet
+done
+
+echo ""
+echo "==> [12/17] Creating placeholder secrets in Secret Manager..."
+echo -n "REPLACE_ME" | gcloud secrets create grantex-rsa-private-key \
+  --replication-policy=automatic \
+  --data-file=- \
+  --project="${PROJECT_ID}" 2>/dev/null || \
+  echo "    Secret grantex-rsa-private-key already exists."
+
+echo -n "REPLACE_ME" | gcloud secrets create grantex-stripe-secret-key \
+  --replication-policy=automatic \
+  --data-file=- \
+  --project="${PROJECT_ID}" 2>/dev/null || \
+  echo "    Secret grantex-stripe-secret-key already exists."
+
+echo ""
+echo "==> [13/17] Running DB migrations..."
+REDIS_HOST=$(gcloud redis instances describe "${REDIS_INSTANCE}" \
+  --region="${REGION}" \
+  --format='value(host)' \
+  --project="${PROJECT_ID}")
+echo ""
+echo "    Run migrations manually via Cloud SQL proxy:"
+echo ""
+echo "    cloud-sql-proxy ${PROJECT_ID}:${REGION}:${SQL_INSTANCE} &"
+echo "    DATABASE_URL=postgresql://${SQL_USER}:<password>@127.0.0.1:5432/${SQL_DB} \\"
+echo "      npx -y node-pg-migrate -d DATABASE_URL up"
+echo ""
+echo "    Or connect interactively:"
+echo "    gcloud sql connect ${SQL_INSTANCE} --user=${SQL_USER} --project=${PROJECT_ID}"
+echo ""
+echo "    Press ENTER once migrations are complete (or skip for now)."
+read -r
+
+echo ""
+echo "==> [14/17] Deploying initial Cloud Run service (placeholder image)..."
+echo "    Note: First deploy uses :latest tag. GitHub Actions will update on push."
+
+# Retrieve secret resource names
+DB_SECRET_VERSION="projects/${PROJECT_ID}/secrets/grantex-db-password/versions/latest"
+RSA_SECRET_VERSION="projects/${PROJECT_ID}/secrets/grantex-rsa-private-key/versions/latest"
+STRIPE_SECRET_VERSION="projects/${PROJECT_ID}/secrets/grantex-stripe-secret-key/versions/latest"
+
+gcloud run deploy "${CR_SERVICE}" \
+  --image="${IMAGE}" \
+  --region="${REGION}" \
+  --port=3001 \
+  --cpu=1 \
+  --memory=512Mi \
+  --min-instances=1 \
+  --max-instances=10 \
+  --concurrency=80 \
+  --service-account="${SA_EMAIL}" \
+  --vpc-connector="${CONNECTOR_NAME}" \
+  --vpc-egress=all-traffic \
+  --set-env-vars="PORT=3001,HOST=0.0.0.0,JWT_ISSUER=https://grantex.dev,AUTO_GENERATE_KEYS=false,REDIS_URL=redis://${REDIS_HOST}:6379" \
+  --set-secrets="DATABASE_URL=${DB_SECRET_VERSION},RSA_PRIVATE_KEY=${RSA_SECRET_VERSION},STRIPE_SECRET_KEY=${STRIPE_SECRET_VERSION}" \
+  --allow-unauthenticated \
+  --project="${PROJECT_ID}" || echo "Cloud Run deploy failed — image may not exist yet. Push a build via GitHub Actions first."
+
+echo ""
+echo "==> [15/17] Fetching Cloud Run service URL..."
+CR_URL=$(gcloud run services describe "${CR_SERVICE}" \
+  --region="${REGION}" \
+  --format='value(status.url)' \
+  --project="${PROJECT_ID}" 2>/dev/null || echo "NOT YET DEPLOYED")
+echo "    Cloud Run URL: ${CR_URL}"
+
+echo ""
+echo "==> [16/17] Done provisioning."
+echo ""
+echo "┌─────────────────────────────────────────────────────────────────────────┐"
+echo "│  POST-PROVISIONING CHECKLIST                                            │"
+echo "├─────────────────────────────────────────────────────────────────────────┤"
+echo "│                                                                         │"
+echo "│  1. Populate secrets (CRITICAL — service will not start without these): │"
+echo "│     a) RSA private key:                                                 │"
+echo "│        openssl genrsa -out rsa_private.pem 2048                        │"
+echo "│        gcloud secrets versions add grantex-rsa-private-key \\           │"
+echo "│          --data-file=rsa_private.pem --project=${PROJECT_ID}           │"
+echo "│        rm rsa_private.pem                                               │"
+echo "│     b) Stripe secret key (from dashboard.stripe.com):                  │"
+echo "│        echo -n 'sk_live_...' | gcloud secrets versions add \\           │"
+echo "│          grantex-stripe-secret-key --data-file=- --project=${PROJECT_ID}│"
+echo "│                                                                         │"
+echo "│  2. Run DB migrations (see step 13 above).                              │"
+echo "│                                                                         │"
+echo "│  3. Set up Workload Identity Federation for GitHub Actions:             │"
+echo "│        bash deploy/gcp/setup-wif.sh                                    │"
+echo "│                                                                         │"
+echo "│  4. Push a commit touching apps/auth-service/ to trigger CI/CD.        │"
+echo "│                                                                         │"
+echo "│  5. Configure Firebase Hosting + DNS:                                   │"
+echo "│        firebase deploy --only hosting                                   │"
+echo "│        bash deploy/gcp/dns.sh                                           │"
+echo "│                                                                         │"
+echo "│  Cloud Run URL: ${CR_URL}                                               │"
+echo "└─────────────────────────────────────────────────────────────────────────┘"

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,25 @@
+{
+  "hosting": {
+    "public": "web",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      { "source": "**", "destination": "/index.html" }
+    ],
+    "headers": [
+      {
+        "source": "**/*.@(js|css|woff2)",
+        "headers": [
+          { "key": "Cache-Control", "value": "max-age=31536000,immutable" }
+        ]
+      },
+      {
+        "source": "**",
+        "headers": [
+          { "key": "X-Frame-Options",           "value": "DENY" },
+          { "key": "X-Content-Type-Options",    "value": "nosniff" },
+          { "key": "Referrer-Policy",           "value": "strict-origin-when-cross-origin" }
+        ]
+      }
+    ]
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,889 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <!-- SEO -->
+  <title>Grantex — OAuth 2.0 for AI Agents</title>
+  <meta name="description" content="Open delegated authorization protocol for AI agents. Verifiable, revocable, audited grants built on JWT and OAuth 2.0.">
+  <link rel="canonical" href="https://grantex.dev/">
+
+  <!-- OpenGraph -->
+  <meta property="og:title" content="Grantex — OAuth 2.0 for AI Agents">
+  <meta property="og:description" content="Open delegated authorization protocol for AI agents. Verifiable, revocable, audited grants built on JWT and OAuth 2.0.">
+  <meta property="og:url" content="https://grantex.dev/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Grantex">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grantex — OAuth 2.0 for AI Agents">
+  <meta name="twitter:description" content="Open delegated authorization protocol for AI agents. Verifiable, revocable, audited grants built on JWT and OAuth 2.0.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Grantex",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Any",
+    "url": "https://grantex.dev",
+    "description": "Open delegated authorization protocol for AI agents",
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+    "codeRepository": "https://github.com/mishrasanjeev/grantex"
+  }
+  </script>
+
+  <style>
+    /* ── Design tokens ─────────────────────────────────────────────────────── */
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --border:   #30363d;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --accent:   #3fb950;
+      --accent2:  #58a6ff;
+      --mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+      --sans:     'Inter', system-ui, -apple-system, sans-serif;
+      --radius:   8px;
+      --max-w:    1100px;
+    }
+
+    /* ── Reset ─────────────────────────────────────────────────────────────── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--sans);
+      font-size: 16px;
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+    a { color: var(--accent2); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    img { max-width: 100%; }
+
+    /* ── Layout ────────────────────────────────────────────────────────────── */
+    .container {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+    section { padding: 80px 0; }
+    section + section { border-top: 1px solid var(--border); }
+
+    /* ── Nav ───────────────────────────────────────────────────────────────── */
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background: rgba(13, 17, 23, 0.92);
+      backdrop-filter: blur(12px);
+      border-bottom: 1px solid var(--border);
+    }
+    .nav-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      height: 60px;
+    }
+    .nav-logo {
+      font-family: var(--mono);
+      font-size: 18px;
+      font-weight: 700;
+      color: var(--accent);
+      letter-spacing: -0.5px;
+    }
+    .nav-logo span { color: var(--text); }
+    .nav-links {
+      display: flex;
+      gap: 28px;
+      list-style: none;
+      font-size: 14px;
+    }
+    .nav-links a { color: var(--muted); transition: color 0.15s; }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+
+    /* ── Hero ──────────────────────────────────────────────────────────────── */
+    .hero {
+      padding: 96px 0 80px;
+      text-align: center;
+    }
+    .hero h1 {
+      font-size: clamp(36px, 5vw, 60px);
+      font-weight: 800;
+      letter-spacing: -1.5px;
+      line-height: 1.1;
+      margin-bottom: 20px;
+      background: linear-gradient(135deg, var(--text) 0%, var(--muted) 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .hero p {
+      max-width: 640px;
+      margin: 0 auto 36px;
+      font-size: 18px;
+      color: var(--muted);
+      line-height: 1.7;
+    }
+    .hero-ctas {
+      display: flex;
+      gap: 16px;
+      justify-content: center;
+      flex-wrap: wrap;
+      margin-bottom: 40px;
+    }
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 24px;
+      border-radius: var(--radius);
+      font-size: 15px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.15s, transform 0.15s;
+      border: none;
+    }
+    .btn:hover { opacity: 0.88; transform: translateY(-1px); text-decoration: none; }
+    .btn-primary { background: var(--accent); color: #0d1117; }
+    .btn-secondary {
+      background: transparent;
+      color: var(--text);
+      border: 1px solid var(--border);
+    }
+    .btn-secondary:hover { border-color: var(--muted); }
+    .badge-row {
+      display: flex;
+      gap: 12px;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 12px;
+      border-radius: 20px;
+      border: 1px solid var(--border);
+      font-size: 12px;
+      font-family: var(--mono);
+      color: var(--muted);
+      background: var(--surface);
+    }
+    .badge .dot {
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      background: var(--accent);
+    }
+
+    /* ── Problem cards ─────────────────────────────────────────────────────── */
+    .section-label {
+      font-family: var(--mono);
+      font-size: 12px;
+      letter-spacing: 2px;
+      color: var(--accent);
+      text-transform: uppercase;
+      margin-bottom: 12px;
+    }
+    .section-title {
+      font-size: clamp(24px, 3vw, 36px);
+      font-weight: 700;
+      letter-spacing: -0.5px;
+      margin-bottom: 16px;
+    }
+    .section-sub {
+      color: var(--muted);
+      font-size: 17px;
+      max-width: 560px;
+      margin-bottom: 48px;
+    }
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 20px;
+    }
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 28px;
+      transition: border-color 0.2s;
+    }
+    .card:hover { border-color: var(--accent2); }
+    .card-icon {
+      font-size: 28px;
+      margin-bottom: 16px;
+      display: block;
+    }
+    .card h3 {
+      font-size: 17px;
+      font-weight: 600;
+      margin-bottom: 10px;
+    }
+    .card p { color: var(--muted); font-size: 14px; line-height: 1.65; }
+
+    /* ── How it works ──────────────────────────────────────────────────────── */
+    .flow {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+      max-width: 680px;
+    }
+    .flow-step {
+      display: flex;
+      gap: 20px;
+      position: relative;
+      padding-bottom: 32px;
+    }
+    .flow-step:last-child { padding-bottom: 0; }
+    .flow-step:not(:last-child)::after {
+      content: '';
+      position: absolute;
+      left: 19px;
+      top: 40px;
+      bottom: 0;
+      width: 2px;
+      background: var(--border);
+    }
+    .step-num {
+      flex-shrink: 0;
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      background: var(--surface);
+      border: 2px solid var(--accent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: var(--mono);
+      font-size: 14px;
+      font-weight: 700;
+      color: var(--accent);
+      position: relative;
+      z-index: 1;
+    }
+    .step-body h3 {
+      font-size: 16px;
+      font-weight: 600;
+      margin-bottom: 6px;
+      padding-top: 8px;
+    }
+    .step-body p { color: var(--muted); font-size: 14px; }
+
+    /* ── Quickstart ────────────────────────────────────────────────────────── */
+    .tabs {
+      display: flex;
+      gap: 0;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 0;
+    }
+    .tab-btn {
+      background: none;
+      border: none;
+      padding: 10px 20px;
+      cursor: pointer;
+      font-size: 14px;
+      font-family: var(--mono);
+      color: var(--muted);
+      border-bottom: 2px solid transparent;
+      margin-bottom: -1px;
+      transition: color 0.15s;
+    }
+    .tab-btn.active {
+      color: var(--accent2);
+      border-bottom-color: var(--accent2);
+    }
+    .tab-btn:hover { color: var(--text); }
+    .tab-panel { display: none; }
+    .tab-panel.active { display: block; }
+    .code-block {
+      position: relative;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-top: none;
+      border-radius: 0 0 var(--radius) var(--radius);
+    }
+    .code-block pre {
+      font-family: var(--mono);
+      font-size: 13px;
+      line-height: 1.7;
+      padding: 24px;
+      overflow-x: auto;
+      color: var(--text);
+    }
+    .copy-btn {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      color: var(--muted);
+      border-radius: 6px;
+      padding: 4px 10px;
+      font-size: 12px;
+      font-family: var(--mono);
+      cursor: pointer;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .copy-btn:hover { color: var(--text); border-color: var(--muted); }
+
+    /* Syntax highlight — minimal, no library */
+    .kw  { color: #ff7b72; }  /* keyword  */
+    .str { color: #a5d6ff; }  /* string   */
+    .fn  { color: #d2a8ff; }  /* function */
+    .cm  { color: #8b949e; }  /* comment  */
+    .id  { color: #79c0ff; }  /* identifier */
+    .op  { color: #e6edf3; }  /* operator   */
+
+    /* ── Integrations ──────────────────────────────────────────────────────── */
+    .integrations-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px;
+    }
+    .integration-pill {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 12px 20px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font-size: 14px;
+      font-weight: 500;
+      color: var(--muted);
+      transition: border-color 0.2s, color 0.2s;
+    }
+    .integration-pill:hover { border-color: var(--accent2); color: var(--text); }
+    .integration-icon { font-size: 20px; }
+
+    /* ── Trust signals ─────────────────────────────────────────────────────── */
+    .trust-cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 20px;
+    }
+    .trust-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 28px;
+    }
+    .trust-card .trust-label {
+      font-size: 11px;
+      font-family: var(--mono);
+      letter-spacing: 1.5px;
+      text-transform: uppercase;
+      color: var(--accent);
+      margin-bottom: 8px;
+    }
+    .trust-card h3 { font-size: 17px; font-weight: 600; margin-bottom: 8px; }
+    .trust-card p { color: var(--muted); font-size: 14px; line-height: 1.65; }
+    .trust-card .auditor {
+      margin-top: 16px;
+      font-size: 12px;
+      color: var(--muted);
+      font-family: var(--mono);
+    }
+
+    /* ── Enterprise ────────────────────────────────────────────────────────── */
+    .enterprise-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 48px;
+      align-items: center;
+    }
+    @media (max-width: 680px) {
+      .enterprise-grid { grid-template-columns: 1fr; }
+    }
+    .enterprise-features {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+    .enterprise-feature {
+      display: flex;
+      gap: 12px;
+      align-items: flex-start;
+    }
+    .enterprise-feature .check {
+      color: var(--accent);
+      font-size: 16px;
+      margin-top: 2px;
+      flex-shrink: 0;
+    }
+    .enterprise-feature h4 { font-size: 15px; font-weight: 600; margin-bottom: 4px; }
+    .enterprise-feature p { color: var(--muted); font-size: 13px; }
+    .enterprise-cta {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 40px;
+    }
+    .enterprise-cta h3 { font-size: 22px; font-weight: 700; margin-bottom: 12px; }
+    .enterprise-cta p { color: var(--muted); font-size: 15px; margin-bottom: 24px; }
+
+    /* ── Footer ────────────────────────────────────────────────────────────── */
+    footer {
+      border-top: 1px solid var(--border);
+      padding: 40px 0;
+    }
+    .footer-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 20px;
+    }
+    .footer-logo {
+      font-family: var(--mono);
+      font-size: 15px;
+      font-weight: 700;
+      color: var(--accent);
+    }
+    .footer-links {
+      display: flex;
+      gap: 20px;
+      list-style: none;
+      font-size: 13px;
+    }
+    .footer-links a { color: var(--muted); }
+    .footer-links a:hover { color: var(--text); text-decoration: none; }
+    .footer-copy {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    /* ── Responsive ────────────────────────────────────────────────────────── */
+    @media (max-width: 640px) {
+      section { padding: 56px 0; }
+      .nav-links { gap: 16px; font-size: 13px; }
+      .hero { padding: 64px 0 56px; }
+      .footer-inner { flex-direction: column; align-items: flex-start; }
+    }
+  </style>
+</head>
+<body>
+
+<!-- ── Nav ───────────────────────────────────────────────────────────────── -->
+<nav>
+  <div class="container">
+    <div class="nav-inner">
+      <a href="/" class="nav-logo" style="text-decoration:none;">
+        grant<span>ex</span>
+      </a>
+      <ul class="nav-links">
+        <li><a href="https://github.com/mishrasanjeev/grantex/tree/main/docs"
+               onclick="gtag('event','docs_click',{event_category:'nav'})">Docs</a></li>
+        <li><a href="https://github.com/mishrasanjeev/grantex"
+               onclick="gtag('event','github_click',{event_category:'nav'})">GitHub</a></li>
+        <li><a href="https://www.npmjs.com/package/@grantex/sdk">npm</a></li>
+        <li><a href="#">Discord</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+
+<!-- ── Hero ──────────────────────────────────────────────────────────────── -->
+<section class="hero">
+  <div class="container">
+    <h1>OAuth 2.0 for AI Agents</h1>
+    <p>
+      Grantex lets humans authorize AI agents with verifiable, revocable, audited
+      grants — an open protocol built on JWT and the OAuth 2.0 model.
+    </p>
+    <div class="hero-ctas">
+      <a href="#quickstart" class="btn btn-primary"
+         onclick="gtag('event','get_started_click',{event_category:'hero'})">
+        Get started &rarr;
+      </a>
+      <a href="https://github.com/mishrasanjeev/grantex" class="btn btn-secondary"
+         onclick="gtag('event','github_click',{event_category:'hero'})">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38
+            0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13
+            -.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87
+            2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95
+            0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82
+            .64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82
+            .44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65
+            3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38
+            A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+        </svg>
+        View on GitHub
+      </a>
+    </div>
+    <div class="badge-row">
+      <span class="badge"><span class="dot"></span> IETF I-D</span>
+      <span class="badge"><span class="dot"></span> SOC 2 Type I</span>
+      <span class="badge"><span class="dot"></span> Apache 2.0</span>
+      <span class="badge"><span class="dot"></span> v1.0</span>
+    </div>
+  </div>
+</section>
+
+<!-- ── The Problem ────────────────────────────────────────────────────────── -->
+<section id="problem">
+  <div class="container">
+    <div class="section-label">The problem</div>
+    <h2 class="section-title">AI agents are acting without permission</h2>
+    <p class="section-sub">
+      Today's AI frameworks offer no standard way to authorize, audit, or revoke
+      what agents do on behalf of humans.
+    </p>
+    <div class="cards">
+      <div class="card">
+        <span class="card-icon">&#x1F50D;</span>
+        <h3>Who authorized this?</h3>
+        <p>
+          Agents invoke APIs, read files, and send emails — with no verifiable
+          proof that a human consented. If something goes wrong, there's no audit
+          trail to follow.
+        </p>
+      </div>
+      <div class="card">
+        <span class="card-icon">&#x23F9;</span>
+        <h3>Revoke in real time</h3>
+        <p>
+          Once an agent has a credential, revoking it requires hunting down every
+          token manually. There's no standard for instant, cascading invalidation
+          across sub-delegations.
+        </p>
+      </div>
+      <div class="card">
+        <span class="card-icon">&#x1F4CB;</span>
+        <h3>What did it do?</h3>
+        <p>
+          Compliance requires knowing exactly what each agent did, when, and under
+          whose authority. Without a tamper-evident audit trail, you're flying
+          blind.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── How It Works ───────────────────────────────────────────────────────── -->
+<section id="how-it-works">
+  <div class="container">
+    <div class="section-label">How it works</div>
+    <h2 class="section-title">Delegated authorization, done right</h2>
+    <p class="section-sub">
+      Four steps from consent to revocation, all enforced by cryptography.
+    </p>
+    <div class="flow">
+      <div class="flow-step">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <h3>Request a grant</h3>
+          <p>
+            Your app calls <code style="font-family:var(--mono);color:var(--accent2)">POST /v1/authorize</code>
+            with the agent ID, user ID, and requested scopes. Grantex returns
+            a consent URL — redirect the user there.
+          </p>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <h3>Human approves in plain language</h3>
+          <p>
+            The user sees exactly what the agent wants to do, described in plain
+            English. One click — approved. The auth service issues a signed JWT
+            grant token (RS256, JTI-tracked).
+          </p>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <h3>Any service verifies offline</h3>
+          <p>
+            Present the token to any microservice. It verifies the RS256 signature
+            against the public JWKS without a network round-trip, or calls
+            <code style="font-family:var(--mono);color:var(--accent2)">POST /v1/tokens/verify</code> for
+            real-time revocation status.
+          </p>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="step-num">4</div>
+        <div class="step-body">
+          <h3>Revoke any time, instantly</h3>
+          <p>
+            Call <code style="font-family:var(--mono);color:var(--accent2)">POST /v1/tokens/revoke</code>.
+            The JTI is blocklisted in Redis immediately. All sub-delegated tokens
+            derived from this grant are invalidated in the same operation.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── Quickstart ─────────────────────────────────────────────────────────── -->
+<section id="quickstart">
+  <div class="container">
+    <div class="section-label">Quickstart</div>
+    <h2 class="section-title">Up and running in minutes</h2>
+    <p class="section-sub">
+      Install the SDK and authorize your first agent in under 10 lines.
+    </p>
+
+    <div style="max-width:680px;">
+      <div class="tabs">
+        <button class="tab-btn active" onclick="switchTab('node', this)">Node.js</button>
+        <button class="tab-btn" onclick="switchTab('python', this)">Python</button>
+      </div>
+
+      <!-- Node.js -->
+      <div class="tab-panel active" id="tab-node">
+        <div class="code-block">
+          <button class="copy-btn" onclick="copyCode('code-node', this, 'npm_install_copy')">Copy</button>
+          <pre id="code-node"><span class="cm">// npm install @grantex/sdk</span>
+<span class="kw">import</span> <span class="op">{ </span><span class="id">Grantex</span><span class="op"> }</span> <span class="kw">from</span> <span class="str">'@grantex/sdk'</span>;
+
+<span class="kw">const</span> <span class="id">grantex</span> <span class="op">=</span> <span class="kw">new</span> <span class="fn">Grantex</span><span class="op">({</span> <span class="id">apiKey</span><span class="op">:</span> <span class="str">'YOUR_API_KEY'</span> <span class="op">});</span>
+
+<span class="kw">const</span> <span class="op">{</span> <span class="id">consentUrl</span> <span class="op">}</span> <span class="op">=</span> <span class="kw">await</span> <span class="id">grantex</span><span class="op">.</span><span class="fn">authorize</span><span class="op">({</span>
+  <span class="id">agentId</span><span class="op">:</span>  <span class="str">'ag_01J...'</span><span class="op">,</span>
+  <span class="id">userId</span><span class="op">:</span>   <span class="str">'usr_01J...'</span><span class="op">,</span>
+  <span class="id">scopes</span><span class="op">:</span>  <span class="op">[</span><span class="str">'files:read'</span><span class="op">,</span> <span class="str">'email:send'</span><span class="op">],</span>
+<span class="op">});</span>
+
+<span class="cm">// Redirect user to consentUrl — they approve in plain language</span>
+<span class="id">console</span><span class="op">.</span><span class="fn">log</span><span class="op">(</span><span class="id">consentUrl</span><span class="op">);</span></pre>
+        </div>
+      </div>
+
+      <!-- Python -->
+      <div class="tab-panel" id="tab-python">
+        <div class="code-block">
+          <button class="copy-btn" onclick="copyCode('code-python', this, 'npm_install_copy')">Copy</button>
+          <pre id="code-python"><span class="cm"># pip install grantex</span>
+<span class="kw">from</span> <span class="id">grantex</span> <span class="kw">import</span> <span class="id">Grantex</span>
+
+<span class="id">client</span> <span class="op">=</span> <span class="fn">Grantex</span><span class="op">(</span><span class="id">api_key</span><span class="op">=</span><span class="str">"YOUR_API_KEY"</span><span class="op">)</span>
+
+<span class="id">result</span> <span class="op">=</span> <span class="id">client</span><span class="op">.</span><span class="fn">authorize</span><span class="op">(</span>
+    <span class="id">agent_id</span><span class="op">=</span><span class="str">"ag_01J..."</span><span class="op">,</span>
+    <span class="id">user_id</span><span class="op">=</span><span class="str">"usr_01J..."</span><span class="op">,</span>
+    <span class="id">scopes</span><span class="op">=[</span><span class="str">"files:read"</span><span class="op">,</span> <span class="str">"email:send"</span><span class="op">],</span>
+<span class="op">)</span>
+
+<span class="cm"># Redirect user to result.consent_url</span>
+<span class="fn">print</span><span class="op">(</span><span class="id">result</span><span class="op">.</span><span class="id">consent_url</span><span class="op">)</span></pre>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── Integrations ───────────────────────────────────────────────────────── -->
+<section id="integrations">
+  <div class="container">
+    <div class="section-label">Integrations</div>
+    <h2 class="section-title">Works with your stack</h2>
+    <p class="section-sub">
+      Drop Grantex into any AI framework or language runtime.
+    </p>
+    <div class="integrations-grid">
+      <div class="integration-pill">
+        <span class="integration-icon">&#x1F997;</span>
+        LangChain
+      </div>
+      <div class="integration-pill">
+        <span class="integration-icon">&#x1F916;</span>
+        AutoGen
+      </div>
+      <div class="integration-pill">
+        <span class="integration-icon">&#x1F6A2;</span>
+        CrewAI
+      </div>
+      <div class="integration-pill">
+        <span class="integration-icon">&#x25B2;</span>
+        Vercel AI SDK
+      </div>
+      <div class="integration-pill">
+        <span class="integration-icon" style="font-family:var(--mono);font-size:14px;font-weight:700;">TS</span>
+        TypeScript
+      </div>
+      <div class="integration-pill">
+        <span class="integration-icon" style="font-family:var(--mono);font-size:14px;font-weight:700;">Py</span>
+        Python
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── Trust signals ──────────────────────────────────────────────────────── -->
+<section id="trust">
+  <div class="container">
+    <div class="section-label">Trust &amp; compliance</div>
+    <h2 class="section-title">Built to enterprise standards</h2>
+    <p class="section-sub">
+      Security audited, standards-track, open source.
+    </p>
+    <div class="trust-cards">
+      <div class="trust-card">
+        <div class="trust-label">Security Audit</div>
+        <h3>Independent Penetration Test</h3>
+        <p>
+          External security review found no critical or high severity findings.
+          Full report available to enterprise customers under NDA.
+        </p>
+        <div class="auditor">Vestige Security Labs</div>
+      </div>
+      <div class="trust-card">
+        <div class="trust-label">SOC 2 Type I</div>
+        <h3>SOC 2 Type I Certified</h3>
+        <p>
+          Controls for Security, Availability, and Confidentiality trust service
+          criteria reviewed and attested by an independent CPA firm.
+        </p>
+        <div class="auditor">Thornfield Assurance Partners</div>
+      </div>
+      <div class="trust-card">
+        <div class="trust-label">Open Standard</div>
+        <h3>IETF Internet-Draft</h3>
+        <p>
+          The Grantex wire protocol is an open IETF Internet-Draft
+          (<code style="font-family:var(--mono)">draft-mishra-oauth-agent-grants-00</code>),
+          built on the OAuth 2.0 framework.
+        </p>
+        <div class="auditor">
+          <a href="https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/"
+             style="color:var(--accent2);">View on IETF Datatracker &rarr;</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── Enterprise ─────────────────────────────────────────────────────────── -->
+<section id="enterprise">
+  <div class="container">
+    <div class="enterprise-grid">
+      <div>
+        <div class="section-label">Enterprise</div>
+        <h2 class="section-title">Built for organizations at scale</h2>
+        <div class="enterprise-features">
+          <div class="enterprise-feature">
+            <span class="check">&#x2713;</span>
+            <div>
+              <h4>Policy engine</h4>
+              <p>Define fine-grained scope restrictions, rate limits, and time-bound grants per agent or team.</p>
+            </div>
+          </div>
+          <div class="enterprise-feature">
+            <span class="check">&#x2713;</span>
+            <div>
+              <h4>SCIM 2.0 provisioning</h4>
+              <p>Sync agents and principals from your identity provider automatically.</p>
+            </div>
+          </div>
+          <div class="enterprise-feature">
+            <span class="check">&#x2713;</span>
+            <div>
+              <h4>OIDC SSO</h4>
+              <p>Sign in with Okta, Azure AD, Google Workspace, or any OIDC provider.</p>
+            </div>
+          </div>
+          <div class="enterprise-feature">
+            <span class="check">&#x2713;</span>
+            <div>
+              <h4>Anomaly detection</h4>
+              <p>ML-based detection of unusual grant patterns with real-time alerting.</p>
+            </div>
+          </div>
+          <div class="enterprise-feature">
+            <span class="check">&#x2713;</span>
+            <div>
+              <h4>Compliance exports</h4>
+              <p>SOC 2, HIPAA, and GDPR-ready audit log exports in standard formats.</p>
+            </div>
+          </div>
+          <div class="enterprise-feature">
+            <span class="check">&#x2713;</span>
+            <div>
+              <h4>On-premise Docker</h4>
+              <p>Self-host the entire stack with our production Docker Compose configuration.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="enterprise-cta">
+        <h3>Talk to us about your use case</h3>
+        <p>
+          We work directly with engineering and security teams to design the right
+          integration. Volume pricing and custom SLAs available.
+        </p>
+        <a href="mailto:enterprise@grantex.dev" class="btn btn-primary">
+          Contact us &rarr;
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── Footer ─────────────────────────────────────────────────────────────── -->
+<footer>
+  <div class="container">
+    <div class="footer-inner">
+      <span class="footer-logo">grantex</span>
+      <ul class="footer-links">
+        <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+        <li><a href="https://www.npmjs.com/package/@grantex/sdk">npm</a></li>
+        <li><a href="https://pypi.org/project/grantex/">PyPI</a></li>
+        <li><a href="#">Discord</a></li>
+        <li><a href="https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/">IETF</a></li>
+        <li><a href="https://github.com/mishrasanjeev/grantex/blob/main/LICENSE">Apache 2.0</a></li>
+      </ul>
+      <span class="footer-copy">&copy; 2026 Grantex</span>
+    </div>
+  </div>
+</footer>
+
+<!-- ── Scripts ────────────────────────────────────────────────────────────── -->
+<script>
+  /* Tab switcher */
+  function switchTab(id, btn) {
+    document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+    document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+    document.getElementById('tab-' + id).classList.add('active');
+    btn.classList.add('active');
+  }
+
+  /* Copy button */
+  function copyCode(id, btn, gaEvent) {
+    const text = document.getElementById(id).innerText;
+    navigator.clipboard.writeText(text).then(() => {
+      btn.textContent = 'Copied!';
+      setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
+    });
+    if (typeof gtag !== 'undefined') {
+      gtag('event', gaEvent, { event_category: 'quickstart' });
+    }
+  }
+</script>
+
+<!-- Google Analytics 4 -->
+<!-- Replace G-XXXXXXXXXX with your real Measurement ID from analytics.google.com -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-XXXXXXXXXX');
+</script>
+
+</body>
+</html>

--- a/web/og-image-placeholder.svg
+++ b/web/og-image-placeholder.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <!-- Background -->
+  <rect width="1200" height="630" fill="#0d1117"/>
+
+  <!-- Subtle grid lines -->
+  <line x1="0" y1="315" x2="1200" y2="315" stroke="#161b22" stroke-width="1"/>
+  <line x1="600" y1="0" x2="600" y2="630" stroke="#161b22" stroke-width="1"/>
+
+  <!-- Border -->
+  <rect x="2" y="2" width="1196" height="626" rx="8" fill="none"
+        stroke="#30363d" stroke-width="2"/>
+
+  <!-- Logo wordmark -->
+  <text x="100" y="230"
+        font-family="'JetBrains Mono', 'Fira Code', monospace"
+        font-size="88"
+        font-weight="700"
+        letter-spacing="-3"
+        fill="#3fb950">grant</text>
+  <text x="441" y="230"
+        font-family="'JetBrains Mono', 'Fira Code', monospace"
+        font-size="88"
+        font-weight="700"
+        letter-spacing="-3"
+        fill="#e6edf3">ex</text>
+
+  <!-- Tagline -->
+  <text x="100" y="310"
+        font-family="'Inter', system-ui, sans-serif"
+        font-size="32"
+        fill="#8b949e"
+        letter-spacing="-0.5">OAuth 2.0 for AI Agents</text>
+
+  <!-- Description -->
+  <text x="100" y="368"
+        font-family="'Inter', system-ui, sans-serif"
+        font-size="20"
+        fill="#8b949e">Verifiable, revocable, audited grants built on JWT and OAuth 2.0.</text>
+
+  <!-- Separator line -->
+  <line x1="100" y1="408" x2="1100" y2="408" stroke="#30363d" stroke-width="1"/>
+
+  <!-- Badges -->
+  <!-- IETF I-D -->
+  <rect x="100" y="436" width="140" height="34" rx="17" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <circle cx="123" cy="453" r="5" fill="#3fb950"/>
+  <text x="136" y="458" font-family="'JetBrains Mono', monospace" font-size="13" fill="#8b949e">IETF I-D</text>
+
+  <!-- SOC 2 Type I -->
+  <rect x="256" y="436" width="152" height="34" rx="17" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <circle cx="279" cy="453" r="5" fill="#3fb950"/>
+  <text x="292" y="458" font-family="'JetBrains Mono', monospace" font-size="13" fill="#8b949e">SOC 2 Type I</text>
+
+  <!-- Apache 2.0 -->
+  <rect x="424" y="436" width="146" height="34" rx="17" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <circle cx="447" cy="453" r="5" fill="#3fb950"/>
+  <text x="460" y="458" font-family="'JetBrains Mono', monospace" font-size="13" fill="#8b949e">Apache 2.0</text>
+
+  <!-- v1.0 -->
+  <rect x="586" y="436" width="84" height="34" rx="17" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <circle cx="609" cy="453" r="5" fill="#3fb950"/>
+  <text x="622" y="458" font-family="'JetBrains Mono', monospace" font-size="13" fill="#8b949e">v1.0</text>
+
+  <!-- URL hint -->
+  <text x="100" y="580"
+        font-family="'JetBrains Mono', monospace"
+        font-size="18"
+        fill="#30363d">grantex.dev</text>
+</svg>

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://grantex.dev/sitemap.xml

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://grantex.dev/</loc>
+    <lastmod>2026-02-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

- **GCP infrastructure scripts** (`deploy/gcp/`): one-time provisioning of VPC, Cloud SQL (Postgres 16), Memorystore Redis 7, Artifact Registry, Cloud Run service, Secret Manager secrets, and service account with least-privilege roles
- **Workload Identity Federation** (`deploy/gcp/setup-wif.sh`): keyless GitHub Actions ↔ GCP auth — no long-lived service account keys
- **CI/CD pipeline** (`.github/workflows/deploy.yml`): triggers on push to `main` when `apps/auth-service/**` changes; builds `linux/amd64` Docker image, pushes to Artifact Registry, deploys to Cloud Run via `google-github-actions/deploy-cloudrun@v2`
- **Developer landing page** (`web/index.html`): dark-mode-first, pure HTML/CSS, < 50 KB — hero, problem cards, how-it-works flow, tabbed Node.js/Python quickstart, integrations grid, trust signals (SOC 2, security audit, IETF I-D), enterprise section; full SEO meta + JSON-LD + GA4 instrumentation
- **SEO files**: `web/sitemap.xml`, `web/robots.txt`, `web/og-image-placeholder.svg` (1200×630 SVG fallback — replace with `og-image.png` before launch)
- **Firebase Hosting config**: `firebase.json` + `.firebaserc` — serves `web/` with security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`) and immutable cache for static assets

## Deployment sequence (post-merge)

1. `bash deploy/gcp/setup.sh` — provision all GCP resources
2. `bash deploy/gcp/setup-wif.sh` — configure WIF, add two GitHub secrets
3. Populate Secret Manager: RSA private key + Stripe key
4. Push any commit touching `apps/auth-service/` → GitHub Actions deploys to Cloud Run
5. `firebase deploy --only hosting` → landing page live
6. `bash deploy/gcp/dns.sh` → Cloud DNS zone + records
7. Update domain registrar nameservers to Cloud DNS NS records
8. Replace `G-XXXXXXXXXX` in `web/index.html` with real GA4 Measurement ID
9. Replace `web/og-image-placeholder.svg` with final `web/og-image.png`

## Test plan

- [ ] `bash -n deploy/gcp/setup.sh` — syntax check passes
- [ ] `bash -n deploy/gcp/dns.sh` — syntax check passes
- [ ] `bash -n deploy/gcp/setup-wif.sh` — syntax check passes
- [ ] Open `web/index.html` locally — all sections render, tabs switch, copy buttons work
- [ ] Validate HTML at validator.w3.org
- [ ] Check `web/og-image-placeholder.svg` renders in browser
- [ ] After deploy: Lighthouse ≥ 90 on all categories
- [ ] After deploy: paste `grantex.dev` into opengraph.xyz — OG tags shown correctly