### PR TITLE
fix(auth): add startup migration runner

### DIFF
--- a/apps/auth-service/package.json
+++ b/apps/auth-service/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "node --env-file=.env --watch dist/index.js",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && node -e \"const{cpSync}=require('fs');cpSync('src/db/migrations','dist/db/migrations',{recursive:true})\"",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/apps/auth-service/src/db/migrate.ts
+++ b/apps/auth-service/src/db/migrate.ts
@@ -1,0 +1,20 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type postgres from 'postgres';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(__dirname, 'migrations');
+
+export async function runMigrations(sql: ReturnType<typeof postgres>): Promise<void> {
+  const files = readdirSync(migrationsDir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+
+  for (const file of files) {
+    const content = readFileSync(join(migrationsDir, file), 'utf-8');
+    await sql.unsafe(content);
+  }
+
+  console.log(`Migrations: applied ${files.length} files`);
+}

--- a/apps/auth-service/src/index.ts
+++ b/apps/auth-service/src/index.ts
@@ -1,6 +1,7 @@
 import { config } from './config.js';
 import { initKeys } from './lib/crypto.js';
 import { getSql } from './db/client.js';
+import { runMigrations } from './db/migrate.js';
 import { getRedis } from './redis/client.js';
 import { buildApp } from './server.js';
 import { hashApiKey } from './lib/hash.js';
@@ -12,6 +13,9 @@ async function main() {
 
   // Initialize DB connection
   const sql = getSql();
+
+  // Run migrations (idempotent — safe to re-run on every startup)
+  await runMigrations(sql);
 
   // Initialize Redis connection
   const redis = getRedis();


### PR DESCRIPTION
## Summary
- Adds `src/db/migrate.ts` — reads all `*.sql` files from `src/db/migrations/` and runs them via `sql.unsafe()` at startup
- All migrations are idempotent (`CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`) so safe to re-run every startup
- Updated `index.ts` to call `runMigrations(sql)` before seed logic
- Updated build script to copy `src/db/migrations/*.sql` to `dist/db/migrations/`
- Restores `d.email` in `/v1/me` query (was removed as workaround for missing column)

## Why
Production Cloud SQL was missing the `email` column (migration 009) causing `/v1/me` to fail, which blocks the portal login flow. Previously migrations were applied manually with no runner, making it easy for production to drift behind.

## Test plan
- [ ] All 184 auth service tests pass
- [ ] `npm run build` copies SQL files to `dist/db/migrations/`
- [ ] After deploy, `/v1/me` returns developer info with the seed API key