### PR TITLE
chore: bump integration packages to 0.1.1

### DIFF
--- a/packages/autogen/package.json
+++ b/packages/autogen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/autogen",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "AutoGen / OpenAI function-calling integration for the Grantex delegated authorization protocol",
   "type": "module",
   "exports": {
@@ -12,7 +12,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@grantex/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CLI tool for local Grantex development",
   "type": "module",
   "bin": {
     "grantex": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/langchain",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "LangChain integration for the Grantex delegated authorization protocol",
   "type": "module",
   "exports": {
@@ -12,7 +12,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/vercel-ai",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Vercel AI SDK integration for the Grantex delegated authorization protocol",
   "type": "module",
   "exports": {
@@ -12,7 +12,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",


### PR DESCRIPTION
## Summary

- Bump `@grantex/langchain`, `@grantex/autogen`, `@grantex/vercel-ai`, and `@grantex/cli` from 0.1.0 to 0.1.1
- Add `README.md` to the `files` array so documentation displays on npmjs.com
- All four packages republished to npm