### PR TITLE
chore: bump SDK versions to 0.1.3 with PKCE docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.1.3] - 2026-02-28
+
+### Added
+- PKCE (S256) support in authorization and token exchange flows
+- `generatePkce()` helper in TypeScript SDK
+- `generate_pkce()` helper in Python SDK
+- Rate limiting on auth-service (100/min global, 20/min token, 10/min authorize)
+- CHANGELOG.md, CODE_OF_CONDUCT.md, issue templates, PR template
+
+### Changed
+- Bumped `@grantex/sdk` to 0.1.3 and `grantex` (Python) to 0.1.3
+
+### Fixed
+- "ML-based detection" copy corrected to "Pattern-based detection" on landing page
+
 ## [0.1.2] - 2026-02-27
 
 ### Added

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -38,6 +38,17 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "keywords": [
+    "grantex",
+    "mcp",
+    "model-context-protocol",
+    "ai-agents",
+    "authorization",
+    "oauth",
+    "claude",
+    "cursor",
+    "windsurf"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/sdk-py/README.md
+++ b/packages/sdk-py/README.md
@@ -67,6 +67,38 @@ print(verified.principal_id) # 'usr_01HXYZ...'
 print(verified.agent_did)    # 'did:web:...'
 ```
 
+## PKCE Support
+
+The SDK includes built-in PKCE (Proof Key for Code Exchange) support using the S256 method:
+
+```python
+from grantex import Grantex, ExchangeTokenParams, generate_pkce
+
+client = Grantex(api_key="YOUR_API_KEY")
+
+# 1. Generate a PKCE challenge
+pkce = generate_pkce()
+# pkce.code_verifier        — random 43-char string (keep secret)
+# pkce.code_challenge       — SHA-256 hash of verifier (send to server)
+# pkce.code_challenge_method — 'S256'
+
+# 2. Pass the challenge when requesting authorization
+request = client.authorize(
+    agent_id="ag_01HXYZ...",
+    user_id="usr_01HXYZ...",
+    scopes=["files:read"],
+    code_challenge=pkce.code_challenge,
+    code_challenge_method=pkce.code_challenge_method,
+)
+
+# 3. Exchange the code with the verifier
+token = client.tokens.exchange(ExchangeTokenParams(
+    code="auth_code_from_redirect",
+    agent_id="ag_01HXYZ...",
+    code_verifier=pkce.code_verifier,
+))
+```
+
 ## Features
 
 | Feature | Description |

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.1.2"
+version = "0.1.3"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -76,7 +76,7 @@ from ._pkce import PkceChallenge, generate_pkce
 from ._verify import verify_grant_token
 from ._webhook import verify_webhook_signature
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 __all__ = [
     # Main client

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -66,6 +66,40 @@ const grantex = new Grantex({
 | `baseUrl` | `string` | `https://api.grantex.dev` | Base URL of the Grantex API |
 | `timeout` | `number` | `30000` | Request timeout in milliseconds |
 
+## PKCE Support
+
+The SDK includes built-in PKCE (Proof Key for Code Exchange) support using the S256 method for secure authorization flows:
+
+```typescript
+import { Grantex, generatePkce } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'YOUR_API_KEY' });
+
+// 1. Generate a PKCE challenge
+const pkce = generatePkce();
+// pkce.codeVerifier       — random 43-char string (keep secret)
+// pkce.codeChallenge      — SHA-256 hash of verifier (send to server)
+// pkce.codeChallengeMethod — 'S256'
+
+// 2. Pass the challenge when requesting authorization
+const { consentUrl } = await grantex.authorize({
+  agentId: 'ag_01J...',
+  userId: 'usr_01J...',
+  scopes: ['files:read'],
+  codeChallenge: pkce.codeChallenge,
+  codeChallengeMethod: pkce.codeChallengeMethod,
+});
+
+// 3. Exchange the code with the verifier
+const token = await grantex.tokens.exchange({
+  code: 'auth_code_from_redirect',
+  agentId: 'ag_01J...',
+  codeVerifier: pkce.codeVerifier,
+});
+```
+
+---
+
 ## API Reference
 
 ### Authorization

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Bump `@grantex/sdk` and `grantex` (Python) to 0.1.3
- Add PKCE (S256) usage examples to both SDK READMEs
- Update CHANGELOG.md with v0.1.3 entries
- Add npm keywords to `@grantex/mcp` for registry discoverability