### PR TITLE
feat: add Next.js starter example with consent flow

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -58,6 +58,7 @@
             "pages": [
               "examples/quickstart-ts",
               "examples/quickstart-py",
+              "examples/nextjs-starter",
               "examples/langchain-agent",
               "examples/vercel-ai-chatbot",
               "examples/crewai-agent",

--- a/docs/examples/nextjs-starter.mdx
+++ b/docs/examples/nextjs-starter.mdx
@@ -1,0 +1,82 @@
+---
+title: "Next.js Starter"
+sidebarTitle: "Next.js Starter"
+description: "Interactive Next.js app showing the full Grantex consent flow."
+---
+
+A full-stack Next.js application that walks through the complete Grantex authorization lifecycle — agent registration, consent UI, token exchange, and audit logging.
+
+Unlike the CLI examples, this demo runs a real web server so you can see the consent redirect flow visually.
+
+## What it demonstrates
+
+- Registering an agent from a server-side API route
+- Creating an authorization request with a redirect URI
+- Redirecting to the Grantex consent UI
+- Exchanging the authorization code for a grant token
+- Logging an audit entry after token exchange
+- Displaying grant details and audit trail in a callback page
+
+## Quick start
+
+```bash
+cd examples/nextjs-starter
+npm install
+cp .env.example .env
+# Edit .env with your GRANTEX_API_KEY
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) and click **Start Demo**.
+
+## Flow overview
+
+```
+Browser                    Next.js Server               Grantex API
+  │                             │                            │
+  │── Click "Start Demo" ──────▶│                            │
+  │                             │── POST /v1/agents ────────▶│
+  │                             │◀── agent { id, did } ──────│
+  │                             │── POST /v1/authorize ─────▶│
+  │                             │◀── { consentUrl } ─────────│
+  │◀── redirect to consentUrl ──│                            │
+  │                             │                            │
+  │── Approve on consent UI ────────────────────────────────▶│
+  │◀── redirect /callback?code=...&state=... ────────────────│
+  │                             │                            │
+  │── POST /api/exchange ──────▶│                            │
+  │                             │── POST /v1/token ─────────▶│
+  │                             │◀── { grantToken } ─────────│
+  │                             │── POST /v1/audit/log ─────▶│
+  │                             │◀── { entryId } ────────────│
+  │◀── grant details + audit ───│                            │
+```
+
+## Project structure
+
+```
+examples/nextjs-starter/
+  app/
+    page.tsx              # Landing page with "Start Demo" button
+    callback/page.tsx     # Receives code, displays grant details
+    api/
+      authorize/route.ts  # Registers agent + starts auth request
+      exchange/route.ts   # Exchanges code for grant token
+      audit/route.ts      # Lists audit entries for display
+  .env.example            # Required environment variables
+```
+
+## Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `GRANTEX_API_KEY` | Your Grantex API key | (required) |
+| `GRANTEX_URL` | Auth service base URL | `https://grantex-auth-dd4mtrt2gq-uc.a.run.app` |
+| `NEXT_PUBLIC_APP_URL` | Public URL of this app (for redirect URI) | `http://localhost:3000` |
+
+## Key design decisions
+
+- **Server-side SDK only** — All Grantex SDK calls happen in API routes. The API key never reaches the browser.
+- **Cookie-based state** — `agentId` and a random `state` are stored in cookies before redirect, then verified on the callback to prevent CSRF.
+- **Fresh agent per demo** — Each click registers a new agent. No database required.
+- **No UI libraries** — Minimal CSS matching the grantex.dev branding.

--- a/examples/nextjs-starter/.env.example
+++ b/examples/nextjs-starter/.env.example
@@ -1,0 +1,8 @@
+# Get your API key from the Grantex developer portal
+GRANTEX_API_KEY=your-api-key-here
+
+# Auth service URL (defaults to live Cloud Run instance)
+GRANTEX_URL=https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+
+# Public URL for this app (used as redirect URI after consent)
+NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/examples/nextjs-starter/.gitignore
+++ b/examples/nextjs-starter/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.next/
+.env
+.env.local

--- a/examples/nextjs-starter/README.md
+++ b/examples/nextjs-starter/README.md
@@ -1,0 +1,36 @@
+# Grantex Next.js Starter
+
+Interactive Next.js demo showing the full Grantex authorization consent flow — agent registration, consent UI, token exchange, and audit logging.
+
+## Prerequisites
+
+- Node.js 18+
+- A Grantex API key (sign up at [grantex.dev](https://grantex.dev))
+
+## Setup
+
+```bash
+cd examples/nextjs-starter
+npm install
+cp .env.example .env
+```
+
+Edit `.env` and set your `GRANTEX_API_KEY`.
+
+## Run
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) and click **Start Demo**.
+
+## How it works
+
+1. **Start Demo** — The app registers a temporary agent and creates an authorization request via `POST /api/authorize`
+2. **Consent UI** — You're redirected to the Grantex consent page where you see the agent name, scopes, and approve/deny buttons
+3. **Callback** — After approval, Grantex redirects back to `/callback?code=...&state=...`
+4. **Token Exchange** — The callback page calls `POST /api/exchange` to swap the authorization code for a grant token
+5. **Results** — The callback page displays the grant ID, scopes, truncated JWT, and audit trail
+
+All SDK calls happen server-side in API routes — the API key never reaches the browser.

--- a/examples/nextjs-starter/app/api/audit/route.ts
+++ b/examples/nextjs-starter/app/api/audit/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Grantex } from '@grantex/sdk';
+
+const BASE_URL = process.env['GRANTEX_URL'] ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+const API_KEY = process.env['GRANTEX_API_KEY'] ?? '';
+
+export async function GET(request: NextRequest) {
+  if (!API_KEY) {
+    return NextResponse.json({ error: 'GRANTEX_API_KEY not configured' }, { status: 500 });
+  }
+
+  const grantId = request.nextUrl.searchParams.get('grantId');
+  if (!grantId) {
+    return NextResponse.json({ error: 'grantId is required' }, { status: 400 });
+  }
+
+  const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
+
+  try {
+    const result = await grantex.audit.list({ grantId });
+    return NextResponse.json({ entries: result.entries });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/examples/nextjs-starter/app/api/authorize/route.ts
+++ b/examples/nextjs-starter/app/api/authorize/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { Grantex } from '@grantex/sdk';
+import { cookies } from 'next/headers';
+
+const BASE_URL = process.env['GRANTEX_URL'] ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+const API_KEY = process.env['GRANTEX_API_KEY'] ?? '';
+const APP_URL = process.env['NEXT_PUBLIC_APP_URL'] ?? 'http://localhost:3000';
+
+export async function POST() {
+  if (!API_KEY) {
+    return NextResponse.json({ error: 'GRANTEX_API_KEY not configured' }, { status: 500 });
+  }
+
+  const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
+
+  try {
+    // Register a fresh agent for this demo session
+    const agent = await grantex.agents.register({
+      name: 'nextjs-demo-agent',
+      description: 'Temporary agent created by the Next.js starter demo',
+      scopes: ['calendar:read', 'email:send'],
+    });
+
+    // Generate a random state for CSRF protection
+    const state = crypto.randomUUID();
+
+    // Create the authorization request with redirect back to our callback
+    const authRequest = await grantex.authorize({
+      agentId: agent.id,
+      userId: 'demo-user',
+      scopes: ['calendar:read', 'email:send'],
+      redirectUri: `${APP_URL}/callback`,
+    });
+
+    // Store agentId and state in cookies for the callback to use
+    const cookieStore = await cookies();
+    cookieStore.set('grantex_agent_id', agent.id, { path: '/', maxAge: 600, httpOnly: false, sameSite: 'lax' });
+    cookieStore.set('grantex_state', state, { path: '/', maxAge: 600, httpOnly: false, sameSite: 'lax' });
+
+    // Append state to the consent URL
+    const consentUrl = new URL(authRequest.consentUrl);
+    consentUrl.searchParams.set('state', state);
+
+    return NextResponse.json({
+      consentUrl: consentUrl.toString(),
+      agentId: agent.id,
+      authRequestId: authRequest.authRequestId,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/examples/nextjs-starter/app/api/exchange/route.ts
+++ b/examples/nextjs-starter/app/api/exchange/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Grantex } from '@grantex/sdk';
+
+const BASE_URL = process.env['GRANTEX_URL'] ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+const API_KEY = process.env['GRANTEX_API_KEY'] ?? '';
+
+export async function POST(request: NextRequest) {
+  if (!API_KEY) {
+    return NextResponse.json({ error: 'GRANTEX_API_KEY not configured' }, { status: 500 });
+  }
+
+  const body = await request.json() as { code?: string; agentId?: string };
+  const { code, agentId } = body;
+
+  if (!code || !agentId) {
+    return NextResponse.json({ error: 'code and agentId are required' }, { status: 400 });
+  }
+
+  const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
+
+  try {
+    // Exchange authorization code for grant token
+    const token = await grantex.tokens.exchange({ code, agentId });
+
+    // Log an audit entry for the demo
+    const auditEntry = await grantex.audit.log({
+      agentId,
+      grantId: token.grantId,
+      action: 'demo.token_exchanged',
+      status: 'success',
+      metadata: { source: 'nextjs-starter' },
+    });
+
+    return NextResponse.json({
+      grantToken: token.grantToken,
+      grantId: token.grantId,
+      scopes: token.scopes,
+      expiresAt: token.expiresAt,
+      auditEntryId: auditEntry.entryId,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/examples/nextjs-starter/app/callback/page.tsx
+++ b/examples/nextjs-starter/app/callback/page.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface GrantResult {
+  grantToken: string;
+  grantId: string;
+  scopes: string[];
+  expiresAt: string;
+  auditEntryId: string;
+}
+
+interface AuditEntry {
+  entryId: string;
+  action: string;
+  status: string;
+  timestamp: string;
+}
+
+export default function CallbackPage() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [grant, setGrant] = useState<GrantResult | null>(null);
+  const [audit, setAudit] = useState<AuditEntry[]>([]);
+
+  useEffect(() => {
+    async function exchange() {
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get('code');
+      const state = params.get('state');
+      const denied = params.get('error');
+
+      if (denied === 'access_denied') {
+        setError('Authorization was denied by the user.');
+        setLoading(false);
+        return;
+      }
+
+      if (!code) {
+        setError('No authorization code received.');
+        setLoading(false);
+        return;
+      }
+
+      // Read agentId and expected state from cookies
+      const cookies = Object.fromEntries(
+        document.cookie.split('; ').filter(Boolean).map((c) => c.split('=').map(decodeURIComponent))
+      );
+      const agentId = cookies['grantex_agent_id'];
+      const expectedState = cookies['grantex_state'];
+
+      if (!agentId) {
+        setError('Missing agent ID cookie — did you start from the home page?');
+        setLoading(false);
+        return;
+      }
+
+      if (state !== expectedState) {
+        setError('State mismatch — possible CSRF. Please restart the demo.');
+        setLoading(false);
+        return;
+      }
+
+      try {
+        // Exchange code for grant token
+        const exchangeRes = await fetch('/api/exchange', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code, agentId }),
+        });
+        const exchangeData = await exchangeRes.json();
+
+        if (!exchangeRes.ok) {
+          setError(exchangeData.error ?? 'Token exchange failed');
+          setLoading(false);
+          return;
+        }
+
+        setGrant(exchangeData);
+
+        // Fetch audit entries
+        const auditRes = await fetch(`/api/audit?grantId=${exchangeData.grantId}`);
+        if (auditRes.ok) {
+          const auditData = await auditRes.json();
+          setAudit(auditData.entries ?? []);
+        }
+      } catch {
+        setError('Network error during token exchange.');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    exchange();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="card" style={{ textAlign: 'center' }}>
+        <span className="spinner" style={{ width: 32, height: 32 }} />
+        <p style={{ marginTop: 16 }}>Exchanging authorization code…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="card">
+        <h1>Authorization Failed</h1>
+        <div className="error" style={{ marginTop: 12 }}>{error}</div>
+        <a href="/" style={{ display: 'inline-block', marginTop: 16 }}>← Try again</a>
+      </div>
+    );
+  }
+
+  if (!grant) return null;
+
+  const truncatedToken = grant.grantToken.length > 60
+    ? grant.grantToken.slice(0, 30) + '…' + grant.grantToken.slice(-20)
+    : grant.grantToken;
+
+  return (
+    <div className="card">
+      <h1>Authorization Complete</h1>
+      <p>The consent flow completed successfully. Here are the grant details.</p>
+
+      <div className="section" style={{ borderTop: 'none', marginTop: 0, paddingTop: 0 }}>
+        <div className="label">Grant ID</div>
+        <div className="mono">{grant.grantId}</div>
+      </div>
+
+      <div className="section">
+        <div className="label">Scopes</div>
+        <div className="scopes">
+          {grant.scopes.map((s) => (
+            <span key={s} className="badge">{s}</span>
+          ))}
+        </div>
+      </div>
+
+      <div className="section">
+        <div className="label">Grant Token (JWT)</div>
+        <div className="mono">{truncatedToken}</div>
+      </div>
+
+      <div className="section">
+        <div className="label">Expires At</div>
+        <div className="mono">{new Date(grant.expiresAt).toLocaleString()}</div>
+      </div>
+
+      {audit.length > 0 && (
+        <div className="section">
+          <h2>Audit Trail</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Action</th>
+                <th>Status</th>
+                <th>Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {audit.map((entry) => (
+                <tr key={entry.entryId}>
+                  <td style={{ fontFamily: 'var(--mono)' }}>{entry.action}</td>
+                  <td>
+                    <span className="badge">{entry.status}</span>
+                  </td>
+                  <td style={{ color: 'var(--muted)', fontSize: 13 }}>
+                    {new Date(entry.timestamp).toLocaleTimeString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="section">
+        <a href="/">← Start a new demo</a>
+      </div>
+    </div>
+  );
+}

--- a/examples/nextjs-starter/app/globals.css
+++ b/examples/nextjs-starter/app/globals.css
@@ -1,0 +1,168 @@
+:root {
+  --bg: #0d1117;
+  --surface: #161b22;
+  --border: #30363d;
+  --text: #e6edf3;
+  --muted: #8b949e;
+  --accent: #3fb950;
+  --accent2: #58a6ff;
+  --mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+  --sans: 'Inter', system-ui, -apple-system, sans-serif;
+  --radius: 8px;
+  --max-w: 720px;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+a { color: var(--accent2); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 32px;
+  max-width: var(--max-w);
+  width: 100%;
+}
+
+h1 {
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+h2 {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+p {
+  color: var(--muted);
+  line-height: 1.6;
+  margin-bottom: 16px;
+}
+
+.badge {
+  display: inline-block;
+  background: rgba(63, 185, 80, 0.15);
+  color: var(--accent);
+  border: 1px solid rgba(63, 185, 80, 0.3);
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: var(--mono);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--accent);
+  color: #0d1117;
+  border: none;
+  border-radius: var(--radius);
+  padding: 12px 24px;
+  font-size: 15px;
+  font-weight: 600;
+  font-family: var(--sans);
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.btn:hover { opacity: 0.85; }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.mono {
+  font-family: var(--mono);
+  font-size: 13px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px 16px;
+  word-break: break-all;
+  line-height: 1.5;
+}
+
+.section {
+  margin-top: 24px;
+  padding-top: 24px;
+  border-top: 1px solid var(--border);
+}
+
+.label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+.scopes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.error {
+  background: rgba(248, 81, 73, 0.1);
+  border: 1px solid rgba(248, 81, 73, 0.4);
+  border-radius: var(--radius);
+  color: #f85149;
+  padding: 12px 16px;
+  font-size: 14px;
+}
+
+.spinner {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  margin-bottom: 16px;
+}
+
+th, td {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+th {
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}

--- a/examples/nextjs-starter/app/layout.tsx
+++ b/examples/nextjs-starter/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Grantex Next.js Demo',
+  description: 'Interactive demo of the Grantex authorization consent flow.',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/nextjs-starter/app/page.tsx
+++ b/examples/nextjs-starter/app/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function Home() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function startDemo() {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch('/api/authorize', { method: 'POST' });
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error ?? 'Failed to start authorization');
+        setLoading(false);
+        return;
+      }
+
+      // Redirect to Grantex consent UI
+      window.location.href = data.consentUrl;
+    } catch {
+      setError('Network error — is the server running?');
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="card">
+      <h1>Grantex Next.js Demo</h1>
+      <p>
+        Interactive demo of the Grantex authorization consent flow.
+        Click the button below to register a temporary agent, start an
+        authorization request, and walk through the consent UI.
+      </p>
+
+      <p style={{ fontSize: 14 }}>
+        <strong style={{ color: 'var(--text)' }}>What happens:</strong>{' '}
+        A fresh agent is registered → you're redirected to the Grantex consent
+        page → after approval the code is exchanged for a grant token →
+        results are displayed on the callback page.
+      </p>
+
+      {error && <div className="error">{error}</div>}
+
+      <button className="btn" onClick={startDemo} disabled={loading} style={{ marginTop: 16 }}>
+        {loading ? <><span className="spinner" /> Starting…</> : 'Start Demo →'}
+      </button>
+    </div>
+  );
+}

--- a/examples/nextjs-starter/next.config.ts
+++ b/examples/nextjs-starter/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/examples/nextjs-starter/package.json
+++ b/examples/nextjs-starter/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "grantex-nextjs-starter",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@grantex/sdk": "^0.1.1",
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/nextjs-starter/tsconfig.json
+++ b/examples/nextjs-starter/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- Add `examples/nextjs-starter/` — full-stack Next.js app demonstrating the interactive Grantex authorization consent flow
- Server-side API routes (`/api/authorize`, `/api/exchange`, `/api/audit`) keep the SDK API key off the browser
- Landing page → consent UI redirect → callback with grant details + audit trail
- Cookie-based CSRF state, fresh agent per demo (no DB needed), dark theme matching grantex.dev
- New docs page at `docs/examples/nextjs-starter.mdx` with ASCII flow diagram
- Added to Examples nav group in `docs/docs.json`

## Test plan
- [ ] `cd examples/nextjs-starter && npm install && npm run dev` starts without errors
- [ ] Click "Start Demo" → redirects to Grantex consent UI
- [ ] Approve → callback page shows grant ID, scopes, JWT, and audit trail
- [ ] Deny → callback page shows "Authorization was denied" error
- [ ] `grantex.mintlify.app/examples/nextjs-starter` docs page renders after deploy