### PR TITLE
fix: resolve docs.json validation errors

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -11,9 +11,6 @@
     "primary": "#3fb950",
     "light": "#58a6ff",
     "dark": "#2ea043",
-    "background": {
-      "dark": "#0d1117"
-    }
   },
   "navigation": {
     "global": {
@@ -210,12 +207,8 @@
   "navbar": {
     "links": [
       {
-        "label": "Dashboard",
-        "url": "https://grantex.dev/dashboard"
-      },
-      {
-        "label": "GitHub",
-        "url": "https://github.com/mishrasanjeev/grantex"
+        "type": "github",
+        "href": "https://github.com/mishrasanjeev/grantex"
       }
     ]
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -11,9 +11,6 @@
     "primary": "#3fb950",
     "light": "#58a6ff",
     "dark": "#2ea043",
-    "background": {
-      "dark": "#0d1117"
-    }
   },
   "navigation": {
     "global": {
@@ -210,12 +207,8 @@
   "navbar": {
     "links": [
       {
-        "label": "Dashboard",
-        "url": "https://grantex.dev/dashboard"
-      },
-      {
-        "label": "GitHub",
-        "url": "https://github.com/mishrasanjeev/grantex"
+        "type": "github",
+        "href": "https://github.com/mishrasanjeev/grantex"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Removed unsupported `colors.background` key
- Fixed `navbar.links` to use `type` + `href` format (Mintlify requires typed links like `github`/`discord`, not freeform `label` + `url`)

## Context
Mintlify deploy was failing with validation errors on these two fields.

## Test plan
- [ ] Mintlify deploy succeeds after merge