### PR TITLE
chore: add discovery links and ecosystem sections to all SDK READMEs

### DIFF
--- a/DEVTO_ARTICLE.md
+++ b/DEVTO_ARTICLE.md
@@ -1,0 +1,178 @@
+---
+title: "Why AI Agents Need Their Own Authorization Protocol (and how we built one)"
+published: true
+description: "OAuth 2.0 was built for humans. AI agents need scoped permissions, delegation chains, real-time revocation, and audit trails. Grantex is an open protocol that provides all of this."
+tags: ai, security, opensource, webdev
+cover_image: https://grantex.dev/og-image.png
+canonical_url: https://grantex.mintlify.app/blog/introducing-grantex
+---
+
+AI agents are shipping fast. They book flights, send emails, move money, and deploy code. But here is the uncomfortable truth: most of them operate with all-or-nothing API keys and zero audit trail. If an agent goes rogue, you find out after the damage is done.
+
+We built [Grantex](https://grantex.dev) to fix that.
+
+## The Problem
+
+Every time you click "Sign in with Google" or grant an app access to your calendar, OAuth 2.0 is doing the work. It has been the backbone of delegated authorization for over a decade. So why can't we just use it for AI agents?
+
+The short answer: agents are not apps.
+
+OAuth 2.0 was designed for human users clicking "Allow" on a consent screen. It works brilliantly for that. But agents operate autonomously, spawn sub-agents, and chain actions across services. OAuth was never designed for:
+
+- **Agent identity** -- agents need their own cryptographic identity, not borrowed user credentials.
+- **Delegation chains** -- a parent agent granting a sub-agent a narrower set of permissions.
+- **Action-level auditing** -- knowing exactly what an agent did, not just that it authenticated.
+- **Real-time revocation** -- killing a misbehaving agent's access in milliseconds, not minutes.
+
+## The Four Gaps in Detail
+
+### 1. Agent Identity vs. App Identity
+
+OAuth issues tokens to registered applications. An app has a `client_id`, a redirect URI, and a set of scopes. This model assumes a fixed, known piece of software.
+
+AI agents are different. A single orchestrator might spawn dozens of sub-agents at runtime, each with a different purpose. These agents need their own cryptographic identity -- not a shared `client_id`. Grantex assigns each agent a DID (Decentralized Identifier) backed by a key pair. The agent's identity is verifiable, rotatable, and independent of the platform it runs on.
+
+### 2. Scope Delegation Chains
+
+OAuth supports a flat model: a user grants scopes to an app, and that is the end of the story. But agents delegate work to other agents. A "research assistant" agent might call a "web search" sub-agent and a "summarizer" sub-agent, each of which should only get the scopes it actually needs.
+
+Grantex models this explicitly. When a parent agent delegates to a child, the child's grant token carries `parentAgt`, `parentGrnt`, and `delegationDepth` claims. The child's scopes must be a strict subset of the parent's. This is not a convention -- it is enforced at the protocol level.
+
+```
+Root user grants: [files:read, files:write, email:send]
+  └─ Parent agent:  [files:read, files:write]  (delegationDepth: 0)
+       └─ Child agent:  [files:read]            (delegationDepth: 1)
+```
+
+If the parent's grant is revoked, every child grant in the chain is automatically invalidated.
+
+### 3. Real-Time Revocation
+
+OAuth token revocation is defined in RFC 7009, but it is advisory. Resource servers are free to keep accepting a token until it expires. For a 1-hour access token, that is a 1-hour window of exposure.
+
+With agents performing high-stakes actions autonomously, you cannot afford that window. Grantex supports both offline verification (fast JWT validation) and online verification that checks revocation state in real time. When you revoke a grant, the very next verification call returns `valid: false`.
+
+### 4. Action-Level Audit Trails
+
+OAuth gives you an access log at the authorization server. You know when a token was issued and when it was refreshed. You do not know what happened next.
+
+Grantex includes a first-class audit subsystem. Every action an agent performs can be logged, and the entries are append-only and hash-chained -- each entry references the hash of the previous one, making tampering detectable. You can query the full trail filtered by agent, grant, principal, or time range.
+
+## The Compliance Dimension
+
+This is not just a technical nicety. The EU AI Act (effective August 2025) requires that high-risk AI systems maintain logs of their operation, support human oversight, and provide transparency about their decision-making. Grantex's audit trail, scoped grants, and real-time revocation map directly onto these requirements.
+
+Similarly, SOC 2 auditors want to see evidence that access is scoped, time-limited, and revocable. Grant tokens with explicit expiration, scope restrictions, and revocation support provide that evidence out of the box.
+
+## Why Not Extend OAuth?
+
+We considered it. The problem is that the primitives do not exist. OAuth has no concept of agent identity, delegation depth, or hash-chained audit logs. Bolting these onto OAuth would mean a constellation of non-standard extensions that no existing library supports.
+
+Grantex is a clean-sheet protocol that speaks the same language as OAuth where it makes sense (JWTs, JWKs, RS256, scopes, authorization codes) but adds the agent-specific primitives as first-class concepts. If you know OAuth, Grantex will feel familiar. But it will also handle the cases OAuth was never designed for.
+
+## What It Looks Like in Code
+
+Here is the full flow in TypeScript:
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+
+const gx = new Grantex({
+  apiKey: process.env.GRANTEX_API_KEY,
+});
+
+// 1. Register an agent
+const agent = await gx.agents.register({
+  name: 'travel-booking-agent',
+  description: 'Books flights and hotels for users',
+  scopes: ['flights:book', 'hotels:search'],
+});
+
+// 2. Request authorization from a user
+const auth = await gx.authorize({
+  agentId: agent.id,
+  userId: 'user_alice',
+  scopes: ['flights:book', 'hotels:search'],
+  callbackUrl: 'https://app.example.com/callback',
+});
+// → redirect user to auth.consentUrl
+
+// 3. Exchange the authorization code for a grant token
+const token = await gx.tokens.exchange({
+  code: callbackCode,
+  agentId: agent.id,
+});
+
+// 4. Verify the token before acting
+const result = await gx.tokens.verify(token.grantToken);
+console.log(result.scopes); // ['flights:book', 'hotels:search']
+
+// 5. Log every action to the audit trail
+await gx.audit.log({
+  agentId: agent.id,
+  grantId: token.grantId,
+  action: 'flight.booked',
+  status: 'success',
+  metadata: { airline: 'Air India', amount: 420 },
+});
+```
+
+The same flow works in Python:
+
+```python
+from grantex import Grantex, ExchangeTokenParams
+
+client = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+agent = client.agents.register(
+    name="travel-booking-agent",
+    scopes=["flights:book", "hotels:search"],
+)
+
+auth = client.authorize(
+    agent_id=agent.id,
+    user_id="user_alice",
+    scopes=["flights:book", "hotels:search"],
+)
+# redirect user to auth.consent_url
+
+token = client.tokens.exchange(
+    ExchangeTokenParams(code=callback_code, agent_id=agent.id)
+)
+print(token.scopes)  # ('flights:book', 'hotels:search')
+```
+
+## What Ships Today
+
+- **Protocol spec v1.0** (final) -- the full specification is [public and frozen](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md).
+- **TypeScript SDK** ([`@grantex/sdk`](https://www.npmjs.com/package/@grantex/sdk)) and **Python SDK** ([`grantex`](https://pypi.org/project/grantex/)) -- production-ready.
+- **7 framework integrations** -- [LangChain](https://www.npmjs.com/package/@grantex/langchain), [AutoGen](https://www.npmjs.com/package/@grantex/autogen), [CrewAI](https://pypi.org/project/grantex-crewai/), [Vercel AI](https://www.npmjs.com/package/@grantex/vercel-ai), [OpenAI Agents SDK](https://pypi.org/project/grantex-openai-agents/), [Google ADK](https://pypi.org/project/grantex-adk/), and an MCP server for Claude Desktop.
+- **CLI** ([`@grantex/cli`](https://www.npmjs.com/package/@grantex/cli)) -- manage agents, grants, and tokens from your terminal.
+- **Enterprise features** -- policy engine, SCIM/SSO, anomaly detection, compliance exports, and Stripe billing.
+- **Full API Reference** with [interactive docs](https://grantex.mintlify.app/api-reference) and a [Postman collection](https://github.com/mishrasanjeev/grantex/blob/main/docs/grantex.postman_collection.json).
+
+## Get Started
+
+Install the SDK:
+
+```bash
+npm install @grantex/sdk        # TypeScript / Node.js
+pip install grantex             # Python
+npm install -g @grantex/cli     # CLI
+```
+
+Then pick your path:
+
+- [Quickstart guide](https://grantex.dev/docs/quickstart) -- up and running in under 5 minutes.
+- [Sign up for a free account](https://grantex.dev/dashboard/signup) -- get your API key.
+- [GitHub repository](https://github.com/mishrasanjeev/grantex) -- star, fork, contribute.
+- [Full documentation](https://grantex.dev/docs) -- guides, SDK reference, examples.
+- [API Reference](https://grantex.mintlify.app/api-reference) -- all 56 endpoints with schemas.
+- [Protocol specification](https://grantex.dev/docs/protocol/specification) -- the full v1.0 spec.
+- [Homepage](https://grantex.dev) -- project overview.
+
+We believe that as agents become more capable, proper authorization becomes more critical, not less. Grantex is our answer to that challenge.
+
+---
+
+*Grantex is open source (Apache 2.0). If you're building agent systems and care about authorization, we'd love your feedback -- [open an issue](https://github.com/mishrasanjeev/grantex/issues) or [star the repo](https://github.com/mishrasanjeev/grantex).*

--- a/LAUNCH_POSTS.md
+++ b/LAUNCH_POSTS.md
@@ -1,0 +1,293 @@
+# Grantex Launch Posts
+
+Copy-paste ready posts for each platform. Edit as needed before posting.
+
+---
+
+## 1. Hacker News — Show HN
+
+**Title:** Show HN: Grantex – Open delegated authorization protocol for AI agents (OAuth 2.0 for agents)
+
+**URL:** https://github.com/mishrasanjeev/grantex
+
+**Text (top comment):**
+
+Most AI agents today operate with all-or-nothing API keys. If your LangChain agent can read your calendar, it can also delete every event. There's no scoping, no revocation, no audit trail. This is where the web was before OAuth.
+
+Grantex is an open protocol (Apache 2.0) for delegated authorization of AI agents. The core idea: a human approves a scoped, time-limited grant for an agent, and that agent receives a signed JWT it can present to any service. Services verify locally via JWKS — no Grantex account needed.
+
+What's different from OAuth 2.0:
+
+- Agent identity: Every agent gets a cryptographic DID, not borrowed user credentials.
+- Delegation chains: A parent agent can delegate a narrower grant to a sub-agent, with depth tracking.
+- Action-level auditing: Append-only, hash-chained log of every action an agent takes.
+- Real-time revocation: Kill a misbehaving agent's access in < 1 second.
+
+What ships today:
+
+- Protocol spec v1.0 (frozen): https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md
+- TypeScript SDK (`@grantex/sdk`): https://www.npmjs.com/package/@grantex/sdk
+- Python SDK (`grantex`): https://pypi.org/project/grantex/
+- 7 framework integrations: LangChain, AutoGen, CrewAI, Vercel AI, OpenAI Agents SDK, Google ADK, MCP server
+- Auth service (Fastify, deployed on Cloud Run)
+- CLI, developer portal, enterprise features (policies, SCIM/SSO, anomaly detection, compliance exports)
+
+Links:
+
+- Homepage: https://grantex.dev
+- Docs: https://grantex.dev/docs
+- API Reference: https://grantex.mintlify.app/api-reference
+- Sign up (free): https://grantex.dev/dashboard/signup
+- Postman collection: https://github.com/mishrasanjeev/grantex/blob/main/docs/grantex.postman_collection.json
+
+The quickstart is ~10 lines of code:
+
+    import { Grantex } from '@grantex/sdk';
+
+    const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+    const agent = await gx.agents.register({ name: 'travel-agent', scopes: ['flights:book'] });
+    const auth = await gx.authorize({ agentId: agent.id, userId: 'user_alice', scopes: ['flights:book'] });
+    // user approves at auth.consentUrl
+    const token = await gx.tokens.exchange({ code, agentId: agent.id });
+    // agent now has a signed JWT — any service can verify it offline
+
+I built this because I think the "give agents your API key" pattern is going to age very badly as agents get more capable. Happy to answer questions about the protocol design, security model, or anything else.
+
+---
+
+## 2. Reddit — r/MachineLearning
+
+**Title:** [P] Grantex: Open authorization protocol for AI agents — scoped permissions, delegation chains, and audit trails
+
+**Body:**
+
+**TL;DR**: Grantex is an open protocol (Apache 2.0) that gives AI agents scoped, human-approved, revocable permissions instead of all-or-nothing API keys. Think OAuth 2.0, but designed for autonomous agents and multi-agent pipelines.
+
+**The problem**: Most agent frameworks today handle auth with a shared API key. The agent has whatever access the key has — no scoping, no revocation, no record of what it did. For research prototypes this is fine. For agents booking flights, sending emails, or executing trades on behalf of real users, it's a liability.
+
+**What Grantex does**:
+
+1. **Agent registers** with a name and required scopes (e.g., `flights:book`, `payments:initiate:max_500`)
+2. **Human approves** specific scopes via a consent UI (like an OAuth consent screen, but designed for agent use cases)
+3. **Agent receives a signed JWT** — scoped, time-limited, revocable
+4. **Any service verifies offline** via published JWKS — no Grantex account needed
+5. **Every action is logged** in an append-only, hash-chained audit trail
+
+Key features that go beyond OAuth:
+
+- **Delegation chains** — parent agent grants narrower permissions to sub-agents, with depth tracking (protocol spec Section 9)
+- **Cryptographic agent identity** — DID-based, not borrowed user credentials
+- **Real-time revocation** — revoke a misbehaving agent in < 1 second
+- **Policy engine** — enforce rules like "max $500 per transaction" or "only during business hours"
+
+**What's available today**:
+
+- Protocol spec v1.0 (frozen, public)
+- SDKs: TypeScript (`npm install @grantex/sdk`) and Python (`pip install grantex`)
+- Integrations: LangChain, CrewAI, AutoGen, Vercel AI, OpenAI Agents SDK, Google ADK, MCP server
+- Auth service, CLI, developer portal
+- Enterprise: SCIM/SSO, anomaly detection, compliance exports
+
+**Links**:
+
+- Homepage: [grantex.dev](https://grantex.dev)
+- GitHub: [github.com/mishrasanjeev/grantex](https://github.com/mishrasanjeev/grantex)
+- Docs: [grantex.dev/docs](https://grantex.dev/docs)
+- API Reference: [grantex.mintlify.app/api-reference](https://grantex.mintlify.app/api-reference)
+- Sign up (free): [grantex.dev/dashboard/signup](https://grantex.dev/dashboard/signup)
+- Protocol spec: [SPEC.md](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md)
+- npm: [npmjs.com/package/@grantex/sdk](https://www.npmjs.com/package/@grantex/sdk)
+- PyPI: [pypi.org/project/grantex](https://pypi.org/project/grantex/)
+
+Interested in feedback from anyone working on agent systems, multi-agent orchestration, or AI safety. The spec is public and I'd love to see other implementations.
+
+---
+
+## 3. Reddit — r/LocalLLaMA
+
+**Title:** Grantex — open protocol for giving AI agents scoped, revocable permissions (instead of just handing them your API keys)
+
+**Body:**
+
+Quick question: when you give your agent access to your email or calendar, how do you scope what it can do? How do you revoke it? How do you know what it actually did?
+
+Right now the answer for most people is "I gave it my API key and hoped for the best." That works for experiments, but it's going to be a real problem as agents get more capable and start acting in the real world.
+
+I built **Grantex** to solve this. It's an open protocol (Apache 2.0) — basically OAuth 2.0 redesigned for agents:
+
+- Agent requests specific scopes (`email:read`, `calendar:write`, `payments:max_100`)
+- Human approves via consent screen
+- Agent gets a signed JWT with those scopes baked in
+- Any service can verify the JWT offline (JWKS, same as OAuth)
+- Human can revoke access instantly
+- Everything the agent does gets logged
+
+It also handles **delegation** — if your agent spawns a sub-agent, the sub-agent gets a narrower grant derived from the parent's, with full chain tracking.
+
+There's a TypeScript SDK, Python SDK, and integrations for LangChain, CrewAI, AutoGen, Vercel AI, OpenAI Agents SDK, Google ADK, and an MCP server (so it works with Claude Desktop/Cursor/Windsurf).
+
+Everything is open source:
+
+- Homepage: [grantex.dev](https://grantex.dev)
+- GitHub: [github.com/mishrasanjeev/grantex](https://github.com/mishrasanjeev/grantex)
+- Docs: [grantex.dev/docs](https://grantex.dev/docs)
+- Sign up (free): [grantex.dev/dashboard/signup](https://grantex.dev/dashboard/signup)
+- npm: `npm install @grantex/sdk`
+- PyPI: `pip install grantex`
+
+Would love to hear how others are handling agent permissions in their setups.
+
+---
+
+## 4. Reddit — r/programming
+
+**Title:** Grantex: An open authorization protocol for AI agents — delegated grants, audit trails, and sub-agent delegation built on JWT/JWKS
+
+**Body:**
+
+I've been working on Grantex, an open protocol for delegated authorization of AI agents. The protocol spec is public and frozen at v1.0.
+
+**Why this exists**: OAuth 2.0 was designed for human users clicking consent buttons. Agents have different needs — they spawn sub-agents, operate autonomously, and need permission boundaries that are narrower than "everything the API key can do." Grantex extends the OAuth model with agent-specific primitives.
+
+**Protocol overview**:
+
+The core primitive is a **Grant Token** — an RS256 JWT with claims for:
+- `sub` — the human principal who approved the grant
+- `agt` — the agent's DID (cryptographic identity)
+- `scp` — approved scopes
+- `exp` — expiration
+- Standard JWT: `iss`, `iat`, `jti`
+
+For delegation, child tokens add: `parentAgt`, `parentGrnt`, `delegationDepth`.
+
+Verification is offline via JWKS (`/.well-known/jwks.json`) — receiving services don't need a Grantex account. Revocation is checked via a lightweight status endpoint or CRL.
+
+**Implementation details**:
+
+- Auth service: Fastify + PostgreSQL + Redis, deployed on Cloud Run
+- JWT signing: RS256, JWKS endpoint, key rotation support
+- Rate limiting: 10/min authorize, 20/min token exchange, 100/min global
+- Audit trail: append-only, hash-chained entries
+- PKCE support (S256) for public clients
+
+**SDKs and integrations**:
+
+- TypeScript: `@grantex/sdk` (ESM, Node 18+, native fetch)
+- Python: `grantex` (httpx, PyJWT, Python 3.9+)
+- Framework integrations: LangChain, AutoGen, CrewAI, Vercel AI SDK, OpenAI Agents SDK, Google ADK
+- MCP server for Claude Desktop / Cursor / Windsurf
+- CLI tool
+- OpenAPI 3.1 spec + Postman collection
+
+Everything is Apache 2.0.
+
+**Links**:
+
+- Homepage: [grantex.dev](https://grantex.dev)
+- GitHub: [github.com/mishrasanjeev/grantex](https://github.com/mishrasanjeev/grantex)
+- Docs: [grantex.dev/docs](https://grantex.dev/docs)
+- API Reference: [grantex.mintlify.app/api-reference](https://grantex.mintlify.app/api-reference)
+- Sign up (free): [grantex.dev/dashboard/signup](https://grantex.dev/dashboard/signup)
+- Protocol spec: [SPEC.md](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md)
+- Postman collection: [grantex.postman_collection.json](https://github.com/mishrasanjeev/grantex/blob/main/docs/grantex.postman_collection.json)
+- npm: [npmjs.com/package/@grantex/sdk](https://www.npmjs.com/package/@grantex/sdk)
+- PyPI: [pypi.org/project/grantex](https://pypi.org/project/grantex/)
+
+---
+
+## 5. Twitter/X Thread (280 char limit, no Blue)
+
+**Tweet 1 — hook (275 chars):**
+
+AI agents book flights, send emails, and move money on your behalf.
+
+Most run on all-or-nothing API keys. No scoping. No audit trail.
+
+We built Grantex — an open authorization protocol for AI agents.
+
+github.com/mishrasanjeev/grantex
+
+🧵
+
+**Tweet 2 — problem (209 chars):**
+
+OAuth 2.0 was built for humans clicking "Allow."
+
+Agents need more:
+→ Own cryptographic identity
+→ Sub-agent delegation with narrower scopes
+→ Action-level audit trails
+→ Instant revocation
+
+**Tweet 3 — solution (256 chars):**
+
+Grantex gives agents 3 things:
+
+1/ Cryptographic identity (DID per agent)
+2/ Delegated grants — scoped, time-limited JWTs approved by humans
+3/ Audit trail — append-only log of every action
+
+Services verify offline via JWKS. Zero lock-in.
+
+**Tweet 4 — ship it (196 chars):**
+
+Works in TypeScript and Python:
+
+npm install @grantex/sdk
+pip install grantex
+
+Register agent → user approves scopes → agent gets signed JWT → any service verifies offline.
+
+**Tweet 5 — integrations (247 chars):**
+
+7 integrations out of the box:
+
+→ LangChain
+→ CrewAI
+→ AutoGen
+→ Vercel AI SDK
+→ OpenAI Agents SDK
+→ Google ADK
+→ MCP (Claude Desktop, Cursor, Windsurf)
+
+Plus CLI, dev portal, policies, SCIM/SSO, anomaly detection.
+
+**Tweet 6 — CTA (185 chars):**
+
+Open source. Apache 2.0.
+
+npm install @grantex/sdk
+pip install grantex
+Docs: grantex.dev/docs
+
+As agents get more capable, proper authorization becomes more critical — not less.
+
+---
+
+## 6. Dev.to Article
+
+**Title:** Why AI Agents Need Their Own Authorization Protocol (and how we built one)
+
+**Tags:** ai, security, opensource, webdev
+
+**Cover image:** https://grantex.dev/og-image.png
+
+**Body:**
+
+*(Cross-post the content from `docs/blog/introducing-grantex.mdx` with these modifications:)*
+
+1. Replace relative links (`/quickstart`, `/protocol/specification`) with full URLs (`https://grantex.dev/docs/quickstart`, etc.)
+2. Add the `cover_image` field pointing to the OG image
+3. Add a "Get Started" section at the bottom with install commands and links
+4. Add the canonical URL: `canonical_url: https://grantex.mintlify.app/blog/introducing-grantex`
+
+---
+
+## Posting Order (recommended)
+
+1. **Dev.to** — publish first so you have a canonical URL for cross-referencing
+2. **Hacker News** — post as "Show HN" (best times: Tuesday-Thursday, 8-10am ET)
+3. **Twitter/X** — post the thread, pin it
+4. **Reddit r/programming** — wait 1-2 hours after HN to avoid looking spammy
+5. **Reddit r/MachineLearning** — same day, different angle (focus on agent safety)
+6. **Reddit r/LocalLLaMA** — most casual tone, focus on practical use case

--- a/packages/autogen/README.md
+++ b/packages/autogen/README.md
@@ -1,8 +1,10 @@
 # @grantex/autogen
 
-AutoGen / OpenAI function-calling integration for the [Grantex](https://github.com/mishrasanjeev/grantex) delegated authorization protocol.
+AutoGen / OpenAI function-calling integration for the [Grantex](https://grantex.dev) delegated authorization protocol.
 
 Adds scope-enforced functions, a function registry, and audit logging for any agent using OpenAI-style function calling.
+
+> **[Homepage](https://grantex.dev)** | **[Docs](https://grantex.dev/docs)** | **[Sign Up Free](https://grantex.dev/dashboard/signup)** | **[GitHub](https://github.com/mishrasanjeev/grantex)**
 
 ## Install
 
@@ -131,6 +133,16 @@ Wraps a `GrantexFunction` with audit logging.
 - [Grantex Protocol](https://github.com/mishrasanjeev/grantex)
 - [TypeScript SDK](https://www.npmjs.com/package/@grantex/sdk)
 - [Spec](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md)
+
+## Grantex Ecosystem
+
+This package is part of the [Grantex](https://grantex.dev) ecosystem. See also:
+
+- [`@grantex/sdk`](https://www.npmjs.com/package/@grantex/sdk) — Core TypeScript SDK
+- [`grantex`](https://pypi.org/project/grantex/) — Python SDK
+- [`@grantex/langchain`](https://www.npmjs.com/package/@grantex/langchain) — LangChain integration
+- [`@grantex/vercel-ai`](https://www.npmjs.com/package/@grantex/vercel-ai) — Vercel AI SDK integration
+- [`@grantex/mcp`](https://www.npmjs.com/package/@grantex/mcp) — MCP server for Claude Desktop / Cursor / Windsurf
 
 ## License
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,8 +1,10 @@
 # @grantex/cli
 
-Command-line tool for the [Grantex](https://github.com/mishrasanjeev/grantex) delegated authorization protocol.
+Command-line tool for the [Grantex](https://grantex.dev) delegated authorization protocol.
 
 Manage agents, grants, audit logs, webhooks, policies, anomalies, and compliance exports from your terminal.
+
+> **[Homepage](https://grantex.dev)** | **[Docs](https://grantex.dev/docs)** | **[Sign Up Free](https://grantex.dev/dashboard/signup)** | **[GitHub](https://github.com/mishrasanjeev/grantex)**
 
 ## Install
 
@@ -118,6 +120,16 @@ grantex config set --url http://localhost:3001 --key dev-api-key-local
 - [TypeScript SDK](https://www.npmjs.com/package/@grantex/sdk)
 - [Self-Hosting Guide](https://github.com/mishrasanjeev/grantex/blob/main/docs/self-hosting.md)
 - [Developer Portal](https://grantex.dev/dashboard)
+
+## Grantex Ecosystem
+
+This package is part of the [Grantex](https://grantex.dev) ecosystem. See also:
+
+- [`@grantex/sdk`](https://www.npmjs.com/package/@grantex/sdk) — Core TypeScript SDK
+- [`grantex`](https://pypi.org/project/grantex/) — Python SDK
+- [`@grantex/langchain`](https://www.npmjs.com/package/@grantex/langchain) — LangChain integration
+- [`@grantex/mcp`](https://www.npmjs.com/package/@grantex/mcp) — MCP server for Claude Desktop / Cursor / Windsurf
+- [`@grantex/vercel-ai`](https://www.npmjs.com/package/@grantex/vercel-ai) — Vercel AI SDK integration
 
 ## License
 

--- a/packages/crewai/README.md
+++ b/packages/crewai/README.md
@@ -8,6 +8,8 @@ Wrap any CrewAI tool with Grantex grant token verification so your agents can on
 [![Python](https://img.shields.io/pypi/pyversions/grantex-crewai)](https://pypi.org/project/grantex-crewai/)
 [![License](https://img.shields.io/pypi/l/grantex-crewai)](https://github.com/mishrasanjeev/grantex/blob/main/LICENSE)
 
+> **[Homepage](https://grantex.dev)** | **[Docs](https://grantex.dev/docs)** | **[Sign Up Free](https://grantex.dev/dashboard/signup)** | **[GitHub](https://github.com/mishrasanjeev/grantex)**
+
 ## Install
 
 ```bash
@@ -148,6 +150,16 @@ Returns the scopes embedded in a grant token. Purely offline — no network call
 - [Grantex Python SDK](https://pypi.org/project/grantex/)
 - [Protocol specification](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md)
 - [CrewAI documentation](https://docs.crewai.com/)
+
+## Grantex Ecosystem
+
+This package is part of the [Grantex](https://grantex.dev) ecosystem. See also:
+
+- [`grantex`](https://pypi.org/project/grantex/) — Core Python SDK
+- [`@grantex/sdk`](https://www.npmjs.com/package/@grantex/sdk) — TypeScript SDK
+- [`grantex-openai-agents`](https://pypi.org/project/grantex-openai-agents/) — OpenAI Agents SDK integration
+- [`grantex-adk`](https://pypi.org/project/grantex-adk/) — Google ADK integration
+- [`@grantex/mcp`](https://www.npmjs.com/package/@grantex/mcp) — MCP server for Claude Desktop / Cursor / Windsurf
 
 ## License
 

--- a/packages/google-adk/README.md
+++ b/packages/google-adk/README.md
@@ -8,6 +8,8 @@ Wrap any function with Grantex grant token verification so your agents can only 
 [![Python](https://img.shields.io/pypi/pyversions/grantex-adk)](https://pypi.org/project/grantex-adk/)
 [![License](https://img.shields.io/pypi/l/grantex-adk)](https://github.com/mishrasanjeev/grantex/blob/main/LICENSE)
 
+> **[Homepage](https://grantex.dev)** | **[Docs](https://grantex.dev/docs)** | **[Sign Up Free](https://grantex.dev/dashboard/signup)** | **[GitHub](https://github.com/mishrasanjeev/grantex)**
+
 ## Install
 
 ```bash
@@ -72,6 +74,16 @@ Decodes the payload of a JWT without verifying the signature. Useful for inspect
 - Python 3.9+
 - `grantex >= 0.1.0`
 - `google-adk >= 0.2.0` (peer dependency)
+
+## Grantex Ecosystem
+
+This package is part of the [Grantex](https://grantex.dev) ecosystem. See also:
+
+- [`grantex`](https://pypi.org/project/grantex/) — Core Python SDK
+- [`@grantex/sdk`](https://www.npmjs.com/package/@grantex/sdk) — TypeScript SDK
+- [`grantex-crewai`](https://pypi.org/project/grantex-crewai/) — CrewAI integration
+- [`grantex-openai-agents`](https://pypi.org/project/grantex-openai-agents/) — OpenAI Agents SDK integration
+- [`@grantex/mcp`](https://www.npmjs.com/package/@grantex/mcp) — MCP server for Claude Desktop / Cursor / Windsurf
 
 ## License
 

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -1,8 +1,10 @@
 # @grantex/langchain
 
-LangChain integration for the [Grantex](https://github.com/mishrasanjeev/grantex) delegated authorization protocol.
+LangChain integration for the [Grantex](https://grantex.dev) delegated authorization protocol.
 
 Adds scope-enforced tools and automatic audit logging to any LangChain agent.
+
+> **[Homepage](https://grantex.dev)** | **[Docs](https://grantex.dev/docs)** | **[Sign Up Free](https://grantex.dev/dashboard/signup)** | **[GitHub](https://github.com/mishrasanjeev/grantex)**
 
 ## Install
 
@@ -99,6 +101,16 @@ LangChain callback handler that writes tool invocations to the Grantex audit tra
 - [TypeScript SDK](https://www.npmjs.com/package/@grantex/sdk)
 - [Python SDK](https://pypi.org/project/grantex/)
 - [Spec](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md)
+
+## Grantex Ecosystem
+
+This package is part of the [Grantex](https://grantex.dev) ecosystem. See also:
+
+- [`@grantex/sdk`](https://www.npmjs.com/package/@grantex/sdk) — Core TypeScript SDK
+- [`grantex`](https://pypi.org/project/grantex/) — Python SDK
+- [`@grantex/vercel-ai`](https://www.npmjs.com/package/@grantex/vercel-ai) — Vercel AI SDK integration
+- [`@grantex/autogen`](https://www.npmjs.com/package/@grantex/autogen) — AutoGen integration
+- [`@grantex/mcp`](https://www.npmjs.com/package/@grantex/mcp) — MCP server for Claude Desktop / Cursor / Windsurf
 
 ## License
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,6 +2,8 @@
 
 MCP (Model Context Protocol) server for the [Grantex](https://grantex.dev) delegated agent authorization protocol. Exposes 13 tools for managing agents, grants, tokens, authorization flows, and audit logs.
 
+> **[Homepage](https://grantex.dev)** | **[Docs](https://grantex.dev/docs)** | **[Sign Up Free](https://grantex.dev/dashboard/signup)** | **[GitHub](https://github.com/mishrasanjeev/grantex)**
+
 ## Quick Start
 
 ```bash
@@ -49,6 +51,16 @@ Add to your MCP config:
 | `grantex_grant_delegate` | Delegate a grant to a sub-agent |
 | `grantex_audit_log` | Log an audit entry |
 | `grantex_audit_list` | List audit entries |
+
+## Grantex Ecosystem
+
+This package is part of the [Grantex](https://grantex.dev) ecosystem. See also:
+
+- [`@grantex/sdk`](https://www.npmjs.com/package/@grantex/sdk) — Core TypeScript SDK
+- [`grantex`](https://pypi.org/project/grantex/) — Python SDK
+- [`@grantex/langchain`](https://www.npmjs.com/package/@grantex/langchain) — LangChain integration
+- [`@grantex/vercel-ai`](https://www.npmjs.com/package/@grantex/vercel-ai) — Vercel AI SDK integration
+- [`@grantex/cli`](https://www.npmjs.com/package/@grantex/cli) — Command-line tool
 
 ## License
 

--- a/packages/openai-agents/README.md
+++ b/packages/openai-agents/README.md
@@ -8,6 +8,8 @@ Wrap any function with Grantex grant token verification so your agents can only 
 [![Python](https://img.shields.io/pypi/pyversions/grantex-openai-agents)](https://pypi.org/project/grantex-openai-agents/)
 [![License](https://img.shields.io/pypi/l/grantex-openai-agents)](https://github.com/mishrasanjeev/grantex/blob/main/LICENSE)
 
+> **[Homepage](https://grantex.dev)** | **[Docs](https://grantex.dev/docs)** | **[Sign Up Free](https://grantex.dev/dashboard/signup)** | **[GitHub](https://github.com/mishrasanjeev/grantex)**
+
 ## Install
 
 ```bash
@@ -68,6 +70,16 @@ Decodes the payload of a JWT without verifying the signature. Useful for inspect
 - Python 3.9+
 - `grantex >= 0.1.0`
 - `openai-agents >= 0.0.3` (peer dependency)
+
+## Grantex Ecosystem
+
+This package is part of the [Grantex](https://grantex.dev) ecosystem. See also:
+
+- [`grantex`](https://pypi.org/project/grantex/) — Core Python SDK
+- [`@grantex/sdk`](https://www.npmjs.com/package/@grantex/sdk) — TypeScript SDK
+- [`grantex-crewai`](https://pypi.org/project/grantex-crewai/) — CrewAI integration
+- [`grantex-adk`](https://pypi.org/project/grantex-adk/) — Google ADK integration
+- [`@grantex/mcp`](https://www.npmjs.com/package/@grantex/mcp) — MCP server for Claude Desktop / Cursor / Windsurf
 
 ## License
 

--- a/packages/sdk-py/README.md
+++ b/packages/sdk-py/README.md
@@ -8,6 +8,8 @@ Grantex lets humans authorize AI agents with **verifiable, revocable, audited gr
 [![Python](https://img.shields.io/pypi/pyversions/grantex)](https://pypi.org/project/grantex/)
 [![License](https://img.shields.io/pypi/l/grantex)](https://github.com/mishrasanjeev/grantex/blob/main/LICENSE)
 
+> **[Homepage](https://grantex.dev)** | **[Docs](https://grantex.dev/docs)** | **[API Reference](https://grantex.mintlify.app/api-reference)** | **[Sign Up Free](https://grantex.dev/dashboard/signup)** | **[GitHub](https://github.com/mishrasanjeev/grantex)**
+
 ## Install
 
 ```bash
@@ -181,6 +183,20 @@ except GrantexNetworkError:
 - [TypeScript SDK](https://www.npmjs.com/package/@grantex/sdk)
 - [IETF Internet-Draft](https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/)
 - [Landing page](https://grantex.dev)
+
+## Grantex Ecosystem
+
+| Package | Description |
+|---|---|
+| [`@grantex/sdk`](https://www.npmjs.com/package/@grantex/sdk) | TypeScript SDK |
+| [`@grantex/langchain`](https://www.npmjs.com/package/@grantex/langchain) | LangChain integration |
+| [`@grantex/autogen`](https://www.npmjs.com/package/@grantex/autogen) | AutoGen integration |
+| [`@grantex/vercel-ai`](https://www.npmjs.com/package/@grantex/vercel-ai) | Vercel AI SDK integration |
+| [`grantex-crewai`](https://pypi.org/project/grantex-crewai/) | CrewAI integration |
+| [`grantex-openai-agents`](https://pypi.org/project/grantex-openai-agents/) | OpenAI Agents SDK integration |
+| [`grantex-adk`](https://pypi.org/project/grantex-adk/) | Google ADK integration |
+| [`@grantex/mcp`](https://www.npmjs.com/package/@grantex/mcp) | MCP server for Claude Desktop / Cursor / Windsurf |
+| [`@grantex/cli`](https://www.npmjs.com/package/@grantex/cli) | Command-line tool |
 
 ## License
 

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -5,6 +5,8 @@ TypeScript SDK for the [Grantex](https://grantex.dev) delegated authorization pr
 [![npm version](https://img.shields.io/npm/v/@grantex/sdk)](https://www.npmjs.com/package/@grantex/sdk)
 [![License](https://img.shields.io/npm/l/@grantex/sdk)](https://github.com/mishrasanjeev/grantex/blob/main/LICENSE)
 
+> **[Homepage](https://grantex.dev)** | **[Docs](https://grantex.dev/docs)** | **[API Reference](https://grantex.mintlify.app/api-reference)** | **[Sign Up Free](https://grantex.dev/dashboard/signup)** | **[GitHub](https://github.com/mishrasanjeev/grantex)**
+
 ## Installation
 
 ```bash
@@ -665,6 +667,20 @@ try {
 - [Protocol Specification](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md)
 - [Python SDK](https://pypi.org/project/grantex/)
 - [API Reference](https://api.grantex.dev/.well-known/jwks.json)
+
+## Grantex Ecosystem
+
+| Package | Description |
+|---|---|
+| [`grantex`](https://pypi.org/project/grantex/) | Python SDK |
+| [`@grantex/langchain`](https://www.npmjs.com/package/@grantex/langchain) | LangChain integration |
+| [`@grantex/autogen`](https://www.npmjs.com/package/@grantex/autogen) | AutoGen integration |
+| [`@grantex/vercel-ai`](https://www.npmjs.com/package/@grantex/vercel-ai) | Vercel AI SDK integration |
+| [`grantex-crewai`](https://pypi.org/project/grantex-crewai/) | CrewAI integration |
+| [`grantex-openai-agents`](https://pypi.org/project/grantex-openai-agents/) | OpenAI Agents SDK integration |
+| [`grantex-adk`](https://pypi.org/project/grantex-adk/) | Google ADK integration |
+| [`@grantex/mcp`](https://www.npmjs.com/package/@grantex/mcp) | MCP server for Claude Desktop / Cursor / Windsurf |
+| [`@grantex/cli`](https://www.npmjs.com/package/@grantex/cli) | Command-line tool |
 
 ## License
 

--- a/packages/vercel-ai/README.md
+++ b/packages/vercel-ai/README.md
@@ -1,8 +1,10 @@
 # @grantex/vercel-ai
 
-[Vercel AI SDK](https://sdk.vercel.ai/) integration for the [Grantex](https://github.com/mishrasanjeev/grantex) delegated authorization protocol.
+[Vercel AI SDK](https://sdk.vercel.ai/) integration for the [Grantex](https://grantex.dev) delegated authorization protocol.
 
 Adds scope-enforced tools and audit logging to any Vercel AI SDK agent.
+
+> **[Homepage](https://grantex.dev)** | **[Docs](https://grantex.dev/docs)** | **[Sign Up Free](https://grantex.dev/dashboard/signup)** | **[GitHub](https://github.com/mishrasanjeev/grantex)**
 
 ## Install
 
@@ -125,6 +127,16 @@ Error thrown when a grant token is missing the required scope.
 - [Vercel AI SDK Docs](https://sdk.vercel.ai/)
 - [TypeScript SDK](https://www.npmjs.com/package/@grantex/sdk)
 - [Spec](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md)
+
+## Grantex Ecosystem
+
+This package is part of the [Grantex](https://grantex.dev) ecosystem. See also:
+
+- [`@grantex/sdk`](https://www.npmjs.com/package/@grantex/sdk) — Core TypeScript SDK
+- [`grantex`](https://pypi.org/project/grantex/) — Python SDK
+- [`@grantex/langchain`](https://www.npmjs.com/package/@grantex/langchain) — LangChain integration
+- [`@grantex/autogen`](https://www.npmjs.com/package/@grantex/autogen) — AutoGen integration
+- [`@grantex/mcp`](https://www.npmjs.com/package/@grantex/mcp) — MCP server for Claude Desktop / Cursor / Windsurf
 
 ## License
 


### PR DESCRIPTION
## Summary
- Added a links bar (Homepage, Docs, API Reference, Sign Up, GitHub) to all 10 package READMEs
- Added a "Grantex Ecosystem" section with cross-links to related packages before the License section
- Fixed 4 READMEs that linked to GitHub instead of grantex.dev in the header

These are the READMEs that render on npm and PyPI — the links help visitors discover the docs site, sign up page, and other packages in the ecosystem.

## Packages updated
- `@grantex/sdk` (TypeScript SDK)
- `grantex` (Python SDK)
- `@grantex/langchain`
- `@grantex/autogen`
- `@grantex/vercel-ai`
- `grantex-crewai`
- `grantex-openai-agents`
- `grantex-adk`
- `@grantex/mcp`
- `@grantex/cli`