### PR TITLE
fix: add projectId to portal deploy workflow

### DIFF
--- a/.github/workflows/deploy-portal.yml
+++ b/.github/workflows/deploy-portal.yml
@@ -45,4 +45,5 @@ jobs:
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          projectId: grantex-prod
           channelId: live


### PR DESCRIPTION
## Summary

- Added `FIREBASE_SERVICE_ACCOUNT` secret to the repo (firebase-adminsdk SA key)
- Added explicit `projectId: grantex-prod` to the Firebase hosting deploy action

## Test plan

- [ ] Re-run Deploy Portal workflow and verify it completes successfully