### PR TITLE
feat: link landing page to docs.grantex.dev

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -575,7 +575,7 @@
         grant<span>ex</span>
       </a>
       <ul class="nav-links">
-        <li><a href="https://github.com/mishrasanjeev/grantex/tree/main/docs"
+        <li><a href="https://docs.grantex.dev"
                onclick="gtag('event','docs_click',{event_category:'nav'})">Docs</a></li>
         <li><a href="https://github.com/mishrasanjeev/grantex"
                onclick="gtag('event','github_click',{event_category:'nav'})">GitHub</a></li>
@@ -603,6 +603,13 @@
       </a>
       <a href="/dashboard/signup" class="btn btn-signup"
          onclick="gtag('event','signup_click',{event_category:'hero'})">Sign up free</a>
+      <a href="https://docs.grantex.dev" class="btn btn-secondary"
+         onclick="gtag('event','docs_click',{event_category:'hero'})">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M1 2.5A2.5 2.5 0 013.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 011 11.5v-9zm3.5-1a1 1 0 00-1 1v6.06A2.5 2.5 0 013.5 8.5H11V1.5H4.5zM5 4h4.75a.75.75 0 010 1.5H5A.75.75 0 015 4zm0 2.5h4.75a.75.75 0 010 1.5H5A.75.75 0 015 6.5z"/>
+        </svg>
+        Read the docs
+      </a>
       <a href="https://github.com/mishrasanjeev/grantex" class="btn btn-secondary"
          onclick="gtag('event','github_click',{event_category:'hero'})">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
@@ -1088,6 +1095,7 @@
     <div class="footer-inner">
       <span class="footer-logo">grantex</span>
       <ul class="footer-links">
+        <li><a href="https://docs.grantex.dev">Docs</a></li>
         <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
         <li><a href="https://pypi.org/project/grantex/">PyPI</a></li>
         <li><a href="https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/">IETF Draft</a></li>


### PR DESCRIPTION
## Summary
- Nav "Docs" link now points to `https://docs.grantex.dev` instead of the GitHub docs directory
- Added a "Read the docs" CTA button in the hero section
- Added "Docs" link in the footer

## Test plan
- [ ] Verify nav Docs link opens docs.grantex.dev
- [ ] Verify hero "Read the docs" button opens docs.grantex.dev
- [ ] Verify footer Docs link opens docs.grantex.dev