### PR TITLE
feat: token refresh, error codes, and documentation guides

### DIFF
--- a/apps/auth-service/src/routes/token.ts
+++ b/apps/auth-service/src/routes/token.ts
@@ -11,6 +11,11 @@ interface TokenBody {
   codeVerifier?: string;
 }
 
+interface RefreshBody {
+  refreshToken: string;
+  agentId: string;
+}
+
 export async function tokenRoutes(app: FastifyInstance): Promise<void> {
   // POST /v1/token — stricter rate limit: 20/min
   app.post<{ Body: TokenBody }>('/v1/token', { config: { rateLimit: { max: 20, timeWindow: '1 minute' } } }, async (request, reply) => {
@@ -134,6 +139,112 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
       expiresAt: expiresAt.toISOString(),
       scopes: authReq['scopes'] as string[],
       refreshToken: refreshId,
+      grantId,
+    });
+  });
+
+  // POST /v1/token/refresh — refresh a grant token (single-use rotation)
+  app.post<{ Body: RefreshBody }>('/v1/token/refresh', { config: { rateLimit: { max: 20, timeWindow: '1 minute' } } }, async (request, reply) => {
+    const { refreshToken, agentId } = request.body;
+
+    if (!refreshToken || !agentId) {
+      return reply.status(400).send({
+        message: 'refreshToken and agentId are required',
+        code: 'BAD_REQUEST',
+        requestId: request.id,
+      });
+    }
+
+    const sql = getSql();
+    const developerId = request.developer.id;
+
+    // Look up refresh token, joining grants and agents
+    const rows = await sql`
+      SELECT rt.id AS refresh_id, rt.grant_id, rt.is_used, rt.expires_at AS refresh_expires_at,
+             g.agent_id, g.principal_id, g.developer_id, g.scopes, g.status AS grant_status,
+             g.expires_at AS grant_expires_at,
+             a.did AS agent_did
+      FROM refresh_tokens rt
+      JOIN grants g ON g.id = rt.grant_id
+      JOIN agents a ON a.id = g.agent_id
+      WHERE rt.id = ${refreshToken}
+        AND g.developer_id = ${developerId}
+    `;
+
+    const row = rows[0];
+    if (!row) {
+      return reply.status(400).send({ message: 'Invalid refresh token', code: 'BAD_REQUEST', requestId: request.id });
+    }
+
+    if (row['agent_id'] !== agentId) {
+      return reply.status(400).send({ message: 'Agent mismatch', code: 'BAD_REQUEST', requestId: request.id });
+    }
+
+    if (row['is_used']) {
+      return reply.status(400).send({ message: 'Refresh token already used', code: 'BAD_REQUEST', requestId: request.id });
+    }
+
+    if (new Date(row['refresh_expires_at'] as string) < new Date()) {
+      return reply.status(400).send({ message: 'Refresh token expired', code: 'BAD_REQUEST', requestId: request.id });
+    }
+
+    if (row['grant_status'] === 'revoked') {
+      return reply.status(400).send({ message: 'Grant has been revoked', code: 'BAD_REQUEST', requestId: request.id });
+    }
+
+    // Mark old refresh token as used
+    await sql`UPDATE refresh_tokens SET is_used = true WHERE id = ${row['refresh_id'] as string}`;
+
+    const grantId = row['grant_id'] as string;
+    const scopes = row['scopes'] as string[];
+    const now = Date.now();
+
+    // Use remaining grant expiry window for the new token
+    const grantExpiresAt = new Date(row['grant_expires_at'] as string);
+    const expTimestamp = Math.floor(grantExpiresAt.getTime() / 1000);
+
+    const jti = newTokenId();
+    const newRefreshId = newRefreshTokenId();
+
+    // Create new grant token record
+    await sql`
+      INSERT INTO grant_tokens (jti, grant_id, expires_at)
+      VALUES (${jti}, ${grantId}, ${grantExpiresAt})
+    `;
+
+    // Create new refresh token (30-day TTL)
+    const refreshExpiresAt = new Date(now + 30 * 86400 * 1000);
+    await sql`
+      INSERT INTO refresh_tokens (id, grant_id, expires_at)
+      VALUES (${newRefreshId}, ${grantId}, ${refreshExpiresAt})
+    `;
+
+    // Sign JWT with same grant claims
+    const jwt = await signGrantToken({
+      sub: row['principal_id'] as string,
+      agt: row['agent_did'] as string,
+      dev: row['developer_id'] as string,
+      scp: scopes,
+      jti,
+      grnt: grantId,
+      exp: expTimestamp,
+    });
+
+    // Fire webhook (best-effort)
+    const webhookData = {
+      grantId,
+      agentId: row['agent_id'] as string,
+      principalId: row['principal_id'] as string,
+      scopes,
+      expiresAt: grantExpiresAt.toISOString(),
+    };
+    fireWebhooks(developerId, 'token.issued', { tokenId: jti, ...webhookData }).catch(() => {});
+
+    return reply.status(201).send({
+      grantToken: jwt,
+      expiresAt: grantExpiresAt.toISOString(),
+      scopes,
+      refreshToken: newRefreshId,
       grantId,
     });
   });

--- a/apps/auth-service/tests/token-refresh.test.ts
+++ b/apps/auth-service/tests/token-refresh.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { buildTestApp, authHeader, seedAuth, sqlMock, TEST_AGENT, TEST_DEVELOPER } from './helpers.js';
+import type { FastifyInstance } from 'fastify';
+import { decodeJwt } from 'jose';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+const validRefreshRow = {
+  refresh_id: 'ref_EXISTING',
+  grant_id: 'grnt_EXISTING',
+  is_used: false,
+  refresh_expires_at: new Date(Date.now() + 86400_000 * 30).toISOString(),
+  agent_id: TEST_AGENT.id,
+  principal_id: 'user_123',
+  developer_id: TEST_DEVELOPER.id,
+  scopes: ['read', 'write'],
+  grant_status: 'active',
+  grant_expires_at: new Date(Date.now() + 86400_000).toISOString(),
+  agent_did: TEST_AGENT.did,
+};
+
+describe('POST /v1/token/refresh', () => {
+  it('refreshes a valid token and returns new grant token with same grantId', async () => {
+    seedAuth();
+    // Refresh token lookup (JOIN grants + agents)
+    sqlMock.mockResolvedValueOnce([validRefreshRow]);
+    // UPDATE refresh_tokens SET is_used = true
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT grant_tokens
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT refresh_tokens (new)
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token/refresh',
+      headers: authHeader(),
+      payload: { refreshToken: 'ref_EXISTING', agentId: TEST_AGENT.id },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{
+      grantToken: string;
+      expiresAt: string;
+      scopes: string[];
+      refreshToken: string;
+      grantId: string;
+    }>();
+
+    expect(typeof body.grantToken).toBe('string');
+    expect(body.grantId).toBe('grnt_EXISTING');
+    expect(body.scopes).toEqual(['read', 'write']);
+    expect(typeof body.refreshToken).toBe('string');
+    expect(body.refreshToken).not.toBe('ref_EXISTING'); // rotated
+
+    // Verify JWT claims
+    const claims = decodeJwt(body.grantToken);
+    expect(claims.sub).toBe('user_123');
+    expect(claims['agt']).toBe(TEST_AGENT.did);
+    expect(claims['dev']).toBe(TEST_DEVELOPER.id);
+    expect(claims['scp']).toEqual(['read', 'write']);
+    expect(claims['grnt']).toBe('grnt_EXISTING');
+  });
+
+  it('returns 400 for already-used refresh token', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ ...validRefreshRow, is_used: true }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token/refresh',
+      headers: authHeader(),
+      payload: { refreshToken: 'ref_USED', agentId: TEST_AGENT.id },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toBe('Refresh token already used');
+  });
+
+  it('returns 400 for expired refresh token', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{
+      ...validRefreshRow,
+      refresh_expires_at: new Date(Date.now() - 1000).toISOString(),
+    }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token/refresh',
+      headers: authHeader(),
+      payload: { refreshToken: 'ref_EXPIRED', agentId: TEST_AGENT.id },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toBe('Refresh token expired');
+  });
+
+  it('returns 400 when grant has been revoked', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ ...validRefreshRow, grant_status: 'revoked' }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token/refresh',
+      headers: authHeader(),
+      payload: { refreshToken: 'ref_REVOKED', agentId: TEST_AGENT.id },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toBe('Grant has been revoked');
+  });
+
+  it('returns 400 when agent does not match', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ ...validRefreshRow, agent_id: 'ag_DIFFERENT' }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token/refresh',
+      headers: authHeader(),
+      payload: { refreshToken: 'ref_MISMATCH', agentId: TEST_AGENT.id },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toBe('Agent mismatch');
+  });
+
+  it('returns 400 for invalid (not found) refresh token', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]); // not found
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token/refresh',
+      headers: authHeader(),
+      payload: { refreshToken: 'ref_NONEXISTENT', agentId: TEST_AGENT.id },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toBe('Invalid refresh token');
+  });
+
+  it('returns 400 when required fields missing', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token/refresh',
+      headers: authHeader(),
+      payload: { refreshToken: 'ref_123' }, // missing agentId
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -50,7 +50,10 @@
             "pages": [
               "guides/rate-limits",
               "guides/webhooks",
-              "guides/self-hosting"
+              "guides/self-hosting",
+              "guides/security-best-practices",
+              "guides/token-verification",
+              "guides/troubleshooting"
             ]
           },
           {

--- a/docs/guides/security-best-practices.mdx
+++ b/docs/guides/security-best-practices.mdx
@@ -1,0 +1,201 @@
+---
+title: "Security Best Practices"
+sidebarTitle: "Security Best Practices"
+description: "Harden your Grantex integration with token storage strategies, scope design, revocation handling, and more."
+---
+
+This guide covers security best practices for integrating Grantex into production applications. Following these recommendations helps protect your users, agents, and data.
+
+## Token Storage
+
+Grant tokens are RS256 JWTs. Where you store them depends on your threat model:
+
+| Strategy | When to use | Notes |
+|----------|-------------|-------|
+| **In-memory** | Short-lived agent tasks (minutes) | Token is lost on process restart — safest default |
+| **Encrypted session store** | Multi-step workflows across requests | Use AES-256-GCM; never store tokens in plaintext |
+| **Encrypted cache (Redis)** | High-throughput services sharing tokens | Set TTL to match token expiry; use TLS in transit |
+
+<Warning>
+Never store grant tokens in browser `localStorage`, cookies, or client-side storage. Grant tokens are meant for server-side agent code only.
+</Warning>
+
+### Refresh Token Storage
+
+Refresh tokens have a 30-day TTL and are single-use. Store them with the same care as API keys:
+
+- Encrypt at rest (e.g., envelope encryption with a KMS)
+- Restrict access to the service that performs token refresh
+- Never log refresh tokens — redact them in your logging pipeline
+
+## Scope Design
+
+Design scopes using the `resource:action` pattern with least privilege:
+
+```
+# Good — narrow, specific
+calendar:read
+payments:initiate:max_500
+files:read:folder_abc
+
+# Bad — overly broad
+calendar
+full_access
+admin
+```
+
+**Principles:**
+
+- **Request only what you need** — agents should declare the minimum scopes required for their task
+- **Prefer read over write** — if the agent only needs to read data, don't request write access
+- **Use parameterized scopes** — `payments:initiate:max_500` is safer than `payments:initiate`
+- **Review scope requests in the consent UI** — users see exactly what the agent is requesting
+
+## Revocation Handling
+
+Tokens can be revoked at any time by the user or developer. Your agent should handle revocation gracefully:
+
+<CodeGroup>
+```typescript TypeScript
+import { Grantex, GrantexAuthError } from '@grantex/sdk';
+
+async function callWithGrant(grantToken: string, fn: () => Promise<void>) {
+  try {
+    await fn();
+  } catch (err) {
+    if (err instanceof GrantexAuthError && err.statusCode === 401) {
+      // Token was revoked — stop the agent gracefully
+      console.log('Grant token revoked, halting agent');
+      return;
+    }
+    throw err;
+  }
+}
+```
+
+```python Python
+from grantex import GrantexAuthError
+
+def call_with_grant(grant_token: str, fn):
+    try:
+        fn()
+    except GrantexAuthError as err:
+        if err.status_code == 401:
+            print("Grant token revoked, halting agent")
+            return
+        raise
+```
+</CodeGroup>
+
+**Best practices:**
+
+- Listen for the `grant.revoked` [webhook event](/guides/webhooks) to react in real time
+- On 401, do not retry — the token has been permanently invalidated
+- Clean up any cached tokens after revocation
+
+## Delegation Security
+
+When delegating grants to sub-agents (SPEC §9):
+
+- **Minimize delegation depth** — each layer adds risk. Keep `delegationDepth` as low as possible
+- **Always narrow scopes** — the sub-agent should have fewer scopes than the parent
+- **Verify the chain** — use `verifyGrantToken()` to inspect `parentAgentDid` and `delegationDepth` claims
+- **Set short expiry** — delegated grants should expire before the parent grant
+
+```typescript
+// Good: narrowing scopes on delegation
+const delegated = await grantex.grants.delegate({
+  parentGrantToken: parentToken,
+  subAgentId: subAgent.id,
+  scopes: ['calendar:read'],  // subset of parent's ['calendar:read', 'calendar:write']
+  expiresIn: '1h',            // shorter than parent's 24h
+});
+```
+
+## PKCE
+
+Always use PKCE (Proof Key for Code Exchange) with S256 in production:
+
+<CodeGroup>
+```typescript TypeScript
+import { Grantex, generatePkce } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const pkce = generatePkce();
+
+const auth = await grantex.authorize({
+  agentId: agent.id,
+  userId: 'user_123',
+  scopes: ['files:read'],
+  codeChallenge: pkce.codeChallenge,
+  codeChallengeMethod: 'S256',
+});
+
+// Later, when exchanging the code:
+const token = await grantex.tokens.exchange({
+  code: callbackCode,
+  agentId: agent.id,
+  codeVerifier: pkce.codeVerifier,
+});
+```
+
+```python Python
+from grantex import Grantex, AuthorizeParams, ExchangeTokenParams, generate_pkce
+
+pkce = generate_pkce()
+
+with Grantex(api_key="gx_live_...") as client:
+    auth = client.authorize(AuthorizeParams(
+        agent_id="agt_abc",
+        user_id="user_123",
+        scopes=["files:read"],
+        code_challenge=pkce.code_challenge,
+        code_challenge_method="S256",
+    ))
+
+    token = client.tokens.exchange(ExchangeTokenParams(
+        code=callback_code,
+        agent_id="agt_abc",
+        code_verifier=pkce.code_verifier,
+    ))
+```
+</CodeGroup>
+
+PKCE prevents authorization code interception attacks. Without it, an attacker who intercepts the code can exchange it for a grant token.
+
+## Audit Trail Best Practices
+
+The audit log is your forensic record. Use it proactively:
+
+- **Log every sensitive action** — file access, payment initiation, data deletion
+- **Include metadata** — resource IDs, amounts, user-facing descriptions
+- **Use appropriate status values** — `success`, `failure`, or `blocked`
+- **Query audit entries regularly** — detect anomalies before they become incidents
+- **Enable the anomaly detection worker** — it flags rate spikes, high failure rates, and off-hours activity automatically
+
+```typescript
+await grantex.audit.log({
+  agentId: agent.id,
+  grantId: grant.id,
+  action: 'payments:initiate',
+  metadata: { amount: 250, currency: 'USD', recipient: 'vendor_xyz' },
+  status: 'success',
+});
+```
+
+## Key Rotation
+
+- Rotate your Grantex API key periodically using `POST /v1/me/rotate-key`
+- After rotation, update all services that use the old key
+- The old key is immediately invalidated — plan for a brief deployment window
+
+## Summary Checklist
+
+<Check>Store tokens in memory or encrypted server-side stores</Check>
+<Check>Use `resource:action` scope format with least privilege</Check>
+<Check>Handle 401 gracefully — never retry revoked tokens</Check>
+<Check>Minimize delegation depth and always narrow scopes</Check>
+<Check>Always use PKCE S256 in production</Check>
+<Check>Log all sensitive agent actions to the audit trail</Check>
+<Check>Enable webhooks for `grant.revoked` events</Check>
+<Check>Rotate API keys periodically</Check>

--- a/docs/guides/token-verification.mdx
+++ b/docs/guides/token-verification.mdx
@@ -1,0 +1,189 @@
+---
+title: "Token Verification Strategy"
+sidebarTitle: "Token Verification"
+description: "Choose between offline, online, and hybrid token verification strategies."
+---
+
+Grantex supports two verification approaches, each with different trade-offs. This guide helps you pick the right strategy — or combine them.
+
+## Offline Verification
+
+Offline verification validates the JWT signature locally using the JWKS endpoint, without calling the Grantex API. This is the fastest option and the recommended default.
+
+**How it works:**
+1. Fetch the public keys from `/.well-known/jwks.json` (cached automatically)
+2. Verify the RS256 signature against the public key
+3. Check `exp`, `iss`, and optionally `aud` and required scopes
+4. Return the decoded claims
+
+**Best for:** High-velocity endpoints, latency-sensitive paths, reducing API calls.
+
+<CodeGroup>
+```typescript TypeScript
+import { verifyGrantToken } from '@grantex/sdk';
+
+const grant = await verifyGrantToken(grantToken, {
+  jwksUri: 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app/.well-known/jwks.json',
+  requiredScopes: ['calendar:read'],
+  audience: 'my-service',  // optional
+});
+
+console.log(grant.principalId);  // 'user_abc123'
+console.log(grant.scopes);       // ['calendar:read']
+console.log(grant.grantId);      // 'grnt_01HXYZ...'
+```
+
+```python Python
+from grantex import verify_grant_token, VerifyGrantTokenOptions
+
+grant = verify_grant_token(
+    grant_token,
+    VerifyGrantTokenOptions(
+        jwks_uri="https://grantex-auth-dd4mtrt2gq-uc.a.run.app/.well-known/jwks.json",
+        required_scopes=["calendar:read"],
+        audience="my-service",  # optional
+    ),
+)
+
+print(grant.principal_id)  # 'user_abc123'
+print(grant.scopes)        # ('calendar:read',)
+print(grant.grant_id)      # 'grnt_01HXYZ...'
+```
+</CodeGroup>
+
+**Trade-off:** Offline verification does not check the revocation list. A revoked token will still pass offline verification until it expires.
+
+<Note>
+The JWKS endpoint (`/.well-known/jwks.json`) is exempt from rate limits. You can fetch it as often as needed.
+</Note>
+
+## Online Verification
+
+Online verification calls `POST /v1/tokens/verify`, which checks the signature, expiry, **and** real-time revocation status on the server.
+
+**Best for:** High-stakes operations (payments, data deletion, privilege escalation).
+
+<CodeGroup>
+```typescript TypeScript
+import { Grantex } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const result = await grantex.tokens.verify(grantToken);
+
+if (!result.valid) {
+  throw new Error('Token is revoked or expired');
+}
+
+console.log(result.scopes);    // ['payments:initiate']
+console.log(result.principal); // 'user_abc123'
+```
+
+```python Python
+from grantex import Grantex
+
+with Grantex(api_key="gx_live_...") as client:
+    result = client.tokens.verify(grant_token)
+
+    if not result.valid:
+        raise ValueError("Token is revoked or expired")
+
+    print(result.scopes)    # ('payments:initiate',)
+    print(result.principal) # 'user_abc123'
+```
+</CodeGroup>
+
+**Trade-off:** Adds network latency (~50-100ms) and counts against your [rate limit](/guides/rate-limits) (100 req/min global).
+
+## Hybrid Approach
+
+The hybrid strategy uses offline verification as the fast path and online verification for sensitive operations. This gives you the best of both worlds.
+
+```typescript
+import { verifyGrantToken, Grantex } from '@grantex/sdk';
+
+const SENSITIVE_SCOPES = ['payments:initiate', 'files:delete', 'admin:write'];
+
+async function verifyToken(grantToken: string): Promise<void> {
+  // Step 1: Always verify the signature offline (fast, no network)
+  const grant = await verifyGrantToken(grantToken, {
+    jwksUri: 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app/.well-known/jwks.json',
+  });
+
+  // Step 2: If the token has sensitive scopes, also verify online
+  const hasSensitiveScope = grant.scopes.some(s => SENSITIVE_SCOPES.includes(s));
+  if (hasSensitiveScope) {
+    const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+    const result = await grantex.tokens.verify(grantToken);
+    if (!result.valid) {
+      throw new Error('Token revoked — blocking sensitive operation');
+    }
+  }
+}
+```
+
+## Caching Verification Results
+
+Per SPEC §7.4, you may cache online verification results for up to **5 minutes**. This reduces API calls while keeping revocation lag acceptable.
+
+```typescript
+const verifyCache = new Map<string, { result: VerifyTokenResponse; cachedAt: number }>();
+const MAX_CACHE_AGE_MS = 5 * 60 * 1000; // 5 minutes
+
+async function cachedVerify(grantex: Grantex, token: string) {
+  const cached = verifyCache.get(token);
+  if (cached && Date.now() - cached.cachedAt < MAX_CACHE_AGE_MS) {
+    return cached.result;
+  }
+
+  const result = await grantex.tokens.verify(token);
+  verifyCache.set(token, { result, cachedAt: Date.now() });
+  return result;
+}
+```
+
+<Warning>
+Do not cache for longer than 5 minutes. Revoked tokens must be detected within a reasonable window.
+</Warning>
+
+## Choosing a Strategy
+
+| Criteria | Offline | Online | Hybrid |
+|----------|---------|--------|--------|
+| **Latency** | ~0ms (after JWKS fetch) | ~50-100ms | Varies |
+| **Revocation check** | No | Yes | Conditional |
+| **Rate limit impact** | None | 1 req per verify | Reduced |
+| **Best for** | Read-only endpoints, high-velocity | Payment, deletion, admin | Most production apps |
+
+**Recommendation:** Start with the hybrid approach. Use offline verification for reads and online for writes or sensitive scopes.
+
+## Token Refresh
+
+When a grant token expires, use the refresh token to obtain a new one without re-prompting the user:
+
+<CodeGroup>
+```typescript TypeScript
+const newToken = await grantex.tokens.refresh({
+  refreshToken: previousResponse.refreshToken,
+  agentId: agent.id,
+});
+
+// newToken.grantToken — new JWT
+// newToken.refreshToken — new refresh token (old one is invalidated)
+// newToken.grantId — same grant, new token
+```
+
+```python Python
+from grantex import RefreshTokenParams
+
+new_token = client.tokens.refresh(RefreshTokenParams(
+    refresh_token=previous_response.refresh_token,
+    agent_id="agt_abc123",
+))
+
+# new_token.grant_token — new JWT
+# new_token.refresh_token — new refresh token (old one is invalidated)
+# new_token.grant_id — same grant, new token
+```
+</CodeGroup>
+
+Refresh tokens are single-use. Each refresh returns a new refresh token, forming a rotation chain. If a refresh token is used twice, the second attempt is rejected — this detects token theft.

--- a/docs/guides/troubleshooting.mdx
+++ b/docs/guides/troubleshooting.mdx
@@ -1,0 +1,203 @@
+---
+title: "Troubleshooting"
+sidebarTitle: "Troubleshooting"
+description: "Common issues and solutions when working with the Grantex API and SDKs."
+---
+
+## "Token invalid" or Verification Fails
+
+If `verifyGrantToken()` or `tokens.verify()` returns invalid results, work through this checklist:
+
+<Steps>
+  <Step title="Check token expiry">
+    Decode the JWT and inspect the `exp` claim. If `exp` is in the past, the token has expired.
+
+    ```bash
+    # Decode a JWT (base64 payload)
+    echo 'YOUR_JWT' | cut -d. -f2 | base64 -d 2>/dev/null | python3 -m json.tool
+    ```
+  </Step>
+  <Step title="Check revocation status">
+    Call `POST /v1/tokens/verify` with the token. If `valid: false`, the token or its grant has been revoked.
+  </Step>
+  <Step title="Verify the JWKS URI">
+    Make sure you're using the correct JWKS endpoint for your environment:
+    - **Production:** `https://grantex-auth-dd4mtrt2gq-uc.a.run.app/.well-known/jwks.json`
+    - **Self-hosted:** `https://your-domain/.well-known/jwks.json`
+  </Step>
+  <Step title="Check clock skew">
+    JWT verification compares `exp` and `iat` against your server's clock. If your server clock is more than a few seconds off, tokens may fail verification. Use NTP to keep clocks synchronized.
+  </Step>
+  <Step title="Check audience mismatch">
+    If you set `audience` in `VerifyGrantTokenOptions`, the JWT's `aud` claim must match. Remove the audience check or ensure the authorization request included the same audience.
+  </Step>
+</Steps>
+
+## "Authorization Stuck" — Consent Flow Not Completing
+
+If the authorization request stays in `pending` status:
+
+1. **Check the consent URL** — ensure the user was redirected to `consentUrl` from the authorization response
+2. **Check the auth request status** — query `GET /v1/consent/:id` to see the current state
+3. **Check expiry** — auth requests expire after the `expiresIn` window (default 24h). If expired, create a new authorization request
+4. **Check the redirect URI** — if provided, the code is delivered via redirect. Ensure your callback handler is working
+5. **Sandbox mode** — in sandbox mode, consent is auto-approved and a code is returned directly in the response
+
+## Rate Limited (429)
+
+When you receive a `429 Too Many Requests` response:
+
+```json
+{
+  "message": "Rate limit exceeded, retry in 42 seconds",
+  "code": "BAD_REQUEST",
+  "requestId": "a1b2c3d4-e5f6-..."
+}
+```
+
+**What to do:**
+
+1. Read the `Retry-After` header for the minimum wait time
+2. Implement exponential backoff with jitter (see [Rate Limits guide](/guides/rate-limits))
+3. Reduce request frequency:
+   - **Use offline verification** instead of `POST /v1/tokens/verify` — the JWKS endpoint is exempt from rate limits
+   - **Use webhooks** instead of polling for grant status changes
+   - **Cache tokens** — don't re-exchange or re-verify tokens unnecessarily
+
+**Rate limits by endpoint:**
+
+| Endpoint | Limit |
+|----------|-------|
+| Global (all endpoints) | 100 req/min |
+| `POST /v1/authorize` | 10 req/min |
+| `POST /v1/token` | 20 req/min |
+| `POST /v1/token/refresh` | 20 req/min |
+| `GET /.well-known/jwks.json` | Exempt |
+
+## Plan Limit Exceeded (402)
+
+A `402 Payment Required` response means you've hit a resource limit for your current plan:
+
+```json
+{
+  "message": "Agent limit reached (free plan: 3)",
+  "code": "PLAN_LIMIT_EXCEEDED",
+  "requestId": "..."
+}
+```
+
+**Options:**
+
+- **Upgrade your plan** — use the billing portal to switch to Pro or Enterprise
+- **Clean up unused resources** — delete inactive agents, revoke expired grants
+- **Check your current usage** via the developer dashboard
+
+## Delegation Failed
+
+If `POST /v1/grants/delegate` returns an error:
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| "Scopes must be a subset" | Sub-agent scopes exceed parent grant scopes | Narrow the requested scopes |
+| "Delegation depth exceeded" | Too many levels of delegation | Reduce the chain or increase the limit |
+| "Parent grant expired" | The parent grant token has expired | Obtain a new grant token first |
+| "Parent grant revoked" | The parent grant was revoked | Re-authorize the parent agent |
+| "Invalid parent grant token" | JWT signature verification failed | Check the token is well-formed |
+
+## Refresh Token Rejected
+
+If `POST /v1/token/refresh` returns 400:
+
+| Error message | Cause | Fix |
+|---------------|-------|-----|
+| "Refresh token already used" | Token was already used (single-use rotation) | Use the new refresh token from the previous refresh response |
+| "Refresh token expired" | Token's 30-day TTL has elapsed | Re-authorize to get a fresh token pair |
+| "Grant has been revoked" | The underlying grant was revoked | Re-authorize the agent |
+| "Agent mismatch" | `agentId` doesn't match the grant's agent | Use the correct agent ID |
+| "Invalid refresh token" | Token ID not found | Check you're passing the correct refresh token value |
+
+## Error Codes Reference
+
+All Grantex API errors include a `code` field. SDKs expose this as `error.code`:
+
+<CodeGroup>
+```typescript TypeScript
+import { GrantexApiError } from '@grantex/sdk';
+
+try {
+  await grantex.tokens.exchange({ code, agentId });
+} catch (err) {
+  if (err instanceof GrantexApiError) {
+    console.log(err.code);       // 'BAD_REQUEST'
+    console.log(err.statusCode); // 400
+    console.log(err.message);    // 'Invalid code'
+    console.log(err.requestId);  // 'a1b2c3d4-...'
+  }
+}
+```
+
+```python Python
+from grantex import GrantexApiError
+
+try:
+    client.tokens.exchange(params)
+except GrantexApiError as err:
+    print(err.code)        # 'BAD_REQUEST'
+    print(err.status_code) # 400
+    print(str(err))        # 'Invalid code'
+    print(err.request_id)  # 'a1b2c3d4-...'
+```
+</CodeGroup>
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `BAD_REQUEST` | 400 | Invalid input, missing fields, or validation failure |
+| `UNAUTHORIZED` | 401 | Invalid or missing API key |
+| `FORBIDDEN` | 403 | Valid API key but insufficient permissions |
+| `NOT_FOUND` | 404 | Resource does not exist |
+| `CONFLICT` | 409 | Resource already exists (e.g., duplicate agent name) |
+| `GONE` | 410 | Resource was deleted |
+| `VALIDATION_ERROR` | 422 | Schema validation failure |
+| `PLAN_LIMIT_EXCEEDED` | 402 | Resource count exceeds plan threshold |
+| `POLICY_DENIED` | 403 | An access policy blocked the operation |
+| `SSO_ERROR` | 400 | SSO/OIDC configuration or callback error |
+| `SERVICE_UNAVAILABLE` | 503 | Service temporarily unavailable |
+| `INTERNAL_ERROR` | 500 | Unexpected server error |
+
+## Inspecting JWT Claims Locally
+
+You can decode a Grantex grant token without verification to inspect its claims:
+
+```bash
+# Using jq (if installed)
+echo 'YOUR_JWT' | cut -d. -f2 | base64 -d 2>/dev/null | jq .
+
+# Using Python
+python3 -c "import sys, json, base64; print(json.dumps(json.loads(base64.urlsafe_b64decode(sys.argv[1].split('.')[1] + '==')), indent=2))" 'YOUR_JWT'
+```
+
+**Grant token claims:**
+
+| Claim | Description |
+|-------|-------------|
+| `iss` | Issuer (Grantex auth service URL) |
+| `sub` | Principal ID (the user who authorized) |
+| `agt` | Agent DID |
+| `dev` | Developer ID |
+| `scp` | Scopes array |
+| `grnt` | Grant record ID |
+| `jti` | Token ID (unique per token) |
+| `iat` | Issued at (Unix timestamp) |
+| `exp` | Expires at (Unix timestamp) |
+| `aud` | Audience (optional) |
+| `parentAgt` | Parent agent DID (delegation only) |
+| `parentGrnt` | Parent grant ID (delegation only) |
+| `delegationDepth` | Delegation depth (delegation only) |
+
+## Getting Help
+
+If none of the above resolves your issue:
+
+- Check the [GitHub Issues](https://github.com/mishrasanjeev/grantex/issues) for known problems
+- Open a new issue with your error message, `requestId`, and reproduction steps
+- For Enterprise support, use the [contact form](https://grantex.dev/#enterprise)

--- a/docs/sdks/python/tokens.mdx
+++ b/docs/sdks/python/tokens.mdx
@@ -6,9 +6,10 @@ description: "Exchange authorization codes for grant tokens, verify tokens onlin
 
 ## Overview
 
-The `tokens` client provides three operations for managing grant tokens:
+The `tokens` client provides four operations for managing grant tokens:
 
 - **Exchange** an authorization code for a grant token
+- **Refresh** a grant token using a refresh token
 - **Verify** a grant token online via the Grantex API
 - **Revoke** a grant token by its token ID (JTI)
 
@@ -64,6 +65,41 @@ with Grantex(api_key="gx_live_...") as client:
         code_verifier="dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
     ))
 ```
+
+## Refresh
+
+Refresh a grant token using a refresh token. Returns a new grant token and a new refresh token (the old refresh token is invalidated). The `grant_id` stays the same.
+
+Refresh tokens are single-use and rotated on every refresh per SPEC §7.4.
+
+```python
+from grantex import Grantex, RefreshTokenParams
+
+with Grantex(api_key="gx_live_...") as client:
+    new_token = client.tokens.refresh(RefreshTokenParams(
+        refresh_token="rt_01HXYZ...",
+        agent_id="agt_abc123",
+    ))
+
+    print(f"New grant token: {new_token.grant_token}")
+    print(f"New refresh token: {new_token.refresh_token}")
+    print(f"Same grant ID: {new_token.grant_id}")
+```
+
+### RefreshTokenParams
+
+| Field           | Type  | Required | Description                                                |
+|-----------------|-------|----------|------------------------------------------------------------|
+| `refresh_token` | `str` | Yes      | The refresh token from a previous `exchange()` or `refresh()` response. |
+| `agent_id`      | `str` | Yes      | The agent ID associated with the grant.                    |
+
+### Response
+
+Returns an `ExchangeTokenResponse` — same shape as `exchange()`. See above for field descriptions.
+
+<Warning>
+Each refresh token can only be used once. If you attempt to reuse a refresh token, the request will be rejected with a `400` error. Always store and use the new `refresh_token` from the response.
+</Warning>
 
 ## Verify
 

--- a/docs/sdks/typescript/tokens.mdx
+++ b/docs/sdks/typescript/tokens.mdx
@@ -70,6 +70,43 @@ console.log(token.refreshToken); // 'rt_01HXYZ...'
 
 ---
 
+## tokens.refresh()
+
+Refresh a grant token using a refresh token. Returns a new grant token and a new refresh token (the old refresh token is invalidated). The `grantId` stays the same.
+
+Refresh tokens are single-use and rotated on every refresh per SPEC §7.4.
+
+```typescript
+const newToken = await grantex.tokens.refresh({
+  refreshToken: token.refreshToken,
+  agentId: agent.id,
+});
+
+console.log(newToken.grantToken);   // new RS256 JWT
+console.log(newToken.refreshToken); // new refresh token (old one invalidated)
+console.log(newToken.grantId);      // same grant ID
+```
+
+### Parameters
+
+<ParamField body="refreshToken" type="string" required>
+  The refresh token from a previous `exchange()` or `refresh()` response.
+</ParamField>
+
+<ParamField body="agentId" type="string" required>
+  The agent ID associated with the grant.
+</ParamField>
+
+### Response: `ExchangeTokenResponse`
+
+Returns the same shape as `exchange()` — see above for field descriptions.
+
+<Warning>
+Each refresh token can only be used once. If you attempt to reuse a refresh token, the request will be rejected with a `400` error. Always store and use the new `refreshToken` from the response.
+</Warning>
+
+---
+
 ## tokens.verify()
 
 Verify a grant token online via the Grantex API. This is useful when you want server-side validation without managing JWKS yourself.

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/conformance",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Conformance test suite for the Grantex protocol",
   "type": "module",
   "bin": {

--- a/packages/conformance/src/suites/token.ts
+++ b/packages/conformance/src/suites/token.ts
@@ -79,6 +79,84 @@ export const tokenSuite: SuiteDefinition = {
       }),
     );
 
+    // ─── Token Refresh ─────────────────────────────────────────────────
+
+    results.push(
+      await test(
+        'POST /v1/token/refresh exchanges refresh token for new grant token',
+        '§7.4',
+        async () => {
+          // First, execute a full flow to get a refresh token
+          const flow = await ctx.flow.executeFullFlow({
+            agentId,
+            agentDid,
+            scopes: ['read', 'write'],
+          });
+          expectString(flow.refreshToken, 'refreshToken');
+
+          // Now refresh
+          const refreshRes = await ctx.http.post<{
+            grantToken: string;
+            refreshToken: string;
+            grantId: string;
+            scopes: string[];
+            expiresAt: string;
+          }>('/v1/token/refresh', {
+            refreshToken: flow.refreshToken,
+            agentId,
+          });
+          expectStatus(refreshRes, 201);
+          expectString(refreshRes.body.grantToken, 'grantToken');
+          expectString(refreshRes.body.refreshToken, 'refreshToken');
+          expectString(refreshRes.body.grantId, 'grantId');
+          expectArray(refreshRes.body.scopes, 'scopes');
+          expectIsoDate(refreshRes.body.expiresAt, 'expiresAt');
+
+          // Same grantId
+          if (refreshRes.body.grantId !== flow.grantId) {
+            throw new Error(
+              `Expected same grantId after refresh: got ${refreshRes.body.grantId}, expected ${flow.grantId}`,
+            );
+          }
+          // Rotated refresh token
+          if (refreshRes.body.refreshToken === flow.refreshToken) {
+            throw new Error('Expected rotated refresh token, but got the same one');
+          }
+
+          ctx.cleanup.trackGrant(refreshRes.body.grantId);
+        },
+      ),
+    );
+
+    results.push(
+      await test(
+        'POST /v1/token/refresh rejects used refresh token (400)',
+        '§7.4',
+        async () => {
+          const flow = await ctx.flow.executeFullFlow({
+            agentId,
+            agentDid,
+            scopes: ['read'],
+          });
+
+          // First refresh — should succeed
+          const first = await ctx.http.post<{ grantId: string }>('/v1/token/refresh', {
+            refreshToken: flow.refreshToken,
+            agentId,
+          });
+          expectStatus(first, 201);
+          ctx.cleanup.trackGrant(first.body.grantId);
+
+          // Second refresh with same (now used) token — should fail
+          const second = await ctx.http.post('/v1/token/refresh', {
+            refreshToken: flow.refreshToken,
+            agentId,
+          });
+          expectStatus(second, 400);
+        },
+      ),
+    );
+
     return results;
   },
 };

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.1.3"
+version = "0.1.4"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -37,6 +37,7 @@ from ._types import (
     DelegateParams,
     ExchangeTokenParams,
     ExchangeTokenResponse,
+    RefreshTokenParams,
     Grant,
     GrantTokenPayload,
     ListAgentsResponse,
@@ -76,7 +77,7 @@ from ._pkce import PkceChallenge, generate_pkce
 from ._verify import verify_grant_token
 from ._webhook import verify_webhook_signature
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 __all__ = [
     # Main client
@@ -123,6 +124,7 @@ __all__ = [
     "DelegateParams",
     "ExchangeTokenParams",
     "ExchangeTokenResponse",
+    "RefreshTokenParams",
     "Grant",
     "GrantTokenPayload",
     "ListAgentsResponse",

--- a/packages/sdk-py/src/grantex/_errors.py
+++ b/packages/sdk-py/src/grantex/_errors.py
@@ -16,11 +16,13 @@ class GrantexApiError(GrantexError):
         status_code: int,
         body: Any = None,
         request_id: str | None = None,
+        code: str | None = None,
     ) -> None:
         super().__init__(message)
         self.status_code = status_code
         self.body = body
         self.request_id = request_id
+        self.code = code
 
 
 class GrantexAuthError(GrantexApiError):

--- a/packages/sdk-py/src/grantex/_http.py
+++ b/packages/sdk-py/src/grantex/_http.py
@@ -71,13 +71,14 @@ class HttpClient:
                 body_data = response.text or None
 
             message = _extract_error_message(body_data, response.status_code)
+            error_code = _extract_error_code(body_data)
 
             if response.status_code in (401, 403):
                 raise GrantexAuthError(
-                    message, response.status_code, body_data, request_id
+                    message, response.status_code, body_data, request_id, error_code
                 )
             raise GrantexApiError(
-                message, response.status_code, body_data, request_id
+                message, response.status_code, body_data, request_id, error_code
             )
 
         if response.status_code == 204:
@@ -93,6 +94,12 @@ class HttpClient:
 
     def __exit__(self, *args: object) -> None:
         self.close()
+
+
+def _extract_error_code(body: Any) -> str | None:
+    if isinstance(body, dict) and isinstance(body.get("code"), str):
+        return str(body["code"])
+    return None
 
 
 def _extract_error_message(body: Any, status: int) -> str:

--- a/packages/sdk-py/src/grantex/_types.py
+++ b/packages/sdk-py/src/grantex/_types.py
@@ -301,6 +301,15 @@ class ExchangeTokenResponse:
         )
 
 
+@dataclass
+class RefreshTokenParams:
+    refresh_token: str
+    agent_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"refreshToken": self.refresh_token, "agentId": self.agent_id}
+
+
 # ─── Audit ────────────────────────────────────────────────────────────────────
 
 

--- a/packages/sdk-py/src/grantex/resources/_tokens.py
+++ b/packages/sdk-py/src/grantex/resources/_tokens.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from .._http import HttpClient
-from .._types import ExchangeTokenParams, ExchangeTokenResponse, VerifyTokenResponse
+from .._types import ExchangeTokenParams, ExchangeTokenResponse, RefreshTokenParams, VerifyTokenResponse
 
 
 class TokensClient:
@@ -10,6 +10,10 @@ class TokensClient:
 
     def exchange(self, params: ExchangeTokenParams) -> ExchangeTokenResponse:
         data = self._http.post("/v1/token", params.to_dict())
+        return ExchangeTokenResponse.from_dict(data)
+
+    def refresh(self, params: RefreshTokenParams) -> ExchangeTokenResponse:
+        data = self._http.post("/v1/token/refresh", params.to_dict())
         return ExchangeTokenResponse.from_dict(data)
 
     def verify(self, token: str) -> VerifyTokenResponse:

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "type": "module",
   "exports": {

--- a/packages/sdk-ts/src/errors.ts
+++ b/packages/sdk-ts/src/errors.ts
@@ -10,6 +10,7 @@ export class GrantexError extends Error {
 export class GrantexApiError extends GrantexError {
   readonly statusCode: number;
   readonly body: unknown;
+  readonly code: string | undefined;
   readonly requestId: string | undefined;
 
   constructor(
@@ -17,11 +18,13 @@ export class GrantexApiError extends GrantexError {
     statusCode: number,
     body: unknown,
     requestId?: string,
+    code?: string,
   ) {
     super(message);
     this.name = 'GrantexApiError';
     this.statusCode = statusCode;
     this.body = body;
+    this.code = code;
     this.requestId = requestId;
     Object.setPrototypeOf(this, new.target.prototype);
   }
@@ -33,8 +36,9 @@ export class GrantexAuthError extends GrantexApiError {
     statusCode: 401 | 403,
     body: unknown,
     requestId?: string,
+    code?: string,
   ) {
-    super(message, statusCode, body, requestId);
+    super(message, statusCode, body, requestId, code);
     this.name = 'GrantexAuthError';
     Object.setPrototypeOf(this, new.target.prototype);
   }

--- a/packages/sdk-ts/src/http.ts
+++ b/packages/sdk-ts/src/http.ts
@@ -87,6 +87,7 @@ export class HttpClient {
       }
 
       const message = extractErrorMessage(responseBody, response.status);
+      const errorCode = extractErrorCode(responseBody);
 
       if (response.status === 401 || response.status === 403) {
         throw new GrantexAuthError(
@@ -94,10 +95,11 @@ export class HttpClient {
           response.status as 401 | 403,
           responseBody,
           requestId,
+          errorCode,
         );
       }
 
-      throw new GrantexApiError(message, response.status, responseBody, requestId);
+      throw new GrantexApiError(message, response.status, responseBody, requestId, errorCode);
     }
 
     if (response.status === 204) {
@@ -106,6 +108,18 @@ export class HttpClient {
 
     return response.json() as Promise<T>;
   }
+}
+
+function extractErrorCode(body: unknown): string | undefined {
+  if (
+    body !== null &&
+    typeof body === 'object' &&
+    'code' in body &&
+    typeof (body as Record<string, unknown>)['code'] === 'string'
+  ) {
+    return (body as Record<string, string>)['code']!;
+  }
+  return undefined;
 }
 
 function extractErrorMessage(body: unknown, status: number): string {

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -43,6 +43,7 @@ export type {
   // Tokens
   ExchangeTokenParams,
   ExchangeTokenResponse,
+  RefreshTokenParams,
   VerifyTokenResponse,
   // Audit
   LogAuditParams,

--- a/packages/sdk-ts/src/resources/tokens.ts
+++ b/packages/sdk-ts/src/resources/tokens.ts
@@ -1,5 +1,5 @@
 import type { HttpClient } from '../http.js';
-import type { ExchangeTokenParams, ExchangeTokenResponse, VerifyTokenResponse } from '../types.js';
+import type { ExchangeTokenParams, ExchangeTokenResponse, RefreshTokenParams, VerifyTokenResponse } from '../types.js';
 
 export class TokensClient {
   readonly #http: HttpClient;
@@ -10,6 +10,10 @@ export class TokensClient {
 
   exchange(params: ExchangeTokenParams): Promise<ExchangeTokenResponse> {
     return this.#http.post<ExchangeTokenResponse>('/v1/token', params);
+  }
+
+  refresh(params: RefreshTokenParams): Promise<ExchangeTokenResponse> {
+    return this.#http.post<ExchangeTokenResponse>('/v1/token/refresh', params);
   }
 
   verify(token: string): Promise<VerifyTokenResponse> {

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -169,6 +169,11 @@ export interface ExchangeTokenResponse {
   grantId: string;
 }
 
+export interface RefreshTokenParams {
+  refreshToken: string;
+  agentId: string;
+}
+
 export interface VerifyTokenResponse {
   valid: boolean;
   grantId?: string;

--- a/packages/sdk-ts/tests/tokens.test.ts
+++ b/packages/sdk-ts/tests/tokens.test.ts
@@ -66,6 +66,35 @@ describe('TokensClient', () => {
     expect(url).toMatch(/\/v1\/tokens\/verify$/);
   });
 
+  it('refresh() POSTs to /v1/token/refresh', async () => {
+    const mockBody = {
+      grantToken: 'eyJ.new...',
+      expiresAt: '2026-03-01T00:00:00Z',
+      scopes: ['calendar:read'],
+      refreshToken: 'rt_new',
+      grantId: 'grnt_01',
+    };
+    const mockFetch = makeFetch(200, mockBody);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.tokens.refresh({
+      refreshToken: 'rt_old',
+      agentId: 'ag_01',
+    });
+
+    expect(result.grantToken).toBe('eyJ.new...');
+    expect(result.grantId).toBe('grnt_01');
+    expect(result.refreshToken).toBe('rt_new');
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/token\/refresh$/);
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
+    expect(body.refreshToken).toBe('rt_old');
+    expect(body.agentId).toBe('ag_01');
+  });
+
   it('revoke() POSTs to /v1/tokens/revoke', async () => {
     const mockFetch = makeFetch(204, null);
     vi.stubGlobal('fetch', mockFetch);


### PR DESCRIPTION
## Summary

- **Token refresh endpoint** — `POST /v1/token/refresh` with single-use rotation per SPEC §7.4. Validates used/expired/revoked/mismatch, signs new JWT with same grantId, fires `token.issued` webhook. 7 tests.
- **SDK `tokens.refresh()`** — Added to both TypeScript and Python SDKs. Returns `ExchangeTokenResponse` with rotated refresh token. Bumped both SDKs to 0.1.4.
- **Error `code` property** — `GrantexApiError.code` now exposes the structured error code (`BAD_REQUEST`, `PLAN_LIMIT_EXCEEDED`, etc.) from API responses in both TS and Python SDKs.
- **3 documentation guides** — Security best practices, token verification strategy, and troubleshooting (with error codes table, JWT inspection, common issues).
- **SDK token docs** — Updated TypeScript and Python token pages with `refresh()` method documentation.
- **Conformance suite** — 2 new refresh token tests (happy path + used token rejection). Bumped to 0.1.1.

## Test plan

- [x] `apps/auth-service`: typecheck passes, 208/209 tests pass (1 pre-existing PKCE test failure)
- [x] `packages/sdk-ts`: typecheck passes, 83 tests pass (was 81)
- [x] `packages/sdk-py`: pytest 93 pass (was 91), mypy --strict clean
- [x] `packages/conformance`: typecheck passes, 27 tests pass, build clean
- [ ] Deploy auth service and run full conformance suite against production
- [ ] Verify 3 new docs pages render on Mintlify
- [ ] Publish sdk-ts 0.1.4, sdk-py 0.1.4, conformance 0.1.1