### PR TITLE
feat(portal): grants + audit log pages

### DIFF
--- a/apps/portal/src/api/audit.ts
+++ b/apps/portal/src/api/audit.ts
@@ -1,17 +1,20 @@
 import { api } from './client';
 import type { AuditEntry } from './types';
 
-export function listAuditEntries(params?: {
+export async function listAuditEntries(params?: {
+  agentId?: string;
+  grantId?: string;
+  principalId?: string;
   action?: string;
-  resourceType?: string;
-  limit?: number;
 }): Promise<AuditEntry[]> {
   const q = new URLSearchParams();
+  if (params?.agentId) q.set('agentId', params.agentId);
+  if (params?.grantId) q.set('grantId', params.grantId);
+  if (params?.principalId) q.set('principalId', params.principalId);
   if (params?.action) q.set('action', params.action);
-  if (params?.resourceType) q.set('resourceType', params.resourceType);
-  if (params?.limit) q.set('limit', String(params.limit));
   const qs = q.toString();
-  return api.get<AuditEntry[]>(`/v1/audit/entries${qs ? `?${qs}` : ''}`);
+  const res = await api.get<{ entries: AuditEntry[] }>(`/v1/audit/entries${qs ? `?${qs}` : ''}`);
+  return res.entries;
 }
 
 export function getAuditEntry(id: string): Promise<AuditEntry> {

--- a/apps/portal/src/api/types.ts
+++ b/apps/portal/src/api/types.ts
@@ -58,15 +58,18 @@ export interface Grant {
 
 // ── Audit ────────────────────────────────────────────────────────────────
 export interface AuditEntry {
-  id: string;
+  entryId: string;
+  agentId: string;
+  agentDid: string;
+  grantId: string;
+  principalId: string;
   developerId: string;
   action: string;
-  resourceType: string;
-  resourceId: string;
   metadata: Record<string, unknown>;
   hash: string;
-  previousHash: string | null;
-  createdAt: string;
+  prevHash: string | null;
+  timestamp: string;
+  status: 'success' | 'failure' | 'blocked';
 }
 
 // ── Policies ─────────────────────────────────────────────────────────────

--- a/apps/portal/src/components/ui/DateRangeFilter.tsx
+++ b/apps/portal/src/components/ui/DateRangeFilter.tsx
@@ -1,0 +1,42 @@
+import { cn } from '../../lib/cn';
+
+const presets = [
+  { label: '24h', days: 1 },
+  { label: '7d', days: 7 },
+  { label: '30d', days: 30 },
+  { label: '90d', days: 90 },
+  { label: 'All', days: 0 },
+] as const;
+
+interface DateRangeFilterProps {
+  activeDays: number;
+  onChange: (days: number) => void;
+  className?: string;
+}
+
+export function DateRangeFilter({ activeDays, onChange, className }: DateRangeFilterProps) {
+  return (
+    <div className={cn('flex items-center gap-1', className)}>
+      {presets.map((p) => (
+        <button
+          key={p.label}
+          onClick={() => onChange(p.days)}
+          className={cn(
+            'px-2.5 py-1 rounded text-xs font-medium transition-colors',
+            activeDays === p.days
+              ? 'bg-gx-accent/15 text-gx-accent'
+              : 'text-gx-muted hover:text-gx-text hover:bg-gx-bg',
+          )}
+        >
+          {p.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function filterByDays<T>(items: T[], days: number, getTime: (item: T) => string): T[] {
+  if (days === 0) return items;
+  const cutoff = Date.now() - days * 86_400_000;
+  return items.filter((item) => new Date(getTime(item)).getTime() >= cutoff);
+}

--- a/apps/portal/src/pages/Dashboard.tsx
+++ b/apps/portal/src/pages/Dashboard.tsx
@@ -28,7 +28,7 @@ export function Dashboard() {
         const [agents, grants, audit, anomalies] = await Promise.all([
           listAgents().catch(() => []),
           listGrants({ status: 'active' }).catch(() => []),
-          listAuditEntries({ limit: 10 }).catch(() => []),
+          listAuditEntries().catch(() => []),
           listAnomalies().catch(() => []),
         ]);
         setStats({
@@ -37,7 +37,7 @@ export function Dashboard() {
           auditEntries: audit.length,
           anomalies: anomalies.length,
         });
-        setRecent(audit);
+        setRecent(audit.slice(-10).reverse());
       } finally {
         setLoading(false);
       }
@@ -82,23 +82,31 @@ export function Dashboard() {
               <thead>
                 <tr className="border-b border-gx-border">
                   <th className="text-left py-2 pr-4 text-xs font-medium text-gx-muted">Action</th>
-                  <th className="text-left py-2 pr-4 text-xs font-medium text-gx-muted">Resource</th>
-                  <th className="text-left py-2 pr-4 text-xs font-medium text-gx-muted">ID</th>
+                  <th className="text-left py-2 pr-4 text-xs font-medium text-gx-muted">Agent</th>
+                  <th className="text-left py-2 pr-4 text-xs font-medium text-gx-muted">Grant</th>
+                  <th className="text-left py-2 pr-4 text-xs font-medium text-gx-muted">Status</th>
                   <th className="text-right py-2 text-xs font-medium text-gx-muted">Time</th>
                 </tr>
               </thead>
               <tbody>
                 {recent.map((entry) => (
-                  <tr key={entry.id} className="border-b border-gx-border/50 last:border-0">
+                  <tr key={entry.entryId} className="border-b border-gx-border/50 last:border-0">
                     <td className="py-2.5 pr-4">
                       <Badge>{entry.action}</Badge>
                     </td>
-                    <td className="py-2.5 pr-4 text-gx-muted">{entry.resourceType}</td>
+                    <td className="py-2.5 pr-4 font-mono text-xs text-gx-muted">
+                      {truncateId(entry.agentId)}
+                    </td>
                     <td className="py-2.5 pr-4 font-mono text-xs text-gx-accent2">
-                      {truncateId(entry.resourceId)}
+                      {truncateId(entry.grantId)}
+                    </td>
+                    <td className="py-2.5 pr-4">
+                      <Badge variant={entry.status === 'success' ? 'success' : entry.status === 'blocked' ? 'warning' : 'danger'}>
+                        {entry.status}
+                      </Badge>
                     </td>
                     <td className="py-2.5 text-right text-gx-muted text-xs">
-                      {timeAgo(entry.createdAt)}
+                      {timeAgo(entry.timestamp)}
                     </td>
                   </tr>
                 ))}

--- a/apps/portal/src/pages/audit/AuditDetail.tsx
+++ b/apps/portal/src/pages/audit/AuditDetail.tsx
@@ -1,0 +1,155 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { getAuditEntry } from '../../api/audit';
+import type { AuditEntry } from '../../api/types';
+import { useToast } from '../../store/toast';
+import { Card } from '../../components/ui/Card';
+import { Badge } from '../../components/ui/Badge';
+import { Spinner } from '../../components/ui/Spinner';
+import { CopyButton } from '../../components/ui/CopyButton';
+import { formatDateTime } from '../../lib/format';
+
+export function AuditDetail() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { show } = useToast();
+
+  const [entry, setEntry] = useState<AuditEntry | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!id) return;
+    getAuditEntry(id)
+      .then(setEntry)
+      .catch(() => {
+        show('Audit entry not found', 'error');
+        navigate('/dashboard/audit');
+      })
+      .finally(() => setLoading(false));
+  }, [id, show, navigate]);
+
+  if (loading || !entry) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link to="/dashboard/audit" className="text-xs text-gx-muted hover:text-gx-text transition-colors">
+          &larr; Audit Log
+        </Link>
+        <h1 className="text-xl font-semibold text-gx-text mt-1">Audit Entry</h1>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+        <Card>
+          <h2 className="text-xs font-medium text-gx-muted mb-4">Entry Details</h2>
+          <dl className="space-y-3">
+            <div>
+              <dt className="text-xs text-gx-muted">Entry ID</dt>
+              <dd className="flex items-center gap-2 mt-0.5">
+                <code className="text-sm font-mono text-gx-accent2">{entry.entryId}</code>
+                <CopyButton text={entry.entryId} />
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gx-muted">Action</dt>
+              <dd className="mt-0.5">
+                <Badge>{entry.action}</Badge>
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gx-muted">Status</dt>
+              <dd className="mt-0.5">
+                <Badge variant={entry.status === 'success' ? 'success' : entry.status === 'blocked' ? 'warning' : 'danger'}>
+                  {entry.status}
+                </Badge>
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gx-muted">Timestamp</dt>
+              <dd className="text-sm text-gx-text mt-0.5">{formatDateTime(entry.timestamp)}</dd>
+            </div>
+          </dl>
+        </Card>
+
+        <Card>
+          <h2 className="text-xs font-medium text-gx-muted mb-4">References</h2>
+          <dl className="space-y-3">
+            <div>
+              <dt className="text-xs text-gx-muted">Agent</dt>
+              <dd className="mt-0.5">
+                <Link
+                  to={`/dashboard/agents/${entry.agentId}`}
+                  className="text-sm font-mono text-gx-accent2 hover:underline"
+                >
+                  {entry.agentId}
+                </Link>
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gx-muted">Agent DID</dt>
+              <dd className="flex items-center gap-2 mt-0.5">
+                <code className="text-sm font-mono text-gx-text">{entry.agentDid}</code>
+                <CopyButton text={entry.agentDid} />
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gx-muted">Grant</dt>
+              <dd className="mt-0.5">
+                <Link
+                  to={`/dashboard/grants/${entry.grantId}`}
+                  className="text-sm font-mono text-gx-accent2 hover:underline"
+                >
+                  {entry.grantId}
+                </Link>
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gx-muted">Principal</dt>
+              <dd className="text-sm font-mono text-gx-text mt-0.5">{entry.principalId}</dd>
+            </div>
+          </dl>
+        </Card>
+      </div>
+
+      {/* Hash chain */}
+      <Card className="mb-6">
+        <h2 className="text-xs font-medium text-gx-muted mb-4">Hash Chain</h2>
+        <dl className="space-y-3">
+          <div>
+            <dt className="text-xs text-gx-muted">Hash</dt>
+            <dd className="flex items-center gap-2 mt-0.5">
+              <code className="text-xs font-mono text-gx-accent break-all">{entry.hash}</code>
+              <CopyButton text={entry.hash} />
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-gx-muted">Previous Hash</dt>
+            <dd className="mt-0.5">
+              {entry.prevHash ? (
+                <code className="text-xs font-mono text-gx-muted break-all">{entry.prevHash}</code>
+              ) : (
+                <span className="text-xs text-gx-muted italic">Genesis entry (no previous hash)</span>
+              )}
+            </dd>
+          </div>
+        </dl>
+      </Card>
+
+      {/* Metadata JSON */}
+      {Object.keys(entry.metadata).length > 0 && (
+        <Card>
+          <h2 className="text-xs font-medium text-gx-muted mb-4">Metadata</h2>
+          <pre className="text-xs font-mono text-gx-text bg-gx-bg rounded-md p-4 overflow-x-auto">
+            {JSON.stringify(entry.metadata, null, 2)}
+          </pre>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/portal/src/pages/audit/AuditLog.tsx
+++ b/apps/portal/src/pages/audit/AuditLog.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { listAuditEntries } from '../../api/audit';
+import type { AuditEntry } from '../../api/types';
+import { useToast } from '../../store/toast';
+import { Card } from '../../components/ui/Card';
+import { Badge } from '../../components/ui/Badge';
+import { Table } from '../../components/ui/Table';
+import { Spinner } from '../../components/ui/Spinner';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { DateRangeFilter, filterByDays } from '../../components/ui/DateRangeFilter';
+import { formatDateTime, truncateId } from '../../lib/format';
+
+export function AuditLog() {
+  const [entries, setEntries] = useState<AuditEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [days, setDays] = useState(0);
+  const [search, setSearch] = useState('');
+  const navigate = useNavigate();
+  const { show } = useToast();
+
+  useEffect(() => {
+    listAuditEntries()
+      .then(setEntries)
+      .catch(() => show('Failed to load audit entries', 'error'))
+      .finally(() => setLoading(false));
+  }, [show]);
+
+  const filtered = useMemo(() => {
+    let result = filterByDays(entries, days, (e) => e.timestamp);
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        (e) =>
+          e.action.toLowerCase().includes(q) ||
+          e.agentId.toLowerCase().includes(q) ||
+          e.grantId.toLowerCase().includes(q) ||
+          e.principalId.toLowerCase().includes(q) ||
+          e.entryId.toLowerCase().includes(q),
+      );
+    }
+    return result.slice().reverse();
+  }, [entries, days, search]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-xl font-semibold text-gx-text">Audit Log</h1>
+        <DateRangeFilter activeDays={days} onChange={setDays} />
+      </div>
+
+      <div className="mb-4">
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by action, agent, grant, or principal..."
+          className="w-full max-w-md px-3 py-2 bg-gx-surface border border-gx-border rounded-md text-sm text-gx-text placeholder-gx-muted/50 focus:outline-none focus:border-gx-accent transition-colors"
+        />
+      </div>
+
+      <Card className="p-0">
+        {filtered.length === 0 ? (
+          <EmptyState
+            title="No audit entries"
+            description={search ? 'No entries match your search.' : 'No audit entries recorded yet.'}
+          />
+        ) : (
+          <div className="p-4">
+            <Table
+              data={filtered}
+              rowKey={(e) => e.entryId}
+              onRowClick={(e) => navigate(`/dashboard/audit/${e.entryId}`)}
+              columns={[
+                {
+                  key: 'action',
+                  header: 'Action',
+                  render: (e) => <Badge>{e.action}</Badge>,
+                },
+                {
+                  key: 'status',
+                  header: 'Status',
+                  render: (e) => (
+                    <Badge variant={e.status === 'success' ? 'success' : e.status === 'blocked' ? 'warning' : 'danger'}>
+                      {e.status}
+                    </Badge>
+                  ),
+                },
+                {
+                  key: 'agent',
+                  header: 'Agent',
+                  render: (e) => (
+                    <span className="font-mono text-xs text-gx-muted">{truncateId(e.agentId)}</span>
+                  ),
+                },
+                {
+                  key: 'grant',
+                  header: 'Grant',
+                  render: (e) => (
+                    <span className="font-mono text-xs text-gx-accent2">{truncateId(e.grantId)}</span>
+                  ),
+                },
+                {
+                  key: 'principal',
+                  header: 'Principal',
+                  render: (e) => (
+                    <span className="text-gx-muted text-xs">{e.principalId}</span>
+                  ),
+                },
+                {
+                  key: 'time',
+                  header: 'Time',
+                  render: (e) => (
+                    <span className="text-gx-muted text-xs">{formatDateTime(e.timestamp)}</span>
+                  ),
+                },
+              ]}
+            />
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/apps/portal/src/pages/grants/GrantDetail.tsx
+++ b/apps/portal/src/pages/grants/GrantDetail.tsx
@@ -1,0 +1,228 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { getGrant, revokeGrant } from '../../api/grants';
+import { listAuditEntries } from '../../api/audit';
+import type { Grant, AuditEntry } from '../../api/types';
+import { useToast } from '../../store/toast';
+import { Card } from '../../components/ui/Card';
+import { Button } from '../../components/ui/Button';
+import { Badge } from '../../components/ui/Badge';
+import { Spinner } from '../../components/ui/Spinner';
+import { CopyButton } from '../../components/ui/CopyButton';
+import { ScopePills } from '../../components/ui/ScopePills';
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog';
+import { Table } from '../../components/ui/Table';
+import { formatDateTime, truncateId } from '../../lib/format';
+
+export function GrantDetail() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { show } = useToast();
+
+  const [grant, setGrant] = useState<Grant | null>(null);
+  const [auditEntries, setAuditEntries] = useState<AuditEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showRevoke, setShowRevoke] = useState(false);
+  const [revoking, setRevoking] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    Promise.all([
+      getGrant(id),
+      listAuditEntries({ grantId: id }).catch(() => []),
+    ])
+      .then(([g, a]) => {
+        setGrant(g);
+        setAuditEntries(a);
+      })
+      .catch(() => {
+        show('Grant not found', 'error');
+        navigate('/dashboard/grants');
+      })
+      .finally(() => setLoading(false));
+  }, [id, show, navigate]);
+
+  async function handleRevoke() {
+    if (!id) return;
+    setRevoking(true);
+    try {
+      await revokeGrant(id);
+      setGrant((prev) => prev ? { ...prev, status: 'revoked' as const } : prev);
+      show('Grant revoked', 'success');
+    } catch {
+      show('Failed to revoke grant', 'error');
+    } finally {
+      setRevoking(false);
+      setShowRevoke(false);
+    }
+  }
+
+  if (loading || !grant) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <Link to="/dashboard/grants" className="text-xs text-gx-muted hover:text-gx-text transition-colors">
+            &larr; Grants
+          </Link>
+          <h1 className="text-xl font-semibold text-gx-text mt-1">
+            Grant {truncateId(grant.grantId)}
+          </h1>
+        </div>
+        {grant.status === 'active' && (
+          <Button variant="danger" size="sm" onClick={() => setShowRevoke(true)}>
+            Revoke
+          </Button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+        <Card>
+          <h2 className="text-xs font-medium text-gx-muted mb-4">Details</h2>
+          <dl className="space-y-3">
+            <div>
+              <dt className="text-xs text-gx-muted">Grant ID</dt>
+              <dd className="flex items-center gap-2 mt-0.5">
+                <code className="text-sm font-mono text-gx-accent2">{grant.grantId}</code>
+                <CopyButton text={grant.grantId} />
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gx-muted">Agent</dt>
+              <dd className="mt-0.5">
+                <Link
+                  to={`/dashboard/agents/${grant.agentId}`}
+                  className="text-sm font-mono text-gx-accent2 hover:underline"
+                >
+                  {grant.agentId}
+                </Link>
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gx-muted">Principal</dt>
+              <dd className="text-sm font-mono text-gx-text mt-0.5">{grant.principalId}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gx-muted">Status</dt>
+              <dd className="mt-0.5">
+                <Badge
+                  variant={
+                    grant.status === 'active' ? 'success' : grant.status === 'revoked' ? 'danger' : 'default'
+                  }
+                >
+                  {grant.status}
+                </Badge>
+              </dd>
+            </div>
+          </dl>
+        </Card>
+
+        <Card>
+          <h2 className="text-xs font-medium text-gx-muted mb-4">Metadata</h2>
+          <dl className="space-y-3">
+            <div>
+              <dt className="text-xs text-gx-muted">Scopes</dt>
+              <dd className="mt-1">
+                <ScopePills scopes={grant.scopes} />
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gx-muted">Delegation Depth</dt>
+              <dd className="text-sm font-mono text-gx-text mt-0.5">{grant.delegationDepth}</dd>
+            </div>
+            {grant.parentGrantId && (
+              <div>
+                <dt className="text-xs text-gx-muted">Parent Grant</dt>
+                <dd className="mt-0.5">
+                  <Link
+                    to={`/dashboard/grants/${grant.parentGrantId}`}
+                    className="text-sm font-mono text-gx-accent2 hover:underline"
+                  >
+                    {grant.parentGrantId}
+                  </Link>
+                </dd>
+              </div>
+            )}
+            <div>
+              <dt className="text-xs text-gx-muted">Issued</dt>
+              <dd className="text-sm text-gx-text mt-0.5">{formatDateTime(grant.issuedAt)}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gx-muted">Expires</dt>
+              <dd className="text-sm text-gx-text mt-0.5">{formatDateTime(grant.expiresAt)}</dd>
+            </div>
+            {grant.revokedAt && (
+              <div>
+                <dt className="text-xs text-gx-muted">Revoked</dt>
+                <dd className="text-sm text-gx-danger mt-0.5">{formatDateTime(grant.revokedAt)}</dd>
+              </div>
+            )}
+          </dl>
+        </Card>
+      </div>
+
+      {/* Related audit entries */}
+      <Card>
+        <h2 className="text-sm font-semibold text-gx-text mb-4">
+          Audit Trail ({auditEntries.length})
+        </h2>
+        {auditEntries.length === 0 ? (
+          <p className="text-sm text-gx-muted py-4 text-center">No audit entries for this grant</p>
+        ) : (
+          <Table
+            data={auditEntries}
+            rowKey={(e) => e.entryId}
+            onRowClick={(e) => navigate(`/dashboard/audit/${e.entryId}`)}
+            columns={[
+              {
+                key: 'action',
+                header: 'Action',
+                render: (e) => <Badge>{e.action}</Badge>,
+              },
+              {
+                key: 'status',
+                header: 'Status',
+                render: (e) => (
+                  <Badge variant={e.status === 'success' ? 'success' : e.status === 'blocked' ? 'warning' : 'danger'}>
+                    {e.status}
+                  </Badge>
+                ),
+              },
+              {
+                key: 'agent',
+                header: 'Agent',
+                render: (e) => (
+                  <span className="font-mono text-xs text-gx-muted">{truncateId(e.agentId)}</span>
+                ),
+              },
+              {
+                key: 'time',
+                header: 'Time',
+                render: (e) => (
+                  <span className="text-gx-muted text-xs">{formatDateTime(e.timestamp)}</span>
+                ),
+              },
+            ]}
+          />
+        )}
+      </Card>
+
+      <ConfirmDialog
+        open={showRevoke}
+        onClose={() => setShowRevoke(false)}
+        onConfirm={handleRevoke}
+        title="Revoke Grant"
+        message="Are you sure you want to revoke this grant? All sub-delegated grants will also be revoked. This cannot be undone."
+        confirmLabel="Revoke"
+        loading={revoking}
+      />
+    </div>
+  );
+}

--- a/apps/portal/src/pages/grants/GrantList.tsx
+++ b/apps/portal/src/pages/grants/GrantList.tsx
@@ -1,0 +1,185 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { listGrants, revokeGrant } from '../../api/grants';
+import type { Grant } from '../../api/types';
+import { useToast } from '../../store/toast';
+import { Card } from '../../components/ui/Card';
+import { Badge } from '../../components/ui/Badge';
+import { Button } from '../../components/ui/Button';
+import { Table } from '../../components/ui/Table';
+import { Spinner } from '../../components/ui/Spinner';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { ScopePills } from '../../components/ui/ScopePills';
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog';
+import { formatDate, truncateId } from '../../lib/format';
+
+const statusOptions = ['all', 'active', 'revoked', 'expired'] as const;
+
+export function GrantList() {
+  const [grants, setGrants] = useState<Grant[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [revokeTarget, setRevokeTarget] = useState<Grant | null>(null);
+  const [revoking, setRevoking] = useState(false);
+  const navigate = useNavigate();
+  const { show } = useToast();
+
+  useEffect(() => {
+    listGrants()
+      .then(setGrants)
+      .catch(() => show('Failed to load grants', 'error'))
+      .finally(() => setLoading(false));
+  }, [show]);
+
+  const filtered = useMemo(() => {
+    if (statusFilter === 'all') return grants;
+    return grants.filter((g) => g.status === statusFilter);
+  }, [grants, statusFilter]);
+
+  async function handleRevoke() {
+    if (!revokeTarget) return;
+    setRevoking(true);
+    try {
+      await revokeGrant(revokeTarget.grantId);
+      setGrants((prev) =>
+        prev.map((g) =>
+          g.grantId === revokeTarget.grantId ? { ...g, status: 'revoked' as const } : g,
+        ),
+      );
+      show('Grant revoked', 'success');
+    } catch {
+      show('Failed to revoke grant', 'error');
+    } finally {
+      setRevoking(false);
+      setRevokeTarget(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-xl font-semibold text-gx-text">Grants</h1>
+        <div className="flex items-center gap-1">
+          {statusOptions.map((s) => (
+            <button
+              key={s}
+              onClick={() => setStatusFilter(s)}
+              className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+                statusFilter === s
+                  ? 'bg-gx-accent/15 text-gx-accent'
+                  : 'text-gx-muted hover:text-gx-text hover:bg-gx-bg'
+              }`}
+            >
+              {s === 'all' ? 'All' : s.charAt(0).toUpperCase() + s.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <Card className="p-0">
+        {filtered.length === 0 ? (
+          <EmptyState
+            title="No grants found"
+            description={statusFilter === 'all' ? 'No grants have been issued yet.' : `No ${statusFilter} grants.`}
+          />
+        ) : (
+          <div className="p-4">
+            <Table
+              data={filtered}
+              rowKey={(g) => g.grantId}
+              onRowClick={(g) => navigate(`/dashboard/grants/${g.grantId}`)}
+              columns={[
+                {
+                  key: 'id',
+                  header: 'Grant ID',
+                  render: (g) => (
+                    <span className="font-mono text-xs text-gx-accent2">
+                      {truncateId(g.grantId)}
+                    </span>
+                  ),
+                },
+                {
+                  key: 'agent',
+                  header: 'Agent',
+                  render: (g) => (
+                    <span className="font-mono text-xs text-gx-muted">
+                      {truncateId(g.agentId)}
+                    </span>
+                  ),
+                },
+                {
+                  key: 'principal',
+                  header: 'Principal',
+                  render: (g) => (
+                    <span className="text-gx-muted text-xs">{g.principalId}</span>
+                  ),
+                },
+                {
+                  key: 'scopes',
+                  header: 'Scopes',
+                  render: (g) => <ScopePills scopes={g.scopes} />,
+                },
+                {
+                  key: 'status',
+                  header: 'Status',
+                  render: (g) => (
+                    <Badge
+                      variant={
+                        g.status === 'active' ? 'success' : g.status === 'revoked' ? 'danger' : 'default'
+                      }
+                    >
+                      {g.status}
+                    </Badge>
+                  ),
+                },
+                {
+                  key: 'issued',
+                  header: 'Issued',
+                  render: (g) => (
+                    <span className="text-gx-muted text-xs">{formatDate(g.issuedAt)}</span>
+                  ),
+                },
+                {
+                  key: 'actions',
+                  header: '',
+                  className: 'text-right',
+                  render: (g) =>
+                    g.status === 'active' ? (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setRevokeTarget(g);
+                        }}
+                      >
+                        Revoke
+                      </Button>
+                    ) : null,
+                },
+              ]}
+            />
+          </div>
+        )}
+      </Card>
+
+      <ConfirmDialog
+        open={!!revokeTarget}
+        onClose={() => setRevokeTarget(null)}
+        onConfirm={handleRevoke}
+        title="Revoke Grant"
+        message="Are you sure you want to revoke this grant? All sub-delegated grants will also be revoked. This cannot be undone."
+        confirmLabel="Revoke"
+        loading={revoking}
+      />
+    </div>
+  );
+}

--- a/apps/portal/src/routes.tsx
+++ b/apps/portal/src/routes.tsx
@@ -6,6 +6,10 @@ import { Dashboard } from './pages/Dashboard';
 import { AgentList } from './pages/agents/AgentList';
 import { AgentForm } from './pages/agents/AgentForm';
 import { AgentDetail } from './pages/agents/AgentDetail';
+import { GrantList } from './pages/grants/GrantList';
+import { GrantDetail } from './pages/grants/GrantDetail';
+import { AuditLog } from './pages/audit/AuditLog';
+import { AuditDetail } from './pages/audit/AuditDetail';
 import { RequireAuth } from './RequireAuth';
 
 // Placeholder pages for future PRs
@@ -33,10 +37,10 @@ export const routes: RouteObject[] = [
       { path: '/dashboard/agents/new', element: <AgentForm /> },
       { path: '/dashboard/agents/:id', element: <AgentDetail /> },
       { path: '/dashboard/agents/:id/edit', element: <AgentForm /> },
-      { path: '/dashboard/grants', element: <Placeholder title="Grants" /> },
-      { path: '/dashboard/grants/:id', element: <Placeholder title="Grant Detail" /> },
-      { path: '/dashboard/audit', element: <Placeholder title="Audit Log" /> },
-      { path: '/dashboard/audit/:id', element: <Placeholder title="Audit Detail" /> },
+      { path: '/dashboard/grants', element: <GrantList /> },
+      { path: '/dashboard/grants/:id', element: <GrantDetail /> },
+      { path: '/dashboard/audit', element: <AuditLog /> },
+      { path: '/dashboard/audit/:id', element: <AuditDetail /> },
       { path: '/dashboard/policies', element: <Placeholder title="Policies" /> },
       { path: '/dashboard/policies/new', element: <Placeholder title="Create Policy" /> },
       { path: '/dashboard/policies/:id/edit', element: <Placeholder title="Edit Policy" /> },


### PR DESCRIPTION
## Summary

- **AuditEntry type fix**: Updated to match actual API response fields (`entryId`, `agentId`, `agentDid`, `grantId`, `principalId`, `prevHash`, `timestamp`, `status`) instead of generic placeholders
- **Audit API fix**: Handle `{ entries: [...] }` wrapper, proper filter params (agentId, grantId, principalId, action)
- **Dashboard fix**: Recent activity table updated to use correct AuditEntry fields
- **DateRangeFilter**: Preset buttons (24h, 7d, 30d, 90d, All) with `filterByDays` helper
- **GrantList**: Status filter tabs (All/Active/Revoked/Expired), revoke action with cascade warning dialog
- **GrantDetail**: Full grant info with delegation depth, parent grant link, agent link, related audit trail table
- **AuditLog**: Date range filter + text search across action/agent/grant/principal. Reverse-chronological table with row-click navigation
- **AuditDetail**: Entry details, cross-references (linked agent/grant/principal), hash chain display (current + previous hash), metadata JSON viewer

## Verification

- `apps/portal`: `npm run typecheck` (0 errors), `npm run build` (success, 246 KB)

## Test plan

- [ ] Grant list loads with status filter tabs working
- [ ] Revoke grant shows cascade warning, updates status in-place
- [ ] Grant detail shows delegation depth, parent link navigates correctly
- [ ] Grant detail audit trail links to audit entries
- [ ] Audit log search filters across all fields
- [ ] Date range filter narrows entries correctly
- [ ] Audit detail shows hash chain and metadata JSON
- [ ] Dashboard recent activity uses correct field names