### PR TITLE
fix: move docs.json to repo root for Mintlify discovery

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,0 +1,231 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
+  "name": "Grantex",
+  "favicon": "/docs/favicon.svg",
+  "logo": {
+    "light": "/docs/logo/light.svg",
+    "dark": "/docs/logo/dark.svg"
+  },
+  "colors": {
+    "primary": "#3fb950",
+    "light": "#58a6ff",
+    "dark": "#2ea043",
+    "background": {
+      "dark": "#0d1117"
+    }
+  },
+  "navigation": {
+    "global": {
+      "tabs": [
+        { "tab": "Documentation", "href": "/docs/introduction" },
+        { "tab": "TypeScript SDK", "href": "/docs/sdks/typescript/overview" },
+        { "tab": "Python SDK", "href": "/docs/sdks/python/overview" },
+        { "tab": "Integrations", "href": "/docs/integrations/overview" },
+        { "tab": "Protocol", "href": "/docs/protocol/specification" }
+      ]
+    },
+    "tabs": [
+      {
+        "tab": "Documentation",
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": [
+              "docs/introduction",
+              "docs/quickstart",
+              "docs/local-development"
+            ]
+          },
+          {
+            "group": "Core Concepts",
+            "pages": [
+              "docs/concepts/how-it-works",
+              "docs/concepts/grant-token",
+              "docs/concepts/scopes",
+              "docs/concepts/delegation"
+            ]
+          },
+          {
+            "group": "Guides",
+            "pages": [
+              "docs/guides/webhooks",
+              "docs/guides/self-hosting"
+            ]
+          },
+          {
+            "group": "Examples",
+            "pages": [
+              "docs/examples/quickstart-ts",
+              "docs/examples/quickstart-py",
+              "docs/examples/langchain-agent",
+              "docs/examples/vercel-ai-chatbot",
+              "docs/examples/crewai-agent",
+              "docs/examples/openai-agents",
+              "docs/examples/google-adk"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "TypeScript SDK",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "docs/sdks/typescript/overview"
+            ]
+          },
+          {
+            "group": "Authorization",
+            "pages": [
+              "docs/sdks/typescript/authorization",
+              "docs/sdks/typescript/tokens",
+              "docs/sdks/typescript/offline-verification",
+              "docs/sdks/typescript/pkce"
+            ]
+          },
+          {
+            "group": "Resources",
+            "pages": [
+              "docs/sdks/typescript/agents",
+              "docs/sdks/typescript/grants",
+              "docs/sdks/typescript/audit",
+              "docs/sdks/typescript/webhooks",
+              "docs/sdks/typescript/policies",
+              "docs/sdks/typescript/compliance",
+              "docs/sdks/typescript/anomalies",
+              "docs/sdks/typescript/billing",
+              "docs/sdks/typescript/scim",
+              "docs/sdks/typescript/sso"
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "docs/sdks/typescript/errors"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Python SDK",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "docs/sdks/python/overview"
+            ]
+          },
+          {
+            "group": "Authorization",
+            "pages": [
+              "docs/sdks/python/authorization",
+              "docs/sdks/python/tokens",
+              "docs/sdks/python/offline-verification",
+              "docs/sdks/python/pkce"
+            ]
+          },
+          {
+            "group": "Resources",
+            "pages": [
+              "docs/sdks/python/agents",
+              "docs/sdks/python/grants",
+              "docs/sdks/python/audit",
+              "docs/sdks/python/webhooks",
+              "docs/sdks/python/policies",
+              "docs/sdks/python/compliance",
+              "docs/sdks/python/anomalies",
+              "docs/sdks/python/billing",
+              "docs/sdks/python/scim",
+              "docs/sdks/python/sso"
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "docs/sdks/python/errors"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Integrations",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "docs/integrations/overview"
+            ]
+          },
+          {
+            "group": "Framework Integrations",
+            "pages": [
+              "docs/integrations/mcp",
+              "docs/integrations/langchain",
+              "docs/integrations/vercel-ai",
+              "docs/integrations/autogen",
+              "docs/integrations/crewai",
+              "docs/integrations/openai-agents",
+              "docs/integrations/google-adk"
+            ]
+          },
+          {
+            "group": "CLI",
+            "pages": [
+              "docs/integrations/cli"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Protocol",
+        "groups": [
+          {
+            "group": "Specification",
+            "pages": [
+              "docs/protocol/specification",
+              "docs/protocol/changelog"
+            ]
+          },
+          {
+            "group": "Security",
+            "pages": [
+              "docs/security/overview",
+              "docs/security/audit-report",
+              "docs/security/soc2-report"
+            ]
+          },
+          {
+            "group": "Community",
+            "pages": [
+              "docs/community/contributing",
+              "docs/community/ietf-draft"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "navbar": {
+    "links": [
+      {
+        "label": "Dashboard",
+        "url": "https://grantex.dev/dashboard"
+      },
+      {
+        "label": "GitHub",
+        "url": "https://github.com/mishrasanjeev/grantex"
+      }
+    ]
+  },
+  "footerSocials": {
+    "github": "https://github.com/mishrasanjeev/grantex"
+  },
+  "feedback": {
+    "thumbsRating": true
+  },
+  "search": {
+    "prompt": "Search Grantex docs..."
+  }
+}


### PR DESCRIPTION
## Summary
- Added `docs.json` at the repo root (Mintlify requires it there)
- All page paths prefixed with `docs/` to resolve to existing MDX files
- Asset paths updated (`/docs/favicon.svg`, `/docs/logo/...`)

## Context
Mintlify was showing default template content because it couldn't find `docs.json` — it only looks at the repo root, not subdirectories.

## Test plan
- [ ] Merge and verify Mintlify auto-deploys with Grantex content
- [ ] Verify all tabs and pages render at grantex.mintlify.app