### PR TITLE
fix(docs): correct Python SDK quickstart and CLI README

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -38,6 +38,7 @@ grantex config show
 grantex agents list
 grantex agents register --name travel-booker --scopes calendar:read,payments:initiate
 grantex agents get ag_01ABC...
+grantex agents update ag_01ABC... --name new-name --scopes calendar:read,email:send
 grantex agents delete ag_01ABC...
 ```
 

--- a/packages/sdk-py/README.md
+++ b/packages/sdk-py/README.md
@@ -28,19 +28,20 @@ request = client.authorize(AuthorizeParams(
     scopes=["files:read", "email:send"],
 ))
 
-# Redirect the user to the consent page
+# Redirect the user to the consent page — they approve in plain language
 print(request.consent_url)
 
-# 2. Exchange for a grant token (after user approves)
-token = client.tokens.create(auth_request_id=request.auth_request_id)
-print(token.grant_token)  # RS256-signed JWT
+# 2. Verify the grant token (offline, no network call)
+from grantex import verify_grant_token
 
-# 3. Verify a token (online)
-result = client.tokens.verify(token.grant_token)
-print(result.scopes)  # ['files:read', 'email:send']
+grant = verify_grant_token(
+    token=grant_token,  # RS256-signed JWT received after user approves
+    jwks_url="https://api.grantex.dev/.well-known/jwks.json",
+)
+print(grant.scopes)  # ['files:read', 'email:send']
 
-# 4. Revoke when done
-client.tokens.revoke(token.grant_token)
+# 3. Revoke when done
+client.tokens.revoke(grant.token_id)
 ```
 
 ## Offline verification


### PR DESCRIPTION
## Summary

- **Python SDK README**: The quickstart showed `client.tokens.create()` which doesn't exist in the SDK. Replaced with the correct `verify_grant_token()` offline verification flow, matching the TypeScript SDK pattern.
- **CLI README**: Added missing `grantex agents update` command documentation.

## Test plan

- [ ] Verify Python SDK quickstart code matches actual API surface
- [ ] Verify CLI agents section lists all implemented commands