### PR TITLE
chore: gitignore web/dashboard build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ build/
 
 # Firebase
 .firebase/
+web/dashboard/
 
 # Coverage & caches
 coverage/


### PR DESCRIPTION
## Summary

- Add `web/dashboard/` to `.gitignore` — this is the compiled portal output copied during Firebase deploys, not source code
- Discarded `.firebaserc` auto-formatting drift from Firebase CLI