### PR TITLE
fix(web): fix broken links and enable GA4

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -485,8 +485,7 @@
                onclick="gtag('event','docs_click',{event_category:'nav'})">Docs</a></li>
         <li><a href="https://github.com/mishrasanjeev/grantex"
                onclick="gtag('event','github_click',{event_category:'nav'})">GitHub</a></li>
-        <li><a href="https://www.npmjs.com/package/@grantex/sdk">npm</a></li>
-        <li><a href="#">Discord</a></li>
+        <li><a href="https://github.com/mishrasanjeev/grantex/tree/main/packages/sdk-ts">SDK</a></li>
       </ul>
     </div>
   </div>
@@ -760,8 +759,8 @@
           built on the OAuth 2.0 framework.
         </p>
         <div class="auditor">
-          <a href="https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/"
-             style="color:var(--accent2);">View on IETF Datatracker &rarr;</a>
+          <a href="https://github.com/mishrasanjeev/grantex/blob/main/docs/ietf-draft/draft-mishra-oauth-agent-grants-00.md"
+             style="color:var(--accent2);">View Internet-Draft &rarr;</a>
         </div>
       </div>
     </div>
@@ -826,7 +825,7 @@
           We work directly with engineering and security teams to design the right
           integration. Volume pricing and custom SLAs available.
         </p>
-        <a href="mailto:enterprise@grantex.dev" class="btn btn-primary">
+        <a href="mailto:mishra.sanjeev@gmail.com" class="btn btn-primary">
           Contact us &rarr;
         </a>
       </div>
@@ -841,10 +840,8 @@
       <span class="footer-logo">grantex</span>
       <ul class="footer-links">
         <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
-        <li><a href="https://www.npmjs.com/package/@grantex/sdk">npm</a></li>
         <li><a href="https://pypi.org/project/grantex/">PyPI</a></li>
-        <li><a href="#">Discord</a></li>
-        <li><a href="https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/">IETF</a></li>
+        <li><a href="https://github.com/mishrasanjeev/grantex/blob/main/docs/ietf-draft/draft-mishra-oauth-agent-grants-00.md">IETF Draft</a></li>
         <li><a href="https://github.com/mishrasanjeev/grantex/blob/main/LICENSE">Apache 2.0</a></li>
       </ul>
       <span class="footer-copy">&copy; 2026 Grantex</span>
@@ -876,13 +873,12 @@
 </script>
 
 <!-- Google Analytics 4 -->
-<!-- Replace G-XXXXXXXXXX with your real Measurement ID from analytics.google.com -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', 'G-XXXXXXXXXX');
+  gtag('config', 'G-DNXYVLS5NY');
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- npm link → GitHub SDK directory (package not yet published on npm)
- IETF Datatracker 404 → GitHub draft file link
- Remove placeholder Discord links from nav and footer
- Enterprise contact → mailto:mishra.sanjeev@gmail.com
- Enable GA4 with measurement ID G-DNXYVLS5NY

## Test plan
- [x] All links verified with curl — no 403/404s remaining