### PR TITLE
chore: add README badges and npm keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Spec Version](https://img.shields.io/badge/spec-v1.0--final-green)](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md)
 [![GitHub Stars](https://img.shields.io/github/stars/mishrasanjeev/grantex?style=social)](https://github.com/mishrasanjeev/grantex)
+[![npm](https://img.shields.io/npm/v/@grantex/sdk)](https://www.npmjs.com/package/@grantex/sdk)
+[![PyPI](https://img.shields.io/pypi/v/grantex)](https://pypi.org/project/grantex/)
+[![CI](https://img.shields.io/github/actions/workflow/status/mishrasanjeev/grantex/ci.yml?branch=main&label=CI)](https://github.com/mishrasanjeev/grantex/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-grantex.dev-3fb950)](https://grantex.dev/docs)
 
 <br/>
 

--- a/packages/autogen/package.json
+++ b/packages/autogen/package.json
@@ -36,6 +36,16 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "keywords": [
+    "grantex",
+    "autogen",
+    "openai",
+    "function-calling",
+    "ai-agents",
+    "authorization",
+    "oauth",
+    "jwt"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,6 +33,15 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "keywords": [
+    "grantex",
+    "cli",
+    "ai-agents",
+    "authorization",
+    "oauth",
+    "jwt",
+    "developer-tools"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -39,6 +39,16 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "keywords": [
+    "grantex",
+    "langchain",
+    "ai-agents",
+    "authorization",
+    "oauth",
+    "jwt",
+    "llm",
+    "agent-tools"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -35,6 +35,17 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "keywords": [
+    "grantex",
+    "ai-agents",
+    "authorization",
+    "oauth",
+    "jwt",
+    "delegated-auth",
+    "sdk",
+    "agent-permissions",
+    "grant-token"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -41,6 +41,16 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "keywords": [
+    "grantex",
+    "vercel-ai",
+    "ai-sdk",
+    "ai-agents",
+    "authorization",
+    "oauth",
+    "jwt",
+    "agent-tools"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Add 4 new badges to README: npm version, PyPI version, CI status, docs link
- Add `keywords` arrays to 5 packages missing them: `@grantex/sdk`, `@grantex/langchain`, `@grantex/autogen`, `@grantex/vercel-ai`, `@grantex/cli`
- Keywords take effect on next `npm publish` (no version bump needed)

## Post-merge
Run to set GitHub repo topics:
```bash
gh repo edit --add-topic ai-agents --add-topic authorization --add-topic oauth --add-topic jwt --add-topic sdk --add-topic ai --add-topic mcp --add-topic delegated-auth --add-topic open-source --add-topic protocol
```

## Test plan
- [ ] Verify badges render on GitHub README preview
- [ ] Verify `keywords` fields are valid JSON in each package.json