### PR TITLE
feat(portal): agent management pages

### DIFF
--- a/apps/portal/src/api/agents.ts
+++ b/apps/portal/src/api/agents.ts
@@ -1,8 +1,9 @@
 import { api } from './client';
 import type { Agent, CreateAgentRequest } from './types';
 
-export function listAgents(): Promise<Agent[]> {
-  return api.get<Agent[]>('/v1/agents');
+export async function listAgents(): Promise<Agent[]> {
+  const res = await api.get<{ agents: Agent[] }>('/v1/agents');
+  return res.agents;
 }
 
 export function getAgent(id: string): Promise<Agent> {
@@ -13,7 +14,7 @@ export function createAgent(data: CreateAgentRequest): Promise<Agent> {
   return api.post<Agent>('/v1/agents', data);
 }
 
-export function updateAgent(id: string, data: Partial<CreateAgentRequest>): Promise<Agent> {
+export function updateAgent(id: string, data: Partial<CreateAgentRequest> & { status?: string }): Promise<Agent> {
   return api.patch<Agent>(`/v1/agents/${encodeURIComponent(id)}`, data);
 }
 

--- a/apps/portal/src/api/grants.ts
+++ b/apps/portal/src/api/grants.ts
@@ -1,12 +1,13 @@
 import { api } from './client';
 import type { Grant } from './types';
 
-export function listGrants(params?: { agentId?: string; status?: string }): Promise<Grant[]> {
+export async function listGrants(params?: { agentId?: string; status?: string }): Promise<Grant[]> {
   const q = new URLSearchParams();
   if (params?.agentId) q.set('agentId', params.agentId);
   if (params?.status) q.set('status', params.status);
   const qs = q.toString();
-  return api.get<Grant[]>(`/v1/grants${qs ? `?${qs}` : ''}`);
+  const res = await api.get<{ grants: Grant[] }>(`/v1/grants${qs ? `?${qs}` : ''}`);
+  return res.grants;
 }
 
 export function getGrant(id: string): Promise<Grant> {
@@ -14,5 +15,5 @@ export function getGrant(id: string): Promise<Grant> {
 }
 
 export function revokeGrant(id: string): Promise<void> {
-  return api.post<void>(`/v1/grants/${encodeURIComponent(id)}/revoke`);
+  return api.del(`/v1/grants/${encodeURIComponent(id)}`);
 }

--- a/apps/portal/src/api/types.ts
+++ b/apps/portal/src/api/types.ts
@@ -24,7 +24,7 @@ export interface RotateKeyResponse {
 
 // ── Agents ───────────────────────────────────────────────────────────────
 export interface Agent {
-  id: string;
+  agentId: string;
   did: string;
   developerId: string;
   name: string;
@@ -43,7 +43,7 @@ export interface CreateAgentRequest {
 
 // ── Grants ───────────────────────────────────────────────────────────────
 export interface Grant {
-  id: string;
+  grantId: string;
   agentId: string;
   principalId: string;
   developerId: string;
@@ -51,9 +51,9 @@ export interface Grant {
   status: 'active' | 'revoked' | 'expired';
   issuedAt: string;
   expiresAt: string;
-  revokedAt: string | null;
+  revokedAt?: string;
   parentGrantId?: string;
-  delegationDepth?: number;
+  delegationDepth: number;
 }
 
 // ── Audit ────────────────────────────────────────────────────────────────

--- a/apps/portal/src/components/ui/ConfirmDialog.tsx
+++ b/apps/portal/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,38 @@
+import { Modal } from './Modal';
+import { Button } from './Button';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  variant?: 'danger' | 'primary';
+  loading?: boolean;
+}
+
+export function ConfirmDialog({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  variant = 'danger',
+  loading,
+}: ConfirmDialogProps) {
+  return (
+    <Modal open={open} onClose={onClose} title={title}>
+      <p className="text-sm text-gx-muted mb-6">{message}</p>
+      <div className="flex justify-end gap-3">
+        <Button variant="secondary" size="sm" onClick={onClose} disabled={loading}>
+          Cancel
+        </Button>
+        <Button variant={variant} size="sm" onClick={onConfirm} disabled={loading}>
+          {confirmLabel}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/portal/src/components/ui/Input.tsx
+++ b/apps/portal/src/components/ui/Input.tsx
@@ -1,0 +1,31 @@
+import { type InputHTMLAttributes } from 'react';
+import { cn } from '../../lib/cn';
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  hint?: string;
+  error?: string;
+}
+
+export function Input({ label, hint, error, className, id, ...props }: InputProps) {
+  return (
+    <div>
+      {label && (
+        <label htmlFor={id} className="block text-sm font-medium text-gx-text mb-1.5">
+          {label}
+          {hint && <span className="text-gx-muted font-normal"> ({hint})</span>}
+        </label>
+      )}
+      <input
+        id={id}
+        className={cn(
+          'w-full px-3 py-2 bg-gx-bg border rounded-md text-sm text-gx-text placeholder-gx-muted/50 focus:outline-none transition-colors',
+          error ? 'border-gx-danger focus:border-gx-danger' : 'border-gx-border focus:border-gx-accent',
+          className,
+        )}
+        {...props}
+      />
+      {error && <p className="mt-1 text-xs text-gx-danger">{error}</p>}
+    </div>
+  );
+}

--- a/apps/portal/src/components/ui/Modal.tsx
+++ b/apps/portal/src/components/ui/Modal.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+}
+
+export function Modal({ open, onClose, title, children }: ModalProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === overlayRef.current) onClose(); }}
+    >
+      <div className="bg-gx-surface border border-gx-border rounded-lg shadow-xl w-full max-w-lg mx-4">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gx-border">
+          <h2 className="text-sm font-semibold text-gx-text">{title}</h2>
+          <button onClick={onClose} className="text-gx-muted hover:text-gx-text transition-colors">
+            &times;
+          </button>
+        </div>
+        <div className="p-5">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/apps/portal/src/components/ui/ScopePills.tsx
+++ b/apps/portal/src/components/ui/ScopePills.tsx
@@ -1,0 +1,21 @@
+import { cn } from '../../lib/cn';
+
+interface ScopePillsProps {
+  scopes: string[];
+  className?: string;
+}
+
+export function ScopePills({ scopes, className }: ScopePillsProps) {
+  return (
+    <div className={cn('flex flex-wrap gap-1.5', className)}>
+      {scopes.map((scope) => (
+        <span
+          key={scope}
+          className="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono bg-gx-accent2/10 text-gx-accent2"
+        >
+          {scope}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/portal/src/components/ui/Select.tsx
+++ b/apps/portal/src/components/ui/Select.tsx
@@ -1,0 +1,33 @@
+import { type SelectHTMLAttributes } from 'react';
+import { cn } from '../../lib/cn';
+
+interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  label?: string;
+  options: { value: string; label: string }[];
+}
+
+export function Select({ label, options, className, id, ...props }: SelectProps) {
+  return (
+    <div>
+      {label && (
+        <label htmlFor={id} className="block text-sm font-medium text-gx-text mb-1.5">
+          {label}
+        </label>
+      )}
+      <select
+        id={id}
+        className={cn(
+          'w-full px-3 py-2 bg-gx-bg border border-gx-border rounded-md text-sm text-gx-text focus:outline-none focus:border-gx-accent transition-colors',
+          className,
+        )}
+        {...props}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/apps/portal/src/components/ui/Table.tsx
+++ b/apps/portal/src/components/ui/Table.tsx
@@ -1,0 +1,53 @@
+import { type ReactNode } from 'react';
+
+interface Column<T> {
+  key: string;
+  header: string;
+  render: (row: T) => ReactNode;
+  className?: string;
+}
+
+interface TableProps<T> {
+  columns: Column<T>[];
+  data: T[];
+  rowKey: (row: T) => string;
+  onRowClick?: (row: T) => void;
+}
+
+export function Table<T>({ columns, data, rowKey, onRowClick }: TableProps<T>) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gx-border">
+            {columns.map((col) => (
+              <th
+                key={col.key}
+                className={`text-left py-2.5 pr-4 text-xs font-medium text-gx-muted ${col.className ?? ''}`}
+              >
+                {col.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row) => (
+            <tr
+              key={rowKey(row)}
+              className={`border-b border-gx-border/50 last:border-0 ${
+                onRowClick ? 'cursor-pointer hover:bg-gx-bg/50 transition-colors' : ''
+              }`}
+              onClick={() => onRowClick?.(row)}
+            >
+              {columns.map((col) => (
+                <td key={col.key} className={`py-3 pr-4 ${col.className ?? ''}`}>
+                  {col.render(row)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/portal/src/pages/agents/AgentDetail.tsx
+++ b/apps/portal/src/pages/agents/AgentDetail.tsx
@@ -1,0 +1,238 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { getAgent, deleteAgent, updateAgent } from '../../api/agents';
+import { listGrants } from '../../api/grants';
+import type { Agent, Grant } from '../../api/types';
+import { useToast } from '../../store/toast';
+import { Card } from '../../components/ui/Card';
+import { Button } from '../../components/ui/Button';
+import { Badge } from '../../components/ui/Badge';
+import { Spinner } from '../../components/ui/Spinner';
+import { CopyButton } from '../../components/ui/CopyButton';
+import { ScopePills } from '../../components/ui/ScopePills';
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog';
+import { Table } from '../../components/ui/Table';
+import { formatDate, formatDateTime, truncateId } from '../../lib/format';
+
+export function AgentDetail() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { show } = useToast();
+
+  const [agent, setAgent] = useState<Agent | null>(null);
+  const [grants, setGrants] = useState<Grant[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showDelete, setShowDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [togglingStatus, setTogglingStatus] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    Promise.all([
+      getAgent(id),
+      listGrants({ agentId: id }).catch(() => []),
+    ])
+      .then(([a, g]) => {
+        setAgent(a);
+        setGrants(g);
+      })
+      .catch(() => {
+        show('Agent not found', 'error');
+        navigate('/dashboard/agents');
+      })
+      .finally(() => setLoading(false));
+  }, [id, show, navigate]);
+
+  async function handleDelete() {
+    if (!id) return;
+    setDeleting(true);
+    try {
+      await deleteAgent(id);
+      show('Agent deleted', 'success');
+      navigate('/dashboard/agents');
+    } catch {
+      show('Failed to delete agent', 'error');
+    } finally {
+      setDeleting(false);
+      setShowDelete(false);
+    }
+  }
+
+  async function toggleStatus() {
+    if (!id || !agent) return;
+    setTogglingStatus(true);
+    const newStatus = agent.status === 'active' ? 'suspended' : 'active';
+    try {
+      const updated = await updateAgent(id, { status: newStatus });
+      setAgent(updated);
+      show(`Agent ${newStatus}`, 'success');
+    } catch {
+      show('Failed to update status', 'error');
+    } finally {
+      setTogglingStatus(false);
+    }
+  }
+
+  if (loading || !agent) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <Link to="/dashboard/agents" className="text-xs text-gx-muted hover:text-gx-text transition-colors">
+            &larr; Agents
+          </Link>
+          <h1 className="text-xl font-semibold text-gx-text mt-1">{agent.name}</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={toggleStatus}
+            disabled={togglingStatus}
+          >
+            {agent.status === 'active' ? 'Suspend' : 'Activate'}
+          </Button>
+          <Link to={`/dashboard/agents/${agent.agentId}/edit`}>
+            <Button variant="secondary" size="sm">Edit</Button>
+          </Link>
+          <Button variant="danger" size="sm" onClick={() => setShowDelete(true)}>
+            Delete
+          </Button>
+        </div>
+      </div>
+
+      {/* Agent details */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+        <Card>
+          <h2 className="text-xs font-medium text-gx-muted mb-4">Details</h2>
+          <dl className="space-y-3">
+            <div>
+              <dt className="text-xs text-gx-muted">Agent ID</dt>
+              <dd className="flex items-center gap-2 mt-0.5">
+                <code className="text-sm font-mono text-gx-accent2">{agent.agentId}</code>
+                <CopyButton text={agent.agentId} />
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gx-muted">DID</dt>
+              <dd className="flex items-center gap-2 mt-0.5">
+                <code className="text-sm font-mono text-gx-text">{agent.did}</code>
+                <CopyButton text={agent.did} />
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gx-muted">Status</dt>
+              <dd className="mt-0.5">
+                <Badge variant={agent.status === 'active' ? 'success' : 'warning'}>
+                  {agent.status}
+                </Badge>
+              </dd>
+            </div>
+            {agent.description && (
+              <div>
+                <dt className="text-xs text-gx-muted">Description</dt>
+                <dd className="text-sm text-gx-text mt-0.5">{agent.description}</dd>
+              </div>
+            )}
+          </dl>
+        </Card>
+
+        <Card>
+          <h2 className="text-xs font-medium text-gx-muted mb-4">Metadata</h2>
+          <dl className="space-y-3">
+            <div>
+              <dt className="text-xs text-gx-muted">Scopes</dt>
+              <dd className="mt-1">
+                <ScopePills scopes={agent.scopes} />
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gx-muted">Created</dt>
+              <dd className="text-sm text-gx-text mt-0.5">{formatDateTime(agent.createdAt)}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gx-muted">Last Updated</dt>
+              <dd className="text-sm text-gx-text mt-0.5">{formatDateTime(agent.updatedAt)}</dd>
+            </div>
+          </dl>
+        </Card>
+      </div>
+
+      {/* Associated grants */}
+      <Card>
+        <h2 className="text-sm font-semibold text-gx-text mb-4">
+          Grants ({grants.length})
+        </h2>
+        {grants.length === 0 ? (
+          <p className="text-sm text-gx-muted py-4 text-center">No grants for this agent</p>
+        ) : (
+          <Table
+            data={grants}
+            rowKey={(g) => g.grantId}
+            onRowClick={(g) => navigate(`/dashboard/grants/${g.grantId}`)}
+            columns={[
+              {
+                key: 'id',
+                header: 'Grant ID',
+                render: (g) => (
+                  <span className="font-mono text-xs text-gx-accent2">
+                    {truncateId(g.grantId)}
+                  </span>
+                ),
+              },
+              {
+                key: 'principal',
+                header: 'Principal',
+                render: (g) => (
+                  <span className="text-gx-muted text-xs">{g.principalId}</span>
+                ),
+              },
+              {
+                key: 'scopes',
+                header: 'Scopes',
+                render: (g) => <ScopePills scopes={g.scopes} />,
+              },
+              {
+                key: 'status',
+                header: 'Status',
+                render: (g) => (
+                  <Badge
+                    variant={
+                      g.status === 'active' ? 'success' : g.status === 'revoked' ? 'danger' : 'default'
+                    }
+                  >
+                    {g.status}
+                  </Badge>
+                ),
+              },
+              {
+                key: 'issued',
+                header: 'Issued',
+                render: (g) => (
+                  <span className="text-gx-muted text-xs">{formatDate(g.issuedAt)}</span>
+                ),
+              },
+            ]}
+          />
+        )}
+      </Card>
+
+      <ConfirmDialog
+        open={showDelete}
+        onClose={() => setShowDelete(false)}
+        onConfirm={handleDelete}
+        title="Delete Agent"
+        message={`Are you sure you want to delete "${agent.name}"? This action cannot be undone.`}
+        confirmLabel="Delete"
+        loading={deleting}
+      />
+    </div>
+  );
+}

--- a/apps/portal/src/pages/agents/AgentForm.tsx
+++ b/apps/portal/src/pages/agents/AgentForm.tsx
@@ -1,0 +1,175 @@
+import { useState, useEffect, type FormEvent, type KeyboardEvent } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { createAgent, getAgent, updateAgent } from '../../api/agents';
+import { useToast } from '../../store/toast';
+import { Card } from '../../components/ui/Card';
+import { Button } from '../../components/ui/Button';
+import { Input } from '../../components/ui/Input';
+import { Spinner } from '../../components/ui/Spinner';
+
+export function AgentForm() {
+  const { id } = useParams<{ id: string }>();
+  const isEdit = !!id;
+  const navigate = useNavigate();
+  const { show } = useToast();
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [scopes, setScopes] = useState<string[]>([]);
+  const [scopeInput, setScopeInput] = useState('');
+  const [loading, setLoading] = useState(isEdit);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    getAgent(id)
+      .then((agent) => {
+        setName(agent.name);
+        setDescription(agent.description ?? '');
+        setScopes(agent.scopes);
+      })
+      .catch(() => {
+        show('Agent not found', 'error');
+        navigate('/dashboard/agents');
+      })
+      .finally(() => setLoading(false));
+  }, [id, show, navigate]);
+
+  function addScope() {
+    const trimmed = scopeInput.trim();
+    if (trimmed && !scopes.includes(trimmed)) {
+      setScopes((prev) => [...prev, trimmed]);
+    }
+    setScopeInput('');
+  }
+
+  function removeScope(scope: string) {
+    setScopes((prev) => prev.filter((s) => s !== scope));
+  }
+
+  function handleScopeKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addScope();
+    }
+    if (e.key === 'Backspace' && !scopeInput && scopes.length > 0) {
+      setScopes((prev) => prev.slice(0, -1));
+    }
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    setSubmitting(true);
+    try {
+      if (isEdit) {
+        await updateAgent(id, {
+          name: name.trim(),
+          description: description.trim() || undefined,
+          scopes,
+        });
+        show('Agent updated', 'success');
+        navigate(`/dashboard/agents/${id}`);
+      } else {
+        const agent = await createAgent({
+          name: name.trim(),
+          description: description.trim() || undefined,
+          scopes,
+        });
+        show('Agent created', 'success');
+        navigate(`/dashboard/agents/${agent.agentId}`);
+      }
+    } catch {
+      show(isEdit ? 'Failed to update agent' : 'Failed to create agent', 'error');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl">
+      <h1 className="text-xl font-semibold text-gx-text mb-6">
+        {isEdit ? 'Edit Agent' : 'Create Agent'}
+      </h1>
+
+      <Card>
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <Input
+            id="name"
+            label="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="My Agent"
+            autoFocus
+          />
+
+          <Input
+            id="description"
+            label="Description"
+            hint="optional"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="A brief description of what this agent does"
+          />
+
+          <div>
+            <label className="block text-sm font-medium text-gx-text mb-1.5">
+              Scopes
+            </label>
+            <div className="flex flex-wrap gap-1.5 p-2 bg-gx-bg border border-gx-border rounded-md min-h-[42px] focus-within:border-gx-accent transition-colors">
+              {scopes.map((scope) => (
+                <span
+                  key={scope}
+                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono bg-gx-accent2/10 text-gx-accent2"
+                >
+                  {scope}
+                  <button
+                    type="button"
+                    onClick={() => removeScope(scope)}
+                    className="hover:text-gx-text transition-colors"
+                  >
+                    &times;
+                  </button>
+                </span>
+              ))}
+              <input
+                value={scopeInput}
+                onChange={(e) => setScopeInput(e.target.value)}
+                onKeyDown={handleScopeKeyDown}
+                onBlur={addScope}
+                placeholder={scopes.length === 0 ? 'Type a scope and press Enter' : ''}
+                className="flex-1 min-w-[120px] bg-transparent text-sm text-gx-text placeholder-gx-muted/50 outline-none"
+              />
+            </div>
+            <p className="mt-1 text-xs text-gx-muted">
+              Press Enter or comma to add a scope
+            </p>
+          </div>
+
+          <div className="flex justify-end gap-3 pt-2">
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => navigate(-1)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={submitting || !name.trim()}>
+              {submitting ? <Spinner className="h-4 w-4" /> : isEdit ? 'Save Changes' : 'Create Agent'}
+            </Button>
+          </div>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/apps/portal/src/pages/agents/AgentList.tsx
+++ b/apps/portal/src/pages/agents/AgentList.tsx
@@ -1,0 +1,152 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { listAgents, deleteAgent } from '../../api/agents';
+import type { Agent } from '../../api/types';
+import { useToast } from '../../store/toast';
+import { Card } from '../../components/ui/Card';
+import { Button } from '../../components/ui/Button';
+import { Badge } from '../../components/ui/Badge';
+import { Table } from '../../components/ui/Table';
+import { Spinner } from '../../components/ui/Spinner';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog';
+import { ScopePills } from '../../components/ui/ScopePills';
+import { formatDate, truncateId } from '../../lib/format';
+
+export function AgentList() {
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [deleteTarget, setDeleteTarget] = useState<Agent | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const navigate = useNavigate();
+  const { show } = useToast();
+
+  useEffect(() => {
+    listAgents()
+      .then(setAgents)
+      .catch(() => show('Failed to load agents', 'error'))
+      .finally(() => setLoading(false));
+  }, [show]);
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await deleteAgent(deleteTarget.agentId);
+      setAgents((prev) => prev.filter((a) => a.agentId !== deleteTarget.agentId));
+      show('Agent deleted', 'success');
+    } catch {
+      show('Failed to delete agent', 'error');
+    } finally {
+      setDeleting(false);
+      setDeleteTarget(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-xl font-semibold text-gx-text">Agents</h1>
+        <Link to="/dashboard/agents/new">
+          <Button size="sm">Create Agent</Button>
+        </Link>
+      </div>
+
+      <Card className="p-0">
+        {agents.length === 0 ? (
+          <EmptyState
+            title="No agents yet"
+            description="Register your first agent to start issuing grants."
+            action={
+              <Link to="/dashboard/agents/new">
+                <Button size="sm">Create Agent</Button>
+              </Link>
+            }
+          />
+        ) : (
+          <div className="p-4">
+            <Table
+              data={agents}
+              rowKey={(a) => a.agentId}
+              onRowClick={(a) => navigate(`/dashboard/agents/${a.agentId}`)}
+              columns={[
+                {
+                  key: 'name',
+                  header: 'Name',
+                  render: (a) => (
+                    <span className="font-medium text-gx-text">{a.name}</span>
+                  ),
+                },
+                {
+                  key: 'id',
+                  header: 'ID',
+                  render: (a) => (
+                    <span className="font-mono text-xs text-gx-accent2">
+                      {truncateId(a.agentId)}
+                    </span>
+                  ),
+                },
+                {
+                  key: 'scopes',
+                  header: 'Scopes',
+                  render: (a) => <ScopePills scopes={a.scopes} />,
+                },
+                {
+                  key: 'status',
+                  header: 'Status',
+                  render: (a) => (
+                    <Badge variant={a.status === 'active' ? 'success' : 'warning'}>
+                      {a.status}
+                    </Badge>
+                  ),
+                },
+                {
+                  key: 'created',
+                  header: 'Created',
+                  render: (a) => (
+                    <span className="text-gx-muted text-xs">{formatDate(a.createdAt)}</span>
+                  ),
+                },
+                {
+                  key: 'actions',
+                  header: '',
+                  className: 'text-right',
+                  render: (a) => (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setDeleteTarget(a);
+                      }}
+                    >
+                      Delete
+                    </Button>
+                  ),
+                },
+              ]}
+            />
+          </div>
+        )}
+      </Card>
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleDelete}
+        title="Delete Agent"
+        message={`Are you sure you want to delete "${deleteTarget?.name}"? This action cannot be undone.`}
+        confirmLabel="Delete"
+        loading={deleting}
+      />
+    </div>
+  );
+}

--- a/apps/portal/src/routes.tsx
+++ b/apps/portal/src/routes.tsx
@@ -3,6 +3,9 @@ import { Shell } from './components/layout/Shell';
 import { Login } from './pages/Login';
 import { Signup } from './pages/Signup';
 import { Dashboard } from './pages/Dashboard';
+import { AgentList } from './pages/agents/AgentList';
+import { AgentForm } from './pages/agents/AgentForm';
+import { AgentDetail } from './pages/agents/AgentDetail';
 import { RequireAuth } from './RequireAuth';
 
 // Placeholder pages for future PRs
@@ -26,9 +29,10 @@ export const routes: RouteObject[] = [
     ),
     children: [
       { path: '/dashboard', element: <Dashboard /> },
-      { path: '/dashboard/agents', element: <Placeholder title="Agents" /> },
-      { path: '/dashboard/agents/new', element: <Placeholder title="Create Agent" /> },
-      { path: '/dashboard/agents/:id', element: <Placeholder title="Agent Detail" /> },
+      { path: '/dashboard/agents', element: <AgentList /> },
+      { path: '/dashboard/agents/new', element: <AgentForm /> },
+      { path: '/dashboard/agents/:id', element: <AgentDetail /> },
+      { path: '/dashboard/agents/:id/edit', element: <AgentForm /> },
       { path: '/dashboard/grants', element: <Placeholder title="Grants" /> },
       { path: '/dashboard/grants/:id', element: <Placeholder title="Grant Detail" /> },
       { path: '/dashboard/audit', element: <Placeholder title="Audit Log" /> },


### PR DESCRIPTION
## Summary

- **Fix API types**: Agent uses `agentId` (not `id`), Grant uses `grantId`, list endpoints return `{ agents: [...] }` / `{ grants: [...] }` wrapper objects, grant revoke uses DELETE (not POST)
- **New UI components**: Input (with label/hint/error), Select, Modal (Escape to close, click-outside dismiss), ConfirmDialog, generic Table, ScopePills
- **AgentList**: Sortable table with name, ID, scopes, status badges, created date. Create button, row-click navigation, delete with confirmation dialog
- **AgentForm**: Create and edit modes. Scope multi-input with Enter/comma to add, Backspace to remove last. Form validation
- **AgentDetail**: Full metadata display (ID, DID, status, description, scopes, timestamps). Associated grants table. Suspend/activate toggle, edit link, delete with confirmation

## Verification

- `apps/portal`: `npm run typecheck` (0 errors), `npm run build` (success, 232 KB)

## Test plan

- [ ] Agent list loads and displays agents in table
- [ ] Create agent form validates name, allows scope entry via Enter/comma
- [ ] Agent detail shows full info + associated grants
- [ ] Suspend/activate toggle updates agent status
- [ ] Delete confirmation dialog works, agent removed from list
- [ ] Edit route pre-fills form with existing agent data
- [ ] Empty state shown when no agents exist