### PR TITLE
feat: security hardening — PKCE support and rate limiting

### DIFF
--- a/apps/auth-service/package-lock.json
+++ b/apps/auth-service/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
+        "@fastify/rate-limit": "^10.3.0",
         "dotenv": "^16.4.5",
         "fastify": "^5.7.3",
         "ioredis": "^5.3.2",
@@ -672,6 +673,27 @@
         "ipaddr.js": "^2.1.0"
       }
     },
+    "node_modules/@fastify/rate-limit": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-10.3.0.tgz",
+      "integrity": "sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "fastify-plugin": "^5.0.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
     "node_modules/@ioredis/commands": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
@@ -738,6 +760,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@pinojs/redact": {

--- a/apps/auth-service/package.json
+++ b/apps/auth-service/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^10.0.0",
+    "@fastify/rate-limit": "^10.3.0",
     "dotenv": "^16.4.5",
     "fastify": "^5.7.3",
     "ioredis": "^5.3.2",

--- a/apps/auth-service/src/db/migrations/011_pkce.sql
+++ b/apps/auth-service/src/db/migrations/011_pkce.sql
@@ -1,0 +1,3 @@
+-- PKCE support: store code challenge on auth requests
+ALTER TABLE auth_requests ADD COLUMN IF NOT EXISTS code_challenge TEXT;
+ALTER TABLE auth_requests ADD COLUMN IF NOT EXISTS code_challenge_method TEXT;

--- a/apps/auth-service/src/lib/pkce.ts
+++ b/apps/auth-service/src/lib/pkce.ts
@@ -1,0 +1,10 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Verify a PKCE code_verifier against a stored code_challenge (S256 only).
+ * Returns true when SHA256(base64url(verifier)) === challenge.
+ */
+export function verifyPkceChallenge(verifier: string, challenge: string): boolean {
+  const hash = createHash('sha256').update(verifier).digest('base64url');
+  return hash === challenge;
+}

--- a/apps/auth-service/src/plugins/auth.ts
+++ b/apps/auth-service/src/plugins/auth.ts
@@ -16,6 +16,10 @@ declare module 'fastify' {
   interface FastifyRequest {
     developer: Developer;
   }
+
+  interface FastifyContextConfig {
+    skipAuth?: boolean;
+  }
 }
 
 async function authenticateRequest(
@@ -61,7 +65,7 @@ export async function authPlugin(app: FastifyInstance): Promise<void> {
   app.addHook('preHandler', async (request, reply) => {
     if (request.url.startsWith('/.well-known/')) return;
     if (request.url.startsWith('/scim/')) return;  // SCIM uses its own bearer token auth
-    if ((request.routeOptions.config as { skipAuth?: boolean } | undefined)?.skipAuth) return;
+    if (request.routeOptions.config.skipAuth) return;
     await authenticateRequest(request, reply);
   });
 }

--- a/apps/auth-service/src/server.ts
+++ b/apps/auth-service/src/server.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import Fastify from 'fastify';
 import cors from '@fastify/cors';
+import rateLimit from '@fastify/rate-limit';
 import { errorsPlugin } from './plugins/errors.js';
 import { authPlugin } from './plugins/auth.js';
 import { jwksRoutes } from './routes/jwks.js';
@@ -34,6 +35,16 @@ export async function buildApp(opts: AppOptions = {}) {
   });
 
   await app.register(cors);
+
+  // Global rate limit: 100 requests/minute per IP
+  await app.register(rateLimit, {
+    max: 100,
+    timeWindow: '1 minute',
+    allowList: (req) => {
+      // Skip rate limiting for JWKS (public key distribution must never be throttled)
+      return req.url.startsWith('/.well-known/');
+    },
+  });
 
   // Call directly on root app (not via app.register) so that error handler
   // and preHandler hooks apply to ALL routes registered at the root scope.

--- a/apps/auth-service/tests/pkce.test.ts
+++ b/apps/auth-service/tests/pkce.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createHash, randomBytes } from 'node:crypto';
+import { buildTestApp, authHeader, seedAuth, sqlMock, TEST_AGENT, TEST_DEVELOPER } from './helpers.js';
+import type { FastifyInstance } from 'fastify';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+function generateTestPkce() {
+  const verifier = randomBytes(32).toString('base64url');
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, challenge };
+}
+
+const validAuthRequest = {
+  id: 'areq_PKCE',
+  agent_id: TEST_AGENT.id,
+  principal_id: 'user_123',
+  developer_id: TEST_DEVELOPER.id,
+  scopes: ['read'],
+  expires_in: '24h',
+  expires_at: new Date(Date.now() + 86400_000).toISOString(),
+  status: 'approved',
+  agent_did: TEST_AGENT.did,
+  code_challenge: null,
+};
+
+describe('PKCE — POST /v1/authorize', () => {
+  it('accepts codeChallenge and codeChallengeMethod S256', async () => {
+    const { challenge } = generateTestPkce();
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ id: TEST_AGENT.id }]); // agent lookup
+    sqlMock.mockResolvedValueOnce([]);                       // policy lookup
+    sqlMock.mockResolvedValueOnce([]);                       // insert
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/authorize',
+      headers: authHeader(),
+      payload: {
+        agentId: TEST_AGENT.id,
+        principalId: 'user_123',
+        scopes: ['read'],
+        codeChallenge: challenge,
+        codeChallengeMethod: 'S256',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('rejects non-S256 codeChallengeMethod', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/authorize',
+      headers: authHeader(),
+      payload: {
+        agentId: TEST_AGENT.id,
+        principalId: 'user_123',
+        scopes: ['read'],
+        codeChallenge: 'some-challenge',
+        codeChallengeMethod: 'plain',
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ message: string }>().message).toContain('S256');
+  });
+});
+
+describe('PKCE — POST /v1/token', () => {
+  it('succeeds when codeVerifier matches stored challenge', async () => {
+    const { verifier, challenge } = generateTestPkce();
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ ...validAuthRequest, code_challenge: challenge }]);
+    sqlMock.mockResolvedValueOnce([]); // INSERT grants
+    sqlMock.mockResolvedValueOnce([]); // INSERT grant_tokens
+    sqlMock.mockResolvedValueOnce([]); // INSERT refresh_tokens
+    sqlMock.mockResolvedValueOnce([]); // UPDATE auth_requests consumed
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token',
+      headers: authHeader(),
+      payload: { code: 'pkce-code', agentId: TEST_AGENT.id, codeVerifier: verifier },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json<{ grantToken: string }>().grantToken).toBeDefined();
+  });
+
+  it('returns 400 when codeVerifier is missing but challenge was stored', async () => {
+    const { challenge } = generateTestPkce();
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ ...validAuthRequest, code_challenge: challenge }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token',
+      headers: authHeader(),
+      payload: { code: 'pkce-code', agentId: TEST_AGENT.id },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ message: string }>().message).toContain('codeVerifier');
+  });
+
+  it('returns 400 when codeVerifier does not match', async () => {
+    const { challenge } = generateTestPkce();
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ ...validAuthRequest, code_challenge: challenge }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token',
+      headers: authHeader(),
+      payload: { code: 'pkce-code', agentId: TEST_AGENT.id, codeVerifier: 'wrong-verifier' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ message: string }>().message).toContain('Invalid codeVerifier');
+  });
+
+  it('succeeds without codeVerifier when no challenge was stored', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ ...validAuthRequest, code_challenge: null }]);
+    sqlMock.mockResolvedValueOnce([]); // INSERT grants
+    sqlMock.mockResolvedValueOnce([]); // INSERT grant_tokens
+    sqlMock.mockResolvedValueOnce([]); // INSERT refresh_tokens
+    sqlMock.mockResolvedValueOnce([]); // UPDATE auth_requests consumed
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token',
+      headers: authHeader(),
+      payload: { code: 'no-pkce-code', agentId: TEST_AGENT.id },
+    });
+
+    expect(res.statusCode).toBe(201);
+  });
+});

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -72,6 +72,7 @@ from ._types import (
     SsoLoginResponse,
     SsoCallbackResponse,
 )
+from ._pkce import PkceChallenge, generate_pkce
 from ._verify import verify_grant_token
 from ._webhook import verify_webhook_signature
 
@@ -84,6 +85,9 @@ __all__ = [
     "SignupParams",
     "SignupResponse",
     "RotateKeyResponse",
+    # PKCE
+    "PkceChallenge",
+    "generate_pkce",
     # Standalone verify
     "verify_grant_token",
     # Webhook signature verification

--- a/packages/sdk-py/src/grantex/_pkce.py
+++ b/packages/sdk-py/src/grantex/_pkce.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import hashlib
+import base64
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PkceChallenge:
+    code_verifier: str
+    code_challenge: str
+    code_challenge_method: str
+
+
+def generate_pkce() -> PkceChallenge:
+    """Generate a PKCE code verifier and S256 challenge pair.
+
+    Use ``code_challenge`` + ``code_challenge_method`` in the authorize request,
+    and ``code_verifier`` in the token exchange request.
+    """
+    verifier_bytes = os.urandom(32)
+    code_verifier = base64.urlsafe_b64encode(verifier_bytes).rstrip(b"=").decode("ascii")
+    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return PkceChallenge(
+        code_verifier=code_verifier,
+        code_challenge=code_challenge,
+        code_challenge_method="S256",
+    )

--- a/packages/sdk-py/src/grantex/_types.py
+++ b/packages/sdk-py/src/grantex/_types.py
@@ -110,6 +110,8 @@ class AuthorizeParams:
     scopes: list[str]
     expires_in: str | None = None
     redirect_uri: str | None = None
+    code_challenge: str | None = None
+    code_challenge_method: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
@@ -121,6 +123,10 @@ class AuthorizeParams:
             body["expiresIn"] = self.expires_in
         if self.redirect_uri is not None:
             body["redirectUri"] = self.redirect_uri
+        if self.code_challenge is not None:
+            body["codeChallenge"] = self.code_challenge
+        if self.code_challenge_method is not None:
+            body["codeChallengeMethod"] = self.code_challenge_method
         return body
 
 
@@ -267,9 +273,13 @@ class VerifyTokenResponse:
 class ExchangeTokenParams:
     code: str
     agent_id: str
+    code_verifier: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {"code": self.code, "agentId": self.agent_id}
+        body: dict[str, Any] = {"code": self.code, "agentId": self.agent_id}
+        if self.code_verifier is not None:
+            body["codeVerifier"] = self.code_verifier
+        return body
 
 
 @dataclass(frozen=True)

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -7,6 +7,9 @@ export { verifyGrantToken } from './verify.js';
 // Webhook signature verification
 export { verifyWebhookSignature } from './webhook.js';
 
+// PKCE helper
+export { generatePkce, type PkceChallenge } from './pkce.js';
+
 // Error classes
 export {
   GrantexError,

--- a/packages/sdk-ts/src/pkce.ts
+++ b/packages/sdk-ts/src/pkce.ts
@@ -1,0 +1,18 @@
+import { randomBytes, createHash } from 'node:crypto';
+
+export interface PkceChallenge {
+  codeVerifier: string;
+  codeChallenge: string;
+  codeChallengeMethod: 'S256';
+}
+
+/**
+ * Generate a PKCE code verifier and S256 challenge pair.
+ * Use `codeChallenge` + `codeChallengeMethod` in the authorize request,
+ * and `codeVerifier` in the token exchange request.
+ */
+export function generatePkce(): PkceChallenge {
+  const codeVerifier = randomBytes(32).toString('base64url');
+  const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
+  return { codeVerifier, codeChallenge, codeChallengeMethod: 'S256' };
+}

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -72,6 +72,10 @@ export interface AuthorizeParams {
   scopes: string[];
   expiresIn?: string;
   redirectUri?: string;
+  /** PKCE S256 code challenge (from generatePkce()) */
+  codeChallenge?: string;
+  /** Must be 'S256' when codeChallenge is provided */
+  codeChallengeMethod?: string;
 }
 
 export interface AuthorizationRequest {
@@ -153,6 +157,8 @@ export interface DelegateParams {
 export interface ExchangeTokenParams {
   code: string;
   agentId: string;
+  /** PKCE code verifier (from generatePkce()) — required if codeChallenge was sent in authorize */
+  codeVerifier?: string;
 }
 
 export interface ExchangeTokenResponse {


### PR DESCRIPTION
## Summary

- **PKCE (S256)**: `POST /v1/authorize` accepts optional `codeChallenge` + `codeChallengeMethod`, stored on `auth_requests`. `POST /v1/token` verifies `codeVerifier` against the stored challenge. New `generatePkce()` helper in both TypeScript and Python SDKs.
- **Rate limiting**: Global 100 req/min per IP via `@fastify/rate-limit`, with stricter limits on sensitive endpoints — 20/min for `POST /v1/token`, 10/min for `POST /v1/authorize`. JWKS endpoint (`/.well-known/jwks.json`) is excluded.

## Test plan

- [x] Auth-service typecheck passes
- [x] Auth-service: 190 tests pass (6 new PKCE tests)
- [x] SDK-TS: 81 tests pass, typecheck clean
- [x] SDK-PY: 91 tests pass
- [ ] Verify PKCE flow end-to-end: authorize with challenge, exchange with verifier
- [ ] Verify rate limit headers (`X-RateLimit-*`) appear in responses
- [ ] Verify 429 returned when limits exceeded