### PR TITLE
feat: add Mintlify blog with 3 launch posts

### DIFF
--- a/docs/blog/grantex-v0-1-whats-included.mdx
+++ b/docs/blog/grantex-v0-1-whats-included.mdx
@@ -1,0 +1,107 @@
+---
+title: "Grantex v0.1: What's Included"
+description: "A complete tour of everything shipping in the Grantex v0.1 release -- SDKs, integrations, CLI, enterprise features, and more."
+date: "2026-02-28"
+authors:
+  - name: "Sanjeev Mishra"
+---
+
+Grantex v0.1 is our first public release, and we wanted it to be comprehensive. Whether you are building a single-agent prototype or deploying a multi-agent system in production, the tooling is here. Let's walk through everything that ships today.
+
+## SDKs
+
+### TypeScript (`@grantex/sdk`)
+
+The TypeScript SDK is the primary client library. It covers the full API surface: agent registration, authorization, token exchange, offline and online verification, grants management, audit logging, and every enterprise endpoint. It uses native `fetch`, ships as ESM, and requires Node 18+.
+
+```bash
+npm install @grantex/sdk
+```
+
+[TypeScript SDK docs](/sdks/typescript/overview)
+
+### Python (`grantex`)
+
+The Python SDK mirrors the TypeScript API with idiomatic Python conventions -- snake_case methods, dataclass responses, and `httpx` under the hood. It supports Python 3.9+ and includes full type annotations for editor autocomplete.
+
+```bash
+pip install grantex
+```
+
+[Python SDK docs](/sdks/python/overview)
+
+## Framework Integrations
+
+We built integrations for every major agent framework so you can add Grantex authorization to your existing stack without rewriting your agent logic.
+
+| Integration | Package | What It Does |
+|---|---|---|
+| **LangChain** | `@grantex/langchain` | LangChain tools that wrap Grantex operations -- use them as agent tools in any LangChain pipeline. |
+| **Vercel AI** | `@grantex/vercel-ai` | Vercel AI SDK tools for building authorized AI chatbots and assistants. |
+| **AutoGen** | `@grantex/autogen` | AutoGen function tools for multi-agent conversations with scoped authorization. |
+| **CrewAI** | `grantex-crewai` | CrewAI tools that let crew agents request and verify grants. |
+| **OpenAI Agents SDK** | `grantex-openai-agents` | Python tools for the OpenAI Agents SDK with built-in authorization. |
+| **Google ADK** | `grantex-adk` | Google Agent Development Kit tools for authorized agent actions. |
+
+Each integration ships with its own documentation page and a runnable example in the `examples/` directory.
+
+[Integrations overview](/integrations/overview)
+
+## MCP Server (`@grantex/mcp`)
+
+The MCP server exposes 13 Grantex tools as an MCP (Model Context Protocol) service. Point Claude Desktop, Cursor, Windsurf, or any MCP-compatible client at it and your AI assistant can manage agents, grants, and tokens through natural language.
+
+```bash
+npx @grantex/mcp
+```
+
+[MCP server docs](/integrations/mcp)
+
+## CLI (`@grantex/cli`)
+
+The Grantex CLI gives you full control from your terminal. Register agents, initiate authorization flows, exchange tokens, query audit logs, manage policies -- everything the SDKs can do, the CLI can do.
+
+```bash
+npx @grantex/cli agents list
+npx @grantex/cli tokens verify <token>
+npx @grantex/cli audit entries --agentId <id>
+```
+
+[CLI docs](/integrations/cli)
+
+## Developer Portal
+
+The developer portal at [grantex.dev/dashboard](https://grantex.dev/dashboard) provides a web UI for managing your Grantex account. View registered agents, browse active grants, inspect audit logs, and configure policies -- all without writing code.
+
+## Enterprise Features
+
+Grantex v0.1 includes a full suite of enterprise capabilities, available out of the box:
+
+- **Policy Engine** -- define JSON-based authorization policies that are evaluated on every grant request. Restrict by scope, time window, IP range, or custom attributes. ([Policies docs](/sdks/typescript/policies))
+
+- **Anomaly Detection** -- automated analysis of agent behavior patterns. Flags unusual activity like scope escalation, off-hours access, or velocity spikes. ([Anomalies docs](/sdks/typescript/anomalies))
+
+- **SCIM Provisioning** -- sync users and groups from your identity provider (Okta, Azure AD, OneLogin) to Grantex. ([SCIM docs](/sdks/typescript/scim))
+
+- **SSO** -- SAML and OIDC single sign-on for the developer portal. ([SSO docs](/sdks/typescript/sso))
+
+- **Compliance Exports** -- generate audit reports in formats that satisfy SOC 2, ISO 27001, and EU AI Act requirements. ([Compliance docs](/sdks/typescript/compliance))
+
+- **Billing** -- Stripe-backed usage metering and plan management with automatic enforcement of plan limits. ([Billing docs](/sdks/typescript/billing))
+
+## Auth Service
+
+The auth service is a production-ready Fastify server backed by PostgreSQL and Redis. It handles authorization flows, token issuance and verification, webhook delivery with retry, rate limiting, and PKCE (S256). It deploys to Cloud Run and is the reference implementation of the Grantex protocol.
+
+[Self-hosting guide](/guides/self-hosting)
+
+## What's Next
+
+This is v0.1, not v1.0. We are actively working on:
+
+- Additional framework integrations based on community demand
+- Expanded policy engine with OPA (Open Policy Agent) support
+- SDK support for more languages (Go, Java, Rust)
+- Hosted multi-tenant service for teams that do not want to self-host
+
+Star the repo, try the [quickstart](/quickstart), and let us know what you would like to see next on [GitHub](https://github.com/mishrasanjeev/grantex).

--- a/docs/blog/introducing-grantex.mdx
+++ b/docs/blog/introducing-grantex.mdx
@@ -1,0 +1,79 @@
+---
+title: "Introducing Grantex: OAuth 2.0 for AI Agents"
+description: "Grantex is an open delegated authorization protocol that brings human-approved, scoped, revocable permissions to AI agents."
+date: "2026-02-28"
+authors:
+  - name: "Sanjeev Mishra"
+---
+
+AI agents are shipping fast. They book flights, send emails, move money, and deploy code. But here is the uncomfortable truth: most of them operate with all-or-nothing API keys and zero audit trail. If an agent goes rogue, you find out after the damage is done.
+
+We built Grantex to fix that.
+
+## The Problem
+
+OAuth 2.0 was designed for human users clicking "Allow" on a consent screen. It works brilliantly for that. But agents are not humans. They operate autonomously, spawn sub-agents, and chain actions across services. OAuth was never designed for:
+
+- **Agent identity** -- agents need their own cryptographic identity, not borrowed user credentials.
+- **Delegation chains** -- a parent agent granting a sub-agent a narrower set of permissions.
+- **Action-level auditing** -- knowing exactly what an agent did, not just that it authenticated.
+- **Real-time revocation** -- killing a misbehaving agent's access in milliseconds, not minutes.
+
+## The Solution
+
+Grantex is an open protocol (Apache 2.0) that provides all of the above. Every agent gets a DID-based identity. Every permission is a scoped, time-limited grant token (JWT) that a human explicitly approved. Every action is logged in an append-only, hash-chained audit trail. And any grant can be revoked instantly.
+
+Here is what the flow looks like in TypeScript:
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+
+const gx = new Grantex({
+  apiKey: process.env.GRANTEX_API_KEY,
+  baseUrl: 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app',
+});
+
+// 1. Register an agent
+const agent = await gx.agents.create({
+  name: 'travel-booking-agent',
+  description: 'Books flights and hotels for users',
+});
+
+// 2. Request authorization from a user
+const auth = await gx.authorize({
+  agentId: agent.id,
+  userId: 'user_alice',
+  scopes: ['flights:book', 'hotels:search'],
+  callbackUrl: 'https://app.example.com/callback',
+});
+// → redirect user to auth.consentUrl
+
+// 3. Exchange the authorization code for a grant token
+const token = await gx.tokens.exchange({
+  code: callbackCode,
+  agentId: agent.id,
+});
+
+// 4. Verify the token before acting
+const result = await gx.tokens.verify(token.grantToken);
+console.log(result.scopes); // ['flights:book', 'hotels:search']
+```
+
+The same flow works in Python, and across every integration we ship.
+
+## What Ships Today
+
+- **Protocol spec v1.0** (final) -- the full specification is public and frozen.
+- **TypeScript SDK** (`@grantex/sdk`) and **Python SDK** (`grantex`) -- production-ready.
+- **7 framework integrations** -- LangChain, AutoGen, CrewAI, Vercel AI, OpenAI Agents SDK, Google ADK, and an MCP server for Claude Desktop.
+- **CLI** (`@grantex/cli`) -- manage agents, grants, and tokens from your terminal.
+- **Enterprise features** -- policy engine, SCIM/SSO, anomaly detection, compliance exports, and Stripe billing.
+
+## Get Started
+
+- [Quickstart guide](/quickstart) -- up and running in under 5 minutes.
+- [GitHub repository](https://github.com/mishrasanjeev/grantex) -- star, fork, contribute.
+- [Protocol specification](/protocol/specification) -- read the full spec.
+- [grantex.dev](https://grantex.dev) -- project homepage.
+
+We believe that as agents become more capable, proper authorization becomes more critical, not less. Grantex is our answer to that challenge.

--- a/docs/blog/why-ai-agents-need-authorization.mdx
+++ b/docs/blog/why-ai-agents-need-authorization.mdx
@@ -1,0 +1,64 @@
+---
+title: "Why AI Agents Need Their Own Authorization Protocol"
+description: "OAuth 2.0 was built for human users. AI agents have fundamentally different requirements -- here's why they need a purpose-built protocol."
+date: "2026-02-28"
+authors:
+  - name: "Sanjeev Mishra"
+---
+
+Every time you click "Sign in with Google" or grant an app access to your calendar, OAuth 2.0 is doing the work. It has been the backbone of delegated authorization for over a decade. So why can't we just use it for AI agents?
+
+The short answer: agents are not apps.
+
+## The Four Gaps
+
+### 1. Agent Identity vs. App Identity
+
+OAuth issues tokens to registered applications. An app has a `client_id`, a redirect URI, and a set of scopes. This model assumes a fixed, known piece of software.
+
+AI agents are different. A single orchestrator might spawn dozens of sub-agents at runtime, each with a different purpose. These agents need their own cryptographic identity -- not a shared `client_id`. Grantex assigns each agent a DID (Decentralized Identifier) backed by a key pair. The agent's identity is verifiable, rotatable, and independent of the platform it runs on.
+
+### 2. Scope Delegation Chains
+
+OAuth supports a flat model: a user grants scopes to an app, and that is the end of the story. But agents delegate work to other agents. A "research assistant" agent might call a "web search" sub-agent and a "summarizer" sub-agent, each of which should only get the scopes it actually needs.
+
+Grantex models this explicitly. When a parent agent delegates to a child, the child's grant token carries `parentAgt`, `parentGrnt`, and `delegationDepth` claims. The child's scopes must be a strict subset of the parent's. This is not a convention -- it is enforced at the protocol level.
+
+```
+Root user grants: [files:read, files:write, email:send]
+  └─ Parent agent:  [files:read, files:write]  (delegationDepth: 0)
+       └─ Child agent:  [files:read]            (delegationDepth: 1)
+```
+
+If the parent's grant is revoked, every child grant in the chain is automatically invalidated.
+
+### 3. Real-Time Revocation
+
+OAuth token revocation is defined in RFC 7009, but it is advisory. Resource servers are free to keep accepting a token until it expires. For a 1-hour access token, that is a 1-hour window of exposure.
+
+With agents performing high-stakes actions autonomously, you cannot afford that window. Grantex supports both offline verification (fast JWT validation) and online verification (`POST /v1/tokens/verify`) that checks revocation state in real time. When you revoke a grant, the very next verification call returns `valid: false`.
+
+### 4. Action-Level Audit Trails
+
+OAuth gives you an access log at the authorization server. You know when a token was issued and when it was refreshed. You do not know what happened next.
+
+Grantex includes a first-class audit subsystem. Every action an agent performs can be logged via `POST /v1/audit/log`, and the entries are append-only and hash-chained -- each entry references the hash of the previous one, making tampering detectable. You can query the full trail with `GET /v1/audit/entries` filtered by agent, grant, principal, or time range.
+
+## The Compliance Dimension
+
+This is not just a technical nicety. The EU AI Act (effective August 2025) requires that high-risk AI systems maintain logs of their operation, support human oversight, and provide transparency about their decision-making. Grantex's audit trail, scoped grants, and real-time revocation map directly onto these requirements.
+
+Similarly, SOC 2 auditors want to see evidence that access is scoped, time-limited, and revocable. Grant tokens with explicit `exp`, `scp`, and revocation support provide that evidence out of the box.
+
+## Why Not Extend OAuth?
+
+We considered it. The problem is that the primitives do not exist. OAuth has no concept of agent identity, delegation depth, or hash-chained audit logs. Bolting these onto OAuth would mean a constellation of non-standard extensions that no existing library supports.
+
+Grantex is a clean-sheet protocol that speaks the same language as OAuth where it makes sense (JWTs, JWKs, RS256, scopes, authorization codes) but adds the agent-specific primitives as first-class concepts. If you know OAuth, Grantex will feel familiar. But it will also handle the cases OAuth was never designed for.
+
+## Learn More
+
+- [How Grantex Works](/concepts/how-it-works) -- visual walkthrough of the authorization flow.
+- [Delegation Deep Dive](/concepts/delegation) -- how multi-agent delegation works.
+- [Protocol Specification](/protocol/specification) -- the full v1.0 spec.
+- [Quickstart](/quickstart) -- get a working integration in under 5 minutes.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -19,7 +19,8 @@
         { "tab": "TypeScript SDK", "href": "/sdks/typescript/overview" },
         { "tab": "Python SDK", "href": "/sdks/python/overview" },
         { "tab": "Integrations", "href": "/integrations/overview" },
-        { "tab": "Protocol", "href": "/protocol/specification" }
+        { "tab": "Protocol", "href": "/protocol/specification" },
+        { "tab": "Blog", "href": "/blog" }
       ]
     },
     "tabs": [
@@ -203,6 +204,10 @@
         ]
       }
     ]
+  },
+  "blog": {
+    "enabled": true,
+    "path": "blog"
   },
   "navbar": {
     "links": [


### PR DESCRIPTION
## Summary
- Add Mintlify blog configuration to `docs.json` (enabled blog + Blog nav tab)
- Add 3 launch blog posts:
  - **Introducing Grantex** — problem, solution, quick code demo
  - **Why AI Agents Need Authorization** — technical deep-dive, OAuth 2.0 comparison
  - **Grantex v0.1: What's Included** — tour of all packages and enterprise features

## Test plan
- [ ] Verify `docs.json` is valid JSON and Mintlify deploys without errors
- [ ] Verify `/blog` page renders with all 3 posts
- [ ] Verify each blog post renders correctly with proper frontmatter
- [ ] Verify Blog tab appears in the global navigation bar