### PR TITLE
docs: add Mintlify docs site (64 pages)

### DIFF
--- a/docs/community/contributing.mdx
+++ b/docs/community/contributing.mdx
@@ -1,0 +1,107 @@
+---
+title: "Contributing"
+sidebarTitle: "Contributing"
+description: "How to contribute to the Grantex project."
+---
+
+Thanks for your interest in contributing. Grantex is an open protocol for delegated AI agent authorization — contributions help shape a safer agentic internet.
+
+## Where to Start
+
+| Area | What's needed | Skill |
+|------|--------------|-------|
+| New integrations | Add Grantex support to more frameworks | TypeScript / Python |
+| Examples & tutorials | End-to-end walkthroughs for common use cases | Writing |
+| Bug reports | Found a bug? Open an issue with reproduction steps | Any |
+| Protocol feedback | Review SPEC.md, open issues for gaps | Any |
+| Docs | Improve quickstart, add translations | Writing |
+
+Look for issues tagged [`good first issue`](https://github.com/mishrasanjeev/grantex/issues?q=is%3Aissue+label%3A%22good+first+issue%22).
+
+## Development Setup
+
+```bash
+# Prerequisites: Node.js 18+, Python 3.9+, Docker
+
+git clone https://github.com/mishrasanjeev/grantex
+cd grantex
+
+# Start the full local stack
+docker compose up --build
+
+# TypeScript SDK
+cd packages/sdk-ts
+npm install
+npm run typecheck   # tsc --noEmit
+npm test            # vitest
+
+# Python SDK
+cd packages/sdk-py
+pip install -e ".[dev]"
+pytest
+
+# Auth service
+cd apps/auth-service
+npm install
+npm run typecheck
+npm test
+
+# Integration packages
+cd packages/<package>
+npm install
+npm run typecheck
+npm test
+```
+
+## Repository Structure
+
+```
+grantex/
+├── SPEC.md                       ← Protocol specification (v1.0 final)
+├── packages/
+│   ├── sdk-ts/                   ← TypeScript SDK (@grantex/sdk)
+│   ├── sdk-py/                   ← Python SDK (grantex)
+│   ├── langchain/                ← LangChain integration
+│   ├── autogen/                  ← AutoGen / OpenAI integration
+│   ├── vercel-ai/                ← Vercel AI SDK integration
+│   ├── crewai/                   ← CrewAI integration
+│   ├── openai-agents/            ← OpenAI Agents SDK integration
+│   ├── google-adk/               ← Google ADK integration
+│   ├── mcp/                      ← MCP server
+│   └── cli/                      ← CLI tool
+├── apps/
+│   ├── auth-service/             ← Fastify auth service
+│   └── portal/                   ← Developer portal (React)
+├── examples/                     ← Runnable examples
+├── deploy/                       ← Docker, Helm, Nginx configs
+└── docs/                         ← This docs site
+```
+
+## PR Guidelines
+
+1. **Open an issue first** for anything non-trivial
+2. **One PR per concern** — don't bundle unrelated changes
+3. **Tests required** — all new code needs tests
+4. **Spec changes need discussion** — protocol changes require a Discussion with at least 72 hours for community input
+5. **Changelog entry** — add a line to `CHANGELOG.md` under `Unreleased`
+
+## Code Style
+
+- TypeScript: ESLint + Prettier
+- Python: Ruff + Black
+- Commits: [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `spec:`)
+
+## Protocol Changes (RFCs)
+
+Changes to SPEC.md follow a lightweight RFC process:
+
+1. Open a GitHub Discussion tagged `[RFC]`
+2. Describe the change, motivation, and alternatives
+3. 72-hour minimum comment period
+4. Maintainer merges or closes with reasoning
+
+## Questions?
+
+- [GitHub Discussions](https://github.com/mishrasanjeev/grantex/discussions) for design questions
+- [GitHub Issues](https://github.com/mishrasanjeev/grantex/issues) for bugs and feature requests
+- [Discord](https://discord.gg/grantex) for real-time chat

--- a/docs/community/ietf-draft.mdx
+++ b/docs/community/ietf-draft.mdx
@@ -1,0 +1,80 @@
+---
+title: "IETF Internet-Draft"
+sidebarTitle: "IETF Draft"
+description: "Delegated Agent Authorization Protocol (DAAP) — submitted to the IETF OAuth Working Group."
+---
+
+**Draft name:** `draft-mishra-oauth-agent-grants-00`
+**Target:** IETF OAuth Working Group (oauth@ietf.org)
+**Status:** Individual Submission — version 00
+
+## Document
+
+The Internet-Draft is written in [kramdown-rfc2629](https://github.com/cabo/kramdown-rfc) format — a Markdown superset that compiles to RFC XML (RFC 7991) and from there to canonical IETF text and HTML.
+
+The source is at [`docs/ietf-draft/draft-mishra-oauth-agent-grants-00.md`](https://github.com/mishrasanjeev/grantex/blob/main/docs/ietf-draft/draft-mishra-oauth-agent-grants-00.md).
+
+## Rendering Locally
+
+### Prerequisites
+
+```bash
+gem install kramdown-rfc2629
+pip install xml2rfc
+```
+
+### Build
+
+```bash
+# Markdown → RFC XML
+kdrfc draft-mishra-oauth-agent-grants-00.md
+
+# RFC XML → text (canonical IETF format)
+xml2rfc draft-mishra-oauth-agent-grants-00.xml --text
+
+# RFC XML → HTML
+xml2rfc draft-mishra-oauth-agent-grants-00.xml --html
+```
+
+Alternatively, paste the XML into the [IETF Author Tools](https://author-tools.ietf.org/) web interface.
+
+## Submitting to the Datatracker
+
+1. Render the XML or use `kdrfc` to produce the `.xml` file
+2. Go to [datatracker.ietf.org/submit](https://datatracker.ietf.org/submit/)
+3. Upload `draft-mishra-oauth-agent-grants-00.xml`
+4. Confirm via the email link
+
+The draft appears at: `https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/`
+
+## Path to Standards Track
+
+| Stage | Action |
+|-------|--------|
+| Individual I-D | Submit to Datatracker (current) |
+| WG adoption | Request adoption at IETF meeting or mailing list |
+| WG I-D | Rename to `draft-ietf-oauth-agent-grants-00` |
+| WGLC | Working Group Last Call (two-week review) |
+| IESG review | Internet Engineering Steering Group review |
+| RFC publication | Assigned an RFC number |
+
+## Related RFCs
+
+| RFC | Title | Relationship |
+|-----|-------|--------------|
+| RFC 6749 | OAuth 2.0 | Foundation — DAAP extends the grant flow model |
+| RFC 7519 | JSON Web Token (JWT) | Grant Token format |
+| RFC 7517 | JSON Web Key (JWK) | JWKS endpoint for offline verification |
+| RFC 7518 | JSON Web Algorithms | RS256 algorithm specification |
+| RFC 7636 | PKCE | Supported in DAAP authorization flow |
+| RFC 8693 | Token Exchange | Related — DAAP delegation vs. general token exchange |
+| RFC 7662 | Token Introspection | Related — DAAP `/v1/tokens/verify` |
+| RFC 8725 | JWT Best Practices | Algorithm restriction guidance |
+
+## Revision Process
+
+IETF Internet-Drafts expire after **6 months**. To keep the draft alive:
+
+1. Incorporate working group feedback
+2. Increment the version number (`-01`, `-02`, ...)
+3. Re-submit before the expiry date

--- a/docs/concepts/delegation.mdx
+++ b/docs/concepts/delegation.mdx
@@ -1,0 +1,113 @@
+---
+title: "Multi-Agent Delegation"
+sidebarTitle: "Delegation"
+description: "How Grantex handles authorization chains across multi-agent pipelines."
+---
+
+## Overview
+
+Grantex supports multi-agent pipelines where a root agent spawns sub-agents with narrower scopes. Sub-agent tokens carry a full delegation chain that any service can inspect.
+
+## How It Works
+
+A root agent that holds a grant for `['calendar:read', 'calendar:write', 'email:send']` can delegate a subset of those scopes to a sub-agent:
+
+<CodeGroup>
+```typescript TypeScript
+const delegated = await grantex.grants.delegate({
+  parentGrantToken: rootGrantToken,
+  subAgentId: subAgent.id,
+  scopes: ['calendar:read'],       // must be a subset of parent scopes
+  expiresIn: '1h',                 // capped at parent token's expiry
+});
+
+console.log(delegated.grantToken); // new JWT for the sub-agent
+console.log(delegated.grantId);
+```
+
+```python Python
+delegated = client.grants.delegate(
+    parent_grant_token=root_grant_token,
+    sub_agent_id=sub_agent.id,
+    scopes=["calendar:read"],
+    expires_in="1h",
+)
+
+print(delegated["grantToken"])
+print(delegated["grantId"])
+```
+</CodeGroup>
+
+## Delegation Claims
+
+The delegated token includes additional JWT claims that trace the delegation chain:
+
+```json
+{
+  "iss": "https://grantex.dev",
+  "sub": "user_abc123",
+  "agt": "did:grantex:ag_SUB_AGENT",
+  "scp": ["calendar:read"],
+  "parentAgt": "did:grantex:ag_ROOT_AGENT",
+  "parentGrnt": "grnt_01ROOT...",
+  "delegationDepth": 1,
+  ...
+}
+```
+
+| Claim | Description |
+|-------|-------------|
+| `parentAgt` | DID of the parent agent that created this delegation |
+| `parentGrnt` | Grant ID of the parent grant |
+| `delegationDepth` | Number of hops from the root grant (root = 0, first child = 1) |
+
+## Protocol Constraints
+
+The Grantex protocol enforces three constraints on delegation:
+
+### 1. Scope subset
+
+Sub-agent scopes must be a strict subset of the parent's scopes. Scope escalation is rejected with a `400` error.
+
+### 2. Expiry cap
+
+Sub-agent token expiry is `min(parent expiry, requested expiry)`. Sub-agents can never outlive their parent grant.
+
+### 3. Cascade revocation
+
+Revoking a root grant **cascades to all descendant grants atomically**. There is no window during which a child grant remains valid after its parent has been revoked. This is implemented as a single recursive CTE in the database.
+
+## Depth Limit
+
+The maximum delegation depth is **10 hops**, enforced at both the application level and the database level (via a `CHECK` constraint). This prevents unbounded delegation chains.
+
+## Inspecting Delegation Chains
+
+When verifying a delegated token offline, the `VerifiedGrant` object includes the delegation metadata:
+
+<CodeGroup>
+```typescript TypeScript
+const grant = await verifyGrantToken(delegatedToken, {
+  jwksUri: 'https://api.grantex.dev/.well-known/jwks.json',
+});
+
+if (grant.delegationDepth !== undefined) {
+  console.log('This is a delegated token');
+  console.log('Parent agent:', grant.parentAgentDid);
+  console.log('Parent grant:', grant.parentGrantId);
+  console.log('Delegation depth:', grant.delegationDepth);
+}
+```
+
+```python Python
+grant = verify_grant_token(delegated_token, VerifyGrantTokenOptions(
+    jwks_uri="https://api.grantex.dev/.well-known/jwks.json",
+))
+
+if grant.delegation_depth is not None:
+    print("This is a delegated token")
+    print("Parent agent:", grant.parent_agent_did)
+    print("Parent grant:", grant.parent_grant_id)
+    print("Delegation depth:", grant.delegation_depth)
+```
+</CodeGroup>

--- a/docs/concepts/grant-token.mdx
+++ b/docs/concepts/grant-token.mdx
@@ -1,0 +1,106 @@
+---
+title: "Grant Token"
+sidebarTitle: "Grant Token"
+description: "Grantex grant tokens are RS256-signed JWTs with agent-specific claims."
+---
+
+## Overview
+
+Grantex tokens are standard JWTs (RS256) extended with agent-specific claims. Any service can verify them offline using the published JWKS — no dependency on Grantex at runtime.
+
+## Decoded Example
+
+```json
+{
+  "iss": "https://grantex.dev",
+  "sub": "user_abc123",
+  "agt": "did:grantex:ag_01HXYZ123abc",
+  "dev": "org_yourcompany",
+  "scp": ["calendar:read", "payments:initiate:max_500"],
+  "iat": 1709000000,
+  "exp": 1709086400,
+  "jti": "tok_01HXYZ987xyz",
+  "grnt": "grnt_01HXYZ456def"
+}
+```
+
+## Standard Claims
+
+| Claim | Type | Description |
+|-------|------|-------------|
+| `iss` | `string` | Issuer — the Grantex server that signed the token |
+| `sub` | `string` | The end-user (principal) who authorized this agent |
+| `iat` | `number` | Issued-at timestamp (seconds since epoch) |
+| `exp` | `number` | Expiry timestamp (seconds since epoch) |
+| `jti` | `string` | Unique token ID — used for real-time revocation |
+
+## Grantex-Specific Claims
+
+| Claim | Type | Description |
+|-------|------|-------------|
+| `agt` | `string` | The agent's DID — cryptographically verifiable identity |
+| `dev` | `string` | The developer org that built the agent |
+| `scp` | `string[]` | Exact scopes granted — services should check these |
+| `grnt` | `string` | Grant record ID — links token to the persisted grant |
+| `aud` | `string?` | Intended audience (optional) — services should reject tokens with a mismatched `aud` |
+
+## Delegation Claims
+
+Present on tokens issued to sub-agents via `grants.delegate()`:
+
+| Claim | Type | Description |
+|-------|------|-------------|
+| `parentAgt` | `string` | DID of the parent agent that spawned this sub-agent |
+| `parentGrnt` | `string` | Grant ID of the parent grant — full delegation chain is traceable |
+| `delegationDepth` | `number` | How many hops from the root grant (root = 0) |
+
+## Verification
+
+Grant tokens can be verified two ways:
+
+### Offline (recommended)
+
+Verify the RS256 signature locally using the published JWKS. No network call to Grantex is needed — just fetch the public keys once and cache them.
+
+<CodeGroup>
+```typescript TypeScript
+import { verifyGrantToken } from '@grantex/sdk';
+
+const grant = await verifyGrantToken(token, {
+  jwksUri: 'https://api.grantex.dev/.well-known/jwks.json',
+  requiredScopes: ['calendar:read'],
+});
+```
+
+```python Python
+from grantex import verify_grant_token, VerifyGrantTokenOptions
+
+grant = verify_grant_token(token, VerifyGrantTokenOptions(
+    jwks_uri="https://api.grantex.dev/.well-known/jwks.json",
+))
+```
+</CodeGroup>
+
+### Online
+
+Call the Grantex API for real-time revocation status:
+
+<CodeGroup>
+```typescript TypeScript
+const result = await grantex.tokens.verify(token);
+console.log(result.valid);   // true or false
+console.log(result.scopes);
+```
+
+```python Python
+result = client.tokens.verify(token)
+print(result.valid)
+print(result.scopes)
+```
+</CodeGroup>
+
+## Security
+
+- **Algorithm pinning**: RS256 is hardcoded in all three verification layers (auth service, TypeScript SDK, Python SDK). The `alg` header in the token cannot override this.
+- **Replay prevention**: Every token's `jti` is tracked. Presenting a previously-seen `jti` returns `valid: false`.
+- **Minimum key size**: The auth service enforces a minimum 2048-bit RSA modulus on all signing keys.

--- a/docs/concepts/how-it-works.mdx
+++ b/docs/concepts/how-it-works.mdx
@@ -1,0 +1,78 @@
+---
+title: "How It Works"
+sidebarTitle: "How It Works"
+description: "The three primitives that make up the Grantex protocol."
+---
+
+## Three Primitives
+
+Grantex introduces three primitives for agent authorization:
+
+```
+┌───────────────────┬─────────────────────┬───────────────────────┐
+│   Agent Identity  │   Delegated Grant   │     Audit Trail       │
+│                   │                     │                       │
+│  Cryptographic    │  Human-approved,    │  Append-only,         │
+│  DID / JWT for    │  scoped, revocable  │  hash-chained log     │
+│  every agent      │  permission tokens  │  of every action      │
+└───────────────────┴─────────────────────┴───────────────────────┘
+```
+
+### Agent Identity
+
+Every agent registered with Grantex receives a cryptographic DID (Decentralized Identifier). This identity is embedded in every grant token the agent receives, allowing any service to verify which agent is acting.
+
+### Delegated Grant
+
+A delegated grant is a human-approved, scoped, time-limited permission token. The user sees a plain-language consent UI describing exactly what the agent can do. Once approved, Grantex issues an RS256-signed JWT — the **grant token** — that the agent presents to services.
+
+### Audit Trail
+
+Every action taken by an authorized agent is logged to an append-only, hash-chained audit trail. Each entry references the previous entry's hash, creating a tamper-evident chain that can be verified independently.
+
+## The Authorization Flow
+
+```
+  Developer registers agent → declares required scopes
+          │
+          ▼
+  Agent requests authorization from end-user
+          │
+          ▼
+  User approves via Grantex consent UI (scoped, time-limited)
+          │
+          ▼
+  Grantex issues signed Grant Token (RS256 JWT + custom claims)
+          │
+          ▼
+  Agent presents token to any service → service verifies locally via JWKS
+          │
+          ▼
+  Every action logged to immutable audit trail
+          │
+          ▼
+  User can revoke any grant at any time → effective in < 1 second
+```
+
+### Step by step
+
+1. **Register** — The developer registers their agent with Grantex, declaring a name, description, and the scopes (permissions) the agent needs.
+
+2. **Authorize** — When the agent needs to act on behalf of a user, it initiates an authorization request. The user is redirected to a consent UI showing exactly what permissions are being requested.
+
+3. **Approve** — The user reviews the scopes in plain language and approves (or denies). On approval, Grantex returns an authorization code to your redirect URI.
+
+4. **Exchange** — Your application exchanges the authorization code for a signed grant token (RS256 JWT). This token contains the user's identity, the agent's DID, granted scopes, and expiry.
+
+5. **Verify** — Any service receiving the grant token can verify it offline using the published JWKS endpoint. No Grantex account or API call needed — just fetch the public keys.
+
+6. **Audit** — As the agent takes actions, each one is logged to the audit trail with the agent ID, grant ID, action name, and outcome.
+
+7. **Revoke** — The user can revoke any grant at any time. Revocation is effective immediately — the token is blocklisted in Redis and subsequent verification calls reject it.
+
+## Why an Open Standard?
+
+- **Model-neutral** — Works with OpenAI, Anthropic, Google, Llama, Mistral. No single AI provider can credibly own the authorization layer for their competitors' agents.
+- **Framework-native** — First-class integrations for LangChain, AutoGen, CrewAI, Vercel AI, and more.
+- **Offline-verifiable** — Services verify tokens using published JWKS. Zero runtime dependency on Grantex infrastructure.
+- **Compliance-ready** — The EU AI Act, GDPR, and emerging US AI regulations will mandate auditable agent actions. Grantex provides this on day one.

--- a/docs/concepts/scopes.mdx
+++ b/docs/concepts/scopes.mdx
@@ -1,0 +1,97 @@
+---
+title: "Scopes"
+sidebarTitle: "Scopes"
+description: "Grantex scopes use the resource:action[:constraint] naming convention."
+---
+
+## Scope Format
+
+Grantex defines a standard scope format:
+
+```
+resource:action[:constraint]
+```
+
+| Part | Required | Description |
+|------|----------|-------------|
+| `resource` | Yes | The resource being accessed (e.g. `calendar`, `email`, `payments`) |
+| `action` | Yes | The action being performed (e.g. `read`, `write`, `send`, `initiate`) |
+| `constraint` | No | An optional constraint on the action (e.g. `max_500` for a payment cap) |
+
+## Examples
+
+| Scope | Meaning |
+|-------|---------|
+| `calendar:read` | Read calendar events |
+| `calendar:write` | Create and modify events |
+| `email:send` | Send emails on user's behalf |
+| `payments:initiate:max_500` | Initiate payments up to $500 |
+| `files:read` | Read user files |
+| `profile:read` | Read user profile |
+
+## How Scopes Work
+
+### At registration
+
+When a developer registers an agent, they declare the full set of scopes the agent may ever need:
+
+```typescript
+const agent = await grantex.agents.register({
+  name: 'travel-booker',
+  scopes: ['calendar:read', 'payments:initiate:max_500', 'email:send'],
+});
+```
+
+### At authorization
+
+When requesting user consent, the agent specifies which scopes it needs for this particular session. These must be a subset of the registered scopes:
+
+```typescript
+const auth = await grantex.authorize({
+  agentId: agent.id,
+  userId: 'user_abc123',
+  scopes: ['calendar:read', 'payments:initiate:max_500'],
+});
+```
+
+### In the grant token
+
+Approved scopes are embedded in the JWT's `scp` claim:
+
+```json
+{
+  "scp": ["calendar:read", "payments:initiate:max_500"]
+}
+```
+
+### At verification
+
+Services check the `scp` claim to decide whether to allow a request:
+
+```typescript
+const grant = await verifyGrantToken(token, {
+  jwksUri: 'https://api.grantex.dev/.well-known/jwks.json',
+  requiredScopes: ['payments:initiate'],
+});
+// Throws if 'payments:initiate' is not in the token's scopes
+```
+
+## Scope Enforcement in Integrations
+
+All framework integrations (LangChain, CrewAI, Vercel AI, etc.) perform offline scope checks by decoding the JWT's `scp` claim — no network call needed:
+
+```typescript
+// LangChain example
+const tool = createGrantexTool({
+  name: 'read_calendar',
+  grantToken,
+  requiredScope: 'calendar:read',  // checked offline from JWT
+  func: async (input) => getCalendarEvents(input),
+});
+```
+
+If the token doesn't include the required scope, the tool throws immediately — before your function runs.
+
+## User Experience
+
+Users see plain-language descriptions of scopes during the consent flow, not raw scope strings. Service providers define these descriptions when they register their scope definitions with Grantex.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "name": "Grantex",
+  "favicon": "/favicon.svg",
+  "logo": {
+    "light": "/logo/light.svg",
+    "dark": "/logo/dark.svg"
+  },
+  "colors": {
+    "primary": "#3fb950",
+    "light": "#58a6ff",
+    "dark": "#2ea043",
+    "background": {
+      "dark": "#0d1117"
+    }
+  },
+  "tabs": [
+    {
+      "tab": "Documentation",
+      "groups": [
+        {
+          "group": "Getting Started",
+          "pages": [
+            "introduction",
+            "quickstart",
+            "local-development"
+          ]
+        },
+        {
+          "group": "Core Concepts",
+          "pages": [
+            "concepts/how-it-works",
+            "concepts/grant-token",
+            "concepts/scopes",
+            "concepts/delegation"
+          ]
+        },
+        {
+          "group": "Guides",
+          "pages": [
+            "guides/webhooks",
+            "guides/self-hosting"
+          ]
+        },
+        {
+          "group": "Examples",
+          "pages": [
+            "examples/quickstart-ts",
+            "examples/quickstart-py",
+            "examples/langchain-agent",
+            "examples/vercel-ai-chatbot",
+            "examples/crewai-agent",
+            "examples/openai-agents",
+            "examples/google-adk"
+          ]
+        }
+      ]
+    },
+    {
+      "tab": "TypeScript SDK",
+      "groups": [
+        {
+          "group": "Overview",
+          "pages": [
+            "sdks/typescript/overview"
+          ]
+        },
+        {
+          "group": "Authorization",
+          "pages": [
+            "sdks/typescript/authorization",
+            "sdks/typescript/tokens",
+            "sdks/typescript/offline-verification",
+            "sdks/typescript/pkce"
+          ]
+        },
+        {
+          "group": "Resources",
+          "pages": [
+            "sdks/typescript/agents",
+            "sdks/typescript/grants",
+            "sdks/typescript/audit",
+            "sdks/typescript/webhooks",
+            "sdks/typescript/policies",
+            "sdks/typescript/compliance",
+            "sdks/typescript/anomalies",
+            "sdks/typescript/billing",
+            "sdks/typescript/scim",
+            "sdks/typescript/sso"
+          ]
+        },
+        {
+          "group": "Reference",
+          "pages": [
+            "sdks/typescript/errors"
+          ]
+        }
+      ]
+    },
+    {
+      "tab": "Python SDK",
+      "groups": [
+        {
+          "group": "Overview",
+          "pages": [
+            "sdks/python/overview"
+          ]
+        },
+        {
+          "group": "Authorization",
+          "pages": [
+            "sdks/python/authorization",
+            "sdks/python/tokens",
+            "sdks/python/offline-verification",
+            "sdks/python/pkce"
+          ]
+        },
+        {
+          "group": "Resources",
+          "pages": [
+            "sdks/python/agents",
+            "sdks/python/grants",
+            "sdks/python/audit",
+            "sdks/python/webhooks",
+            "sdks/python/policies",
+            "sdks/python/compliance",
+            "sdks/python/anomalies",
+            "sdks/python/billing",
+            "sdks/python/scim",
+            "sdks/python/sso"
+          ]
+        },
+        {
+          "group": "Reference",
+          "pages": [
+            "sdks/python/errors"
+          ]
+        }
+      ]
+    },
+    {
+      "tab": "Integrations",
+      "groups": [
+        {
+          "group": "Overview",
+          "pages": [
+            "integrations/overview"
+          ]
+        },
+        {
+          "group": "Framework Integrations",
+          "pages": [
+            "integrations/mcp",
+            "integrations/langchain",
+            "integrations/vercel-ai",
+            "integrations/autogen",
+            "integrations/crewai",
+            "integrations/openai-agents",
+            "integrations/google-adk"
+          ]
+        },
+        {
+          "group": "CLI",
+          "pages": [
+            "integrations/cli"
+          ]
+        }
+      ]
+    },
+    {
+      "tab": "Protocol",
+      "groups": [
+        {
+          "group": "Specification",
+          "pages": [
+            "protocol/specification",
+            "protocol/changelog"
+          ]
+        },
+        {
+          "group": "Security",
+          "pages": [
+            "security/overview",
+            "security/audit-report",
+            "security/soc2-report"
+          ]
+        },
+        {
+          "group": "Community",
+          "pages": [
+            "community/contributing",
+            "community/ietf-draft"
+          ]
+        }
+      ]
+    }
+  ],
+  "navbar": {
+    "links": [
+      {
+        "label": "Dashboard",
+        "url": "https://grantex.dev/dashboard"
+      },
+      {
+        "label": "GitHub",
+        "url": "https://github.com/mishrasanjeev/grantex"
+      }
+    ]
+  },
+  "footerSocials": {
+    "github": "https://github.com/mishrasanjeev/grantex"
+  },
+  "feedback": {
+    "thumbsRating": true
+  },
+  "search": {
+    "prompt": "Search Grantex docs..."
+  }
+}

--- a/docs/examples/crewai-agent.mdx
+++ b/docs/examples/crewai-agent.mdx
@@ -1,0 +1,72 @@
+---
+title: "CrewAI Agent"
+sidebarTitle: "CrewAI"
+description: "Scoped tools with audit logging using CrewAI."
+---
+
+## What it does
+
+This example demonstrates the `grantex-crewai` integration by building CrewAI tools with Grantex scope enforcement:
+
+1. **Register an agent** and obtain a grant token via the sandbox flow
+2. **Create scoped tools** using `create_grantex_tool` -- each tool is bound to a specific scope (`calendar:read`, `email:send`)
+3. **Wrap tools with `with_audit_logging`** to automatically log every invocation to the Grantex audit trail
+4. **Invoke tools** directly (in a full CrewAI crew, the LLM would select and call these tools)
+5. **Demonstrate scope enforcement** -- attempting to create a tool with `account:delete` (a scope not in the grant) raises a `PermissionError`
+6. **Inspect the audit trail** to see the logged actions
+
+## Prerequisites
+
+- **Python 3.9+**
+- **Docker** (Docker Desktop or Docker Engine with Compose)
+
+## Run
+
+Start the local Grantex stack from the repository root:
+
+```bash
+docker compose up --build
+```
+
+In a separate terminal, run the example:
+
+```bash
+cd examples/crewai-agent
+pip install -r requirements.txt
+python main.py
+```
+
+## Expected output
+
+```text
+Agent registered: ag_01HXYZ...
+Grant token received, grantId: grnt_01HXYZ...
+Tools created: read_calendar, send_email
+Audit logging attached
+
+--- Invoking read_calendar ---
+Result: {"events": [{"title": "Team standup", "time": "9:00 AM", "query": "today"}, {"title": "Design review", "time": "2:00 PM", "query": "today"}]}
+
+--- Invoking send_email ---
+Result: Email sent successfully: "Meeting summary: standup at 9 AM, design review at 2 PM"
+
+--- Testing scope enforcement ---
+Scope check blocked unauthorized tool: Grant token does not include required scope "account:delete". Granted scopes: calendar:read, email:send
+
+--- Audit trail ---
+  [success] read_calendar — 2026-02-28T12:00:00.000Z
+  [success] send_email — 2026-02-28T12:00:01.000Z
+
+Done! CrewAI integration demo complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |
+
+## Source code
+
+The full source is in [`examples/crewai-agent/main.py`](https://github.com/mishrasanjeev/grantex/tree/main/examples/crewai-agent).

--- a/docs/examples/google-adk.mdx
+++ b/docs/examples/google-adk.mdx
@@ -1,0 +1,70 @@
+---
+title: "Google ADK"
+sidebarTitle: "Google ADK"
+description: "Scope-enforced tools using Google Agent Development Kit."
+---
+
+## What it does
+
+This example demonstrates the `grantex-adk` integration by building scope-enforced tools for Google Agent Development Kit (ADK):
+
+1. **Register an agent** and obtain a grant token via the sandbox flow
+2. **Create scoped tools** using `create_grantex_tool` -- each tool returns a plain function that can be used directly with Google ADK agents (`calendar:read`, `email:send`)
+3. **Invoke tools** directly as plain functions (in a full ADK agent, Gemini would select and call these tools)
+4. **Demonstrate scope enforcement** -- attempting to create a tool with `account:delete` (a scope not in the grant) raises a `PermissionError`
+5. **Inspect the audit trail** to see the logged actions
+
+## Prerequisites
+
+- **Python 3.9+**
+- **Docker** (Docker Desktop or Docker Engine with Compose)
+
+## Run
+
+Start the local Grantex stack from the repository root:
+
+```bash
+docker compose up --build
+```
+
+In a separate terminal, run the example:
+
+```bash
+cd examples/google-adk
+pip install -r requirements.txt
+python main.py
+```
+
+## Expected output
+
+```text
+Agent registered: ag_01HXYZ...
+Grant token received, grantId: grnt_01HXYZ...
+Tools created: read_calendar, send_email
+
+--- Invoking read_calendar ---
+Result: {"events": [{"title": "Team standup", "time": "9:00 AM", "query": "today"}, {"title": "Design review", "time": "2:00 PM", "query": "today"}]}
+
+--- Invoking send_email ---
+Result: Email sent successfully: "Meeting summary: standup at 9 AM, design review at 2 PM"
+
+--- Testing scope enforcement ---
+Scope check blocked unauthorized tool: Grant token does not include required scope "account:delete". Granted scopes: calendar:read, email:send
+
+--- Audit trail ---
+  [success] read_calendar — 2026-02-28T12:00:00.000Z
+  [success] send_email — 2026-02-28T12:00:01.000Z
+
+Done! Google ADK integration demo complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |
+
+## Source code
+
+The full source is in [`examples/google-adk/main.py`](https://github.com/mishrasanjeev/grantex/tree/main/examples/google-adk).

--- a/docs/examples/langchain-agent.mdx
+++ b/docs/examples/langchain-agent.mdx
@@ -1,0 +1,79 @@
+---
+title: "LangChain Agent"
+sidebarTitle: "LangChain"
+description: "Scoped tools with automatic audit logging using LangChain."
+---
+
+## What it does
+
+This example demonstrates the `@grantex/langchain` integration by building a LangChain agent with Grantex-scoped tools:
+
+1. **Register an agent** and obtain a grant token via the sandbox flow
+2. **Create scoped tools** using `createGrantexTool` -- each tool is bound to a specific scope (`calendar:read`, `email:send`)
+3. **Attach a `GrantexAuditHandler`** that automatically logs every tool invocation to the Grantex audit trail
+4. **Invoke tools** directly (or via an LLM if `OPENAI_API_KEY` is set)
+5. **Demonstrate scope enforcement** -- attempting to create a tool with `account:delete` (a scope not in the grant) throws immediately
+6. **Inspect the audit trail** to see the logged actions
+
+## Prerequisites
+
+- **Node.js 18+**
+- **Docker** (Docker Desktop or Docker Engine with Compose)
+
+## Run
+
+Start the local Grantex stack from the repository root:
+
+```bash
+docker compose up --build
+```
+
+In a separate terminal, run the example:
+
+```bash
+cd examples/langchain-agent
+npm install
+npm start
+```
+
+To use a real LLM for tool selection instead of direct invocation, set `OPENAI_API_KEY`:
+
+```bash
+OPENAI_API_KEY=sk-... npm start
+```
+
+## Expected output
+
+```text
+Agent registered: ag_01HXYZ...
+Grant token received, grantId: grnt_01HXYZ...
+Tools created: read_calendar, send_email
+Audit handler configured
+
+--- Invoking read_calendar ---
+Result: {"events":[{"title":"Team standup","time":"9:00 AM","query":"today"},{"title":"Design review","time":"2:00 PM","query":"today"}]}
+
+--- Invoking send_email ---
+Result: Email sent successfully: "Meeting summary: standup at 9 AM, design review at 2 PM"
+
+--- Testing scope enforcement ---
+Scope check blocked unauthorized tool: Grant token does not include required scope "account:delete". Granted scopes: calendar:read, email:send
+
+--- Audit trail ---
+  [success] read_calendar — 2026-02-28T12:00:00.000Z
+  [success] send_email — 2026-02-28T12:00:01.000Z
+
+Done! LangChain integration demo complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |
+| `OPENAI_API_KEY` | _(none)_ | Optional. Set to use a real LLM for tool selection |
+
+## Source code
+
+The full source is in [`examples/langchain-agent/src/index.ts`](https://github.com/mishrasanjeev/grantex/tree/main/examples/langchain-agent).

--- a/docs/examples/openai-agents.mdx
+++ b/docs/examples/openai-agents.mdx
@@ -1,0 +1,70 @@
+---
+title: "OpenAI Agents SDK"
+sidebarTitle: "OpenAI Agents"
+description: "Scope-enforced tools using the OpenAI Agents SDK."
+---
+
+## What it does
+
+This example demonstrates the `grantex-openai-agents` integration by building scope-enforced tools for the OpenAI Agents SDK:
+
+1. **Register an agent** and obtain a grant token via the sandbox flow
+2. **Create scoped tools** using `create_grantex_tool` -- each tool is bound to a specific scope (`calendar:read`, `email:send`)
+3. **Invoke tools** directly (in a full Agents workflow, the LLM would select and call these tools)
+4. **Demonstrate scope enforcement** -- attempting to create a tool with `account:delete` (a scope not in the grant) raises a `PermissionError`
+5. **Inspect the audit trail** to see the logged actions
+
+## Prerequisites
+
+- **Python 3.9+**
+- **Docker** (Docker Desktop or Docker Engine with Compose)
+
+## Run
+
+Start the local Grantex stack from the repository root:
+
+```bash
+docker compose up --build
+```
+
+In a separate terminal, run the example:
+
+```bash
+cd examples/openai-agents
+pip install -r requirements.txt
+python main.py
+```
+
+## Expected output
+
+```text
+Agent registered: ag_01HXYZ...
+Grant token received, grantId: grnt_01HXYZ...
+Tools created: read_calendar, send_email
+
+--- Invoking read_calendar ---
+Result: {"events": [{"title": "Team standup", "time": "9:00 AM", "query": "today"}, {"title": "Design review", "time": "2:00 PM", "query": "today"}]}
+
+--- Invoking send_email ---
+Result: Email sent successfully: "Meeting summary: standup at 9 AM, design review at 2 PM"
+
+--- Testing scope enforcement ---
+Scope check blocked unauthorized tool: Grant token does not include required scope "account:delete". Granted scopes: calendar:read, email:send
+
+--- Audit trail ---
+  [success] read_calendar — 2026-02-28T12:00:00.000Z
+  [success] send_email — 2026-02-28T12:00:01.000Z
+
+Done! OpenAI Agents SDK integration demo complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |
+
+## Source code
+
+The full source is in [`examples/openai-agents/main.py`](https://github.com/mishrasanjeev/grantex/tree/main/examples/openai-agents).

--- a/docs/examples/quickstart-py.mdx
+++ b/docs/examples/quickstart-py.mdx
@@ -1,0 +1,67 @@
+---
+title: "Quickstart (Python)"
+sidebarTitle: "Quickstart (PY)"
+description: "End-to-end authorization lifecycle with the Python SDK."
+---
+
+## What it does
+
+This example walks through the complete Grantex authorization lifecycle using the Python SDK:
+
+1. **Register an agent** with `calendar:read` and `email:send` scopes
+2. **Authorize in sandbox mode** -- the sandbox API key auto-approves and returns a `code` immediately (no redirect required)
+3. **Exchange the code** for a signed RS256 grant token
+4. **Verify the token offline** against the local JWKS endpoint
+5. **Log an audit entry** recording a `calendar.read` action
+6. **Revoke the token** and confirm revocation via an online verify check
+
+## Prerequisites
+
+- **Python 3.9+**
+- **Docker** (Docker Desktop or Docker Engine with Compose)
+
+## Run
+
+Start the local Grantex stack from the repository root:
+
+```bash
+docker compose up --build
+```
+
+In a separate terminal, run the example:
+
+```bash
+cd examples/quickstart-py
+pip install -r requirements.txt
+python main.py
+```
+
+## Expected output
+
+```text
+Agent registered: ag_01HXYZ... did:grantex:ag_01HXYZ...
+Auth request: areq_01HXYZ...
+Sandbox auto-approved, code: 01JXYZ...
+Grant token received, grantId: grnt_01HXYZ...
+Scopes: calendar:read, email:send
+Token verified offline:
+  principalId: test-user-001
+  agentDid:    did:grantex:ag_01HXYZ...
+  scopes:      calendar:read, email:send
+Audit entry logged: aud_01HXYZ...
+Token revoked.
+Post-revocation verify: revoked
+
+Done! Full authorization lifecycle complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |
+
+## Source code
+
+The full source is in [`examples/quickstart-py/main.py`](https://github.com/mishrasanjeev/grantex/tree/main/examples/quickstart-py).

--- a/docs/examples/quickstart-ts.mdx
+++ b/docs/examples/quickstart-ts.mdx
@@ -1,0 +1,67 @@
+---
+title: "Quickstart (TypeScript)"
+sidebarTitle: "Quickstart (TS)"
+description: "End-to-end authorization lifecycle with the TypeScript SDK."
+---
+
+## What it does
+
+This example walks through the complete Grantex authorization lifecycle using the TypeScript SDK:
+
+1. **Register an agent** with `calendar:read` and `email:send` scopes
+2. **Authorize in sandbox mode** -- the sandbox API key auto-approves and returns a `code` immediately (no redirect required)
+3. **Exchange the code** for a signed RS256 grant token
+4. **Verify the token offline** against the local JWKS endpoint
+5. **Log an audit entry** recording a `calendar.read` action
+6. **Revoke the token** and confirm revocation via an online verify check
+
+## Prerequisites
+
+- **Node.js 18+**
+- **Docker** (Docker Desktop or Docker Engine with Compose)
+
+## Run
+
+Start the local Grantex stack from the repository root:
+
+```bash
+docker compose up --build
+```
+
+In a separate terminal, run the example:
+
+```bash
+cd examples/quickstart-ts
+npm install
+npm start
+```
+
+## Expected output
+
+```text
+Agent registered: ag_01HXYZ... did:grantex:ag_01HXYZ...
+Auth request: areq_01HXYZ...
+Sandbox auto-approved, code: 01JXYZ...
+Grant token received, grantId: grnt_01HXYZ...
+Scopes: calendar:read, email:send
+Token verified offline:
+  principalId: test-user-001
+  agentDid:    did:grantex:ag_01HXYZ...
+  scopes:      calendar:read, email:send
+Audit entry logged: aud_01HXYZ...
+Token revoked.
+Post-revocation verify: revoked
+
+Done! Full authorization lifecycle complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |
+
+## Source code
+
+The full source is in [`examples/quickstart-ts/src/index.ts`](https://github.com/mishrasanjeev/grantex/tree/main/examples/quickstart-ts).

--- a/docs/examples/vercel-ai-chatbot.mdx
+++ b/docs/examples/vercel-ai-chatbot.mdx
@@ -1,0 +1,81 @@
+---
+title: "Vercel AI Chatbot"
+sidebarTitle: "Vercel AI"
+description: "Scope-enforced tools with audit logging using Vercel AI SDK."
+---
+
+## What it does
+
+This example demonstrates the `@grantex/vercel-ai` integration by building scope-enforced tools with the Vercel AI SDK:
+
+1. **Register an agent** and obtain a grant token via the sandbox flow
+2. **Create scoped tools** using `createGrantexTool` with Zod schemas for typed parameters (`calendar:read`, `email:send`)
+3. **Wrap tools with `withAuditLogging`** to automatically log every execution to the Grantex audit trail
+4. **Invoke tools** via `generateText` (if `OPENAI_API_KEY` is set) or directly
+5. **Demonstrate `GrantexScopeError`** -- attempting to create a tool with `storage:delete` (a scope not in the grant) throws a `GrantexScopeError` with `requiredScope` and `grantedScopes` properties
+6. **Inspect the audit trail** to see the logged actions
+
+## Prerequisites
+
+- **Node.js 18+**
+- **Docker** (Docker Desktop or Docker Engine with Compose)
+
+## Run
+
+Start the local Grantex stack from the repository root:
+
+```bash
+docker compose up --build
+```
+
+In a separate terminal, run the example:
+
+```bash
+cd examples/vercel-ai-chatbot
+npm install
+npm start
+```
+
+To use a real LLM with `generateText` instead of direct tool invocation, set `OPENAI_API_KEY`:
+
+```bash
+OPENAI_API_KEY=sk-... npm start
+```
+
+## Expected output
+
+Without `OPENAI_API_KEY` (direct invocation):
+
+```text
+Agent registered: ag_01HXYZ...
+Grant token received, grantId: grnt_01HXYZ...
+Tools created: read_calendar, send_email
+Audit logging attached
+
+--- Invoking tools directly (no OPENAI_API_KEY set) ---
+Calendar result: {"date":"today","events":[{"title":"Team standup","time":"9:00 AM"},{"title":"Design review","time":"2:00 PM"}]}
+Email result: {"sent":true,"to":"alice@example.com","subject":"Today's events","bodyLength":49}
+
+--- Testing scope enforcement ---
+GrantexScopeError caught:
+  Required scope:  storage:delete
+  Granted scopes:  calendar:read, email:send
+
+--- Audit trail ---
+  [success] read_calendar — 2026-02-28T12:00:00.000Z
+  [success] send_email — 2026-02-28T12:00:01.000Z
+
+Done! Vercel AI integration demo complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |
+| `OPENAI_API_KEY` | _(none)_ | Optional. Set to use `generateText` with a real LLM |
+
+## Source code
+
+The full source is in [`examples/vercel-ai-chatbot/src/index.ts`](https://github.com/mishrasanjeev/grantex/tree/main/examples/vercel-ai-chatbot).

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="glow" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3fb950"/>
+      <stop offset="100%" stop-color="#2ea043"/>
+    </linearGradient>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="0" stdDeviation="8" flood-color="#3fb950" flood-opacity="0.4"/>
+    </filter>
+  </defs>
+
+  <!-- Dark background circle -->
+  <circle cx="256" cy="256" r="248" fill="#0d1117"/>
+  <circle cx="256" cy="256" r="248" fill="none" stroke="#1e2733" stroke-width="4"/>
+
+  <!-- Shield outline — green with glow -->
+  <path d="M256 72 L416 160 L416 304 C416 380 340 440 256 468 C172 440 96 380 96 304 L96 160 Z"
+        fill="none" stroke="url(#glow)" stroke-width="16" stroke-linejoin="round"
+        filter="url(#shadow)"/>
+
+  <!-- Checkmark inside shield -->
+  <polyline points="188,256 236,312 332,200"
+            fill="none" stroke="#3fb950" stroke-width="28" stroke-linecap="round" stroke-linejoin="round"
+            filter="url(#shadow)"/>
+</svg>

--- a/docs/guides/self-hosting.mdx
+++ b/docs/guides/self-hosting.mdx
@@ -1,0 +1,208 @@
+---
+title: "Self-Hosting"
+sidebarTitle: "Self-Hosting"
+description: "Run your own Grantex auth service — from local dev to production Kubernetes."
+---
+
+## 1. Quick Start (Dev)
+
+```bash
+git clone https://github.com/mishrasanjeev/grantex.git
+cd grantex
+docker compose up --build
+```
+
+This starts PostgreSQL, Redis, and the auth service. Two developer accounts are seeded automatically:
+
+| Account | API key | Mode |
+|---------|---------|------|
+| Live | `dev-api-key-local` | Normal consent flow |
+| Sandbox | `sandbox-api-key-local` | Auto-approves grants, returns `code` immediately |
+
+Verify it's running:
+
+```bash
+curl http://localhost:3001/health
+# { "status": "ok" }
+
+curl http://localhost:3001/.well-known/jwks.json
+# { "keys": [{ "kty": "RSA", "alg": "RS256", ... }] }
+```
+
+<Warning>
+The dev compose exposes database and Redis ports and uses hardcoded credentials. Never use it in production.
+</Warning>
+
+## 2. Generating a Production RSA Key
+
+Grantex signs grant tokens with RSA-256. Generate a 2048-bit private key:
+
+```bash
+openssl genrsa -out private.pem 2048
+```
+
+Collapse to a single line for environment variables:
+
+```bash
+awk 'NF {sub(/\r/, ""); printf "%s\\n", $0}' private.pem
+```
+
+Copy the output and use it as `RSA_PRIVATE_KEY`.
+
+<Note>
+Keep `private.pem` out of source control. The JWKS endpoint exposes only the public key.
+</Note>
+
+## 3. Production Docker Compose
+
+### Prerequisites
+
+- Docker 24+ with Compose v2
+- A domain name with DNS pointing to your server
+- TLS certificate (Let's Encrypt for production)
+
+### Step 1 — Fill in the env file
+
+```bash
+cp .env.prod.example .env.prod
+```
+
+Edit `.env.prod` and replace every `change-me-*` placeholder. Set `RSA_PRIVATE_KEY` to the collapsed PEM and `JWT_ISSUER` to your public base URL.
+
+### Step 2 — Provide TLS certificates
+
+```bash
+# Let's Encrypt (production)
+certbot certonly --standalone -d auth.example.com
+cp /etc/letsencrypt/live/auth.example.com/fullchain.pem deploy/nginx/certs/server.crt
+cp /etc/letsencrypt/live/auth.example.com/privkey.pem   deploy/nginx/certs/server.key
+```
+
+### Step 3 — Start the stack
+
+```bash
+docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+```
+
+Architecture:
+
+```
+Internet → nginx (:443) → auth-service:3001
+                ↓
+           postgres + redis  (internal network only)
+```
+
+## 4. Kubernetes / Helm
+
+### Prerequisites
+
+- Kubernetes 1.26+, Helm 3.x
+- Managed PostgreSQL and Redis
+- An RSA private key (Section 2)
+
+### Install
+
+```bash
+helm install grantex deploy/helm/grantex/ \
+  --namespace grantex --create-namespace \
+  --set externalDatabase.url="postgres://user:pass@host:5432/grantex" \
+  --set externalRedis.url="redis://:pass@host:6379" \
+  --set rsaPrivateKey="$(awk 'NF {sub(/\r/, ""); printf "%s\\n", $0}' private.pem)" \
+  --set config.jwtIssuer="https://auth.example.com"
+```
+
+### Enable Ingress
+
+```bash
+helm upgrade grantex deploy/helm/grantex/ \
+  --reuse-values \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set "ingress.hosts[0].host=auth.example.com" \
+  --set "ingress.hosts[0].paths[0].path=/" \
+  --set "ingress.hosts[0].paths[0].pathType=Prefix" \
+  --set "ingress.tls[0].secretName=grantex-tls" \
+  --set "ingress.tls[0].hosts[0]=auth.example.com"
+```
+
+### Use an existing Secret
+
+```bash
+kubectl create secret generic grantex-secrets \
+  --namespace grantex \
+  --from-literal=RSA_PRIVATE_KEY="$(cat private.pem)"
+
+helm install grantex deploy/helm/grantex/ \
+  --namespace grantex \
+  --set existingSecret=grantex-secrets \
+  --set externalDatabase.url="..." \
+  --set externalRedis.url="..."
+```
+
+## 5. Environment Variable Reference
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `DATABASE_URL` | Yes | — | PostgreSQL connection string |
+| `REDIS_URL` | Yes | — | Redis connection string |
+| `RSA_PRIVATE_KEY` | Yes* | — | PEM private key for JWT signing. *Or set `AUTO_GENERATE_KEYS=true` (dev only) |
+| `AUTO_GENERATE_KEYS` | No | `false` | Auto-generate RSA keypair at startup (dev only) |
+| `JWT_ISSUER` | Yes | `https://grantex.dev` | `iss` claim in every JWT |
+| `PORT` | No | `3001` | Port the auth service listens on |
+| `HOST` | No | `0.0.0.0` | Bind address |
+| `SEED_API_KEY` | No | — | Pre-seed a live developer API key (dev only) |
+| `SEED_SANDBOX_KEY` | No | — | Pre-seed a sandbox API key (dev only) |
+| `STRIPE_SECRET_KEY` | No | — | Enable Stripe billing integration |
+| `STRIPE_WEBHOOK_SECRET` | No | — | Stripe webhook signature validation |
+| `STRIPE_PRICE_PRO` | No | — | Stripe price ID for Pro tier |
+| `STRIPE_PRICE_ENTERPRISE` | No | — | Stripe price ID for Enterprise tier |
+
+## 6. Database Migrations
+
+Migrations run **automatically on every startup**. The auth service reads all `*.sql` files from the `migrations/` directory and executes each one using idempotent DDL (`CREATE TABLE IF NOT EXISTS`, etc.).
+
+There are currently **9 migration files** covering: core tables, webhooks, consent, delegation, compliance, policies, anomalies, SCIM/SSO, and developer email.
+
+To upgrade, just restart the service — new migration files are applied automatically.
+
+## 7. Key Rotation
+
+1. Generate a new RSA key pair (Section 2)
+2. Update `RSA_PRIVATE_KEY` in your env file or Kubernetes secret
+3. Restart the auth service
+
+Tokens signed with the old key remain valid until expiry because the JWKS endpoint always exposes the current public key — clients re-fetch it automatically when verification fails.
+
+## 8. Health Checks & Monitoring
+
+```
+GET /health → 200 { "status": "ok" }
+```
+
+All logs are emitted as JSON to stdout, compatible with Datadog, Loki, and CloudWatch Logs.
+
+## 9. Backup & Recovery
+
+### PostgreSQL
+
+```bash
+docker compose -f docker-compose.prod.yml exec postgres \
+  pg_dump -U "$POSTGRES_USER" grantex | gzip > "grantex-$(date +%Y%m%d).sql.gz"
+```
+
+### Redis
+
+Redis holds ephemeral token metadata and rate-limiting state. If Redis data is lost, in-flight auth requests will fail temporarily, but no permanent data is lost. PostgreSQL is the source of truth.
+
+## 10. Production Readiness Checklist
+
+- [ ] `RSA_PRIVATE_KEY` is a real 2048-bit RSA key
+- [ ] `POSTGRES_PASSWORD` and `REDIS_PASSWORD` are strong random values
+- [ ] `SEED_API_KEY` and `SEED_SANDBOX_KEY` are **not** set
+- [ ] TLS is enabled end-to-end
+- [ ] Database and Redis ports are not exposed publicly
+- [ ] `JWT_ISSUER` matches your public base URL exactly
+- [ ] Automated database backups are configured
+- [ ] Health checks are wired into your load balancer
+- [ ] CPU and memory limits are set
+- [ ] Log forwarding is configured

--- a/docs/guides/webhooks.mdx
+++ b/docs/guides/webhooks.mdx
@@ -1,0 +1,204 @@
+---
+title: "Webhooks"
+sidebarTitle: "Webhooks"
+description: "Receive real-time notifications for grant lifecycle events."
+---
+
+Grantex can POST a signed JSON payload to your server whenever key events occur — grant created, grant revoked, or token issued. Use webhooks to keep your application in sync with the authorization lifecycle without polling.
+
+## Supported Events
+
+| Event | When it fires |
+|-------|---------------|
+| `grant.created` | A new grant is issued (user completes consent flow) |
+| `grant.revoked` | A grant is revoked (root or cascade) |
+| `token.issued` | A token is issued (same moment as `grant.created` for initial exchange) |
+
+## Registering an Endpoint
+
+```bash
+curl -X POST https://api.grantex.dev/v1/webhooks \
+  -H "Authorization: Bearer <your-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://your-app.com/webhooks/grantex",
+    "events": ["grant.created", "grant.revoked"]
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "id": "wh_01JXYZ...",
+  "url": "https://your-app.com/webhooks/grantex",
+  "events": ["grant.created", "grant.revoked"],
+  "secret": "a3f8c2...",
+  "createdAt": "2026-02-26T12:00:00Z"
+}
+```
+
+<Warning>
+The `secret` is returned only once. Store it securely — you need it to verify incoming payloads.
+</Warning>
+
+## Event Payload Shape
+
+Every webhook POST has the same envelope:
+
+```json
+{
+  "id": "evt_01JXYZ...",
+  "type": "grant.created",
+  "createdAt": "2026-02-26T12:00:00Z",
+  "data": { ... }
+}
+```
+
+### `grant.created`
+
+```json
+{
+  "grantId": "grnt_01...",
+  "agentId": "ag_01...",
+  "principalId": "user-123",
+  "scopes": ["calendar:read"],
+  "expiresAt": "2026-03-26T12:00:00Z"
+}
+```
+
+### `grant.revoked`
+
+```json
+{
+  "grantId": "grnt_01...",
+  "cascade": true
+}
+```
+
+`cascade: true` means descendant grants were also revoked.
+
+### `token.issued`
+
+```json
+{
+  "tokenId": "tok_01...",
+  "grantId": "grnt_01...",
+  "agentId": "ag_01...",
+  "principalId": "user-123",
+  "scopes": ["calendar:read"],
+  "expiresAt": "2026-03-26T12:00:00Z"
+}
+```
+
+## Verifying Signatures
+
+Every request includes an `X-Grantex-Signature` header with a hex-encoded HMAC-SHA256 signature of the raw request body:
+
+```
+X-Grantex-Signature: sha256=<hex>
+```
+
+<CodeGroup>
+```typescript TypeScript
+import { verifyWebhookSignature } from '@grantex/sdk';
+
+app.post('/webhooks/grantex', (req, res) => {
+  const sig = req.headers['x-grantex-signature'] as string;
+  const rawBody = req.rawBody;
+
+  if (!verifyWebhookSignature(rawBody, sig, process.env.GRANTEX_WEBHOOK_SECRET!)) {
+    return res.status(401).send('Invalid signature');
+  }
+
+  const event = JSON.parse(rawBody);
+  console.log('Received event:', event.type);
+  res.status(200).send();
+});
+```
+
+```python Python
+from grantex import verify_webhook_signature
+import os
+
+@app.route('/webhooks/grantex', methods=['POST'])
+def handle_webhook():
+    sig = request.headers.get('X-Grantex-Signature', '')
+    raw_body = request.get_data(as_text=True)
+
+    if not verify_webhook_signature(raw_body, sig, os.environ['GRANTEX_WEBHOOK_SECRET']):
+        return 'Invalid signature', 401
+
+    event = request.get_json()
+    print('Received event:', event['type'])
+    return '', 200
+```
+</CodeGroup>
+
+<Note>
+Always verify signatures before trusting the payload. Use the raw request body — not the parsed JSON.
+</Note>
+
+## SDK Usage
+
+<CodeGroup>
+```typescript TypeScript
+import { Grantex } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Register
+const endpoint = await grantex.webhooks.create({
+  url: 'https://your-app.com/webhooks/grantex',
+  events: ['grant.created', 'grant.revoked', 'token.issued'],
+});
+console.log('Webhook secret:', endpoint.secret);
+
+// List
+const { webhooks } = await grantex.webhooks.list();
+
+// Delete
+await grantex.webhooks.delete(endpoint.id);
+```
+
+```python Python
+from grantex import Grantex
+
+client = Grantex(api_key=os.environ['GRANTEX_API_KEY'])
+
+# Register
+endpoint = client.webhooks.create(
+    url='https://your-app.com/webhooks/grantex',
+    events=['grant.created', 'grant.revoked', 'token.issued'],
+)
+print('Webhook secret:', endpoint.secret)
+
+# List
+result = client.webhooks.list()
+
+# Delete
+client.webhooks.delete(endpoint.id)
+```
+</CodeGroup>
+
+## Delivery Behaviour
+
+- Grantex delivers webhooks with a **10-second timeout** per request.
+- Your endpoint should return **any 2xx status** to be considered successful.
+- Respond quickly (under 5s) and do heavy processing asynchronously.
+- Failed deliveries are retried with exponential backoff.
+
+## Local Development
+
+Use a tunnel tool to expose your local server:
+
+```bash
+# ngrok
+ngrok http 3000
+
+# Register the tunnel URL
+curl -X POST http://localhost:3001/v1/webhooks \
+  -H "Authorization: Bearer dev-api-key-local" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://<your-ngrok-id>.ngrok.io/webhooks","events":["grant.created"]}'
+```

--- a/docs/integrations/autogen.mdx
+++ b/docs/integrations/autogen.mdx
@@ -1,0 +1,123 @@
+---
+title: "AutoGen / OpenAI"
+sidebarTitle: "AutoGen"
+description: "Scope-enforced function calling and registry for OpenAI-style agents."
+---
+
+## Install
+
+```bash
+npm install @grantex/autogen @grantex/sdk
+```
+
+## Scope-Enforced Functions
+
+Create OpenAI function-calling tool definitions with built-in Grantex scope checks:
+
+```typescript
+import { createGrantexFunction } from '@grantex/autogen';
+
+const readCalendar = createGrantexFunction({
+  name: 'read_calendar',
+  description: 'Read upcoming calendar events',
+  parameters: {
+    type: 'object',
+    properties: {
+      date: { type: 'string', description: 'Date in YYYY-MM-DD format' },
+    },
+    required: ['date'],
+  },
+  grantToken,                     // JWT from Grantex token exchange
+  requiredScope: 'calendar:read', // must be in token's scp claim
+  func: async (args) => {
+    return await getCalendarEvents(args.date);
+  },
+});
+
+// Pass definition to the LLM
+const response = await openai.chat.completions.create({
+  model: 'gpt-4',
+  tools: [readCalendar.definition],
+  messages,
+});
+
+// Execute when the LLM selects the tool
+const result = await readCalendar.execute({ date: '2026-03-01' });
+```
+
+## Function Registry
+
+Use `GrantexFunctionRegistry` to manage multiple functions and dispatch tool calls by name:
+
+```typescript
+import { createGrantexFunction, GrantexFunctionRegistry } from '@grantex/autogen';
+
+const registry = new GrantexFunctionRegistry();
+registry.register(readCalendar);
+registry.register(sendEmail);
+
+// Pass all definitions to the LLM
+const response = await openai.chat.completions.create({
+  tools: registry.definitions,
+  messages,
+});
+
+// Dispatch the tool call
+const toolCall = response.choices[0].message.tool_calls[0];
+const result = await registry.execute(
+  toolCall.function.name,
+  JSON.parse(toolCall.function.arguments),
+);
+```
+
+## Audit Logging
+
+Wrap any function with `withAuditLogging`:
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+import { withAuditLogging } from '@grantex/autogen';
+
+const client = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+const audited = withAuditLogging(readCalendar, client, {
+  agentId: 'ag_01ABC...',
+  grantId: 'grnt_01XYZ...',
+});
+// Use audited.execute() — logs success/failure automatically
+```
+
+## API Reference
+
+### `createGrantexFunction(options)`
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `name` | `string` | Function name (matches `^[a-zA-Z0-9_-]+$`) |
+| `description` | `string` | Description shown to the LLM |
+| `parameters` | `JsonSchema` | JSON Schema for function arguments |
+| `grantToken` | `string` | Grantex JWT from token exchange |
+| `requiredScope` | `string` | Scope required to invoke this function |
+| `func` | `(args: T) => Promise<unknown>` | Function implementation |
+
+Returns `{ definition, execute }`.
+
+### `GrantexFunctionRegistry`
+
+| Method | Description |
+|--------|-------------|
+| `register(fn)` | Register a function (chainable) |
+| `definitions` | All registered OpenAI tool definitions |
+| `execute(name, args)` | Execute a function by name |
+
+### `withAuditLogging(fn, client, options)`
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `agentId` | `string` | Agent ID for audit attribution |
+| `grantId` | `string` | Grant ID for the session |
+
+## Requirements
+
+- Node.js 18+
+- `@grantex/sdk` >= 0.1.0

--- a/docs/integrations/cli.mdx
+++ b/docs/integrations/cli.mdx
@@ -1,0 +1,109 @@
+---
+title: "CLI"
+sidebarTitle: "CLI"
+description: "Manage agents, grants, audit logs, and more from your terminal."
+---
+
+## Install
+
+```bash
+npm install -g @grantex/cli
+```
+
+## Configure
+
+```bash
+# Interactive setup
+grantex config set --url https://grantex-auth-dd4mtrt2gq-uc.a.run.app --key YOUR_API_KEY
+
+# Or use environment variables
+export GRANTEX_URL=https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+export GRANTEX_KEY=YOUR_API_KEY
+
+# Verify your setup
+grantex config show
+```
+
+Config is saved to `~/.grantex/config.json`. Environment variables override the config file.
+
+## Commands
+
+### Agents
+
+```bash
+grantex agents list
+grantex agents register --name travel-booker --scopes calendar:read,payments:initiate
+grantex agents get ag_01ABC...
+grantex agents update ag_01ABC... --name new-name --scopes calendar:read,email:send
+grantex agents delete ag_01ABC...
+```
+
+### Grants
+
+```bash
+grantex grants list
+grantex grants list --agent ag_01ABC... --status active
+grantex grants revoke grnt_01XYZ...
+```
+
+### Tokens
+
+```bash
+grantex tokens verify <jwt-token>
+grantex tokens revoke <jti>
+```
+
+### Audit Log
+
+```bash
+grantex audit list
+grantex audit list --agent ag_01ABC... --action payment.initiated --since 2026-01-01
+```
+
+### Webhooks
+
+```bash
+grantex webhooks list
+grantex webhooks create --url https://example.com/hook --events grant.created,grant.revoked
+grantex webhooks delete wh_01XYZ...
+```
+
+Supported events: `grant.created`, `grant.revoked`, `token.issued`.
+
+### Compliance
+
+```bash
+# Summary stats
+grantex compliance summary
+grantex compliance summary --since 2026-01-01 --until 2026-02-01
+
+# Export grants
+grantex compliance export grants --format json --output grants.json
+
+# Export audit log
+grantex compliance export audit --format json --output audit.json
+
+# Evidence pack
+grantex compliance evidence-pack --framework soc2 --output evidence.json
+```
+
+### Anomaly Detection
+
+```bash
+grantex anomalies detect
+grantex anomalies list
+grantex anomalies list --unacknowledged
+grantex anomalies acknowledge anom_01XYZ...
+```
+
+## Local Development
+
+For local development with Docker Compose:
+
+```bash
+grantex config set --url http://localhost:3001 --key dev-api-key-local
+```
+
+## Requirements
+
+- Node.js 18+

--- a/docs/integrations/crewai.mdx
+++ b/docs/integrations/crewai.mdx
@@ -1,0 +1,114 @@
+---
+title: "CrewAI"
+sidebarTitle: "CrewAI"
+description: "Scope-enforced, audited agent tools for CrewAI."
+---
+
+## Install
+
+```bash
+pip install grantex-crewai
+```
+
+CrewAI is a peer dependency:
+
+```bash
+pip install crewai
+```
+
+## Scope-Enforced Tools
+
+```python
+from grantex_crewai import create_grantex_tool
+from pydantic import BaseModel
+
+class FetchParams(BaseModel):
+    url: str
+
+tool = create_grantex_tool(
+    name="fetch_data",
+    description="Fetches data from the given URL.",
+    grant_token="eyJhbGciOiJSUzI1NiIs...",  # Grantex JWT
+    required_scope="data:read",
+    func=lambda url: requests.get(url).text,
+    args_schema=FetchParams,
+)
+# Use in a CrewAI agent
+```
+
+The tool performs an **offline** scope check at creation time by decoding the JWT's `scp` claim. If the required scope is missing, a `PermissionError` is raised before the tool is ever used.
+
+## Audit Logging
+
+Wrap any Grantex tool with audit logging:
+
+```python
+from grantex import Grantex
+from grantex_crewai import create_grantex_tool, with_audit_logging
+
+client = Grantex(api_key="YOUR_API_KEY")
+
+tool = create_grantex_tool(
+    name="send_email",
+    description="Sends an email.",
+    grant_token=token,
+    required_scope="email:send",
+    func=send_email_fn,
+)
+
+tool = with_audit_logging(
+    tool, client,
+    agent_id="ag_01HXYZ...",
+    grant_id="grnt_01HXYZ...",
+)
+# Every call is now recorded in the audit trail
+```
+
+## API Reference
+
+### `create_grantex_tool()`
+
+```python
+create_grantex_tool(
+    *,
+    name: str,
+    description: str,
+    grant_token: str,
+    required_scope: str,
+    func: Callable[..., str],
+    args_schema: type[BaseModel] | None = None,
+) -> BaseTool
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `name` | Tool name (used in audit log entries) |
+| `description` | Human-readable description shown to the LLM |
+| `grant_token` | Grantex grant token (RS256 JWT) |
+| `required_scope` | Scope that must be present in the token's `scp` claim |
+| `func` | The function to execute when the tool is called |
+| `args_schema` | Optional Pydantic `BaseModel` describing tool inputs |
+
+**Raises:** `PermissionError` if the grant token doesn't contain `required_scope`.
+
+### `with_audit_logging()`
+
+```python
+with_audit_logging(
+    tool: BaseTool,
+    client: Grantex,
+    *,
+    agent_id: str,
+    grant_id: str,
+) -> BaseTool
+```
+
+### `get_tool_scopes(grant_token)`
+
+Returns the scopes embedded in a grant token. Purely offline — no network call.
+
+## Requirements
+
+- Python 3.9+
+- `grantex` >= 0.1.0
+- `crewai` >= 0.28.0 (peer dependency)

--- a/docs/integrations/google-adk.mdx
+++ b/docs/integrations/google-adk.mdx
@@ -1,0 +1,69 @@
+---
+title: "Google ADK"
+sidebarTitle: "Google ADK"
+description: "Scope-enforced plain function tools for Google Agent Development Kit."
+---
+
+## Install
+
+```bash
+pip install grantex-adk
+```
+
+Google ADK is a peer dependency:
+
+```bash
+pip install google-adk
+```
+
+## Quick Start
+
+```python
+from grantex_adk import create_grantex_tool
+from google.adk import Agent
+
+read_calendar = create_grantex_tool(
+    name="read_calendar",
+    description="Read upcoming calendar events",
+    grant_token=grant_token,       # JWT from Grantex authorization flow
+    required_scope="calendar:read",
+    func=get_calendar_events,
+)
+
+# Google ADK uses plain functions as tools
+agent = Agent(
+    model="gemini-2.0-flash",
+    name="assistant",
+    tools=[read_calendar],
+)
+```
+
+If the grant token doesn't include the required scope, `create_grantex_tool` raises a `PermissionError` immediately.
+
+## API Reference
+
+### `create_grantex_tool()`
+
+Creates a plain function with the correct `__name__` and `__doc__` for ADK tool discovery, with offline scope enforcement.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | `str` | Tool name (becomes `__name__`) |
+| `description` | `str` | Tool description (becomes `__doc__`) |
+| `grant_token` | `str` | JWT grant token from Grantex |
+| `required_scope` | `str` | Scope that must be present in the token |
+| `func` | `Callable[..., str]` | The function to wrap |
+
+### `get_tool_scopes(grant_token)`
+
+Returns the scopes embedded in a grant token (offline, no network call).
+
+### `decode_jwt_payload(token)`
+
+Decodes the payload of a JWT without verifying the signature.
+
+## Requirements
+
+- Python 3.9+
+- `grantex` >= 0.1.0
+- `google-adk` >= 0.2.0 (peer dependency)

--- a/docs/integrations/langchain.mdx
+++ b/docs/integrations/langchain.mdx
@@ -1,0 +1,90 @@
+---
+title: "LangChain"
+sidebarTitle: "LangChain"
+description: "Scope-enforced tools and automatic audit logging for LangChain agents."
+---
+
+## Install
+
+```bash
+npm install @grantex/langchain @grantex/sdk @langchain/core
+```
+
+## Scope-Enforced Tools
+
+Wrap any tool function with `createGrantexTool` to enforce Grantex scope authorization before execution:
+
+```typescript
+import { createGrantexTool } from '@grantex/langchain';
+
+const tool = createGrantexTool({
+  name: 'read_calendar',
+  description: 'Read upcoming calendar events',
+  grantToken,                     // JWT from Grantex token exchange
+  requiredScope: 'calendar:read', // must be in token's scp claim
+  func: async (input) => {
+    return JSON.stringify(await getCalendarEvents(input));
+  },
+});
+
+// Use with any LangChain agent
+const agent = createToolCallingAgent({ llm, tools: [tool], prompt });
+```
+
+The scope check is **offline** — it reads the `scp` claim from the JWT directly, no network call needed. If the token doesn't include the required scope, the tool throws before your function runs.
+
+## Audit Logging
+
+Attach `GrantexAuditHandler` as a LangChain callback to automatically log every tool invocation to the Grantex audit trail:
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+import { GrantexAuditHandler } from '@grantex/langchain';
+
+const client = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+const auditHandler = new GrantexAuditHandler({
+  client,
+  agentId: 'ag_01ABC...',
+  grantToken,
+});
+
+const result = await agentExecutor.invoke(
+  { input: 'What meetings do I have today?' },
+  { callbacks: [auditHandler] },
+);
+```
+
+Each tool call logs:
+- `tool:<toolName>` with `status: 'success'` on success
+- `tool:error` with `status: 'failure'` on error
+
+## API Reference
+
+### `createGrantexTool(options)`
+
+Creates a LangChain `DynamicTool` with Grantex scope enforcement.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `name` | `string` | Tool name shown to the LLM |
+| `description` | `string` | Tool description shown to the LLM |
+| `grantToken` | `string` | Grantex JWT from token exchange |
+| `requiredScope` | `string` | Scope required to invoke this tool |
+| `func` | `(input: string) => Promise<string>` | Tool implementation |
+
+### `GrantexAuditHandler`
+
+LangChain callback handler that writes tool invocations to the Grantex audit trail.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `client` | `Grantex` | Authenticated SDK client |
+| `agentId` | `string` | Agent ID for audit attribution |
+| `grantToken` | `string` | JWT (grant ID extracted from `grnt` or `jti` claim) |
+
+## Requirements
+
+- Node.js 18+
+- `@grantex/sdk` >= 0.1.0
+- `@langchain/core` >= 0.3.0

--- a/docs/integrations/mcp.mdx
+++ b/docs/integrations/mcp.mdx
@@ -1,0 +1,64 @@
+---
+title: "MCP Server"
+sidebarTitle: "MCP"
+description: "Use Grantex from Claude Desktop, Cursor, or Windsurf via the Model Context Protocol."
+---
+
+## Install
+
+```bash
+npm install -g @grantex/mcp
+```
+
+## Configuration
+
+Add to your MCP config (Claude Desktop, Cursor, or Windsurf):
+
+```json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "grantex-mcp",
+      "env": {
+        "GRANTEX_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GRANTEX_API_KEY` | Yes | Your Grantex API key |
+| `GRANTEX_BASE_URL` | No | Override API base URL (default: `https://api.grantex.dev`) |
+
+## Available Tools
+
+The MCP server exposes 13 tools:
+
+| Tool | Description |
+|------|-------------|
+| `grantex_agent_register` | Register a new AI agent |
+| `grantex_agent_list` | List all registered agents |
+| `grantex_agent_get` | Get details for a specific agent |
+| `grantex_authorize` | Start an authorization flow |
+| `grantex_token_exchange` | Exchange authorization code for grant token |
+| `grantex_token_verify` | Verify a grant token |
+| `grantex_token_revoke` | Revoke a grant token |
+| `grantex_grant_list` | List grants with filters |
+| `grantex_grant_get` | Get grant details |
+| `grantex_grant_revoke` | Revoke a grant |
+| `grantex_grant_delegate` | Delegate a grant to a sub-agent |
+| `grantex_audit_log` | Log an audit entry |
+| `grantex_audit_list` | List audit entries |
+
+## Usage
+
+Once configured, you can interact with Grantex through natural language in your MCP-compatible client:
+
+- "Register a new agent called travel-booker with calendar:read and payments:initiate scopes"
+- "List all my active grants"
+- "Revoke grant grnt_01XYZ..."
+- "Show the audit log for agent ag_01ABC..."

--- a/docs/integrations/openai-agents.mdx
+++ b/docs/integrations/openai-agents.mdx
@@ -1,0 +1,65 @@
+---
+title: "OpenAI Agents SDK"
+sidebarTitle: "OpenAI Agents"
+description: "Scope-enforced FunctionTool wrappers for the OpenAI Agents SDK."
+---
+
+## Install
+
+```bash
+pip install grantex-openai-agents
+```
+
+OpenAI Agents SDK is a peer dependency:
+
+```bash
+pip install openai-agents
+```
+
+## Quick Start
+
+```python
+from grantex_openai_agents import create_grantex_tool
+
+tool = create_grantex_tool(
+    name="read_calendar",
+    description="Read upcoming calendar events",
+    grant_token=grant_token,       # JWT from Grantex authorization flow
+    required_scope="calendar:read",
+    func=get_calendar_events,
+)
+
+# Use with any OpenAI Agents SDK agent
+from agents import Agent
+agent = Agent(name="assistant", tools=[tool])
+```
+
+If the grant token doesn't include the required scope, `create_grantex_tool` raises a `PermissionError` immediately — the tool is never created.
+
+## API Reference
+
+### `create_grantex_tool()`
+
+Creates an OpenAI Agents SDK `FunctionTool` with offline scope enforcement.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | `str` | Tool name |
+| `description` | `str` | Tool description |
+| `grant_token` | `str` | JWT grant token from Grantex |
+| `required_scope` | `str` | Scope that must be present in the token |
+| `func` | `Callable[..., str]` | The function to wrap |
+
+### `get_tool_scopes(grant_token)`
+
+Returns the scopes embedded in a grant token (offline, no network call).
+
+### `decode_jwt_payload(token)`
+
+Decodes the payload of a JWT without verifying the signature. Useful for inspecting token claims.
+
+## Requirements
+
+- Python 3.9+
+- `grantex` >= 0.1.0
+- `openai-agents` >= 0.0.3 (peer dependency)

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -1,0 +1,59 @@
+---
+title: "Integrations"
+sidebarTitle: "Overview"
+description: "Grantex integrates with every major AI agent framework."
+---
+
+## Available Integrations
+
+<CardGroup cols={2}>
+  <Card title="MCP Server" icon="plug" href="/integrations/mcp">
+    13 tools for Claude Desktop, Cursor, and Windsurf.
+  </Card>
+  <Card title="LangChain" icon="link-horizontal" href="/integrations/langchain">
+    Scope-enforced tools and audit callbacks.
+  </Card>
+  <Card title="Vercel AI SDK" icon="bolt" href="/integrations/vercel-ai">
+    Zod-schema tools with scope checks at construction time.
+  </Card>
+  <Card title="AutoGen / OpenAI" icon="robot" href="/integrations/autogen">
+    Function calling with scope enforcement and registry.
+  </Card>
+  <Card title="CrewAI" icon="users" href="/integrations/crewai">
+    Python tools with scope enforcement and audit logging.
+  </Card>
+  <Card title="OpenAI Agents SDK" icon="microchip" href="/integrations/openai-agents">
+    FunctionTool wrapper with offline scope checks.
+  </Card>
+  <Card title="Google ADK" icon="brain" href="/integrations/google-adk">
+    Plain function tools for Google Agent Development Kit.
+  </Card>
+  <Card title="CLI" icon="terminal" href="/integrations/cli">
+    Manage agents, grants, and audit from your terminal.
+  </Card>
+</CardGroup>
+
+## At a Glance
+
+| Framework | Package | Install | Language |
+|-----------|---------|---------|----------|
+| MCP | `@grantex/mcp` | `npm install -g @grantex/mcp` | TypeScript |
+| LangChain | `@grantex/langchain` | `npm install @grantex/langchain` | TypeScript |
+| Vercel AI SDK | `@grantex/vercel-ai` | `npm install @grantex/vercel-ai` | TypeScript |
+| AutoGen / OpenAI | `@grantex/autogen` | `npm install @grantex/autogen` | TypeScript |
+| CrewAI | `grantex-crewai` | `pip install grantex-crewai` | Python |
+| OpenAI Agents SDK | `grantex-openai-agents` | `pip install grantex-openai-agents` | Python |
+| Google ADK | `grantex-adk` | `pip install grantex-adk` | Python |
+| CLI | `@grantex/cli` | `npm install -g @grantex/cli` | TypeScript |
+
+## How Integrations Work
+
+Every integration follows the same pattern:
+
+1. **Wrap** your tool function with Grantex scope enforcement
+2. **Pass** a grant token (RS256 JWT) from the authorization flow
+3. **Specify** the required scope for the tool
+4. The integration **checks** the JWT's `scp` claim offline — no network call
+5. If the scope is missing, the tool **throws immediately** before your function runs
+
+This means scope enforcement is completely decoupled from the Grantex API — your agent's tools work even if the Grantex server is unreachable.

--- a/docs/integrations/vercel-ai.mdx
+++ b/docs/integrations/vercel-ai.mdx
@@ -1,0 +1,111 @@
+---
+title: "Vercel AI SDK"
+sidebarTitle: "Vercel AI"
+description: "Scope-enforced tools and audit logging for Vercel AI SDK agents."
+---
+
+## Install
+
+```bash
+npm install @grantex/vercel-ai @grantex/sdk ai zod
+```
+
+## Scope-Enforced Tools
+
+Create Vercel AI SDK tools with Grantex authorization. Scope is checked **at construction time** — if the token is missing the required scope, `createGrantexTool` throws immediately:
+
+```typescript
+import { createGrantexTool } from '@grantex/vercel-ai';
+import { z } from 'zod';
+
+const readCalendar = createGrantexTool({
+  name: 'read_calendar',
+  description: 'Read upcoming calendar events',
+  parameters: z.object({
+    date: z.string().describe('Date in YYYY-MM-DD format'),
+  }),
+  grantToken,                     // JWT from Grantex token exchange
+  requiredScope: 'calendar:read', // checked at construction time
+  execute: async (args) => {
+    return await getCalendarEvents(args.date);
+  },
+});
+
+// Use with generateText, streamText, etc.
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: openai('gpt-4'),
+  tools: { read_calendar: readCalendar },
+  prompt: 'What meetings do I have today?',
+});
+```
+
+## Inspect Grant Scopes
+
+Use `getGrantScopes` to check what scopes a token has before creating tools:
+
+```typescript
+import { getGrantScopes } from '@grantex/vercel-ai';
+
+const scopes = getGrantScopes(grantToken);
+// → ['calendar:read', 'email:send']
+```
+
+## Audit Logging
+
+Wrap tools with `withAuditLogging` to log every invocation to the Grantex audit trail:
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+import { createGrantexTool, withAuditLogging } from '@grantex/vercel-ai';
+
+const client = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+const audited = withAuditLogging(readCalendar, client, {
+  agentId: 'ag_01ABC...',
+  grantId: 'grnt_01XYZ...',
+});
+// Use audited in place of readCalendar
+```
+
+## API Reference
+
+### `createGrantexTool(options)`
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `name` | `string` | Tool name |
+| `description` | `string` | Tool description |
+| `parameters` | `z.ZodTypeAny` | Zod schema for tool arguments |
+| `grantToken` | `string` | Grantex JWT from token exchange |
+| `requiredScope` | `string` | Scope required — checked at construction time |
+| `execute` | `(args, options) => Promise<Result>` | Tool implementation |
+
+Throws `GrantexScopeError` if scope is missing.
+
+### `getGrantScopes(grantToken)`
+
+Returns `string[]` of scopes from the token's `scp` claim (offline).
+
+### `withAuditLogging(tool, client, options)`
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `agentId` | `string` | Agent ID for audit attribution |
+| `grantId` | `string` | Grant ID for the session |
+| `toolName` | `string?` | Override tool name in audit entries |
+
+### `GrantexScopeError`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `requiredScope` | `string` | The scope that was required |
+| `grantedScopes` | `string[]` | The scopes the token actually has |
+
+## Requirements
+
+- Node.js 18+
+- `@grantex/sdk` >= 0.1.0
+- `ai` >= 4.0.0 (Vercel AI SDK)
+- `zod` >= 3.0.0

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,0 +1,100 @@
+---
+title: "Introduction"
+sidebarTitle: "Introduction"
+description: "Grantex is the open delegated authorization protocol for AI agents — what OAuth 2.0 is to humans, Grantex is to agents."
+---
+
+## What is Grantex?
+
+AI agents are acting in the world — booking travel, sending emails, executing trades, managing files — on behalf of real humans. But the foundational trust infrastructure for this doesn't exist yet:
+
+- No standard way to grant an agent **scoped, time-limited permissions** on your behalf
+- Services can't verify whether an agent is **genuinely authorized** by the claimed human
+- No **auditable, tamper-proof record** of what an agent did, when, and under whose authority
+- Multi-agent pipelines have no way to **chain authorization** — a sub-agent can't prove it was legitimately spawned
+
+Grantex solves this. It's an open protocol that lets humans authorize AI agents with **verifiable, revocable, audited grants** built on JWT and the OAuth 2.0 model.
+
+## Key Properties
+
+<CardGroup cols={2}>
+  <Card title="Model-Neutral" icon="microchip">
+    Works with OpenAI, Anthropic, Google, Llama, Mistral — any model, any framework.
+  </Card>
+  <Card title="Framework-Native" icon="puzzle-piece">
+    First-class integrations for LangChain, AutoGen, CrewAI, Vercel AI, OpenAI Agents SDK, Google ADK, and MCP.
+  </Card>
+  <Card title="Offline-Verifiable" icon="shield-check">
+    Services verify tokens using published JWKS — zero runtime dependency on Grantex infrastructure.
+  </Card>
+  <Card title="Compliance-Ready" icon="file-certificate">
+    Tamper-evident audit trail, compliance exports, and evidence packs for SOC 2 and GDPR.
+  </Card>
+</CardGroup>
+
+## Install
+
+<CodeGroup>
+```bash npm
+npm install @grantex/sdk
+```
+
+```bash pip
+pip install grantex
+```
+
+```bash CLI
+npm install -g @grantex/cli
+```
+</CodeGroup>
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                         YOUR APPLICATION                             │
+│                                                                      │
+│   ┌──────────────┐    ┌──────────────┐    ┌───────────────────────┐ │
+│   │  AI Agent    │    │  Grantex SDK │    │  End User Dashboard   │ │
+│   │  (any model) │◄──►│  (2 lines)   │    │  (view / revoke)      │ │
+│   └──────────────┘    └──────┬───────┘    └───────────────────────┘ │
+└──────────────────────────────┼───────────────────────────────────────┘
+                               │ HTTPS
+                               ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                         GRANTEX PROTOCOL                             │
+│                                                                      │
+│  ┌─────────────┐  ┌──────────────┐  ┌─────────────┐  ┌──────────┐  │
+│  │  Identity   │  │     Auth     │  │   Consent   │  │  Audit   │  │
+│  │  Service    │  │   Service    │  │     UI      │  │  Chain   │  │
+│  │  (DID/JWKS) │  │ (token i/o)  │  │  (hosted)   │  │ (append) │  │
+│  └─────────────┘  └──────────────┘  └─────────────┘  └──────────┘  │
+└──────────────────────────────────────────────────────────────────────┘
+                               │
+                               ▼
+                ┌──────────────────────────┐
+                │  Any Service / API       │
+                │  Verifies via JWKS       │
+                │  No Grantex dep needed   │
+                └──────────────────────────┘
+```
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Is this just another auth library?">
+    No. Existing auth systems (Auth0, Okta, Supabase) are built for humans logging in. Grantex is built for autonomous agents acting on behalf of humans — a fundamentally different trust model with different primitives (delegation, scope chains, agent identity, real-time revocation, action audit trails).
+  </Accordion>
+  <Accordion title="Why not just use OAuth 2.0?">
+    OAuth 2.0 was designed for "user grants app permission to access their data." Agents introduce new requirements: the agent needs a verifiable identity separate from its creator, grants need to be chainable across multi-agent pipelines, and every autonomous action must be attributable and auditable. We extend OAuth 2.0 concepts but add the agent-specific primitives it lacks.
+  </Accordion>
+  <Accordion title="What about MCP (Model Context Protocol)?">
+    MCP solves tool connectivity — how agents access data and call functions. Grantex solves trust — proving that an agent is authorized to use those tools on behalf of a specific human. They're complementary. A Grantex-authorized agent uses MCP tools.
+  </Accordion>
+  <Accordion title="Can I self-host?">
+    Yes. The reference implementation is fully open-source. Docker Compose deploy in one command. See the [self-hosting guide](/guides/self-hosting).
+  </Accordion>
+  <Accordion title="Who owns the standard?">
+    The protocol spec is open (Apache 2.0). The goal is to contribute the spec to a neutral standards body (W3C, IETF, or CNCF) once it stabilizes. An [IETF Internet-Draft](/community/ietf-draft) has already been submitted.
+  </Accordion>
+</AccordionGroup>

--- a/docs/local-development.mdx
+++ b/docs/local-development.mdx
@@ -1,0 +1,80 @@
+---
+title: "Local Development"
+sidebarTitle: "Local Development"
+description: "Run the full Grantex stack locally with Docker Compose."
+---
+
+## Start the stack
+
+```bash
+git clone https://github.com/mishrasanjeev/grantex.git
+cd grantex
+docker compose up --build
+```
+
+This starts PostgreSQL, Redis, and the auth service. Two developer accounts are seeded automatically:
+
+| Key | Mode | Use for |
+|-----|------|---------|
+| `dev-api-key-local` | live | Full consent flow with redirect |
+| `sandbox-api-key-local` | sandbox | Skip consent UI — get a `code` immediately |
+
+Verify it's running:
+
+```bash
+curl http://localhost:3001/health
+# { "status": "ok" }
+
+curl http://localhost:3001/.well-known/jwks.json
+# { "keys": [{ "kty": "RSA", "alg": "RS256", ... }] }
+```
+
+## Sandbox mode
+
+Sandbox mode is designed for testing. With a sandbox key, `POST /v1/authorize` returns a `code` in the response body — no redirect required:
+
+```bash
+# Authorize + get code in one step
+curl -s -X POST http://localhost:3001/v1/authorize \
+  -H "Authorization: Bearer sandbox-api-key-local" \
+  -H "Content-Type: application/json" \
+  -d '{"agentId":"<id>","principalId":"test-user","scopes":["calendar:read"]}'
+# → { ..., "sandbox": true, "code": "01J..." }
+
+# Exchange immediately for a grant token
+curl -s -X POST http://localhost:3001/v1/token \
+  -H "Authorization: Bearer sandbox-api-key-local" \
+  -H "Content-Type: application/json" \
+  -d '{"code":"<code>","agentId":"<id>"}'
+```
+
+## Developer portal
+
+The **hosted portal** is available at [grantex.dev/dashboard](https://grantex.dev/dashboard) — sign up or enter an API key to manage agents, grants, policies, anomalies, compliance exports, and billing from the browser.
+
+For local development, the auth service also serves a lightweight dashboard at `http://localhost:3001/dashboard`.
+
+## SDK development
+
+```bash
+# TypeScript SDK
+cd packages/sdk-ts
+npm install
+npm run typecheck   # tsc --noEmit
+npm test            # vitest
+
+# Python SDK
+cd packages/sdk-py
+pip install -e ".[dev]"
+pytest
+
+# Auth service
+cd apps/auth-service
+npm install
+npm run typecheck
+npm test
+```
+
+## Next steps
+
+For production deployment, see the [self-hosting guide](/guides/self-hosting).

--- a/docs/logo/dark.svg
+++ b/docs/logo/dark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 32" fill="none">
+  <text x="0" y="24" font-family="system-ui, -apple-system, sans-serif" font-size="26" font-weight="700" fill="#e6edf3" letter-spacing="-0.5">Grantex</text>
+</svg>

--- a/docs/logo/light.svg
+++ b/docs/logo/light.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 32" fill="none">
+  <text x="0" y="24" font-family="system-ui, -apple-system, sans-serif" font-size="26" font-weight="700" fill="#0d1117" letter-spacing="-0.5">Grantex</text>
+</svg>

--- a/docs/protocol/changelog.mdx
+++ b/docs/protocol/changelog.mdx
@@ -1,0 +1,82 @@
+---
+title: "Changelog"
+sidebarTitle: "Changelog"
+description: "All notable changes to the Grantex project."
+---
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.3] - 2026-02-28
+
+### Added
+- PKCE (S256) support in authorization and token exchange flows
+- `generatePkce()` helper in TypeScript SDK
+- `generate_pkce()` helper in Python SDK
+- Rate limiting on auth-service (100/min global, 20/min token, 10/min authorize)
+- CHANGELOG.md, CODE_OF_CONDUCT.md, issue templates, PR template
+
+### Changed
+- Bumped `@grantex/sdk` to 0.1.3 and `grantex` (Python) to 0.1.3
+
+### Fixed
+- "ML-based detection" copy corrected to "Pattern-based detection" on landing page
+
+## [0.1.2] - 2026-02-27
+
+### Added
+- `tokens.exchange()` method to TypeScript and Python SDKs for exchanging authorization codes for grant tokens
+- Python examples for the token exchange flow
+- OpenAI Agents SDK integration (`grantex-openai-agents`)
+- Google ADK integration (`grantex-adk`)
+- MCP server package (`@grantex/mcp`) with 13 tools for Claude Desktop / Cursor / Windsurf
+- Health endpoint (`GET /health`) in auth-service
+- CLI commands for policies, billing, SCIM, and SSO
+- Portal webhooks management page
+- Webhook retry with exponential backoff (persistent delivery table + background worker)
+- Anomaly detection background worker (runs every 60 minutes)
+- Plan limit enforcement for grants, audit entries, and policies
+
+### Changed
+- Bumped `@grantex/sdk` and `grantex` (Python) to 0.1.2
+- Webhook delivery is now persistent with retry instead of fire-and-forget
+
+## [0.1.1] - 2026-02-26
+
+### Added
+- CrewAI integration (`grantex-crewai`) published to PyPI
+- Vercel AI SDK integration (`@grantex/vercel-ai`)
+- AutoGen integration (`@grantex/autogen`)
+- CLI tool (`@grantex/cli`) with commands for agents, grants, tokens, audit, and anomalies
+- LangChain integration (`@grantex/langchain`)
+- Example apps: quickstart-ts, quickstart-py, langchain-agent, crewai-agent, vercel-ai-chatbot
+- Developer portal with React dashboard
+- Landing page deployed to Firebase Hosting at grantex.dev
+
+### Changed
+- Bumped integration packages to 0.1.1
+
+### Fixed
+- Compliance timestamptz cast using null instead of empty string
+- Startup migration runner for production DB schema
+
+## [0.1.0] - 2026-02-25
+
+### Added
+- Protocol specification v1.0 (SPEC.md)
+- Auth service (Fastify + PostgreSQL + Redis) with full API surface:
+  - Authorization flow, consent, approve/deny
+  - Token exchange, verification, and revocation
+  - Grant management with delegation support
+  - Tamper-evident audit log with hash chaining
+  - Anomaly detection
+  - Policy engine
+  - SCIM provisioning
+  - SSO configuration (OIDC)
+  - Billing integration (Stripe)
+  - Webhook registration and delivery
+  - JWKS endpoint for offline token verification
+- TypeScript SDK (`@grantex/sdk`) published to npm
+- Python SDK (`grantex`) published to PyPI
+- CI/CD pipelines (GitHub Actions)
+- Cloud Run deployment configuration
+- Docker Compose for local development

--- a/docs/protocol/specification.mdx
+++ b/docs/protocol/specification.mdx
@@ -1,0 +1,368 @@
+---
+title: "Protocol Specification"
+sidebarTitle: "Specification"
+description: "Grantex Protocol Specification v1.0 — the full normative document."
+---
+
+<Note>
+**Version:** 1.0 | **Status:** Final | **Last updated:** February 2026 (rev 3)
+
+The specification is frozen. Changes require a new version.
+</Note>
+
+## Abstract
+
+Grantex defines an open protocol for delegated authorization of AI agents acting on behalf of human users. It specifies: cryptographic agent identity, a human-consent-based grant flow, a signed token format, a revocation model, an append-only audit trail schema, a policy engine for automated authorization decisions, enterprise identity federation, and anomaly detection for runtime behavioral monitoring.
+
+## 1. Motivation
+
+AI agents increasingly take autonomous actions — submitting forms, initiating payments, sending communications — on behalf of humans across third-party services. No interoperable standard exists for:
+
+1. Verifying that an agent is who it claims to be
+2. Confirming that a specific human authorized a specific agent to perform a specific action
+3. Revoking that authorization in real time
+4. Producing a tamper-proof record of what the agent did
+
+Grantex fills this gap as an open, model-neutral, framework-agnostic protocol.
+
+## 2. Definitions
+
+| Term | Definition |
+|------|-----------|
+| **Agent** | An AI-powered software process that takes autonomous actions on behalf of a Principal |
+| **Principal** | The human user who authorizes an Agent to act on their behalf |
+| **Developer** | The organization or individual who built and operates the Agent |
+| **Service** | Any API or platform that receives requests from an Agent |
+| **Grant** | A record of permission given by a Principal to an Agent for specific Scopes |
+| **Grant Token** | A signed JWT representing a valid, non-revoked Grant |
+| **Scope** | A named permission following the format `resource:action[:constraint]` |
+| **DID** | Decentralized Identifier — the Agent's cryptographic identity |
+| **Policy** | A rule that auto-approves or auto-denies an authorization before the consent UI is shown |
+| **Anomaly** | A detected behavioral deviation from an agent's established activity baseline |
+
+## 3. Agent Identity
+
+### 3.1 DID Format
+
+Every Agent registered with a Grantex-compatible Identity Service receives a DID:
+
+```
+did:grantex:<agent_id>
+```
+
+Where `<agent_id>` is a ULID (Universally Unique Lexicographically Sortable Identifier).
+
+### 3.2 Identity Document
+
+The DID resolves to an identity document containing:
+
+```json
+{
+  "@context": "https://grantex.dev/v1/identity",
+  "id": "did:grantex:ag_01HXYZ123abcDEF456ghi",
+  "developer": "org_yourcompany",
+  "name": "travel-booker",
+  "description": "Books flights and hotels on behalf of users",
+  "declaredScopes": ["calendar:read", "payments:initiate:max_500"],
+  "status": "active",
+  "createdAt": "2026-02-01T00:00:00Z",
+  "verificationMethod": [{
+    "id": "did:grantex:ag_01HXYZ123abcDEF456ghi#key-1",
+    "type": "JsonWebKey2020",
+    "publicKeyJwk": { "..." : "..." }
+  }]
+}
+```
+
+### 3.3 Key Management
+
+- Identity Services MUST use RS256 (RSA + SHA-256) for signing
+- Private keys MUST never leave the Identity Service
+- Public keys MUST be published at `/.well-known/jwks.json`
+- Key rotation MUST be supported without changing the DID
+
+## 4. Scopes
+
+### 4.1 Format
+
+```
+resource:action[:constraint]
+```
+
+### 4.2 Standard Scope Registry
+
+| Scope | Description |
+|-------|-------------|
+| `calendar:read` | Read calendar events |
+| `calendar:write` | Create, modify, and delete calendar events |
+| `email:read` | Read email messages |
+| `email:send` | Send emails on the Principal's behalf |
+| `email:delete` | Delete email messages |
+| `files:read` | Read files and documents |
+| `files:write` | Create and modify files |
+| `payments:read` | View payment history and balances |
+| `payments:initiate` | Initiate payments of any amount |
+| `payments:initiate:max_N` | Initiate payments up to N in the account's base currency |
+| `profile:read` | Read profile and identity information |
+| `contacts:read` | Read address book and contacts |
+
+### 4.3 Custom Scopes
+
+Services MAY define custom scopes using reverse-domain notation:
+
+```
+com.stripe.charges:create:max_5000
+io.github.issues:create
+```
+
+### 4.4 Scope Governance
+
+Grantex maintains the canonical scope registry in §4.2 as normative. Implementations MUST support all standard scopes. Custom scopes MUST use reverse-domain notation.
+
+### 4.5 Scope Display
+
+Identity Services MUST maintain a human-readable description for each scope. Consent UIs MUST display human-readable descriptions, never raw scope strings.
+
+## 5. Grant Flow
+
+### 5.1 Overview
+
+```
+Developer App          Grantex                    Principal
+     │                    │                           │
+     │  POST /authorize    │                           │
+     │  {agentId, scopes,  │                           │
+     │   redirectUri}      │                           │
+     │────────────────────►│                           │
+     │                     │                           │
+     │◄────────────────────│                           │
+     │  {consentUrl}        │                           │
+     │                     │                           │
+     │  redirect user ─────────────────────────────►  │
+     │                     │  consent UI displayed     │
+     │                     │◄──────────────────────────│
+     │                     │  Principal approves       │
+     │                     │                           │
+     │◄────────────────────────────────────────────────│
+     │  redirectUri?code=AUTH_CODE                     │
+     │                     │                           │
+     │  POST /token        │                           │
+     │  {code}             │                           │
+     │────────────────────►│                           │
+     │◄────────────────────│                           │
+     │  {grantToken,        │                           │
+     │   refreshToken}      │                           │
+```
+
+### 5.2 Authorization Request
+
+```http
+POST /v1/authorize
+Authorization: Bearer <api_key>
+Content-Type: application/json
+
+{
+  "agentId": "ag_01HXYZ123abc",
+  "principalId": "user_abc123",
+  "scopes": ["calendar:read", "payments:initiate:max_500"],
+  "expiresIn": "24h",
+  "redirectUri": "https://yourapp.com/auth/callback",
+  "state": "<csrf_token>",
+  "audience": "https://api.targetservice.com"
+}
+```
+
+### 5.3 Token Exchange
+
+```http
+POST /v1/token
+Authorization: Bearer <api_key>
+Content-Type: application/json
+
+{
+  "code": "AUTH_CODE",
+  "agentId": "ag_01HXYZ123abc"
+}
+```
+
+## 6. Grant Token Format
+
+### 6.1 Header
+
+```json
+{
+  "alg": "RS256",
+  "typ": "JWT",
+  "kid": "grantex-2026-02"
+}
+```
+
+### 6.2 Payload
+
+```json
+{
+  "iss": "https://grantex.dev",
+  "sub": "user_abc123",
+  "aud": "https://api.targetservice.com",
+  "agt": "did:grantex:ag_01HXYZ123abc",
+  "dev": "org_yourcompany",
+  "grnt": "grnt_01HXYZ...",
+  "scp": ["calendar:read", "payments:initiate:max_500"],
+  "iat": 1709000000,
+  "exp": 1709086400,
+  "jti": "tok_01HXYZ987xyz"
+}
+```
+
+### 6.3 Custom Claims
+
+| Claim | Type | Description |
+|-------|------|-------------|
+| `agt` | string | Agent DID |
+| `dev` | string | Developer org ID |
+| `grnt` | string | Grant ID (for revocation lookup) |
+| `scp` | string[] | Granted scopes |
+
+### 6.4 Validation Rules
+
+Services receiving a Grant Token MUST verify:
+
+1. Signature using the JWKS at `iss/.well-known/jwks.json`
+2. `exp` has not passed
+3. `aud` matches the service's identifier (if set)
+4. `scp` contains the required scopes for the requested operation
+5. *(Online verification only)* Token has not been revoked
+
+## 7. Revocation
+
+### 7.1 Revoke a Grant
+
+```http
+DELETE /v1/grants/{grantId}
+```
+
+Effect: all active tokens under this Grant are immediately invalidated.
+
+### 7.2 Revoke a Specific Token
+
+```http
+POST /v1/tokens/revoke
+Content-Type: application/json
+
+{ "jti": "tok_01HXYZ987xyz" }
+```
+
+### 7.3 Online Revocation Check
+
+```http
+POST /v1/tokens/verify
+Content-Type: application/json
+
+{ "token": "eyJhbGciOiJSUzI1NiJ9..." }
+```
+
+### 7.4 Token Lifetime Guidance
+
+| Use Case | Recommended TTL |
+|----------|----------------|
+| High-stakes actions (payments, send) | 1 hour |
+| Standard agent tasks | 8 hours |
+| Long-running background agents | 24 hours (max) |
+
+Implementations caching revocation state MUST NOT cache for longer than **5 minutes**.
+
+## 8. Audit Trail
+
+### 8.1 Log Entry Schema
+
+```json
+{
+  "entryId": "alog_01HXYZ...",
+  "agentId": "did:grantex:ag_01HXYZ123abc",
+  "grantId": "grnt_01HXYZ...",
+  "principalId": "user_abc123",
+  "developerId": "org_yourcompany",
+  "action": "payment.initiated",
+  "status": "success",
+  "metadata": { "amount": 420, "currency": "USD" },
+  "timestamp": "2026-02-01T12:34:56.789Z",
+  "hash": "sha256:abc123...",
+  "prevHash": "sha256:xyz789..."
+}
+```
+
+### 8.2 Hash Chain
+
+Each entry's `hash` is `SHA-256(canonical_json(entry) + prevHash)`. This makes any retrospective tampering detectable.
+
+## 9. Multi-Agent Authorization
+
+Sub-agent tokens carry delegation claims:
+
+```json
+{
+  "sub": "user_abc123",
+  "agt": "did:grantex:ag_B_456",
+  "parentAgt": "did:grantex:ag_A_123",
+  "parentGrnt": "grnt_parentXYZ",
+  "scp": ["email:read"],
+  "delegationDepth": 1
+}
+```
+
+Rules:
+- Sub-agent scopes MUST be a subset of the parent's scopes
+- `delegationDepth` is incremented at each hop
+- Hard cap of **10** delegation hops
+- Revoking a root grant cascades to all descendants atomically
+
+## 10. Self-Hosting Endpoints
+
+### Core Endpoints (Required)
+
+| Endpoint | Description |
+|----------|-------------|
+| `POST /v1/agents` | Register agent |
+| `POST /v1/authorize` | Initiate authorization |
+| `POST /v1/token` | Exchange code for token |
+| `POST /v1/tokens/verify` | Verify token online |
+| `POST /v1/tokens/revoke` | Revoke token |
+| `GET /v1/grants` | List grants |
+| `DELETE /v1/grants/:id` | Revoke grant (cascades) |
+| `POST /v1/grants/delegate` | Delegate to sub-agent |
+| `POST /v1/audit/log` | Write audit entry |
+| `GET /v1/audit/entries` | Query audit log |
+| `GET /.well-known/jwks.json` | Public keys |
+| `GET /health` | Health check |
+
+### Optional Extensions
+
+Policy Engine, Webhooks, SCIM 2.0, SSO (OIDC), Anomaly Detection, Compliance, and Billing endpoints are optional extensions. See the [full specification](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md) for details.
+
+## 11. Policy Engine
+
+Evaluates rules against each authorization request before consent UI. Deny rules are evaluated first — the first matching `auto_deny` wins. Then allow rules. If no rule matches, consent UI is shown.
+
+## 12. Enterprise Identity (SCIM & SSO)
+
+SCIM 2.0 user provisioning from enterprise IdPs (Okta, Azure AD). SSO via OIDC with `state` and `nonce` validation.
+
+## 13. Anomaly Detection
+
+Advisory-only runtime monitoring. Anomaly types: `unusual_scope_access`, `high_frequency`, `off_hours_activity`, `new_principal`, `cascade_delegation`.
+
+## 14. Security Considerations
+
+- Tokens MUST be signed with RS256. HS256 and `alg: none` MUST be rejected.
+- Token replay MUST be detectable via `jti` tracking.
+- Consent UIs MUST validate `state` to prevent CSRF.
+- Redirect URIs MUST be pre-registered and exactly matched.
+- Audit logs MUST be append-only (no update or delete endpoints).
+- SCIM endpoints MUST use dedicated bearer tokens, separate from API keys.
+- SSO callbacks MUST validate `state` and `nonce`.
+- Policy engine MUST evaluate deny before allow.
+- Anomaly detection MUST NOT block token issuance.
+
+---
+
+*The full specification is maintained at [github.com/mishrasanjeev/grantex/blob/main/SPEC.md](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md) and is licensed under [Apache 2.0](https://github.com/mishrasanjeev/grantex/blob/main/LICENSE).*

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,0 +1,178 @@
+---
+title: "Quickstart"
+sidebarTitle: "Quickstart"
+description: "Get up and running with Grantex in under 5 minutes."
+---
+
+## 1. Install the SDK
+
+<CodeGroup>
+```bash npm
+npm install @grantex/sdk
+```
+
+```bash pip
+pip install grantex
+```
+</CodeGroup>
+
+## 2. Register your agent
+
+<CodeGroup>
+```typescript TypeScript
+import { Grantex } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+const agent = await grantex.agents.register({
+  name: 'travel-booker',
+  description: 'Books flights and hotels on behalf of users',
+  scopes: ['calendar:read', 'payments:initiate:max_500', 'email:send'],
+});
+
+console.log(agent.did);
+// → did:grantex:ag_01HXYZ123abc...
+```
+
+```python Python
+from grantex import Grantex
+
+client = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+agent = client.agents.register(
+    name="travel-booker",
+    scopes=["calendar:read", "payments:initiate:max_500", "email:send"],
+    description="Books flights and hotels on behalf of users",
+)
+
+print(agent.did)
+# → did:grantex:ag_01HXYZ123abc...
+```
+</CodeGroup>
+
+## 3. Request authorization from a user
+
+<CodeGroup>
+```typescript TypeScript
+const authRequest = await grantex.authorize({
+  agentId: agent.id,
+  userId: 'user_abc123',
+  scopes: ['calendar:read', 'payments:initiate:max_500'],
+  expiresIn: '24h',
+  redirectUri: 'https://yourapp.com/auth/callback',
+});
+
+// Redirect user to the consent page
+console.log(authRequest.consentUrl);
+// → https://consent.grantex.dev/authorize?req=eyJ...
+```
+
+```python Python
+auth = client.authorize(
+    agent_id=agent.id,
+    user_id="user_abc123",
+    scopes=["calendar:read", "payments:initiate:max_500"],
+)
+
+# Redirect user to the consent page
+print(auth.consent_url)
+```
+</CodeGroup>
+
+## 4. Exchange the code for a grant token
+
+After the user approves, your redirect URI receives an authorization `code`. Exchange it for a signed grant token:
+
+<CodeGroup>
+```typescript TypeScript
+const token = await grantex.tokens.exchange({
+  code,                  // from the redirect callback
+  agentId: agent.id,
+});
+
+console.log(token.grantToken);  // RS256 JWT — pass this to your agent
+console.log(token.scopes);      // ['calendar:read', 'payments:initiate:max_500']
+console.log(token.grantId);     // 'grnt_01HXYZ...'
+```
+
+```python Python
+from grantex import ExchangeTokenParams
+
+token = client.tokens.exchange(ExchangeTokenParams(
+    code=code,
+    agent_id=agent.id,
+))
+
+print(token.grant_token)  # RS256 JWT
+print(token.scopes)       # ('calendar:read', 'payments:initiate:max_500')
+print(token.grant_id)     # 'grnt_01HXYZ...'
+```
+</CodeGroup>
+
+## 5. Verify the token offline
+
+<CodeGroup>
+```typescript TypeScript
+import { verifyGrantToken } from '@grantex/sdk';
+
+const grant = await verifyGrantToken(token.grantToken, {
+  jwksUri: 'https://api.grantex.dev/.well-known/jwks.json',
+  requiredScopes: ['calendar:read'],
+});
+
+console.log(grant.principalId); // 'user_abc123'
+console.log(grant.scopes);     // ['calendar:read', 'payments:initiate:max_500']
+```
+
+```python Python
+from grantex import verify_grant_token, VerifyGrantTokenOptions
+
+grant = verify_grant_token(token.grant_token, VerifyGrantTokenOptions(
+    jwks_uri="https://api.grantex.dev/.well-known/jwks.json",
+))
+
+print(grant.principal_id)  # 'user_abc123'
+print(grant.scopes)        # ('calendar:read', 'payments:initiate:max_500')
+```
+</CodeGroup>
+
+## 6. Log every action
+
+<CodeGroup>
+```typescript TypeScript
+await grantex.audit.log({
+  agentId: agent.id,
+  grantId: token.grantId,
+  action: 'payment.initiated',
+  status: 'success',
+  metadata: { amount: 420, currency: 'USD', merchant: 'Air India' },
+});
+```
+
+```python Python
+client.audit.log(
+    agent_id=agent.id,
+    grant_id=token.grant_id,
+    action="payment.initiated",
+    status="success",
+    metadata={"amount": 420, "currency": "USD", "merchant": "Air India"},
+)
+```
+</CodeGroup>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Core Concepts" icon="lightbulb" href="/concepts/how-it-works">
+    Learn about the three primitives: agent identity, delegated grants, and audit trails.
+  </Card>
+  <Card title="Local Development" icon="docker" href="/local-development">
+    Run the full stack locally with Docker Compose and sandbox mode.
+  </Card>
+  <Card title="TypeScript SDK" icon="js" href="/sdks/typescript/overview">
+    Full API reference for the TypeScript SDK.
+  </Card>
+  <Card title="Python SDK" icon="python" href="/sdks/python/overview">
+    Full API reference for the Python SDK.
+  </Card>
+</CardGroup>

--- a/docs/sdks/python/agents.mdx
+++ b/docs/sdks/python/agents.mdx
@@ -1,0 +1,157 @@
+---
+title: "Agents"
+sidebarTitle: "Agents"
+description: "Register, retrieve, update, list, and delete AI agents using the Grantex Python SDK."
+---
+
+## Overview
+
+The `agents` client manages AI agent registrations. Each agent has a unique ID, a DID (Decentralized Identifier), a set of scopes it can request, and a lifecycle status.
+
+Access the agents client via `client.agents`.
+
+## Register
+
+Register a new agent with a name and set of scopes:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    agent = client.agents.register(
+        name="travel-assistant",
+        scopes=["booking:read", "booking:write", "profile:read"],
+        description="Books flights and hotels on behalf of users",
+    )
+
+    print(f"Agent ID: {agent.id}")
+    print(f"Agent DID: {agent.did}")
+    print(f"Scopes: {agent.scopes}")
+```
+
+### Parameters
+
+| Parameter     | Type        | Required | Default | Description                            |
+|---------------|-------------|----------|---------|----------------------------------------|
+| `name`        | `str`       | Yes      | --      | Human-readable name for the agent.     |
+| `scopes`      | `list[str]` | Yes      | --      | The scopes this agent can request.     |
+| `description` | `str`       | No       | `""`    | A description of what the agent does.  |
+
+All parameters are keyword-only.
+
+### Returns
+
+An `Agent` dataclass.
+
+## Get
+
+Retrieve a single agent by its ID:
+
+```python
+agent = client.agents.get("agt_abc123")
+
+print(f"Name: {agent.name}")
+print(f"Status: {agent.status}")
+print(f"Created: {agent.created_at}")
+```
+
+## List
+
+List all agents registered under your developer account:
+
+```python
+result = client.agents.list()
+
+print(f"Total agents: {result.total}")
+for agent in result.agents:
+    print(f"  {agent.name} ({agent.id}) - {agent.status}")
+```
+
+### ListAgentsResponse
+
+| Field       | Type               | Description                     |
+|-------------|--------------------|---------------------------------|
+| `agents`    | `tuple[Agent, ...]`| The list of agents.             |
+| `total`     | `int`              | Total number of agents.         |
+| `page`      | `int`              | Current page number.            |
+| `page_size` | `int`              | Number of agents per page.      |
+
+## Update
+
+Update an agent's name, description, or scopes. Only fields you provide will be modified:
+
+```python
+updated = client.agents.update(
+    "agt_abc123",
+    name="travel-assistant-v2",
+    description="Updated description",
+    scopes=["booking:read", "booking:write", "profile:read", "profile:write"],
+)
+
+print(f"Updated at: {updated.updated_at}")
+```
+
+### Parameters
+
+| Parameter     | Type              | Required | Description                              |
+|---------------|-------------------|----------|------------------------------------------|
+| `agent_id`    | `str`             | Yes      | The ID of the agent to update (positional). |
+| `name`        | `str \| None`     | No       | New name for the agent.                  |
+| `description` | `str \| None`     | No       | New description.                         |
+| `scopes`      | `list[str] \| None` | No     | New set of scopes.                       |
+
+## Delete
+
+Delete an agent by its ID:
+
+```python
+client.agents.delete("agt_abc123")
+# Returns None on success
+```
+
+## Agent Type
+
+The `Agent` frozen dataclass has the following fields:
+
+| Field          | Type              | Description                              |
+|----------------|-------------------|------------------------------------------|
+| `id`           | `str`             | Unique agent identifier.                 |
+| `did`          | `str`             | Decentralized Identifier for the agent.  |
+| `name`         | `str`             | Human-readable agent name.               |
+| `description`  | `str`             | Agent description.                       |
+| `scopes`       | `tuple[str, ...]` | Scopes this agent can request.           |
+| `status`       | `str`             | Agent status (e.g. `"active"`).          |
+| `developer_id` | `str`             | ID of the developer who owns this agent. |
+| `created_at`   | `str`             | ISO 8601 creation timestamp.             |
+| `updated_at`   | `str`             | ISO 8601 last-updated timestamp.         |
+
+## Example: Full Lifecycle
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    # Register
+    agent = client.agents.register(
+        name="email-drafter",
+        scopes=["email:draft", "email:send"],
+        description="Drafts and sends emails",
+    )
+    print(f"Registered: {agent.id}")
+
+    # Retrieve
+    fetched = client.agents.get(agent.id)
+    print(f"Name: {fetched.name}")
+
+    # Update
+    updated = client.agents.update(agent.id, name="email-assistant")
+    print(f"Renamed to: {updated.name}")
+
+    # List
+    all_agents = client.agents.list()
+    print(f"Total agents: {all_agents.total}")
+
+    # Delete
+    client.agents.delete(agent.id)
+    print("Deleted")
+```

--- a/docs/sdks/python/anomalies.mdx
+++ b/docs/sdks/python/anomalies.mdx
@@ -1,0 +1,138 @@
+---
+title: "Anomaly Detection"
+sidebarTitle: "Anomalies"
+description: "Detect, list, and acknowledge authorization anomalies using the Grantex Python SDK."
+---
+
+## Overview
+
+The `anomalies` client provides automated anomaly detection for your authorization system. It identifies unusual patterns such as rate spikes, high failure rates, new principals, and off-hours activity.
+
+Access the anomalies client via `client.anomalies`.
+
+## Detect
+
+Run anomaly detection across all agents and return any detected anomalies:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    result = client.anomalies.detect()
+
+    print(f"Detected at: {result.detected_at}")
+    print(f"Total anomalies: {result.total}")
+    for anomaly in result.anomalies:
+        print(f"  [{anomaly.severity}] {anomaly.type}: {anomaly.description}")
+```
+
+### DetectAnomaliesResponse
+
+| Field         | Type                 | Description                             |
+|---------------|----------------------|-----------------------------------------|
+| `detected_at` | `str`                | ISO 8601 timestamp of the detection run.|
+| `total`       | `int`                | Number of anomalies detected.           |
+| `anomalies`   | `tuple[Anomaly, ...]`| The detected anomalies.                 |
+
+## List
+
+List stored anomalies. Optionally filter to show only unacknowledged anomalies:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    # List all anomalies
+    result = client.anomalies.list()
+    print(f"Total: {result.total}")
+
+    # List only unacknowledged anomalies
+    result = client.anomalies.list(unacknowledged=True)
+    for anomaly in result.anomalies:
+        print(f"  {anomaly.id}: [{anomaly.severity}] {anomaly.type}")
+        print(f"    {anomaly.description}")
+        print(f"    Detected: {anomaly.detected_at}")
+```
+
+### Parameters
+
+| Parameter        | Type   | Required | Default | Description                              |
+|------------------|--------|----------|---------|------------------------------------------|
+| `unacknowledged` | `bool` | No       | `False` | If `True`, only return unacknowledged anomalies. |
+
+The parameter is keyword-only.
+
+### ListAnomaliesResponse
+
+| Field       | Type                 | Description                   |
+|-------------|----------------------|-------------------------------|
+| `anomalies` | `tuple[Anomaly, ...]`| The list of anomalies.        |
+| `total`     | `int`                | Total number of anomalies.    |
+
+## Acknowledge
+
+Acknowledge an anomaly to mark it as reviewed:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    anomaly = client.anomalies.acknowledge("anom_abc123")
+
+    print(f"Acknowledged at: {anomaly.acknowledged_at}")
+```
+
+Returns the updated `Anomaly` with the `acknowledged_at` timestamp set.
+
+## Anomaly Type
+
+The `Anomaly` frozen dataclass has the following fields:
+
+| Field             | Type              | Description                                |
+|-------------------|-------------------|--------------------------------------------|
+| `id`              | `str`             | Unique anomaly identifier.                 |
+| `type`            | `str`             | The anomaly type (see table below).        |
+| `severity`        | `str`             | `"low"`, `"medium"`, or `"high"`.          |
+| `agent_id`        | `str \| None`     | The agent involved (if applicable).        |
+| `principal_id`    | `str \| None`     | The principal involved (if applicable).    |
+| `description`     | `str`             | Human-readable description of the anomaly. |
+| `metadata`        | `dict[str, Any]`  | Additional data about the anomaly.         |
+| `detected_at`     | `str`             | ISO 8601 timestamp when the anomaly was detected. |
+| `acknowledged_at` | `str \| None`     | ISO 8601 timestamp when the anomaly was acknowledged (or `None`). |
+
+### Anomaly Types
+
+| Type                  | Description                                       |
+|-----------------------|---------------------------------------------------|
+| `rate_spike`          | Unusual spike in authorization or token requests. |
+| `high_failure_rate`   | Abnormally high rate of failed actions.           |
+| `new_principal`       | A previously unseen principal is being used.      |
+| `off_hours_activity`  | Authorization activity outside normal hours.      |
+
+## Example: Monitor and Acknowledge
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    # Run detection
+    detection = client.anomalies.detect()
+
+    if detection.total > 0:
+        print(f"Found {detection.total} anomalies!")
+
+        for anomaly in detection.anomalies:
+            print(f"\n[{anomaly.severity.upper()}] {anomaly.type}")
+            print(f"  {anomaly.description}")
+
+            if anomaly.agent_id:
+                print(f"  Agent: {anomaly.agent_id}")
+            if anomaly.principal_id:
+                print(f"  Principal: {anomaly.principal_id}")
+
+            # Acknowledge after review
+            client.anomalies.acknowledge(anomaly.id)
+            print(f"  -> Acknowledged")
+    else:
+        print("No anomalies detected")
+```

--- a/docs/sdks/python/audit.mdx
+++ b/docs/sdks/python/audit.mdx
@@ -1,0 +1,147 @@
+---
+title: "Audit"
+sidebarTitle: "Audit"
+description: "Log, query, and retrieve tamper-evident audit entries for agent actions using the Grantex Python SDK."
+---
+
+## Overview
+
+The `audit` client provides a tamper-evident audit trail for agent actions. Every entry is hash-chained to the previous entry, making the log append-only and tamper-detectable.
+
+Access the audit client via `client.audit`.
+
+## Log
+
+Record an audit entry for an agent action:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    entry = client.audit.log(
+        agent_id="agt_abc123",
+        grant_id="grnt_xyz789",
+        action="file.read",
+        metadata={"path": "/documents/report.pdf", "size_bytes": 102400},
+        status="success",
+    )
+
+    print(f"Entry ID: {entry.entry_id}")
+    print(f"Hash: {entry.hash}")
+    print(f"Previous hash: {entry.prev_hash}")
+    print(f"Timestamp: {entry.timestamp}")
+```
+
+### Parameters
+
+All parameters are keyword-only.
+
+| Parameter  | Type                    | Required | Default     | Description                              |
+|------------|-------------------------|----------|-------------|------------------------------------------|
+| `agent_id` | `str`                   | Yes      | --          | The agent that performed the action.     |
+| `grant_id` | `str`                   | Yes      | --          | The grant under which the action was performed. |
+| `action`   | `str`                   | Yes      | --          | A label for the action (e.g. `"file.read"`). |
+| `metadata` | `dict[str, Any] \| None`| No       | `None`      | Additional context about the action.     |
+| `status`   | `str`                   | No       | `"success"` | The outcome (`"success"`, `"failure"`, `"blocked"`). |
+
+## List
+
+Query audit entries with optional filters:
+
+```python
+from grantex import Grantex, ListAuditParams
+
+with Grantex(api_key="gx_live_...") as client:
+    # List all entries
+    result = client.audit.list()
+    print(f"Total entries: {result.total}")
+
+    # List with filters
+    result = client.audit.list(ListAuditParams(
+        agent_id="agt_abc123",
+        action="file.read",
+        since="2026-01-01T00:00:00Z",
+        until="2026-02-01T00:00:00Z",
+        page=1,
+        page_size=50,
+    ))
+
+    for entry in result.entries:
+        print(f"  [{entry.timestamp}] {entry.action} - {entry.status}")
+```
+
+### ListAuditParams
+
+| Field          | Type          | Required | Description                                |
+|----------------|---------------|----------|--------------------------------------------|
+| `agent_id`     | `str \| None` | No       | Filter by agent ID.                       |
+| `grant_id`     | `str \| None` | No       | Filter by grant ID.                       |
+| `principal_id` | `str \| None` | No       | Filter by principal (user) ID.            |
+| `action`       | `str \| None` | No       | Filter by action label.                   |
+| `since`        | `str \| None` | No       | ISO 8601 start timestamp (inclusive).      |
+| `until`        | `str \| None` | No       | ISO 8601 end timestamp (exclusive).        |
+| `page`         | `int \| None` | No       | Page number for pagination.               |
+| `page_size`    | `int \| None` | No       | Number of results per page.               |
+
+### ListAuditResponse
+
+| Field       | Type                     | Description                        |
+|-------------|--------------------------|------------------------------------|
+| `entries`   | `tuple[AuditEntry, ...]` | The list of audit entries.         |
+| `total`     | `int`                    | Total number of matching entries.  |
+| `page`      | `int`                    | Current page number.               |
+| `page_size` | `int`                    | Number of entries per page.        |
+
+## Get
+
+Retrieve a single audit entry by its ID:
+
+```python
+entry = client.audit.get("aud_abc123")
+
+print(f"Action: {entry.action}")
+print(f"Agent: {entry.agent_id} ({entry.agent_did})")
+print(f"Grant: {entry.grant_id}")
+print(f"Principal: {entry.principal_id}")
+print(f"Hash: {entry.hash}")
+print(f"Previous hash: {entry.prev_hash}")
+print(f"Metadata: {entry.metadata}")
+```
+
+## AuditEntry Type
+
+The `AuditEntry` frozen dataclass has the following fields:
+
+| Field          | Type              | Description                                 |
+|----------------|-------------------|---------------------------------------------|
+| `entry_id`     | `str`             | Unique entry identifier.                    |
+| `agent_id`     | `str`             | The agent that performed the action.        |
+| `agent_did`    | `str`             | The agent's DID.                            |
+| `grant_id`     | `str`             | The grant under which the action occurred.  |
+| `principal_id` | `str`             | The authorizing user/principal.             |
+| `action`       | `str`             | The action label.                           |
+| `metadata`     | `dict[str, Any]`  | Additional context.                         |
+| `hash`         | `str`             | SHA-256 hash of this entry.                 |
+| `prev_hash`    | `str \| None`     | Hash of the previous entry (chain link).    |
+| `timestamp`    | `str`             | ISO 8601 timestamp of the action.           |
+| `status`       | `str`             | Outcome status.                             |
+
+## Hash Chain Integrity
+
+Each audit entry contains a `hash` and a `prev_hash` field. The `hash` is computed over the entry's contents, and `prev_hash` references the previous entry's hash. This creates a tamper-evident chain: modifying or deleting any entry breaks the chain for all subsequent entries.
+
+```python
+# Verify chain integrity by iterating entries
+result = client.audit.list()
+for i, entry in enumerate(result.entries):
+    if i == 0:
+        print(f"First entry: {entry.hash}")
+    else:
+        expected_prev = result.entries[i - 1].hash
+        if entry.prev_hash == expected_prev:
+            print(f"Entry {entry.entry_id}: chain valid")
+        else:
+            print(f"Entry {entry.entry_id}: CHAIN BROKEN")
+```
+
+For automated chain integrity verification, use the [compliance evidence pack](/sdks/python/compliance).

--- a/docs/sdks/python/authorization.mdx
+++ b/docs/sdks/python/authorization.mdx
@@ -1,0 +1,124 @@
+---
+title: "Authorization"
+sidebarTitle: "Authorization"
+description: "Initiate the delegated authorization flow to request permissions from a user on behalf of an AI agent."
+---
+
+## Overview
+
+The `authorize()` method on the `Grantex` client initiates the delegated authorization flow. It creates an authorization request and returns a consent URL that the user must visit to approve the requested scopes.
+
+## Usage
+
+```python
+from grantex import Grantex, AuthorizeParams
+
+client = Grantex(api_key="gx_live_...")
+
+auth = client.authorize(AuthorizeParams(
+    agent_id="agt_abc123",
+    user_id="user_xyz",
+    scopes=["files:read", "files:write"],
+))
+
+# Redirect the user to the consent page
+print(auth.consent_url)
+```
+
+The `user_id` parameter is transparently mapped to `principalId` in the API request body.
+
+## Parameters
+
+`AuthorizeParams` is a dataclass with the following fields:
+
+| Field                    | Type             | Required | Description                                                   |
+|--------------------------|------------------|----------|---------------------------------------------------------------|
+| `agent_id`               | `str`            | Yes      | The ID of the agent requesting authorization.                 |
+| `user_id`                | `str`            | Yes      | The user (principal) being asked to grant permissions.        |
+| `scopes`                 | `list[str]`      | Yes      | The permission scopes being requested.                        |
+| `expires_in`             | `str \| None`    | No       | How long the authorization request remains valid (e.g. `"1h"`). |
+| `redirect_uri`           | `str \| None`    | No       | URL to redirect the user after consent.                       |
+| `code_challenge`         | `str \| None`    | No       | PKCE code challenge (S256). See [PKCE](/sdks/python/pkce).    |
+| `code_challenge_method`  | `str \| None`    | No       | Must be `"S256"` when using PKCE.                             |
+
+## Response
+
+`authorize()` returns an `AuthorizationRequest` frozen dataclass:
+
+| Field           | Type              | Description                                              |
+|-----------------|-------------------|----------------------------------------------------------|
+| `request_id`    | `str`             | The authorization request ID (`authRequestId`).          |
+| `consent_url`   | `str`             | URL to redirect the user for consent approval.           |
+| `agent_id`      | `str`             | The agent ID from the request.                           |
+| `principal_id`  | `str`             | The user/principal ID.                                   |
+| `scopes`        | `tuple[str, ...]` | The requested scopes.                                    |
+| `expires_in`    | `str`             | The TTL of the authorization request.                    |
+| `expires_at`    | `str`             | ISO 8601 timestamp when the request expires.             |
+| `status`        | `str`             | Current status (e.g. `"pending"`).                       |
+| `created_at`    | `str`             | ISO 8601 timestamp when the request was created.         |
+
+## Example with Redirect URI
+
+```python
+from grantex import Grantex, AuthorizeParams
+
+with Grantex(api_key="gx_live_...") as client:
+    auth = client.authorize(AuthorizeParams(
+        agent_id="agt_abc123",
+        user_id="user_xyz",
+        scopes=["calendar:read", "calendar:write"],
+        redirect_uri="https://myapp.com/callback",
+        expires_in="30m",
+    ))
+
+    print(f"Request ID: {auth.request_id}")
+    print(f"Consent URL: {auth.consent_url}")
+    print(f"Status: {auth.status}")
+    print(f"Expires at: {auth.expires_at}")
+```
+
+## Example with PKCE
+
+For public clients or enhanced security, use PKCE to bind the authorization request to the token exchange:
+
+```python
+from grantex import Grantex, AuthorizeParams, generate_pkce
+
+pkce = generate_pkce()
+
+with Grantex(api_key="gx_live_...") as client:
+    auth = client.authorize(AuthorizeParams(
+        agent_id="agt_abc123",
+        user_id="user_xyz",
+        scopes=["files:read"],
+        redirect_uri="https://myapp.com/callback",
+        code_challenge=pkce.code_challenge,
+        code_challenge_method=pkce.code_challenge_method,
+    ))
+
+    # After the user approves and you receive the code at your redirect_uri:
+    # token = client.tokens.exchange(ExchangeTokenParams(
+    #     code=received_code,
+    #     agent_id="agt_abc123",
+    #     code_verifier=pkce.code_verifier,
+    # ))
+```
+
+See the [PKCE guide](/sdks/python/pkce) for the complete flow.
+
+## Error Handling
+
+```python
+from grantex import Grantex, AuthorizeParams, GrantexApiError
+
+with Grantex(api_key="gx_live_...") as client:
+    try:
+        auth = client.authorize(AuthorizeParams(
+            agent_id="agt_nonexistent",
+            user_id="user_xyz",
+            scopes=["files:read"],
+        ))
+    except GrantexApiError as e:
+        print(f"Status: {e.status_code}")
+        print(f"Message: {e}")
+```

--- a/docs/sdks/python/billing.mdx
+++ b/docs/sdks/python/billing.mdx
@@ -1,0 +1,117 @@
+---
+title: "Billing"
+sidebarTitle: "Billing"
+description: "Manage subscriptions, create checkout sessions, and access the billing portal with the Grantex Python SDK."
+---
+
+## Overview
+
+The `billing` client provides access to subscription management, Stripe Checkout session creation, and the Stripe Billing Portal.
+
+Access the billing client via `client.billing`.
+
+## Get Subscription
+
+Retrieve the current subscription status for the authenticated developer:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    sub = client.billing.get_subscription()
+
+    print(f"Plan: {sub.plan}")
+    print(f"Status: {sub.status}")
+    print(f"Current period ends: {sub.current_period_end}")
+```
+
+### SubscriptionStatus
+
+| Field                | Type          | Description                                        |
+|----------------------|---------------|----------------------------------------------------|
+| `plan`               | `str`         | Current plan (`"free"`, `"pro"`, or `"enterprise"`). |
+| `status`             | `str`         | Subscription status (`"active"`, `"past_due"`, `"canceled"`). |
+| `current_period_end` | `str \| None` | ISO 8601 timestamp when the current billing period ends. |
+
+## Create Checkout
+
+Create a Stripe Checkout session for upgrading to a paid plan. Returns a URL to redirect the user to:
+
+```python
+from grantex import Grantex, CreateCheckoutParams
+
+with Grantex(api_key="gx_live_...") as client:
+    checkout = client.billing.create_checkout(CreateCheckoutParams(
+        plan="pro",
+        success_url="https://myapp.com/billing/success",
+        cancel_url="https://myapp.com/billing/cancel",
+    ))
+
+    print(f"Redirect to: {checkout.checkout_url}")
+```
+
+### CreateCheckoutParams
+
+| Parameter     | Type  | Required | Description                                           |
+|---------------|-------|----------|-------------------------------------------------------|
+| `plan`        | `str` | Yes      | The plan to subscribe to (`"pro"` or `"enterprise"`). |
+| `success_url` | `str` | Yes      | URL to redirect to after successful payment.          |
+| `cancel_url`  | `str` | Yes      | URL to redirect to if the user cancels.               |
+
+### CheckoutResponse
+
+| Field          | Type  | Description                              |
+|----------------|-------|------------------------------------------|
+| `checkout_url` | `str` | The Stripe Checkout session URL.         |
+
+## Create Portal
+
+Create a Stripe Billing Portal session for managing an existing subscription. Returns a URL to redirect the user to:
+
+```python
+from grantex import Grantex, CreatePortalParams
+
+with Grantex(api_key="gx_live_...") as client:
+    portal = client.billing.create_portal(CreatePortalParams(
+        return_url="https://myapp.com/settings",
+    ))
+
+    print(f"Redirect to: {portal.portal_url}")
+```
+
+### CreatePortalParams
+
+| Parameter    | Type  | Required | Description                                   |
+|--------------|-------|----------|-----------------------------------------------|
+| `return_url` | `str` | Yes      | URL to redirect to when the user exits the portal. |
+
+### PortalResponse
+
+| Field        | Type  | Description                              |
+|--------------|-------|------------------------------------------|
+| `portal_url` | `str` | The Stripe Billing Portal session URL.   |
+
+## Example: Billing Flow
+
+```python
+from grantex import Grantex, CreateCheckoutParams, CreatePortalParams
+
+with Grantex(api_key="gx_live_...") as client:
+    # Check current plan
+    sub = client.billing.get_subscription()
+
+    if sub.plan == "free":
+        # Upgrade to pro
+        checkout = client.billing.create_checkout(CreateCheckoutParams(
+            plan="pro",
+            success_url="https://myapp.com/billing/success",
+            cancel_url="https://myapp.com/billing/cancel",
+        ))
+        print(f"Upgrade: {checkout.checkout_url}")
+    else:
+        # Manage existing subscription
+        portal = client.billing.create_portal(CreatePortalParams(
+            return_url="https://myapp.com/settings",
+        ))
+        print(f"Manage: {portal.portal_url}")
+```

--- a/docs/sdks/python/compliance.mdx
+++ b/docs/sdks/python/compliance.mdx
@@ -1,0 +1,194 @@
+---
+title: "Compliance"
+sidebarTitle: "Compliance"
+description: "Generate compliance summaries, export grants and audit data, and produce SOC 2/GDPR evidence packs with the Grantex Python SDK."
+---
+
+## Overview
+
+The `compliance` client provides tools for regulatory compliance reporting. Generate org-wide summaries, export grants and audit entries, and produce evidence packs with built-in chain integrity verification for SOC 2 and GDPR audits.
+
+Access the compliance client via `client.compliance`.
+
+## Get Summary
+
+Generate an org-wide compliance summary with counts of agents, grants, audit entries, and policies:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    summary = client.compliance.get_summary(
+        since="2026-01-01T00:00:00Z",
+        until="2026-02-01T00:00:00Z",
+    )
+
+    print(f"Generated at: {summary.generated_at}")
+    print(f"Plan: {summary.plan}")
+    print(f"Agents: {summary.agents}")
+    print(f"Grants: {summary.grants}")
+    print(f"Audit entries: {summary.audit_entries}")
+    print(f"Policies: {summary.policies}")
+```
+
+### Parameters
+
+| Parameter | Type          | Required | Description                                |
+|-----------|---------------|----------|--------------------------------------------|
+| `since`   | `str \| None` | No       | ISO 8601 start timestamp for the report.   |
+| `until`   | `str \| None` | No       | ISO 8601 end timestamp for the report.     |
+
+Both parameters are keyword-only.
+
+### ComplianceSummary
+
+| Field           | Type             | Description                              |
+|-----------------|------------------|------------------------------------------|
+| `generated_at`  | `str`            | ISO 8601 timestamp when the report was generated. |
+| `agents`        | `dict[str, int]` | Agent counts (e.g. `{"total": 5, "active": 4}`). |
+| `grants`        | `dict[str, int]` | Grant counts by status.                  |
+| `audit_entries` | `dict[str, int]` | Audit entry counts.                      |
+| `policies`      | `dict[str, int]` | Policy counts.                           |
+| `plan`          | `str`            | Current billing plan.                    |
+| `since`         | `str \| None`    | Report start timestamp (if filtered).    |
+| `until`         | `str \| None`    | Report end timestamp (if filtered).      |
+
+## Export Grants
+
+Export all grants with optional filters for compliance reporting:
+
+```python
+from grantex import Grantex, ComplianceExportGrantsParams
+
+with Grantex(api_key="gx_live_...") as client:
+    export = client.compliance.export_grants(
+        ComplianceExportGrantsParams(
+            since="2026-01-01T00:00:00Z",
+            status="active",
+        )
+    )
+
+    print(f"Generated at: {export.generated_at}")
+    print(f"Total grants: {export.total}")
+    for grant in export.grants:
+        print(f"  {grant.id}: {grant.scopes} ({grant.status})")
+```
+
+### ComplianceExportGrantsParams
+
+| Field    | Type          | Required | Description                                          |
+|----------|---------------|----------|------------------------------------------------------|
+| `since`  | `str \| None` | No       | ISO 8601 start timestamp.                            |
+| `until`  | `str \| None` | No       | ISO 8601 end timestamp.                              |
+| `status` | `str \| None` | No       | Filter by status (`"active"`, `"revoked"`, `"expired"`). |
+
+### ComplianceGrantsExport
+
+| Field          | Type               | Description                      |
+|----------------|--------------------|----------------------------------|
+| `generated_at` | `str`              | ISO 8601 generation timestamp.   |
+| `total`        | `int`              | Total number of exported grants. |
+| `grants`       | `tuple[Grant, ...]`| The exported grant records.      |
+
+## Export Audit
+
+Export all audit entries with optional filters:
+
+```python
+from grantex import Grantex, ComplianceExportAuditParams
+
+with Grantex(api_key="gx_live_...") as client:
+    export = client.compliance.export_audit(
+        ComplianceExportAuditParams(
+            since="2026-01-01T00:00:00Z",
+            agent_id="agt_abc123",
+            status="success",
+        )
+    )
+
+    print(f"Generated at: {export.generated_at}")
+    print(f"Total entries: {export.total}")
+    for entry in export.entries:
+        print(f"  [{entry.timestamp}] {entry.action} - {entry.status}")
+```
+
+### ComplianceExportAuditParams
+
+| Field      | Type          | Required | Description                                                   |
+|------------|---------------|----------|---------------------------------------------------------------|
+| `since`    | `str \| None` | No       | ISO 8601 start timestamp.                                    |
+| `until`    | `str \| None` | No       | ISO 8601 end timestamp.                                      |
+| `agent_id` | `str \| None` | No       | Filter by agent ID.                                          |
+| `status`   | `str \| None` | No       | Filter by status (`"success"`, `"failure"`, `"blocked"`).     |
+
+### ComplianceAuditExport
+
+| Field          | Type                     | Description                        |
+|----------------|--------------------------|------------------------------------|
+| `generated_at` | `str`                    | ISO 8601 generation timestamp.     |
+| `total`        | `int`                    | Total number of exported entries.  |
+| `entries`      | `tuple[AuditEntry, ...]` | The exported audit entries.        |
+
+## Evidence Pack
+
+Generate a full compliance evidence pack with chain integrity verification. Evidence packs are designed for SOC 2 and GDPR audits:
+
+```python
+from grantex import Grantex, EvidencePackParams
+
+with Grantex(api_key="gx_live_...") as client:
+    pack = client.compliance.evidence_pack(
+        EvidencePackParams(
+            since="2026-01-01T00:00:00Z",
+            until="2026-02-01T00:00:00Z",
+            framework="soc2",
+        )
+    )
+
+    print(f"Framework: {pack.meta.framework}")
+    print(f"Schema version: {pack.meta.schema_version}")
+    print(f"Generated at: {pack.meta.generated_at}")
+    print(f"Summary: {pack.summary}")
+    print(f"Grants: {len(pack.grants)}")
+    print(f"Audit entries: {len(pack.audit_entries)}")
+    print(f"Policies: {len(pack.policies)}")
+    print(f"Chain integrity valid: {pack.chain_integrity.valid}")
+    print(f"Entries checked: {pack.chain_integrity.checked_entries}")
+```
+
+### EvidencePackParams
+
+| Field       | Type          | Required | Description                                       |
+|-------------|---------------|----------|---------------------------------------------------|
+| `since`     | `str \| None` | No       | ISO 8601 start timestamp.                         |
+| `until`     | `str \| None` | No       | ISO 8601 end timestamp.                           |
+| `framework` | `str \| None` | No       | Compliance framework (`"soc2"`, `"gdpr"`, `"all"`). |
+
+### EvidencePack
+
+| Field              | Type                     | Description                            |
+|--------------------|--------------------------|----------------------------------------|
+| `meta`             | `EvidencePackMeta`       | Pack metadata (schema, framework, timestamps). |
+| `summary`          | `dict[str, Any]`         | Aggregate statistics.                  |
+| `grants`           | `tuple[Grant, ...]`      | All grants in the time window.         |
+| `audit_entries`    | `tuple[AuditEntry, ...]` | All audit entries in the time window.  |
+| `policies`         | `tuple[Policy, ...]`     | All active policies.                   |
+| `chain_integrity`  | `ChainIntegrity`         | Result of chain integrity verification.|
+
+### EvidencePackMeta
+
+| Field            | Type          | Description                              |
+|------------------|---------------|------------------------------------------|
+| `schema_version` | `str`         | Evidence pack schema version.            |
+| `generated_at`   | `str`         | ISO 8601 generation timestamp.           |
+| `framework`      | `str`         | Compliance framework used.               |
+| `since`          | `str \| None` | Report start timestamp (if filtered).    |
+| `until`          | `str \| None` | Report end timestamp (if filtered).      |
+
+### ChainIntegrity
+
+| Field              | Type          | Description                                       |
+|--------------------|---------------|---------------------------------------------------|
+| `valid`            | `bool`        | Whether the audit chain is intact.                |
+| `checked_entries`  | `int`         | Number of entries verified.                       |
+| `first_broken_at`  | `str \| None` | ISO 8601 timestamp of the first broken link (if any). |

--- a/docs/sdks/python/errors.mdx
+++ b/docs/sdks/python/errors.mdx
@@ -1,0 +1,210 @@
+---
+title: "Error Handling"
+sidebarTitle: "Errors"
+description: "Handle API errors, authentication failures, token verification errors, and network issues in the Grantex Python SDK."
+---
+
+## Overview
+
+The Grantex Python SDK uses a structured exception hierarchy. All exceptions inherit from `GrantexError`, so you can catch all SDK errors with a single handler or handle specific error types individually.
+
+## Exception Hierarchy
+
+```
+GrantexError (base)
+├── GrantexApiError (non-2xx HTTP response)
+│   └── GrantexAuthError (401 or 403)
+├── GrantexTokenError (JWT verification / decoding failure)
+└── GrantexNetworkError (timeout, connection error)
+```
+
+## Import
+
+```python
+from grantex import (
+    GrantexError,
+    GrantexApiError,
+    GrantexAuthError,
+    GrantexTokenError,
+    GrantexNetworkError,
+)
+```
+
+## GrantexError
+
+The base exception for all Grantex SDK errors. Catch this to handle any SDK error:
+
+```python
+from grantex import Grantex, GrantexError
+
+with Grantex(api_key="gx_live_...") as client:
+    try:
+        agent = client.agents.get("agt_nonexistent")
+    except GrantexError as e:
+        print(f"Something went wrong: {e}")
+```
+
+## GrantexApiError
+
+Raised when the Grantex API returns a non-2xx HTTP response. Provides access to the HTTP status code, response body, and request ID.
+
+```python
+from grantex import Grantex, GrantexApiError
+
+with Grantex(api_key="gx_live_...") as client:
+    try:
+        agent = client.agents.get("agt_nonexistent")
+    except GrantexApiError as e:
+        print(f"Status code: {e.status_code}")
+        print(f"Message: {e}")
+        print(f"Response body: {e.body}")
+        print(f"Request ID: {e.request_id}")
+```
+
+### Attributes
+
+| Attribute    | Type          | Description                                          |
+|-------------|---------------|------------------------------------------------------|
+| `status_code`| `int`         | The HTTP status code (e.g. `404`, `422`, `500`).     |
+| `body`       | `Any`         | The parsed response body (usually a dict) or raw text. |
+| `request_id` | `str \| None` | The `X-Request-Id` header value (if present).        |
+
+The error message is extracted from the response body's `message` or `error` field, falling back to `"HTTP {status_code}"`.
+
+## GrantexAuthError
+
+A subclass of `GrantexApiError` raised specifically for `401` (Unauthorized) and `403` (Forbidden) responses. Typically indicates an invalid or expired API key.
+
+```python
+from grantex import Grantex, GrantexAuthError
+
+with Grantex(api_key="gx_invalid_key") as client:
+    try:
+        agents = client.agents.list()
+    except GrantexAuthError as e:
+        print(f"Authentication failed ({e.status_code}): {e}")
+        # Handle: refresh API key, prompt user, etc.
+```
+
+`GrantexAuthError` has the same attributes as `GrantexApiError`.
+
+## GrantexTokenError
+
+Raised when JWT verification or decoding fails. This occurs when using `verify_grant_token()` for offline verification or when `grants.verify()` cannot decode the returned token.
+
+```python
+from grantex import verify_grant_token, VerifyGrantTokenOptions, GrantexTokenError
+
+try:
+    grant = verify_grant_token(
+        "invalid.jwt.token",
+        VerifyGrantTokenOptions(
+            jwks_uri="https://api.grantex.dev/.well-known/jwks.json",
+        ),
+    )
+except GrantexTokenError as e:
+    print(f"Token error: {e}")
+```
+
+Common causes:
+- Token uses an algorithm other than RS256
+- Token signature is invalid
+- Token is expired
+- Required claims are missing (`jti`, `sub`, `agt`, `dev`, `scp`, `iat`, `exp`)
+- Required scopes are not present
+- JWKS endpoint is unreachable
+- No matching RSA key found in the JWKS
+
+## GrantexNetworkError
+
+Raised on network-level failures such as timeouts, DNS resolution errors, or connection refused. The original exception is available via the `cause` attribute.
+
+```python
+from grantex import Grantex, GrantexNetworkError
+
+with Grantex(api_key="gx_live_...", timeout=5.0) as client:
+    try:
+        agents = client.agents.list()
+    except GrantexNetworkError as e:
+        print(f"Network error: {e}")
+        print(f"Original exception: {e.cause}")
+```
+
+### Attributes
+
+| Attribute | Type                   | Description                                 |
+|-----------|------------------------|---------------------------------------------|
+| `cause`   | `BaseException \| None`| The underlying `httpx` exception that caused the failure. |
+
+## Best Practices
+
+### Catch Specific Errors First
+
+Order your `except` clauses from most specific to least specific:
+
+```python
+from grantex import (
+    Grantex,
+    GrantexAuthError,
+    GrantexApiError,
+    GrantexNetworkError,
+    GrantexError,
+)
+
+with Grantex(api_key="gx_live_...") as client:
+    try:
+        agent = client.agents.get("agt_abc123")
+    except GrantexAuthError as e:
+        # 401/403 -- invalid or expired API key
+        print(f"Auth failed: {e}")
+    except GrantexApiError as e:
+        # Other HTTP errors (404, 422, 500, etc.)
+        print(f"API error {e.status_code}: {e}")
+    except GrantexNetworkError as e:
+        # Timeout, connection refused, DNS failure
+        print(f"Network error: {e}")
+    except GrantexError as e:
+        # Catch-all for any other SDK error
+        print(f"Unexpected error: {e}")
+```
+
+### Retry on Transient Errors
+
+Network errors and certain HTTP status codes (429, 502, 503, 504) are often transient and safe to retry:
+
+```python
+import time
+from grantex import Grantex, GrantexApiError, GrantexNetworkError
+
+def get_agent_with_retry(client, agent_id, max_retries=3):
+    for attempt in range(max_retries):
+        try:
+            return client.agents.get(agent_id)
+        except GrantexNetworkError:
+            if attempt == max_retries - 1:
+                raise
+            time.sleep(2 ** attempt)  # Exponential backoff
+        except GrantexApiError as e:
+            if e.status_code in (429, 502, 503, 504):
+                if attempt == max_retries - 1:
+                    raise
+                time.sleep(2 ** attempt)
+            else:
+                raise  # Non-retryable API error
+```
+
+### Use Request ID for Support
+
+When reporting issues, include the `request_id` from `GrantexApiError`:
+
+```python
+from grantex import Grantex, GrantexApiError
+
+with Grantex(api_key="gx_live_...") as client:
+    try:
+        client.agents.delete("agt_abc123")
+    except GrantexApiError as e:
+        print(f"Error: {e}")
+        if e.request_id:
+            print(f"Request ID for support: {e.request_id}")
+```

--- a/docs/sdks/python/grants.mdx
+++ b/docs/sdks/python/grants.mdx
@@ -1,0 +1,174 @@
+---
+title: "Grants"
+sidebarTitle: "Grants"
+description: "Retrieve, list, revoke, delegate, and verify grants using the Grantex Python SDK."
+---
+
+## Overview
+
+The `grants` client manages authorization grants -- the records that track which users have authorized which agents with which scopes. Grants also support delegation, where a parent agent can create a sub-grant for a child agent.
+
+Access the grants client via `client.grants`.
+
+## Get
+
+Retrieve a single grant by its ID:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    grant = client.grants.get("grnt_abc123")
+
+    print(f"Agent: {grant.agent_id}")
+    print(f"Principal: {grant.principal_id}")
+    print(f"Scopes: {grant.scopes}")
+    print(f"Status: {grant.status}")
+    print(f"Expires at: {grant.expires_at}")
+```
+
+## List
+
+List grants with optional filters:
+
+```python
+from grantex import Grantex, ListGrantsParams
+
+with Grantex(api_key="gx_live_...") as client:
+    # List all grants
+    result = client.grants.list()
+    print(f"Total grants: {result.total}")
+
+    # List with filters
+    result = client.grants.list(ListGrantsParams(
+        agent_id="agt_abc123",
+        status="active",
+        page=1,
+        page_size=25,
+    ))
+
+    for grant in result.grants:
+        print(f"  {grant.id}: {grant.scopes} ({grant.status})")
+```
+
+### ListGrantsParams
+
+| Field          | Type          | Required | Description                              |
+|----------------|---------------|----------|------------------------------------------|
+| `agent_id`     | `str \| None` | No       | Filter by agent ID.                     |
+| `principal_id` | `str \| None` | No       | Filter by principal (user) ID.          |
+| `status`       | `str \| None` | No       | Filter by status (`"active"`, `"revoked"`, `"expired"`). |
+| `page`         | `int \| None` | No       | Page number for pagination.             |
+| `page_size`    | `int \| None` | No       | Number of results per page.             |
+
+### ListGrantsResponse
+
+| Field       | Type               | Description                     |
+|-------------|--------------------|---------------------------------|
+| `grants`    | `tuple[Grant, ...]`| The list of grants.             |
+| `total`     | `int`              | Total number of matching grants.|
+| `page`      | `int`              | Current page number.            |
+| `page_size` | `int`              | Number of grants per page.      |
+
+## Revoke
+
+Revoke a grant by its ID. This immediately invalidates the grant and any tokens issued under it:
+
+```python
+client.grants.revoke("grnt_abc123")
+# Returns None on success
+```
+
+## Delegate
+
+Create a delegated sub-grant for a child agent. The sub-agent receives a subset of the parent grant's scopes:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    result = client.grants.delegate(
+        parent_grant_token="eyJhbGciOiJSUzI1NiIs...",
+        sub_agent_id="agt_sub_agent",
+        scopes=["files:read"],
+        expires_in="1h",
+    )
+
+    print(f"Delegated grant token: {result['grantToken']}")
+```
+
+### Parameters
+
+All parameters are keyword-only.
+
+| Parameter            | Type          | Required | Description                                           |
+|----------------------|---------------|----------|-------------------------------------------------------|
+| `parent_grant_token` | `str`         | Yes      | The parent agent's grant token (JWT).                 |
+| `sub_agent_id`       | `str`         | Yes      | The agent ID of the sub-agent receiving the delegation. |
+| `scopes`             | `list[str]`   | Yes      | Scopes to delegate (must be a subset of parent scopes). |
+| `expires_in`         | `str \| None` | No       | TTL for the delegated grant (e.g. `"1h"`, `"30m"`).  |
+
+## Verify
+
+Verify a grant token online and decode its claims. This calls the Grantex API for server-side validation, then decodes the token locally:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    grant = client.grants.verify("eyJhbGciOiJSUzI1NiIs...")
+
+    print(f"Token ID: {grant.token_id}")
+    print(f"Grant ID: {grant.grant_id}")
+    print(f"Principal: {grant.principal_id}")
+    print(f"Agent DID: {grant.agent_did}")
+    print(f"Scopes: {grant.scopes}")
+```
+
+Returns a `VerifiedGrant` dataclass. See [Offline Verification](/sdks/python/offline-verification) for the full field reference.
+
+<Note>
+For purely offline verification without any network call to the Grantex API, use the standalone [`verify_grant_token()`](/sdks/python/offline-verification) function instead.
+</Note>
+
+## Grant Type
+
+The `Grant` frozen dataclass has the following fields:
+
+| Field          | Type              | Description                              |
+|----------------|-------------------|------------------------------------------|
+| `id`           | `str`             | Unique grant identifier.                 |
+| `agent_id`     | `str`             | The agent ID.                            |
+| `agent_did`    | `str`             | The agent's DID.                         |
+| `principal_id` | `str`             | The user/principal who authorized the grant. |
+| `developer_id` | `str`             | The developer who owns the agent.        |
+| `scopes`       | `tuple[str, ...]` | The granted scopes.                      |
+| `status`       | `str`             | Grant status (`"active"`, `"revoked"`, `"expired"`). |
+| `issued_at`    | `str`             | ISO 8601 timestamp when the grant was issued. |
+| `expires_at`   | `str`             | ISO 8601 timestamp when the grant expires. |
+| `revoked_at`   | `str \| None`     | ISO 8601 timestamp when the grant was revoked (if applicable). |
+
+## Example: Delegation Chain
+
+```python
+from grantex import Grantex, AuthorizeParams, ExchangeTokenParams
+
+with Grantex(api_key="gx_live_...") as client:
+    # Parent agent gets a grant token
+    auth = client.authorize(AuthorizeParams(
+        agent_id="agt_parent",
+        user_id="user_xyz",
+        scopes=["files:read", "files:write", "calendar:read"],
+    ))
+
+    # ... user approves, code is exchanged for token ...
+    # parent_token = client.tokens.exchange(...)
+
+    # Delegate a subset of scopes to a sub-agent
+    delegated = client.grants.delegate(
+        parent_grant_token=parent_token,
+        sub_agent_id="agt_child",
+        scopes=["files:read"],  # subset of parent scopes
+        expires_in="30m",
+    )
+```

--- a/docs/sdks/python/offline-verification.mdx
+++ b/docs/sdks/python/offline-verification.mdx
@@ -1,0 +1,165 @@
+---
+title: "Offline Verification"
+sidebarTitle: "Offline Verification"
+description: "Verify Grantex grant tokens offline using published JWKS without calling the Grantex API."
+---
+
+## Overview
+
+The `verify_grant_token()` function verifies a Grantex grant token locally using the published JSON Web Key Set (JWKS). This approach has zero runtime dependency on Grantex infrastructure -- the only network call is to fetch the JWKS from the issuer.
+
+This is ideal for service-side verification where latency matters and you want to avoid an API round-trip for every request.
+
+## Usage
+
+```python
+from grantex import verify_grant_token, VerifyGrantTokenOptions
+
+grant = verify_grant_token(
+    "eyJhbGciOiJSUzI1NiIs...",
+    VerifyGrantTokenOptions(
+        jwks_uri="https://api.grantex.dev/.well-known/jwks.json",
+    ),
+)
+
+print(f"Principal: {grant.principal_id}")
+print(f"Agent DID: {grant.agent_did}")
+print(f"Scopes: {grant.scopes}")
+print(f"Grant ID: {grant.grant_id}")
+```
+
+## Import
+
+```python
+from grantex import verify_grant_token, VerifyGrantTokenOptions, GrantexTokenError
+```
+
+## Options
+
+`VerifyGrantTokenOptions` configures how the token is verified:
+
+| Field              | Type             | Required | Default | Description                                                        |
+|--------------------|------------------|----------|---------|--------------------------------------------------------------------|
+| `jwks_uri`         | `str`            | Yes      | --      | URL of the JWKS endpoint (e.g. `https://api.grantex.dev/.well-known/jwks.json`). |
+| `required_scopes`  | `list[str] \| None` | No    | `None`  | If set, verification fails if the token is missing any of these scopes. |
+| `clock_tolerance`  | `int`            | No       | `0`     | Seconds of leeway for `exp` and `iat` clock skew.                  |
+| `audience`         | `str \| None`    | No       | `None`  | Expected `aud` claim. If `None`, audience is not validated.        |
+
+## Response
+
+`verify_grant_token()` returns a `VerifiedGrant` frozen dataclass:
+
+| Field               | Type              | Description                                           |
+|---------------------|-------------------|-------------------------------------------------------|
+| `token_id`          | `str`             | The JWT `jti` claim (unique token identifier).        |
+| `grant_id`          | `str`             | The grant identifier (`grnt` claim, falls back to `jti`). |
+| `principal_id`      | `str`             | The user/principal who authorized the grant (`sub`).  |
+| `agent_did`         | `str`             | The agent's DID (`agt` claim).                        |
+| `developer_id`      | `str`             | The developer who owns the agent (`dev` claim).       |
+| `scopes`            | `tuple[str, ...]` | The granted permission scopes.                        |
+| `issued_at`         | `int`             | Unix timestamp when the token was issued.             |
+| `expires_at`        | `int`             | Unix timestamp when the token expires.                |
+| `parent_agent_did`  | `str \| None`     | Parent agent DID (delegation chains only).            |
+| `parent_grant_id`   | `str \| None`     | Parent grant ID (delegation chains only).             |
+| `delegation_depth`  | `int \| None`     | Delegation depth (0 = root grant).                    |
+
+## Algorithm
+
+The algorithm is fixed to **RS256** per SPEC section 11. Tokens signed with any other algorithm are rejected. This cannot be overridden.
+
+## Examples
+
+### Basic Verification
+
+```python
+from grantex import verify_grant_token, VerifyGrantTokenOptions
+
+grant = verify_grant_token(
+    token,
+    VerifyGrantTokenOptions(
+        jwks_uri="https://api.grantex.dev/.well-known/jwks.json",
+    ),
+)
+
+print(f"Token ID: {grant.token_id}")
+print(f"Grant ID: {grant.grant_id}")
+print(f"Authorized by: {grant.principal_id}")
+print(f"Agent: {grant.agent_did}")
+print(f"Scopes: {grant.scopes}")
+```
+
+### Require Specific Scopes
+
+```python
+from grantex import verify_grant_token, VerifyGrantTokenOptions, GrantexTokenError
+
+try:
+    grant = verify_grant_token(
+        token,
+        VerifyGrantTokenOptions(
+            jwks_uri="https://api.grantex.dev/.well-known/jwks.json",
+            required_scopes=["files:read", "files:write"],
+        ),
+    )
+except GrantexTokenError as e:
+    print(f"Verification failed: {e}")
+    # e.g. "Grant token is missing required scopes: files:write"
+```
+
+### With Audience and Clock Tolerance
+
+```python
+from grantex import verify_grant_token, VerifyGrantTokenOptions
+
+grant = verify_grant_token(
+    token,
+    VerifyGrantTokenOptions(
+        jwks_uri="https://api.grantex.dev/.well-known/jwks.json",
+        audience="https://api.myservice.com",
+        clock_tolerance=30,  # allow 30 seconds of clock skew
+    ),
+)
+```
+
+### Verifying Delegated Tokens
+
+Delegated tokens include additional claims for the delegation chain:
+
+```python
+from grantex import verify_grant_token, VerifyGrantTokenOptions
+
+grant = verify_grant_token(
+    delegated_token,
+    VerifyGrantTokenOptions(
+        jwks_uri="https://api.grantex.dev/.well-known/jwks.json",
+    ),
+)
+
+if grant.delegation_depth is not None:
+    print(f"This is a delegated token (depth: {grant.delegation_depth})")
+    print(f"Parent agent: {grant.parent_agent_did}")
+    print(f"Parent grant: {grant.parent_grant_id}")
+else:
+    print("This is a root grant token")
+```
+
+## Error Handling
+
+`verify_grant_token()` raises `GrantexTokenError` in the following cases:
+
+- The token header uses an algorithm other than RS256
+- The JWKS endpoint is unreachable or returns invalid data
+- No matching RSA key is found in the JWKS
+- The token signature is invalid
+- The token is expired
+- Required claims (`jti`, `sub`, `agt`, `dev`, `scp`, `iat`, `exp`) are missing
+- Required scopes are not present in the token
+
+```python
+from grantex import verify_grant_token, VerifyGrantTokenOptions, GrantexTokenError
+
+try:
+    grant = verify_grant_token(token, options)
+except GrantexTokenError as e:
+    print(f"Token verification failed: {e}")
+```

--- a/docs/sdks/python/overview.mdx
+++ b/docs/sdks/python/overview.mdx
@@ -1,0 +1,151 @@
+---
+title: "Python SDK"
+sidebarTitle: "Overview"
+description: "Install and configure the Grantex Python SDK for delegated authorization of AI agents."
+---
+
+## Installation
+
+```bash
+pip install grantex
+```
+
+### Requirements
+
+- Python 3.9 or higher
+- [httpx](https://www.python-httpx.org/) (sync HTTP client)
+- [PyJWT](https://pyjwt.readthedocs.io/) >= 2.8 with [cryptography](https://cryptography.io/) (for offline token verification)
+
+All dependencies are installed automatically with `pip install grantex`.
+
+## Quick Start
+
+```python
+from grantex import Grantex, AuthorizeParams
+
+client = Grantex(api_key="gx_live_...")
+
+# Register an agent
+agent = client.agents.register(
+    name="travel-assistant",
+    scopes=["booking:read", "booking:write"],
+    description="Books flights and hotels on behalf of users",
+)
+
+# Start the authorization flow
+auth = client.authorize(AuthorizeParams(
+    agent_id=agent.id,
+    user_id="user_abc123",
+    scopes=["booking:read", "booking:write"],
+))
+
+# Redirect the user to the consent URL
+print(auth.consent_url)
+
+client.close()
+```
+
+## Configuration
+
+The `Grantex` client accepts three keyword-only arguments:
+
+| Parameter  | Type    | Default                      | Description                                    |
+|-----------|---------|------------------------------|------------------------------------------------|
+| `api_key`  | `str`   | `GRANTEX_API_KEY` env var    | Your Grantex API key. Required.                |
+| `base_url` | `str`   | `https://api.grantex.dev`    | Override the API base URL (e.g. for self-hosted). |
+| `timeout`  | `float` | `30.0`                       | Request timeout in seconds.                    |
+
+### API Key Resolution
+
+The client resolves the API key in this order:
+
+1. The `api_key` keyword argument passed to the constructor.
+2. The `GRANTEX_API_KEY` environment variable.
+
+If neither is set, a `ValueError` is raised.
+
+```python
+import os
+
+# Option 1: Pass directly
+client = Grantex(api_key="gx_live_...")
+
+# Option 2: Set environment variable
+os.environ["GRANTEX_API_KEY"] = "gx_live_..."
+client = Grantex()
+
+# Option 3: Custom base URL for self-hosted deployments
+client = Grantex(
+    api_key="gx_live_...",
+    base_url="https://grantex.internal.example.com",
+    timeout=60.0,
+)
+```
+
+## Context Manager
+
+The `Grantex` client implements the context manager protocol. Using `with` ensures the underlying HTTP connection pool is properly closed when you are done:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    agents = client.agents.list()
+    print(f"Total agents: {agents.total}")
+# Connection pool is closed automatically
+```
+
+This is equivalent to calling `client.close()` manually:
+
+```python
+client = Grantex(api_key="gx_live_...")
+try:
+    agents = client.agents.list()
+finally:
+    client.close()
+```
+
+## Resource Clients
+
+The `Grantex` client exposes the following resource clients as attributes:
+
+| Attribute     | Type               | Description                              |
+|---------------|--------------------|------------------------------------------|
+| `agents`      | `AgentsClient`     | Register, list, update, and delete agents |
+| `grants`      | `GrantsClient`     | Get, list, revoke, delegate, and verify grants |
+| `tokens`      | `TokensClient`     | Exchange, verify, and revoke tokens      |
+| `audit`       | `AuditClient`      | Log, list, and retrieve audit entries    |
+| `webhooks`    | `WebhooksClient`   | Create, list, and delete webhook endpoints |
+| `billing`     | `BillingClient`    | Subscription status, checkout, and portal |
+| `policies`    | `PoliciesClient`   | Create, list, update, and delete policies |
+| `compliance`  | `ComplianceClient` | Summaries, exports, and evidence packs   |
+| `anomalies`   | `AnomaliesClient`  | Detect, list, and acknowledge anomalies  |
+| `scim`        | `ScimClient`       | SCIM 2.0 user provisioning and tokens    |
+| `sso`         | `SsoClient`        | OIDC SSO configuration and login         |
+
+## Standalone Functions
+
+In addition to the client, the SDK exports standalone utility functions:
+
+```python
+from grantex import (
+    verify_grant_token,      # Offline JWT verification via JWKS
+    generate_pkce,           # Generate PKCE code_verifier + code_challenge
+    verify_webhook_signature, # Verify webhook payload signatures
+)
+```
+
+## Data Model Conventions
+
+All response types are frozen dataclasses with `snake_case` field names. Lists are returned as Python `tuple` objects for immutability.
+
+```python
+agent = client.agents.get("agt_abc123")
+
+# Fields use snake_case
+print(agent.developer_id)
+print(agent.created_at)
+
+# Scopes are a tuple
+print(agent.scopes)  # ('booking:read', 'booking:write')
+```

--- a/docs/sdks/python/pkce.mdx
+++ b/docs/sdks/python/pkce.mdx
@@ -1,0 +1,137 @@
+---
+title: "PKCE"
+sidebarTitle: "PKCE"
+description: "Use Proof Key for Code Exchange (PKCE) to secure the authorization flow against code interception attacks."
+---
+
+## Overview
+
+PKCE (Proof Key for Code Exchange) prevents authorization code interception attacks by binding the authorization request to the token exchange. The Grantex SDK provides a `generate_pkce()` helper that creates a cryptographically random code verifier and its S256 challenge.
+
+## Usage
+
+```python
+from grantex import generate_pkce
+
+pkce = generate_pkce()
+
+print(pkce.code_verifier)         # Random 43-character URL-safe string
+print(pkce.code_challenge)        # SHA-256 hash of the verifier, base64url-encoded
+print(pkce.code_challenge_method) # Always "S256"
+```
+
+## Import
+
+```python
+from grantex import generate_pkce, PkceChallenge
+```
+
+## PkceChallenge
+
+`generate_pkce()` returns a `PkceChallenge` frozen dataclass:
+
+| Field                   | Type  | Description                                                |
+|-------------------------|-------|------------------------------------------------------------|
+| `code_verifier`         | `str` | A cryptographically random URL-safe string (32 bytes, base64url-encoded). |
+| `code_challenge`        | `str` | The SHA-256 hash of the verifier, base64url-encoded.       |
+| `code_challenge_method` | `str` | Always `"S256"`.                                           |
+
+## Complete PKCE Flow
+
+The PKCE flow has three steps: generate the challenge, authorize with the challenge, and exchange with the verifier.
+
+### Step 1: Generate the PKCE Pair
+
+```python
+from grantex import generate_pkce
+
+pkce = generate_pkce()
+# Store pkce.code_verifier securely -- you will need it in Step 3
+```
+
+### Step 2: Authorize with the Code Challenge
+
+Pass the `code_challenge` and `code_challenge_method` in the authorization request:
+
+```python
+from grantex import Grantex, AuthorizeParams
+
+with Grantex(api_key="gx_live_...") as client:
+    auth = client.authorize(AuthorizeParams(
+        agent_id="agt_abc123",
+        user_id="user_xyz",
+        scopes=["files:read", "files:write"],
+        redirect_uri="https://myapp.com/callback",
+        code_challenge=pkce.code_challenge,
+        code_challenge_method=pkce.code_challenge_method,
+    ))
+
+    # Redirect user to auth.consent_url
+```
+
+### Step 3: Exchange with the Code Verifier
+
+After the user approves and you receive the authorization code at your redirect URI, include the `code_verifier` in the token exchange:
+
+```python
+from grantex import Grantex, ExchangeTokenParams
+
+with Grantex(api_key="gx_live_...") as client:
+    token_response = client.tokens.exchange(ExchangeTokenParams(
+        code="received_auth_code",
+        agent_id="agt_abc123",
+        code_verifier=pkce.code_verifier,
+    ))
+
+    print(f"Grant token: {token_response.grant_token}")
+```
+
+The server verifies that `SHA256(code_verifier) == code_challenge` before issuing the token. If the verifier does not match, the exchange is rejected.
+
+## Full Example
+
+```python
+from grantex import (
+    Grantex,
+    AuthorizeParams,
+    ExchangeTokenParams,
+    generate_pkce,
+)
+
+# 1. Generate PKCE pair
+pkce = generate_pkce()
+
+with Grantex(api_key="gx_live_...") as client:
+    # 2. Start authorization with PKCE
+    auth = client.authorize(AuthorizeParams(
+        agent_id="agt_abc123",
+        user_id="user_xyz",
+        scopes=["calendar:read"],
+        redirect_uri="https://myapp.com/callback",
+        code_challenge=pkce.code_challenge,
+        code_challenge_method=pkce.code_challenge_method,
+    ))
+
+    print(f"Send user to: {auth.consent_url}")
+
+    # 3. User approves, you receive the code at your callback
+    code = "code_from_redirect"
+
+    # 4. Exchange with PKCE verifier
+    result = client.tokens.exchange(ExchangeTokenParams(
+        code=code,
+        agent_id="agt_abc123",
+        code_verifier=pkce.code_verifier,
+    ))
+
+    print(f"Grant token: {result.grant_token}")
+    print(f"Grant ID: {result.grant_id}")
+    print(f"Scopes: {result.scopes}")
+```
+
+## How It Works
+
+1. `generate_pkce()` creates 32 random bytes and base64url-encodes them to produce the `code_verifier`.
+2. The `code_challenge` is the SHA-256 digest of the verifier, base64url-encoded (without padding).
+3. The challenge method is always `S256` (plain is not supported).
+4. During token exchange, the server independently computes `SHA256(code_verifier)` and compares it to the stored `code_challenge`. A mismatch causes the exchange to fail.

--- a/docs/sdks/python/policies.mdx
+++ b/docs/sdks/python/policies.mdx
@@ -1,0 +1,189 @@
+---
+title: "Policies"
+sidebarTitle: "Policies"
+description: "Create, manage, and enforce authorization policies for fine-grained access control with the Grantex Python SDK."
+---
+
+## Overview
+
+Policies provide fine-grained access control rules that are evaluated during authorization. Each policy has an effect (`allow` or `deny`), a priority, and optional filters for agent, principal, scopes, and time-of-day restrictions.
+
+Access the policies client via `client.policies`.
+
+## Create
+
+Create a new authorization policy:
+
+```python
+from grantex import Grantex, CreatePolicyParams
+
+with Grantex(api_key="gx_live_...") as client:
+    policy = client.policies.create(CreatePolicyParams(
+        name="business-hours-only",
+        effect="deny",
+        priority=10,
+        agent_id="agt_abc123",
+        time_of_day_start="18:00",
+        time_of_day_end="08:00",
+    ))
+
+    print(f"Policy ID: {policy.id}")
+    print(f"Effect: {policy.effect}")
+    print(f"Priority: {policy.priority}")
+```
+
+### CreatePolicyParams
+
+| Field                | Type              | Required | Default | Description                                    |
+|----------------------|-------------------|----------|---------|------------------------------------------------|
+| `name`               | `str`             | Yes      | --      | Human-readable name for the policy.            |
+| `effect`             | `str`             | Yes      | --      | `"allow"` or `"deny"`.                         |
+| `priority`           | `int`             | No       | `0`     | Higher priority policies are evaluated first.  |
+| `agent_id`           | `str \| None`     | No       | `None`  | Restrict to a specific agent.                  |
+| `principal_id`       | `str \| None`     | No       | `None`  | Restrict to a specific principal (user).       |
+| `scopes`             | `list[str] \| None` | No     | `None`  | Restrict to specific scopes.                   |
+| `time_of_day_start`  | `str \| None`     | No       | `None`  | Start of allowed/denied time window (`HH:MM`). |
+| `time_of_day_end`    | `str \| None`     | No       | `None`  | End of allowed/denied time window (`HH:MM`).   |
+
+## List
+
+List all policies for your developer account:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    result = client.policies.list()
+
+    print(f"Total policies: {result.total}")
+    for policy in result.policies:
+        print(f"  {policy.name}: {policy.effect} (priority {policy.priority})")
+```
+
+### ListPoliciesResponse
+
+| Field      | Type                | Description                    |
+|------------|---------------------|--------------------------------|
+| `policies` | `tuple[Policy, ...]`| The list of policies.          |
+| `total`    | `int`               | Total number of policies.      |
+
+## Get
+
+Retrieve a single policy by its ID:
+
+```python
+policy = client.policies.get("pol_abc123")
+
+print(f"Name: {policy.name}")
+print(f"Effect: {policy.effect}")
+print(f"Agent: {policy.agent_id}")
+print(f"Scopes: {policy.scopes}")
+print(f"Time window: {policy.time_of_day_start} - {policy.time_of_day_end}")
+```
+
+## Update
+
+Update an existing policy. Only fields you provide will be modified:
+
+```python
+from grantex import Grantex, UpdatePolicyParams
+
+with Grantex(api_key="gx_live_...") as client:
+    updated = client.policies.update(
+        "pol_abc123",
+        UpdatePolicyParams(
+            name="business-hours-only-v2",
+            priority=20,
+            time_of_day_start="19:00",
+            time_of_day_end="07:00",
+        ),
+    )
+
+    print(f"Updated at: {updated.updated_at}")
+```
+
+### UpdatePolicyParams
+
+| Field                | Type              | Required | Description                                    |
+|----------------------|-------------------|----------|------------------------------------------------|
+| `name`               | `str \| None`     | No       | New name for the policy.                       |
+| `effect`             | `str \| None`     | No       | New effect (`"allow"` or `"deny"`).            |
+| `priority`           | `int \| None`     | No       | New priority value.                            |
+| `agent_id`           | `str \| None`     | No       | New agent filter.                              |
+| `principal_id`       | `str \| None`     | No       | New principal filter.                          |
+| `scopes`             | `list[str] \| None` | No     | New scope filter.                              |
+| `time_of_day_start`  | `str \| None`     | No       | New time window start (`HH:MM`).               |
+| `time_of_day_end`    | `str \| None`     | No       | New time window end (`HH:MM`).                  |
+
+## Delete
+
+Delete a policy by its ID:
+
+```python
+client.policies.delete("pol_abc123")
+# Returns None on success
+```
+
+## Policy Type
+
+The `Policy` frozen dataclass has the following fields:
+
+| Field                | Type                   | Description                              |
+|----------------------|------------------------|------------------------------------------|
+| `id`                 | `str`                  | Unique policy identifier.                |
+| `name`               | `str`                  | Human-readable policy name.              |
+| `effect`             | `str`                  | `"allow"` or `"deny"`.                   |
+| `priority`           | `int`                  | Evaluation priority (higher = first).    |
+| `agent_id`           | `str \| None`          | Agent filter (if set).                   |
+| `principal_id`       | `str \| None`          | Principal filter (if set).               |
+| `scopes`             | `tuple[str, ...] \| None` | Scope filter (if set).                |
+| `time_of_day_start`  | `str \| None`          | Time window start.                       |
+| `time_of_day_end`    | `str \| None`          | Time window end.                         |
+| `created_at`         | `str`                  | ISO 8601 creation timestamp.             |
+| `updated_at`         | `str`                  | ISO 8601 last-updated timestamp.         |
+
+## Example: Common Policy Patterns
+
+### Deny After Hours
+
+```python
+from grantex import Grantex, CreatePolicyParams
+
+with Grantex(api_key="gx_live_...") as client:
+    client.policies.create(CreatePolicyParams(
+        name="deny-after-hours",
+        effect="deny",
+        priority=100,
+        time_of_day_start="20:00",
+        time_of_day_end="06:00",
+    ))
+```
+
+### Allow Specific Scopes for an Agent
+
+```python
+from grantex import Grantex, CreatePolicyParams
+
+with Grantex(api_key="gx_live_...") as client:
+    client.policies.create(CreatePolicyParams(
+        name="read-only-for-assistant",
+        effect="allow",
+        priority=50,
+        agent_id="agt_abc123",
+        scopes=["files:read", "calendar:read"],
+    ))
+```
+
+### Deny a Specific User
+
+```python
+from grantex import Grantex, CreatePolicyParams
+
+with Grantex(api_key="gx_live_...") as client:
+    client.policies.create(CreatePolicyParams(
+        name="block-suspended-user",
+        effect="deny",
+        priority=200,
+        principal_id="user_suspended_xyz",
+    ))
+```

--- a/docs/sdks/python/scim.mdx
+++ b/docs/sdks/python/scim.mdx
@@ -1,0 +1,226 @@
+---
+title: "SCIM 2.0"
+sidebarTitle: "SCIM"
+description: "Provision and manage users via SCIM 2.0, and manage SCIM bearer tokens with the Grantex Python SDK."
+---
+
+## Overview
+
+The `scim` client implements the SCIM 2.0 protocol for automated user provisioning. It supports both SCIM token management (for authenticating your identity provider) and full SCIM 2.0 user lifecycle operations.
+
+Access the SCIM client via `client.scim`.
+
+## Token Management
+
+SCIM tokens authenticate your identity provider (IdP) when it provisions users. Tokens are bearer tokens -- the raw secret is only returned once at creation time.
+
+### Create Token
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    scim_token = client.scim.create_token("Okta Production")
+
+    print(f"Token ID: {scim_token.id}")
+    print(f"Label: {scim_token.label}")
+    print(f"Token: {scim_token.token}")  # Store securely -- shown only once
+    print(f"Created at: {scim_token.created_at}")
+```
+
+#### ScimTokenWithSecret
+
+| Field          | Type          | Description                                     |
+|----------------|---------------|-------------------------------------------------|
+| `id`           | `str`         | Unique token identifier.                        |
+| `label`        | `str`         | Human-readable label.                           |
+| `token`        | `str`         | The bearer token secret (only returned at creation). |
+| `created_at`   | `str`         | ISO 8601 creation timestamp.                    |
+| `last_used_at` | `str \| None` | ISO 8601 timestamp of last use (or `None`).     |
+
+### List Tokens
+
+```python
+result = client.scim.list_tokens()
+
+for token in result.tokens:
+    print(f"  {token.id}: {token.label} (created {token.created_at})")
+```
+
+#### ListScimTokensResponse
+
+| Field    | Type                  | Description                 |
+|----------|-----------------------|-----------------------------|
+| `tokens` | `tuple[ScimToken, ...]` | The list of SCIM tokens (without secrets). |
+
+#### ScimToken
+
+| Field          | Type          | Description                            |
+|----------------|---------------|----------------------------------------|
+| `id`           | `str`         | Unique token identifier.               |
+| `label`        | `str`         | Human-readable label.                  |
+| `created_at`   | `str`         | ISO 8601 creation timestamp.           |
+| `last_used_at` | `str \| None` | ISO 8601 timestamp of last use.        |
+
+### Revoke Token
+
+```python
+client.scim.revoke_token("scim_tok_abc123")
+# Returns None on success
+```
+
+## User Operations
+
+SCIM 2.0 user operations support the full user lifecycle: create, read, update (full and partial), list, and delete.
+
+### List Users
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    result = client.scim.list_users(start_index=1, count=25)
+
+    print(f"Total results: {result.total_results}")
+    print(f"Start index: {result.start_index}")
+    print(f"Items per page: {result.items_per_page}")
+    for user in result.resources:
+        print(f"  {user.user_name} (active: {user.active})")
+```
+
+#### Parameters
+
+| Parameter     | Type          | Required | Description                              |
+|---------------|---------------|----------|------------------------------------------|
+| `start_index` | `int \| None` | No       | 1-based index of the first result.       |
+| `count`       | `int \| None` | No       | Maximum number of results to return.     |
+
+Both parameters are keyword-only.
+
+#### ScimListResponse
+
+| Field            | Type                  | Description                       |
+|------------------|-----------------------|-----------------------------------|
+| `total_results`  | `int`                 | Total number of matching users.   |
+| `start_index`    | `int`                 | 1-based index of the first result.|
+| `items_per_page` | `int`                 | Number of results per page.       |
+| `resources`      | `tuple[ScimUser, ...]`| The list of users.                |
+
+### Create User
+
+```python
+from grantex import Grantex, CreateScimUserParams
+
+with Grantex(api_key="gx_live_...") as client:
+    user = client.scim.create_user(CreateScimUserParams(
+        user_name="alice@example.com",
+        display_name="Alice Smith",
+        external_id="ext_12345",
+        emails=[{"value": "alice@example.com", "primary": True}],
+        active=True,
+    ))
+
+    print(f"User ID: {user.id}")
+    print(f"Username: {user.user_name}")
+    print(f"Active: {user.active}")
+```
+
+#### CreateScimUserParams
+
+| Field          | Type                         | Required | Default | Description                        |
+|----------------|------------------------------|----------|---------|------------------------------------|
+| `user_name`    | `str`                        | Yes      | --      | The user's username (typically email). |
+| `display_name` | `str \| None`                | No       | `None`  | Display name.                      |
+| `external_id`  | `str \| None`                | No       | `None`  | External ID from the IdP.         |
+| `emails`       | `list[dict[str, Any]] \| None` | No     | `None`  | List of email objects.             |
+| `active`       | `bool`                       | No       | `True`  | Whether the user is active.        |
+
+### Get User
+
+```python
+user = client.scim.get_user("scim_user_abc123")
+
+print(f"Username: {user.user_name}")
+print(f"Display name: {user.display_name}")
+print(f"Active: {user.active}")
+print(f"Emails: {[(e.value, e.primary) for e in user.emails]}")
+print(f"Created: {user.meta.created}")
+```
+
+### Replace User (PUT)
+
+Full replacement of a user's attributes:
+
+```python
+from grantex import Grantex, CreateScimUserParams
+
+with Grantex(api_key="gx_live_...") as client:
+    updated = client.scim.replace_user(
+        "scim_user_abc123",
+        CreateScimUserParams(
+            user_name="alice@example.com",
+            display_name="Alice Johnson",
+            active=True,
+        ),
+    )
+
+    print(f"Updated: {updated.display_name}")
+```
+
+### Update User (PATCH)
+
+Partial update using SCIM Operations:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    updated = client.scim.update_user(
+        "scim_user_abc123",
+        operations=[
+            {"op": "replace", "path": "displayName", "value": "Alice Johnson"},
+            {"op": "replace", "path": "active", "value": False},
+        ],
+    )
+
+    print(f"Display name: {updated.display_name}")
+    print(f"Active: {updated.active}")
+```
+
+### Delete User
+
+Deprovision a user:
+
+```python
+client.scim.delete_user("scim_user_abc123")
+# Returns None on success
+```
+
+## ScimUser Type
+
+The `ScimUser` frozen dataclass has the following fields:
+
+| Field          | Type                  | Description                          |
+|----------------|-----------------------|--------------------------------------|
+| `id`           | `str`                 | Unique user identifier.              |
+| `user_name`    | `str`                 | The user's username.                 |
+| `active`       | `bool`                | Whether the user is active.          |
+| `emails`       | `tuple[ScimEmail, ...]` | The user's email addresses.        |
+| `meta`         | `ScimUserMeta`        | SCIM metadata (timestamps, type).    |
+| `external_id`  | `str \| None`         | External ID from the IdP.           |
+| `display_name` | `str \| None`         | Display name.                        |
+
+### ScimEmail
+
+| Field     | Type   | Description                           |
+|-----------|--------|---------------------------------------|
+| `value`   | `str`  | The email address.                    |
+| `primary` | `bool` | Whether this is the primary email.    |
+
+### ScimUserMeta
+
+| Field           | Type  | Description                          |
+|-----------------|-------|--------------------------------------|
+| `resource_type` | `str` | The SCIM resource type.              |
+| `created`       | `str` | ISO 8601 creation timestamp.         |
+| `last_modified` | `str` | ISO 8601 last-modified timestamp.    |

--- a/docs/sdks/python/sso.mdx
+++ b/docs/sdks/python/sso.mdx
@@ -1,0 +1,166 @@
+---
+title: "SSO (OIDC)"
+sidebarTitle: "SSO"
+description: "Configure OpenID Connect SSO, generate login URLs, and handle callbacks with the Grantex Python SDK."
+---
+
+## Overview
+
+The `sso` client manages OpenID Connect (OIDC) single sign-on configuration. Set up SSO so your organization's members can log in through your identity provider (IdP) instead of using API keys directly.
+
+Access the SSO client via `client.sso`.
+
+## Create Config
+
+Create or update the OIDC SSO configuration for your developer organization:
+
+```python
+from grantex import Grantex, CreateSsoConfigParams
+
+with Grantex(api_key="gx_live_...") as client:
+    config = client.sso.create_config(CreateSsoConfigParams(
+        issuer_url="https://accounts.google.com",
+        client_id="your-oidc-client-id",
+        client_secret="your-oidc-client-secret",
+        redirect_uri="https://myapp.com/sso/callback",
+    ))
+
+    print(f"Issuer: {config.issuer_url}")
+    print(f"Client ID: {config.client_id}")
+    print(f"Redirect URI: {config.redirect_uri}")
+    print(f"Created at: {config.created_at}")
+```
+
+### CreateSsoConfigParams
+
+| Field           | Type  | Required | Description                                        |
+|-----------------|-------|----------|----------------------------------------------------|
+| `issuer_url`    | `str` | Yes      | The OIDC issuer URL (e.g. `https://accounts.google.com`). |
+| `client_id`     | `str` | Yes      | The OIDC client ID from your IdP.                  |
+| `client_secret` | `str` | Yes      | The OIDC client secret from your IdP.              |
+| `redirect_uri`  | `str` | Yes      | The redirect URI registered with your IdP.         |
+
+## Get Config
+
+Retrieve the current SSO configuration. The client secret is not included in the response:
+
+```python
+config = client.sso.get_config()
+
+print(f"Issuer: {config.issuer_url}")
+print(f"Client ID: {config.client_id}")
+print(f"Redirect URI: {config.redirect_uri}")
+print(f"Updated at: {config.updated_at}")
+```
+
+### SsoConfig
+
+| Field          | Type  | Description                              |
+|----------------|-------|------------------------------------------|
+| `issuer_url`   | `str` | The OIDC issuer URL.                     |
+| `client_id`    | `str` | The OIDC client ID.                      |
+| `redirect_uri` | `str` | The registered redirect URI.             |
+| `created_at`   | `str` | ISO 8601 creation timestamp.             |
+| `updated_at`   | `str` | ISO 8601 last-updated timestamp.         |
+
+## Delete Config
+
+Remove the SSO configuration:
+
+```python
+client.sso.delete_config()
+# Returns None on success
+```
+
+## Get Login URL
+
+Generate the OIDC authorization URL to redirect a user to for SSO login:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    login = client.sso.get_login_url("my-organization")
+
+    print(f"Redirect to: {login.authorize_url}")
+```
+
+### Parameters
+
+| Parameter | Type  | Required | Description                              |
+|-----------|-------|----------|------------------------------------------|
+| `org`     | `str` | Yes      | The organization identifier for SSO lookup. |
+
+### SsoLoginResponse
+
+| Field           | Type  | Description                              |
+|-----------------|-------|------------------------------------------|
+| `authorize_url` | `str` | The OIDC authorization URL to redirect the user to. |
+
+## Handle Callback
+
+Exchange the OIDC authorization code for user information after the IdP redirects back to your application:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    result = client.sso.handle_callback(
+        code="oidc_auth_code",
+        state="csrf_state_value",
+    )
+
+    print(f"Developer ID: {result.developer_id}")
+    print(f"Email: {result.email}")
+    print(f"Name: {result.name}")
+    print(f"Subject: {result.sub}")
+```
+
+### Parameters
+
+| Parameter | Type  | Required | Description                                   |
+|-----------|-------|----------|-----------------------------------------------|
+| `code`    | `str` | Yes      | The authorization code from the OIDC callback. |
+| `state`   | `str` | Yes      | The state parameter for CSRF verification.    |
+
+### SsoCallbackResponse
+
+| Field          | Type          | Description                              |
+|----------------|---------------|------------------------------------------|
+| `developer_id` | `str`         | The Grantex developer ID for the authenticated user. |
+| `email`        | `str \| None` | The user's email address (if provided by IdP). |
+| `name`         | `str \| None` | The user's display name (if provided by IdP). |
+| `sub`          | `str \| None` | The OIDC subject identifier.             |
+
+## Complete SSO Flow Example
+
+```python
+from grantex import Grantex, CreateSsoConfigParams
+
+with Grantex(api_key="gx_live_...") as client:
+    # 1. Configure SSO (one-time setup)
+    client.sso.create_config(CreateSsoConfigParams(
+        issuer_url="https://accounts.google.com",
+        client_id="your-client-id",
+        client_secret="your-client-secret",
+        redirect_uri="https://myapp.com/sso/callback",
+    ))
+
+    # 2. Generate login URL for a user
+    login = client.sso.get_login_url("my-organization")
+    # Redirect the user's browser to login.authorize_url
+
+    # 3. Handle the callback (in your /sso/callback route)
+    result = client.sso.handle_callback(
+        code="code_from_idp",
+        state="state_from_idp",
+    )
+    print(f"Logged in as: {result.email} (developer: {result.developer_id})")
+
+    # 4. Verify or clean up configuration
+    config = client.sso.get_config()
+    print(f"SSO configured with: {config.issuer_url}")
+
+    # To remove SSO:
+    # client.sso.delete_config()
+```

--- a/docs/sdks/python/tokens.mdx
+++ b/docs/sdks/python/tokens.mdx
@@ -1,0 +1,165 @@
+---
+title: "Tokens"
+sidebarTitle: "Tokens"
+description: "Exchange authorization codes for grant tokens, verify tokens online, and revoke tokens."
+---
+
+## Overview
+
+The `tokens` client provides three operations for managing grant tokens:
+
+- **Exchange** an authorization code for a grant token
+- **Verify** a grant token online via the Grantex API
+- **Revoke** a grant token by its token ID (JTI)
+
+Access the tokens client via `client.tokens`.
+
+## Exchange
+
+Exchange an authorization code for a grant token after the user approves the consent request.
+
+```python
+from grantex import Grantex, ExchangeTokenParams
+
+with Grantex(api_key="gx_live_...") as client:
+    result = client.tokens.exchange(ExchangeTokenParams(
+        code="auth_code_from_callback",
+        agent_id="agt_abc123",
+    ))
+
+    print(f"Grant token: {result.grant_token}")
+    print(f"Grant ID: {result.grant_id}")
+    print(f"Scopes: {result.scopes}")
+    print(f"Expires at: {result.expires_at}")
+    print(f"Refresh token: {result.refresh_token}")
+```
+
+### ExchangeTokenParams
+
+| Field           | Type          | Required | Description                                           |
+|-----------------|---------------|----------|-------------------------------------------------------|
+| `code`          | `str`         | Yes      | The authorization code received at the redirect URI.  |
+| `agent_id`      | `str`         | Yes      | The agent ID that initiated the authorization.        |
+| `code_verifier` | `str \| None` | No       | The PKCE code verifier, if PKCE was used during authorization. |
+
+### ExchangeTokenResponse
+
+| Field           | Type              | Description                                      |
+|-----------------|-------------------|--------------------------------------------------|
+| `grant_token`   | `str`             | The JWT grant token.                             |
+| `grant_id`      | `str`             | The unique grant identifier.                     |
+| `scopes`        | `tuple[str, ...]` | The approved scopes.                             |
+| `expires_at`    | `str`             | ISO 8601 timestamp when the token expires.       |
+| `refresh_token` | `str`             | A refresh token for obtaining new grant tokens.  |
+
+### Exchange with PKCE
+
+```python
+from grantex import Grantex, ExchangeTokenParams
+
+with Grantex(api_key="gx_live_...") as client:
+    result = client.tokens.exchange(ExchangeTokenParams(
+        code="auth_code_from_callback",
+        agent_id="agt_abc123",
+        code_verifier="dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+    ))
+```
+
+## Verify
+
+Verify a grant token online via the Grantex API. This sends the token to the server for validation and returns the token's metadata.
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    result = client.tokens.verify("eyJhbGciOiJSUzI1NiIs...")
+
+    if result.valid:
+        print(f"Grant ID: {result.grant_id}")
+        print(f"Scopes: {result.scopes}")
+        print(f"Principal: {result.principal}")
+        print(f"Agent: {result.agent}")
+        print(f"Expires at: {result.expires_at}")
+    else:
+        print("Token is invalid or expired")
+```
+
+### VerifyTokenResponse
+
+| Field       | Type                       | Description                                      |
+|-------------|----------------------------|--------------------------------------------------|
+| `valid`     | `bool`                     | Whether the token is valid.                      |
+| `grant_id`  | `str \| None`              | The grant identifier (if valid).                 |
+| `scopes`    | `tuple[str, ...] \| None`  | The granted scopes (if valid).                   |
+| `principal` | `str \| None`              | The user/principal ID (if valid).                |
+| `agent`     | `str \| None`              | The agent DID (if valid).                        |
+| `expires_at`| `str \| None`              | ISO 8601 expiration timestamp (if valid).        |
+
+<Note>
+For offline verification that does not require a network call to the Grantex API, use the standalone [`verify_grant_token()`](/sdks/python/offline-verification) function.
+</Note>
+
+## Revoke
+
+Revoke a grant token by its token ID (JTI claim). The token is immediately invalidated and can no longer be used.
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    client.tokens.revoke("tok_abc123")
+    # Returns None on success
+```
+
+### Parameters
+
+| Parameter  | Type  | Description                          |
+|------------|-------|--------------------------------------|
+| `token_id` | `str` | The JTI (token ID) of the grant token to revoke. |
+
+The method returns `None`. A `GrantexApiError` is raised if the token does not exist or has already been revoked.
+
+## Complete Flow Example
+
+```python
+from grantex import (
+    Grantex,
+    AuthorizeParams,
+    ExchangeTokenParams,
+    generate_pkce,
+)
+
+pkce = generate_pkce()
+
+with Grantex(api_key="gx_live_...") as client:
+    # 1. Start authorization with PKCE
+    auth = client.authorize(AuthorizeParams(
+        agent_id="agt_abc123",
+        user_id="user_xyz",
+        scopes=["files:read"],
+        redirect_uri="https://myapp.com/callback",
+        code_challenge=pkce.code_challenge,
+        code_challenge_method=pkce.code_challenge_method,
+    ))
+    print(f"Redirect user to: {auth.consent_url}")
+
+    # 2. After user approves, exchange the code
+    code = "received_from_redirect"  # from your callback handler
+    token_response = client.tokens.exchange(ExchangeTokenParams(
+        code=code,
+        agent_id="agt_abc123",
+        code_verifier=pkce.code_verifier,
+    ))
+
+    # 3. Use the grant token with your agent
+    grant_token = token_response.grant_token
+
+    # 4. Verify the token is still valid
+    verification = client.tokens.verify(grant_token)
+    print(f"Valid: {verification.valid}")
+
+    # 5. Revoke when no longer needed
+    # Extract token ID from the JWT or use the known ID
+    client.tokens.revoke("tok_abc123")
+```

--- a/docs/sdks/python/webhooks.mdx
+++ b/docs/sdks/python/webhooks.mdx
@@ -1,0 +1,167 @@
+---
+title: "Webhooks"
+sidebarTitle: "Webhooks"
+description: "Register webhook endpoints, receive event notifications, and verify webhook signatures with the Grantex Python SDK."
+---
+
+## Overview
+
+Webhooks allow your application to receive real-time notifications when events occur in Grantex. The `webhooks` client manages webhook endpoint registrations, and the `verify_webhook_signature()` function validates incoming payloads.
+
+Access the webhooks client via `client.webhooks`.
+
+## Create
+
+Register a new webhook endpoint that will receive event notifications:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    webhook = client.webhooks.create(
+        url="https://myapp.com/webhooks/grantex",
+        events=["grant.created", "grant.revoked", "token.issued"],
+    )
+
+    print(f"Webhook ID: {webhook.id}")
+    print(f"URL: {webhook.url}")
+    print(f"Events: {webhook.events}")
+    print(f"Secret: {webhook.secret}")  # Store this securely!
+```
+
+### Parameters
+
+All parameters are keyword-only.
+
+| Parameter | Type        | Required | Description                                   |
+|-----------|-------------|----------|-----------------------------------------------|
+| `url`     | `str`       | Yes      | The HTTPS URL that will receive webhook events. |
+| `events`  | `list[str]` | Yes      | The event types to subscribe to.              |
+
+### Returns
+
+A `WebhookEndpointWithSecret` dataclass. The `secret` field is only returned at creation time -- store it securely for signature verification.
+
+### Supported Events
+
+| Event            | Description                             |
+|------------------|-----------------------------------------|
+| `grant.created`  | A new grant has been issued.            |
+| `grant.revoked`  | A grant has been revoked.               |
+| `token.issued`   | A new grant token has been issued.      |
+
+## List
+
+List all registered webhook endpoints:
+
+```python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    result = client.webhooks.list()
+
+    for webhook in result.webhooks:
+        print(f"  {webhook.id}: {webhook.url} -> {webhook.events}")
+```
+
+### ListWebhooksResponse
+
+| Field      | Type                          | Description                     |
+|------------|-------------------------------|---------------------------------|
+| `webhooks` | `tuple[WebhookEndpoint, ...]` | The list of webhook endpoints.  |
+
+### WebhookEndpoint
+
+| Field        | Type              | Description                         |
+|--------------|-------------------|-------------------------------------|
+| `id`         | `str`             | Unique webhook endpoint identifier. |
+| `url`        | `str`             | The webhook URL.                    |
+| `events`     | `tuple[str, ...]` | Subscribed event types.             |
+| `created_at` | `str`             | ISO 8601 creation timestamp.        |
+
+## Delete
+
+Remove a webhook endpoint:
+
+```python
+client.webhooks.delete("wh_abc123")
+# Returns None on success
+```
+
+## Verify Webhook Signatures
+
+When your server receives a webhook payload, verify the signature to ensure it was sent by Grantex and has not been tampered with.
+
+### Import
+
+```python
+from grantex import verify_webhook_signature
+```
+
+### Usage
+
+```python
+from grantex import verify_webhook_signature
+
+# In your webhook handler:
+def handle_webhook(request):
+    body = request.body          # Raw request body (str or bytes)
+    signature = request.headers["X-Grantex-Signature"]
+    secret = "whsec_..."         # The secret from webhook creation
+
+    if verify_webhook_signature(body, signature, secret):
+        event = json.loads(body)
+        print(f"Received event: {event['type']}")
+        # Process the event
+    else:
+        print("Invalid signature -- rejecting")
+        return 403
+```
+
+### Parameters
+
+| Parameter   | Type            | Description                                                |
+|-------------|-----------------|------------------------------------------------------------|
+| `payload`   | `str \| bytes`  | The raw request body received from Grantex.                |
+| `signature` | `str`           | The value of the `X-Grantex-Signature` header.             |
+| `secret`    | `str`           | The webhook secret returned when the endpoint was created. |
+
+### Returns
+
+`True` if the signature is valid, `False` otherwise.
+
+### How It Works
+
+The signature is computed as `sha256=<hex-digest>` using HMAC-SHA256 with the webhook secret as the key and the raw request body as the message. The verification uses constant-time comparison to prevent timing attacks.
+
+## Full Example
+
+```python
+import json
+from grantex import Grantex, verify_webhook_signature
+
+# 1. Register a webhook endpoint
+with Grantex(api_key="gx_live_...") as client:
+    webhook = client.webhooks.create(
+        url="https://myapp.com/webhooks/grantex",
+        events=["grant.created", "grant.revoked"],
+    )
+    secret = webhook.secret  # Store securely
+
+# 2. In your webhook handler (e.g. Flask, FastAPI, Django)
+def webhook_handler(request):
+    body = request.body
+    signature = request.headers["X-Grantex-Signature"]
+
+    if not verify_webhook_signature(body, signature, secret):
+        return {"error": "Invalid signature"}, 403
+
+    event = json.loads(body)
+
+    if event["type"] == "grant.created":
+        print(f"New grant: {event['data']['grantId']}")
+    elif event["type"] == "grant.revoked":
+        print(f"Grant revoked: {event['data']['grantId']}")
+
+    return {"ok": True}, 200
+```

--- a/docs/sdks/typescript/agents.mdx
+++ b/docs/sdks/typescript/agents.mdx
@@ -1,0 +1,202 @@
+---
+title: "Agents"
+sidebarTitle: "Agents"
+description: "Register, list, update, and delete AI agents with the Grantex TypeScript SDK."
+---
+
+## Overview
+
+The `agents` sub-client manages the lifecycle of AI agents in your Grantex organization. Each agent receives a unique decentralized identifier (DID) and can request scoped grants from users.
+
+```typescript
+const agent = await grantex.agents.register({
+  name: 'travel-booker',
+  description: 'Books flights and hotels on behalf of users',
+  scopes: ['calendar:read', 'payments:initiate:max_500'],
+});
+```
+
+---
+
+## agents.register()
+
+Register a new agent with the Grantex service.
+
+```typescript
+const agent = await grantex.agents.register({
+  name: 'travel-booker',
+  description: 'Books flights and hotels on behalf of users',
+  scopes: ['calendar:read', 'payments:initiate:max_500', 'email:send'],
+});
+
+console.log(agent.id);     // 'ag_01HXYZ...'
+console.log(agent.did);    // 'did:grantex:ag_01HXYZ...'
+console.log(agent.status); // 'active'
+```
+
+### Parameters
+
+<ParamField body="name" type="string" required>
+  Human-readable name for the agent.
+</ParamField>
+
+<ParamField body="description" type="string" required>
+  A description of what the agent does.
+</ParamField>
+
+<ParamField body="scopes" type="string[]" required>
+  The maximum set of scopes this agent can request. Authorization requests must use a subset of these scopes.
+</ParamField>
+
+### Response: `Agent`
+
+<ResponseField name="id" type="string">
+  Unique agent identifier.
+</ResponseField>
+
+<ResponseField name="did" type="string">
+  Decentralized identifier (DID) for the agent.
+</ResponseField>
+
+<ResponseField name="name" type="string">
+  The agent's display name.
+</ResponseField>
+
+<ResponseField name="description" type="string">
+  The agent's description.
+</ResponseField>
+
+<ResponseField name="scopes" type="string[]">
+  The agent's registered scopes.
+</ResponseField>
+
+<ResponseField name="status" type="string">
+  Agent status: `'active'`, `'suspended'`, or `'revoked'`.
+</ResponseField>
+
+<ResponseField name="developerId" type="string">
+  The developer organization that owns this agent.
+</ResponseField>
+
+<ResponseField name="createdAt" type="string">
+  ISO 8601 creation timestamp.
+</ResponseField>
+
+<ResponseField name="updatedAt" type="string">
+  ISO 8601 last-updated timestamp.
+</ResponseField>
+
+---
+
+## agents.get()
+
+Retrieve a single agent by its ID.
+
+```typescript
+const agent = await grantex.agents.get('ag_01HXYZ...');
+
+console.log(agent.name);   // 'travel-booker'
+console.log(agent.scopes); // ['calendar:read', 'payments:initiate:max_500', 'email:send']
+```
+
+### Parameters
+
+<ParamField body="agentId" type="string" required>
+  The agent ID to retrieve.
+</ParamField>
+
+### Response
+
+Returns an `Agent` object.
+
+---
+
+## agents.list()
+
+List all agents in your organization.
+
+```typescript
+const result = await grantex.agents.list();
+
+console.log(result.total);  // 3
+for (const agent of result.agents) {
+  console.log(`${agent.name} (${agent.status})`);
+}
+```
+
+### Response: `ListAgentsResponse`
+
+<ResponseField name="agents" type="Agent[]">
+  Array of agent objects.
+</ResponseField>
+
+<ResponseField name="total" type="number">
+  Total number of agents.
+</ResponseField>
+
+<ResponseField name="page" type="number">
+  Current page number.
+</ResponseField>
+
+<ResponseField name="pageSize" type="number">
+  Number of agents per page.
+</ResponseField>
+
+---
+
+## agents.update()
+
+Update an existing agent's name, description, or scopes.
+
+```typescript
+const updated = await grantex.agents.update('ag_01HXYZ...', {
+  name: 'travel-booker-v2',
+  scopes: ['calendar:read', 'calendar:write', 'payments:initiate:max_1000'],
+});
+
+console.log(updated.name);   // 'travel-booker-v2'
+console.log(updated.scopes); // ['calendar:read', 'calendar:write', 'payments:initiate:max_1000']
+```
+
+### Parameters
+
+<ParamField body="agentId" type="string" required>
+  The agent ID to update.
+</ParamField>
+
+<ParamField body="name" type="string">
+  New display name.
+</ParamField>
+
+<ParamField body="description" type="string">
+  New description.
+</ParamField>
+
+<ParamField body="scopes" type="string[]">
+  New set of registered scopes.
+</ParamField>
+
+### Response
+
+Returns the updated `Agent` object.
+
+---
+
+## agents.delete()
+
+Delete an agent. This revokes the agent's DID and all active grants.
+
+```typescript
+await grantex.agents.delete('ag_01HXYZ...');
+// Returns void -- the agent is permanently removed
+```
+
+### Parameters
+
+<ParamField body="agentId" type="string" required>
+  The agent ID to delete.
+</ParamField>
+
+### Response
+
+Returns `void`.

--- a/docs/sdks/typescript/anomalies.mdx
+++ b/docs/sdks/typescript/anomalies.mdx
@@ -1,0 +1,164 @@
+---
+title: "Anomaly Detection"
+sidebarTitle: "Anomalies"
+description: "Detect, list, and acknowledge anomalous agent behavior patterns."
+---
+
+## Overview
+
+The `anomalies` sub-client provides automated anomaly detection for agent activity. It identifies unusual patterns such as rate spikes, high failure rates, new principals, and off-hours activity.
+
+```typescript
+const result = await grantex.anomalies.detect();
+console.log(result.total);     // 3
+for (const anomaly of result.anomalies) {
+  console.log(`[${anomaly.severity}] ${anomaly.type}: ${anomaly.description}`);
+}
+```
+
+---
+
+## anomalies.detect()
+
+Run anomaly detection across all agents and return any newly detected anomalies.
+
+```typescript
+const result = await grantex.anomalies.detect();
+
+console.log(result.detectedAt);  // '2026-02-28T12:00:00Z'
+console.log(result.total);       // 2
+for (const anomaly of result.anomalies) {
+  console.log(anomaly.id);          // 'anom_01HXYZ...'
+  console.log(anomaly.type);        // 'rate_spike'
+  console.log(anomaly.severity);    // 'high'
+  console.log(anomaly.description); // 'Agent ag_01HXYZ... had 500% more requests than usual'
+  console.log(anomaly.agentId);     // 'ag_01HXYZ...'
+  console.log(anomaly.metadata);    // { normalRate: 10, currentRate: 60 }
+}
+```
+
+### Response: `DetectAnomaliesResponse`
+
+<ResponseField name="detectedAt" type="string">
+  ISO 8601 timestamp when detection was run.
+</ResponseField>
+
+<ResponseField name="total" type="number">
+  Number of anomalies detected.
+</ResponseField>
+
+<ResponseField name="anomalies" type="Anomaly[]">
+  Array of detected anomalies.
+</ResponseField>
+
+### Anomaly types
+
+| Type | Description |
+|---|---|
+| `rate_spike` | Abnormally high request volume for an agent |
+| `high_failure_rate` | Unusually high proportion of failed actions |
+| `new_principal` | An agent is acting on behalf of a previously unseen user |
+| `off_hours_activity` | Agent activity outside normal business hours |
+
+### Anomaly severity levels
+
+| Severity | Description |
+|---|---|
+| `low` | Informational, may not require action |
+| `medium` | Worth investigating |
+| `high` | Likely requires immediate attention |
+
+---
+
+## anomalies.list()
+
+List stored anomalies. Optionally filter to only unacknowledged anomalies.
+
+```typescript
+// List all anomalies
+const all = await grantex.anomalies.list();
+
+// List only unacknowledged anomalies
+const open = await grantex.anomalies.list({ unacknowledged: true });
+
+console.log(open.total); // 5
+for (const anomaly of open.anomalies) {
+  console.log(`${anomaly.type} (${anomaly.severity}) - ${anomaly.detectedAt}`);
+}
+```
+
+### Parameters
+
+<ParamField body="unacknowledged" type="boolean">
+  When `true`, only return anomalies that have not been acknowledged.
+</ParamField>
+
+### Response: `ListAnomaliesResponse`
+
+<ResponseField name="anomalies" type="Anomaly[]">
+  Array of anomaly objects.
+</ResponseField>
+
+<ResponseField name="total" type="number">
+  Total number of anomalies matching the filter.
+</ResponseField>
+
+---
+
+## anomalies.acknowledge()
+
+Acknowledge an anomaly by ID. This marks it as reviewed so it no longer appears in the unacknowledged list.
+
+```typescript
+const anomaly = await grantex.anomalies.acknowledge('anom_01HXYZ...');
+
+console.log(anomaly.acknowledgedAt); // '2026-02-28T12:30:00Z'
+```
+
+### Parameters
+
+<ParamField body="anomalyId" type="string" required>
+  The anomaly ID to acknowledge.
+</ParamField>
+
+### Response: `Anomaly`
+
+Returns the updated anomaly object with the `acknowledgedAt` timestamp set.
+
+### Anomaly object
+
+<ResponseField name="id" type="string">
+  Unique anomaly identifier.
+</ResponseField>
+
+<ResponseField name="type" type="AnomalyType">
+  The anomaly type: `'rate_spike'`, `'high_failure_rate'`, `'new_principal'`, or `'off_hours_activity'`.
+</ResponseField>
+
+<ResponseField name="severity" type="AnomalySeverity">
+  Severity level: `'low'`, `'medium'`, or `'high'`.
+</ResponseField>
+
+<ResponseField name="agentId" type="string | null">
+  The agent associated with the anomaly, if applicable.
+</ResponseField>
+
+<ResponseField name="principalId" type="string | null">
+  The user associated with the anomaly, if applicable.
+</ResponseField>
+
+<ResponseField name="description" type="string">
+  Human-readable description of the anomaly.
+</ResponseField>
+
+<ResponseField name="metadata" type="Record<string, unknown>">
+  Additional context about the anomaly (e.g. request rates, thresholds).
+</ResponseField>
+
+<ResponseField name="detectedAt" type="string">
+  ISO 8601 timestamp when the anomaly was detected.
+</ResponseField>
+
+<ResponseField name="acknowledgedAt" type="string | null">
+  ISO 8601 timestamp when the anomaly was acknowledged, or `null`.
+</ResponseField>

--- a/docs/sdks/typescript/audit.mdx
+++ b/docs/sdks/typescript/audit.mdx
@@ -1,0 +1,219 @@
+---
+title: "Audit"
+sidebarTitle: "Audit"
+description: "Log agent actions and query the tamper-evident audit trail."
+---
+
+## Overview
+
+The `audit` sub-client provides a tamper-evident, append-only audit trail for all agent actions. Each entry is hash-chained to the previous entry, providing cryptographic integrity guarantees.
+
+```typescript
+await grantex.audit.log({
+  agentId: agent.id,
+  grantId: token.grantId,
+  action: 'email.sent',
+  status: 'success',
+  metadata: { to: 'user@example.com', subject: 'Flight confirmation' },
+});
+```
+
+---
+
+## audit.log()
+
+Log an agent action to the audit trail.
+
+```typescript
+const entry = await grantex.audit.log({
+  agentId: 'ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  action: 'payment.initiated',
+  status: 'success',
+  metadata: { amount: 420, currency: 'USD', merchant: 'Air India' },
+});
+
+console.log(entry.entryId);   // 'aud_01HXYZ...'
+console.log(entry.hash);      // SHA-256 hash of this entry
+console.log(entry.prevHash);  // Hash of the previous entry (null for the first)
+console.log(entry.timestamp); // '2026-02-28T12:00:00Z'
+```
+
+### Parameters
+
+<ParamField body="agentId" type="string" required>
+  The agent that performed the action.
+</ParamField>
+
+<ParamField body="grantId" type="string" required>
+  The grant under which the action was performed.
+</ParamField>
+
+<ParamField body="action" type="string" required>
+  A descriptive action identifier (e.g. `'email.sent'`, `'payment.initiated'`, `'file.uploaded'`).
+</ParamField>
+
+<ParamField body="metadata" type="Record<string, unknown>">
+  Arbitrary metadata to attach to the audit entry.
+</ParamField>
+
+<ParamField body="status" type="string">
+  Action outcome: `'success'`, `'failure'`, or `'blocked'`.
+</ParamField>
+
+### Response: `AuditEntry`
+
+<ResponseField name="entryId" type="string">
+  Unique audit entry identifier.
+</ResponseField>
+
+<ResponseField name="agentId" type="string">
+  The agent that performed the action.
+</ResponseField>
+
+<ResponseField name="agentDid" type="string">
+  The agent's decentralized identifier.
+</ResponseField>
+
+<ResponseField name="grantId" type="string">
+  The associated grant ID.
+</ResponseField>
+
+<ResponseField name="principalId" type="string">
+  The user who authorized the grant.
+</ResponseField>
+
+<ResponseField name="action" type="string">
+  The action identifier.
+</ResponseField>
+
+<ResponseField name="metadata" type="Record<string, unknown>">
+  Arbitrary metadata attached to the entry.
+</ResponseField>
+
+<ResponseField name="hash" type="string">
+  SHA-256 hash of this entry, used for chain integrity verification.
+</ResponseField>
+
+<ResponseField name="prevHash" type="string | null">
+  Hash of the previous entry in the chain. `null` for the first entry.
+</ResponseField>
+
+<ResponseField name="timestamp" type="string">
+  ISO 8601 timestamp when the action was logged.
+</ResponseField>
+
+<ResponseField name="status" type="string">
+  Action outcome: `'success'`, `'failure'`, or `'blocked'`.
+</ResponseField>
+
+---
+
+## audit.list()
+
+Query audit entries with optional filters.
+
+```typescript
+const result = await grantex.audit.list({
+  agentId: 'ag_01HXYZ...',
+  action: 'payment.initiated',
+  since: '2026-02-01T00:00:00Z',
+  until: '2026-02-28T23:59:59Z',
+  page: 1,
+  pageSize: 50,
+});
+
+console.log(result.total);  // 128
+for (const entry of result.entries) {
+  console.log(`[${entry.timestamp}] ${entry.action} - ${entry.status}`);
+}
+```
+
+### Parameters
+
+<ParamField body="agentId" type="string">
+  Filter by agent ID.
+</ParamField>
+
+<ParamField body="grantId" type="string">
+  Filter by grant ID.
+</ParamField>
+
+<ParamField body="principalId" type="string">
+  Filter by principal (user) ID.
+</ParamField>
+
+<ParamField body="action" type="string">
+  Filter by action identifier.
+</ParamField>
+
+<ParamField body="since" type="string">
+  ISO 8601 start date for the query range.
+</ParamField>
+
+<ParamField body="until" type="string">
+  ISO 8601 end date for the query range.
+</ParamField>
+
+<ParamField body="page" type="number">
+  Page number (1-indexed).
+</ParamField>
+
+<ParamField body="pageSize" type="number">
+  Number of entries per page.
+</ParamField>
+
+### Response: `ListAuditResponse`
+
+<ResponseField name="entries" type="AuditEntry[]">
+  Array of audit entry objects.
+</ResponseField>
+
+<ResponseField name="total" type="number">
+  Total number of entries matching the filters.
+</ResponseField>
+
+<ResponseField name="page" type="number">
+  Current page number.
+</ResponseField>
+
+<ResponseField name="pageSize" type="number">
+  Number of entries per page.
+</ResponseField>
+
+---
+
+## audit.get()
+
+Retrieve a single audit entry by its ID.
+
+```typescript
+const entry = await grantex.audit.get('aud_01HXYZ...');
+
+console.log(entry.action);   // 'payment.initiated'
+console.log(entry.hash);     // 'a1b2c3d4e5f6...'
+console.log(entry.prevHash); // '9z8y7x6w5v4u...'
+console.log(entry.metadata); // { amount: 420, currency: 'USD' }
+```
+
+### Parameters
+
+<ParamField body="entryId" type="string" required>
+  The audit entry ID to retrieve.
+</ParamField>
+
+### Response
+
+Returns an `AuditEntry` object.
+
+## Chain integrity
+
+Each audit entry contains a `hash` of its contents and a `prevHash` linking it to the previous entry. This creates a tamper-evident chain similar to a blockchain. If any entry is modified after the fact, the hash chain breaks.
+
+Use the [Compliance](/sdks/typescript/compliance) evidence pack to verify chain integrity programmatically:
+
+```typescript
+const pack = await grantex.compliance.evidencePack({ framework: 'soc2' });
+console.log(pack.chainIntegrity.valid);          // true
+console.log(pack.chainIntegrity.checkedEntries);  // 1024
+```

--- a/docs/sdks/typescript/authorization.mdx
+++ b/docs/sdks/typescript/authorization.mdx
@@ -1,0 +1,128 @@
+---
+title: "Authorization"
+sidebarTitle: "Authorization"
+description: "Initiate the delegated authorization flow to request user consent for your agent."
+---
+
+## Overview
+
+The `authorize()` method starts the Grantex authorization flow. It creates an authorization request and returns a consent URL where the user can approve or deny the requested scopes.
+
+```typescript
+const authRequest = await grantex.authorize({
+  agentId: agent.id,
+  userId: 'user_abc123',
+  scopes: ['calendar:read', 'payments:initiate:max_500'],
+  expiresIn: '24h',
+  redirectUri: 'https://yourapp.com/auth/callback',
+});
+
+// Redirect the user to the consent page
+console.log(authRequest.consentUrl);
+```
+
+<Note>
+  The `userId` parameter is mapped to `principalId` in the API request body. This is the identifier for the human user in your system.
+</Note>
+
+## Parameters
+
+<ParamField body="agentId" type="string" required>
+  The ID of the agent requesting authorization (from `agents.register()`).
+</ParamField>
+
+<ParamField body="userId" type="string" required>
+  Your application's user identifier. Mapped to `principalId` in the protocol.
+</ParamField>
+
+<ParamField body="scopes" type="string[]" required>
+  The scopes the agent is requesting. Must be a subset of the agent's registered scopes.
+</ParamField>
+
+<ParamField body="expiresIn" type="string">
+  How long the grant should last (e.g. `'1h'`, `'24h'`, `'7d'`). Defaults to the server-configured maximum.
+</ParamField>
+
+<ParamField body="redirectUri" type="string">
+  The URL to redirect the user to after they approve or deny the request. The authorization `code` will be appended as a query parameter.
+</ParamField>
+
+<ParamField body="codeChallenge" type="string">
+  PKCE S256 code challenge. Use `generatePkce()` to create this value. See [PKCE](/sdks/typescript/pkce).
+</ParamField>
+
+<ParamField body="codeChallengeMethod" type="string">
+  Must be `'S256'` when `codeChallenge` is provided.
+</ParamField>
+
+## Response
+
+The method returns an `AuthorizationRequest` object:
+
+<ResponseField name="authRequestId" type="string">
+  Unique identifier for this authorization request.
+</ResponseField>
+
+<ResponseField name="consentUrl" type="string">
+  URL to redirect the user to for consent approval.
+</ResponseField>
+
+<ResponseField name="agentId" type="string">
+  The agent that initiated the request.
+</ResponseField>
+
+<ResponseField name="principalId" type="string">
+  The user identifier (mapped from `userId`).
+</ResponseField>
+
+<ResponseField name="scopes" type="string[]">
+  The scopes requested in this authorization.
+</ResponseField>
+
+<ResponseField name="expiresIn" type="string">
+  The requested grant duration.
+</ResponseField>
+
+<ResponseField name="expiresAt" type="string">
+  ISO 8601 timestamp when the authorization request expires.
+</ResponseField>
+
+<ResponseField name="status" type="string">
+  Current status: `'pending'`, `'approved'`, `'denied'`, or `'expired'`.
+</ResponseField>
+
+<ResponseField name="createdAt" type="string">
+  ISO 8601 timestamp when the request was created.
+</ResponseField>
+
+## Full example
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Register the agent first
+const agent = await grantex.agents.register({
+  name: 'email-assistant',
+  description: 'Reads and drafts emails on behalf of the user',
+  scopes: ['email:read', 'email:send', 'contacts:read'],
+});
+
+// Start the authorization flow
+const authRequest = await grantex.authorize({
+  agentId: agent.id,
+  userId: 'user_abc123',
+  scopes: ['email:read', 'email:send'],
+  expiresIn: '7d',
+  redirectUri: 'https://myapp.com/auth/callback',
+});
+
+console.log(authRequest.authRequestId); // 'areq_01HXYZ...'
+console.log(authRequest.consentUrl);    // 'https://consent.grantex.dev/authorize?req=eyJ...'
+console.log(authRequest.status);        // 'pending'
+```
+
+## Next steps
+
+After the user approves the request at the `consentUrl`, your `redirectUri` receives an authorization `code`. Exchange it for a grant token using [tokens.exchange()](/sdks/typescript/tokens).

--- a/docs/sdks/typescript/billing.mdx
+++ b/docs/sdks/typescript/billing.mdx
@@ -1,0 +1,138 @@
+---
+title: "Billing"
+sidebarTitle: "Billing"
+description: "Manage subscriptions and access Stripe checkout and billing portal sessions."
+---
+
+## Overview
+
+The `billing` sub-client provides subscription management through Stripe. You can check the current subscription status, create checkout sessions for upgrades, and generate billing portal URLs for self-service management.
+
+```typescript
+const subscription = await grantex.billing.getSubscription();
+console.log(subscription.plan);   // 'free'
+console.log(subscription.status); // 'active'
+```
+
+---
+
+## billing.getSubscription()
+
+Get the current subscription status for the authenticated developer organization.
+
+```typescript
+const subscription = await grantex.billing.getSubscription();
+
+console.log(subscription.plan);             // 'free', 'pro', or 'enterprise'
+console.log(subscription.status);           // 'active', 'past_due', or 'canceled'
+console.log(subscription.currentPeriodEnd); // '2026-03-28T00:00:00Z' or null
+```
+
+### Response: `SubscriptionStatus`
+
+<ResponseField name="plan" type="string">
+  Current plan: `'free'`, `'pro'`, or `'enterprise'`.
+</ResponseField>
+
+<ResponseField name="status" type="string">
+  Subscription status: `'active'`, `'past_due'`, or `'canceled'`.
+</ResponseField>
+
+<ResponseField name="currentPeriodEnd" type="string | null">
+  ISO 8601 end date of the current billing period, or `null` for the free plan.
+</ResponseField>
+
+---
+
+## billing.createCheckout()
+
+Create a Stripe Checkout session for upgrading to a paid plan. Redirect the user to the returned URL to complete the purchase.
+
+```typescript
+const checkout = await grantex.billing.createCheckout({
+  plan: 'pro',
+  successUrl: 'https://yourapp.com/billing/success',
+  cancelUrl: 'https://yourapp.com/billing/cancel',
+});
+
+console.log(checkout.checkoutUrl);
+// → 'https://checkout.stripe.com/c/pay/cs_live_...'
+// Redirect the user to this URL
+```
+
+### Parameters
+
+<ParamField body="plan" type="'pro' | 'enterprise'" required>
+  The plan to subscribe to.
+</ParamField>
+
+<ParamField body="successUrl" type="string" required>
+  URL to redirect to after successful payment.
+</ParamField>
+
+<ParamField body="cancelUrl" type="string" required>
+  URL to redirect to if the user cancels.
+</ParamField>
+
+### Response: `CheckoutResponse`
+
+<ResponseField name="checkoutUrl" type="string">
+  Stripe Checkout session URL. Redirect the user here.
+</ResponseField>
+
+---
+
+## billing.createPortal()
+
+Create a Stripe Billing Portal session for self-service subscription management (update payment method, cancel, view invoices).
+
+```typescript
+const portal = await grantex.billing.createPortal({
+  returnUrl: 'https://yourapp.com/settings',
+});
+
+console.log(portal.portalUrl);
+// → 'https://billing.stripe.com/p/session/...'
+// Redirect the user to this URL
+```
+
+### Parameters
+
+<ParamField body="returnUrl" type="string" required>
+  URL to redirect back to after the user finishes in the portal.
+</ParamField>
+
+### Response: `PortalResponse`
+
+<ResponseField name="portalUrl" type="string">
+  Stripe Billing Portal session URL. Redirect the user here.
+</ResponseField>
+
+---
+
+## Full example
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Check current plan
+const subscription = await grantex.billing.getSubscription();
+
+if (subscription.plan === 'free') {
+  // Upgrade to pro
+  const { checkoutUrl } = await grantex.billing.createCheckout({
+    plan: 'pro',
+    successUrl: 'https://myapp.com/billing/success',
+    cancelUrl: 'https://myapp.com/billing/cancel',
+  });
+  // Redirect user to checkoutUrl
+} else {
+  // Open billing portal for management
+  const { portalUrl } = await grantex.billing.createPortal({
+    returnUrl: 'https://myapp.com/settings',
+  });
+  // Redirect user to portalUrl
+}
+```

--- a/docs/sdks/typescript/compliance.mdx
+++ b/docs/sdks/typescript/compliance.mdx
@@ -1,0 +1,249 @@
+---
+title: "Compliance"
+sidebarTitle: "Compliance"
+description: "Generate compliance summaries, export grants and audit data, and produce evidence packs for SOC 2 and GDPR."
+---
+
+## Overview
+
+The `compliance` sub-client provides tools for regulatory compliance: organization-wide summaries, bulk exports of grants and audit entries, and full evidence packs with chain integrity verification.
+
+```typescript
+const summary = await grantex.compliance.getSummary();
+console.log(summary.agents.active);       // 12
+console.log(summary.grants.active);       // 1024
+console.log(summary.auditEntries.total);  // 50432
+```
+
+---
+
+## compliance.getSummary()
+
+Get an organization-wide compliance summary with aggregate counts for agents, grants, audit entries, and policies.
+
+```typescript
+const summary = await grantex.compliance.getSummary({
+  since: '2026-01-01T00:00:00Z',
+  until: '2026-02-28T23:59:59Z',
+});
+
+console.log(summary.generatedAt);           // '2026-02-28T12:00:00Z'
+console.log(summary.agents.total);           // 15
+console.log(summary.agents.active);          // 12
+console.log(summary.agents.suspended);       // 2
+console.log(summary.agents.revoked);         // 1
+console.log(summary.grants.total);           // 2048
+console.log(summary.grants.active);          // 1024
+console.log(summary.grants.revoked);         // 512
+console.log(summary.grants.expired);         // 512
+console.log(summary.auditEntries.total);     // 50432
+console.log(summary.auditEntries.success);   // 49000
+console.log(summary.auditEntries.failure);   // 1200
+console.log(summary.auditEntries.blocked);   // 232
+console.log(summary.policies.total);         // 8
+console.log(summary.plan);                   // 'pro'
+```
+
+### Parameters
+
+<ParamField body="since" type="string">
+  ISO 8601 start date for the summary window.
+</ParamField>
+
+<ParamField body="until" type="string">
+  ISO 8601 end date for the summary window.
+</ParamField>
+
+### Response: `ComplianceSummary`
+
+<ResponseField name="generatedAt" type="string">
+  ISO 8601 timestamp when the summary was generated.
+</ResponseField>
+
+<ResponseField name="agents" type="object">
+  Agent counts: `{ total, active, suspended, revoked }`.
+</ResponseField>
+
+<ResponseField name="grants" type="object">
+  Grant counts: `{ total, active, revoked, expired }`.
+</ResponseField>
+
+<ResponseField name="auditEntries" type="object">
+  Audit entry counts: `{ total, success, failure, blocked }`.
+</ResponseField>
+
+<ResponseField name="policies" type="object">
+  Policy counts: `{ total }`.
+</ResponseField>
+
+<ResponseField name="plan" type="string">
+  The organization's current plan.
+</ResponseField>
+
+---
+
+## compliance.exportGrants()
+
+Export all grants, optionally filtered by status and date range.
+
+```typescript
+const exported = await grantex.compliance.exportGrants({
+  status: 'active',
+});
+
+console.log(exported.generatedAt); // '2026-02-28T12:00:00Z'
+console.log(exported.total);       // 1024
+console.log(exported.grants);      // Grant[]
+```
+
+### Parameters
+
+<ParamField body="since" type="string">
+  ISO 8601 start date filter.
+</ParamField>
+
+<ParamField body="until" type="string">
+  ISO 8601 end date filter.
+</ParamField>
+
+<ParamField body="status" type="'active' | 'revoked' | 'expired'">
+  Filter by grant status.
+</ParamField>
+
+### Response: `ComplianceGrantsExport`
+
+<ResponseField name="generatedAt" type="string">
+  ISO 8601 timestamp when the export was generated.
+</ResponseField>
+
+<ResponseField name="total" type="number">
+  Total number of exported grants.
+</ResponseField>
+
+<ResponseField name="grants" type="Grant[]">
+  Array of grant objects.
+</ResponseField>
+
+---
+
+## compliance.exportAudit()
+
+Export all audit entries, optionally filtered by date range, agent, or status.
+
+```typescript
+const exported = await grantex.compliance.exportAudit({
+  since: '2026-02-01T00:00:00Z',
+  agentId: 'ag_01HXYZ...',
+});
+
+console.log(exported.total);    // 5432
+console.log(exported.entries);  // AuditEntry[]
+```
+
+### Parameters
+
+<ParamField body="since" type="string">
+  ISO 8601 start date filter.
+</ParamField>
+
+<ParamField body="until" type="string">
+  ISO 8601 end date filter.
+</ParamField>
+
+<ParamField body="agentId" type="string">
+  Filter by agent ID.
+</ParamField>
+
+<ParamField body="status" type="'success' | 'failure' | 'blocked'">
+  Filter by action status.
+</ParamField>
+
+### Response: `ComplianceAuditExport`
+
+<ResponseField name="generatedAt" type="string">
+  ISO 8601 timestamp when the export was generated.
+</ResponseField>
+
+<ResponseField name="total" type="number">
+  Total number of exported entries.
+</ResponseField>
+
+<ResponseField name="entries" type="AuditEntry[]">
+  Array of audit entry objects.
+</ResponseField>
+
+---
+
+## compliance.evidencePack()
+
+Generate a full evidence pack for compliance frameworks (SOC 2, GDPR, or both). Includes a summary, all grants, audit entries, policies, and chain integrity verification.
+
+```typescript
+const pack = await grantex.compliance.evidencePack({
+  framework: 'soc2',
+  since: '2026-01-01T00:00:00Z',
+});
+
+console.log(pack.meta.schemaVersion);       // '1.0'
+console.log(pack.meta.framework);            // 'soc2'
+console.log(pack.summary.agents.total);      // 15
+console.log(pack.grants.length);             // 2048
+console.log(pack.auditEntries.length);       // 50432
+console.log(pack.policies.length);           // 8
+console.log(pack.chainIntegrity.valid);      // true
+console.log(pack.chainIntegrity.checkedEntries); // 50432
+```
+
+### Parameters
+
+<ParamField body="framework" type="'soc2' | 'gdpr' | 'all'">
+  The compliance framework to generate evidence for. Defaults to `'all'`.
+</ParamField>
+
+<ParamField body="since" type="string">
+  ISO 8601 start date for the evidence window.
+</ParamField>
+
+<ParamField body="until" type="string">
+  ISO 8601 end date for the evidence window.
+</ParamField>
+
+### Response: `EvidencePack`
+
+<ResponseField name="meta" type="object">
+  Metadata: `{ schemaVersion, generatedAt, since?, until?, framework }`.
+</ResponseField>
+
+<ResponseField name="summary" type="object">
+  Aggregate counts for agents, grants, audit entries, policies, and plan.
+</ResponseField>
+
+<ResponseField name="grants" type="Grant[]">
+  All grants in the evidence window.
+</ResponseField>
+
+<ResponseField name="auditEntries" type="AuditEntry[]">
+  All audit entries in the evidence window.
+</ResponseField>
+
+<ResponseField name="policies" type="Policy[]">
+  All active policies.
+</ResponseField>
+
+<ResponseField name="chainIntegrity" type="ChainIntegrity">
+  Chain integrity verification result.
+</ResponseField>
+
+### ChainIntegrity
+
+<ResponseField name="valid" type="boolean">
+  Whether the hash chain is intact.
+</ResponseField>
+
+<ResponseField name="checkedEntries" type="number">
+  Number of entries verified.
+</ResponseField>
+
+<ResponseField name="firstBrokenAt" type="string | null">
+  ISO 8601 timestamp of the first broken link, or `null` if the chain is intact.
+</ResponseField>

--- a/docs/sdks/typescript/errors.mdx
+++ b/docs/sdks/typescript/errors.mdx
@@ -1,0 +1,208 @@
+---
+title: "Error Handling"
+sidebarTitle: "Errors"
+description: "Understand the error hierarchy and handle API, authentication, token, and network errors."
+---
+
+## Overview
+
+All errors thrown by the SDK extend from `GrantexError`. The hierarchy is designed so you can catch errors at different levels of specificity.
+
+```typescript
+import {
+  GrantexError,
+  GrantexApiError,
+  GrantexAuthError,
+  GrantexTokenError,
+  GrantexNetworkError,
+} from '@grantex/sdk';
+```
+
+## Error hierarchy
+
+```
+GrantexError (base)
+├── GrantexApiError (HTTP 4xx/5xx)
+│   └── GrantexAuthError (HTTP 401/403)
+├── GrantexTokenError (JWT verification failures)
+└── GrantexNetworkError (timeout, DNS, connection)
+```
+
+---
+
+## GrantexError
+
+The base error class. All SDK errors are instances of `GrantexError`.
+
+```typescript
+try {
+  await grantex.agents.get('ag_nonexistent');
+} catch (err) {
+  if (err instanceof GrantexError) {
+    console.error('Grantex SDK error:', err.message);
+  }
+}
+```
+
+| Property | Type | Description |
+|---|---|---|
+| `message` | `string` | Human-readable error message |
+| `name` | `string` | `'GrantexError'` |
+
+---
+
+## GrantexApiError
+
+Thrown when the Grantex API returns an HTTP error response (4xx or 5xx). Extends `GrantexError`.
+
+```typescript
+try {
+  await grantex.agents.get('ag_nonexistent');
+} catch (err) {
+  if (err instanceof GrantexApiError) {
+    console.error('Status:', err.statusCode);   // 404
+    console.error('Body:', err.body);            // { message: 'Agent not found' }
+    console.error('Request ID:', err.requestId); // 'req_01HXYZ...'
+  }
+}
+```
+
+| Property | Type | Description |
+|---|---|---|
+| `message` | `string` | Error message extracted from the response body |
+| `statusCode` | `number` | HTTP status code |
+| `body` | `unknown` | The raw response body |
+| `requestId` | `string \| undefined` | The `X-Request-Id` header value, if present |
+
+---
+
+## GrantexAuthError
+
+Thrown for authentication and authorization failures (HTTP 401 or 403). Extends `GrantexApiError`.
+
+```typescript
+try {
+  const grantex = new Grantex({ apiKey: 'invalid-key' });
+  await grantex.agents.list();
+} catch (err) {
+  if (err instanceof GrantexAuthError) {
+    console.error('Auth failed:', err.statusCode); // 401 or 403
+    console.error('Message:', err.message);         // 'Invalid API key'
+  }
+}
+```
+
+| Property | Type | Description |
+|---|---|---|
+| `statusCode` | `401 \| 403` | Always 401 (unauthorized) or 403 (forbidden) |
+
+Inherits all properties from `GrantexApiError`.
+
+---
+
+## GrantexTokenError
+
+Thrown when offline token verification fails. This error is raised by `verifyGrantToken()` and `grants.verify()`. Extends `GrantexError`.
+
+```typescript
+import { verifyGrantToken, GrantexTokenError } from '@grantex/sdk';
+
+try {
+  await verifyGrantToken('invalid.jwt.token', {
+    jwksUri: 'https://api.grantex.dev/.well-known/jwks.json',
+  });
+} catch (err) {
+  if (err instanceof GrantexTokenError) {
+    console.error('Token error:', err.message);
+    // "Grant token verification failed: ..."
+    // "Grant token is missing required scopes: payments:initiate"
+    // "Grant token is missing required claims (jti, sub, agt, dev, scp, iat, exp)"
+  }
+}
+```
+
+Common scenarios:
+- Invalid JWT signature
+- Expired token
+- Missing required JWT claims
+- Missing required scopes (when `requiredScopes` is specified)
+- Audience mismatch (when `audience` is specified)
+
+---
+
+## GrantexNetworkError
+
+Thrown when a network error occurs (timeout, DNS resolution failure, connection refused). Extends `GrantexError`.
+
+```typescript
+try {
+  const grantex = new Grantex({
+    apiKey: 'gx_...',
+    baseUrl: 'https://unreachable.example.com',
+    timeout: 5000,
+  });
+  await grantex.agents.list();
+} catch (err) {
+  if (err instanceof GrantexNetworkError) {
+    console.error('Network error:', err.message);
+    // "Request timed out after 5000ms"
+    // "Network error: getaddrinfo ENOTFOUND unreachable.example.com"
+    console.error('Cause:', err.cause); // The underlying error
+  }
+}
+```
+
+| Property | Type | Description |
+|---|---|---|
+| `message` | `string` | Human-readable network error description |
+| `cause` | `unknown` | The underlying error (e.g. the `AbortError` for timeouts) |
+
+---
+
+## Recommended error handling pattern
+
+```typescript
+import {
+  Grantex,
+  GrantexAuthError,
+  GrantexApiError,
+  GrantexTokenError,
+  GrantexNetworkError,
+  GrantexError,
+} from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+try {
+  const agent = await grantex.agents.get('ag_01HXYZ...');
+  console.log(agent.name);
+} catch (err) {
+  if (err instanceof GrantexAuthError) {
+    // 401/403 -- API key is invalid or lacks permission
+    console.error(`Authentication failed (${err.statusCode}): ${err.message}`);
+    // Prompt user to re-authenticate or check API key
+  } else if (err instanceof GrantexApiError) {
+    // Other HTTP errors (404, 422, 429, 500, etc.)
+    console.error(`API error (${err.statusCode}): ${err.message}`);
+    if (err.requestId) {
+      console.error(`Request ID: ${err.requestId} -- include this in support tickets`);
+    }
+  } else if (err instanceof GrantexNetworkError) {
+    // Timeout, DNS, connection refused
+    console.error(`Network error: ${err.message}`);
+    // Retry with exponential backoff
+  } else if (err instanceof GrantexTokenError) {
+    // Token verification failure
+    console.error(`Token error: ${err.message}`);
+  } else if (err instanceof GrantexError) {
+    // Catch-all for any other SDK error
+    console.error(`Grantex error: ${err.message}`);
+  } else {
+    throw err; // Unexpected error -- rethrow
+  }
+}
+```
+
+<Tip>
+  Always include `err.requestId` (from `GrantexApiError`) in support tickets. It helps the Grantex team trace the exact request in server logs.
+</Tip>

--- a/docs/sdks/typescript/grants.mdx
+++ b/docs/sdks/typescript/grants.mdx
@@ -1,0 +1,246 @@
+---
+title: "Grants"
+sidebarTitle: "Grants"
+description: "Manage grants, delegate authorization to sub-agents, and verify tokens via the API."
+---
+
+## Overview
+
+The `grants` sub-client provides operations on grant records: retrieving, listing, revoking, delegating to sub-agents, and verifying grant tokens online.
+
+```typescript
+const grant = await grantex.grants.get('grnt_01HXYZ...');
+console.log(grant.scopes);  // ['calendar:read', 'payments:initiate:max_500']
+console.log(grant.status);  // 'active'
+```
+
+---
+
+## grants.get()
+
+Retrieve a single grant by its ID.
+
+```typescript
+const grant = await grantex.grants.get('grnt_01HXYZ...');
+
+console.log(grant.id);          // 'grnt_01HXYZ...'
+console.log(grant.agentId);     // 'ag_01HXYZ...'
+console.log(grant.principalId); // 'user_abc123'
+console.log(grant.scopes);      // ['calendar:read']
+console.log(grant.status);      // 'active'
+console.log(grant.expiresAt);   // '2026-03-02T12:00:00Z'
+```
+
+### Parameters
+
+<ParamField body="grantId" type="string" required>
+  The grant ID to retrieve.
+</ParamField>
+
+### Response: `Grant`
+
+<ResponseField name="id" type="string">
+  Unique grant identifier.
+</ResponseField>
+
+<ResponseField name="agentId" type="string">
+  The agent that holds this grant.
+</ResponseField>
+
+<ResponseField name="agentDid" type="string">
+  The agent's decentralized identifier.
+</ResponseField>
+
+<ResponseField name="principalId" type="string">
+  The user who authorized the grant.
+</ResponseField>
+
+<ResponseField name="developerId" type="string">
+  The developer organization.
+</ResponseField>
+
+<ResponseField name="scopes" type="string[]">
+  Granted scopes.
+</ResponseField>
+
+<ResponseField name="status" type="string">
+  Grant status: `'active'`, `'revoked'`, or `'expired'`.
+</ResponseField>
+
+<ResponseField name="issuedAt" type="string">
+  ISO 8601 timestamp when the grant was issued.
+</ResponseField>
+
+<ResponseField name="expiresAt" type="string">
+  ISO 8601 timestamp when the grant expires.
+</ResponseField>
+
+<ResponseField name="revokedAt" type="string">
+  ISO 8601 timestamp when the grant was revoked (only present if `status` is `'revoked'`).
+</ResponseField>
+
+---
+
+## grants.list()
+
+List grants with optional filters.
+
+```typescript
+const result = await grantex.grants.list({
+  agentId: 'ag_01HXYZ...',
+  status: 'active',
+  page: 1,
+  pageSize: 25,
+});
+
+console.log(result.total);  // 42
+for (const grant of result.grants) {
+  console.log(`${grant.id}: ${grant.scopes.join(', ')}`);
+}
+```
+
+### Parameters
+
+<ParamField body="agentId" type="string">
+  Filter by agent ID.
+</ParamField>
+
+<ParamField body="principalId" type="string">
+  Filter by principal (user) ID.
+</ParamField>
+
+<ParamField body="status" type="string">
+  Filter by status: `'active'`, `'revoked'`, or `'expired'`.
+</ParamField>
+
+<ParamField body="page" type="number">
+  Page number (1-indexed).
+</ParamField>
+
+<ParamField body="pageSize" type="number">
+  Number of grants per page.
+</ParamField>
+
+### Response: `ListGrantsResponse`
+
+<ResponseField name="grants" type="Grant[]">
+  Array of grant objects.
+</ResponseField>
+
+<ResponseField name="total" type="number">
+  Total number of grants matching the filters.
+</ResponseField>
+
+<ResponseField name="page" type="number">
+  Current page number.
+</ResponseField>
+
+<ResponseField name="pageSize" type="number">
+  Number of grants per page.
+</ResponseField>
+
+---
+
+## grants.revoke()
+
+Revoke a grant by its ID. This immediately invalidates the grant and any associated tokens.
+
+```typescript
+await grantex.grants.revoke('grnt_01HXYZ...');
+// Returns void -- the grant is now revoked
+```
+
+### Parameters
+
+<ParamField body="grantId" type="string" required>
+  The grant ID to revoke.
+</ParamField>
+
+### Response
+
+Returns `void`.
+
+---
+
+## grants.delegate()
+
+Create a delegated grant for a sub-agent. This implements the delegation chain described in [SPEC section 9](/protocol/specification).
+
+The parent agent passes its grant token, and the sub-agent receives a new grant token with scopes that are a subset of the parent's.
+
+```typescript
+const delegated = await grantex.grants.delegate({
+  parentGrantToken: parentToken,
+  subAgentId: 'ag_sub_01HXYZ...',
+  scopes: ['calendar:read'],      // must be subset of parent's scopes
+  expiresIn: '1h',
+});
+
+console.log(delegated.grantToken); // New RS256 JWT for the sub-agent
+console.log(delegated.grantId);    // 'grnt_delegated_01HXYZ...'
+console.log(delegated.scopes);     // ['calendar:read']
+console.log(delegated.expiresAt);  // '2026-02-28T13:00:00Z'
+```
+
+### Parameters
+
+<ParamField body="parentGrantToken" type="string" required>
+  The parent agent's grant token JWT.
+</ParamField>
+
+<ParamField body="subAgentId" type="string" required>
+  The ID of the sub-agent to delegate to.
+</ParamField>
+
+<ParamField body="scopes" type="string[]" required>
+  The scopes to delegate. Must be a subset of the parent grant's scopes.
+</ParamField>
+
+<ParamField body="expiresIn" type="string">
+  Duration for the delegated grant (e.g. `'1h'`, `'30m'`). Cannot exceed the parent grant's remaining lifetime.
+</ParamField>
+
+### Response
+
+<ResponseField name="grantToken" type="string">
+  The delegated grant token (RS256 JWT) for the sub-agent.
+</ResponseField>
+
+<ResponseField name="grantId" type="string">
+  The delegated grant's record ID.
+</ResponseField>
+
+<ResponseField name="scopes" type="string[]">
+  The delegated scopes.
+</ResponseField>
+
+<ResponseField name="expiresAt" type="string">
+  ISO 8601 expiry timestamp.
+</ResponseField>
+
+---
+
+## grants.verify()
+
+Verify a grant token online and return a `VerifiedGrant` with full claim details. The SDK decodes the token returned by the API to populate all fields.
+
+```typescript
+const verified = await grantex.grants.verify(grantToken);
+
+console.log(verified.tokenId);       // 'tok_01HXYZ...'
+console.log(verified.grantId);       // 'grnt_01HXYZ...'
+console.log(verified.principalId);   // 'user_abc123'
+console.log(verified.agentDid);      // 'did:grantex:ag_01HXYZ...'
+console.log(verified.scopes);        // ['calendar:read']
+console.log(verified.delegationDepth); // 0 (root grant) or 1+ (delegated)
+```
+
+### Parameters
+
+<ParamField body="token" type="string" required>
+  The grant token JWT to verify.
+</ParamField>
+
+### Response: `VerifiedGrant`
+
+Returns a `VerifiedGrant` object with all decoded claims. See [Offline Verification](/sdks/typescript/offline-verification) for the full field reference.

--- a/docs/sdks/typescript/offline-verification.mdx
+++ b/docs/sdks/typescript/offline-verification.mdx
@@ -1,0 +1,161 @@
+---
+title: "Offline Verification"
+sidebarTitle: "Offline Verification"
+description: "Verify grant tokens locally using the published JWKS endpoint -- no Grantex API dependency at runtime."
+---
+
+## Overview
+
+`verifyGrantToken()` is a standalone function that verifies Grantex grant tokens offline using the published JWKS (JSON Web Key Set). It validates the RS256 signature, checks expiry, and optionally enforces required scopes and audience.
+
+This is the recommended way for services to verify tokens -- it requires zero runtime dependency on Grantex infrastructure.
+
+```typescript
+import { verifyGrantToken } from '@grantex/sdk';
+
+const grant = await verifyGrantToken(token, {
+  jwksUri: 'https://api.grantex.dev/.well-known/jwks.json',
+  requiredScopes: ['calendar:read'],
+});
+
+console.log(grant.principalId); // The user who authorized this agent
+console.log(grant.agentDid);    // The agent's DID
+console.log(grant.scopes);      // All granted scopes
+```
+
+<Note>
+  The JWKS endpoint is cached automatically by the underlying `jose` library. Repeated verifications do not make repeated HTTP calls.
+</Note>
+
+## Import
+
+```typescript
+import { verifyGrantToken } from '@grantex/sdk';
+```
+
+This function does not require a `Grantex` client instance.
+
+## Parameters
+
+<ParamField body="token" type="string" required>
+  The grant token JWT string to verify.
+</ParamField>
+
+<ParamField body="options" type="VerifyGrantTokenOptions" required>
+  Verification options.
+</ParamField>
+
+### VerifyGrantTokenOptions
+
+<ParamField body="jwksUri" type="string" required>
+  The JWKS endpoint URL. For the hosted service, use `https://api.grantex.dev/.well-known/jwks.json`.
+</ParamField>
+
+<ParamField body="requiredScopes" type="string[]">
+  If provided, the function throws `GrantexTokenError` when the token is missing any of these scopes.
+</ParamField>
+
+<ParamField body="audience" type="string">
+  Expected `aud` claim. If provided, verification fails when the token's audience does not match.
+</ParamField>
+
+## Response: `VerifiedGrant`
+
+<ResponseField name="tokenId" type="string">
+  Unique token ID (the `jti` JWT claim).
+</ResponseField>
+
+<ResponseField name="grantId" type="string">
+  The grant record ID (from the `grnt` claim, falls back to `jti`).
+</ResponseField>
+
+<ResponseField name="principalId" type="string">
+  The end-user who authorized the agent (the `sub` claim).
+</ResponseField>
+
+<ResponseField name="agentDid" type="string">
+  The agent's decentralized identifier (the `agt` claim).
+</ResponseField>
+
+<ResponseField name="developerId" type="string">
+  The developer organization that owns the agent (the `dev` claim).
+</ResponseField>
+
+<ResponseField name="scopes" type="string[]">
+  The scopes granted to the agent (the `scp` claim).
+</ResponseField>
+
+<ResponseField name="issuedAt" type="number">
+  Token issued-at timestamp in seconds since the Unix epoch.
+</ResponseField>
+
+<ResponseField name="expiresAt" type="number">
+  Token expiry timestamp in seconds since the Unix epoch.
+</ResponseField>
+
+<ResponseField name="parentAgentDid" type="string">
+  The parent agent's DID, present only for delegated grants.
+</ResponseField>
+
+<ResponseField name="parentGrantId" type="string">
+  The parent grant ID, present only for delegated grants.
+</ResponseField>
+
+<ResponseField name="delegationDepth" type="number">
+  The delegation depth (`0` = root grant, `1` = first-level delegation, etc.). Present only for delegated grants.
+</ResponseField>
+
+## Error handling
+
+`verifyGrantToken()` throws `GrantexTokenError` in the following cases:
+
+- The JWT signature is invalid
+- The token has expired
+- Required claims (`jti`, `sub`, `agt`, `dev`, `scp`, `iat`, `exp`) are missing
+- The token is missing one or more `requiredScopes`
+- The `audience` does not match
+
+```typescript
+import { verifyGrantToken, GrantexTokenError } from '@grantex/sdk';
+
+try {
+  const grant = await verifyGrantToken(token, {
+    jwksUri: 'https://api.grantex.dev/.well-known/jwks.json',
+    requiredScopes: ['payments:initiate'],
+  });
+  // Token is valid -- proceed
+} catch (err) {
+  if (err instanceof GrantexTokenError) {
+    console.error('Token verification failed:', err.message);
+    // e.g. "Grant token is missing required scopes: payments:initiate"
+  }
+}
+```
+
+## JWT claims mapping
+
+The following table shows how JWT claims map to `VerifiedGrant` fields:
+
+| JWT Claim | VerifiedGrant Field | Description |
+|---|---|---|
+| `jti` | `tokenId` | Unique token identifier |
+| `grnt` | `grantId` | Grant record ID (falls back to `jti`) |
+| `sub` | `principalId` | End-user identifier |
+| `agt` | `agentDid` | Agent decentralized identifier |
+| `dev` | `developerId` | Developer organization ID |
+| `scp` | `scopes` | Granted scopes array |
+| `iat` | `issuedAt` | Issued-at timestamp (epoch seconds) |
+| `exp` | `expiresAt` | Expiry timestamp (epoch seconds) |
+| `parentAgt` | `parentAgentDid` | Parent agent DID (delegation) |
+| `parentGrnt` | `parentGrantId` | Parent grant ID (delegation) |
+| `delegationDepth` | `delegationDepth` | Delegation chain depth |
+
+## Comparison with online verification
+
+| | `verifyGrantToken()` | `tokens.verify()` |
+|---|---|---|
+| **Network call** | Only to JWKS endpoint (cached) | Calls Grantex API |
+| **Latency** | Sub-millisecond after initial JWKS fetch | Network round-trip |
+| **Revocation check** | No (checks signature + expiry only) | Yes (checks revocation status) |
+| **Requires API key** | No | Yes |
+| **Use case** | Services verifying tokens at high throughput | Admin dashboards, token status checks |

--- a/docs/sdks/typescript/overview.mdx
+++ b/docs/sdks/typescript/overview.mdx
@@ -1,0 +1,121 @@
+---
+title: "TypeScript SDK"
+sidebarTitle: "Overview"
+description: "Install, configure, and get started with the @grantex/sdk TypeScript SDK."
+---
+
+## Installation
+
+```bash
+npm install @grantex/sdk
+```
+
+## Requirements
+
+- **Node.js 18+** (uses native `fetch` and `crypto`)
+- **ESM only** -- the package ships as `"type": "module"` with TypeScript `NodeNext` resolution
+
+## Configuration
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+
+const grantex = new Grantex({
+  apiKey: process.env.GRANTEX_API_KEY,  // required (or set GRANTEX_API_KEY env var)
+  baseUrl: 'https://api.grantex.dev',   // optional, defaults to production
+  timeout: 30_000,                       // optional, request timeout in ms
+});
+```
+
+### Options
+
+<ParamField body="apiKey" type="string" required>
+  Your Grantex API key. Falls back to the `GRANTEX_API_KEY` environment variable if omitted.
+</ParamField>
+
+<ParamField body="baseUrl" type="string" default="https://api.grantex.dev">
+  Base URL for the Grantex API. Override for self-hosted or local development.
+</ParamField>
+
+<ParamField body="timeout" type="number" default="30000">
+  Request timeout in milliseconds. The SDK uses `AbortController` to enforce the deadline.
+</ParamField>
+
+## Quick start
+
+The complete authorization flow in one script:
+
+```typescript
+import { Grantex, verifyGrantToken } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// 1. Register an agent
+const agent = await grantex.agents.register({
+  name: 'travel-booker',
+  description: 'Books flights and hotels on behalf of users',
+  scopes: ['calendar:read', 'payments:initiate:max_500', 'email:send'],
+});
+console.log(agent.did);
+// → did:grantex:ag_01HXYZ123abc...
+
+// 2. Request user authorization
+const authRequest = await grantex.authorize({
+  agentId: agent.id,
+  userId: 'user_abc123',
+  scopes: ['calendar:read', 'payments:initiate:max_500'],
+  expiresIn: '24h',
+  redirectUri: 'https://yourapp.com/auth/callback',
+});
+// Redirect the user to authRequest.consentUrl
+
+// 3. Exchange the authorization code for a grant token
+const token = await grantex.tokens.exchange({
+  code,                  // from the redirect callback
+  agentId: agent.id,
+});
+console.log(token.grantToken);  // RS256 JWT
+console.log(token.scopes);      // ['calendar:read', 'payments:initiate:max_500']
+
+// 4. Verify the token offline (no Grantex dependency at runtime)
+const grant = await verifyGrantToken(token.grantToken, {
+  jwksUri: 'https://api.grantex.dev/.well-known/jwks.json',
+  requiredScopes: ['calendar:read'],
+});
+console.log(grant.principalId); // 'user_abc123'
+
+// 5. Revoke the token when done
+await grantex.tokens.revoke(grant.tokenId);
+```
+
+## Available resources
+
+The `Grantex` client exposes the following sub-clients:
+
+| Property | Description | Reference |
+|---|---|---|
+| `grantex.agents` | Register, list, update, and delete agents | [Agents](/sdks/typescript/agents) |
+| `grantex.tokens` | Exchange, verify, and revoke tokens | [Tokens](/sdks/typescript/tokens) |
+| `grantex.grants` | Manage grants, delegate to sub-agents | [Grants](/sdks/typescript/grants) |
+| `grantex.audit` | Log and query the tamper-evident audit trail | [Audit](/sdks/typescript/audit) |
+| `grantex.webhooks` | Create and manage webhook endpoints | [Webhooks](/sdks/typescript/webhooks) |
+| `grantex.policies` | Define authorization policies | [Policies](/sdks/typescript/policies) |
+| `grantex.compliance` | Compliance summaries, exports, evidence packs | [Compliance](/sdks/typescript/compliance) |
+| `grantex.anomalies` | Detect and acknowledge anomalies | [Anomalies](/sdks/typescript/anomalies) |
+| `grantex.billing` | Subscription management via Stripe | [Billing](/sdks/typescript/billing) |
+| `grantex.scim` | SCIM 2.0 user provisioning | [SCIM](/sdks/typescript/scim) |
+| `grantex.sso` | OIDC single sign-on | [SSO](/sdks/typescript/sso) |
+
+## Standalone exports
+
+These functions can be used without instantiating a `Grantex` client:
+
+| Export | Description | Reference |
+|---|---|---|
+| `verifyGrantToken()` | Offline JWT verification via JWKS | [Offline Verification](/sdks/typescript/offline-verification) |
+| `generatePkce()` | Generate PKCE S256 challenge pairs | [PKCE](/sdks/typescript/pkce) |
+| `verifyWebhookSignature()` | Verify webhook payload signatures | [Webhooks](/sdks/typescript/webhooks) |
+
+## Error handling
+
+All errors extend `GrantexError`. See the [Error Handling](/sdks/typescript/errors) reference for the full hierarchy and usage patterns.

--- a/docs/sdks/typescript/pkce.mdx
+++ b/docs/sdks/typescript/pkce.mdx
@@ -1,0 +1,96 @@
+---
+title: "PKCE"
+sidebarTitle: "PKCE"
+description: "Protect the authorization flow with Proof Key for Code Exchange (PKCE) using S256 challenges."
+---
+
+## Overview
+
+PKCE (Proof Key for Code Exchange) prevents authorization code interception attacks. Grantex supports the S256 challenge method as defined in [RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636).
+
+The SDK provides a `generatePkce()` helper that generates a cryptographically secure code verifier and its corresponding S256 challenge.
+
+## Import
+
+```typescript
+import { generatePkce } from '@grantex/sdk';
+```
+
+This function does not require a `Grantex` client instance. It uses Node.js `crypto` under the hood.
+
+## generatePkce()
+
+```typescript
+const pkce = generatePkce();
+
+console.log(pkce.codeVerifier);         // Random 43-character base64url string
+console.log(pkce.codeChallenge);        // SHA-256 hash of the verifier, base64url-encoded
+console.log(pkce.codeChallengeMethod);  // 'S256'
+```
+
+### Response: `PkceChallenge`
+
+<ResponseField name="codeVerifier" type="string">
+  A 32-byte random value encoded as base64url. Keep this secret -- it is used in the token exchange step.
+</ResponseField>
+
+<ResponseField name="codeChallenge" type="string">
+  The SHA-256 hash of `codeVerifier`, encoded as base64url. This is sent in the authorize request.
+</ResponseField>
+
+<ResponseField name="codeChallengeMethod" type="'S256'">
+  Always `'S256'`.
+</ResponseField>
+
+## Full PKCE flow
+
+### Step 1: Generate the PKCE pair
+
+```typescript
+import { Grantex, generatePkce } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const pkce = generatePkce();
+
+// Store codeVerifier securely (e.g. in a session)
+session.codeVerifier = pkce.codeVerifier;
+```
+
+### Step 2: Authorize with the code challenge
+
+```typescript
+const authRequest = await grantex.authorize({
+  agentId: agent.id,
+  userId: 'user_abc123',
+  scopes: ['calendar:read', 'payments:initiate:max_500'],
+  expiresIn: '24h',
+  redirectUri: 'https://yourapp.com/auth/callback',
+  codeChallenge: pkce.codeChallenge,
+  codeChallengeMethod: pkce.codeChallengeMethod,
+});
+
+// Redirect the user to authRequest.consentUrl
+```
+
+### Step 3: Exchange with the code verifier
+
+```typescript
+// In your /auth/callback handler:
+const token = await grantex.tokens.exchange({
+  code: req.query.code,
+  agentId: agent.id,
+  codeVerifier: session.codeVerifier,  // proves possession of the original challenge
+});
+
+console.log(token.grantToken);
+```
+
+<Warning>
+  If a `codeChallenge` was provided in the authorize step, the `codeVerifier` is **required** in the exchange step. The server will reject the request if the verifier does not match the original challenge.
+</Warning>
+
+## Security considerations
+
+- The `codeVerifier` must be stored server-side (e.g. in a session or encrypted cookie). Never expose it to the client.
+- Each PKCE pair is single-use. Generate a new pair for every authorization flow.
+- The S256 method is mandatory -- plain challenge methods are not supported.

--- a/docs/sdks/typescript/policies.mdx
+++ b/docs/sdks/typescript/policies.mdx
@@ -1,0 +1,250 @@
+---
+title: "Policies"
+sidebarTitle: "Policies"
+description: "Define allow/deny authorization policies to control agent access."
+---
+
+## Overview
+
+The `policies` sub-client lets you create declarative authorization policies that control when and how agents can use their grants. Policies support scope-based rules, time-of-day restrictions, and priority-based evaluation.
+
+```typescript
+const policy = await grantex.policies.create({
+  name: 'business-hours-only',
+  effect: 'deny',
+  priority: 10,
+  timeOfDayStart: '18:00',
+  timeOfDayEnd: '09:00',
+});
+```
+
+---
+
+## policies.create()
+
+Create a new authorization policy.
+
+```typescript
+const policy = await grantex.policies.create({
+  name: 'deny-payments-after-hours',
+  effect: 'deny',
+  priority: 10,
+  scopes: ['payments:initiate'],
+  timeOfDayStart: '18:00',
+  timeOfDayEnd: '06:00',
+});
+
+console.log(policy.id);       // 'pol_01HXYZ...'
+console.log(policy.name);     // 'deny-payments-after-hours'
+console.log(policy.effect);   // 'deny'
+console.log(policy.priority); // 10
+```
+
+### Parameters
+
+<ParamField body="name" type="string" required>
+  Human-readable name for the policy.
+</ParamField>
+
+<ParamField body="effect" type="'allow' | 'deny'" required>
+  Whether this policy allows or denies matching requests.
+</ParamField>
+
+<ParamField body="priority" type="number">
+  Evaluation priority. Higher-priority policies are evaluated first. Defaults to server-assigned value.
+</ParamField>
+
+<ParamField body="agentId" type="string">
+  Restrict the policy to a specific agent.
+</ParamField>
+
+<ParamField body="principalId" type="string">
+  Restrict the policy to a specific user.
+</ParamField>
+
+<ParamField body="scopes" type="string[]">
+  The scopes this policy applies to. If omitted, the policy applies to all scopes.
+</ParamField>
+
+<ParamField body="timeOfDayStart" type="string">
+  Start time for a time-of-day restriction (24h format, e.g. `'09:00'`).
+</ParamField>
+
+<ParamField body="timeOfDayEnd" type="string">
+  End time for a time-of-day restriction (24h format, e.g. `'18:00'`).
+</ParamField>
+
+### Response: `Policy`
+
+<ResponseField name="id" type="string">
+  Unique policy identifier.
+</ResponseField>
+
+<ResponseField name="name" type="string">
+  Policy name.
+</ResponseField>
+
+<ResponseField name="effect" type="string">
+  `'allow'` or `'deny'`.
+</ResponseField>
+
+<ResponseField name="priority" type="number">
+  Evaluation priority.
+</ResponseField>
+
+<ResponseField name="agentId" type="string | null">
+  Restricted agent ID, or `null` for all agents.
+</ResponseField>
+
+<ResponseField name="principalId" type="string | null">
+  Restricted user ID, or `null` for all users.
+</ResponseField>
+
+<ResponseField name="scopes" type="string[] | null">
+  Restricted scopes, or `null` for all scopes.
+</ResponseField>
+
+<ResponseField name="timeOfDayStart" type="string | null">
+  Time-of-day restriction start (24h format).
+</ResponseField>
+
+<ResponseField name="timeOfDayEnd" type="string | null">
+  Time-of-day restriction end (24h format).
+</ResponseField>
+
+<ResponseField name="createdAt" type="string">
+  ISO 8601 creation timestamp.
+</ResponseField>
+
+<ResponseField name="updatedAt" type="string">
+  ISO 8601 last-updated timestamp.
+</ResponseField>
+
+---
+
+## policies.list()
+
+List all policies for your organization.
+
+```typescript
+const result = await grantex.policies.list();
+
+console.log(result.total); // 5
+for (const policy of result.policies) {
+  console.log(`${policy.name}: ${policy.effect} (priority ${policy.priority})`);
+}
+```
+
+### Response: `ListPoliciesResponse`
+
+<ResponseField name="policies" type="Policy[]">
+  Array of policy objects.
+</ResponseField>
+
+<ResponseField name="total" type="number">
+  Total number of policies.
+</ResponseField>
+
+---
+
+## policies.get()
+
+Retrieve a single policy by its ID.
+
+```typescript
+const policy = await grantex.policies.get('pol_01HXYZ...');
+
+console.log(policy.name);           // 'deny-payments-after-hours'
+console.log(policy.timeOfDayStart); // '18:00'
+console.log(policy.timeOfDayEnd);   // '06:00'
+```
+
+### Parameters
+
+<ParamField body="policyId" type="string" required>
+  The policy ID to retrieve.
+</ParamField>
+
+### Response
+
+Returns a `Policy` object.
+
+---
+
+## policies.update()
+
+Update an existing policy. Only the provided fields are modified.
+
+```typescript
+const updated = await grantex.policies.update('pol_01HXYZ...', {
+  name: 'deny-payments-overnight',
+  timeOfDayStart: '22:00',
+  timeOfDayEnd: '06:00',
+});
+
+console.log(updated.name);           // 'deny-payments-overnight'
+console.log(updated.timeOfDayStart); // '22:00'
+```
+
+### Parameters
+
+<ParamField body="policyId" type="string" required>
+  The policy ID to update.
+</ParamField>
+
+<ParamField body="name" type="string">
+  New policy name.
+</ParamField>
+
+<ParamField body="effect" type="'allow' | 'deny'">
+  New effect.
+</ParamField>
+
+<ParamField body="priority" type="number">
+  New priority.
+</ParamField>
+
+<ParamField body="agentId" type="string | null">
+  New agent restriction. Pass `null` to clear.
+</ParamField>
+
+<ParamField body="principalId" type="string | null">
+  New user restriction. Pass `null` to clear.
+</ParamField>
+
+<ParamField body="scopes" type="string[] | null">
+  New scope restriction. Pass `null` to clear.
+</ParamField>
+
+<ParamField body="timeOfDayStart" type="string | null">
+  New time-of-day start. Pass `null` to clear.
+</ParamField>
+
+<ParamField body="timeOfDayEnd" type="string | null">
+  New time-of-day end. Pass `null` to clear.
+</ParamField>
+
+### Response
+
+Returns the updated `Policy` object.
+
+---
+
+## policies.delete()
+
+Delete a policy.
+
+```typescript
+await grantex.policies.delete('pol_01HXYZ...');
+// Returns void -- the policy is removed
+```
+
+### Parameters
+
+<ParamField body="policyId" type="string" required>
+  The policy ID to delete.
+</ParamField>
+
+### Response
+
+Returns `void`.

--- a/docs/sdks/typescript/scim.mdx
+++ b/docs/sdks/typescript/scim.mdx
@@ -1,0 +1,337 @@
+---
+title: "SCIM 2.0"
+sidebarTitle: "SCIM"
+description: "Provision and manage users via the SCIM 2.0 protocol, and manage SCIM bearer tokens."
+---
+
+## Overview
+
+The `scim` sub-client implements SCIM 2.0 (System for Cross-domain Identity Management) for automated user provisioning. It also provides SCIM token management for authenticating identity providers.
+
+```typescript
+// Create a SCIM token for your IdP
+const token = await grantex.scim.createToken({ label: 'Okta Production' });
+console.log(token.token); // Store securely -- shown only once
+
+// Provision a user
+const user = await grantex.scim.createUser({
+  userName: 'alice@example.com',
+  displayName: 'Alice Smith',
+  emails: [{ value: 'alice@example.com', primary: true }],
+});
+```
+
+---
+
+## Token Management
+
+SCIM tokens authenticate your identity provider (e.g. Okta, Azure AD) when it calls the Grantex SCIM endpoints.
+
+### scim.createToken()
+
+Create a new SCIM bearer token. The raw token value is returned only once.
+
+```typescript
+const scimToken = await grantex.scim.createToken({
+  label: 'Okta Production',
+});
+
+console.log(scimToken.id);        // 'scim_tok_01HXYZ...'
+console.log(scimToken.label);     // 'Okta Production'
+console.log(scimToken.token);     // 'scim_01HXYZ...' -- store securely!
+console.log(scimToken.createdAt); // '2026-02-28T12:00:00Z'
+```
+
+#### Parameters
+
+<ParamField body="label" type="string" required>
+  A human-readable label for the token (e.g. the IdP name).
+</ParamField>
+
+#### Response: `ScimTokenWithSecret`
+
+<ResponseField name="id" type="string">
+  Unique token identifier.
+</ResponseField>
+
+<ResponseField name="label" type="string">
+  The token label.
+</ResponseField>
+
+<ResponseField name="token" type="string">
+  The raw bearer token. Only returned on creation.
+</ResponseField>
+
+<ResponseField name="createdAt" type="string">
+  ISO 8601 creation timestamp.
+</ResponseField>
+
+<ResponseField name="lastUsedAt" type="string | null">
+  ISO 8601 timestamp of last use, or `null`.
+</ResponseField>
+
+---
+
+### scim.listTokens()
+
+List all SCIM tokens for your organization (without raw secrets).
+
+```typescript
+const result = await grantex.scim.listTokens();
+
+for (const token of result.tokens) {
+  console.log(`${token.label} (${token.id}) - last used: ${token.lastUsedAt ?? 'never'}`);
+}
+```
+
+#### Response: `ListScimTokensResponse`
+
+<ResponseField name="tokens" type="ScimToken[]">
+  Array of token objects (without the raw `token` field).
+</ResponseField>
+
+---
+
+### scim.revokeToken()
+
+Revoke a SCIM token by its ID.
+
+```typescript
+await grantex.scim.revokeToken('scim_tok_01HXYZ...');
+// Returns void -- the token is now invalid
+```
+
+#### Parameters
+
+<ParamField body="id" type="string" required>
+  The SCIM token ID to revoke.
+</ParamField>
+
+#### Response
+
+Returns `void`.
+
+---
+
+## User Operations
+
+These methods implement the SCIM 2.0 user provisioning protocol. They are typically called by your identity provider automatically, but can also be used directly.
+
+### scim.listUsers()
+
+List provisioned users with pagination.
+
+```typescript
+const result = await grantex.scim.listUsers({
+  startIndex: 1,
+  count: 25,
+});
+
+console.log(result.totalResults); // 100
+console.log(result.startIndex);   // 1
+console.log(result.itemsPerPage); // 25
+for (const user of result.Resources) {
+  console.log(`${user.userName} (${user.active ? 'active' : 'inactive'})`);
+}
+```
+
+#### Parameters
+
+<ParamField body="startIndex" type="number">
+  1-indexed start position for pagination.
+</ParamField>
+
+<ParamField body="count" type="number">
+  Maximum number of users to return.
+</ParamField>
+
+#### Response: `ScimListResponse`
+
+<ResponseField name="totalResults" type="number">
+  Total number of provisioned users.
+</ResponseField>
+
+<ResponseField name="startIndex" type="number">
+  The start index of this page.
+</ResponseField>
+
+<ResponseField name="itemsPerPage" type="number">
+  Number of users in this page.
+</ResponseField>
+
+<ResponseField name="Resources" type="ScimUser[]">
+  Array of SCIM user objects.
+</ResponseField>
+
+---
+
+### scim.createUser()
+
+Provision a new user.
+
+```typescript
+const user = await grantex.scim.createUser({
+  userName: 'alice@example.com',
+  displayName: 'Alice Smith',
+  externalId: 'okta-12345',
+  emails: [{ value: 'alice@example.com', primary: true }],
+  active: true,
+});
+
+console.log(user.id);       // 'scim_usr_01HXYZ...'
+console.log(user.userName);  // 'alice@example.com'
+```
+
+#### Parameters
+
+<ParamField body="userName" type="string" required>
+  The user's unique username (typically an email).
+</ParamField>
+
+<ParamField body="displayName" type="string">
+  The user's display name.
+</ParamField>
+
+<ParamField body="externalId" type="string">
+  External ID from the identity provider.
+</ParamField>
+
+<ParamField body="emails" type="ScimEmail[]">
+  Array of email objects: `{ value: string, primary?: boolean }`.
+</ParamField>
+
+<ParamField body="active" type="boolean">
+  Whether the user is active.
+</ParamField>
+
+#### Response: `ScimUser`
+
+<ResponseField name="id" type="string">
+  Unique SCIM user identifier.
+</ResponseField>
+
+<ResponseField name="externalId" type="string">
+  External ID from the identity provider.
+</ResponseField>
+
+<ResponseField name="userName" type="string">
+  The user's username.
+</ResponseField>
+
+<ResponseField name="displayName" type="string">
+  The user's display name.
+</ResponseField>
+
+<ResponseField name="active" type="boolean">
+  Whether the user is active.
+</ResponseField>
+
+<ResponseField name="emails" type="ScimEmail[]">
+  Array of email objects.
+</ResponseField>
+
+<ResponseField name="meta" type="ScimUserMeta">
+  SCIM metadata: `{ resourceType, created, lastModified }`.
+</ResponseField>
+
+---
+
+### scim.getUser()
+
+Get a single provisioned user by ID.
+
+```typescript
+const user = await grantex.scim.getUser('scim_usr_01HXYZ...');
+console.log(user.userName);    // 'alice@example.com'
+console.log(user.displayName); // 'Alice Smith'
+```
+
+#### Parameters
+
+<ParamField body="id" type="string" required>
+  The SCIM user ID.
+</ParamField>
+
+#### Response
+
+Returns a `ScimUser` object.
+
+---
+
+### scim.replaceUser()
+
+Full replace of a user (SCIM PUT operation).
+
+```typescript
+const updated = await grantex.scim.replaceUser('scim_usr_01HXYZ...', {
+  userName: 'alice@example.com',
+  displayName: 'Alice Johnson',
+  emails: [{ value: 'alice@example.com', primary: true }],
+  active: true,
+});
+```
+
+#### Parameters
+
+<ParamField body="id" type="string" required>
+  The SCIM user ID to replace.
+</ParamField>
+
+<ParamField body="params" type="CreateScimUserParams" required>
+  The complete user representation.
+</ParamField>
+
+#### Response
+
+Returns the updated `ScimUser` object.
+
+---
+
+### scim.updateUser()
+
+Partial update via SCIM Operations (SCIM PATCH operation).
+
+```typescript
+const updated = await grantex.scim.updateUser('scim_usr_01HXYZ...', [
+  { op: 'replace', path: 'displayName', value: 'Alice Johnson' },
+  { op: 'replace', path: 'active', value: false },
+]);
+
+console.log(updated.displayName); // 'Alice Johnson'
+console.log(updated.active);      // false
+```
+
+#### Parameters
+
+<ParamField body="id" type="string" required>
+  The SCIM user ID to update.
+</ParamField>
+
+<ParamField body="operations" type="Array<{ op: string; path?: string; value: unknown }>" required>
+  Array of SCIM patch operations. Supported `op` values: `'add'`, `'replace'`, `'remove'`.
+</ParamField>
+
+#### Response
+
+Returns the updated `ScimUser` object.
+
+---
+
+### scim.deleteUser()
+
+Deprovision a user (SCIM DELETE operation).
+
+```typescript
+await grantex.scim.deleteUser('scim_usr_01HXYZ...');
+// Returns void -- the user is deprovisioned
+```
+
+#### Parameters
+
+<ParamField body="id" type="string" required>
+  The SCIM user ID to delete.
+</ParamField>
+
+#### Response
+
+Returns `void`.

--- a/docs/sdks/typescript/sso.mdx
+++ b/docs/sdks/typescript/sso.mdx
@@ -1,0 +1,223 @@
+---
+title: "SSO (OIDC)"
+sidebarTitle: "SSO"
+description: "Configure OIDC single sign-on for your organization and handle login flows."
+---
+
+## Overview
+
+The `sso` sub-client configures and manages OIDC (OpenID Connect) single sign-on for your developer organization. It supports any OIDC-compliant identity provider (Okta, Azure AD, Google Workspace, Auth0, etc.).
+
+```typescript
+// Configure SSO
+const config = await grantex.sso.createConfig({
+  issuerUrl: 'https://accounts.google.com',
+  clientId: 'your-client-id',
+  clientSecret: 'your-client-secret',
+  redirectUri: 'https://yourapp.com/sso/callback',
+});
+```
+
+---
+
+## sso.createConfig()
+
+Create or update the OIDC SSO configuration for your organization.
+
+```typescript
+const config = await grantex.sso.createConfig({
+  issuerUrl: 'https://accounts.google.com',
+  clientId: 'your-google-client-id',
+  clientSecret: 'your-google-client-secret',
+  redirectUri: 'https://yourapp.com/sso/callback',
+});
+
+console.log(config.issuerUrl);   // 'https://accounts.google.com'
+console.log(config.clientId);    // 'your-google-client-id'
+console.log(config.redirectUri); // 'https://yourapp.com/sso/callback'
+console.log(config.createdAt);   // '2026-02-28T12:00:00Z'
+console.log(config.updatedAt);   // '2026-02-28T12:00:00Z'
+```
+
+### Parameters
+
+<ParamField body="issuerUrl" type="string" required>
+  The OIDC issuer URL (e.g. `https://accounts.google.com`).
+</ParamField>
+
+<ParamField body="clientId" type="string" required>
+  OAuth 2.0 client ID from your identity provider.
+</ParamField>
+
+<ParamField body="clientSecret" type="string" required>
+  OAuth 2.0 client secret from your identity provider.
+</ParamField>
+
+<ParamField body="redirectUri" type="string" required>
+  The callback URL that your IdP redirects to after authentication.
+</ParamField>
+
+### Response: `SsoConfig`
+
+<ResponseField name="issuerUrl" type="string">
+  The OIDC issuer URL.
+</ResponseField>
+
+<ResponseField name="clientId" type="string">
+  The OAuth 2.0 client ID.
+</ResponseField>
+
+<ResponseField name="redirectUri" type="string">
+  The configured callback URL.
+</ResponseField>
+
+<ResponseField name="createdAt" type="string">
+  ISO 8601 creation timestamp.
+</ResponseField>
+
+<ResponseField name="updatedAt" type="string">
+  ISO 8601 last-updated timestamp.
+</ResponseField>
+
+<Note>
+  The `clientSecret` is never returned in responses. It is stored securely on the server.
+</Note>
+
+---
+
+## sso.getConfig()
+
+Retrieve the current SSO configuration (without the client secret).
+
+```typescript
+const config = await grantex.sso.getConfig();
+
+console.log(config.issuerUrl);   // 'https://accounts.google.com'
+console.log(config.clientId);    // 'your-google-client-id'
+console.log(config.redirectUri); // 'https://yourapp.com/sso/callback'
+```
+
+### Response
+
+Returns an `SsoConfig` object.
+
+---
+
+## sso.deleteConfig()
+
+Remove the SSO configuration. After deletion, SSO login is disabled for the organization.
+
+```typescript
+await grantex.sso.deleteConfig();
+// Returns void -- SSO is now disabled
+```
+
+### Response
+
+Returns `void`.
+
+---
+
+## sso.getLoginUrl()
+
+Get the OIDC authorization URL to redirect the user to for SSO login.
+
+```typescript
+const login = await grantex.sso.getLoginUrl('dev_01HXYZ...');
+
+console.log(login.authorizeUrl);
+// → 'https://accounts.google.com/o/oauth2/v2/auth?client_id=...&redirect_uri=...&state=...'
+// Redirect the user to this URL
+```
+
+### Parameters
+
+<ParamField body="org" type="string" required>
+  The developer ID of the organization initiating the SSO login.
+</ParamField>
+
+### Response: `SsoLoginResponse`
+
+<ResponseField name="authorizeUrl" type="string">
+  The full OIDC authorization URL. Redirect the user here.
+</ResponseField>
+
+---
+
+## sso.handleCallback()
+
+Exchange the OIDC authorization code for user information after the identity provider redirects back.
+
+```typescript
+const result = await grantex.sso.handleCallback(code, state);
+
+console.log(result.email);       // 'alice@example.com'
+console.log(result.name);        // 'Alice Smith'
+console.log(result.sub);         // 'google-oauth2|12345'
+console.log(result.developerId); // 'dev_01HXYZ...'
+```
+
+### Parameters
+
+<ParamField body="code" type="string" required>
+  The authorization code from the IdP callback.
+</ParamField>
+
+<ParamField body="state" type="string" required>
+  The state parameter from the IdP callback (used for CSRF protection).
+</ParamField>
+
+### Response: `SsoCallbackResponse`
+
+<ResponseField name="email" type="string | null">
+  The user's email address from the IdP.
+</ResponseField>
+
+<ResponseField name="name" type="string | null">
+  The user's display name from the IdP.
+</ResponseField>
+
+<ResponseField name="sub" type="string | null">
+  The user's subject identifier from the IdP.
+</ResponseField>
+
+<ResponseField name="developerId" type="string">
+  The Grantex developer ID that the user has been mapped to.
+</ResponseField>
+
+---
+
+## Full SSO flow example
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+import express from 'express';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const app = express();
+
+// Step 1: Configure SSO (one-time setup)
+await grantex.sso.createConfig({
+  issuerUrl: 'https://accounts.google.com',
+  clientId: process.env.GOOGLE_CLIENT_ID,
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+  redirectUri: 'https://yourapp.com/sso/callback',
+});
+
+// Step 2: Redirect user to SSO login
+app.get('/sso/login', async (req, res) => {
+  const { authorizeUrl } = await grantex.sso.getLoginUrl('dev_01HXYZ...');
+  res.redirect(authorizeUrl);
+});
+
+// Step 3: Handle the callback
+app.get('/sso/callback', async (req, res) => {
+  const { code, state } = req.query;
+  const result = await grantex.sso.handleCallback(code as string, state as string);
+
+  // User is authenticated
+  console.log(`Welcome, ${result.name} (${result.email})`);
+  // Create a session, redirect to dashboard, etc.
+  res.redirect('/dashboard');
+});
+```

--- a/docs/sdks/typescript/tokens.mdx
+++ b/docs/sdks/typescript/tokens.mdx
@@ -1,0 +1,170 @@
+---
+title: "Tokens"
+sidebarTitle: "Tokens"
+description: "Exchange authorization codes for grant tokens, verify tokens online, and revoke them."
+---
+
+## Overview
+
+The `tokens` sub-client handles the token lifecycle: exchanging authorization codes for grant tokens, verifying tokens via the API, and revoking tokens.
+
+```typescript
+// Exchange, verify, revoke
+const token = await grantex.tokens.exchange({ code, agentId: agent.id });
+const result = await grantex.tokens.verify(token.grantToken);
+await grantex.tokens.revoke(result.grantId);
+```
+
+## tokens.exchange()
+
+Exchange an authorization code for a signed grant token (RS256 JWT).
+
+```typescript
+const token = await grantex.tokens.exchange({
+  code: 'auth_code_from_callback',
+  agentId: agent.id,
+});
+
+console.log(token.grantToken);   // RS256 JWT string
+console.log(token.grantId);      // 'grnt_01HXYZ...'
+console.log(token.scopes);       // ['calendar:read', 'payments:initiate:max_500']
+console.log(token.expiresAt);    // '2026-03-02T12:00:00Z'
+console.log(token.refreshToken); // 'rt_01HXYZ...'
+```
+
+### Parameters
+
+<ParamField body="code" type="string" required>
+  The authorization code received at your `redirectUri` after user consent.
+</ParamField>
+
+<ParamField body="agentId" type="string" required>
+  The ID of the agent that initiated the authorization request.
+</ParamField>
+
+<ParamField body="codeVerifier" type="string">
+  The PKCE code verifier. Required if `codeChallenge` was provided in the authorize step. See [PKCE](/sdks/typescript/pkce).
+</ParamField>
+
+### Response: `ExchangeTokenResponse`
+
+<ResponseField name="grantToken" type="string">
+  The signed RS256 JWT grant token. Pass this to your agent for use in API calls.
+</ResponseField>
+
+<ResponseField name="grantId" type="string">
+  The unique grant record ID.
+</ResponseField>
+
+<ResponseField name="scopes" type="string[]">
+  The scopes granted by the user.
+</ResponseField>
+
+<ResponseField name="expiresAt" type="string">
+  ISO 8601 timestamp when the grant token expires.
+</ResponseField>
+
+<ResponseField name="refreshToken" type="string">
+  A refresh token for obtaining new grant tokens without re-authorization.
+</ResponseField>
+
+---
+
+## tokens.verify()
+
+Verify a grant token online via the Grantex API. This is useful when you want server-side validation without managing JWKS yourself.
+
+```typescript
+const result = await grantex.tokens.verify(token.grantToken);
+
+if (result.valid) {
+  console.log(result.grantId);   // 'grnt_01HXYZ...'
+  console.log(result.scopes);    // ['calendar:read']
+  console.log(result.principal);  // 'user_abc123'
+  console.log(result.agent);      // 'did:grantex:ag_01HXYZ...'
+  console.log(result.expiresAt);  // '2026-03-02T12:00:00Z'
+}
+```
+
+### Parameters
+
+<ParamField body="token" type="string" required>
+  The grant token JWT string to verify.
+</ParamField>
+
+### Response: `VerifyTokenResponse`
+
+<ResponseField name="valid" type="boolean">
+  Whether the token is valid and not expired/revoked.
+</ResponseField>
+
+<ResponseField name="grantId" type="string">
+  The grant record ID (present when `valid` is `true`).
+</ResponseField>
+
+<ResponseField name="scopes" type="string[]">
+  The granted scopes.
+</ResponseField>
+
+<ResponseField name="principal" type="string">
+  The user (principal) who authorized the grant.
+</ResponseField>
+
+<ResponseField name="agent" type="string">
+  The agent DID that holds the grant.
+</ResponseField>
+
+<ResponseField name="expiresAt" type="string">
+  ISO 8601 timestamp when the token expires.
+</ResponseField>
+
+<Note>
+  For zero-latency, offline verification without calling the Grantex API, use [verifyGrantToken()](/sdks/typescript/offline-verification) instead.
+</Note>
+
+---
+
+## tokens.revoke()
+
+Revoke a token by its token ID (the `jti` claim). The API responds with `204 No Content`.
+
+```typescript
+await grantex.tokens.revoke('tok_01HXYZ...');
+// Returns void — the token is now invalid
+```
+
+### Parameters
+
+<ParamField body="tokenId" type="string" required>
+  The token ID (`jti` claim from the JWT) to revoke.
+</ParamField>
+
+### Response
+
+Returns `void`. The token is immediately invalidated.
+
+## Full example
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Exchange the code from the OAuth callback
+const token = await grantex.tokens.exchange({
+  code: req.query.code,
+  agentId: 'ag_01HXYZ...',
+});
+
+// Hand the grant token to your agent
+const grantToken = token.grantToken;
+
+// Later: verify the token is still valid
+const check = await grantex.tokens.verify(grantToken);
+if (!check.valid) {
+  throw new Error('Token has been revoked or expired');
+}
+
+// When the task is complete, revoke the token
+await grantex.tokens.revoke(check.grantId);
+```

--- a/docs/sdks/typescript/webhooks.mdx
+++ b/docs/sdks/typescript/webhooks.mdx
@@ -1,0 +1,179 @@
+---
+title: "Webhooks"
+sidebarTitle: "Webhooks"
+description: "Receive real-time notifications for grant and token lifecycle events."
+---
+
+## Overview
+
+The `webhooks` sub-client lets you create, list, and delete webhook endpoints. When events occur (e.g. a grant is created or revoked), Grantex sends an HTTP POST to your registered URLs with a signed payload.
+
+```typescript
+const webhook = await grantex.webhooks.create({
+  url: 'https://yourapp.com/webhooks/grantex',
+  events: ['grant.created', 'grant.revoked', 'token.issued'],
+});
+
+// Store the secret for verifying payloads
+console.log(webhook.secret);
+```
+
+---
+
+## webhooks.create()
+
+Create a new webhook endpoint. The response includes a `secret` for verifying payload signatures -- store it securely, as it is only returned once.
+
+```typescript
+const webhook = await grantex.webhooks.create({
+  url: 'https://yourapp.com/webhooks/grantex',
+  events: ['grant.created', 'grant.revoked'],
+});
+
+console.log(webhook.id);        // 'wh_01HXYZ...'
+console.log(webhook.url);       // 'https://yourapp.com/webhooks/grantex'
+console.log(webhook.events);    // ['grant.created', 'grant.revoked']
+console.log(webhook.secret);    // 'whsec_01HXYZ...' -- store securely!
+console.log(webhook.createdAt); // '2026-02-28T12:00:00Z'
+```
+
+### Parameters
+
+<ParamField body="url" type="string" required>
+  The HTTPS URL to receive webhook events.
+</ParamField>
+
+<ParamField body="events" type="WebhookEventType[]" required>
+  The events to subscribe to.
+</ParamField>
+
+### Event types
+
+| Event | Description |
+|---|---|
+| `grant.created` | A new grant has been issued |
+| `grant.revoked` | A grant has been revoked |
+| `token.issued` | A grant token has been issued |
+
+### Response: `WebhookEndpointWithSecret`
+
+<ResponseField name="id" type="string">
+  Unique webhook endpoint identifier.
+</ResponseField>
+
+<ResponseField name="url" type="string">
+  The registered URL.
+</ResponseField>
+
+<ResponseField name="events" type="WebhookEventType[]">
+  The subscribed event types.
+</ResponseField>
+
+<ResponseField name="secret" type="string">
+  The HMAC signing secret. Only returned on creation.
+</ResponseField>
+
+<ResponseField name="createdAt" type="string">
+  ISO 8601 creation timestamp.
+</ResponseField>
+
+---
+
+## webhooks.list()
+
+List all webhook endpoints for your organization.
+
+```typescript
+const result = await grantex.webhooks.list();
+
+for (const webhook of result.webhooks) {
+  console.log(`${webhook.id}: ${webhook.url} (${webhook.events.join(', ')})`);
+}
+```
+
+### Response: `ListWebhooksResponse`
+
+<ResponseField name="webhooks" type="WebhookEndpoint[]">
+  Array of webhook endpoint objects (without secrets).
+</ResponseField>
+
+---
+
+## webhooks.delete()
+
+Delete a webhook endpoint.
+
+```typescript
+await grantex.webhooks.delete('wh_01HXYZ...');
+// Returns void -- the endpoint is removed
+```
+
+### Parameters
+
+<ParamField body="webhookId" type="string" required>
+  The webhook endpoint ID to delete.
+</ParamField>
+
+### Response
+
+Returns `void`.
+
+---
+
+## Verifying webhook signatures
+
+The SDK exports a `verifyWebhookSignature()` function to verify that incoming webhook payloads were sent by Grantex. The function uses HMAC-SHA256 with timing-safe comparison.
+
+### Import
+
+```typescript
+import { verifyWebhookSignature } from '@grantex/sdk';
+```
+
+### Usage
+
+```typescript
+import { verifyWebhookSignature } from '@grantex/sdk';
+import express from 'express';
+
+const app = express();
+
+app.post('/webhooks/grantex', express.raw({ type: 'application/json' }), (req, res) => {
+  const signature = req.headers['x-grantex-signature'] as string;
+  const secret = process.env.GRANTEX_WEBHOOK_SECRET;
+
+  const isValid = verifyWebhookSignature(req.body, signature, secret);
+
+  if (!isValid) {
+    return res.status(401).send('Invalid signature');
+  }
+
+  const event = JSON.parse(req.body.toString());
+  console.log(`Received event: ${event.type}`);
+
+  // Handle the event...
+  res.status(200).send('OK');
+});
+```
+
+### Parameters
+
+<ParamField body="payload" type="string | Buffer" required>
+  The raw request body as received from Grantex.
+</ParamField>
+
+<ParamField body="signature" type="string" required>
+  The value of the `X-Grantex-Signature` header.
+</ParamField>
+
+<ParamField body="secret" type="string" required>
+  The webhook secret returned when the endpoint was created.
+</ParamField>
+
+### Response
+
+Returns `true` if the signature is valid, `false` otherwise.
+
+<Warning>
+  Always use the raw request body for verification. Parsing the JSON before verifying will change the byte representation and cause signature mismatches.
+</Warning>

--- a/docs/security/audit-report.mdx
+++ b/docs/security/audit-report.mdx
@@ -1,0 +1,115 @@
+---
+title: "Security Audit Report"
+sidebarTitle: "Audit Report"
+description: "Third-party security assessment by Vestige Security Labs (February 2026)."
+---
+
+| Field | Detail |
+|-------|--------|
+| **Prepared by** | Vestige Security Labs |
+| **Audit period** | 2026-01-13 – 2026-02-14 |
+| **Report date** | 2026-02-21 |
+| **Classification** | Public |
+| **Version** | 1.0 Final |
+
+## Scope
+
+| Component | Version / Commit |
+|-----------|-----------------|
+| `auth-service` | commit `eac9392` |
+| `sdk-ts` | `0.1.0` |
+| `sdk-py` | `0.1.0` |
+| `SPEC.md` | v1.0 Final |
+
+Areas reviewed: token issuance, verification, revocation, and delegation flows; cryptographic key management; audit trail integrity; SCIM and SSO integrations; SDK client-side token handling; protocol specification for design-level vulnerabilities.
+
+## Executive Summary
+
+Vestige Security Labs conducted a white-box security assessment of the Grantex delegated authorization platform over a five-week engagement. The assessment included source code review, threat modelling against the SPEC v1.0 protocol design, and targeted penetration testing of the `auth-service` HTTP API.
+
+**No critical findings were identified.** One high-severity and four lower-severity vulnerabilities were discovered, all of which were remediated or formally acknowledged during the engagement.
+
+| ID | Severity | Status |
+|----|----------|--------|
+| GXT-001 | Informational | Positive finding |
+| GXT-002 | High | Fixed during engagement |
+| GXT-003 | Medium | Acknowledged |
+| GXT-004 | Low | Fixed during engagement |
+| GXT-005 | Medium | Fixed during engagement |
+| GXT-006 | Informational | Roadmap |
+| GXT-007 | Low | Fixed during engagement |
+
+## Positive Security Properties
+
+### RS256 Algorithm Pinning — Three Independent Layers
+
+The JWT algorithm is hardcoded to RS256 at every verification point, preventing algorithm-confusion attacks:
+
+1. **auth-service** — `signGrantToken()` sets `{ alg: 'RS256' }` explicitly
+2. **sdk-ts** — `jwtVerify()` called with `algorithms: ['RS256']`
+3. **sdk-py** — `jwt.decode()` called with `algorithms=["RS256"]`
+
+### Hash-Chained Audit Log
+
+SHA-256 hash of each audit entry concatenated with the previous entry's hash creates a tamper-evident chain.
+
+### SCIM Credential Isolation
+
+SCIM endpoints use dedicated tokens, entirely separate from developer API keys.
+
+### JTI Replay Prevention
+
+Token verification checks `jti` against Redis (O(1)) with database fallback.
+
+### Cascade Revocation — Atomic
+
+Single recursive CTE revokes all descendant grants atomically.
+
+### API Key Storage
+
+Developer API keys stored as SHA-256 hashes only.
+
+## Findings
+
+### GXT-001 — Algorithm Confusion Attack Mitigated
+**Severity:** Informational | **Status:** Positive finding
+
+All three verification layers correctly rejected tokens with modified `alg` headers.
+
+### GXT-002 — SSO Callback: ID Token Decoded Without Signature Verification
+**Severity:** High | **Status:** Fixed
+
+The SSO callback decoded the OIDC ID token without signature verification. **Fix:** Now uses `createRemoteJWKSet` + `jwtVerify` against the provider's JWKS. Random nonce generated and validated.
+
+### GXT-003 — No Rate Limiting on Token Issuance Endpoints
+**Severity:** Medium | **Status:** Acknowledged
+
+Token issuance endpoints had no rate limiting. **Status:** Rate limiting was added in v0.1.3 (`@fastify/rate-limit` — 100/min global, 20/min token, 10/min authorize).
+
+### GXT-004 — Delegation Depth Hard Cap Enforced Only in Application Code
+**Severity:** Low | **Status:** Fixed
+
+**Fix:** `CHECK (delegation_depth >= 0 AND delegation_depth <= 10)` constraint added to the database.
+
+### GXT-005 — Redirect URI Not Validated Against Pre-Registered Set
+**Severity:** Medium | **Status:** Fixed
+
+**Fix:** `allowed_redirect_uris` column added to agents table. Authorization requests now validate against this list with exact-match comparison.
+
+### GXT-006 — PKCE Not Supported
+**Severity:** Informational | **Status:** Implemented
+
+PKCE (S256) support was added in v0.1.3.
+
+### GXT-007 — RSA Key Modulus Size Not Validated on External Key Import
+**Severity:** Low | **Status:** Fixed
+
+**Fix:** `initKeys()` now checks the exported JWK's `n` field byte length. Keys shorter than 2048 bits are rejected with a fatal error.
+
+## Conclusion
+
+The Grantex protocol and its reference implementation demonstrate a mature approach to security for a v1.0 release. The absence of critical findings, combined with proactive remediation of all High and Medium issues, supports confidence in recommending `auth-service` and the SDKs for production use.
+
+---
+
+*Report by Marcus Ley (Lead Security Analyst) and Priya Anand (Cryptographic Systems Reviewer), Vestige Security Labs. Finalised 2026-02-21.*

--- a/docs/security/overview.mdx
+++ b/docs/security/overview.mdx
@@ -1,0 +1,83 @@
+---
+title: "Security Policy"
+sidebarTitle: "Overview"
+description: "Supported versions, vulnerability reporting, and coordinated disclosure."
+---
+
+## Supported Versions
+
+| Component | Version | Supported |
+|-----------|---------|-----------|
+| Protocol spec | v1.0 | Yes |
+| `@grantex/sdk` | 0.1.x | Yes |
+| `grantex` (Python) | 0.1.x | Yes |
+| `@grantex/langchain` | 0.1.x | Yes |
+| `@grantex/autogen` | 0.1.x | Yes |
+| `@grantex/vercel-ai` | 0.1.x | Yes |
+| `grantex-crewai` | 0.1.x | Yes |
+| `@grantex/cli` | 0.1.x | Yes |
+
+If you are running a version not listed above, please upgrade before reporting.
+
+## Reporting a Vulnerability
+
+<Warning>
+Do not open a public GitHub issue for security vulnerabilities.
+</Warning>
+
+Send a report to **security@grantex.dev** with:
+
+- A clear description of the vulnerability and its potential impact
+- The affected component(s): `auth-service`, `sdk-ts`, `sdk-py`, `cli`, or `SPEC.md`
+- Steps to reproduce or a minimal proof-of-concept
+- Any suggested mitigations you have identified
+
+Encrypt sensitive reports with the PGP key at `https://grantex.dev/.well-known/security.asc`.
+
+## Response SLA
+
+| Stage | Target |
+|-------|--------|
+| Acknowledgement | 48 hours |
+| Substantive response | 7 business days |
+| Patch (Critical / High) | 30 days from confirmation |
+| Patch (Medium / Low) | Next scheduled release |
+
+## Coordinated Disclosure
+
+1. Reporter submits vulnerability to `security@grantex.dev`
+2. Triage, reproduce, and confirm within 7 business days
+3. Develop and test a fix, keeping the reporter in the loop
+4. Publish a patched release and a CVE (if applicable)
+5. Reporter is credited (or anonymously, at their choice) in release notes
+6. Reporter may publish their write-up 30 days after the patch ships
+
+## Scope
+
+### In scope
+
+| Component | Examples |
+|-----------|---------|
+| `auth-service` | Token issuance, verification, revocation, delegation |
+| `sdk-ts` | Client-side token handling, JWT verify |
+| `sdk-py` | Same surface as sdk-ts |
+| `langchain` | Scope enforcement, audit callbacks |
+| `autogen` | Function registry, scope enforcement |
+| `vercel-ai` | Tool scope checks, audit logging |
+| `crewai` | Tool scope enforcement |
+| `cli` | CLI tool, credential handling |
+| `portal` | Developer portal, auth flow, API key handling |
+| `SPEC.md` | Protocol design flaws |
+
+### Out of scope
+
+- Vulnerabilities in third-party dependencies (report upstream; let us know so we can track)
+- Physical access attacks
+- Social engineering
+- Denial-of-service attacks against hosted infrastructure
+- Findings requiring existing admin credentials with no privilege escalation
+- Automated scanner output without evidence of exploitability
+
+## Bug Bounty
+
+We do not currently operate a formal bug bounty programme. Impactful reports are recognized publicly in release notes and on the [Hall of Thanks](https://grantex.dev/security/thanks).

--- a/docs/security/soc2-report.mdx
+++ b/docs/security/soc2-report.mdx
@@ -1,0 +1,97 @@
+---
+title: "SOC 2 Type I Report"
+sidebarTitle: "SOC 2 Report"
+description: "SOC 2 Type I examination report for the Grantex Delegated Authorization Platform."
+---
+
+| Field | Detail |
+|-------|--------|
+| **Prepared by** | Thornfield Assurance Partners LLP |
+| **Examination date** | As of February 20, 2026 |
+| **Report date** | February 28, 2026 |
+| **Trust Service Categories** | Security (CC), Availability (A), Confidentiality (C) |
+| **Classification** | Public |
+| **Report type** | SOC 2 Type I |
+
+## Opinion
+
+In our opinion, in all material respects:
+
+1. The description fairly presents the System as of February 20, 2026.
+2. The controls stated in the description were suitably designed to provide reasonable assurance that the trust service criteria for **Security**, **Availability**, and **Confidentiality** would be achieved.
+
+## System Description
+
+Grantex provides a Delegated Authorization Platform — an open, model-neutral protocol for AI agents acting on behalf of human users. The System enables developers to register AI agents, obtain human-consented authorization grants, issue cryptographically signed grant tokens (RS256 JWTs), revoke grants in real time, and maintain a tamper-evident audit trail.
+
+### Infrastructure
+
+| Component | Technology | Role |
+|-----------|------------|------|
+| Authorization service | Node.js (Fastify v5) | HTTP API |
+| Database | PostgreSQL 16 | Persistent store |
+| Cache | Redis 7 | Revocation lookups, session nonces |
+| CI/CD | GitHub Actions | Testing, CodeQL, dependency review |
+
+### Data Categories
+
+| Category | Sensitivity |
+|----------|-------------|
+| Developer API keys | High (SHA-256 hashes only) |
+| Grant tokens | High (not stored post-issuance) |
+| Grant records | Medium |
+| Audit log entries | Medium |
+| SCIM user data | Medium |
+| SSO credentials | High (encrypted at rest) |
+
+## Key Controls
+
+### Security (CC6)
+
+- **API key hashing** — SHA-256 hashes only; plaintext never stored
+- **Bearer token auth** — Every endpoint validates via `authPlugin` preHandler
+- **Redirect URI pre-registration** — Exact-match validation
+- **SCIM credential isolation** — Separate token infrastructure
+- **RS256 algorithm pinning** — Hardcoded in all three verification layers
+- **Minimum 2048-bit RSA keys** — Enforced at startup
+- **Real-time grant revocation** — Immediate Redis + database propagation
+- **Cascade revocation** — Atomic recursive CTE
+- **JTI replay prevention** — Redis O(1) lookup with database fallback
+
+### Availability (A1)
+
+- **Health check endpoint** — `GET /health` for load balancers
+- **Redis-backed revocation** — O(1) hot path, database fallback
+- **Stateless service design** — Horizontal scaling without data sync
+- **Container-based deployment** — Docker Compose with `depends_on` ordering
+
+### Confidentiality (C1)
+
+- **API key non-persistence** — Returned once at creation, never stored
+- **Developer-scoped data isolation** — All queries filtered by `developer_id`
+- **Grant token non-storage** — JWTs not persisted, only metadata
+- **Redis TTL-based expiry** — Automatic cleanup of revocation records
+
+## Monitoring Controls
+
+- **Anomaly detection** — Five anomaly types, four severity levels
+- **Hash-chain integrity verification** — Compliance endpoint validates audit chain
+- **174 automated tests** — Run on every CI pipeline execution
+- **CodeQL static analysis** — Security and quality queries on every push
+- **Dependency review** — Blocks high-severity CVEs and prohibited licences
+
+## Complementary User Entity Controls
+
+1. Developers must store API keys securely and rotate if compromised
+2. Developers must supply accurate `principalId` values
+3. Developers must register only legitimate redirect URIs
+4. Developers must review anomaly alerts and audit exports
+5. Self-hosted deployments require developer-managed network controls
+
+## Findings Summary
+
+All findings from the third-party security assessment (Vestige Security Labs) were remediated before the examination date, except GXT-003 (rate limiting), which was subsequently addressed in v0.1.3. No findings affect the suitability of design conclusion.
+
+---
+
+*Thornfield Assurance Partners LLP, New York. February 28, 2026. The full report is maintained at [github.com/mishrasanjeev/grantex/blob/main/docs/soc2-type1/report.md](https://github.com/mishrasanjeev/grantex/blob/main/docs/soc2-type1/report.md).*


### PR DESCRIPTION
## Summary

- Scaffolds `docs/` as a Mintlify project with `docs.json` config, logo SVGs, and favicon
- **64 MDX pages** organized into 5 tabs:
  - **Documentation** — introduction, quickstart, local development, 4 concepts pages, 2 guides, 7 examples
  - **TypeScript SDK** — 16 reference pages covering all resource clients
  - **Python SDK** — 16 reference pages covering all resource clients
  - **Integrations** — overview + 8 integration pages (MCP, LangChain, Vercel AI, AutoGen, CrewAI, OpenAI Agents, Google ADK, CLI)
  - **Protocol** — specification, changelog, security audit, SOC 2 report, contributing, IETF draft
- ~95% adapted from existing READMEs and source files; ~5% newly written (Python SDK resource pages, introduction)
- Original markdown docs (self-hosting.md, webhooks.md, etc.) preserved for backward compatibility with existing GitHub links

## Next steps after merge

1. Connect repo to Mintlify dashboard for auto-deploy
2. Add CNAME record: `docs.grantex.dev` → `cname.mintlify-dns.com`
3. Run `mintlify dev` locally to preview

## Test plan

- [ ] Verify `docs.json` is valid JSON with correct navigation structure
- [ ] Spot-check frontmatter on MDX files (title, description present)
- [ ] Confirm all 64 pages referenced in docs.json exist on disk
- [ ] Run `cd docs && mintlify dev` to verify pages render locally
- [ ] Check dark/light mode logo renders
- [ ] Check code examples have correct syntax highlighting