### PR TITLE
feat: add /docs redirect to Mintlify docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ curl -s -X POST http://localhost:3001/v1/token \
 
 For local development, the auth service also serves a lightweight dashboard at `http://localhost:3001/dashboard`.
 
-See the [self-hosting guide](https://grantex.mintlify.app/guides/self-hosting) for production deployment guidance.
+See the [self-hosting guide](https://grantex.dev/docs/guides/self-hosting) for production deployment guidance.
 
 ---
 
@@ -566,7 +566,7 @@ MCP solves tool connectivity — how agents access data and call functions. Gran
 The protocol spec is open (Apache 2.0). Grantex Inc. maintains a hosted reference implementation. Our goal is to contribute the spec to a neutral standards body (W3C, IETF, or CNCF) once it stabilizes.
 
 **Can I self-host?**  
-Yes. The reference implementation is fully open-source. Docker Compose deploy in one command. See the [self-hosting guide](https://grantex.mintlify.app/guides/self-hosting).
+Yes. The reference implementation is fully open-source. Docker Compose deploy in one command. See the [self-hosting guide](https://grantex.dev/docs/guides/self-hosting).
 
 ---
 
@@ -578,7 +578,7 @@ Protocol specification and SDKs: [Apache 2.0](https://github.com/mishrasanjeev/g
 
 <div align="center">
 
-**[Docs](https://grantex.mintlify.app)** · **[Spec](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md)** · **[Dashboard](https://grantex.dev/dashboard)** · **[Self-Hosting](https://grantex.mintlify.app/guides/self-hosting)** · **[Roadmap](https://github.com/mishrasanjeev/grantex/blob/main/ROADMAP.md)** · **[Contributing](https://grantex.mintlify.app/community/contributing)** · **[GitHub](https://github.com/mishrasanjeev/grantex)**
+**[Docs](https://grantex.dev/docs)** · **[Spec](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md)** · **[Dashboard](https://grantex.dev/dashboard)** · **[Self-Hosting](https://grantex.dev/docs/guides/self-hosting)** · **[Roadmap](https://github.com/mishrasanjeev/grantex/blob/main/ROADMAP.md)** · **[Contributing](https://grantex.dev/docs/community/contributing)** · **[GitHub](https://github.com/mishrasanjeev/grantex)**
 
 <br/>
 

--- a/firebase.json
+++ b/firebase.json
@@ -2,6 +2,10 @@
   "hosting": {
     "public": "web",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "redirects": [
+      { "source": "/docs", "destination": "https://grantex.mintlify.app", "type": 302 },
+      { "source": "/docs/:path*", "destination": "https://grantex.mintlify.app/:path*", "type": 302 }
+    ],
     "rewrites": [
       { "source": "/dashboard/**", "destination": "/dashboard/index.html" },
       { "source": "**", "destination": "/index.html" }

--- a/web/index.html
+++ b/web/index.html
@@ -575,7 +575,7 @@
         grant<span>ex</span>
       </a>
       <ul class="nav-links">
-        <li><a href="https://grantex.mintlify.app"
+        <li><a href="/docs"
                onclick="gtag('event','docs_click',{event_category:'nav'})">Docs</a></li>
         <li><a href="https://github.com/mishrasanjeev/grantex"
                onclick="gtag('event','github_click',{event_category:'nav'})">GitHub</a></li>
@@ -603,7 +603,7 @@
       </a>
       <a href="/dashboard/signup" class="btn btn-signup"
          onclick="gtag('event','signup_click',{event_category:'hero'})">Sign up free</a>
-      <a href="https://grantex.mintlify.app" class="btn btn-secondary"
+      <a href="/docs" class="btn btn-secondary"
          onclick="gtag('event','docs_click',{event_category:'hero'})">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
           <path d="M1 2.5A2.5 2.5 0 013.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 011 11.5v-9zm3.5-1a1 1 0 00-1 1v6.06A2.5 2.5 0 013.5 8.5H11V1.5H4.5zM5 4h4.75a.75.75 0 010 1.5H5A.75.75 0 015 4zm0 2.5h4.75a.75.75 0 010 1.5H5A.75.75 0 015 6.5z"/>
@@ -1095,7 +1095,7 @@
     <div class="footer-inner">
       <span class="footer-logo">grantex</span>
       <ul class="footer-links">
-        <li><a href="https://grantex.mintlify.app">Docs</a></li>
+        <li><a href="/docs">Docs</a></li>
         <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
         <li><a href="https://pypi.org/project/grantex/">PyPI</a></li>
         <li><a href="https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/">IETF Draft</a></li>


### PR DESCRIPTION
## Summary
- Added Firebase redirect: `grantex.dev/docs` → `grantex.mintlify.app` (302)
- Subpaths also redirect: `grantex.dev/docs/quickstart` → `grantex.mintlify.app/quickstart`
- Updated landing page and README links to use `/docs` path
- Temporary until `docs.grantex.dev` custom domain is configured in Mintlify

## Test plan
- [ ] Deploy and verify `grantex.dev/docs` redirects to Mintlify
- [ ] Verify `grantex.dev/docs/quickstart` redirects correctly
- [ ] Verify nav, hero, and footer links work