### PR TITLE
feat(portal): polish — error boundary, 404, skeletons, mobile sidebar, deploy

### DIFF
--- a/.github/workflows/deploy-portal.yml
+++ b/.github/workflows/deploy-portal.yml
@@ -1,0 +1,48 @@
+name: Deploy Portal
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/portal/**'
+      - 'web/**'
+      - 'firebase.json'
+      - '.firebaserc'
+      - '.github/workflows/deploy-portal.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Build & Deploy to Firebase
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/portal/package-lock.json
+
+      - name: Install portal dependencies
+        working-directory: apps/portal
+        run: npm ci
+
+      - name: Build portal
+        working-directory: apps/portal
+        run: npm run build
+
+      - name: Copy portal build to web/dashboard
+        run: |
+          mkdir -p web/dashboard
+          cp -r apps/portal/dist/* web/dashboard/
+
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          channelId: live

--- a/apps/portal/src/components/ErrorBoundary.tsx
+++ b/apps/portal/src/components/ErrorBoundary.tsx
@@ -1,0 +1,60 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { Card } from './ui/Card';
+import { Button } from './ui/Button';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen bg-gx-bg flex items-center justify-center p-6">
+          <Card className="max-w-lg w-full text-center">
+            <div className="text-4xl mb-4">!</div>
+            <h1 className="text-lg font-semibold text-gx-text mb-2">Something went wrong</h1>
+            <p className="text-sm text-gx-muted mb-4">
+              {this.state.error?.message || 'An unexpected error occurred.'}
+            </p>
+            <div className="flex justify-center gap-3">
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => this.setState({ hasError: false, error: null })}
+              >
+                Try Again
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => { window.location.href = '/dashboard'; }}
+              >
+                Go to Dashboard
+              </Button>
+            </div>
+          </Card>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/portal/src/components/layout/Shell.tsx
+++ b/apps/portal/src/components/layout/Shell.tsx
@@ -1,14 +1,19 @@
+import { useState, useCallback } from 'react';
 import { Outlet } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 import { TopBar } from './TopBar';
 import { ToastContainer } from '../ui/Toast';
 
 export function Shell() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const closeSidebar = useCallback(() => setSidebarOpen(false), []);
+
   return (
     <div className="min-h-screen bg-gx-bg">
-      <Sidebar />
-      <div className="ml-56">
-        <TopBar />
+      <Sidebar open={sidebarOpen} onClose={closeSidebar} />
+      <div className="lg:ml-56">
+        <TopBar onMenuClick={() => setSidebarOpen(true)} />
         <main className="p-6">
           <Outlet />
         </main>

--- a/apps/portal/src/components/layout/Sidebar.tsx
+++ b/apps/portal/src/components/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
 import { cn } from '../../lib/cn';
 
 const links = [
@@ -13,36 +14,72 @@ const links = [
   { to: '/dashboard/settings', label: 'Settings', icon: 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z' },
 ];
 
-export function Sidebar() {
+interface SidebarProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function Sidebar({ open, onClose }: SidebarProps) {
+  const location = useLocation();
+
+  // Close sidebar on route change (mobile)
+  useEffect(() => {
+    onClose();
+  }, [location.pathname, onClose]);
+
   return (
-    <aside className="fixed left-0 top-0 bottom-0 w-56 bg-gx-surface border-r border-gx-border flex flex-col">
-      <div className="h-14 flex items-center px-5 border-b border-gx-border">
-        <a href="/" className="font-mono text-base font-bold text-gx-accent no-underline">
-          grant<span className="text-gx-text">ex</span>
-        </a>
-      </div>
-      <nav className="flex-1 py-3 px-3 space-y-0.5 overflow-y-auto">
-        {links.map((link) => (
-          <NavLink
-            key={link.to}
-            to={link.to}
-            end={link.to === '/dashboard'}
-            className={({ isActive }) =>
-              cn(
-                'flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors',
-                isActive
-                  ? 'bg-gx-accent/10 text-gx-accent'
-                  : 'text-gx-muted hover:text-gx-text hover:bg-gx-bg',
-              )
-            }
+    <>
+      {/* Overlay (mobile only) */}
+      {open && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 lg:hidden"
+          onClick={onClose}
+        />
+      )}
+
+      {/* Sidebar */}
+      <aside
+        className={cn(
+          'fixed left-0 top-0 bottom-0 w-56 bg-gx-surface border-r border-gx-border flex flex-col z-50 transition-transform duration-200 lg:translate-x-0',
+          open ? 'translate-x-0' : '-translate-x-full',
+        )}
+      >
+        <div className="h-14 flex items-center justify-between px-5 border-b border-gx-border">
+          <a href="/" className="font-mono text-base font-bold text-gx-accent no-underline">
+            grant<span className="text-gx-text">ex</span>
+          </a>
+          <button
+            onClick={onClose}
+            className="lg:hidden text-gx-muted hover:text-gx-text transition-colors"
           >
-            <svg className="w-4.5 h-4.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d={link.icon} />
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
-            {link.label}
-          </NavLink>
-        ))}
-      </nav>
-    </aside>
+          </button>
+        </div>
+        <nav className="flex-1 py-3 px-3 space-y-0.5 overflow-y-auto">
+          {links.map((link) => (
+            <NavLink
+              key={link.to}
+              to={link.to}
+              end={link.to === '/dashboard'}
+              className={({ isActive }) =>
+                cn(
+                  'flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors',
+                  isActive
+                    ? 'bg-gx-accent/10 text-gx-accent'
+                    : 'text-gx-muted hover:text-gx-text hover:bg-gx-bg',
+                )
+              }
+            >
+              <svg className="w-4.5 h-4.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d={link.icon} />
+              </svg>
+              {link.label}
+            </NavLink>
+          ))}
+        </nav>
+      </aside>
+    </>
   );
 }

--- a/apps/portal/src/components/layout/TopBar.tsx
+++ b/apps/portal/src/components/layout/TopBar.tsx
@@ -1,19 +1,31 @@
 import { useAuth } from '../../store/auth';
 import { Badge } from '../ui/Badge';
 
-export function TopBar() {
+interface TopBarProps {
+  onMenuClick: () => void;
+}
+
+export function TopBar({ onMenuClick }: TopBarProps) {
   const { developer, logout } = useAuth();
 
   return (
     <header className="h-14 border-b border-gx-border bg-gx-surface/80 backdrop-blur-sm flex items-center justify-between px-6">
-      <div />
+      <button
+        onClick={onMenuClick}
+        className="lg:hidden text-gx-muted hover:text-gx-text transition-colors"
+      >
+        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+      <div className="hidden lg:block" />
       <div className="flex items-center gap-4">
         {developer && (
           <>
             <Badge variant={developer.mode === 'live' ? 'success' : 'warning'}>
               {developer.mode}
             </Badge>
-            <span className="text-sm text-gx-muted">{developer.name}</span>
+            <span className="text-sm text-gx-muted hidden sm:inline">{developer.name}</span>
           </>
         )}
         <button

--- a/apps/portal/src/components/ui/Skeleton.tsx
+++ b/apps/portal/src/components/ui/Skeleton.tsx
@@ -1,0 +1,72 @@
+import { cn } from '../../lib/cn';
+
+interface SkeletonProps {
+  className?: string;
+}
+
+export function Skeleton({ className }: SkeletonProps) {
+  return (
+    <div
+      className={cn(
+        'animate-pulse rounded-md bg-gx-border/40',
+        className,
+      )}
+    />
+  );
+}
+
+export function SkeletonCard() {
+  return (
+    <div className="bg-gx-surface border border-gx-border rounded-lg p-6">
+      <Skeleton className="h-3 w-24 mb-3" />
+      <Skeleton className="h-8 w-16 mb-3" />
+      <div className="flex gap-2">
+        <Skeleton className="h-3 w-16" />
+        <Skeleton className="h-3 w-16" />
+      </div>
+    </div>
+  );
+}
+
+export function SkeletonTable({ rows = 5 }: { rows?: number }) {
+  return (
+    <div className="bg-gx-surface border border-gx-border rounded-lg overflow-hidden">
+      <div className="border-b border-gx-border p-4">
+        <div className="flex gap-4">
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-3 w-32" />
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-3 w-16" />
+        </div>
+      </div>
+      {Array.from({ length: rows }, (_, i) => (
+        <div key={i} className="border-b border-gx-border/50 p-4">
+          <div className="flex gap-4">
+            <Skeleton className="h-3 w-28" />
+            <Skeleton className="h-3 w-36" />
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="h-3 w-14" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function PageSkeleton() {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <Skeleton className="h-6 w-32" />
+        <Skeleton className="h-8 w-24 rounded-md" />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+        <SkeletonCard />
+        <SkeletonCard />
+        <SkeletonCard />
+        <SkeletonCard />
+      </div>
+      <SkeletonTable />
+    </div>
+  );
+}

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { AuthProvider } from './store/auth';
 import { ToastProvider } from './store/toast';
 import { App } from './App';
@@ -8,12 +9,14 @@ import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <AuthProvider>
-        <ToastProvider>
-          <App />
-        </ToastProvider>
-      </AuthProvider>
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <AuthProvider>
+          <ToastProvider>
+            <App />
+          </ToastProvider>
+        </AuthProvider>
+      </BrowserRouter>
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/apps/portal/src/pages/NotFound.tsx
+++ b/apps/portal/src/pages/NotFound.tsx
@@ -1,0 +1,22 @@
+import { useNavigate } from 'react-router-dom';
+import { Card } from '../components/ui/Card';
+import { Button } from '../components/ui/Button';
+
+export function NotFound() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex items-center justify-center py-20">
+      <Card className="max-w-md w-full text-center">
+        <p className="text-5xl font-bold font-mono text-gx-muted mb-2">404</p>
+        <h1 className="text-lg font-semibold text-gx-text mb-2">Page not found</h1>
+        <p className="text-sm text-gx-muted mb-6">
+          The page you're looking for doesn't exist or has been moved.
+        </p>
+        <Button size="sm" onClick={() => navigate('/dashboard')}>
+          Back to Dashboard
+        </Button>
+      </Card>
+    </div>
+  );
+}

--- a/apps/portal/src/routes.tsx
+++ b/apps/portal/src/routes.tsx
@@ -1,4 +1,4 @@
-import { Navigate, type RouteObject } from 'react-router-dom';
+import { type RouteObject } from 'react-router-dom';
 import { Shell } from './components/layout/Shell';
 import { Login } from './pages/Login';
 import { Signup } from './pages/Signup';
@@ -16,6 +16,7 @@ import { AnomalyList } from './pages/anomalies/AnomalyList';
 import { ComplianceDashboard } from './pages/compliance/ComplianceDashboard';
 import { BillingPage } from './pages/billing/BillingPage';
 import { SettingsPage } from './pages/settings/SettingsPage';
+import { NotFound } from './pages/NotFound';
 import { RequireAuth } from './RequireAuth';
 
 export const routes: RouteObject[] = [
@@ -44,7 +45,8 @@ export const routes: RouteObject[] = [
       { path: '/dashboard/compliance', element: <ComplianceDashboard /> },
       { path: '/dashboard/billing', element: <BillingPage /> },
       { path: '/dashboard/settings', element: <SettingsPage /> },
+      { path: '/dashboard/*', element: <NotFound /> },
     ],
   },
-  { path: '*', element: <Navigate to="/dashboard/login" replace /> },
+  { path: '*', element: <NotFound /> },
 ];


### PR DESCRIPTION
## Summary
- **ErrorBoundary**: class component wrapping the entire app, catches render errors with a recovery UI (try again / go to dashboard)
- **404 page**: proper NotFound component for unmatched routes, both inside the authenticated Shell and at the top level
- **Skeleton components**: `Skeleton`, `SkeletonCard`, `SkeletonTable`, `PageSkeleton` — reusable loading placeholders with pulse animation
- **Mobile responsive sidebar**: collapsible sidebar with hamburger toggle in TopBar, overlay backdrop on mobile, auto-close on navigation; desktop sidebar unchanged (`lg:` breakpoint)
- **Deploy workflow**: `deploy-portal.yml` — builds portal, copies to `web/dashboard/`, deploys to Firebase Hosting on push to main

## Test plan
- [ ] `npm run typecheck` passes (0 errors)
- [ ] `npm run build` succeeds
- [ ] Navigate to `/dashboard/nonexistent` — shows 404 page within Shell
- [ ] Navigate to `/random-path` — shows 404 page
- [ ] Resize browser below `lg` breakpoint — sidebar collapses, hamburger appears
- [ ] Click hamburger — sidebar slides in with overlay, click link — sidebar closes
- [ ] Trigger a render error — ErrorBoundary catches it with recovery options