### PR TITLE
feat: add favicon

### DIFF
--- a/apps/portal/index.html
+++ b/apps/portal/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Grantex Dashboard</title>
+    <link rel="icon" type="image/svg+xml" href="/dashboard/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />

--- a/apps/portal/public/favicon.svg
+++ b/apps/portal/public/favicon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="glow" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3fb950"/>
+      <stop offset="100%" stop-color="#2ea043"/>
+    </linearGradient>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="0" stdDeviation="8" flood-color="#3fb950" flood-opacity="0.4"/>
+    </filter>
+  </defs>
+
+  <!-- Dark background circle -->
+  <circle cx="256" cy="256" r="248" fill="#0d1117"/>
+  <circle cx="256" cy="256" r="248" fill="none" stroke="#1e2733" stroke-width="4"/>
+
+  <!-- Shield outline — green with glow -->
+  <path d="M256 72 L416 160 L416 304 C416 380 340 440 256 468 C172 440 96 380 96 304 L96 160 Z"
+        fill="none" stroke="url(#glow)" stroke-width="16" stroke-linejoin="round"
+        filter="url(#shadow)"/>
+
+  <!-- Checkmark inside shield -->
+  <polyline points="188,256 236,312 332,200"
+            fill="none" stroke="#3fb950" stroke-width="28" stroke-linecap="round" stroke-linejoin="round"
+            filter="url(#shadow)"/>
+</svg>

--- a/web/favicon.svg
+++ b/web/favicon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="glow" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3fb950"/>
+      <stop offset="100%" stop-color="#2ea043"/>
+    </linearGradient>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="0" stdDeviation="8" flood-color="#3fb950" flood-opacity="0.4"/>
+    </filter>
+  </defs>
+
+  <!-- Dark background circle -->
+  <circle cx="256" cy="256" r="248" fill="#0d1117"/>
+  <circle cx="256" cy="256" r="248" fill="none" stroke="#1e2733" stroke-width="4"/>
+
+  <!-- Shield outline — green with glow -->
+  <path d="M256 72 L416 160 L416 304 C416 380 340 440 256 468 C172 440 96 380 96 304 L96 160 Z"
+        fill="none" stroke="url(#glow)" stroke-width="16" stroke-linejoin="round"
+        filter="url(#shadow)"/>
+
+  <!-- Checkmark inside shield -->
+  <polyline points="188,256 236,312 332,200"
+            fill="none" stroke="#3fb950" stroke-width="28" stroke-linecap="round" stroke-linejoin="round"
+            filter="url(#shadow)"/>
+</svg>

--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,7 @@
   <!-- SEO -->
   <title>Grantex — OAuth 2.0 for AI Agents</title>
   <meta name="description" content="Open delegated authorization protocol for AI agents. Verifiable, revocable, audited grants built on JWT and OAuth 2.0.">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="canonical" href="https://grantex.dev/">
 
   <!-- OpenGraph -->


### PR DESCRIPTION
## Summary

- Add SVG favicon (green shield + checkmark on dark bg) matching grantex.dev color scheme
- Wire favicon into landing page (`web/index.html`) and developer portal (`apps/portal/index.html`)

## Test plan

- [ ] Open grantex.dev — favicon shows in browser tab
- [ ] Open grantex.dev/dashboard — same favicon shows