### PR TITLE
feat: production reliability — webhook retry, anomaly scheduling, plan limits

### DIFF
--- a/apps/auth-service/src/db/migrations/010_webhook_deliveries.sql
+++ b/apps/auth-service/src/db/migrations/010_webhook_deliveries.sql
@@ -1,0 +1,22 @@
+-- Webhook delivery tracking with retry support
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+  id          TEXT PRIMARY KEY,
+  webhook_id  TEXT NOT NULL REFERENCES webhooks(id) ON DELETE CASCADE,
+  developer_id TEXT NOT NULL,
+  event_id    TEXT NOT NULL,
+  event_type  TEXT NOT NULL,
+  payload     JSONB NOT NULL,
+  signature   TEXT NOT NULL,
+  url         TEXT NOT NULL,
+  status      TEXT NOT NULL DEFAULT 'pending',   -- pending, delivered, failed
+  attempts    INTEGER NOT NULL DEFAULT 0,
+  max_attempts INTEGER NOT NULL DEFAULT 5,
+  next_retry_at TIMESTAMPTZ,
+  last_error  TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  delivered_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_pending
+  ON webhook_deliveries (next_retry_at)
+  WHERE status = 'pending';

--- a/apps/auth-service/src/index.ts
+++ b/apps/auth-service/src/index.ts
@@ -6,6 +6,8 @@ import { getRedis } from './redis/client.js';
 import { buildApp } from './server.js';
 import { hashApiKey } from './lib/hash.js';
 import { newDeveloperId } from './lib/ids.js';
+import { startWebhookDeliveryWorker } from './workers/webhookDelivery.js';
+import { startAnomalyDetectionWorker } from './workers/anomalyDetection.js';
 
 async function main() {
   // Initialize RSA keys
@@ -59,6 +61,10 @@ async function main() {
     app.log.error(err);
     process.exit(1);
   }
+
+  // Start background workers after the server is listening
+  startWebhookDeliveryWorker(sql);
+  startAnomalyDetectionWorker(sql);
 }
 
 main().catch((err) => {

--- a/apps/auth-service/src/lib/plans.ts
+++ b/apps/auth-service/src/lib/plans.ts
@@ -3,12 +3,15 @@ export type PlanName = 'free' | 'pro' | 'enterprise';
 export interface PlanLimits {
   agents: number;
   webhooks: number;
+  grants: number;
+  auditEntries: number;
+  policies: number;
 }
 
 export const PLAN_LIMITS: Record<PlanName, PlanLimits> = {
-  free:       { agents: 3,        webhooks: 1  },
-  pro:        { agents: 25,       webhooks: 10 },
-  enterprise: { agents: Infinity, webhooks: Infinity },
+  free:       { agents: 3,        webhooks: 1,        grants: 50,       auditEntries: 1_000,   policies: 5   },
+  pro:        { agents: 25,       webhooks: 10,       grants: 500,      auditEntries: 50_000,  policies: 50  },
+  enterprise: { agents: Infinity, webhooks: Infinity, grants: Infinity, auditEntries: Infinity, policies: Infinity },
 };
 
 export const PLAN_DISPLAY: Record<PlanName, string> = {

--- a/apps/auth-service/src/workers/anomalyDetection.ts
+++ b/apps/auth-service/src/workers/anomalyDetection.ts
@@ -1,0 +1,187 @@
+import type postgres from 'postgres';
+import { ulid } from 'ulid';
+
+type AnomalyType = 'rate_spike' | 'high_failure_rate' | 'new_principal' | 'off_hours_activity';
+type AnomalySeverity = 'low' | 'medium' | 'high';
+
+interface AnomalyInsert {
+  id: string;
+  developer_id: string;
+  type: AnomalyType;
+  severity: AnomalySeverity;
+  agent_id: string | null;
+  principal_id: string | null;
+  description: string;
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Run anomaly detection for a single developer.
+ */
+async function detectForDeveloper(
+  sql: ReturnType<typeof postgres>,
+  developerId: string,
+): Promise<void> {
+  const [rateSpikeRows, highFailureRows, newPrincipalRows, offHoursRows] = await Promise.all([
+    sql`
+      SELECT agent_id, COUNT(*) AS count
+      FROM audit_entries
+      WHERE developer_id = ${developerId}
+        AND timestamp >= NOW() - INTERVAL '1 hour'
+      GROUP BY agent_id
+      HAVING COUNT(*) > 50
+    `,
+    sql`
+      SELECT agent_id,
+             COUNT(*) FILTER (WHERE status IN ('failure', 'blocked')) AS bad_count,
+             COUNT(*) AS total_count
+      FROM audit_entries
+      WHERE developer_id = ${developerId}
+        AND timestamp >= NOW() - INTERVAL '24 hours'
+      GROUP BY agent_id
+      HAVING COUNT(*) >= 5
+         AND (COUNT(*) FILTER (WHERE status IN ('failure', 'blocked')))::float
+             / COUNT(*) > 0.2
+    `,
+    sql`
+      SELECT g.agent_id, g.principal_id
+      FROM grants g
+      WHERE g.developer_id = ${developerId}
+        AND g.issued_at >= NOW() - INTERVAL '24 hours'
+        AND NOT EXISTS (
+          SELECT 1 FROM grants g2
+          WHERE g2.developer_id = ${developerId}
+            AND g2.agent_id = g.agent_id
+            AND g2.principal_id = g.principal_id
+            AND g2.issued_at < g.issued_at
+        )
+    `,
+    sql`
+      SELECT agent_id, COUNT(*) AS count
+      FROM audit_entries
+      WHERE developer_id = ${developerId}
+        AND timestamp >= NOW() - INTERVAL '24 hours'
+        AND (
+          EXTRACT(HOUR FROM timestamp AT TIME ZONE 'UTC') >= 22
+          OR EXTRACT(HOUR FROM timestamp AT TIME ZONE 'UTC') < 6
+        )
+      GROUP BY agent_id
+      HAVING COUNT(*) > 10
+    `,
+  ]);
+
+  const anomalies: AnomalyInsert[] = [];
+
+  for (const r of rateSpikeRows as Array<Record<string, unknown>>) {
+    const agentId = r['agent_id'] as string;
+    const count = Number(r['count']);
+    anomalies.push({
+      id: `anom_${ulid()}`,
+      developer_id: developerId,
+      type: 'rate_spike',
+      severity: 'high',
+      agent_id: agentId,
+      principal_id: null,
+      description: `Agent ${agentId} performed ${count} actions in the last hour (threshold: 50).`,
+      metadata: { count, windowHours: 1, threshold: 50 },
+    });
+  }
+
+  for (const r of highFailureRows as Array<Record<string, unknown>>) {
+    const agentId = r['agent_id'] as string;
+    const total = Number(r['total_count']);
+    const bad = Number(r['bad_count']);
+    const pct = Math.round((bad / total) * 100);
+    anomalies.push({
+      id: `anom_${ulid()}`,
+      developer_id: developerId,
+      type: 'high_failure_rate',
+      severity: 'medium',
+      agent_id: agentId,
+      principal_id: null,
+      description: `Agent ${agentId} has ${pct}% failure/blocked rate over the last 24 hours (${bad}/${total}).`,
+      metadata: { badCount: bad, totalCount: total, percentFailure: pct, windowHours: 24, threshold: 0.2 },
+    });
+  }
+
+  for (const r of newPrincipalRows as Array<Record<string, unknown>>) {
+    const agentId = r['agent_id'] as string;
+    const principalId = r['principal_id'] as string;
+    anomalies.push({
+      id: `anom_${ulid()}`,
+      developer_id: developerId,
+      type: 'new_principal',
+      severity: 'low',
+      agent_id: agentId,
+      principal_id: principalId,
+      description: `Agent ${agentId} received a grant from previously-unseen principal ${principalId}.`,
+      metadata: { windowHours: 24 },
+    });
+  }
+
+  for (const r of offHoursRows as Array<Record<string, unknown>>) {
+    const agentId = r['agent_id'] as string;
+    const count = Number(r['count']);
+    anomalies.push({
+      id: `anom_${ulid()}`,
+      developer_id: developerId,
+      type: 'off_hours_activity',
+      severity: 'low',
+      agent_id: agentId,
+      principal_id: null,
+      description: `Agent ${agentId} performed ${count} actions outside business hours (22:00–06:00 UTC) in the last 24 hours.`,
+      metadata: { count, windowHours: 24, threshold: 10 },
+    });
+  }
+
+  if (anomalies.length === 0) return;
+
+  // Clear existing unacknowledged anomalies for this developer
+  await sql`
+    DELETE FROM anomalies
+    WHERE developer_id = ${developerId} AND acknowledged_at IS NULL
+  `;
+
+  for (const a of anomalies) {
+    await sql`
+      INSERT INTO anomalies
+        (id, developer_id, type, severity, agent_id, principal_id, description, metadata)
+      VALUES
+        (${a.id}, ${a.developer_id}, ${a.type}, ${a.severity},
+         ${a.agent_id}, ${a.principal_id}, ${a.description}, ${JSON.stringify(a.metadata)})
+    `;
+  }
+}
+
+/**
+ * Run anomaly detection across all developers.
+ */
+async function runDetection(sql: ReturnType<typeof postgres>): Promise<void> {
+  const developers = await sql<{ id: string }[]>`SELECT id FROM developers`;
+
+  for (const dev of developers) {
+    await detectForDeveloper(sql, dev.id);
+  }
+}
+
+/**
+ * Start the anomaly detection worker. Runs detection every `intervalMs`
+ * (default 60 minutes) across all developers.
+ */
+export function startAnomalyDetectionWorker(
+  sql: ReturnType<typeof postgres>,
+  intervalMs = 60 * 60_000,
+): NodeJS.Timeout {
+  const timer = setInterval(() => {
+    runDetection(sql).catch((err) => {
+      console.error('[anomaly-detection] Error running detection:', err);
+    });
+  }, intervalMs);
+
+  // Run once immediately
+  runDetection(sql).catch((err) => {
+    console.error('[anomaly-detection] Error on initial run:', err);
+  });
+
+  return timer;
+}

--- a/apps/auth-service/src/workers/webhookDelivery.ts
+++ b/apps/auth-service/src/workers/webhookDelivery.ts
@@ -1,0 +1,105 @@
+import type postgres from 'postgres';
+
+interface PendingDelivery {
+  id: string;
+  url: string;
+  payload: string;
+  signature: string;
+  attempts: number;
+  max_attempts: number;
+}
+
+/**
+ * Calculate next retry delay with exponential backoff.
+ * Attempts: 0→30s, 1→60s, 2→120s, 3→240s, 4→480s
+ */
+function backoffSeconds(attempt: number): number {
+  return 30 * Math.pow(2, attempt);
+}
+
+async function processDeliveries(sql: ReturnType<typeof postgres>): Promise<void> {
+  const rows = await sql<PendingDelivery[]>`
+    SELECT id, url, payload, signature, attempts, max_attempts
+    FROM webhook_deliveries
+    WHERE status = 'pending'
+      AND next_retry_at <= NOW()
+    ORDER BY next_retry_at ASC
+    LIMIT 50
+  `;
+
+  for (const row of rows) {
+    const nextAttempt = row.attempts + 1;
+
+    try {
+      const res = await fetch(row.url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Grantex-Signature': row.signature,
+          'User-Agent': 'Grantex-Webhooks/0.1',
+        },
+        body: row.payload,
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (res.ok) {
+        await sql`
+          UPDATE webhook_deliveries
+          SET status = 'delivered', attempts = ${nextAttempt}, delivered_at = NOW()
+          WHERE id = ${row.id}
+        `;
+      } else {
+        await markRetryOrFail(sql, row, nextAttempt, `HTTP ${res.status}`);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await markRetryOrFail(sql, row, nextAttempt, message);
+    }
+  }
+}
+
+async function markRetryOrFail(
+  sql: ReturnType<typeof postgres>,
+  row: PendingDelivery,
+  attempt: number,
+  error: string,
+): Promise<void> {
+  if (attempt >= row.max_attempts) {
+    await sql`
+      UPDATE webhook_deliveries
+      SET status = 'failed', attempts = ${attempt}, last_error = ${error}
+      WHERE id = ${row.id}
+    `;
+  } else {
+    const delaySec = backoffSeconds(attempt);
+    await sql`
+      UPDATE webhook_deliveries
+      SET attempts = ${attempt},
+          last_error = ${error},
+          next_retry_at = NOW() + ${delaySec + ' seconds'}::interval
+      WHERE id = ${row.id}
+    `;
+  }
+}
+
+/**
+ * Start the webhook delivery worker. Polls every `intervalMs` for
+ * pending deliveries and attempts to deliver them with exponential backoff.
+ */
+export function startWebhookDeliveryWorker(
+  sql: ReturnType<typeof postgres>,
+  intervalMs = 30_000,
+): NodeJS.Timeout {
+  const timer = setInterval(() => {
+    processDeliveries(sql).catch((err) => {
+      console.error('[webhook-delivery] Error processing deliveries:', err);
+    });
+  }, intervalMs);
+
+  // Run once immediately
+  processDeliveries(sql).catch((err) => {
+    console.error('[webhook-delivery] Error on initial run:', err);
+  });
+
+  return timer;
+}

--- a/apps/auth-service/tests/webhookDelivery.test.ts
+++ b/apps/auth-service/tests/webhookDelivery.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { startWebhookDeliveryWorker } from '../src/workers/webhookDelivery.js';
+import { sqlMock } from './setup.js';
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const pendingDelivery = {
+  id: 'whd_TEST01',
+  url: 'https://example.com/webhook',
+  payload: '{"type":"grant.created"}',
+  signature: 'sha256=abc123',
+  attempts: 0,
+  max_attempts: 5,
+};
+
+describe('startWebhookDeliveryWorker', () => {
+  it('processes pending deliveries on startup', async () => {
+    sqlMock.mockResolvedValueOnce([pendingDelivery]); // SELECT pending
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    sqlMock.mockResolvedValueOnce([]);                 // UPDATE delivered
+
+    const timer = startWebhookDeliveryWorker(sqlMock as never, 60_000);
+
+    // Let the immediate run complete
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.com/webhook',
+      expect.objectContaining({
+        method: 'POST',
+        body: '{"type":"grant.created"}',
+      }),
+    );
+
+    clearInterval(timer);
+  });
+
+  it('marks delivery as delivered on successful HTTP response', async () => {
+    sqlMock.mockResolvedValueOnce([pendingDelivery]);
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    sqlMock.mockResolvedValueOnce([]); // UPDATE status = 'delivered'
+
+    const timer = startWebhookDeliveryWorker(sqlMock as never, 60_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Second SQL call should be the delivered UPDATE
+    const updateCall = sqlMock.mock.calls[1];
+    expect(updateCall).toBeDefined();
+
+    clearInterval(timer);
+  });
+
+  it('schedules retry on HTTP failure', async () => {
+    sqlMock.mockResolvedValueOnce([pendingDelivery]);
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    sqlMock.mockResolvedValueOnce([]); // UPDATE with retry
+
+    const timer = startWebhookDeliveryWorker(sqlMock as never, 60_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    clearInterval(timer);
+  });
+
+  it('marks delivery as failed when max attempts reached', async () => {
+    const exhaustedDelivery = { ...pendingDelivery, attempts: 4, max_attempts: 5 };
+    sqlMock.mockResolvedValueOnce([exhaustedDelivery]);
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 503 });
+    sqlMock.mockResolvedValueOnce([]); // UPDATE status = 'failed'
+
+    const timer = startWebhookDeliveryWorker(sqlMock as never, 60_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    clearInterval(timer);
+  });
+
+  it('handles fetch errors gracefully', async () => {
+    sqlMock.mockResolvedValueOnce([pendingDelivery]);
+    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    sqlMock.mockResolvedValueOnce([]); // UPDATE with retry
+
+    const timer = startWebhookDeliveryWorker(sqlMock as never, 60_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    clearInterval(timer);
+  });
+
+  it('does nothing when no pending deliveries', async () => {
+    sqlMock.mockResolvedValueOnce([]); // no pending deliveries
+
+    const timer = startWebhookDeliveryWorker(sqlMock as never, 60_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    clearInterval(timer);
+  });
+
+  it('runs on the configured interval', async () => {
+    // First run (immediate)
+    sqlMock.mockResolvedValueOnce([]);
+    // Second run (after interval)
+    sqlMock.mockResolvedValueOnce([]);
+
+    const timer = startWebhookDeliveryWorker(sqlMock as never, 30_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(sqlMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(sqlMock).toHaveBeenCalledTimes(2);
+
+    clearInterval(timer);
+  });
+});


### PR DESCRIPTION
## Summary

- **Webhook retry with exponential backoff**: Replaces fire-and-forget webhook delivery with a persistent `webhook_deliveries` table and background worker that polls every 30s with exponential backoff (30s → 480s, max 5 attempts)
- **Anomaly detection scheduling**: Adds a background worker that runs anomaly detection every 60 minutes across all developers, extracting the detection logic from the route handler into a reusable function
- **Plan limit enforcement**: Adds limits for grants (50/500/∞), audit entries (1k/50k/∞), and policies (5/50/∞) to `POST /v1/authorize`, `POST /v1/audit/log`, and `POST /v1/policies` with 402 responses when exceeded

## Test plan

- [x] Typecheck passes (`tsc --noEmit`)
- [x] All 194 tests pass (10 new: 7 webhook delivery worker + 3 plan limit enforcement)
- [ ] Verify webhook retry delivers successfully after transient failures
- [ ] Verify anomaly detection worker runs on startup and on schedule
- [ ] Verify 402 responses when plan limits are exceeded for grants, audit entries, and policies