### PR TITLE
feat: add example apps and GitHub repo polish

### DIFF
--- a/assets/social-preview.svg
+++ b/assets/social-preview.svg
@@ -1,0 +1,8 @@
+<svg width="1280" height="640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1280" height="640" fill="#0d1117"/>
+  <rect x="0" y="0" width="1280" height="4" fill="#3fb950"/>
+  <text x="640" y="260" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="96" font-weight="700" fill="#e6edf3">Grantex</text>
+  <text x="640" y="340" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="32" fill="#8b949e">Delegated authorization for AI agents</text>
+  <text x="640" y="420" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="22" fill="#3fb950">OAuth 2.0 for agents  ·  Offline-verifiable JWTs  ·  Tamper-proof audit trails</text>
+  <text x="640" y="560" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="20" fill="#484f58">grantex.dev</text>
+</svg>

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,49 @@
+# Grantex Examples
+
+Runnable examples showing how to use the Grantex SDK and framework integrations.
+
+## Prerequisites
+
+- **Node.js 18+**
+- **Docker** (for the local Grantex stack)
+
+## Start the local stack
+
+From the repo root:
+
+```bash
+docker compose up -d
+```
+
+This starts PostgreSQL, Redis, and the Grantex auth service on `http://localhost:3001`. Two API keys are seeded automatically:
+
+| Key | Mode | Purpose |
+|---|---|---|
+| `dev-api-key-local` | live | Full consent flow with redirect |
+| `sandbox-api-key-local` | sandbox | Auto-approved — no consent UI needed |
+
+All examples use the sandbox key by default.
+
+## Examples
+
+| Example | Description | Key packages |
+|---|---|---|
+| [`quickstart-ts`](./quickstart-ts/) | Core authorization flow — register, authorize, token, verify, audit, revoke | `@grantex/sdk` |
+| [`langchain-agent`](./langchain-agent/) | LangChain agent with scoped tools and audit callbacks | `@grantex/sdk`, `@grantex/langchain` |
+| [`vercel-ai-chatbot`](./vercel-ai-chatbot/) | Vercel AI SDK tools with scope enforcement and audit logging | `@grantex/sdk`, `@grantex/vercel-ai` |
+
+## Running an example
+
+```bash
+cd examples/<example-name>
+npm install
+npm start
+```
+
+Each example has its own README with expected output and environment variable options.
+
+## Notes
+
+- **Sandbox mode** auto-approves authorization requests so you can test the full token lifecycle without a consent UI.
+- The **LangChain** and **Vercel AI** examples work without an `OPENAI_API_KEY` — they invoke tools directly to demonstrate the Grantex integration. Set the key to use a real LLM.
+- All examples point at `http://localhost:3001` by default. Override with the `GRANTEX_URL` environment variable.

--- a/examples/langchain-agent/README.md
+++ b/examples/langchain-agent/README.md
@@ -1,0 +1,63 @@
+# Grantex + LangChain — Scoped Tools with Audit Logging
+
+Demo of a LangChain agent using Grantex-scoped tools and automatic audit logging.
+
+## What it does
+
+1. Registers an agent with `calendar:read` and `email:send` scopes
+2. Gets a grant token via the sandbox flow (no consent UI)
+3. Creates two scoped tools using `createGrantexTool` (calendar read + email send)
+4. Sets up `GrantexAuditHandler` for automatic tool invocation logging
+5. Invokes tools and logs each action to the audit trail
+6. Demonstrates scope enforcement — attempting to create a tool with an unauthorized scope fails immediately
+
+## Prerequisites
+
+- Node.js 18+
+- Docker (for the local Grantex stack)
+
+**Optional**: Set `OPENAI_API_KEY` to use a real LLM. Without it, the example invokes tools directly to demonstrate the Grantex integration.
+
+## Run
+
+```bash
+# Start the local Grantex stack (from repo root)
+docker compose up -d
+
+# Run the example
+cd examples/langchain-agent
+npm install
+npm start
+```
+
+## Expected output
+
+```
+Agent registered: ag_01...
+Grant token received, grantId: grnt_01...
+Tools created: read_calendar, send_email
+Audit handler configured
+
+--- Invoking read_calendar ---
+Result: {"events":[{"title":"Team standup","time":"9:00 AM",...}]}
+
+--- Invoking send_email ---
+Result: Email sent successfully: "Meeting summary: ..."
+
+--- Testing scope enforcement ---
+Scope check blocked unauthorized tool: Grantex: agent is not authorized for scope 'account:delete'. ...
+
+--- Audit trail ---
+  [success] tool:read_calendar — 2026-02-27T...
+  [success] tool:send_email — 2026-02-27T...
+
+Done! LangChain integration demo complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `GRANTEX_URL` | `http://localhost:3001` | Auth service base URL |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key (sandbox mode) |
+| `OPENAI_API_KEY` | — | OpenAI key (optional, for real LLM agent) |

--- a/examples/langchain-agent/package.json
+++ b/examples/langchain-agent/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "grantex-langchain-agent",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "npx tsx src/index.ts"
+  },
+  "dependencies": {
+    "@grantex/sdk": "^0.1.1",
+    "@grantex/langchain": "^0.1.1",
+    "@langchain/core": "^0.3.0",
+    "@langchain/openai": "^0.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/examples/langchain-agent/src/index.ts
+++ b/examples/langchain-agent/src/index.ts
@@ -1,0 +1,152 @@
+/**
+ * Grantex + LangChain — Scoped Tools with Audit Logging
+ *
+ * Shows a LangChain agent using Grantex-scoped tools:
+ *   1. Register agent & get a grant token (sandbox flow)
+ *   2. Create scoped tools via createGrantexTool
+ *   3. Attach GrantexAuditHandler for automatic audit logging
+ *   4. Invoke tools and inspect the audit trail
+ *
+ * Prerequisites:
+ *   docker compose up          # from repo root
+ *   cd examples/langchain-agent
+ *   npm install && npm start
+ *
+ * Optional: Set OPENAI_API_KEY to use a real LLM agent.
+ * Without it, this example directly invokes the tools to demonstrate
+ * Grantex scope enforcement and audit logging.
+ */
+
+import { Grantex } from '@grantex/sdk';
+import { createGrantexTool, GrantexAuditHandler } from '@grantex/langchain';
+
+const BASE_URL = process.env['GRANTEX_URL'] ?? 'http://localhost:3001';
+const API_KEY = process.env['GRANTEX_API_KEY'] ?? 'sandbox-api-key-local';
+
+async function getGrantToken(
+  grantex: Grantex,
+  agentId: string,
+): Promise<{ grantToken: string; grantId: string }> {
+  const authRequest = await grantex.authorize({
+    agentId,
+    userId: 'test-user-001',
+    scopes: ['calendar:read', 'email:send'],
+  });
+
+  const code = (authRequest as unknown as Record<string, unknown>)['code'] as string;
+  if (!code) throw new Error('No code returned — use the sandbox API key.');
+
+  const res = await fetch(`${BASE_URL}/v1/token`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ code, agentId }),
+  });
+  if (!res.ok) throw new Error(`Token exchange failed: ${await res.text()}`);
+  return res.json() as Promise<{ grantToken: string; grantId: string }>;
+}
+
+async function main(): Promise<void> {
+  const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
+
+  // ── 1. Register agent & get grant token ────────────────────────────
+  const agent = await grantex.agents.register({
+    name: 'langchain-demo-agent',
+    description: 'Demo LangChain agent with Grantex authorization',
+    scopes: ['calendar:read', 'email:send'],
+  });
+  console.log('Agent registered:', agent.id);
+
+  const { grantToken, grantId } = await getGrantToken(grantex, agent.id);
+  console.log('Grant token received, grantId:', grantId);
+
+  // ── 2. Create scoped tools ─────────────────────────────────────────
+  const calendarTool = createGrantexTool({
+    name: 'read_calendar',
+    description: "Read the user's upcoming calendar events",
+    grantToken,
+    requiredScope: 'calendar:read',
+    func: async (input: string) => {
+      // Simulated calendar API call
+      return JSON.stringify({
+        events: [
+          { title: 'Team standup', time: '9:00 AM', query: input },
+          { title: 'Design review', time: '2:00 PM', query: input },
+        ],
+      });
+    },
+  });
+
+  const emailTool = createGrantexTool({
+    name: 'send_email',
+    description: 'Send an email on behalf of the user',
+    grantToken,
+    requiredScope: 'email:send',
+    func: async (input: string) => {
+      // Simulated email API call
+      return `Email sent successfully: "${input}"`;
+    },
+  });
+
+  console.log('Tools created: read_calendar, send_email');
+
+  // ── 3. Set up audit handler ────────────────────────────────────────
+  const auditHandler = new GrantexAuditHandler({
+    client: grantex,
+    agentId: agent.id,
+    grantToken,
+  });
+  console.log('Audit handler configured');
+
+  // ── 4. Invoke tools directly ───────────────────────────────────────
+  // In a full LangChain agent, the LLM selects and calls these tools.
+  // Here we invoke them directly to show the Grantex integration.
+
+  console.log('\n--- Invoking read_calendar ---');
+  const calendarResult = await calendarTool.invoke('today');
+  console.log('Result:', calendarResult);
+
+  // Manually fire the audit handler to simulate what LangChain would do
+  await auditHandler.handleToolStart({ name: 'read_calendar' }, 'today');
+
+  console.log('\n--- Invoking send_email ---');
+  const emailResult = await emailTool.invoke(
+    'Meeting summary: standup at 9 AM, design review at 2 PM',
+  );
+  console.log('Result:', emailResult);
+  await auditHandler.handleToolStart(
+    { name: 'send_email' },
+    'Meeting summary: standup at 9 AM, design review at 2 PM',
+  );
+
+  // ── 5. Demonstrate scope enforcement ───────────────────────────────
+  console.log('\n--- Testing scope enforcement ---');
+  try {
+    createGrantexTool({
+      name: 'delete_account',
+      description: 'Delete the user account',
+      grantToken,
+      requiredScope: 'account:delete', // not in our grant!
+      func: async () => 'deleted',
+    });
+    console.log('ERROR: should have thrown');
+  } catch (err) {
+    console.log('Scope check blocked unauthorized tool:', (err as Error).message);
+  }
+
+  // ── 6. Inspect audit trail ─────────────────────────────────────────
+  console.log('\n--- Audit trail ---');
+  const auditLog = await grantex.audit.list({ agentId: agent.id, grantId });
+  for (const entry of auditLog.entries) {
+    console.log(`  [${entry.status}] ${entry.action} — ${entry.timestamp}`);
+  }
+
+  console.log('\nDone! LangChain integration demo complete.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/langchain-agent/tsconfig.json
+++ b/examples/langchain-agent/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/examples/quickstart-ts/README.md
+++ b/examples/quickstart-ts/README.md
@@ -1,0 +1,55 @@
+# Grantex Quickstart — Basic Authorization Flow
+
+End-to-end demo of the core Grantex authorization lifecycle using the TypeScript SDK with zero framework dependencies.
+
+## What it does
+
+1. Registers an agent with `calendar:read` and `email:send` scopes
+2. Initiates authorization in sandbox mode (auto-approved, no consent UI)
+3. Exchanges the authorization code for a grant token (JWT)
+4. Verifies the token offline using the local JWKS endpoint
+5. Logs an audit entry for a simulated calendar read
+6. Revokes the token and confirms revocation
+
+## Prerequisites
+
+- Node.js 18+
+- Docker (for the local Grantex stack)
+
+## Run
+
+```bash
+# Start the local Grantex stack (from repo root)
+docker compose up -d
+
+# Run the example
+cd examples/quickstart-ts
+npm install
+npm start
+```
+
+## Expected output
+
+```
+Agent registered: ag_01... did:grantex:ag_01...
+Auth request: areq_01...
+Sandbox auto-approved, code: 01J...
+Grant token received, grantId: grnt_01...
+Scopes: calendar:read, email:send
+Token verified offline:
+  principalId: test-user-001
+  agentDid:    did:grantex:ag_01...
+  scopes:      calendar:read, email:send
+Audit entry logged: aud_01...
+Token revoked.
+Post-revocation verify: revoked
+
+Done! Full authorization lifecycle complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `GRANTEX_URL` | `http://localhost:3001` | Auth service base URL |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key (sandbox mode) |

--- a/examples/quickstart-ts/package.json
+++ b/examples/quickstart-ts/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "grantex-quickstart-ts",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "npx tsx src/index.ts"
+  },
+  "dependencies": {
+    "@grantex/sdk": "^0.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/examples/quickstart-ts/src/index.ts
+++ b/examples/quickstart-ts/src/index.ts
@@ -1,0 +1,108 @@
+/**
+ * Grantex Quickstart — Basic Authorization Flow
+ *
+ * Shows the core Grantex flow with no framework dependencies:
+ *   1. Register an agent
+ *   2. Authorize in sandbox mode (auto-approved)
+ *   3. Exchange code for a grant token
+ *   4. Verify the token offline
+ *   5. Log an audit entry
+ *   6. Revoke the token
+ *
+ * Prerequisites:
+ *   docker compose up          # from repo root
+ *   cd examples/quickstart-ts
+ *   npm install && npm start
+ */
+
+import { Grantex, verifyGrantToken } from '@grantex/sdk';
+
+const BASE_URL = process.env['GRANTEX_URL'] ?? 'http://localhost:3001';
+const API_KEY = process.env['GRANTEX_API_KEY'] ?? 'sandbox-api-key-local';
+
+async function main(): Promise<void> {
+  const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
+
+  // ── 1. Register an agent ───────────────────────────────────────────
+  const agent = await grantex.agents.register({
+    name: 'quickstart-agent',
+    description: 'Demo agent for the Grantex quickstart',
+    scopes: ['calendar:read', 'email:send'],
+  });
+  console.log('Agent registered:', agent.id, agent.did);
+
+  // ── 2. Authorize (sandbox mode — auto-approved) ────────────────────
+  const authRequest = await grantex.authorize({
+    agentId: agent.id,
+    userId: 'test-user-001',
+    scopes: ['calendar:read', 'email:send'],
+  });
+  console.log('Auth request:', authRequest.authRequestId);
+
+  // In sandbox mode the response includes a `code` we can exchange immediately.
+  // The SDK types don't include the sandbox-only fields, so we cast.
+  const code = (authRequest as unknown as Record<string, unknown>)['code'] as string;
+  if (!code) {
+    console.error('No code returned — are you using the sandbox API key?');
+    process.exit(1);
+  }
+  console.log('Sandbox auto-approved, code:', code);
+
+  // ── 3. Exchange code for a grant token ─────────────────────────────
+  // POST /v1/token is not part of the SDK surface, so we use fetch directly.
+  const tokenRes = await fetch(`${BASE_URL}/v1/token`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ code, agentId: agent.id }),
+  });
+  if (!tokenRes.ok) {
+    console.error('Token exchange failed:', await tokenRes.text());
+    process.exit(1);
+  }
+  const token = (await tokenRes.json()) as {
+    grantToken: string;
+    expiresAt: string;
+    scopes: string[];
+    grantId: string;
+  };
+  console.log('Grant token received, grantId:', token.grantId);
+  console.log('Scopes:', token.scopes.join(', '));
+
+  // ── 4. Verify the token offline ────────────────────────────────────
+  const verified = await verifyGrantToken(token.grantToken, {
+    jwksUri: `${BASE_URL}/.well-known/jwks.json`,
+    requiredScopes: ['calendar:read'],
+  });
+  console.log('Token verified offline:');
+  console.log('  principalId:', verified.principalId);
+  console.log('  agentDid:   ', verified.agentDid);
+  console.log('  scopes:     ', verified.scopes.join(', '));
+
+  // ── 5. Log an audit entry ──────────────────────────────────────────
+  const entry = await grantex.audit.log({
+    agentId: agent.id,
+    grantId: token.grantId,
+    action: 'calendar.read',
+    status: 'success',
+    metadata: { query: 'today', results: 3 },
+  });
+  console.log('Audit entry logged:', entry.entryId);
+
+  // ── 6. Revoke the token ────────────────────────────────────────────
+  await grantex.tokens.revoke(verified.tokenId);
+  console.log('Token revoked.');
+
+  // Verify revocation — online check should now say invalid
+  const check = await grantex.tokens.verify(token.grantToken);
+  console.log('Post-revocation verify:', check.valid ? 'still valid' : 'revoked');
+
+  console.log('\nDone! Full authorization lifecycle complete.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/quickstart-ts/tsconfig.json
+++ b/examples/quickstart-ts/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/examples/vercel-ai-chatbot/README.md
+++ b/examples/vercel-ai-chatbot/README.md
@@ -1,0 +1,66 @@
+# Grantex + Vercel AI SDK — Scoped Tools with Audit Logging
+
+Demo of Vercel AI SDK tools with Grantex scope enforcement and audit logging.
+
+## What it does
+
+1. Registers an agent with `calendar:read` and `email:send` scopes
+2. Gets a grant token via the sandbox flow (no consent UI)
+3. Creates two Vercel AI tools with Zod schemas and Grantex scope checks
+4. Wraps tools with `withAuditLogging` for automatic audit trail entries
+5. Invokes tools via `generateText` (with OpenAI) or directly (without)
+6. Demonstrates `GrantexScopeError` thrown at construction time when a scope is missing
+
+## Prerequisites
+
+- Node.js 18+
+- Docker (for the local Grantex stack)
+
+**Optional**: Set `OPENAI_API_KEY` to use `generateText` with a real LLM. Without it, the example invokes tools directly to demonstrate scope enforcement and audit logging.
+
+## Run
+
+```bash
+# Start the local Grantex stack (from repo root)
+docker compose up -d
+
+# Run the example
+cd examples/vercel-ai-chatbot
+npm install
+npm start
+
+# Or with a real LLM:
+OPENAI_API_KEY=sk-... npm start
+```
+
+## Expected output
+
+```
+Agent registered: ag_01...
+Grant token received, grantId: grnt_01...
+Tools created: read_calendar, send_email
+Audit logging attached
+
+--- Invoking tools directly (no OPENAI_API_KEY set) ---
+Calendar result: {"date":"today","events":[...]}
+Email result: {"sent":true,"to":"alice@example.com",...}
+
+--- Testing scope enforcement ---
+GrantexScopeError caught:
+  Required scope:  storage:delete
+  Granted scopes:  calendar:read, email:send
+
+--- Audit trail ---
+  [success] tool:read_calendar — 2026-02-27T...
+  [success] tool:send_email — 2026-02-27T...
+
+Done! Vercel AI integration demo complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `GRANTEX_URL` | `http://localhost:3001` | Auth service base URL |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key (sandbox mode) |
+| `OPENAI_API_KEY` | — | OpenAI key (optional, enables `generateText`) |

--- a/examples/vercel-ai-chatbot/package.json
+++ b/examples/vercel-ai-chatbot/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "grantex-vercel-ai-chatbot",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "npx tsx src/index.ts"
+  },
+  "dependencies": {
+    "@grantex/sdk": "^0.1.1",
+    "@grantex/vercel-ai": "^0.1.1",
+    "ai": "^6.0.0",
+    "@ai-sdk/openai": "^3.0.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/examples/vercel-ai-chatbot/src/index.ts
+++ b/examples/vercel-ai-chatbot/src/index.ts
@@ -1,0 +1,196 @@
+/**
+ * Grantex + Vercel AI SDK — Scoped Tools with Audit Logging
+ *
+ * Shows Vercel AI SDK tools with Grantex scope enforcement:
+ *   1. Register agent & get a grant token (sandbox flow)
+ *   2. Create scoped tools via createGrantexTool with Zod schemas
+ *   3. Wrap tools with withAuditLogging
+ *   4. Invoke tools using generateText
+ *   5. Demonstrate GrantexScopeError when scope is missing
+ *
+ * Prerequisites:
+ *   docker compose up          # from repo root
+ *   cd examples/vercel-ai-chatbot
+ *   npm install
+ *   OPENAI_API_KEY=sk-... npm start
+ *
+ * Without OPENAI_API_KEY, the example skips the generateText call
+ * and demonstrates tool creation, scope checks, and audit logging directly.
+ */
+
+import { Grantex } from '@grantex/sdk';
+import {
+  createGrantexTool,
+  withAuditLogging,
+  GrantexScopeError,
+} from '@grantex/vercel-ai';
+import { z } from 'zod';
+
+const BASE_URL = process.env['GRANTEX_URL'] ?? 'http://localhost:3001';
+const API_KEY = process.env['GRANTEX_API_KEY'] ?? 'sandbox-api-key-local';
+
+async function getGrantToken(
+  grantex: Grantex,
+  agentId: string,
+): Promise<{ grantToken: string; grantId: string }> {
+  const authRequest = await grantex.authorize({
+    agentId,
+    userId: 'test-user-001',
+    scopes: ['calendar:read', 'email:send'],
+  });
+
+  const code = (authRequest as unknown as Record<string, unknown>)['code'] as string;
+  if (!code) throw new Error('No code returned — use the sandbox API key.');
+
+  const res = await fetch(`${BASE_URL}/v1/token`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ code, agentId }),
+  });
+  if (!res.ok) throw new Error(`Token exchange failed: ${await res.text()}`);
+  return res.json() as Promise<{ grantToken: string; grantId: string }>;
+}
+
+async function main(): Promise<void> {
+  const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
+
+  // ── 1. Register agent & get grant token ────────────────────────────
+  const agent = await grantex.agents.register({
+    name: 'vercel-ai-demo-agent',
+    description: 'Demo Vercel AI agent with Grantex authorization',
+    scopes: ['calendar:read', 'email:send'],
+  });
+  console.log('Agent registered:', agent.id);
+
+  const { grantToken, grantId } = await getGrantToken(grantex, agent.id);
+  console.log('Grant token received, grantId:', grantId);
+
+  // ── 2. Create scoped tools with Zod schemas ───────────────────────
+  const calendarTool = createGrantexTool({
+    name: 'read_calendar',
+    description: "Read the user's upcoming calendar events",
+    parameters: z.object({
+      date: z.string().describe('Date to query, e.g. "today" or "2026-03-01"'),
+    }),
+    grantToken,
+    requiredScope: 'calendar:read',
+    execute: async ({ date }) => {
+      // Simulated calendar API
+      return {
+        date,
+        events: [
+          { title: 'Team standup', time: '9:00 AM' },
+          { title: 'Design review', time: '2:00 PM' },
+        ],
+      };
+    },
+  });
+
+  const emailTool = createGrantexTool({
+    name: 'send_email',
+    description: 'Send an email on behalf of the user',
+    parameters: z.object({
+      to: z.string().describe('Recipient email address'),
+      subject: z.string().describe('Email subject'),
+      body: z.string().describe('Email body text'),
+    }),
+    grantToken,
+    requiredScope: 'email:send',
+    execute: async ({ to, subject, body }) => {
+      // Simulated email API
+      return { sent: true, to, subject, bodyLength: body.length };
+    },
+  });
+
+  console.log('Tools created: read_calendar, send_email');
+
+  // ── 3. Wrap with audit logging ─────────────────────────────────────
+  const auditedCalendar = withAuditLogging(calendarTool, grantex, {
+    agentId: agent.id,
+    grantId,
+  });
+
+  const auditedEmail = withAuditLogging(emailTool, grantex, {
+    agentId: agent.id,
+    grantId,
+  });
+
+  console.log('Audit logging attached');
+
+  // ── 4. Invoke tools ────────────────────────────────────────────────
+  if (process.env['OPENAI_API_KEY']) {
+    // With an OpenAI key, use generateText to let the LLM pick tools
+    const { generateText } = await import('ai');
+    const { openai } = await import('@ai-sdk/openai');
+
+    console.log('\n--- Running with LLM (generateText) ---');
+    const result = await generateText({
+      model: openai('gpt-4o-mini'),
+      tools: {
+        read_calendar: auditedCalendar,
+        send_email: auditedEmail,
+      },
+      prompt:
+        "Check my calendar for today and send an email to alice@example.com with a summary of today's events.",
+    });
+    console.log('LLM response:', result.text);
+  } else {
+    // Without an OpenAI key, invoke tools directly
+    console.log('\n--- Invoking tools directly (no OPENAI_API_KEY set) ---');
+
+    const calendarResult = await auditedCalendar.execute(
+      { date: 'today' },
+      { toolCallId: 'call_1', messages: [] },
+    );
+    console.log('Calendar result:', JSON.stringify(calendarResult));
+
+    const emailResult = await auditedEmail.execute(
+      {
+        to: 'alice@example.com',
+        subject: "Today's events",
+        body: 'Team standup at 9 AM, Design review at 2 PM',
+      },
+      { toolCallId: 'call_2', messages: [] },
+    );
+    console.log('Email result:', JSON.stringify(emailResult));
+  }
+
+  // ── 5. Demonstrate GrantexScopeError ───────────────────────────────
+  console.log('\n--- Testing scope enforcement ---');
+  try {
+    createGrantexTool({
+      name: 'delete_files',
+      description: 'Delete files from storage',
+      parameters: z.object({ path: z.string() }),
+      grantToken,
+      requiredScope: 'storage:delete', // not in our grant!
+      execute: async () => ({ deleted: true }),
+    });
+    console.log('ERROR: should have thrown');
+  } catch (err) {
+    if (err instanceof GrantexScopeError) {
+      console.log('GrantexScopeError caught:');
+      console.log('  Required scope: ', err.requiredScope);
+      console.log('  Granted scopes: ', err.grantedScopes.join(', '));
+    } else {
+      throw err;
+    }
+  }
+
+  // ── 6. Inspect audit trail ─────────────────────────────────────────
+  console.log('\n--- Audit trail ---');
+  const auditLog = await grantex.audit.list({ agentId: agent.id, grantId });
+  for (const entry of auditLog.entries) {
+    console.log(`  [${entry.status}] ${entry.action} — ${entry.timestamp}`);
+  }
+
+  console.log('\nDone! Vercel AI integration demo complete.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/vercel-ai-chatbot/tsconfig.json
+++ b/examples/vercel-ai-chatbot/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Add 3 runnable example apps under `examples/`:
  - **quickstart-ts** — core authorization lifecycle (register → authorize → token → verify → audit → revoke)
  - **langchain-agent** — LangChain scoped tools with `GrantexAuditHandler` callbacks
  - **vercel-ai-chatbot** — Vercel AI SDK tools with scope enforcement and `withAuditLogging`
- All examples use sandbox mode (`sandbox-api-key-local`) for zero-config testing against `docker compose up`
- Add social preview SVG (`assets/social-preview.svg`)
- Set repo homepage to https://grantex.dev, add 13 discovery topics, enable Discussions
- Create GitHub release tags for 4 packages bumped to 0.1.1 (`@grantex/langchain`, `@grantex/autogen`, `@grantex/vercel-ai`, `@grantex/cli`)

## Test plan

- [x] `npx tsc --noEmit` passes for all 3 examples
- [x] Existing SDK-TS tests pass (78/78)
- [x] Existing auth-service tests pass (184/184)
- [x] `gh repo view` confirms homepage, topics, discussions enabled
- [x] `gh release list` shows 4 new 0.1.1 releases