### PR TITLE
fix: generate MDX endpoint pages from OpenAPI via Mintlify scraper

### DIFF
--- a/docs/api-reference/agents/delete-an-agent.mdx
+++ b/docs/api-reference/agents/delete-an-agent.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/agents/{id}
+---

--- a/docs/api-reference/agents/get-agent-by-id.mdx
+++ b/docs/api-reference/agents/get-agent-by-id.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/agents/{id}
+---

--- a/docs/api-reference/agents/list-all-agents.mdx
+++ b/docs/api-reference/agents/list-all-agents.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/agents
+---

--- a/docs/api-reference/agents/register-a-new-agent.mdx
+++ b/docs/api-reference/agents/register-a-new-agent.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/agents
+---

--- a/docs/api-reference/agents/update-an-agent.mdx
+++ b/docs/api-reference/agents/update-an-agent.mdx
@@ -1,0 +1,3 @@
+---
+openapi: patch /v1/agents/{id}
+---

--- a/docs/api-reference/anomalies/acknowledge-an-anomaly.mdx
+++ b/docs/api-reference/anomalies/acknowledge-an-anomaly.mdx
@@ -1,0 +1,3 @@
+---
+openapi: patch /v1/anomalies/{id}/acknowledge
+---

--- a/docs/api-reference/anomalies/list-detected-anomalies.mdx
+++ b/docs/api-reference/anomalies/list-detected-anomalies.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/anomalies
+---

--- a/docs/api-reference/anomalies/run-anomaly-detection.mdx
+++ b/docs/api-reference/anomalies/run-anomaly-detection.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/anomalies/detect
+---

--- a/docs/api-reference/audit/get-audit-entry-by-id.mdx
+++ b/docs/api-reference/audit/get-audit-entry-by-id.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/audit/{id}
+---

--- a/docs/api-reference/audit/list-audit-entries.mdx
+++ b/docs/api-reference/audit/list-audit-entries.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/audit/entries
+---

--- a/docs/api-reference/audit/log-an-audit-entry.mdx
+++ b/docs/api-reference/audit/log-an-audit-entry.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/audit/log
+---

--- a/docs/api-reference/authentication/get-current-developer-profile.mdx
+++ b/docs/api-reference/authentication/get-current-developer-profile.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/me
+---

--- a/docs/api-reference/authentication/register-a-new-developer-account.mdx
+++ b/docs/api-reference/authentication/register-a-new-developer-account.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/signup
+---

--- a/docs/api-reference/authentication/rotate-api-key.mdx
+++ b/docs/api-reference/authentication/rotate-api-key.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/keys/rotate
+---

--- a/docs/api-reference/authorization/approve-an-authorization-request.mdx
+++ b/docs/api-reference/authorization/approve-an-authorization-request.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/authorize/{id}/approve
+---

--- a/docs/api-reference/authorization/create-an-authorization-request.mdx
+++ b/docs/api-reference/authorization/create-an-authorization-request.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/authorize
+---

--- a/docs/api-reference/authorization/deny-an-authorization-request.mdx
+++ b/docs/api-reference/authorization/deny-an-authorization-request.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/authorize/{id}/deny
+---

--- a/docs/api-reference/billing/create-a-stripe-billing-portal-session.mdx
+++ b/docs/api-reference/billing/create-a-stripe-billing-portal-session.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/billing/portal
+---

--- a/docs/api-reference/billing/create-a-stripe-checkout-session.mdx
+++ b/docs/api-reference/billing/create-a-stripe-checkout-session.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/billing/checkout
+---

--- a/docs/api-reference/billing/get-current-subscription.mdx
+++ b/docs/api-reference/billing/get-current-subscription.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/billing/subscription
+---

--- a/docs/api-reference/billing/stripe-webhook-handler.mdx
+++ b/docs/api-reference/billing/stripe-webhook-handler.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/billing/webhook
+---

--- a/docs/api-reference/compliance/export-audit-entries-for-compliance.mdx
+++ b/docs/api-reference/compliance/export-audit-entries-for-compliance.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/compliance/export/audit
+---

--- a/docs/api-reference/compliance/export-grants-for-compliance.mdx
+++ b/docs/api-reference/compliance/export-grants-for-compliance.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/compliance/export/grants
+---

--- a/docs/api-reference/compliance/generate-compliance-evidence-pack.mdx
+++ b/docs/api-reference/compliance/generate-compliance-evidence-pack.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/compliance/evidence-pack
+---

--- a/docs/api-reference/compliance/get-compliance-summary.mdx
+++ b/docs/api-reference/compliance/get-compliance-summary.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/compliance/summary
+---

--- a/docs/api-reference/consent/approve-consent-end-user-action.mdx
+++ b/docs/api-reference/consent/approve-consent-end-user-action.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/consent/{id}/approve
+---

--- a/docs/api-reference/consent/consent-ui-page.mdx
+++ b/docs/api-reference/consent/consent-ui-page.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /consent
+---

--- a/docs/api-reference/consent/deny-consent-end-user-action.mdx
+++ b/docs/api-reference/consent/deny-consent-end-user-action.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/consent/{id}/deny
+---

--- a/docs/api-reference/consent/get-consent-request-details.mdx
+++ b/docs/api-reference/consent/get-consent-request-details.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/consent/{id}
+---

--- a/docs/api-reference/grants/delegate-a-grant-to-a-sub-agent.mdx
+++ b/docs/api-reference/grants/delegate-a-grant-to-a-sub-agent.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/grants/delegate
+---

--- a/docs/api-reference/grants/get-grant-by-id.mdx
+++ b/docs/api-reference/grants/get-grant-by-id.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/grants/{id}
+---

--- a/docs/api-reference/grants/list-grants.mdx
+++ b/docs/api-reference/grants/list-grants.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/grants
+---

--- a/docs/api-reference/grants/revoke-a-grant.mdx
+++ b/docs/api-reference/grants/revoke-a-grant.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/grants/{id}
+---

--- a/docs/api-reference/grants/verify-a-grant-tokens-revocation-status.mdx
+++ b/docs/api-reference/grants/verify-a-grant-tokens-revocation-status.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/grants/verify
+---

--- a/docs/api-reference/policies/create-an-access-policy.mdx
+++ b/docs/api-reference/policies/create-an-access-policy.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/policies
+---

--- a/docs/api-reference/policies/delete-a-policy.mdx
+++ b/docs/api-reference/policies/delete-a-policy.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/policies/{id}
+---

--- a/docs/api-reference/policies/get-policy-by-id.mdx
+++ b/docs/api-reference/policies/get-policy-by-id.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/policies/{id}
+---

--- a/docs/api-reference/policies/list-access-policies.mdx
+++ b/docs/api-reference/policies/list-access-policies.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/policies
+---

--- a/docs/api-reference/policies/update-a-policy.mdx
+++ b/docs/api-reference/policies/update-a-policy.mdx
@@ -1,0 +1,3 @@
+---
+openapi: patch /v1/policies/{id}
+---

--- a/docs/api-reference/scim/create-a-scim-provisioning-token.mdx
+++ b/docs/api-reference/scim/create-a-scim-provisioning-token.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/scim/tokens
+---

--- a/docs/api-reference/scim/create-a-scim-user.mdx
+++ b/docs/api-reference/scim/create-a-scim-user.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /scim/v2/Users
+---

--- a/docs/api-reference/scim/delete-a-scim-token.mdx
+++ b/docs/api-reference/scim/delete-a-scim-token.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/scim/tokens/{id}
+---

--- a/docs/api-reference/scim/delete-a-scim-user.mdx
+++ b/docs/api-reference/scim/delete-a-scim-user.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /scim/v2/Users/{id}
+---

--- a/docs/api-reference/scim/get-scim-user-by-id.mdx
+++ b/docs/api-reference/scim/get-scim-user-by-id.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /scim/v2/Users/{id}
+---

--- a/docs/api-reference/scim/list-scim-tokens.mdx
+++ b/docs/api-reference/scim/list-scim-tokens.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/scim/tokens
+---

--- a/docs/api-reference/scim/list-scim-users.mdx
+++ b/docs/api-reference/scim/list-scim-users.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /scim/v2/Users
+---

--- a/docs/api-reference/scim/patch-a-scim-user.mdx
+++ b/docs/api-reference/scim/patch-a-scim-user.mdx
@@ -1,0 +1,3 @@
+---
+openapi: patch /scim/v2/Users/{id}
+---

--- a/docs/api-reference/scim/replace-a-scim-user.mdx
+++ b/docs/api-reference/scim/replace-a-scim-user.mdx
@@ -1,0 +1,3 @@
+---
+openapi: put /scim/v2/Users/{id}
+---

--- a/docs/api-reference/scim/scim-service-provider-configuration.mdx
+++ b/docs/api-reference/scim/scim-service-provider-configuration.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /scim/v2/ServiceProviderConfig
+---

--- a/docs/api-reference/sso/configure-oidc-sso.mdx
+++ b/docs/api-reference/sso/configure-oidc-sso.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/sso/config
+---

--- a/docs/api-reference/sso/get-sso-configuration.mdx
+++ b/docs/api-reference/sso/get-sso-configuration.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/sso/config
+---

--- a/docs/api-reference/sso/initiate-sso-login.mdx
+++ b/docs/api-reference/sso/initiate-sso-login.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /sso/login
+---

--- a/docs/api-reference/sso/remove-sso-configuration.mdx
+++ b/docs/api-reference/sso/remove-sso-configuration.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/sso/config
+---

--- a/docs/api-reference/sso/sso-callback.mdx
+++ b/docs/api-reference/sso/sso-callback.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /sso/callback
+---

--- a/docs/api-reference/system/developer-dashboard.mdx
+++ b/docs/api-reference/system/developer-dashboard.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /dashboard
+---

--- a/docs/api-reference/system/health-check.mdx
+++ b/docs/api-reference/system/health-check.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /health
+---

--- a/docs/api-reference/system/json-web-key-set.mdx
+++ b/docs/api-reference/system/json-web-key-set.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /.well-known/jwks.json
+---

--- a/docs/api-reference/system/principal-permissions-dashboard.mdx
+++ b/docs/api-reference/system/principal-permissions-dashboard.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /dashboard/principal
+---

--- a/docs/api-reference/tokens/exchange-authorization-code-for-grant-token.mdx
+++ b/docs/api-reference/tokens/exchange-authorization-code-for-grant-token.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/token
+---

--- a/docs/api-reference/tokens/revoke-a-grant-token.mdx
+++ b/docs/api-reference/tokens/revoke-a-grant-token.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/tokens/revoke
+---

--- a/docs/api-reference/tokens/verify-a-grant-token-online.mdx
+++ b/docs/api-reference/tokens/verify-a-grant-token-online.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/tokens/verify
+---

--- a/docs/api-reference/webhooks/delete-a-webhook.mdx
+++ b/docs/api-reference/webhooks/delete-a-webhook.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/webhooks/{id}
+---

--- a/docs/api-reference/webhooks/list-webhooks.mdx
+++ b/docs/api-reference/webhooks/list-webhooks.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/webhooks
+---

--- a/docs/api-reference/webhooks/register-a-webhook.mdx
+++ b/docs/api-reference/webhooks/register-a-webhook.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/webhooks
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,6 +12,7 @@
     "light": "#58a6ff",
     "dark": "#2ea043"
   },
+  "openapi": "openapi.yaml",
   "navigation": {
     "global": {
       "tabs": [
@@ -48,7 +49,6 @@
           {
             "group": "Guides",
             "pages": [
-              "api-reference/introduction",
               "guides/webhooks",
               "guides/self-hosting"
             ]
@@ -180,7 +180,153 @@
       },
       {
         "tab": "API Reference",
-        "openapi": "openapi.yaml"
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "api-reference/introduction"
+            ]
+          },
+          {
+            "group": "System",
+            "pages": [
+              "api-reference/system/health-check",
+              "api-reference/system/json-web-key-set",
+              "api-reference/system/developer-dashboard",
+              "api-reference/system/principal-permissions-dashboard"
+            ]
+          },
+          {
+            "group": "Authentication",
+            "pages": [
+              "api-reference/authentication/register-a-new-developer-account",
+              "api-reference/authentication/get-current-developer-profile",
+              "api-reference/authentication/rotate-api-key"
+            ]
+          },
+          {
+            "group": "Agents",
+            "pages": [
+              "api-reference/agents/register-a-new-agent",
+              "api-reference/agents/list-all-agents",
+              "api-reference/agents/get-agent-by-id",
+              "api-reference/agents/update-an-agent",
+              "api-reference/agents/delete-an-agent"
+            ]
+          },
+          {
+            "group": "Authorization",
+            "pages": [
+              "api-reference/authorization/create-an-authorization-request",
+              "api-reference/authorization/approve-an-authorization-request",
+              "api-reference/authorization/deny-an-authorization-request"
+            ]
+          },
+          {
+            "group": "Tokens",
+            "pages": [
+              "api-reference/tokens/exchange-authorization-code-for-grant-token",
+              "api-reference/tokens/verify-a-grant-token-online",
+              "api-reference/tokens/revoke-a-grant-token"
+            ]
+          },
+          {
+            "group": "Grants",
+            "pages": [
+              "api-reference/grants/list-grants",
+              "api-reference/grants/get-grant-by-id",
+              "api-reference/grants/revoke-a-grant",
+              "api-reference/grants/verify-a-grant-tokens-revocation-status",
+              "api-reference/grants/delegate-a-grant-to-a-sub-agent"
+            ]
+          },
+          {
+            "group": "Audit",
+            "pages": [
+              "api-reference/audit/log-an-audit-entry",
+              "api-reference/audit/list-audit-entries",
+              "api-reference/audit/get-audit-entry-by-id"
+            ]
+          },
+          {
+            "group": "Policies",
+            "pages": [
+              "api-reference/policies/create-an-access-policy",
+              "api-reference/policies/list-access-policies",
+              "api-reference/policies/get-policy-by-id",
+              "api-reference/policies/update-a-policy",
+              "api-reference/policies/delete-a-policy"
+            ]
+          },
+          {
+            "group": "Webhooks",
+            "pages": [
+              "api-reference/webhooks/register-a-webhook",
+              "api-reference/webhooks/list-webhooks",
+              "api-reference/webhooks/delete-a-webhook"
+            ]
+          },
+          {
+            "group": "Billing",
+            "pages": [
+              "api-reference/billing/get-current-subscription",
+              "api-reference/billing/create-a-stripe-checkout-session",
+              "api-reference/billing/create-a-stripe-billing-portal-session",
+              "api-reference/billing/stripe-webhook-handler"
+            ]
+          },
+          {
+            "group": "Anomalies",
+            "pages": [
+              "api-reference/anomalies/run-anomaly-detection",
+              "api-reference/anomalies/list-detected-anomalies",
+              "api-reference/anomalies/acknowledge-an-anomaly"
+            ]
+          },
+          {
+            "group": "Compliance",
+            "pages": [
+              "api-reference/compliance/get-compliance-summary",
+              "api-reference/compliance/export-grants-for-compliance",
+              "api-reference/compliance/export-audit-entries-for-compliance",
+              "api-reference/compliance/generate-compliance-evidence-pack"
+            ]
+          },
+          {
+            "group": "SCIM",
+            "pages": [
+              "api-reference/scim/create-a-scim-provisioning-token",
+              "api-reference/scim/list-scim-tokens",
+              "api-reference/scim/delete-a-scim-token",
+              "api-reference/scim/scim-service-provider-configuration",
+              "api-reference/scim/list-scim-users",
+              "api-reference/scim/create-a-scim-user",
+              "api-reference/scim/get-scim-user-by-id",
+              "api-reference/scim/replace-a-scim-user",
+              "api-reference/scim/patch-a-scim-user",
+              "api-reference/scim/delete-a-scim-user"
+            ]
+          },
+          {
+            "group": "SSO",
+            "pages": [
+              "api-reference/sso/configure-oidc-sso",
+              "api-reference/sso/get-sso-configuration",
+              "api-reference/sso/remove-sso-configuration",
+              "api-reference/sso/initiate-sso-login",
+              "api-reference/sso/sso-callback"
+            ]
+          },
+          {
+            "group": "Consent",
+            "pages": [
+              "api-reference/consent/consent-ui-page",
+              "api-reference/consent/get-consent-request-details",
+              "api-reference/consent/approve-consent-end-user-action",
+              "api-reference/consent/deny-consent-end-user-action"
+            ]
+          }
+        ]
       },
       {
         "tab": "Protocol",


### PR DESCRIPTION
## Summary
- Use `@mintlify/scraping` CLI to generate 56 individual MDX endpoint files from `openapi.yaml`
- Each MDX file has `openapi: method /path` frontmatter that Mintlify resolves against the spec
- Add top-level `"openapi": "openapi.yaml"` to `docs.json` so the MDX files can reference the spec
- Update API Reference tab navigation with the generated page paths grouped by tag

## Problem
Previous attempts used Mintlify's declarative `openapi` tab feature which didn't generate pages. The correct approach is individual MDX files created by the official scraper tool.

## Test plan
- [ ] After Mintlify deploys, verify API Reference tab shows all 16 endpoint groups in the sidebar
- [ ] Verify individual endpoints render with request/response schemas and interactive playground
- [ ] Spot-check: `POST /v1/agents`, `POST /v1/token`, `GET /v1/grants`