### PR TITLE
fix: remove duplicate Blog tab from docs navbar

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -21,8 +21,7 @@
         { "tab": "Python SDK", "href": "/sdks/python/overview" },
         { "tab": "Integrations", "href": "/integrations/overview" },
         { "tab": "API Reference", "href": "/api-reference" },
-        { "tab": "Protocol", "href": "/protocol/specification" },
-        { "tab": "Blog", "href": "/blog/introducing-grantex" }
+        { "tab": "Protocol", "href": "/protocol/specification" }
       ]
     },
     "tabs": [


### PR DESCRIPTION
## Summary
- Remove Blog from `navigation.global.tabs` — it was already defined in `navigation.tabs`, causing it to appear twice in the Mintlify navbar

## Test plan
- [ ] Verify only one Blog tab appears at `grantex.mintlify.app/introduction` after Mintlify redeploy