### PR TITLE
feat: add developer signup endpoint and API key rotation

### DIFF
--- a/apps/auth-service/src/db/migrations/009_developer_email.sql
+++ b/apps/auth-service/src/db/migrations/009_developer_email.sql
@@ -1,0 +1,1 @@
+ALTER TABLE developers ADD COLUMN IF NOT EXISTS email TEXT;

--- a/apps/auth-service/src/lib/hash.ts
+++ b/apps/auth-service/src/lib/hash.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 
 export function sha256hex(input: string): string {
   return createHash('sha256').update(input).digest('hex');
@@ -6,6 +6,11 @@ export function sha256hex(input: string): string {
 
 export function hashApiKey(key: string): string {
   return sha256hex(key);
+}
+
+export function generateApiKey(mode: 'live' | 'sandbox' = 'live'): string {
+  const prefix = mode === 'sandbox' ? 'gx_test_' : 'gx_live_';
+  return prefix + randomBytes(32).toString('base64url');
 }
 
 export interface AuditHashFields {

--- a/apps/auth-service/src/routes/signup.ts
+++ b/apps/auth-service/src/routes/signup.ts
@@ -1,0 +1,70 @@
+import type { FastifyInstance } from 'fastify';
+import { getSql } from '../db/client.js';
+import { newDeveloperId } from '../lib/ids.js';
+import { hashApiKey, generateApiKey } from '../lib/hash.js';
+
+interface SignupBody {
+  name: string;
+  email?: string;
+}
+
+export async function signupRoutes(app: FastifyInstance): Promise<void> {
+  // POST /v1/signup — create a new developer account (public)
+  app.post<{ Body: SignupBody }>(
+    '/v1/signup',
+    { config: { skipAuth: true } },
+    async (request, reply) => {
+      const { name, email } = request.body;
+      if (!name) {
+        return reply.status(400).send({ message: 'name is required', code: 'BAD_REQUEST', requestId: request.id });
+      }
+
+      const sql = getSql();
+
+      if (email) {
+        const existing = await sql`SELECT id FROM developers WHERE email = ${email} LIMIT 1`;
+        if (existing.length > 0) {
+          return reply.status(409).send({ message: 'A developer with this email already exists', code: 'CONFLICT', requestId: request.id });
+        }
+      }
+
+      const id = newDeveloperId();
+      const apiKey = generateApiKey();
+      const keyHash = hashApiKey(apiKey);
+
+      const rows = await sql`
+        INSERT INTO developers (id, name, email, api_key_hash, mode)
+        VALUES (${id}, ${name}, ${email ?? null}, ${keyHash}, 'live')
+        RETURNING id, name, email, mode, created_at
+      `;
+
+      return reply.status(201).send({
+        developerId: rows[0]!['id'],
+        apiKey,
+        name: rows[0]!['name'],
+        email: rows[0]!['email'] ?? null,
+        mode: rows[0]!['mode'],
+        createdAt: rows[0]!['created_at'],
+      });
+    },
+  );
+
+  // POST /v1/keys/rotate — rotate API key (authenticated)
+  app.post('/v1/keys/rotate', async (request, reply) => {
+    const sql = getSql();
+    const developerId = request.developer.id;
+    const mode = request.developer.mode;
+
+    const apiKey = generateApiKey(mode);
+    const keyHash = hashApiKey(apiKey);
+
+    await sql`
+      UPDATE developers SET api_key_hash = ${keyHash} WHERE id = ${developerId}
+    `;
+
+    return reply.send({
+      apiKey,
+      rotatedAt: new Date().toISOString(),
+    });
+  });
+}

--- a/apps/auth-service/src/server.ts
+++ b/apps/auth-service/src/server.ts
@@ -20,6 +20,7 @@ import { complianceRoutes } from './routes/compliance.js';
 import { anomaliesRoutes } from './routes/anomalies.js';
 import { scimRoutes } from './routes/scim.js';
 import { ssoRoutes } from './routes/sso.js';
+import { signupRoutes } from './routes/signup.js';
 
 export type AppOptions = {
   logger?: boolean | object;
@@ -58,6 +59,7 @@ export async function buildApp(opts: AppOptions = {}) {
   await app.register(anomaliesRoutes);
   await app.register(scimRoutes);
   await app.register(ssoRoutes);
+  await app.register(signupRoutes);
 
   return app;
 }

--- a/apps/auth-service/tests/signup.test.ts
+++ b/apps/auth-service/tests/signup.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { buildTestApp, sqlMock, seedAuth, authHeader, TEST_DEVELOPER } from './helpers.js';
+
+describe('POST /v1/signup', () => {
+  it('creates a developer and returns 201 with API key', async () => {
+    const app = await buildTestApp();
+    const now = new Date().toISOString();
+
+    // No auth SQL call (skipAuth: true)
+    // 1st call: email uniqueness check (no email → skipped)
+    // 1st call: INSERT
+    sqlMock.mockResolvedValueOnce([{
+      id: 'dev_TEST_NEW',
+      name: 'Acme Corp',
+      email: null,
+      mode: 'live',
+      created_at: now,
+    }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/signup',
+      payload: { name: 'Acme Corp' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.developerId).toBe('dev_TEST_NEW');
+    expect(body.name).toBe('Acme Corp');
+    expect(body.apiKey).toMatch(/^gx_live_/);
+    expect(body.mode).toBe('live');
+    expect(body.createdAt).toBe(now);
+  });
+
+  it('creates a developer with email', async () => {
+    const app = await buildTestApp();
+    const now = new Date().toISOString();
+
+    // 1st call: email uniqueness check
+    sqlMock.mockResolvedValueOnce([]);
+    // 2nd call: INSERT
+    sqlMock.mockResolvedValueOnce([{
+      id: 'dev_TEST_EMAIL',
+      name: 'Acme Corp',
+      email: 'dev@acme.com',
+      mode: 'live',
+      created_at: now,
+    }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/signup',
+      payload: { name: 'Acme Corp', email: 'dev@acme.com' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.email).toBe('dev@acme.com');
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const app = await buildTestApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/signup',
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('BAD_REQUEST');
+  });
+
+  it('returns 409 for duplicate email', async () => {
+    const app = await buildTestApp();
+
+    // email uniqueness check returns existing row
+    sqlMock.mockResolvedValueOnce([{ id: 'dev_EXISTING' }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/signup',
+      payload: { name: 'Acme Corp', email: 'taken@acme.com' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('CONFLICT');
+  });
+
+  it('does not require auth', async () => {
+    const app = await buildTestApp();
+    const now = new Date().toISOString();
+
+    sqlMock.mockResolvedValueOnce([{
+      id: 'dev_NO_AUTH',
+      name: 'No Auth',
+      email: null,
+      mode: 'live',
+      created_at: now,
+    }]);
+
+    // No Authorization header
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/signup',
+      payload: { name: 'No Auth' },
+    });
+
+    expect(res.statusCode).toBe(201);
+  });
+});
+
+describe('POST /v1/keys/rotate', () => {
+  it('rotates API key and returns 200', async () => {
+    const app = await buildTestApp();
+
+    // 1st call: auth check
+    seedAuth();
+    // 2nd call: UPDATE
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/keys/rotate',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.apiKey).toMatch(/^gx_live_/);
+    expect(body.rotatedAt).toBeDefined();
+  });
+
+  it('returns 401 without auth', async () => {
+    const app = await buildTestApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/keys/rotate',
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -12,6 +12,9 @@ from ._errors import (
 )
 from ._types import (
     Agent,
+    RotateKeyResponse,
+    SignupParams,
+    SignupResponse,
     Anomaly,
     AuditEntry,
     AuthorizationRequest,
@@ -75,6 +78,10 @@ __version__ = "0.1.1"
 __all__ = [
     # Main client
     "Grantex",
+    # Signup
+    "SignupParams",
+    "SignupResponse",
+    "RotateKeyResponse",
     # Standalone verify
     "verify_grant_token",
     # Webhook signature verification

--- a/packages/sdk-py/src/grantex/_types.py
+++ b/packages/sdk-py/src/grantex/_types.py
@@ -4,6 +4,55 @@ from dataclasses import dataclass
 from typing import Any
 
 
+# ─── Signup ───────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SignupParams:
+    name: str
+    email: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {"name": self.name}
+        if self.email is not None:
+            body["email"] = self.email
+        return body
+
+
+@dataclass(frozen=True)
+class SignupResponse:
+    developer_id: str
+    api_key: str
+    name: str
+    email: str | None
+    mode: str
+    created_at: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SignupResponse:
+        return cls(
+            developer_id=data["developerId"],
+            api_key=data["apiKey"],
+            name=data["name"],
+            email=data.get("email"),
+            mode=data["mode"],
+            created_at=data["createdAt"],
+        )
+
+
+@dataclass(frozen=True)
+class RotateKeyResponse:
+    api_key: str
+    rotated_at: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RotateKeyResponse:
+        return cls(
+            api_key=data["apiKey"],
+            rotated_at=data["rotatedAt"],
+        )
+
+
 # ─── Agent ────────────────────────────────────────────────────────────────────
 
 

--- a/packages/sdk-py/tests/test_signup.py
+++ b/packages/sdk-py/tests/test_signup.py
@@ -1,0 +1,81 @@
+"""Tests for Grantex.signup() and Grantex.rotate_key()."""
+from __future__ import annotations
+
+import pytest
+import respx
+import httpx
+
+from grantex import Grantex, SignupParams
+
+MOCK_SIGNUP_RESPONSE = {
+    "developerId": "dev_NEW01",
+    "apiKey": "gx_live_abc123",
+    "name": "Acme Corp",
+    "email": None,
+    "mode": "live",
+    "createdAt": "2026-02-27T00:00:00Z",
+}
+
+MOCK_ROTATE_RESPONSE = {
+    "apiKey": "gx_live_newkey456",
+    "rotatedAt": "2026-02-27T01:00:00Z",
+}
+
+
+@pytest.fixture
+def client() -> Grantex:
+    return Grantex(api_key="test-key")
+
+
+@respx.mock
+def test_signup_happy_path() -> None:
+    route = respx.post("https://api.grantex.dev/v1/signup").mock(
+        return_value=httpx.Response(201, json=MOCK_SIGNUP_RESPONSE)
+    )
+    result = Grantex.signup(SignupParams(name="Acme Corp"))
+
+    assert result.developer_id == "dev_NEW01"
+    assert result.api_key == "gx_live_abc123"
+    assert result.name == "Acme Corp"
+    assert result.mode == "live"
+
+
+@respx.mock
+def test_signup_with_email() -> None:
+    payload = {**MOCK_SIGNUP_RESPONSE, "email": "dev@acme.com"}
+    respx.post("https://api.grantex.dev/v1/signup").mock(
+        return_value=httpx.Response(201, json=payload)
+    )
+    result = Grantex.signup(SignupParams(name="Acme Corp", email="dev@acme.com"))
+
+    assert result.email == "dev@acme.com"
+
+
+@respx.mock
+def test_signup_custom_base_url() -> None:
+    route = respx.post("https://custom.api.dev/v1/signup").mock(
+        return_value=httpx.Response(201, json=MOCK_SIGNUP_RESPONSE)
+    )
+    Grantex.signup(SignupParams(name="Acme Corp"), base_url="https://custom.api.dev")
+
+    assert route.called
+
+
+@respx.mock
+def test_signup_conflict_raises() -> None:
+    respx.post("https://api.grantex.dev/v1/signup").mock(
+        return_value=httpx.Response(409, json={"message": "A developer with this email already exists"})
+    )
+    with pytest.raises(ValueError, match="A developer with this email already exists"):
+        Grantex.signup(SignupParams(name="Acme Corp", email="taken@acme.com"))
+
+
+@respx.mock
+def test_rotate_key_happy_path(client: Grantex) -> None:
+    respx.post("https://api.grantex.dev/v1/keys/rotate").mock(
+        return_value=httpx.Response(200, json=MOCK_ROTATE_RESPONSE)
+    )
+    result = client.rotate_key()
+
+    assert result.api_key == "gx_live_newkey456"
+    assert result.rotated_at == "2026-02-27T01:00:00Z"

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -19,6 +19,10 @@ export {
 // Types
 export type {
   GrantexClientOptions,
+  // Signup
+  SignupParams,
+  SignupResponse,
+  RotateKeyResponse,
   // Agents
   Agent,
   RegisterAgentParams,

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -9,6 +9,27 @@ export interface GrantexClientOptions {
   timeout?: number;
 }
 
+// ─── Signup ─────────────────────────────────────────────────────────────────
+
+export interface SignupParams {
+  name: string;
+  email?: string;
+}
+
+export interface SignupResponse {
+  developerId: string;
+  apiKey: string;
+  name: string;
+  email: string | null;
+  mode: 'live' | 'sandbox';
+  createdAt: string;
+}
+
+export interface RotateKeyResponse {
+  apiKey: string;
+  rotatedAt: string;
+}
+
 // ─── Agents ──────────────────────────────────────────────────────────────────
 
 export interface RegisterAgentParams {

--- a/packages/sdk-ts/tests/signup.test.ts
+++ b/packages/sdk-ts/tests/signup.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Grantex } from '../src/client.js';
+
+const MOCK_SIGNUP_RESPONSE = {
+  developerId: 'dev_NEW01',
+  apiKey: 'gx_live_abc123',
+  name: 'Acme Corp',
+  email: null,
+  mode: 'live' as const,
+  createdAt: '2026-02-27T00:00:00Z',
+};
+
+const MOCK_ROTATE_RESPONSE = {
+  apiKey: 'gx_live_newkey456',
+  rotatedAt: '2026-02-27T01:00:00Z',
+};
+
+function makeFetch(status: number, body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+describe('Grantex.signup()', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('POSTs to /v1/signup without auth header', async () => {
+    const mockFetch = makeFetch(201, MOCK_SIGNUP_RESPONSE);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await Grantex.signup({ name: 'Acme Corp' });
+
+    expect(result.developerId).toBe('dev_NEW01');
+    expect(result.apiKey).toBe('gx_live_abc123');
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/signup$/);
+    expect(init.method).toBe('POST');
+    // No Authorization header
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBeUndefined();
+  });
+
+  it('sends email in the body when provided', async () => {
+    const mockFetch = makeFetch(201, { ...MOCK_SIGNUP_RESPONSE, email: 'dev@acme.com' });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await Grantex.signup({ name: 'Acme Corp', email: 'dev@acme.com' });
+
+    expect(result.email).toBe('dev@acme.com');
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.email).toBe('dev@acme.com');
+  });
+
+  it('uses custom baseUrl', async () => {
+    const mockFetch = makeFetch(201, MOCK_SIGNUP_RESPONSE);
+    vi.stubGlobal('fetch', mockFetch);
+
+    await Grantex.signup({ name: 'Acme Corp' }, { baseUrl: 'https://custom.api.dev' });
+
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toBe('https://custom.api.dev/v1/signup');
+  });
+
+  it('throws on error response', async () => {
+    vi.stubGlobal('fetch', makeFetch(409, { message: 'A developer with this email already exists' }));
+
+    await expect(Grantex.signup({ name: 'Acme Corp', email: 'taken@acme.com' }))
+      .rejects.toThrow('A developer with this email already exists');
+  });
+});
+
+describe('Grantex.rotateKey()', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('POSTs to /v1/keys/rotate', async () => {
+    const mockFetch = makeFetch(200, MOCK_ROTATE_RESPONSE);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.rotateKey();
+
+    expect(result.apiKey).toBe('gx_live_newkey456');
+    expect(result.rotatedAt).toBe('2026-02-27T01:00:00Z');
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/keys\/rotate$/);
+    expect(init.method).toBe('POST');
+  });
+});


### PR DESCRIPTION
## Summary
- Add public `POST /v1/signup` endpoint for self-service developer registration — returns a `gx_live_` prefixed API key, supports optional email with uniqueness check (409 on conflict)
- Add authenticated `POST /v1/keys/rotate` endpoint to rotate API keys (invalidates old key, returns new one)
- Add `generateApiKey()` helper, DB migration for `email` column on `developers`, and SDK support (`Grantex.signup()` static method + `rotateKey()`/`rotate_key()` instance method) in both TypeScript and Python

## Test plan
- [ ] Auth-service: 181 tests pass (`npm test`) including 7 new signup/rotate tests
- [ ] TS SDK: 78 tests pass (`npm test`) including 5 new signup tests
- [ ] Python SDK: 90 tests pass (`pytest`) including 5 new signup tests
- [ ] All typechecks clean (`tsc --noEmit`, `mypy --strict`)