### PR TITLE
fix: remove trailing comma in docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -10,7 +10,7 @@
   "colors": {
     "primary": "#3fb950",
     "light": "#58a6ff",
-    "dark": "#2ea043",
+    "dark": "#2ea043"
   },
   "navigation": {
     "global": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -10,7 +10,7 @@
   "colors": {
     "primary": "#3fb950",
     "light": "#58a6ff",
-    "dark": "#2ea043",
+    "dark": "#2ea043"
   },
   "navigation": {
     "global": {


### PR DESCRIPTION
## Summary
- Fixed invalid trailing comma in `colors` object in both `docs.json` and `docs/docs.json`
- This was causing Mintlify to silently fail JSON parsing and fall back to the default template

## Test plan
- [ ] Mintlify deploys Grantex content instead of default template