### PR TITLE
fix(deploy): minimize infra costs and fix Cloud Run deploy

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,1 +1,7 @@
-{ "projects": { "default": "grantex-prod" } }
+{
+  "projects": { "default": "grantex-prod" },
+  "targets": {},
+  "hosting": {
+    "site": "grantex-prod"
+  }
+}

--- a/apps/auth-service/.gcloudignore
+++ b/apps/auth-service/.gcloudignore
@@ -1,0 +1,10 @@
+node_modules/
+dist/
+.git
+tests/
+*.test.ts
+*.spec.ts
+vitest.config.ts
+.env
+.env.*
+coverage/


### PR DESCRIPTION
## Summary
- Cloud SQL: `db-f1-micro` instead of `db-g1-small` (~$7/mo vs ~$26/mo)
- Cloud Run: `min-instances=0` (scale to zero), `256Mi` memory instead of `512Mi`
- Cloud Run: remove reserved `PORT` env var (set automatically by Cloud Run), use short secret name format
- Add `.firebaserc` hosting site name so `firebase deploy --only hosting` works
- Add `apps/auth-service/.gcloudignore` to exclude `node_modules` from Cloud Build uploads

## Test plan
- [x] Cloud Build image built and pushed successfully
- [x] Cloud Run deployed and serving at https://grantex-auth-876335597959.us-central1.run.app
- [x] JWKS endpoint returns valid RSA public key
- [x] Firebase Hosting deployed at https://grantex-prod.web.app
- [x] Cloud DNS records configured for grantex.dev, api.grantex.dev, www.grantex.dev