### PR TITLE
feat(portal): policies + anomalies pages

### DIFF
--- a/apps/portal/src/api/anomalies.ts
+++ b/apps/portal/src/api/anomalies.ts
@@ -1,14 +1,15 @@
 import { api } from './client';
 import type { Anomaly } from './types';
 
-export function listAnomalies(): Promise<Anomaly[]> {
-  return api.get<Anomaly[]>('/v1/anomalies');
+export async function listAnomalies(): Promise<Anomaly[]> {
+  const res = await api.get<{ anomalies: Anomaly[]; total: number }>('/v1/anomalies');
+  return res.anomalies;
 }
 
-export function detectAnomalies(): Promise<{ detected: number }> {
-  return api.post<{ detected: number }>('/v1/anomalies/detect');
+export function detectAnomalies(): Promise<{ detectedAt: string; total: number; anomalies: Anomaly[] }> {
+  return api.post<{ detectedAt: string; total: number; anomalies: Anomaly[] }>('/v1/anomalies/detect');
 }
 
-export function acknowledgeAnomaly(id: string): Promise<void> {
-  return api.post<void>(`/v1/anomalies/${encodeURIComponent(id)}/acknowledge`);
+export function acknowledgeAnomaly(id: string): Promise<Anomaly> {
+  return api.patch<Anomaly>(`/v1/anomalies/${encodeURIComponent(id)}/acknowledge`);
 }

--- a/apps/portal/src/api/policies.ts
+++ b/apps/portal/src/api/policies.ts
@@ -1,8 +1,9 @@
 import { api } from './client';
 import type { Policy, CreatePolicyRequest } from './types';
 
-export function listPolicies(): Promise<Policy[]> {
-  return api.get<Policy[]>('/v1/policies');
+export async function listPolicies(): Promise<Policy[]> {
+  const res = await api.get<{ policies: Policy[]; total: number }>('/v1/policies');
+  return res.policies;
 }
 
 export function getPolicy(id: string): Promise<Policy> {

--- a/apps/portal/src/api/types.ts
+++ b/apps/portal/src/api/types.ts
@@ -75,12 +75,14 @@ export interface AuditEntry {
 // ── Policies ─────────────────────────────────────────────────────────────
 export interface Policy {
   id: string;
-  developerId: string;
   name: string;
   effect: 'allow' | 'deny';
-  scopes: string[];
-  conditions: Record<string, unknown>;
   priority: number;
+  agentId: string | null;
+  principalId: string | null;
+  scopes: string[] | null;
+  timeOfDayStart: string | null;
+  timeOfDayEnd: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -88,23 +90,25 @@ export interface Policy {
 export interface CreatePolicyRequest {
   name: string;
   effect: 'allow' | 'deny';
-  scopes: string[];
-  conditions?: Record<string, unknown>;
   priority?: number;
+  agentId?: string;
+  principalId?: string;
+  scopes?: string[];
+  timeOfDayStart?: string;
+  timeOfDayEnd?: string;
 }
 
 // ── Anomalies ────────────────────────────────────────────────────────────
 export interface Anomaly {
   id: string;
-  developerId: string;
-  type: string;
-  severity: 'low' | 'medium' | 'high' | 'critical';
+  type: 'rate_spike' | 'high_failure_rate' | 'new_principal' | 'off_hours_activity';
+  severity: 'low' | 'medium' | 'high';
+  agentId: string | null;
+  principalId: string | null;
   description: string;
-  resourceType: string;
-  resourceId: string;
   metadata: Record<string, unknown>;
-  acknowledged: boolean;
-  createdAt: string;
+  detectedAt: string;
+  acknowledgedAt: string | null;
 }
 
 // ── Compliance ───────────────────────────────────────────────────────────

--- a/apps/portal/src/pages/anomalies/AnomalyList.tsx
+++ b/apps/portal/src/pages/anomalies/AnomalyList.tsx
@@ -1,0 +1,141 @@
+import { useState, useEffect } from 'react';
+import { listAnomalies, detectAnomalies, acknowledgeAnomaly } from '../../api/anomalies';
+import type { Anomaly } from '../../api/types';
+import { useToast } from '../../store/toast';
+import { Card } from '../../components/ui/Card';
+import { Button } from '../../components/ui/Button';
+import { Badge } from '../../components/ui/Badge';
+import { Spinner } from '../../components/ui/Spinner';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { formatDateTime, truncateId } from '../../lib/format';
+
+const severityVariant = {
+  low: 'default',
+  medium: 'warning',
+  high: 'danger',
+} as const;
+
+const typeLabels: Record<Anomaly['type'], string> = {
+  rate_spike: 'Rate Spike',
+  high_failure_rate: 'High Failure Rate',
+  new_principal: 'New Principal',
+  off_hours_activity: 'Off-Hours Activity',
+};
+
+export function AnomalyList() {
+  const [anomalies, setAnomalies] = useState<Anomaly[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [detecting, setDetecting] = useState(false);
+  const { show } = useToast();
+
+  useEffect(() => {
+    listAnomalies()
+      .then(setAnomalies)
+      .catch(() => show('Failed to load anomalies', 'error'))
+      .finally(() => setLoading(false));
+  }, [show]);
+
+  async function handleDetect() {
+    setDetecting(true);
+    try {
+      const result = await detectAnomalies();
+      show(`Detection complete: ${result.total} anomal${result.total === 1 ? 'y' : 'ies'} found`, 'info');
+      // Reload the full list
+      const fresh = await listAnomalies();
+      setAnomalies(fresh);
+    } catch {
+      show('Detection failed', 'error');
+    } finally {
+      setDetecting(false);
+    }
+  }
+
+  async function handleAcknowledge(id: string) {
+    try {
+      const updated = await acknowledgeAnomaly(id);
+      setAnomalies((prev) => prev.map((a) => (a.id === id ? updated : a)));
+      show('Anomaly acknowledged', 'success');
+    } catch {
+      show('Failed to acknowledge', 'error');
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-xl font-semibold text-gx-text">Anomalies</h1>
+        <Button size="sm" variant="secondary" onClick={handleDetect} disabled={detecting}>
+          {detecting ? <Spinner className="h-4 w-4" /> : 'Run Detection'}
+        </Button>
+      </div>
+
+      {anomalies.length === 0 ? (
+        <Card>
+          <EmptyState
+            title="No anomalies detected"
+            description="Run detection to scan for unusual patterns."
+            action={
+              <Button size="sm" variant="secondary" onClick={handleDetect} disabled={detecting}>
+                Run Detection
+              </Button>
+            }
+          />
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {anomalies.map((a) => (
+            <Card key={a.id} className={a.acknowledgedAt ? 'opacity-60' : ''}>
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1.5">
+                    <Badge variant={severityVariant[a.severity]}>
+                      {a.severity}
+                    </Badge>
+                    <Badge>{typeLabels[a.type]}</Badge>
+                    {a.acknowledgedAt && (
+                      <Badge variant="success">acknowledged</Badge>
+                    )}
+                  </div>
+                  <p className="text-sm text-gx-text mb-2">{a.description}</p>
+                  <div className="flex items-center gap-4 text-xs text-gx-muted">
+                    {a.agentId && (
+                      <span>
+                        Agent: <span className="font-mono text-gx-accent2">{truncateId(a.agentId)}</span>
+                      </span>
+                    )}
+                    {a.principalId && (
+                      <span>
+                        Principal: <span className="font-mono">{a.principalId}</span>
+                      </span>
+                    )}
+                    <span>Detected: {formatDateTime(a.detectedAt)}</span>
+                    {a.acknowledgedAt && (
+                      <span>Acknowledged: {formatDateTime(a.acknowledgedAt)}</span>
+                    )}
+                  </div>
+                </div>
+                {!a.acknowledgedAt && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => handleAcknowledge(a.id)}
+                  >
+                    Acknowledge
+                  </Button>
+                )}
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/portal/src/pages/policies/PolicyForm.tsx
+++ b/apps/portal/src/pages/policies/PolicyForm.tsx
@@ -1,0 +1,237 @@
+import { useState, useEffect, type FormEvent, type KeyboardEvent } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { createPolicy, getPolicy, updatePolicy } from '../../api/policies';
+import { useToast } from '../../store/toast';
+import { Card } from '../../components/ui/Card';
+import { Button } from '../../components/ui/Button';
+import { Input } from '../../components/ui/Input';
+import { Select } from '../../components/ui/Select';
+import { Spinner } from '../../components/ui/Spinner';
+
+export function PolicyForm() {
+  const { id } = useParams<{ id: string }>();
+  const isEdit = !!id;
+  const navigate = useNavigate();
+  const { show } = useToast();
+
+  const [name, setName] = useState('');
+  const [effect, setEffect] = useState<'allow' | 'deny'>('allow');
+  const [priority, setPriority] = useState('0');
+  const [agentId, setAgentId] = useState('');
+  const [principalId, setPrincipalId] = useState('');
+  const [scopes, setScopes] = useState<string[]>([]);
+  const [scopeInput, setScopeInput] = useState('');
+  const [timeStart, setTimeStart] = useState('');
+  const [timeEnd, setTimeEnd] = useState('');
+  const [loading, setLoading] = useState(isEdit);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    getPolicy(id)
+      .then((p) => {
+        setName(p.name);
+        setEffect(p.effect);
+        setPriority(String(p.priority));
+        setAgentId(p.agentId ?? '');
+        setPrincipalId(p.principalId ?? '');
+        setScopes(p.scopes ?? []);
+        setTimeStart(p.timeOfDayStart ?? '');
+        setTimeEnd(p.timeOfDayEnd ?? '');
+      })
+      .catch(() => {
+        show('Policy not found', 'error');
+        navigate('/dashboard/policies');
+      })
+      .finally(() => setLoading(false));
+  }, [id, show, navigate]);
+
+  function addScope() {
+    const trimmed = scopeInput.trim();
+    if (trimmed && !scopes.includes(trimmed)) {
+      setScopes((prev) => [...prev, trimmed]);
+    }
+    setScopeInput('');
+  }
+
+  function removeScope(scope: string) {
+    setScopes((prev) => prev.filter((s) => s !== scope));
+  }
+
+  function handleScopeKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addScope();
+    }
+    if (e.key === 'Backspace' && !scopeInput && scopes.length > 0) {
+      setScopes((prev) => prev.slice(0, -1));
+    }
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    setSubmitting(true);
+    const data = {
+      name: name.trim(),
+      effect,
+      priority: parseInt(priority, 10) || 0,
+      ...(agentId.trim() ? { agentId: agentId.trim() } : {}),
+      ...(principalId.trim() ? { principalId: principalId.trim() } : {}),
+      ...(scopes.length > 0 ? { scopes } : {}),
+      ...(timeStart.trim() ? { timeOfDayStart: timeStart.trim() } : {}),
+      ...(timeEnd.trim() ? { timeOfDayEnd: timeEnd.trim() } : {}),
+    };
+
+    try {
+      if (isEdit) {
+        await updatePolicy(id, data);
+        show('Policy updated', 'success');
+      } else {
+        await createPolicy(data);
+        show('Policy created', 'success');
+      }
+      navigate('/dashboard/policies');
+    } catch {
+      show(isEdit ? 'Failed to update policy' : 'Failed to create policy', 'error');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl">
+      <h1 className="text-xl font-semibold text-gx-text mb-6">
+        {isEdit ? 'Edit Policy' : 'Create Policy'}
+      </h1>
+
+      <Card>
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <Input
+            id="name"
+            label="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Deny off-hours access"
+            autoFocus
+          />
+
+          <div className="grid grid-cols-2 gap-4">
+            <Select
+              id="effect"
+              label="Effect"
+              value={effect}
+              onChange={(e) => setEffect(e.target.value as 'allow' | 'deny')}
+              options={[
+                { value: 'allow', label: 'Allow' },
+                { value: 'deny', label: 'Deny' },
+              ]}
+            />
+            <Input
+              id="priority"
+              label="Priority"
+              type="number"
+              value={priority}
+              onChange={(e) => setPriority(e.target.value)}
+              placeholder="0"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Input
+              id="agentId"
+              label="Agent ID"
+              hint="optional"
+              value={agentId}
+              onChange={(e) => setAgentId(e.target.value)}
+              placeholder="ag_..."
+              className="font-mono"
+            />
+            <Input
+              id="principalId"
+              label="Principal ID"
+              hint="optional"
+              value={principalId}
+              onChange={(e) => setPrincipalId(e.target.value)}
+              placeholder="Any principal"
+              className="font-mono"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gx-text mb-1.5">
+              Scopes <span className="text-gx-muted font-normal">(optional)</span>
+            </label>
+            <div className="flex flex-wrap gap-1.5 p-2 bg-gx-bg border border-gx-border rounded-md min-h-[42px] focus-within:border-gx-accent transition-colors">
+              {scopes.map((scope) => (
+                <span
+                  key={scope}
+                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono bg-gx-accent2/10 text-gx-accent2"
+                >
+                  {scope}
+                  <button
+                    type="button"
+                    onClick={() => removeScope(scope)}
+                    className="hover:text-gx-text transition-colors"
+                  >
+                    &times;
+                  </button>
+                </span>
+              ))}
+              <input
+                value={scopeInput}
+                onChange={(e) => setScopeInput(e.target.value)}
+                onKeyDown={handleScopeKeyDown}
+                onBlur={addScope}
+                placeholder={scopes.length === 0 ? 'Applies to all scopes' : ''}
+                className="flex-1 min-w-[120px] bg-transparent text-sm text-gx-text placeholder-gx-muted/50 outline-none"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Input
+              id="timeStart"
+              label="Time-of-day start"
+              hint="optional, HH:MM"
+              type="time"
+              value={timeStart}
+              onChange={(e) => setTimeStart(e.target.value)}
+            />
+            <Input
+              id="timeEnd"
+              label="Time-of-day end"
+              hint="optional, HH:MM"
+              type="time"
+              value={timeEnd}
+              onChange={(e) => setTimeEnd(e.target.value)}
+            />
+          </div>
+
+          <div className="flex justify-end gap-3 pt-2">
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => navigate('/dashboard/policies')}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={submitting || !name.trim()}>
+              {submitting ? <Spinner className="h-4 w-4" /> : isEdit ? 'Save Changes' : 'Create Policy'}
+            </Button>
+          </div>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/apps/portal/src/pages/policies/PolicyList.tsx
+++ b/apps/portal/src/pages/policies/PolicyList.tsx
@@ -1,0 +1,176 @@
+import { useState, useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { listPolicies, deletePolicy } from '../../api/policies';
+import type { Policy } from '../../api/types';
+import { useToast } from '../../store/toast';
+import { Card } from '../../components/ui/Card';
+import { Button } from '../../components/ui/Button';
+import { Badge } from '../../components/ui/Badge';
+import { Table } from '../../components/ui/Table';
+import { Spinner } from '../../components/ui/Spinner';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { ScopePills } from '../../components/ui/ScopePills';
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog';
+import { truncateId } from '../../lib/format';
+
+export function PolicyList() {
+  const [policies, setPolicies] = useState<Policy[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [deleteTarget, setDeleteTarget] = useState<Policy | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const navigate = useNavigate();
+  const { show } = useToast();
+
+  useEffect(() => {
+    listPolicies()
+      .then(setPolicies)
+      .catch(() => show('Failed to load policies', 'error'))
+      .finally(() => setLoading(false));
+  }, [show]);
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await deletePolicy(deleteTarget.id);
+      setPolicies((prev) => prev.filter((p) => p.id !== deleteTarget.id));
+      show('Policy deleted', 'success');
+    } catch {
+      show('Failed to delete policy', 'error');
+    } finally {
+      setDeleting(false);
+      setDeleteTarget(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-xl font-semibold text-gx-text">Policies</h1>
+        <Link to="/dashboard/policies/new">
+          <Button size="sm">Create Policy</Button>
+        </Link>
+      </div>
+
+      <Card className="p-0">
+        {policies.length === 0 ? (
+          <EmptyState
+            title="No policies"
+            description="Create a policy to control agent permissions."
+            action={
+              <Link to="/dashboard/policies/new">
+                <Button size="sm">Create Policy</Button>
+              </Link>
+            }
+          />
+        ) : (
+          <div className="p-4">
+            <Table
+              data={policies}
+              rowKey={(p) => p.id}
+              columns={[
+                {
+                  key: 'priority',
+                  header: '#',
+                  className: 'w-12',
+                  render: (p) => (
+                    <span className="font-mono text-xs text-gx-muted">{p.priority}</span>
+                  ),
+                },
+                {
+                  key: 'name',
+                  header: 'Name',
+                  render: (p) => (
+                    <span className="font-medium text-gx-text">{p.name}</span>
+                  ),
+                },
+                {
+                  key: 'effect',
+                  header: 'Effect',
+                  render: (p) => (
+                    <Badge variant={p.effect === 'allow' ? 'success' : 'danger'}>
+                      {p.effect}
+                    </Badge>
+                  ),
+                },
+                {
+                  key: 'scopes',
+                  header: 'Scopes',
+                  render: (p) =>
+                    p.scopes ? (
+                      <ScopePills scopes={p.scopes} />
+                    ) : (
+                      <span className="text-xs text-gx-muted italic">all</span>
+                    ),
+                },
+                {
+                  key: 'agent',
+                  header: 'Agent',
+                  render: (p) =>
+                    p.agentId ? (
+                      <span className="font-mono text-xs text-gx-accent2">{truncateId(p.agentId)}</span>
+                    ) : (
+                      <span className="text-xs text-gx-muted italic">any</span>
+                    ),
+                },
+                {
+                  key: 'time',
+                  header: 'Time Window',
+                  render: (p) =>
+                    p.timeOfDayStart && p.timeOfDayEnd ? (
+                      <span className="font-mono text-xs text-gx-muted">
+                        {p.timeOfDayStart}–{p.timeOfDayEnd}
+                      </span>
+                    ) : (
+                      <span className="text-xs text-gx-muted italic">always</span>
+                    ),
+                },
+                {
+                  key: 'actions',
+                  header: '',
+                  className: 'text-right',
+                  render: (p) => (
+                    <div className="flex items-center justify-end gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => navigate(`/dashboard/policies/${p.id}/edit`)}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setDeleteTarget(p)}
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  ),
+                },
+              ]}
+            />
+          </div>
+        )}
+      </Card>
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleDelete}
+        title="Delete Policy"
+        message={`Are you sure you want to delete "${deleteTarget?.name}"? This action cannot be undone.`}
+        confirmLabel="Delete"
+        loading={deleting}
+      />
+    </div>
+  );
+}

--- a/apps/portal/src/routes.tsx
+++ b/apps/portal/src/routes.tsx
@@ -10,6 +10,9 @@ import { GrantList } from './pages/grants/GrantList';
 import { GrantDetail } from './pages/grants/GrantDetail';
 import { AuditLog } from './pages/audit/AuditLog';
 import { AuditDetail } from './pages/audit/AuditDetail';
+import { PolicyList } from './pages/policies/PolicyList';
+import { PolicyForm } from './pages/policies/PolicyForm';
+import { AnomalyList } from './pages/anomalies/AnomalyList';
 import { RequireAuth } from './RequireAuth';
 
 // Placeholder pages for future PRs
@@ -41,10 +44,10 @@ export const routes: RouteObject[] = [
       { path: '/dashboard/grants/:id', element: <GrantDetail /> },
       { path: '/dashboard/audit', element: <AuditLog /> },
       { path: '/dashboard/audit/:id', element: <AuditDetail /> },
-      { path: '/dashboard/policies', element: <Placeholder title="Policies" /> },
-      { path: '/dashboard/policies/new', element: <Placeholder title="Create Policy" /> },
-      { path: '/dashboard/policies/:id/edit', element: <Placeholder title="Edit Policy" /> },
-      { path: '/dashboard/anomalies', element: <Placeholder title="Anomalies" /> },
+      { path: '/dashboard/policies', element: <PolicyList /> },
+      { path: '/dashboard/policies/new', element: <PolicyForm /> },
+      { path: '/dashboard/policies/:id/edit', element: <PolicyForm /> },
+      { path: '/dashboard/anomalies', element: <AnomalyList /> },
       { path: '/dashboard/compliance', element: <Placeholder title="Compliance" /> },
       { path: '/dashboard/billing', element: <Placeholder title="Billing" /> },
       { path: '/dashboard/settings', element: <Placeholder title="Settings" /> },


### PR DESCRIPTION
## Summary

- **Policy/Anomaly type fixes**: Updated to match actual API response fields — policies have `agentId`, `principalId`, `scopes`, `timeOfDayStart`/`End`; anomalies have typed `type` enum, `detectedAt`, `acknowledgedAt`
- **API module fixes**: Both return wrapper objects (`{ policies: [...] }`, `{ anomalies: [...] }`), anomaly acknowledge is PATCH not POST
- **PolicyList**: Priority-sorted table with effect color coding (green allow / red deny), scope pills, agent/time-window columns, edit/delete actions
- **PolicyForm**: Create and edit modes with time-of-day pickers, scope multi-input, optional agent/principal filters, priority number input
- **AnomalyList**: Alert cards with severity badges (low/medium/high), human-readable type labels, description, agent/principal references, acknowledge button, "Run Detection" trigger that refreshes the list

## Verification

- `apps/portal`: `npm run typecheck` (0 errors), `npm run build` (success, 256 KB)

## Test plan

- [ ] Policy list shows priority-sorted policies with effect badges
- [ ] Create policy form with time-of-day pickers works
- [ ] Edit policy pre-fills all fields including scopes and time window
- [ ] Delete policy shows confirmation, removes from list
- [ ] Anomaly list shows severity-colored cards
- [ ] "Run Detection" triggers scan and refreshes list
- [ ] Acknowledge button marks anomaly, card dims
- [ ] Acknowledged anomalies show timestamp