### PR TITLE
fix: move admin route outside RequireAuth wrapper

### DIFF
--- a/apps/portal/src/routes.tsx
+++ b/apps/portal/src/routes.tsx
@@ -24,6 +24,7 @@ import { RequireAuth } from './RequireAuth';
 export const routes: RouteObject[] = [
   { path: '/dashboard/login', element: <Login /> },
   { path: '/dashboard/signup', element: <Signup /> },
+  { path: '/dashboard/admin', element: <AdminPage /> },
   {
     element: (
       <RequireAuth>
@@ -48,7 +49,6 @@ export const routes: RouteObject[] = [
       { path: '/dashboard/compliance', element: <ComplianceDashboard /> },
       { path: '/dashboard/billing', element: <BillingPage /> },
       { path: '/dashboard/settings', element: <SettingsPage /> },
-      { path: '/dashboard/admin', element: <AdminPage /> },
       { path: '/dashboard/*', element: <NotFound /> },
     ],
   },


### PR DESCRIPTION
## Summary
- Move `/dashboard/admin` route outside the `RequireAuth` wrapper so it doesn't redirect to login
- The admin page handles its own auth via the admin API key prompt

## Test plan
- [ ] Visit `grantex.dev/dashboard/admin` without being logged in — should show admin key prompt, not redirect to login