### PR TITLE
feat: add @grantex/conformance test suite

### DIFF
--- a/packages/conformance/README.md
+++ b/packages/conformance/README.md
@@ -1,0 +1,115 @@
+# @grantex/conformance
+
+Conformance test suite for the [Grantex protocol](https://grantex.dev). Validates that a server implementation correctly implements the Grantex specification by running black-box HTTP tests against a live endpoint.
+
+## Quick Start
+
+```bash
+npx @grantex/conformance --base-url http://localhost:3001 --api-key YOUR_API_KEY
+```
+
+## Installation
+
+```bash
+npm install -g @grantex/conformance
+```
+
+## Usage
+
+```
+grantex-conformance --base-url URL --api-key KEY [options]
+
+Options:
+  --base-url <url>       Base URL of the Grantex auth service (required)
+  --api-key <key>        API key for authentication (required)
+  --suite <name>         Run a specific suite only
+  --include <ext,...>    Include optional extensions (comma-separated)
+  --format <format>      Output format: text or json (default: text)
+  --bail                 Stop on first failure
+  -h, --help             Display help
+```
+
+### Run all core suites
+
+```bash
+grantex-conformance --base-url http://localhost:3001 --api-key sk_test_xxx
+```
+
+### Run a single suite
+
+```bash
+grantex-conformance --base-url http://localhost:3001 --api-key sk_test_xxx --suite health
+```
+
+### Include optional extensions
+
+```bash
+grantex-conformance --base-url http://localhost:3001 --api-key sk_test_xxx \
+  --include policies,webhooks,scim
+```
+
+### JSON output
+
+```bash
+grantex-conformance --base-url http://localhost:3001 --api-key sk_test_xxx --format json
+```
+
+## Core Suites (37 tests)
+
+| Suite | Tests | Description |
+|-------|-------|-------------|
+| `health` | 2 | Health check endpoint and JWKS key validation |
+| `agents` | 5 | Agent registration, listing, retrieval, update, deletion |
+| `authorize` | 4 | Authorization request creation and consent flow |
+| `token` | 3 | Token exchange, invalid code rejection, code reuse prevention |
+| `tokens` | 4 | Token verification, revocation, post-revoke verification |
+| `grants` | 4 | Grant listing, retrieval, revocation, status validation |
+| `delegation` | 5 | Grant delegation, JWT claims, scope enforcement, depth limits, cascade revocation |
+| `audit` | 5 | Audit log creation, hash chain integrity, entry retrieval |
+| `security` | 5 | Auth enforcement, JWKS algorithm, scope escalation prevention, audit immutability |
+
+## Optional Extensions
+
+| Suite | Tests | Description |
+|-------|-------|-------------|
+| `policies` | 5 | Policy CRUD operations |
+| `webhooks` | 3 | Webhook registration and management |
+| `scim` | 6 | SCIM 2.0 provisioning endpoints |
+| `sso` | 4 | SSO configuration and flow |
+| `anomalies` | 3 | Anomaly detection and acknowledgement |
+| `compliance` | 4 | Compliance reporting and evidence export |
+
+## Programmatic API
+
+```typescript
+import { runConformanceTests } from '@grantex/conformance/runner';
+import { reportJson } from '@grantex/conformance/reporter';
+
+const report = await runConformanceTests({
+  baseUrl: 'http://localhost:3001',
+  apiKey: 'sk_test_xxx',
+  format: 'json',
+  bail: false,
+});
+
+console.log(reportJson(report));
+```
+
+## Server Requirements
+
+- The server must implement the Grantex protocol endpoints
+- An API key with sufficient permissions to create agents, authorize, and manage grants
+- For sandbox mode servers, authorization codes are returned directly
+- For non-sandbox servers, the `/v1/consent/:id/approve` endpoint must be available
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All tests passed |
+| `1` | One or more tests failed |
+| `2` | Configuration or runtime error |
+
+## License
+
+Apache-2.0

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@grantex/conformance",
+  "version": "0.1.0",
+  "description": "Conformance test suite for the Grantex protocol",
+  "type": "module",
+  "bin": {
+    "grantex-conformance": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "dev": "node --loader ts-node/esm src/index.ts"
+  },
+  "dependencies": {
+    "chalk": "^5.3.0",
+    "commander": "^12.0.0"
+  },
+  "overrides": {
+    "esbuild": ">=0.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.3.3",
+    "vitest": "^1.3.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "keywords": [
+    "grantex",
+    "conformance",
+    "testing",
+    "protocol",
+    "ai-agents",
+    "authorization",
+    "oauth"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mishrasanjeev/grantex"
+  }
+}

--- a/packages/conformance/src/cleanup.ts
+++ b/packages/conformance/src/cleanup.ts
@@ -1,0 +1,63 @@
+import type { ConformanceHttpClient } from './http-client.js';
+
+export class CleanupTracker {
+  private agents: string[] = [];
+  private grants: string[] = [];
+  private policies: string[] = [];
+  private webhooks: string[] = [];
+
+  constructor(private readonly http: ConformanceHttpClient) {}
+
+  trackAgent(id: string): void {
+    this.agents.push(id);
+  }
+
+  trackGrant(id: string): void {
+    this.grants.push(id);
+  }
+
+  trackPolicy(id: string): void {
+    this.policies.push(id);
+  }
+
+  trackWebhook(id: string): void {
+    this.webhooks.push(id);
+  }
+
+  async teardown(): Promise<void> {
+    // Delete in reverse order of dependency: grants → agents → policies → webhooks
+    for (const id of this.grants) {
+      try {
+        await this.http.delete(`/v1/grants/${id}`);
+      } catch {
+        // best-effort
+      }
+    }
+    for (const id of this.agents) {
+      try {
+        await this.http.delete(`/v1/agents/${id}`);
+      } catch {
+        // best-effort
+      }
+    }
+    for (const id of this.policies) {
+      try {
+        await this.http.delete(`/v1/policies/${id}`);
+      } catch {
+        // best-effort
+      }
+    }
+    for (const id of this.webhooks) {
+      try {
+        await this.http.delete(`/v1/webhooks/${id}`);
+      } catch {
+        // best-effort
+      }
+    }
+
+    this.agents = [];
+    this.grants = [];
+    this.policies = [];
+    this.webhooks = [];
+  }
+}

--- a/packages/conformance/src/cli.ts
+++ b/packages/conformance/src/cli.ts
@@ -1,0 +1,52 @@
+import { Command } from 'commander';
+import type { RunConfig } from './types.js';
+import { runConformanceTests } from './runner.js';
+import { reportText, reportJson } from './reporter.js';
+
+export async function run(): Promise<void> {
+  const program = new Command();
+
+  program
+    .name('grantex-conformance')
+    .description('Conformance test suite for the Grantex protocol')
+    .requiredOption('--base-url <url>', 'Base URL of the Grantex auth service')
+    .requiredOption('--api-key <key>', 'API key for authentication')
+    .option('--suite <name>', 'Run a specific suite only')
+    .option('--include <extensions>', 'Include optional extensions (comma-separated)')
+    .option('--format <format>', 'Output format: text or json', 'text')
+    .option('--bail', 'Stop on first failure', false)
+    .action(async (opts: {
+      baseUrl: string;
+      apiKey: string;
+      suite?: string;
+      include?: string;
+      format: string;
+      bail: boolean;
+    }) => {
+      const config: RunConfig = {
+        baseUrl: opts.baseUrl.replace(/\/$/, ''),
+        apiKey: opts.apiKey,
+        suite: opts.suite,
+        include: opts.include ? opts.include.split(',').map((s) => s.trim()) : undefined,
+        format: opts.format === 'json' ? 'json' : 'text',
+        bail: opts.bail,
+      };
+
+      try {
+        const report = await runConformanceTests(config);
+
+        if (config.format === 'json') {
+          process.stdout.write(reportJson(report) + '\n');
+        } else {
+          process.stdout.write(reportText(report));
+        }
+
+        process.exit(report.summary.failed > 0 ? 1 : 0);
+      } catch (err) {
+        process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+        process.exit(2);
+      }
+    });
+
+  await program.parseAsync(process.argv);
+}

--- a/packages/conformance/src/flow.ts
+++ b/packages/conformance/src/flow.ts
@@ -1,0 +1,122 @@
+import type { ConformanceHttpClient } from './http-client.js';
+import type { CleanupTracker } from './cleanup.js';
+
+export interface FlowResult {
+  agentId: string;
+  agentDid: string;
+  authRequestId: string;
+  code: string;
+  grantToken: string;
+  refreshToken: string;
+  grantId: string;
+  scopes: string[];
+  expiresAt: string;
+  principalId: string;
+}
+
+interface AuthorizeResponse {
+  authRequestId: string;
+  consentUrl: string;
+  expiresAt: string;
+  code?: string;
+  sandbox?: boolean;
+  policyEnforced?: boolean;
+}
+
+interface ConsentApproveResponse {
+  code: string;
+}
+
+interface TokenResponse {
+  grantToken: string;
+  expiresAt: string;
+  scopes: string[];
+  refreshToken: string;
+  grantId: string;
+}
+
+interface AgentResponse {
+  agentId: string;
+  did: string;
+  name: string;
+  scopes: string[];
+}
+
+export interface FlowOptions {
+  agentName?: string;
+  scopes?: string[];
+  principalId?: string;
+}
+
+export class AuthFlowHelper {
+  constructor(
+    private readonly http: ConformanceHttpClient,
+    private readonly cleanup: CleanupTracker,
+  ) {}
+
+  async executeFullFlow(options?: FlowOptions): Promise<FlowResult> {
+    const agentName = options?.agentName ?? `conformance-agent-${Date.now()}`;
+    const scopes = options?.scopes ?? ['read', 'write'];
+    const principalId = options?.principalId ?? `principal-${Date.now()}`;
+
+    // 1. Create agent
+    const agentRes = await this.http.post<AgentResponse>('/v1/agents', {
+      name: agentName,
+      scopes,
+    });
+    if (agentRes.status !== 201) {
+      throw new Error(`Failed to create agent: ${agentRes.status} ${agentRes.rawText}`);
+    }
+    const { agentId, did: agentDid } = agentRes.body;
+    this.cleanup.trackAgent(agentId);
+
+    // 2. Authorize
+    const authRes = await this.http.post<AuthorizeResponse>('/v1/authorize', {
+      agentId,
+      principalId,
+      scopes,
+    });
+    if (authRes.status !== 201) {
+      throw new Error(`Failed to authorize: ${authRes.status} ${authRes.rawText}`);
+    }
+    const { authRequestId } = authRes.body;
+
+    // 3. Get code — sandbox auto-provides it, otherwise approve consent
+    let code: string;
+    if (authRes.body.code) {
+      code = authRes.body.code;
+    } else {
+      const consentRes = await this.http.requestPublic<ConsentApproveResponse>(
+        'POST',
+        `/v1/consent/${authRequestId}/approve`,
+      );
+      if (consentRes.status !== 200) {
+        throw new Error(`Failed to approve consent: ${consentRes.status} ${consentRes.rawText}`);
+      }
+      code = consentRes.body.code;
+    }
+
+    // 4. Exchange code for token
+    const tokenRes = await this.http.post<TokenResponse>('/v1/token', {
+      code,
+      agentId,
+    });
+    if (tokenRes.status !== 201) {
+      throw new Error(`Failed to exchange token: ${tokenRes.status} ${tokenRes.rawText}`);
+    }
+    this.cleanup.trackGrant(tokenRes.body.grantId);
+
+    return {
+      agentId,
+      agentDid,
+      authRequestId,
+      code,
+      grantToken: tokenRes.body.grantToken,
+      refreshToken: tokenRes.body.refreshToken,
+      grantId: tokenRes.body.grantId,
+      scopes: tokenRes.body.scopes,
+      expiresAt: tokenRes.body.expiresAt,
+      principalId,
+    };
+  }
+}

--- a/packages/conformance/src/helpers.ts
+++ b/packages/conformance/src/helpers.ts
@@ -1,0 +1,90 @@
+import type { HttpResponse, TestResult, TestStatus } from './types.js';
+
+export async function test(
+  name: string,
+  specRef: string,
+  fn: () => Promise<void>,
+): Promise<TestResult> {
+  const start = Date.now();
+  try {
+    await fn();
+    return { name, status: 'pass', durationMs: Date.now() - start, specRef };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { name, status: 'fail', durationMs: Date.now() - start, specRef, error };
+  }
+}
+
+export function skip(name: string, specRef: string, reason: string): TestResult {
+  return { name, status: 'skip', durationMs: 0, specRef, error: reason };
+}
+
+export class AssertionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AssertionError';
+  }
+}
+
+export function expectStatus(res: HttpResponse, expected: number): void {
+  if (res.status !== expected) {
+    throw new AssertionError(
+      `Expected status ${expected}, got ${res.status}: ${res.rawText.slice(0, 200)}`,
+    );
+  }
+}
+
+export function expectKeys(body: unknown, keys: string[]): void {
+  if (typeof body !== 'object' || body === null) {
+    throw new AssertionError(`Expected object, got ${typeof body}`);
+  }
+  const obj = body as Record<string, unknown>;
+  const missing = keys.filter((k) => !(k in obj));
+  if (missing.length > 0) {
+    throw new AssertionError(`Missing keys: ${missing.join(', ')}`);
+  }
+}
+
+export function expectString(val: unknown, field: string): void {
+  if (typeof val !== 'string' || val.length === 0) {
+    throw new AssertionError(`Expected non-empty string for "${field}", got ${JSON.stringify(val)}`);
+  }
+}
+
+export function expectArray(val: unknown, field: string): void {
+  if (!Array.isArray(val)) {
+    throw new AssertionError(`Expected array for "${field}", got ${typeof val}`);
+  }
+}
+
+export function expectBoolean(val: unknown, field: string): void {
+  if (typeof val !== 'boolean') {
+    throw new AssertionError(`Expected boolean for "${field}", got ${typeof val}`);
+  }
+}
+
+export function expectIsoDate(val: unknown, field: string): void {
+  if (typeof val !== 'string') {
+    throw new AssertionError(`Expected ISO date string for "${field}", got ${typeof val}`);
+  }
+  const d = new Date(val);
+  if (isNaN(d.getTime())) {
+    throw new AssertionError(`Invalid ISO date for "${field}": ${val}`);
+  }
+}
+
+export function expectEqual(actual: unknown, expected: unknown, field: string): void {
+  if (actual !== expected) {
+    throw new AssertionError(
+      `Expected "${field}" to be ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+export function expectIncludes(arr: unknown[], value: unknown, field: string): void {
+  if (!arr.includes(value)) {
+    throw new AssertionError(
+      `Expected "${field}" to include ${JSON.stringify(value)}, got ${JSON.stringify(arr)}`,
+    );
+  }
+}

--- a/packages/conformance/src/http-client.ts
+++ b/packages/conformance/src/http-client.ts
@@ -1,0 +1,90 @@
+import type { HttpResponse } from './types.js';
+
+const USER_AGENT = '@grantex/conformance/0.1.0';
+
+export class ConformanceHttpClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly apiKey: string,
+  ) {}
+
+  async request<T = unknown>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<HttpResponse<T>> {
+    return this.doRequest<T>(method, path, body, {
+      Authorization: `Bearer ${this.apiKey}`,
+    });
+  }
+
+  async requestPublic<T = unknown>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<HttpResponse<T>> {
+    return this.doRequest<T>(method, path, body, {});
+  }
+
+  async get<T = unknown>(path: string): Promise<HttpResponse<T>> {
+    return this.request<T>('GET', path);
+  }
+
+  async post<T = unknown>(path: string, body?: unknown): Promise<HttpResponse<T>> {
+    return this.request<T>('POST', path, body);
+  }
+
+  async patch<T = unknown>(path: string, body?: unknown): Promise<HttpResponse<T>> {
+    return this.request<T>('PATCH', path, body);
+  }
+
+  async delete(path: string): Promise<HttpResponse> {
+    return this.request('DELETE', path);
+  }
+
+  async doRequestWithToken<T = unknown>(
+    method: string,
+    path: string,
+    token: string,
+    body?: unknown,
+  ): Promise<HttpResponse<T>> {
+    return this.doRequest<T>(method, path, body, {
+      Authorization: `Bearer ${token}`,
+    });
+  }
+
+  private async doRequest<T = unknown>(
+    method: string,
+    path: string,
+    body: unknown,
+    headers: Record<string, string>,
+  ): Promise<HttpResponse<T>> {
+    const url = `${this.baseUrl}${path}`;
+    const init: RequestInit = {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': USER_AGENT,
+        ...headers,
+      },
+    };
+
+    if (body !== undefined) {
+      init.body = JSON.stringify(body);
+    }
+
+    const start = Date.now();
+    const res = await fetch(url, init);
+    const durationMs = Date.now() - start;
+
+    const rawText = await res.text();
+    let parsed: T;
+    try {
+      parsed = JSON.parse(rawText) as T;
+    } catch {
+      parsed = rawText as T;
+    }
+
+    return { status: res.status, body: parsed, rawText, durationMs };
+  }
+}

--- a/packages/conformance/src/index.ts
+++ b/packages/conformance/src/index.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { run } from './cli.js';
+
+run();

--- a/packages/conformance/src/reporter.ts
+++ b/packages/conformance/src/reporter.ts
@@ -1,0 +1,80 @@
+import chalk from 'chalk';
+import type { ConformanceReport, TestResult, SuiteResult } from './types.js';
+
+function statusIcon(status: TestResult['status']): string {
+  switch (status) {
+    case 'pass':
+      return chalk.green('✓');
+    case 'fail':
+      return chalk.red('✗');
+    case 'skip':
+      return chalk.yellow('○');
+  }
+}
+
+function statusLabel(status: TestResult['status']): string {
+  switch (status) {
+    case 'pass':
+      return chalk.green('PASS');
+    case 'fail':
+      return chalk.red('FAIL');
+    case 'skip':
+      return chalk.yellow('SKIP');
+  }
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+export function reportText(report: ConformanceReport): string {
+  const lines: string[] = [];
+
+  lines.push('');
+  lines.push(chalk.bold('Grantex Conformance Test Suite'));
+  lines.push(chalk.dim('─'.repeat(50)));
+  lines.push('');
+
+  for (const suite of report.suites) {
+    const tag = suite.optional ? chalk.dim(' (optional)') : '';
+    lines.push(chalk.bold(`  ${suite.name}${tag}`));
+    lines.push(chalk.dim(`  ${suite.description}`));
+    lines.push('');
+
+    for (const t of suite.tests) {
+      const duration = chalk.dim(`(${formatDuration(t.durationMs)})`);
+      const ref = chalk.dim(`[${t.specRef}]`);
+      lines.push(`    ${statusIcon(t.status)} ${t.name} ${duration} ${ref}`);
+      if (t.error) {
+        lines.push(chalk.red(`      ${t.error}`));
+      }
+    }
+    lines.push('');
+  }
+
+  lines.push(chalk.dim('─'.repeat(50)));
+
+  const { total, passed, failed, skipped, durationMs } = report.summary;
+  const parts: string[] = [];
+  if (passed > 0) parts.push(chalk.green(`${passed} passed`));
+  if (failed > 0) parts.push(chalk.red(`${failed} failed`));
+  if (skipped > 0) parts.push(chalk.yellow(`${skipped} skipped`));
+  parts.push(`${total} total`);
+
+  lines.push(`  ${parts.join(', ')} ${chalk.dim(`in ${formatDuration(durationMs)}`)}`);
+  lines.push('');
+
+  if (failed === 0) {
+    lines.push(chalk.green.bold('  All tests passed!'));
+  } else {
+    lines.push(chalk.red.bold(`  ${failed} test(s) failed.`));
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+export function reportJson(report: ConformanceReport): string {
+  return JSON.stringify(report, null, 2);
+}

--- a/packages/conformance/src/runner.ts
+++ b/packages/conformance/src/runner.ts
@@ -1,0 +1,133 @@
+import type { RunConfig, ConformanceReport, SuiteResult, SuiteContext, SuiteDefinition } from './types.js';
+import { ConformanceHttpClient } from './http-client.js';
+import { CleanupTracker } from './cleanup.js';
+import { AuthFlowHelper } from './flow.js';
+
+// Core suites
+import { healthSuite } from './suites/health.js';
+import { agentsSuite } from './suites/agents.js';
+import { authorizeSuite } from './suites/authorize.js';
+import { tokenSuite } from './suites/token.js';
+import { tokensSuite } from './suites/tokens.js';
+import { grantsSuite } from './suites/grants.js';
+import { delegationSuite } from './suites/delegation.js';
+import { auditSuite } from './suites/audit.js';
+import { securitySuite } from './suites/security.js';
+
+// Optional suites
+import { policiesSuite } from './suites/policies.js';
+import { webhooksSuite } from './suites/webhooks.js';
+import { scimSuite } from './suites/scim.js';
+import { ssoSuite } from './suites/sso.js';
+import { anomaliesSuite } from './suites/anomalies.js';
+import { complianceSuite } from './suites/compliance.js';
+
+const coreSuites: SuiteDefinition[] = [
+  healthSuite,
+  agentsSuite,
+  authorizeSuite,
+  tokenSuite,
+  tokensSuite,
+  grantsSuite,
+  delegationSuite,
+  auditSuite,
+  securitySuite,
+];
+
+const optionalSuites: SuiteDefinition[] = [
+  policiesSuite,
+  webhooksSuite,
+  scimSuite,
+  ssoSuite,
+  anomaliesSuite,
+  complianceSuite,
+];
+
+export async function runConformanceTests(config: RunConfig): Promise<ConformanceReport> {
+  const allSuites = [...coreSuites];
+
+  if (config.include) {
+    for (const ext of config.include) {
+      const found = optionalSuites.find((s) => s.name === ext);
+      if (found) {
+        allSuites.push(found);
+      }
+    }
+  }
+
+  let suitesToRun = allSuites;
+  if (config.suite) {
+    suitesToRun = allSuites.filter((s) => s.name === config.suite);
+    if (suitesToRun.length === 0) {
+      const available = allSuites.map((s) => s.name).join(', ');
+      throw new Error(`Unknown suite "${config.suite}". Available: ${available}`);
+    }
+  }
+
+  const results: SuiteResult[] = [];
+  const overallStart = Date.now();
+  let bailed = false;
+
+  for (const suite of suitesToRun) {
+    if (bailed) break;
+
+    const http = new ConformanceHttpClient(config.baseUrl, config.apiKey);
+    const cleanup = new CleanupTracker(http);
+    const flow = new AuthFlowHelper(http, cleanup);
+
+    const ctx: SuiteContext = {
+      baseUrl: config.baseUrl,
+      apiKey: config.apiKey,
+      http,
+      flow,
+      cleanup,
+    };
+
+    const suiteStart = Date.now();
+    try {
+      const tests = await suite.run(ctx);
+      results.push({
+        name: suite.name,
+        description: suite.description,
+        optional: suite.optional,
+        tests,
+        durationMs: Date.now() - suiteStart,
+      });
+
+      if (config.bail && tests.some((t) => t.status === 'fail')) {
+        bailed = true;
+      }
+    } catch (err) {
+      results.push({
+        name: suite.name,
+        description: suite.description,
+        optional: suite.optional,
+        tests: [
+          {
+            name: `${suite.name} setup`,
+            status: 'fail',
+            durationMs: Date.now() - suiteStart,
+            specRef: '',
+            error: err instanceof Error ? err.message : String(err),
+          },
+        ],
+        durationMs: Date.now() - suiteStart,
+      });
+      if (config.bail) bailed = true;
+    } finally {
+      await cleanup.teardown();
+    }
+  }
+
+  const allTests = results.flatMap((s) => s.tests);
+  return {
+    suites: results,
+    summary: {
+      total: allTests.length,
+      passed: allTests.filter((t) => t.status === 'pass').length,
+      failed: allTests.filter((t) => t.status === 'fail').length,
+      skipped: allTests.filter((t) => t.status === 'skip').length,
+      durationMs: Date.now() - overallStart,
+    },
+  };
+}

--- a/packages/conformance/src/suites/agents.ts
+++ b/packages/conformance/src/suites/agents.ts
@@ -1,0 +1,72 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectKeys, expectString, expectArray } from '../helpers.js';
+
+export const agentsSuite: SuiteDefinition = {
+  name: 'agents',
+  description: 'Agent registration and management (CRUD)',
+  optional: false,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+    let agentId = '';
+
+    results.push(
+      await test('POST /v1/agents creates agent with agentId and did', '§10', async () => {
+        const res = await ctx.http.post<{
+          agentId: string;
+          did: string;
+          name: string;
+          scopes: string[];
+        }>('/v1/agents', {
+          name: `conformance-agent-${Date.now()}`,
+          scopes: ['read', 'write'],
+        });
+        expectStatus(res, 201);
+        expectKeys(res.body, ['agentId', 'did', 'name', 'scopes', 'status', 'createdAt']);
+        expectString(res.body.agentId, 'agentId');
+        expectString(res.body.did, 'did');
+        agentId = res.body.agentId;
+        ctx.cleanup.trackAgent(agentId);
+      }),
+    );
+
+    results.push(
+      await test('GET /v1/agents lists agents', '§10', async () => {
+        const res = await ctx.http.get<{ agents: unknown[] }>('/v1/agents');
+        expectStatus(res, 200);
+        expectKeys(res.body, ['agents']);
+        expectArray(res.body.agents, 'agents');
+      }),
+    );
+
+    results.push(
+      await test('GET /v1/agents/:id returns agent details', '§10', async () => {
+        if (!agentId) throw new Error('No agent created in previous test');
+        const res = await ctx.http.get<{ agentId: string }>(`/v1/agents/${agentId}`);
+        expectStatus(res, 200);
+        expectKeys(res.body, ['agentId', 'did', 'name', 'scopes', 'status']);
+      }),
+    );
+
+    results.push(
+      await test('PATCH /v1/agents/:id updates agent', '§10', async () => {
+        if (!agentId) throw new Error('No agent created in previous test');
+        const res = await ctx.http.patch<{ agentId: string; name: string }>(
+          `/v1/agents/${agentId}`,
+          { name: `updated-${Date.now()}` },
+        );
+        expectStatus(res, 200);
+        expectKeys(res.body, ['agentId', 'name']);
+      }),
+    );
+
+    results.push(
+      await test('DELETE /v1/agents/:id returns 204', '§10', async () => {
+        if (!agentId) throw new Error('No agent created in previous test');
+        const res = await ctx.http.delete(`/v1/agents/${agentId}`);
+        expectStatus(res, 204);
+      }),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/suites/anomalies.ts
+++ b/packages/conformance/src/suites/anomalies.ts
@@ -1,0 +1,42 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectKeys, expectArray } from '../helpers.js';
+
+export const anomaliesSuite: SuiteDefinition = {
+  name: 'anomalies',
+  description: 'Anomaly detection and acknowledgement',
+  optional: true,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+
+    results.push(
+      await test('POST /v1/anomalies/detect runs detection (200)', '§12', async () => {
+        const res = await ctx.http.post<{
+          detectedAt: string;
+          total: number;
+          anomalies: unknown[];
+        }>('/v1/anomalies/detect');
+        expectStatus(res, 200);
+        expectKeys(res.body, ['detectedAt', 'total', 'anomalies']);
+        expectArray(res.body.anomalies, 'anomalies');
+      }),
+    );
+
+    results.push(
+      await test('GET /v1/anomalies lists anomalies', '§12', async () => {
+        const res = await ctx.http.get<{ anomalies: unknown[]; total: number }>('/v1/anomalies');
+        expectStatus(res, 200);
+        expectKeys(res.body, ['anomalies', 'total']);
+        expectArray(res.body.anomalies, 'anomalies');
+      }),
+    );
+
+    results.push(
+      await test('PATCH /v1/anomalies/:id/acknowledge returns 404 for invalid ID', '§12', async () => {
+        const res = await ctx.http.patch('/v1/anomalies/nonexistent-id/acknowledge');
+        expectStatus(res, 404);
+      }),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/suites/audit.ts
+++ b/packages/conformance/src/suites/audit.ts
@@ -1,0 +1,115 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectKeys, expectString, expectArray, expectEqual } from '../helpers.js';
+
+export const auditSuite: SuiteDefinition = {
+  name: 'audit',
+  description: 'Audit logging with hash chain integrity',
+  optional: false,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+
+    // Get a flow for audit entry data
+    const flow = await ctx.flow.executeFullFlow({
+      agentName: `conformance-audit-${Date.now()}`,
+      scopes: ['read'],
+    });
+
+    let entry1Id = '';
+    let entry1Hash = '';
+    let entry2Id = '';
+    let entry2Hash = '';
+    let entry2PrevHash = '';
+
+    results.push(
+      await test(
+        'POST /v1/audit/log creates entry with entryId, hash, prevHash (201)',
+        '§8',
+        async () => {
+          const res = await ctx.http.post<{
+            entryId: string;
+            hash: string;
+            prevHash: string | null;
+          }>('/v1/audit/log', {
+            agentId: flow.agentId,
+            agentDid: flow.agentDid,
+            grantId: flow.grantId,
+            principalId: flow.principalId,
+            action: 'conformance.test.1',
+          });
+          expectStatus(res, 201);
+          expectKeys(res.body, ['entryId', 'hash', 'prevHash']);
+          expectString(res.body.entryId, 'entryId');
+          expectString(res.body.hash, 'hash');
+          entry1Id = res.body.entryId;
+          entry1Hash = res.body.hash;
+        },
+      ),
+    );
+
+    results.push(
+      await test(
+        'Hash chain integrity: entry2.prevHash === entry1.hash',
+        '§8',
+        async () => {
+          const res = await ctx.http.post<{
+            entryId: string;
+            hash: string;
+            prevHash: string | null;
+          }>('/v1/audit/log', {
+            agentId: flow.agentId,
+            agentDid: flow.agentDid,
+            grantId: flow.grantId,
+            principalId: flow.principalId,
+            action: 'conformance.test.2',
+          });
+          expectStatus(res, 201);
+          entry2Id = res.body.entryId;
+          entry2Hash = res.body.hash;
+          entry2PrevHash = res.body.prevHash as string;
+
+          // The prevHash of entry2 should equal the hash of entry1
+          // Note: prevHash chains per-developer, so this only holds if no other
+          // entries were created between entry1 and entry2
+          if (entry1Hash && entry2PrevHash) {
+            expectEqual(entry2PrevHash, entry1Hash, 'prevHash chain');
+          }
+        },
+      ),
+    );
+
+    results.push(
+      await test('GET /v1/audit/entries returns entries list', '§8', async () => {
+        const res = await ctx.http.get<{ entries: unknown[] }>('/v1/audit/entries');
+        expectStatus(res, 200);
+        expectKeys(res.body, ['entries']);
+        expectArray(res.body.entries, 'entries');
+      }),
+    );
+
+    results.push(
+      await test('GET /v1/audit/:id returns single entry', '§8', async () => {
+        if (!entry1Id) throw new Error('No audit entry created');
+        const res = await ctx.http.get<{
+          entryId: string;
+          hash: string;
+          action: string;
+        }>(`/v1/audit/${entry1Id}`);
+        expectStatus(res, 200);
+        expectKeys(res.body, ['entryId', 'hash', 'action']);
+        expectEqual(res.body.entryId, entry1Id, 'entryId');
+      }),
+    );
+
+    results.push(
+      await test('Audit hash is a valid SHA-256 hex string', '§8', async () => {
+        if (!entry1Hash) throw new Error('No hash from previous test');
+        // SHA-256 hex string is 64 characters
+        if (!/^[a-f0-9]{64}$/i.test(entry1Hash)) {
+          throw new Error(`Expected SHA-256 hex hash, got: ${entry1Hash}`);
+        }
+      }),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/suites/authorize.ts
+++ b/packages/conformance/src/suites/authorize.ts
@@ -1,0 +1,94 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectKeys, expectString, expectIsoDate } from '../helpers.js';
+
+export const authorizeSuite: SuiteDefinition = {
+  name: 'authorize',
+  description: 'Authorization request creation and consent flow',
+  optional: false,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+    let agentId = '';
+
+    // Create an agent for authorize tests
+    const agentRes = await ctx.http.post<{ agentId: string }>('/v1/agents', {
+      name: `conformance-auth-${Date.now()}`,
+      scopes: ['read', 'write'],
+    });
+    if (agentRes.status === 201) {
+      agentId = agentRes.body.agentId;
+      ctx.cleanup.trackAgent(agentId);
+    }
+
+    results.push(
+      await test(
+        'POST /v1/authorize returns authRequestId, consentUrl, expiresAt (201)',
+        '§5.1',
+        async () => {
+          if (!agentId) throw new Error('Agent setup failed');
+          const res = await ctx.http.post<{
+            authRequestId: string;
+            consentUrl: string;
+            expiresAt: string;
+          }>('/v1/authorize', {
+            agentId,
+            principalId: `principal-${Date.now()}`,
+            scopes: ['read'],
+          });
+          expectStatus(res, 201);
+          expectKeys(res.body, ['authRequestId', 'consentUrl', 'expiresAt']);
+          expectString(res.body.authRequestId, 'authRequestId');
+          expectString(res.body.consentUrl, 'consentUrl');
+          expectIsoDate(res.body.expiresAt, 'expiresAt');
+        },
+      ),
+    );
+
+    results.push(
+      await test('POST /v1/authorize rejects missing required fields (400)', '§5.1', async () => {
+        const res = await ctx.http.post('/v1/authorize', {});
+        expectStatus(res, 400);
+      }),
+    );
+
+    results.push(
+      await test('POST /v1/authorize rejects non-existent agent (404)', '§5.1', async () => {
+        const res = await ctx.http.post('/v1/authorize', {
+          agentId: 'nonexistent-agent-id',
+          principalId: 'principal-test',
+          scopes: ['read'],
+        });
+        expectStatus(res, 404);
+      }),
+    );
+
+    results.push(
+      await test('Consent approval produces authorization code', '§5.2', async () => {
+        if (!agentId) throw new Error('Agent setup failed');
+        const authRes = await ctx.http.post<{
+          authRequestId: string;
+          code?: string;
+        }>('/v1/authorize', {
+          agentId,
+          principalId: `principal-consent-${Date.now()}`,
+          scopes: ['read'],
+        });
+        expectStatus(authRes, 201);
+
+        let code: string;
+        if (authRes.body.code) {
+          code = authRes.body.code;
+        } else {
+          const consentRes = await ctx.http.requestPublic<{ code: string }>(
+            'POST',
+            `/v1/consent/${authRes.body.authRequestId}/approve`,
+          );
+          expectStatus(consentRes, 200);
+          code = consentRes.body.code;
+        }
+        expectString(code, 'code');
+      }),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/suites/authorize.ts
+++ b/packages/conformance/src/suites/authorize.ts
@@ -7,24 +7,13 @@ export const authorizeSuite: SuiteDefinition = {
   optional: false,
   run: async (ctx: SuiteContext): Promise<TestResult[]> => {
     const results: TestResult[] = [];
-    let agentId = '';
-
-    // Create an agent for authorize tests
-    const agentRes = await ctx.http.post<{ agentId: string }>('/v1/agents', {
-      name: `conformance-auth-${Date.now()}`,
-      scopes: ['read', 'write'],
-    });
-    if (agentRes.status === 201) {
-      agentId = agentRes.body.agentId;
-      ctx.cleanup.trackAgent(agentId);
-    }
+    const { agentId } = ctx.sharedAgent;
 
     results.push(
       await test(
         'POST /v1/authorize returns authRequestId, consentUrl, expiresAt (201)',
         '§5.1',
         async () => {
-          if (!agentId) throw new Error('Agent setup failed');
           const res = await ctx.http.post<{
             authRequestId: string;
             consentUrl: string;
@@ -63,7 +52,6 @@ export const authorizeSuite: SuiteDefinition = {
 
     results.push(
       await test('Consent approval produces authorization code', '§5.2', async () => {
-        if (!agentId) throw new Error('Agent setup failed');
         const authRes = await ctx.http.post<{
           authRequestId: string;
           code?: string;

--- a/packages/conformance/src/suites/compliance.ts
+++ b/packages/conformance/src/suites/compliance.ts
@@ -1,0 +1,62 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectKeys, expectArray } from '../helpers.js';
+
+export const complianceSuite: SuiteDefinition = {
+  name: 'compliance',
+  description: 'Compliance reporting and evidence export',
+  optional: true,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+
+    results.push(
+      await test('GET /v1/compliance/summary returns summary', '§12', async () => {
+        const res = await ctx.http.get<{
+          generatedAt: string;
+          agents: Record<string, number>;
+          grants: Record<string, number>;
+        }>('/v1/compliance/summary');
+        expectStatus(res, 200);
+        expectKeys(res.body, ['generatedAt', 'agents', 'grants', 'auditEntries', 'policies']);
+      }),
+    );
+
+    results.push(
+      await test('GET /v1/compliance/export/grants returns grants export', '§12', async () => {
+        const res = await ctx.http.get<{
+          generatedAt: string;
+          total: number;
+          grants: unknown[];
+        }>('/v1/compliance/export/grants');
+        expectStatus(res, 200);
+        expectKeys(res.body, ['generatedAt', 'total', 'grants']);
+        expectArray(res.body.grants, 'grants');
+      }),
+    );
+
+    results.push(
+      await test('GET /v1/compliance/export/audit returns audit export', '§12', async () => {
+        const res = await ctx.http.get<{
+          generatedAt: string;
+          total: number;
+          entries: unknown[];
+        }>('/v1/compliance/export/audit');
+        expectStatus(res, 200);
+        expectKeys(res.body, ['generatedAt', 'total', 'entries']);
+        expectArray(res.body.entries, 'entries');
+      }),
+    );
+
+    results.push(
+      await test('GET /v1/compliance/evidence-pack returns evidence pack', '§12', async () => {
+        const res = await ctx.http.get<{
+          meta: Record<string, unknown>;
+          summary: Record<string, unknown>;
+        }>('/v1/compliance/evidence-pack');
+        expectStatus(res, 200);
+        expectKeys(res.body, ['meta', 'summary', 'grants', 'auditEntries', 'policies', 'chainIntegrity']);
+      }),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/suites/delegation.ts
+++ b/packages/conformance/src/suites/delegation.ts
@@ -1,0 +1,192 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectKeys, expectString, expectEqual } from '../helpers.js';
+
+export const delegationSuite: SuiteDefinition = {
+  name: 'delegation',
+  description: 'Grant delegation and scope enforcement',
+  optional: false,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+
+    // Create parent flow
+    const parentFlow = await ctx.flow.executeFullFlow({
+      agentName: `conformance-parent-${Date.now()}`,
+      scopes: ['read', 'write'],
+    });
+
+    // Create sub-agent for delegation
+    const subAgentRes = await ctx.http.post<{ agentId: string; did: string }>('/v1/agents', {
+      name: `conformance-sub-${Date.now()}`,
+      scopes: ['read', 'write'],
+    });
+    if (subAgentRes.status !== 201) {
+      throw new Error(`Failed to create sub-agent: ${subAgentRes.status}`);
+    }
+    ctx.cleanup.trackAgent(subAgentRes.body.agentId);
+
+    results.push(
+      await test(
+        'POST /v1/grants/delegate returns 201 with grantToken',
+        '§9',
+        async () => {
+          const res = await ctx.http.post<{
+            grantToken: string;
+            expiresAt: string;
+            scopes: string[];
+            grantId: string;
+          }>('/v1/grants/delegate', {
+            parentGrantToken: parentFlow.grantToken,
+            subAgentId: subAgentRes.body.agentId,
+            scopes: ['read'],
+          });
+          expectStatus(res, 201);
+          expectKeys(res.body, ['grantToken', 'expiresAt', 'scopes', 'grantId']);
+          expectString(res.body.grantToken, 'grantToken');
+          ctx.cleanup.trackGrant(res.body.grantId);
+        },
+      ),
+    );
+
+    results.push(
+      await test(
+        'Delegated JWT contains parentAgt, parentGrnt, delegationDepth',
+        '§9',
+        async () => {
+          const res = await ctx.http.post<{ grantToken: string; grantId: string }>(
+            '/v1/grants/delegate',
+            {
+              parentGrantToken: parentFlow.grantToken,
+              subAgentId: subAgentRes.body.agentId,
+              scopes: ['read'],
+            },
+          );
+          expectStatus(res, 201);
+          ctx.cleanup.trackGrant(res.body.grantId);
+
+          // Decode JWT payload
+          const parts = res.body.grantToken.split('.');
+          const payload = JSON.parse(atob(parts[1]!)) as {
+            parentAgt: string;
+            parentGrnt: string;
+            delegationDepth: number;
+          };
+          expectString(payload.parentAgt, 'parentAgt');
+          expectString(payload.parentGrnt, 'parentGrnt');
+          expectEqual(typeof payload.delegationDepth, 'number', 'delegationDepth type');
+          expectEqual(payload.delegationDepth, 1, 'delegationDepth');
+        },
+      ),
+    );
+
+    results.push(
+      await test(
+        'Delegation rejects scope superset (400)',
+        '§9',
+        async () => {
+          const res = await ctx.http.post('/v1/grants/delegate', {
+            parentGrantToken: parentFlow.grantToken,
+            subAgentId: subAgentRes.body.agentId,
+            scopes: ['read', 'write', 'admin'],
+          });
+          expectStatus(res, 400);
+        },
+      ),
+    );
+
+    results.push(
+      await test(
+        'Delegation depth limit is enforced',
+        '§9',
+        async () => {
+          // Create a chain: parent → child → grandchild
+          const child2Res = await ctx.http.post<{ agentId: string }>('/v1/agents', {
+            name: `conformance-child2-${Date.now()}`,
+            scopes: ['read'],
+          });
+          if (child2Res.status !== 201) throw new Error('Failed to create child2 agent');
+          ctx.cleanup.trackAgent(child2Res.body.agentId);
+
+          // Delegate parent → child
+          const del1 = await ctx.http.post<{ grantToken: string; grantId: string }>(
+            '/v1/grants/delegate',
+            {
+              parentGrantToken: parentFlow.grantToken,
+              subAgentId: subAgentRes.body.agentId,
+              scopes: ['read'],
+            },
+          );
+          expectStatus(del1, 201);
+          ctx.cleanup.trackGrant(del1.body.grantId);
+
+          // Delegate child → grandchild
+          const del2 = await ctx.http.post<{ grantToken: string; grantId: string }>(
+            '/v1/grants/delegate',
+            {
+              parentGrantToken: del1.body.grantToken,
+              subAgentId: child2Res.body.agentId,
+              scopes: ['read'],
+            },
+          );
+          // Depth 2 — may succeed or fail depending on server config
+          // We just verify it returns a meaningful response
+          if (del2.status === 201) {
+            ctx.cleanup.trackGrant(del2.body.grantId);
+            // Check depth incremented
+            const parts = del2.body.grantToken.split('.');
+            const payload = JSON.parse(atob(parts[1]!)) as { delegationDepth: number };
+            expectEqual(payload.delegationDepth, 2, 'delegationDepth');
+          } else {
+            // Server enforces depth limit — this is also valid
+            expectStatus(del2, 400);
+          }
+        },
+      ),
+    );
+
+    results.push(
+      await test(
+        'Revoking parent cascades to delegated grants',
+        '§9',
+        async () => {
+          // Create a fresh parent flow for cascade test
+          const cascadeFlow = await ctx.flow.executeFullFlow({
+            agentName: `conformance-cascade-parent-${Date.now()}`,
+            scopes: ['read'],
+          });
+
+          const cascadeSubRes = await ctx.http.post<{ agentId: string }>('/v1/agents', {
+            name: `conformance-cascade-sub-${Date.now()}`,
+            scopes: ['read'],
+          });
+          expectStatus(cascadeSubRes, 201);
+          ctx.cleanup.trackAgent(cascadeSubRes.body.agentId);
+
+          // Delegate
+          const delRes = await ctx.http.post<{ grantToken: string; grantId: string }>(
+            '/v1/grants/delegate',
+            {
+              parentGrantToken: cascadeFlow.grantToken,
+              subAgentId: cascadeSubRes.body.agentId,
+              scopes: ['read'],
+            },
+          );
+          expectStatus(delRes, 201);
+          ctx.cleanup.trackGrant(delRes.body.grantId);
+
+          // Revoke parent grant
+          const revokeRes = await ctx.http.delete(`/v1/grants/${cascadeFlow.grantId}`);
+          expectStatus(revokeRes, 204);
+
+          // Verify child token is now invalid
+          const verifyRes = await ctx.http.post<{ valid: boolean }>('/v1/tokens/verify', {
+            token: delRes.body.grantToken,
+          });
+          expectStatus(verifyRes, 200);
+          expectEqual(verifyRes.body.valid, false, 'valid');
+        },
+      ),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/suites/grants.ts
+++ b/packages/conformance/src/suites/grants.ts
@@ -1,0 +1,53 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectKeys, expectArray, expectEqual } from '../helpers.js';
+
+export const grantsSuite: SuiteDefinition = {
+  name: 'grants',
+  description: 'Grant listing, retrieval, and revocation',
+  optional: false,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+
+    const flow = await ctx.flow.executeFullFlow();
+
+    results.push(
+      await test('GET /v1/grants lists grants', '§7.1', async () => {
+        const res = await ctx.http.get<{ grants: unknown[] }>('/v1/grants');
+        expectStatus(res, 200);
+        expectKeys(res.body, ['grants']);
+        expectArray(res.body.grants, 'grants');
+      }),
+    );
+
+    results.push(
+      await test('GET /v1/grants/:id returns grant details', '§7.1', async () => {
+        const res = await ctx.http.get<{
+          grantId: string;
+          agentId: string;
+          scopes: string[];
+          status: string;
+        }>(`/v1/grants/${flow.grantId}`);
+        expectStatus(res, 200);
+        expectKeys(res.body, ['grantId', 'agentId', 'scopes', 'status']);
+        expectEqual(res.body.grantId, flow.grantId, 'grantId');
+      }),
+    );
+
+    results.push(
+      await test('DELETE /v1/grants/:id returns 204', '§7.1', async () => {
+        const res = await ctx.http.delete(`/v1/grants/${flow.grantId}`);
+        expectStatus(res, 204);
+      }),
+    );
+
+    results.push(
+      await test('Grant status is revoked after DELETE', '§7.1', async () => {
+        const res = await ctx.http.get<{ status: string }>(`/v1/grants/${flow.grantId}`);
+        expectStatus(res, 200);
+        expectEqual(res.body.status, 'revoked', 'status');
+      }),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/suites/grants.ts
+++ b/packages/conformance/src/suites/grants.ts
@@ -7,8 +7,9 @@ export const grantsSuite: SuiteDefinition = {
   optional: false,
   run: async (ctx: SuiteContext): Promise<TestResult[]> => {
     const results: TestResult[] = [];
+    const { agentId, agentDid } = ctx.sharedAgent;
 
-    const flow = await ctx.flow.executeFullFlow();
+    const flow = await ctx.flow.executeFullFlow({ agentId, agentDid });
 
     results.push(
       await test('GET /v1/grants lists grants', '§7.1', async () => {

--- a/packages/conformance/src/suites/health.ts
+++ b/packages/conformance/src/suites/health.ts
@@ -1,0 +1,41 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectKeys, expectString } from '../helpers.js';
+
+export const healthSuite: SuiteDefinition = {
+  name: 'health',
+  description: 'Health check and JWKS endpoints',
+  optional: false,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+
+    results.push(
+      await test('GET /health returns 200 with status ok', '§3.3', async () => {
+        const res = await ctx.http.requestPublic<{ status: string }>('GET', '/health');
+        expectStatus(res, 200);
+        expectKeys(res.body, ['status']);
+        expectString(res.body.status, 'status');
+      }),
+    );
+
+    results.push(
+      await test('JWKS endpoint has RS256 keys', '§10', async () => {
+        const res = await ctx.http.requestPublic<{ keys: Array<{ kty: string; alg?: string }> }>(
+          'GET',
+          '/.well-known/jwks.json',
+        );
+        expectStatus(res, 200);
+        expectKeys(res.body, ['keys']);
+        const keys = res.body.keys;
+        if (!Array.isArray(keys) || keys.length === 0) {
+          throw new Error('JWKS must contain at least one key');
+        }
+        const rsaKeys = keys.filter((k) => k.kty === 'RSA');
+        if (rsaKeys.length === 0) {
+          throw new Error('JWKS must contain at least one RSA key');
+        }
+      }),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/suites/policies.ts
+++ b/packages/conformance/src/suites/policies.ts
@@ -1,0 +1,74 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectKeys, expectString, expectArray, expectEqual } from '../helpers.js';
+
+export const policiesSuite: SuiteDefinition = {
+  name: 'policies',
+  description: 'Policy CRUD and enforcement',
+  optional: true,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+    let policyId = '';
+
+    results.push(
+      await test('POST /v1/policies creates policy (201)', '§12', async () => {
+        const res = await ctx.http.post<{
+          id: string;
+          name: string;
+          effect: string;
+        }>('/v1/policies', {
+          name: `conformance-policy-${Date.now()}`,
+          effect: 'allow',
+          scopes: ['read'],
+        });
+        expectStatus(res, 201);
+        expectKeys(res.body, ['id', 'name', 'effect']);
+        expectString(res.body.id, 'id');
+        policyId = res.body.id;
+        ctx.cleanup.trackPolicy(policyId);
+      }),
+    );
+
+    results.push(
+      await test('GET /v1/policies lists policies', '§12', async () => {
+        const res = await ctx.http.get<{ policies: unknown[] }>('/v1/policies');
+        expectStatus(res, 200);
+        expectKeys(res.body, ['policies']);
+        expectArray(res.body.policies, 'policies');
+      }),
+    );
+
+    results.push(
+      await test('GET /v1/policies/:id returns policy details', '§12', async () => {
+        if (!policyId) throw new Error('No policy created');
+        const res = await ctx.http.get<{ id: string; effect: string }>(
+          `/v1/policies/${policyId}`,
+        );
+        expectStatus(res, 200);
+        expectKeys(res.body, ['id', 'name', 'effect']);
+        expectEqual(res.body.id, policyId, 'id');
+      }),
+    );
+
+    results.push(
+      await test('PATCH /v1/policies/:id updates policy', '§12', async () => {
+        if (!policyId) throw new Error('No policy created');
+        const res = await ctx.http.patch<{ id: string; effect: string }>(
+          `/v1/policies/${policyId}`,
+          { effect: 'deny' },
+        );
+        expectStatus(res, 200);
+        expectEqual(res.body.effect, 'deny', 'effect');
+      }),
+    );
+
+    results.push(
+      await test('DELETE /v1/policies/:id returns 204', '§12', async () => {
+        if (!policyId) throw new Error('No policy created');
+        const res = await ctx.http.delete(`/v1/policies/${policyId}`);
+        expectStatus(res, 204);
+      }),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/suites/scim.ts
+++ b/packages/conformance/src/suites/scim.ts
@@ -1,0 +1,101 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectKeys, expectString, expectArray } from '../helpers.js';
+
+export const scimSuite: SuiteDefinition = {
+  name: 'scim',
+  description: 'SCIM 2.0 provisioning endpoints',
+  optional: true,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+    let scimToken = '';
+    let scimTokenId = '';
+    let userId = '';
+
+    results.push(
+      await test('POST /v1/scim/tokens creates SCIM token (201)', '§13', async () => {
+        const res = await ctx.http.post<{
+          id: string;
+          label: string;
+          token: string;
+        }>('/v1/scim/tokens', {
+          label: `conformance-scim-${Date.now()}`,
+        });
+        expectStatus(res, 201);
+        expectKeys(res.body, ['id', 'label', 'token']);
+        expectString(res.body.token, 'token');
+        scimToken = res.body.token;
+        scimTokenId = res.body.id;
+      }),
+    );
+
+    results.push(
+      await test('GET /v1/scim/tokens lists SCIM tokens', '§13', async () => {
+        const res = await ctx.http.get<{ tokens: unknown[] }>('/v1/scim/tokens');
+        expectStatus(res, 200);
+        expectKeys(res.body, ['tokens']);
+        expectArray(res.body.tokens, 'tokens');
+      }),
+    );
+
+    results.push(
+      await test('GET /scim/v2/ServiceProviderConfig returns config', '§13', async () => {
+        const res = await ctx.http.requestPublic<{ schemas: string[] }>(
+          'GET',
+          '/scim/v2/ServiceProviderConfig',
+        );
+        expectStatus(res, 200);
+        expectKeys(res.body, ['schemas']);
+      }),
+    );
+
+    results.push(
+      await test('POST /scim/v2/Users creates user (201)', '§13', async () => {
+        if (!scimToken) throw new Error('No SCIM token created');
+        const res = await ctx.http.doRequestWithToken<{
+          id: string;
+          userName: string;
+          schemas: string[];
+        }>('POST', '/scim/v2/Users', scimToken, {
+          userName: `conformance-user-${Date.now()}@example.com`,
+          displayName: 'Conformance Test User',
+        });
+        expectStatus(res, 201);
+        expectKeys(res.body, ['id', 'userName', 'schemas']);
+        expectString(res.body.id, 'id');
+        userId = res.body.id;
+      }),
+    );
+
+    results.push(
+      await test('GET /scim/v2/Users lists users', '§13', async () => {
+        if (!scimToken) throw new Error('No SCIM token created');
+        const res = await ctx.http.doRequestWithToken<{ Resources: unknown[] }>(
+          'GET',
+          '/scim/v2/Users',
+          scimToken,
+        );
+        expectStatus(res, 200);
+        expectKeys(res.body, ['Resources', 'totalResults']);
+      }),
+    );
+
+    results.push(
+      await test('DELETE /scim/v2/Users/:id returns 204', '§13', async () => {
+        if (!scimToken || !userId) throw new Error('No SCIM user created');
+        const res = await ctx.http.doRequestWithToken(
+          'DELETE',
+          `/scim/v2/Users/${userId}`,
+          scimToken,
+        );
+        expectStatus(res, 204);
+
+        // Clean up SCIM token
+        if (scimTokenId) {
+          await ctx.http.delete(`/v1/scim/tokens/${scimTokenId}`);
+        }
+      }),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/suites/security.ts
+++ b/packages/conformance/src/suites/security.ts
@@ -1,0 +1,107 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectEqual } from '../helpers.js';
+
+export const securitySuite: SuiteDefinition = {
+  name: 'security',
+  description: 'Authentication, authorization, and security enforcement',
+  optional: false,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+
+    results.push(
+      await test('Request without auth returns 401', '§14', async () => {
+        const res = await ctx.http.requestPublic('GET', '/v1/agents');
+        expectStatus(res, 401);
+      }),
+    );
+
+    results.push(
+      await test('Request with bad auth returns 401', '§14', async () => {
+        const badHttp = await import('../http-client.js');
+        const client = new badHttp.ConformanceHttpClient(ctx.baseUrl, 'invalid-api-key-12345');
+        const res = await client.get('/v1/agents');
+        expectStatus(res, 401);
+      }),
+    );
+
+    results.push(
+      await test('JWKS only contains RS256 keys', '§14', async () => {
+        const res = await ctx.http.requestPublic<{
+          keys: Array<{ kty: string; alg?: string; use?: string }>;
+        }>('GET', '/.well-known/jwks.json');
+        expectStatus(res, 200);
+        for (const key of res.body.keys) {
+          if (key.alg && key.alg !== 'RS256') {
+            throw new Error(`Expected RS256 algorithm, found: ${key.alg}`);
+          }
+          if (key.kty !== 'RSA') {
+            throw new Error(`Expected RSA key type, found: ${key.kty}`);
+          }
+        }
+      }),
+    );
+
+    results.push(
+      await test('Delegation scope enforcement prevents escalation', '§14', async () => {
+        const flow = await ctx.flow.executeFullFlow({
+          agentName: `conformance-sec-scope-${Date.now()}`,
+          scopes: ['read'],
+        });
+
+        const subAgentRes = await ctx.http.post<{ agentId: string }>('/v1/agents', {
+          name: `conformance-sec-sub-${Date.now()}`,
+          scopes: ['read', 'write', 'admin'],
+        });
+        expectStatus(subAgentRes, 201);
+        ctx.cleanup.trackAgent(subAgentRes.body.agentId);
+
+        // Try to delegate with more scopes than parent has
+        const delRes = await ctx.http.post('/v1/grants/delegate', {
+          parentGrantToken: flow.grantToken,
+          subAgentId: subAgentRes.body.agentId,
+          scopes: ['read', 'write'],
+        });
+        expectStatus(delRes, 400);
+      }),
+    );
+
+    results.push(
+      await test('Audit log is append-only (PUT/DELETE return 404 or 405)', '§14', async () => {
+        const flow = await ctx.flow.executeFullFlow({
+          agentName: `conformance-sec-audit-${Date.now()}`,
+          scopes: ['read'],
+        });
+
+        // Create an audit entry
+        const logRes = await ctx.http.post<{ entryId: string }>('/v1/audit/log', {
+          agentId: flow.agentId,
+          agentDid: flow.agentDid,
+          grantId: flow.grantId,
+          principalId: flow.principalId,
+          action: 'conformance.security.test',
+        });
+        expectStatus(logRes, 201);
+
+        // Try PUT on audit entry — should fail
+        const putRes = await ctx.http.request('PUT', `/v1/audit/${logRes.body.entryId}`, {
+          action: 'modified',
+        });
+        if (putRes.status !== 404 && putRes.status !== 405) {
+          throw new Error(
+            `Expected 404 or 405 for PUT /v1/audit/:id, got ${putRes.status}`,
+          );
+        }
+
+        // Try DELETE on audit entry — should fail
+        const delRes = await ctx.http.delete(`/v1/audit/${logRes.body.entryId}`);
+        if (delRes.status !== 404 && delRes.status !== 405) {
+          throw new Error(
+            `Expected 404 or 405 for DELETE /v1/audit/:id, got ${delRes.status}`,
+          );
+        }
+      }),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/suites/sso.ts
+++ b/packages/conformance/src/suites/sso.ts
@@ -1,0 +1,56 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectKeys, expectString } from '../helpers.js';
+
+export const ssoSuite: SuiteDefinition = {
+  name: 'sso',
+  description: 'SSO configuration and flow',
+  optional: true,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+
+    results.push(
+      await test('POST /v1/sso/config creates SSO config (201)', '§13', async () => {
+        const res = await ctx.http.post<{
+          issuerUrl: string;
+          clientId: string;
+          redirectUri: string;
+        }>('/v1/sso/config', {
+          issuerUrl: 'https://accounts.google.com',
+          clientId: 'conformance-test-client',
+          clientSecret: 'conformance-test-secret',
+          redirectUri: 'https://example.com/sso/callback',
+        });
+        expectStatus(res, 201);
+        expectKeys(res.body, ['issuerUrl', 'clientId', 'redirectUri']);
+      }),
+    );
+
+    results.push(
+      await test('GET /v1/sso/config returns SSO config', '§13', async () => {
+        const res = await ctx.http.get<{
+          issuerUrl: string;
+          clientId: string;
+        }>('/v1/sso/config');
+        expectStatus(res, 200);
+        expectKeys(res.body, ['issuerUrl', 'clientId', 'redirectUri']);
+        expectString(res.body.issuerUrl, 'issuerUrl');
+      }),
+    );
+
+    results.push(
+      await test('GET /sso/login requires org parameter', '§13', async () => {
+        const res = await ctx.http.requestPublic('GET', '/sso/login');
+        expectStatus(res, 400);
+      }),
+    );
+
+    results.push(
+      await test('DELETE /v1/sso/config returns 204', '§13', async () => {
+        const res = await ctx.http.delete('/v1/sso/config');
+        expectStatus(res, 204);
+      }),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/suites/token.ts
+++ b/packages/conformance/src/suites/token.ts
@@ -1,0 +1,94 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectKeys, expectString, expectArray, expectIsoDate } from '../helpers.js';
+
+export const tokenSuite: SuiteDefinition = {
+  name: 'token',
+  description: 'Token exchange (code → grant token)',
+  optional: false,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+
+    results.push(
+      await test(
+        'POST /v1/token exchanges code for grantToken, refreshToken, grantId, scopes, expiresAt',
+        '§5.3',
+        async () => {
+          const flow = await ctx.flow.executeFullFlow();
+          expectString(flow.grantToken, 'grantToken');
+          expectString(flow.refreshToken, 'refreshToken');
+          expectString(flow.grantId, 'grantId');
+          expectArray(flow.scopes, 'scopes');
+          expectIsoDate(flow.expiresAt, 'expiresAt');
+        },
+      ),
+    );
+
+    results.push(
+      await test('POST /v1/token rejects invalid code (400)', '§5.3', async () => {
+        // Create agent first
+        const agentRes = await ctx.http.post<{ agentId: string }>('/v1/agents', {
+          name: `conformance-bad-code-${Date.now()}`,
+          scopes: ['read'],
+        });
+        expectStatus(agentRes, 201);
+        ctx.cleanup.trackAgent(agentRes.body.agentId);
+
+        const res = await ctx.http.post('/v1/token', {
+          code: 'invalid-code-12345',
+          agentId: agentRes.body.agentId,
+        });
+        expectStatus(res, 400);
+      }),
+    );
+
+    results.push(
+      await test('POST /v1/token rejects reused code (400)', '§5.3', async () => {
+        // Execute a full flow to get a valid code
+        const agentRes = await ctx.http.post<{ agentId: string }>('/v1/agents', {
+          name: `conformance-reuse-${Date.now()}`,
+          scopes: ['read'],
+        });
+        expectStatus(agentRes, 201);
+        ctx.cleanup.trackAgent(agentRes.body.agentId);
+
+        const authRes = await ctx.http.post<{
+          authRequestId: string;
+          code?: string;
+        }>('/v1/authorize', {
+          agentId: agentRes.body.agentId,
+          principalId: `principal-reuse-${Date.now()}`,
+          scopes: ['read'],
+        });
+        expectStatus(authRes, 201);
+
+        let code: string;
+        if (authRes.body.code) {
+          code = authRes.body.code;
+        } else {
+          const consentRes = await ctx.http.requestPublic<{ code: string }>(
+            'POST',
+            `/v1/consent/${authRes.body.authRequestId}/approve`,
+          );
+          code = consentRes.body.code;
+        }
+
+        // First exchange — should succeed
+        const first = await ctx.http.post<{ grantId: string }>('/v1/token', {
+          code,
+          agentId: agentRes.body.agentId,
+        });
+        expectStatus(first, 201);
+        ctx.cleanup.trackGrant(first.body.grantId);
+
+        // Second exchange with same code — should fail
+        const second = await ctx.http.post('/v1/token', {
+          code,
+          agentId: agentRes.body.agentId,
+        });
+        expectStatus(second, 400);
+      }),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/suites/tokens.ts
+++ b/packages/conformance/src/suites/tokens.ts
@@ -1,0 +1,71 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectKeys, expectEqual, expectBoolean } from '../helpers.js';
+
+export const tokensSuite: SuiteDefinition = {
+  name: 'tokens',
+  description: 'Token verification and revocation',
+  optional: false,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+    let grantToken = '';
+    let refreshToken = '';
+
+    // Execute full flow to get tokens
+    const flow = await ctx.flow.executeFullFlow();
+    grantToken = flow.grantToken;
+    refreshToken = flow.refreshToken;
+
+    results.push(
+      await test('POST /v1/tokens/verify returns valid=true for active token', '§7.2', async () => {
+        const res = await ctx.http.post<{
+          valid: boolean;
+          grantId: string;
+          scopes: string[];
+          principal: string;
+          agent: string;
+          expiresAt: string;
+        }>('/v1/tokens/verify', { token: grantToken });
+        expectStatus(res, 200);
+        expectKeys(res.body, ['valid', 'grantId', 'scopes', 'principal', 'agent', 'expiresAt']);
+        expectEqual(res.body.valid, true, 'valid');
+      }),
+    );
+
+    results.push(
+      await test('POST /v1/tokens/revoke returns 204', '§7.3', async () => {
+        // Decode the JWT to get jti
+        const parts = grantToken.split('.');
+        const payload = JSON.parse(atob(parts[1]!)) as { jti: string };
+        const res = await ctx.http.post('/v1/tokens/revoke', { jti: payload.jti });
+        expectStatus(res, 204);
+      }),
+    );
+
+    results.push(
+      await test(
+        'POST /v1/tokens/verify returns valid=false after revocation',
+        '§7.3',
+        async () => {
+          const res = await ctx.http.post<{ valid: boolean }>('/v1/tokens/verify', {
+            token: grantToken,
+          });
+          expectStatus(res, 200);
+          expectEqual(res.body.valid, false, 'valid');
+        },
+      ),
+    );
+
+    results.push(
+      await test('POST /v1/tokens/verify returns valid=false for garbage token', '§7.2', async () => {
+        const res = await ctx.http.post<{ valid: boolean }>('/v1/tokens/verify', {
+          token: 'not.a.valid.jwt.token',
+        });
+        expectStatus(res, 200);
+        expectBoolean(res.body.valid, 'valid');
+        expectEqual(res.body.valid, false, 'valid');
+      }),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/suites/tokens.ts
+++ b/packages/conformance/src/suites/tokens.ts
@@ -7,13 +7,11 @@ export const tokensSuite: SuiteDefinition = {
   optional: false,
   run: async (ctx: SuiteContext): Promise<TestResult[]> => {
     const results: TestResult[] = [];
-    let grantToken = '';
-    let refreshToken = '';
+    const { agentId, agentDid } = ctx.sharedAgent;
 
-    // Execute full flow to get tokens
-    const flow = await ctx.flow.executeFullFlow();
-    grantToken = flow.grantToken;
-    refreshToken = flow.refreshToken;
+    // Execute full flow to get tokens (reuse shared agent)
+    const flow = await ctx.flow.executeFullFlow({ agentId, agentDid });
+    const grantToken = flow.grantToken;
 
     results.push(
       await test('POST /v1/tokens/verify returns valid=true for active token', '§7.2', async () => {

--- a/packages/conformance/src/suites/webhooks.ts
+++ b/packages/conformance/src/suites/webhooks.ts
@@ -1,0 +1,51 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectKeys, expectString, expectArray } from '../helpers.js';
+
+export const webhooksSuite: SuiteDefinition = {
+  name: 'webhooks',
+  description: 'Webhook registration and management',
+  optional: true,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+    let webhookId = '';
+
+    results.push(
+      await test('POST /v1/webhooks creates webhook (201)', '§11', async () => {
+        const res = await ctx.http.post<{
+          id: string;
+          url: string;
+          events: string[];
+          secret: string;
+        }>('/v1/webhooks', {
+          url: 'https://example.com/webhook',
+          events: ['grant.created', 'grant.revoked'],
+        });
+        expectStatus(res, 201);
+        expectKeys(res.body, ['id', 'url', 'events', 'secret']);
+        expectString(res.body.id, 'id');
+        expectString(res.body.secret, 'secret');
+        webhookId = res.body.id;
+        ctx.cleanup.trackWebhook(webhookId);
+      }),
+    );
+
+    results.push(
+      await test('GET /v1/webhooks lists webhooks', '§11', async () => {
+        const res = await ctx.http.get<{ webhooks: unknown[] }>('/v1/webhooks');
+        expectStatus(res, 200);
+        expectKeys(res.body, ['webhooks']);
+        expectArray(res.body.webhooks, 'webhooks');
+      }),
+    );
+
+    results.push(
+      await test('DELETE /v1/webhooks/:id returns 204', '§11', async () => {
+        if (!webhookId) throw new Error('No webhook created');
+        const res = await ctx.http.delete(`/v1/webhooks/${webhookId}`);
+        expectStatus(res, 204);
+      }),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/types.ts
+++ b/packages/conformance/src/types.ts
@@ -1,0 +1,59 @@
+export interface RunConfig {
+  baseUrl: string;
+  apiKey: string;
+  suite?: string;
+  include?: string[];
+  format: 'text' | 'json';
+  bail: boolean;
+}
+
+export interface HttpResponse<T = unknown> {
+  status: number;
+  body: T;
+  rawText: string;
+  durationMs: number;
+}
+
+export type TestStatus = 'pass' | 'fail' | 'skip';
+
+export interface TestResult {
+  name: string;
+  status: TestStatus;
+  durationMs: number;
+  specRef: string;
+  error?: string;
+}
+
+export interface SuiteResult {
+  name: string;
+  description: string;
+  optional: boolean;
+  tests: TestResult[];
+  durationMs: number;
+}
+
+export interface ConformanceReport {
+  suites: SuiteResult[];
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+    skipped: number;
+    durationMs: number;
+  };
+}
+
+export interface SuiteContext {
+  baseUrl: string;
+  apiKey: string;
+  http: import('./http-client.js').ConformanceHttpClient;
+  flow: import('./flow.js').AuthFlowHelper;
+  cleanup: import('./cleanup.js').CleanupTracker;
+}
+
+export interface SuiteDefinition {
+  name: string;
+  description: string;
+  optional: boolean;
+  run: (ctx: SuiteContext) => Promise<TestResult[]>;
+}

--- a/packages/conformance/src/types.ts
+++ b/packages/conformance/src/types.ts
@@ -43,12 +43,20 @@ export interface ConformanceReport {
   };
 }
 
+export interface SharedAgent {
+  agentId: string;
+  agentDid: string;
+  name: string;
+}
+
 export interface SuiteContext {
   baseUrl: string;
   apiKey: string;
   http: import('./http-client.js').ConformanceHttpClient;
   flow: import('./flow.js').AuthFlowHelper;
   cleanup: import('./cleanup.js').CleanupTracker;
+  /** Pre-created agent shared across suites to avoid plan limits */
+  sharedAgent: SharedAgent;
 }
 
 export interface SuiteDefinition {

--- a/packages/conformance/tests/helpers.test.ts
+++ b/packages/conformance/tests/helpers.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import {
+  test as testHelper,
+  expectStatus,
+  expectKeys,
+  expectString,
+  expectArray,
+  expectBoolean,
+  expectIsoDate,
+  expectEqual,
+  expectIncludes,
+  skip,
+  AssertionError,
+} from '../src/helpers.js';
+import type { HttpResponse } from '../src/types.js';
+
+function mockResponse<T>(status: number, body: T): HttpResponse<T> {
+  return { status, body, rawText: JSON.stringify(body), durationMs: 10 };
+}
+
+describe('test()', () => {
+  it('returns pass on success', async () => {
+    const result = await testHelper('my test', '§1', async () => {
+      // no-op
+    });
+    expect(result.name).toBe('my test');
+    expect(result.status).toBe('pass');
+    expect(result.specRef).toBe('§1');
+    expect(result.error).toBeUndefined();
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns fail on thrown error', async () => {
+    const result = await testHelper('fail test', '§2', async () => {
+      throw new Error('something broke');
+    });
+    expect(result.status).toBe('fail');
+    expect(result.error).toBe('something broke');
+  });
+
+  it('returns fail on non-Error throw', async () => {
+    const result = await testHelper('fail test', '§2', async () => {
+      throw 'string error';
+    });
+    expect(result.status).toBe('fail');
+    expect(result.error).toBe('string error');
+  });
+});
+
+describe('skip()', () => {
+  it('returns skip result', () => {
+    const result = skip('skipped test', '§3', 'not applicable');
+    expect(result.status).toBe('skip');
+    expect(result.error).toBe('not applicable');
+    expect(result.durationMs).toBe(0);
+  });
+});
+
+describe('expectStatus()', () => {
+  it('passes on matching status', () => {
+    const res = mockResponse(200, {});
+    expect(() => expectStatus(res, 200)).not.toThrow();
+  });
+
+  it('throws on mismatched status', () => {
+    const res = mockResponse(404, { message: 'not found' });
+    expect(() => expectStatus(res, 200)).toThrow(AssertionError);
+    expect(() => expectStatus(res, 200)).toThrow('Expected status 200, got 404');
+  });
+});
+
+describe('expectKeys()', () => {
+  it('passes when all keys present', () => {
+    expect(() => expectKeys({ a: 1, b: 2, c: 3 }, ['a', 'b'])).not.toThrow();
+  });
+
+  it('throws on missing keys', () => {
+    expect(() => expectKeys({ a: 1 }, ['a', 'b', 'c'])).toThrow('Missing keys: b, c');
+  });
+
+  it('throws on non-object', () => {
+    expect(() => expectKeys('string', ['a'])).toThrow('Expected object');
+    expect(() => expectKeys(null, ['a'])).toThrow('Expected object');
+  });
+});
+
+describe('expectString()', () => {
+  it('passes on non-empty string', () => {
+    expect(() => expectString('hello', 'field')).not.toThrow();
+  });
+
+  it('throws on empty string', () => {
+    expect(() => expectString('', 'field')).toThrow('non-empty string');
+  });
+
+  it('throws on non-string', () => {
+    expect(() => expectString(42, 'field')).toThrow('non-empty string');
+  });
+});
+
+describe('expectArray()', () => {
+  it('passes on array', () => {
+    expect(() => expectArray([1, 2], 'field')).not.toThrow();
+  });
+
+  it('throws on non-array', () => {
+    expect(() => expectArray('not-array', 'field')).toThrow('Expected array');
+  });
+});
+
+describe('expectBoolean()', () => {
+  it('passes on boolean', () => {
+    expect(() => expectBoolean(true, 'field')).not.toThrow();
+    expect(() => expectBoolean(false, 'field')).not.toThrow();
+  });
+
+  it('throws on non-boolean', () => {
+    expect(() => expectBoolean(1, 'field')).toThrow('Expected boolean');
+  });
+});
+
+describe('expectIsoDate()', () => {
+  it('passes on valid ISO date', () => {
+    expect(() => expectIsoDate('2026-02-28T00:00:00.000Z', 'field')).not.toThrow();
+  });
+
+  it('throws on invalid date', () => {
+    expect(() => expectIsoDate('not-a-date', 'field')).toThrow('Invalid ISO date');
+  });
+
+  it('throws on non-string', () => {
+    expect(() => expectIsoDate(42, 'field')).toThrow('Expected ISO date string');
+  });
+});
+
+describe('expectEqual()', () => {
+  it('passes on equal values', () => {
+    expect(() => expectEqual(42, 42, 'field')).not.toThrow();
+    expect(() => expectEqual('abc', 'abc', 'field')).not.toThrow();
+  });
+
+  it('throws on unequal values', () => {
+    expect(() => expectEqual(42, 43, 'field')).toThrow('Expected "field" to be 43');
+  });
+});
+
+describe('expectIncludes()', () => {
+  it('passes when value is included', () => {
+    expect(() => expectIncludes([1, 2, 3], 2, 'field')).not.toThrow();
+  });
+
+  it('throws when value is not included', () => {
+    expect(() => expectIncludes([1, 2, 3], 4, 'field')).toThrow('to include 4');
+  });
+});

--- a/packages/conformance/tests/reporter.test.ts
+++ b/packages/conformance/tests/reporter.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { reportJson } from '../src/reporter.js';
+import type { ConformanceReport } from '../src/types.js';
+
+function makeReport(overrides?: Partial<ConformanceReport>): ConformanceReport {
+  return {
+    suites: [
+      {
+        name: 'health',
+        description: 'Health check',
+        optional: false,
+        durationMs: 100,
+        tests: [
+          { name: 'test1', status: 'pass', durationMs: 50, specRef: '§1' },
+          { name: 'test2', status: 'fail', durationMs: 50, specRef: '§2', error: 'oops' },
+        ],
+      },
+    ],
+    summary: {
+      total: 2,
+      passed: 1,
+      failed: 1,
+      skipped: 0,
+      durationMs: 100,
+    },
+    ...overrides,
+  };
+}
+
+describe('reportJson()', () => {
+  it('outputs valid JSON', () => {
+    const report = makeReport();
+    const output = reportJson(report);
+    const parsed = JSON.parse(output);
+    expect(parsed.summary.total).toBe(2);
+    expect(parsed.summary.passed).toBe(1);
+    expect(parsed.summary.failed).toBe(1);
+  });
+
+  it('includes suite and test details', () => {
+    const report = makeReport();
+    const output = reportJson(report);
+    const parsed = JSON.parse(output);
+    expect(parsed.suites).toHaveLength(1);
+    expect(parsed.suites[0].name).toBe('health');
+    expect(parsed.suites[0].tests).toHaveLength(2);
+    expect(parsed.suites[0].tests[0].status).toBe('pass');
+    expect(parsed.suites[0].tests[1].status).toBe('fail');
+    expect(parsed.suites[0].tests[1].error).toBe('oops');
+  });
+
+  it('handles all-passing report', () => {
+    const report = makeReport({
+      suites: [
+        {
+          name: 'test',
+          description: 'All pass',
+          optional: false,
+          durationMs: 50,
+          tests: [
+            { name: 'pass1', status: 'pass', durationMs: 25, specRef: '§1' },
+            { name: 'pass2', status: 'pass', durationMs: 25, specRef: '§2' },
+          ],
+        },
+      ],
+      summary: { total: 2, passed: 2, failed: 0, skipped: 0, durationMs: 50 },
+    });
+    const parsed = JSON.parse(reportJson(report));
+    expect(parsed.summary.failed).toBe(0);
+  });
+
+  it('handles skipped tests', () => {
+    const report = makeReport({
+      suites: [
+        {
+          name: 'test',
+          description: 'With skip',
+          optional: true,
+          durationMs: 10,
+          tests: [
+            { name: 'skip1', status: 'skip', durationMs: 0, specRef: '§1', error: 'skipped' },
+          ],
+        },
+      ],
+      summary: { total: 1, passed: 0, failed: 0, skipped: 1, durationMs: 10 },
+    });
+    const parsed = JSON.parse(reportJson(report));
+    expect(parsed.summary.skipped).toBe(1);
+    expect(parsed.suites[0].optional).toBe(true);
+  });
+});

--- a/packages/conformance/tsconfig.build.json
+++ b/packages/conformance/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/packages/conformance/tsconfig.json
+++ b/packages/conformance/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitOverride": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/conformance/vitest.config.ts
+++ b/packages/conformance/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `@grantex/conformance` — a black-box HTTP conformance test suite for validating Grantex protocol implementations
- Ships as both a CLI (`npx @grantex/conformance`) and programmatic API
- 9 core suites with 37 tests covering health, agents, authorize, token, tokens, grants, delegation, audit, and security
- 6 optional extension suites (25 tests) for policies, webhooks, SCIM, SSO, anomalies, and compliance
- No dependency on `@grantex/sdk` — uses raw HTTP client that never throws on 4xx/5xx
- AuthFlowHelper handles sandbox auto-code and consent approve fallback

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 27 internal unit tests pass (helpers + reporter)
- [x] `npm run build` — produces dist/ with all suites
- [ ] Run against local auth service: `node dist/index.js --base-url http://localhost:3001 --api-key $SEED_API_KEY`
- [ ] Verify `--format json` outputs valid JSON
- [ ] Verify `--suite health` runs only health suite
- [ ] Verify `--bail` stops on first failure