### PR TITLE
feat(portal): compliance, billing & settings pages

### DIFF
--- a/apps/portal/src/api/billing.ts
+++ b/apps/portal/src/api/billing.ts
@@ -5,10 +5,16 @@ export function getSubscription(): Promise<Subscription> {
   return api.get<Subscription>('/v1/billing/subscription');
 }
 
-export function createCheckout(plan: string): Promise<{ url: string }> {
-  return api.post<{ url: string }>('/v1/billing/checkout', { plan });
+export function createCheckout(plan: string): Promise<{ checkoutUrl: string }> {
+  return api.post<{ checkoutUrl: string }>('/v1/billing/checkout', {
+    plan,
+    successUrl: `${window.location.origin}/dashboard/billing?success=true`,
+    cancelUrl: `${window.location.origin}/dashboard/billing`,
+  });
 }
 
-export function getPortalUrl(): Promise<{ url: string }> {
-  return api.post<{ url: string }>('/v1/billing/portal');
+export function getPortalUrl(): Promise<{ portalUrl: string }> {
+  return api.post<{ portalUrl: string }>('/v1/billing/portal', {
+    returnUrl: `${window.location.origin}/dashboard/billing`,
+  });
 }

--- a/apps/portal/src/api/compliance.ts
+++ b/apps/portal/src/api/compliance.ts
@@ -5,6 +5,14 @@ export function getComplianceSummary(): Promise<ComplianceSummary> {
   return api.get<ComplianceSummary>('/v1/compliance/summary');
 }
 
-export function exportComplianceReport(framework: string): Promise<Blob> {
-  return api.get<Blob>(`/v1/compliance/export?framework=${encodeURIComponent(framework)}`);
+export function exportGrants(): Promise<{ generatedAt: string; total: number; grants: unknown[] }> {
+  return api.get('/v1/compliance/export/grants');
+}
+
+export function exportAudit(): Promise<{ generatedAt: string; total: number; entries: unknown[] }> {
+  return api.get('/v1/compliance/export/audit');
+}
+
+export function exportEvidencePack(framework: string): Promise<Record<string, unknown>> {
+  return api.get(`/v1/compliance/evidence-pack?framework=${encodeURIComponent(framework)}`);
 }

--- a/apps/portal/src/api/types.ts
+++ b/apps/portal/src/api/types.ts
@@ -113,13 +113,12 @@ export interface Anomaly {
 
 // ── Compliance ───────────────────────────────────────────────────────────
 export interface ComplianceSummary {
-  totalGrants: number;
-  activeGrants: number;
-  revokedGrants: number;
-  totalAgents: number;
-  auditEntries: number;
-  anomalies: number;
-  complianceScore: number;
+  generatedAt: string;
+  agents: { total: number; active: number; suspended: number; revoked: number };
+  grants: { total: number; active: number; revoked: number; expired: number };
+  auditEntries: { total: number; success: number; failure: number; blocked: number };
+  policies: { total: number };
+  plan: string;
 }
 
 // ── Billing ──────────────────────────────────────────────────────────────

--- a/apps/portal/src/pages/billing/BillingPage.tsx
+++ b/apps/portal/src/pages/billing/BillingPage.tsx
@@ -1,0 +1,163 @@
+import { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { getSubscription, createCheckout, getPortalUrl } from '../../api/billing';
+import type { Subscription } from '../../api/types';
+import { useToast } from '../../store/toast';
+import { Card } from '../../components/ui/Card';
+import { Button } from '../../components/ui/Button';
+import { Badge } from '../../components/ui/Badge';
+import { Spinner } from '../../components/ui/Spinner';
+
+const PLANS = [
+  {
+    name: 'free',
+    label: 'Free',
+    price: '$0',
+    features: ['5 agents', '100 grants', '1,000 audit entries', 'Community support'],
+  },
+  {
+    name: 'pro',
+    label: 'Pro',
+    price: '$49/mo',
+    features: ['50 agents', '10,000 grants', '100,000 audit entries', 'Priority support', 'SOC 2 evidence packs'],
+  },
+  {
+    name: 'enterprise',
+    label: 'Enterprise',
+    price: '$249/mo',
+    features: ['Unlimited agents', 'Unlimited grants', 'Unlimited audit entries', 'Dedicated support', 'All compliance packs', 'SSO & SCIM'],
+  },
+];
+
+export function BillingPage() {
+  const [subscription, setSubscription] = useState<Subscription | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [checkingOut, setCheckingOut] = useState<string | null>(null);
+  const [openingPortal, setOpeningPortal] = useState(false);
+  const { show } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    if (searchParams.get('success') === 'true') {
+      show('Subscription activated!', 'success');
+      setSearchParams({}, { replace: true });
+    }
+  }, [searchParams, setSearchParams, show]);
+
+  useEffect(() => {
+    getSubscription()
+      .then(setSubscription)
+      .catch(() => show('Failed to load subscription', 'error'))
+      .finally(() => setLoading(false));
+  }, [show]);
+
+  async function handleCheckout(plan: string) {
+    setCheckingOut(plan);
+    try {
+      const { checkoutUrl } = await createCheckout(plan);
+      window.location.href = checkoutUrl;
+    } catch {
+      show('Failed to start checkout', 'error');
+      setCheckingOut(null);
+    }
+  }
+
+  async function handleManage() {
+    setOpeningPortal(true);
+    try {
+      const { portalUrl } = await getPortalUrl();
+      window.location.href = portalUrl;
+    } catch {
+      show('Failed to open billing portal', 'error');
+      setOpeningPortal(false);
+    }
+  }
+
+  if (loading || !subscription) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  const currentPlan = subscription.plan;
+
+  return (
+    <div>
+      <h1 className="text-xl font-semibold text-gx-text mb-6">Billing</h1>
+
+      {/* Current plan */}
+      <Card className="mb-8">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm text-gx-muted mb-1">Current Plan</p>
+            <div className="flex items-center gap-3">
+              <p className="text-2xl font-bold text-gx-text capitalize">{currentPlan}</p>
+              <Badge>{subscription.status}</Badge>
+            </div>
+            {subscription.currentPeriodEnd && (
+              <p className="text-xs text-gx-muted mt-2">
+                Current period ends {new Date(subscription.currentPeriodEnd).toLocaleDateString()}
+              </p>
+            )}
+          </div>
+          {currentPlan !== 'free' && (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleManage}
+              disabled={openingPortal}
+            >
+              {openingPortal ? <Spinner className="h-3 w-3" /> : 'Manage Subscription'}
+            </Button>
+          )}
+        </div>
+      </Card>
+
+      {/* Plan cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {PLANS.map((plan) => {
+          const isCurrent = plan.name === currentPlan;
+          const isUpgrade = !isCurrent && plan.name !== 'free';
+
+          return (
+            <Card key={plan.name}>
+              <div className="flex flex-col h-full">
+                <div className="mb-4">
+                  <div className="flex items-center gap-2 mb-1">
+                    <h3 className="text-lg font-semibold text-gx-text">{plan.label}</h3>
+                    {isCurrent && <Badge>Current</Badge>}
+                  </div>
+                  <p className="text-2xl font-bold font-mono text-gx-accent">{plan.price}</p>
+                </div>
+                <ul className="space-y-2 mb-6 flex-1">
+                  {plan.features.map((feature) => (
+                    <li key={feature} className="flex items-start gap-2 text-sm text-gx-muted">
+                      <span className="text-gx-accent mt-0.5">&#10003;</span>
+                      {feature}
+                    </li>
+                  ))}
+                </ul>
+                {isUpgrade && (
+                  <Button
+                    size="sm"
+                    onClick={() => handleCheckout(plan.name)}
+                    disabled={checkingOut === plan.name}
+                  >
+                    {checkingOut === plan.name ? <Spinner className="h-3 w-3" /> : 'Upgrade'}
+                  </Button>
+                )}
+                {isCurrent && plan.name !== 'free' && (
+                  <Button variant="secondary" size="sm" disabled>
+                    Current Plan
+                  </Button>
+                )}
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/portal/src/pages/compliance/ComplianceDashboard.tsx
+++ b/apps/portal/src/pages/compliance/ComplianceDashboard.tsx
@@ -1,0 +1,167 @@
+import { useState, useEffect } from 'react';
+import { getComplianceSummary, exportGrants, exportAudit, exportEvidencePack } from '../../api/compliance';
+import type { ComplianceSummary } from '../../api/types';
+import { useToast } from '../../store/toast';
+import { Card } from '../../components/ui/Card';
+import { Button } from '../../components/ui/Button';
+import { Badge } from '../../components/ui/Badge';
+import { Spinner } from '../../components/ui/Spinner';
+
+function downloadJson(data: unknown, filename: string) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function ComplianceDashboard() {
+  const [summary, setSummary] = useState<ComplianceSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [exporting, setExporting] = useState<string | null>(null);
+  const { show } = useToast();
+
+  useEffect(() => {
+    getComplianceSummary()
+      .then(setSummary)
+      .catch(() => show('Failed to load compliance data', 'error'))
+      .finally(() => setLoading(false));
+  }, [show]);
+
+  async function handleExport(type: string) {
+    setExporting(type);
+    try {
+      if (type === 'grants') {
+        const data = await exportGrants();
+        downloadJson(data, `grantex-grants-${Date.now()}.json`);
+      } else if (type === 'audit') {
+        const data = await exportAudit();
+        downloadJson(data, `grantex-audit-${Date.now()}.json`);
+      } else {
+        const data = await exportEvidencePack(type);
+        downloadJson(data, `grantex-evidence-${type}-${Date.now()}.json`);
+      }
+      show('Export downloaded', 'success');
+    } catch {
+      show('Export failed', 'error');
+    } finally {
+      setExporting(null);
+    }
+  }
+
+  if (loading || !summary) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-xl font-semibold text-gx-text">Compliance</h1>
+        <Badge>{summary.plan} plan</Badge>
+      </div>
+
+      {/* Summary stats */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+        <Card>
+          <p className="text-xs text-gx-muted mb-1">Agents</p>
+          <p className="text-2xl font-bold font-mono text-gx-accent2">{summary.agents.total}</p>
+          <div className="flex gap-2 mt-2 text-xs text-gx-muted">
+            <span>{summary.agents.active} active</span>
+            <span>{summary.agents.suspended} suspended</span>
+          </div>
+        </Card>
+        <Card>
+          <p className="text-xs text-gx-muted mb-1">Grants</p>
+          <p className="text-2xl font-bold font-mono text-gx-accent">{summary.grants.total}</p>
+          <div className="flex gap-2 mt-2 text-xs text-gx-muted">
+            <span>{summary.grants.active} active</span>
+            <span>{summary.grants.revoked} revoked</span>
+            <span>{summary.grants.expired} expired</span>
+          </div>
+        </Card>
+        <Card>
+          <p className="text-xs text-gx-muted mb-1">Audit Entries</p>
+          <p className="text-2xl font-bold font-mono text-gx-text">{summary.auditEntries.total}</p>
+          <div className="flex gap-2 mt-2 text-xs text-gx-muted">
+            <span className="text-gx-accent">{summary.auditEntries.success} success</span>
+            <span className="text-gx-danger">{summary.auditEntries.failure} failure</span>
+            <span className="text-gx-warning">{summary.auditEntries.blocked} blocked</span>
+          </div>
+        </Card>
+        <Card>
+          <p className="text-xs text-gx-muted mb-1">Policies</p>
+          <p className="text-2xl font-bold font-mono text-gx-text">{summary.policies.total}</p>
+        </Card>
+      </div>
+
+      {/* Exports */}
+      <Card>
+        <h2 className="text-sm font-semibold text-gx-text mb-4">Exports</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div className="flex items-center justify-between p-3 bg-gx-bg rounded-md border border-gx-border">
+            <div>
+              <p className="text-sm font-medium text-gx-text">Grants Export</p>
+              <p className="text-xs text-gx-muted">All grants with delegation info</p>
+            </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => handleExport('grants')}
+              disabled={exporting === 'grants'}
+            >
+              {exporting === 'grants' ? <Spinner className="h-3 w-3" /> : 'Download'}
+            </Button>
+          </div>
+          <div className="flex items-center justify-between p-3 bg-gx-bg rounded-md border border-gx-border">
+            <div>
+              <p className="text-sm font-medium text-gx-text">Audit Log Export</p>
+              <p className="text-xs text-gx-muted">Full audit trail with hash chain</p>
+            </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => handleExport('audit')}
+              disabled={exporting === 'audit'}
+            >
+              {exporting === 'audit' ? <Spinner className="h-3 w-3" /> : 'Download'}
+            </Button>
+          </div>
+          <div className="flex items-center justify-between p-3 bg-gx-bg rounded-md border border-gx-border">
+            <div>
+              <p className="text-sm font-medium text-gx-text">SOC 2 Evidence Pack</p>
+              <p className="text-xs text-gx-muted">Summary + grants + audit + policies + chain integrity</p>
+            </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => handleExport('soc2')}
+              disabled={exporting === 'soc2'}
+            >
+              {exporting === 'soc2' ? <Spinner className="h-3 w-3" /> : 'Download'}
+            </Button>
+          </div>
+          <div className="flex items-center justify-between p-3 bg-gx-bg rounded-md border border-gx-border">
+            <div>
+              <p className="text-sm font-medium text-gx-text">GDPR Evidence Pack</p>
+              <p className="text-xs text-gx-muted">Full evidence pack for GDPR compliance</p>
+            </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => handleExport('gdpr')}
+              disabled={exporting === 'gdpr'}
+            >
+              {exporting === 'gdpr' ? <Spinner className="h-3 w-3" /> : 'Download'}
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/apps/portal/src/pages/settings/SettingsPage.tsx
+++ b/apps/portal/src/pages/settings/SettingsPage.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { useAuth } from '../../store/auth';
+import { rotateKey } from '../../api/auth';
+import { setApiKey } from '../../api/client';
+import { useToast } from '../../store/toast';
+import { Card } from '../../components/ui/Card';
+import { Button } from '../../components/ui/Button';
+import { Badge } from '../../components/ui/Badge';
+import { Spinner } from '../../components/ui/Spinner';
+import { CopyButton } from '../../components/ui/CopyButton';
+
+export function SettingsPage() {
+  const { developer, apiKey, login } = useAuth();
+  const { show } = useToast();
+  const [rotating, setRotating] = useState(false);
+  const [newKey, setNewKey] = useState<string | null>(null);
+
+  async function handleRotateKey() {
+    setRotating(true);
+    try {
+      const { apiKey: rotatedKey } = await rotateKey();
+      setNewKey(rotatedKey);
+      // Update client and auth state with new key
+      setApiKey(rotatedKey);
+      localStorage.setItem('grantex_api_key', rotatedKey);
+      await login(rotatedKey);
+      show('API key rotated successfully', 'success');
+    } catch {
+      show('Failed to rotate API key', 'error');
+    } finally {
+      setRotating(false);
+    }
+  }
+
+  if (!developer) return null;
+
+  return (
+    <div className="max-w-2xl">
+      <h1 className="text-xl font-semibold text-gx-text mb-6">Settings</h1>
+
+      {/* Profile */}
+      <Card className="mb-6">
+        <h2 className="text-sm font-semibold text-gx-text mb-4">Profile</h2>
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-gx-muted">Developer ID</span>
+            <span className="text-sm font-mono text-gx-text">{developer.developerId}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-gx-muted">Name</span>
+            <span className="text-sm text-gx-text">{developer.name}</span>
+          </div>
+          {developer.email && (
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-gx-muted">Email</span>
+              <span className="text-sm text-gx-text">{developer.email}</span>
+            </div>
+          )}
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-gx-muted">Mode</span>
+            <Badge>{developer.mode}</Badge>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-gx-muted">Plan</span>
+            <Badge>{developer.plan}</Badge>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-gx-muted">Created</span>
+            <span className="text-sm text-gx-text">{new Date(developer.createdAt).toLocaleDateString()}</span>
+          </div>
+        </div>
+      </Card>
+
+      {/* API Key */}
+      <Card>
+        <h2 className="text-sm font-semibold text-gx-text mb-4">API Key</h2>
+
+        <div className="p-3 bg-gx-bg rounded-md border border-gx-border mb-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-xs text-gx-muted mb-1">Current Key</p>
+              <p className="text-sm font-mono text-gx-text">
+                {apiKey ? `${apiKey.slice(0, 8)}${'•'.repeat(24)}` : '••••••••••••••••'}
+              </p>
+            </div>
+            {apiKey && <CopyButton text={apiKey} />}
+          </div>
+        </div>
+
+        {newKey && (
+          <div className="p-3 bg-gx-accent/10 rounded-md border border-gx-accent/30 mb-4">
+            <p className="text-xs text-gx-accent font-semibold mb-1">New API Key (save it now!)</p>
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-sm font-mono text-gx-text break-all">{newKey}</p>
+              <CopyButton text={newKey} />
+            </div>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-gx-muted">
+            Rotating your key will invalidate the current one immediately.
+          </p>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleRotateKey}
+            disabled={rotating}
+          >
+            {rotating ? <Spinner className="h-3 w-3" /> : 'Rotate Key'}
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/apps/portal/src/routes.tsx
+++ b/apps/portal/src/routes.tsx
@@ -13,17 +13,10 @@ import { AuditDetail } from './pages/audit/AuditDetail';
 import { PolicyList } from './pages/policies/PolicyList';
 import { PolicyForm } from './pages/policies/PolicyForm';
 import { AnomalyList } from './pages/anomalies/AnomalyList';
+import { ComplianceDashboard } from './pages/compliance/ComplianceDashboard';
+import { BillingPage } from './pages/billing/BillingPage';
+import { SettingsPage } from './pages/settings/SettingsPage';
 import { RequireAuth } from './RequireAuth';
-
-// Placeholder pages for future PRs
-function Placeholder({ title }: { title: string }) {
-  return (
-    <div className="py-8">
-      <h1 className="text-xl font-semibold text-gx-text mb-2">{title}</h1>
-      <p className="text-sm text-gx-muted">Coming soon.</p>
-    </div>
-  );
-}
 
 export const routes: RouteObject[] = [
   { path: '/dashboard/login', element: <Login /> },
@@ -48,9 +41,9 @@ export const routes: RouteObject[] = [
       { path: '/dashboard/policies/new', element: <PolicyForm /> },
       { path: '/dashboard/policies/:id/edit', element: <PolicyForm /> },
       { path: '/dashboard/anomalies', element: <AnomalyList /> },
-      { path: '/dashboard/compliance', element: <Placeholder title="Compliance" /> },
-      { path: '/dashboard/billing', element: <Placeholder title="Billing" /> },
-      { path: '/dashboard/settings', element: <Placeholder title="Settings" /> },
+      { path: '/dashboard/compliance', element: <ComplianceDashboard /> },
+      { path: '/dashboard/billing', element: <BillingPage /> },
+      { path: '/dashboard/settings', element: <SettingsPage /> },
     ],
   },
   { path: '*', element: <Navigate to="/dashboard/login" replace /> },


### PR DESCRIPTION
## Summary
- **ComplianceDashboard**: summary stats (agents/grants/audit/policies with breakdowns), 4 export options (grants JSON, audit JSON, SOC 2 evidence pack, GDPR evidence pack) with client-side download
- **BillingPage**: current plan display with status badge, plan comparison cards (Free/Pro/Enterprise), Stripe Checkout upgrade flow, Stripe Customer Portal for subscription management, success redirect handling
- **SettingsPage**: developer profile display (ID, name, email, mode, plan, created date), masked API key with copy button, key rotation with new key reveal
- Fixed `ComplianceSummary` type to match actual API shape (nested objects for agents/grants/auditEntries/policies)
- Fixed billing API module with correct request bodies (`successUrl`/`cancelUrl`, `returnUrl`) and response fields (`checkoutUrl`, `portalUrl`)
- Removed placeholder components from routes — all pages now have real implementations