### PR TITLE
fix: API Reference endpoint pages 404 — use OpenAPI method+path format

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,7 +12,6 @@
     "light": "#58a6ff",
     "dark": "#2ea043"
   },
-  "openapi": "openapi.yaml",
   "navigation": {
     "global": {
       "tabs": [
@@ -180,6 +179,7 @@
       },
       {
         "tab": "API Reference",
+        "openapi": "openapi.yaml",
         "groups": [
           {
             "group": "Overview",
@@ -190,140 +190,140 @@
           {
             "group": "System",
             "pages": [
-              "api-reference/system/get-health",
-              "api-reference/system/get-jwks",
-              "api-reference/system/get-dashboard",
-              "api-reference/system/get-principal-dashboard"
+              "GET /health",
+              "GET /.well-known/jwks.json",
+              "GET /dashboard",
+              "GET /dashboard/principal"
             ]
           },
           {
             "group": "Authentication",
             "pages": [
-              "api-reference/authentication/signup",
-              "api-reference/authentication/get-me",
-              "api-reference/authentication/rotate-api-key"
+              "POST /v1/signup",
+              "GET /v1/me",
+              "POST /v1/keys/rotate"
             ]
           },
           {
             "group": "Agents",
             "pages": [
-              "api-reference/agents/register-agent",
-              "api-reference/agents/list-agents",
-              "api-reference/agents/get-agent",
-              "api-reference/agents/update-agent",
-              "api-reference/agents/delete-agent"
+              "POST /v1/agents",
+              "GET /v1/agents",
+              "GET /v1/agents/{id}",
+              "PATCH /v1/agents/{id}",
+              "DELETE /v1/agents/{id}"
             ]
           },
           {
             "group": "Authorization",
             "pages": [
-              "api-reference/authorization/create-authorization-request",
-              "api-reference/authorization/approve-authorization-request",
-              "api-reference/authorization/deny-authorization-request"
+              "POST /v1/authorize",
+              "POST /v1/authorize/{id}/approve",
+              "POST /v1/authorize/{id}/deny"
             ]
           },
           {
             "group": "Tokens",
             "pages": [
-              "api-reference/tokens/exchange-token",
-              "api-reference/tokens/verify-token",
-              "api-reference/tokens/revoke-token"
+              "POST /v1/token",
+              "POST /v1/tokens/verify",
+              "POST /v1/tokens/revoke"
             ]
           },
           {
             "group": "Grants",
             "pages": [
-              "api-reference/grants/list-grants",
-              "api-reference/grants/get-grant",
-              "api-reference/grants/revoke-grant",
-              "api-reference/grants/verify-grant",
-              "api-reference/grants/delegate-grant"
+              "GET /v1/grants",
+              "GET /v1/grants/{id}",
+              "DELETE /v1/grants/{id}",
+              "POST /v1/grants/verify",
+              "POST /v1/grants/delegate"
             ]
           },
           {
             "group": "Audit",
             "pages": [
-              "api-reference/audit/create-audit-entry",
-              "api-reference/audit/list-audit-entries",
-              "api-reference/audit/get-audit-entry"
+              "POST /v1/audit/log",
+              "GET /v1/audit/entries",
+              "GET /v1/audit/{id}"
             ]
           },
           {
             "group": "Policies",
             "pages": [
-              "api-reference/policies/create-policy",
-              "api-reference/policies/list-policies",
-              "api-reference/policies/get-policy",
-              "api-reference/policies/update-policy",
-              "api-reference/policies/delete-policy"
+              "POST /v1/policies",
+              "GET /v1/policies",
+              "GET /v1/policies/{id}",
+              "PATCH /v1/policies/{id}",
+              "DELETE /v1/policies/{id}"
             ]
           },
           {
             "group": "Webhooks",
             "pages": [
-              "api-reference/webhooks/create-webhook",
-              "api-reference/webhooks/list-webhooks",
-              "api-reference/webhooks/delete-webhook"
+              "POST /v1/webhooks",
+              "GET /v1/webhooks",
+              "DELETE /v1/webhooks/{id}"
             ]
           },
           {
             "group": "Billing",
             "pages": [
-              "api-reference/billing/get-subscription",
-              "api-reference/billing/create-checkout-session",
-              "api-reference/billing/create-billing-portal",
-              "api-reference/billing/handle-stripe-webhook"
+              "GET /v1/billing/subscription",
+              "POST /v1/billing/checkout",
+              "POST /v1/billing/portal",
+              "POST /v1/billing/webhook"
             ]
           },
           {
             "group": "Anomalies",
             "pages": [
-              "api-reference/anomalies/detect-anomalies",
-              "api-reference/anomalies/list-anomalies",
-              "api-reference/anomalies/acknowledge-anomaly"
+              "POST /v1/anomalies/detect",
+              "GET /v1/anomalies",
+              "PATCH /v1/anomalies/{id}/acknowledge"
             ]
           },
           {
             "group": "Compliance",
             "pages": [
-              "api-reference/compliance/get-compliance-summary",
-              "api-reference/compliance/export-grants",
-              "api-reference/compliance/export-audit-entries",
-              "api-reference/compliance/get-evidence-pack"
+              "GET /v1/compliance/summary",
+              "GET /v1/compliance/export/grants",
+              "GET /v1/compliance/export/audit",
+              "GET /v1/compliance/evidence-pack"
             ]
           },
           {
             "group": "SCIM",
             "pages": [
-              "api-reference/scim/create-scim-token",
-              "api-reference/scim/list-scim-tokens",
-              "api-reference/scim/delete-scim-token",
-              "api-reference/scim/get-scim-service-provider-config",
-              "api-reference/scim/list-scim-users",
-              "api-reference/scim/create-scim-user",
-              "api-reference/scim/get-scim-user",
-              "api-reference/scim/replace-scim-user",
-              "api-reference/scim/update-scim-user",
-              "api-reference/scim/delete-scim-user"
+              "POST /v1/scim/tokens",
+              "GET /v1/scim/tokens",
+              "DELETE /v1/scim/tokens/{id}",
+              "GET /scim/v2/ServiceProviderConfig",
+              "GET /scim/v2/Users",
+              "POST /scim/v2/Users",
+              "GET /scim/v2/Users/{id}",
+              "PUT /scim/v2/Users/{id}",
+              "PATCH /scim/v2/Users/{id}",
+              "DELETE /scim/v2/Users/{id}"
             ]
           },
           {
             "group": "SSO",
             "pages": [
-              "api-reference/sso/create-sso-config",
-              "api-reference/sso/get-sso-config",
-              "api-reference/sso/delete-sso-config",
-              "api-reference/sso/sso-login",
-              "api-reference/sso/sso-callback"
+              "POST /v1/sso/config",
+              "GET /v1/sso/config",
+              "DELETE /v1/sso/config",
+              "GET /sso/login",
+              "GET /sso/callback"
             ]
           },
           {
             "group": "Consent",
             "pages": [
-              "api-reference/consent/get-consent-page",
-              "api-reference/consent/get-consent-details",
-              "api-reference/consent/approve-consent",
-              "api-reference/consent/deny-consent"
+              "GET /consent",
+              "GET /v1/consent/{id}",
+              "POST /v1/consent/{id}/approve",
+              "POST /v1/consent/{id}/deny"
             ]
           }
         ]


### PR DESCRIPTION
## Summary
- Move `openapi` config from top-level to the API Reference tab level
- Replace custom slug page references (e.g. `api-reference/agents/register-agent`) with Mintlify's required `"METHOD /path"` format (e.g. `"POST /v1/agents"`)
- Mintlify auto-generates endpoint pages from the OpenAPI spec when pages use this format

## Problem
All auto-generated API endpoint pages returned 404 because Mintlify expects `"POST /v1/agents"` format in the pages array, not custom file paths.

## Test plan
- [ ] After Mintlify deploys, verify API Reference tab shows all endpoint groups
- [ ] Verify individual endpoints like `POST /v1/agents` render with request/response schemas
- [ ] Verify the API playground "try it" functionality works