### PR TITLE
fix: blog pages 404 — register as Mintlify navigation pages

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -22,7 +22,7 @@
         { "tab": "Integrations", "href": "/integrations/overview" },
         { "tab": "API Reference", "href": "/api-reference" },
         { "tab": "Protocol", "href": "/protocol/specification" },
-        { "tab": "Blog", "href": "/blog" }
+        { "tab": "Blog", "href": "/blog/introducing-grantex" }
       ]
     },
     "tabs": [
@@ -354,12 +354,21 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "Blog",
+        "groups": [
+          {
+            "group": "Posts",
+            "pages": [
+              "blog/introducing-grantex",
+              "blog/why-ai-agents-need-authorization",
+              "blog/grantex-v0-1-whats-included"
+            ]
+          }
+        ]
       }
     ]
-  },
-  "blog": {
-    "enabled": true,
-    "path": "blog"
   },
   "navbar": {
     "links": [


### PR DESCRIPTION
## Summary
- Remove invalid `"blog": { "enabled": true, "path": "blog" }` config (not a real Mintlify feature)
- Add Blog tab to `navigation.tabs` with the 3 posts as regular pages
- Fix Blog tab href to point to `/blog/introducing-grantex` (first post)

## Problem
`/blog` returned 404 because Mintlify has no native blog feature. The blog config was silently ignored and the `.mdx` files in `docs/blog/` were never registered as navigable pages.

## Test plan
- [ ] Verify Blog tab appears in nav bar after Mintlify deploys
- [ ] Verify all 3 blog posts render at their URLs