### PR TITLE
fix: update vercel-ai for ai SDK v5, fix CLI dep

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grantex/sdk": "file:../sdk-ts",
+        "@grantex/sdk": "^0.1.1",
         "chalk": "^5.3.0",
         "commander": "^12.0.0"
       },
@@ -27,7 +27,7 @@
     },
     "../sdk-ts": {
       "name": "@grantex/sdk",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "jose": "^5.2.4"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,7 @@
     "dev": "node --loader ts-node/esm src/index.ts"
   },
   "dependencies": {
-    "@grantex/sdk": "file:../sdk-ts",
+    "@grantex/sdk": "^0.1.1",
     "chalk": "^5.3.0",
     "commander": "^12.0.0"
   },

--- a/packages/crewai/pyproject.toml
+++ b/packages/crewai/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "hatchling.build"
 name = "grantex-crewai"
 version = "0.1.0"
 description = "Grantex integration for CrewAI — scope-enforced, audited agent tools"
+license = { text = "Apache-2.0" }
 requires-python = ">=3.9"
 dependencies = [
     "grantex>=0.1.0",

--- a/packages/vercel-ai/src/audit.ts
+++ b/packages/vercel-ai/src/audit.ts
@@ -34,7 +34,7 @@ export function withAuditLogging<PARAMETERS extends z.ZodTypeAny, RESULT>(
   const action = `tool:${toolName}`;
   const originalExecute = grantexTool.execute;
 
-  const wrappedExecute: typeof originalExecute = async (args, execOptions) => {
+  const wrappedExecute = (async (args: z.infer<PARAMETERS>, execOptions: import('@ai-sdk/provider-utils').ToolCallOptions) => {
     try {
       const result = await originalExecute(args, execOptions);
       await client.audit.log({
@@ -58,7 +58,7 @@ export function withAuditLogging<PARAMETERS extends z.ZodTypeAny, RESULT>(
       });
       throw err;
     }
-  };
+  }) as GrantexTool<PARAMETERS, RESULT>['execute'];
 
   return Object.defineProperty(
     { ...grantexTool, execute: wrappedExecute },

--- a/packages/vercel-ai/src/types.ts
+++ b/packages/vercel-ai/src/types.ts
@@ -1,5 +1,5 @@
 import type { z } from 'zod';
-import type { ToolExecutionOptions } from 'ai';
+import type { ToolCallOptions } from '@ai-sdk/provider-utils';
 
 // ─── createGrantexTool options ────────────────────────────────────────────────
 
@@ -28,8 +28,8 @@ export interface CreateGrantexToolOptions<
   /** The tool implementation — receives the validated Zod-parsed args. */
   execute: (
     args: z.infer<PARAMETERS>,
-    options: ToolExecutionOptions,
-  ) => Promise<RESULT>;
+    options: ToolCallOptions,
+  ) => PromiseLike<RESULT>;
 }
 
 // ─── withAuditLogging options ─────────────────────────────────────────────────

--- a/packages/vercel-ai/tests/audit.test.ts
+++ b/packages/vercel-ai/tests/audit.test.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import type { Grantex } from '@grantex/sdk';
 
 vi.mock('ai', () => ({
-  tool: (t: unknown) => t,
+  zodSchema: (schema: unknown) => schema,
 }));
 
 import { createGrantexTool } from '../src/tool.js';
@@ -113,7 +113,7 @@ describe('withAuditLogging', () => {
     });
 
     expect(wrapped.description).toBe(original.description);
-    expect(wrapped.parameters).toBe(original.parameters);
+    expect(wrapped.inputSchema).toBe(original.inputSchema);
   });
 
   it('does not log when scope check fails at construction', () => {

--- a/packages/vercel-ai/tests/tool.test.ts
+++ b/packages/vercel-ai/tests/tool.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { z } from 'zod';
 
-// Mock `ai` so tool() is a simple identity function — no real LLM deps
+// Mock `ai` so zodSchema() is an identity function — no real LLM deps
 vi.mock('ai', () => ({
-  tool: (t: unknown) => t,
+  zodSchema: (schema: unknown) => schema,
 }));
 
 import { createGrantexTool, getGrantScopes } from '../src/tool.js';
@@ -52,7 +52,7 @@ describe('createGrantexTool', () => {
     });
 
     expect(t.description).toBe('Fetches a URL.');
-    expect(t.parameters).toBe(PARAMS);
+    expect(t.inputSchema).toBe(PARAMS);
     expect(typeof t.execute).toBe('function');
     expect(t[TOOL_NAME_KEY]).toBe('fetch_data');
   });


### PR DESCRIPTION
## Summary
- Fix `@grantex/vercel-ai` build for Vercel AI SDK v5 (new `inputSchema`/`ToolCallOptions` API)
- Add missing `license` field to `grantex-crewai` pyproject.toml
- Change `@grantex/cli` dependency on `@grantex/sdk` from `file:` to `^0.1.1`

## Test plan
- [x] `packages/vercel-ai`: 12/12 tests pass
- [x] All packages built successfully
- [x] Published to npm: `@grantex/sdk`, `@grantex/autogen`, `@grantex/vercel-ai`, `@grantex/cli`
- [x] Published to PyPI: `grantex`, `grantex-crewai`