### PR TITLE
feat: end-user permission dashboard with principal session tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Grantex introduces three primitives:
           │
           ▼
   User can revoke any grant at any time → effective in < 1 second
+          │
+          ▼
+  End-user permission dashboard → users self-service view & revoke access
 ```
 
 ---
@@ -178,6 +181,17 @@ const grant = await verifyGrantToken(token, {
   requiredScopes: ['payments:initiate'],
 });
 // Throws if token is expired, revoked, tampered, or missing required scopes
+```
+
+### 7. Give users control over their permissions
+
+```typescript
+// Generate a short-lived link for the end-user to view & revoke agent access
+const session = await grantex.principalSessions.create({
+  principalId: 'user_abc123',
+  expiresIn: '2h',
+});
+// Send session.dashboardUrl to the user via email, in-app notification, etc.
 ```
 
 ---

--- a/apps/auth-service/src/lib/revoke.ts
+++ b/apps/auth-service/src/lib/revoke.ts
@@ -1,0 +1,66 @@
+import { getSql } from '../db/client.js';
+import { getRedis } from '../redis/client.js';
+import { fireWebhooks } from './webhook.js';
+
+export interface RevokeResult {
+  revoked: boolean;
+  descendantCount: number;
+}
+
+/**
+ * Revoke a grant and cascade-revoke all descendant grants.
+ * Sets Redis revocation keys and fires webhook events.
+ */
+export async function revokeGrantCascade(
+  grantId: string,
+  developerId: string,
+): Promise<RevokeResult> {
+  const sql = getSql();
+
+  const rows = await sql`
+    UPDATE grants
+    SET status = 'revoked', revoked_at = NOW()
+    WHERE id = ${grantId}
+      AND developer_id = ${developerId}
+      AND status = 'active'
+    RETURNING id, expires_at
+  `;
+
+  const grant = rows[0];
+  if (!grant) {
+    return { revoked: false, descendantCount: 0 };
+  }
+
+  // Set Redis revocation key with TTL
+  const redis = getRedis();
+  const expiresAt = new Date(grant['expires_at'] as string);
+  const ttlSeconds = Math.max(1, Math.floor((expiresAt.getTime() - Date.now()) / 1000));
+  await redis.set(`revoked:grant:${grantId}`, '1', 'EX', ttlSeconds);
+
+  // Cascade-revoke all descendant grants via recursive CTE
+  const descendantRows = await sql`
+    WITH RECURSIVE descendants AS (
+      SELECT id, expires_at FROM grants WHERE parent_grant_id = ${grantId} AND status = 'active'
+      UNION ALL
+      SELECT g.id, g.expires_at FROM grants g
+      JOIN descendants d ON g.parent_grant_id = d.id WHERE g.status = 'active'
+    )
+    UPDATE grants SET status = 'revoked', revoked_at = NOW()
+    WHERE id IN (SELECT id FROM descendants)
+    RETURNING id, expires_at
+  `;
+
+  for (const row of descendantRows) {
+    const descExpiresAt = new Date(row['expires_at'] as string);
+    const descTtl = Math.max(1, Math.floor((descExpiresAt.getTime() - Date.now()) / 1000));
+    await redis.set(`revoked:grant:${row['id'] as string}`, '1', 'EX', descTtl);
+  }
+
+  // Fire webhook event (best-effort, non-blocking)
+  fireWebhooks(developerId, 'grant.revoked', {
+    grantId,
+    cascade: descendantRows.length > 0,
+  }).catch(() => {});
+
+  return { revoked: true, descendantCount: descendantRows.length };
+}

--- a/apps/auth-service/src/routes/principal.ts
+++ b/apps/auth-service/src/routes/principal.ts
@@ -1,0 +1,425 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { getSql } from '../db/client.js';
+import {
+  signPrincipalSessionToken,
+  verifyPrincipalSessionToken,
+  parseExpiresIn,
+} from '../lib/crypto.js';
+import { revokeGrantCascade } from '../lib/revoke.js';
+
+const MAX_SESSION_SECONDS = 86400; // 24h
+
+async function verifyPrincipalAuth(
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<{ principalId: string; developerId: string } | null> {
+  const auth = request.headers.authorization;
+  if (!auth || !auth.startsWith('Bearer ')) {
+    reply.status(401).send({ message: 'Missing session token', code: 'UNAUTHORIZED' });
+    return null;
+  }
+  const token = auth.slice(7);
+  try {
+    return await verifyPrincipalSessionToken(token);
+  } catch {
+    reply.status(401).send({ message: 'Invalid or expired session token', code: 'UNAUTHORIZED' });
+    return null;
+  }
+}
+
+export async function principalRoutes(app: FastifyInstance): Promise<void> {
+  // POST /v1/principal-sessions — developer creates a session for an end-user
+  app.post<{ Body: { principalId?: string; expiresIn?: string } }>(
+    '/v1/principal-sessions',
+    async (request, reply) => {
+      const { principalId, expiresIn } = request.body ?? {};
+
+      if (!principalId) {
+        return reply.status(400).send({
+          message: 'principalId is required',
+          code: 'BAD_REQUEST',
+          requestId: request.id,
+        });
+      }
+
+      // Parse and validate expiresIn
+      let seconds = 3600; // default 1h
+      if (expiresIn) {
+        try {
+          seconds = parseExpiresIn(expiresIn);
+        } catch {
+          return reply.status(400).send({
+            message: 'Invalid expiresIn format. Use e.g. "1h", "30m", "24h".',
+            code: 'BAD_REQUEST',
+            requestId: request.id,
+          });
+        }
+        if (seconds > MAX_SESSION_SECONDS) {
+          seconds = MAX_SESSION_SECONDS;
+        }
+      }
+
+      // Verify at least one active grant exists for this principal+developer
+      const sql = getSql();
+      const grantRows = await sql`
+        SELECT id FROM grants
+        WHERE developer_id = ${request.developer.id}
+          AND principal_id = ${principalId}
+          AND status = 'active'
+        LIMIT 1
+      `;
+
+      if (grantRows.length === 0) {
+        return reply.status(404).send({
+          message: 'No active grants found for this principal',
+          code: 'NOT_FOUND',
+          requestId: request.id,
+        });
+      }
+
+      const sessionToken = await signPrincipalSessionToken(
+        { principalId, developerId: request.developer.id },
+        seconds,
+      );
+
+      const expiresAt = new Date(Date.now() + seconds * 1000).toISOString();
+
+      return reply.status(201).send({
+        sessionToken,
+        dashboardUrl: `${request.protocol}://${request.hostname}/permissions?session=${sessionToken}`,
+        expiresAt,
+      });
+    },
+  );
+
+  // GET /v1/principal/grants — end-user views their grants (session JWT auth)
+  app.get(
+    '/v1/principal/grants',
+    { config: { skipAuth: true } },
+    async (request, reply) => {
+      const session = await verifyPrincipalAuth(request, reply);
+      if (!session) return;
+
+      const sql = getSql();
+      const rows = await sql`
+        SELECT g.id, g.agent_id, g.scopes, g.status, g.issued_at, g.expires_at,
+               g.delegation_depth,
+               a.name AS agent_name, a.description AS agent_description, a.did AS agent_did
+        FROM grants g
+        LEFT JOIN agents a ON a.id = g.agent_id AND a.developer_id = g.developer_id
+        WHERE g.developer_id = ${session.developerId}
+          AND g.principal_id = ${session.principalId}
+          AND g.status = 'active'
+        ORDER BY g.issued_at DESC
+      `;
+
+      const grants = rows.map((row) => ({
+        grantId: row['id'],
+        agentId: row['agent_id'],
+        agentName: row['agent_name'] ?? null,
+        agentDescription: row['agent_description'] ?? null,
+        agentDid: row['agent_did'] ?? null,
+        scopes: row['scopes'],
+        status: row['status'],
+        issuedAt: row['issued_at'],
+        expiresAt: row['expires_at'],
+        delegationDepth: (row['delegation_depth'] as number | undefined) ?? 0,
+      }));
+
+      return reply.send({ grants, principalId: session.principalId });
+    },
+  );
+
+  // GET /v1/principal/audit — end-user views their audit log (session JWT auth)
+  app.get(
+    '/v1/principal/audit',
+    { config: { skipAuth: true } },
+    async (request, reply) => {
+      const session = await verifyPrincipalAuth(request, reply);
+      if (!session) return;
+
+      const sql = getSql();
+      const rows = await sql`
+        SELECT id, agent_id, agent_did, grant_id, principal_id, action, metadata, status, timestamp
+        FROM audit_entries
+        WHERE developer_id = ${session.developerId}
+          AND principal_id = ${session.principalId}
+        ORDER BY timestamp DESC
+        LIMIT 100
+      `;
+
+      const entries = rows.map((row) => ({
+        entryId: row['id'],
+        agentId: row['agent_id'],
+        agentDid: row['agent_did'],
+        grantId: row['grant_id'],
+        principalId: row['principal_id'],
+        action: row['action'],
+        metadata: row['metadata'],
+        status: row['status'],
+        timestamp: row['timestamp'],
+      }));
+
+      return reply.send({ entries });
+    },
+  );
+
+  // DELETE /v1/principal/grants/:id — end-user revokes a grant (session JWT auth)
+  app.delete<{ Params: { id: string } }>(
+    '/v1/principal/grants/:id',
+    { config: { skipAuth: true } },
+    async (request, reply) => {
+      const session = await verifyPrincipalAuth(request, reply);
+      if (!session) return;
+
+      // Verify the grant belongs to this principal+developer
+      const sql = getSql();
+      const grantRows = await sql`
+        SELECT id FROM grants
+        WHERE id = ${request.params.id}
+          AND developer_id = ${session.developerId}
+          AND principal_id = ${session.principalId}
+          AND status = 'active'
+      `;
+
+      if (grantRows.length === 0) {
+        return reply.status(404).send({
+          message: 'Grant not found',
+          code: 'NOT_FOUND',
+          requestId: request.id,
+        });
+      }
+
+      await revokeGrantCascade(request.params.id, session.developerId);
+
+      return reply.status(204).send();
+    },
+  );
+
+  // GET /permissions — public HTML page for end-users to manage their permissions
+  app.get(
+    '/permissions',
+    { config: { skipAuth: true } },
+    async (_request, reply) => {
+      await reply.type('text/html').send(permissionsPageHtml());
+    },
+  );
+}
+
+function permissionsPageHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Manage Permissions — Grantex</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; background: #f8f9fa; color: #111827; min-height: 100vh; }
+
+    .header { background: #1a1a2e; color: white; padding: 14px 24px; display: flex; align-items: center; gap: 12px; }
+    .header h1 { font-size: 17px; font-weight: 700; letter-spacing: -0.02em; }
+    .header .pill { background: rgba(255,255,255,0.15); font-size: 11px; padding: 2px 9px; border-radius: 12px; font-weight: 500; }
+
+    .page { max-width: 900px; margin: 0 auto; padding: 32px 24px; }
+
+    .section-title { font-size: 18px; font-weight: 700; color: #111827; margin-bottom: 4px; }
+    .section-sub { font-size: 14px; color: #6b7280; margin-bottom: 20px; }
+
+    .grant-list { display: flex; flex-direction: column; gap: 12px; margin-bottom: 40px; }
+    .grant-card { background: white; border: 1px solid #e5e7eb; border-radius: 10px; padding: 18px 20px; display: flex; align-items: flex-start; gap: 16px; }
+    .agent-icon { width: 40px; height: 40px; border-radius: 10px; background: #ede9fe; display: flex; align-items: center; justify-content: center; font-size: 18px; flex-shrink: 0; }
+    .grant-body { flex: 1; min-width: 0; }
+    .grant-name { font-size: 15px; font-weight: 600; color: #111827; }
+    .grant-desc { font-size: 12px; color: #9ca3af; margin-top: 1px; }
+    .grant-did { font-family: monospace; font-size: 11px; color: #9ca3af; margin-top: 1px; }
+    .grant-scopes { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 8px; }
+    .scope { background: #ede9fe; color: #5b21b6; font-size: 11px; padding: 2px 7px; border-radius: 4px; font-family: monospace; }
+    .grant-meta { margin-top: 8px; font-size: 12px; color: #9ca3af; display: flex; gap: 16px; flex-wrap: wrap; }
+    .grant-actions { display: flex; flex-direction: column; align-items: flex-end; gap: 8px; flex-shrink: 0; }
+
+    .badge { display: inline-block; font-size: 11px; font-weight: 600; padding: 2px 9px; border-radius: 10px; }
+    .b-active  { background: #d1fae5; color: #065f46; }
+    .b-revoked { background: #fee2e2; color: #991b1b; }
+    .b-expired { background: #fef3c7; color: #92400e; }
+    .depth-badge { background: #e0e7ff; color: #3730a3; font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; }
+
+    .btn-revoke { padding: 6px 14px; background: #fff; border: 1px solid #fca5a5; color: #dc2626; border-radius: 6px; font-size: 12px; font-weight: 500; cursor: pointer; white-space: nowrap; }
+    .btn-revoke:hover { background: #fee2e2; }
+
+    .audit-wrap { background: white; border: 1px solid #e5e7eb; border-radius: 8px; overflow: hidden; }
+    table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    thead th { background: #f9fafb; padding: 9px 14px; text-align: left; font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: #6b7280; border-bottom: 1px solid #e5e7eb; white-space: nowrap; }
+    tbody td { padding: 11px 14px; border-bottom: 1px solid #f3f4f6; vertical-align: top; }
+    tbody tr:last-child td { border-bottom: none; }
+    tbody tr:hover td { background: #fafafa; }
+    .mono { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 12px; }
+
+    .b-success { background: #d1fae5; color: #065f46; }
+    .b-failure { background: #fee2e2; color: #991b1b; }
+    .b-blocked { background: #fef3c7; color: #92400e; }
+
+    .empty { padding: 44px; text-align: center; color: #9ca3af; font-size: 14px; }
+    #err { background: #fee2e2; border: 1px solid #fca5a5; color: #b91c1c; padding: 10px 16px; border-radius: 6px; font-size: 13px; margin-bottom: 20px; display: none; }
+    #loading { padding: 72px 24px; text-align: center; color: #9ca3af; font-size: 14px; }
+    .expired-msg { padding: 72px 24px; text-align: center; }
+    .expired-msg h2 { font-size: 20px; font-weight: 700; color: #111827; margin-bottom: 8px; }
+    .expired-msg p { color: #6b7280; font-size: 14px; }
+  </style>
+</head>
+<body>
+
+<div class="header">
+  <h1>Grantex</h1>
+  <span class="pill">Manage Permissions</span>
+</div>
+
+<div id="loading">Loading your permissions...</div>
+<div id="expired" style="display:none">
+  <div class="expired-msg">
+    <h2>Session Expired</h2>
+    <p>Your session link has expired or is invalid. Please request a new link from the application.</p>
+  </div>
+</div>
+
+<div id="main" style="display:none">
+  <div class="page">
+    <div id="err"></div>
+
+    <div class="section-title">Apps with access</div>
+    <div class="section-sub">These agents are authorized to act on your behalf. You can revoke access at any time.</div>
+    <div id="grant-list" class="grant-list"></div>
+
+    <div class="section-title">Recent activity</div>
+    <div class="section-sub" style="margin-bottom:12px">Actions taken by agents on your behalf.</div>
+    <div class="audit-wrap">
+      <table>
+        <thead><tr><th>Action</th><th>Result</th><th>Agent</th><th>Metadata</th><th>When</th></tr></thead>
+        <tbody id="audit-body"></tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<script>
+  var sessionToken = new URLSearchParams(window.location.search).get('session');
+
+  if (!sessionToken) {
+    document.getElementById('loading').style.display = 'none';
+    document.getElementById('expired').style.display = '';
+  } else {
+    loadData();
+  }
+
+  function apiFetch(path) {
+    return fetch(path, { headers: { Authorization: 'Bearer ' + sessionToken } }).then(function(res) {
+      if (res.status === 401) throw new Error('SESSION_EXPIRED');
+      if (!res.ok) throw new Error(res.status + ' ' + res.statusText);
+      return res.json();
+    });
+  }
+
+  function loadData() {
+    Promise.all([
+      apiFetch('/v1/principal/grants'),
+      apiFetch('/v1/principal/audit'),
+    ]).then(function(results) {
+      document.getElementById('loading').style.display = 'none';
+      document.getElementById('main').style.display = '';
+      renderGrants(results[0].grants || []);
+      renderAudit(results[1].entries || []);
+    }).catch(function(e) {
+      document.getElementById('loading').style.display = 'none';
+      if (e.message === 'SESSION_EXPIRED') {
+        document.getElementById('expired').style.display = '';
+      } else {
+        document.getElementById('main').style.display = '';
+        var err = document.getElementById('err');
+        err.textContent = 'Error: ' + e.message;
+        err.style.display = 'block';
+      }
+    });
+  }
+
+  function renderGrants(grants) {
+    var el = document.getElementById('grant-list');
+    if (!grants.length) {
+      el.innerHTML = '<div class="empty">No active permissions found.</div>';
+      return;
+    }
+    el.innerHTML = grants.map(function(g) {
+      var name = g.agentName || g.agentId;
+      var desc = g.agentDescription ? '<div class="grant-desc">' + esc(g.agentDescription) + '</div>' : '';
+      var did = g.agentDid ? '<div class="grant-did">' + esc(g.agentDid) + '</div>' : '';
+      var depthBadge = g.delegationDepth > 0
+        ? '<span class="depth-badge">sub-agent depth ' + g.delegationDepth + '</span>'
+        : '';
+      var scopes = (g.scopes || []).map(function(s) {
+        return '<span class="scope">' + esc(s) + '</span>';
+      }).join('');
+      return '<div class="grant-card">'
+        + '<div class="agent-icon">&#129302;</div>'
+        + '<div class="grant-body">'
+        + '<div class="grant-name">' + esc(name) + '</div>'
+        + desc + did
+        + '<div class="grant-scopes">' + scopes + '</div>'
+        + '<div class="grant-meta">'
+        + '<span>Granted ' + fmtTime(g.issuedAt) + '</span>'
+        + '<span>Expires ' + fmtTime(g.expiresAt) + '</span>'
+        + '</div>'
+        + '</div>'
+        + '<div class="grant-actions">'
+        + '<span class="badge b-active">active</span>'
+        + depthBadge
+        + '<button class="btn-revoke" onclick="revokeGrant(\\''+g.grantId+'\\')">Revoke access</button>'
+        + '</div>'
+        + '</div>';
+    }).join('');
+  }
+
+  function renderAudit(entries) {
+    var tbody = document.getElementById('audit-body');
+    if (!entries.length) {
+      tbody.innerHTML = '<tr><td colspan="5" class="empty">No activity yet.</td></tr>';
+      return;
+    }
+    tbody.innerHTML = entries.map(function(e) {
+      var s = e.status || 'success';
+      var meta = e.metadata && Object.keys(e.metadata).length
+        ? JSON.stringify(e.metadata).slice(0, 80)
+        : '\\u2014';
+      return '<tr>'
+        + '<td class="mono">' + esc(e.action || '\\u2014') + '</td>'
+        + '<td><span class="badge b-' + s + '">' + s + '</span></td>'
+        + '<td style="font-size:12px;color:#6b7280">' + esc((e.agentId || '').slice(0, 22)) + '</td>'
+        + '<td><span class="mono" style="font-size:11px;color:#6b7280">' + esc(meta) + '</span></td>'
+        + '<td style="font-size:12px;color:#9ca3af;white-space:nowrap">' + fmtTime(e.timestamp) + '</td>'
+        + '</tr>';
+    }).join('');
+  }
+
+  function revokeGrant(grantId) {
+    if (!confirm('Revoke this access?\\n\\nThe agent will no longer be able to act on your behalf. This cannot be undone.')) return;
+    fetch('/v1/principal/grants/' + grantId, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer ' + sessionToken },
+    }).then(function(res) {
+      if (res.status === 401) { document.getElementById('main').style.display = 'none'; document.getElementById('expired').style.display = ''; return; }
+      if (!res.ok && res.status !== 204) throw new Error(res.statusText);
+      loadData();
+    }).catch(function(e) { alert('Failed to revoke: ' + e.message); });
+  }
+
+  function fmtTime(ts) {
+    if (!ts) return '\\u2014';
+    var d = new Date(ts);
+    return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+
+  function esc(str) {
+    return String(str || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  }
+</script>
+</body>
+</html>`;
+}

--- a/apps/auth-service/src/server.ts
+++ b/apps/auth-service/src/server.ts
@@ -25,6 +25,7 @@ import { signupRoutes } from './routes/signup.js';
 import { meRoutes } from './routes/me.js';
 import { healthRoutes } from './routes/health.js';
 import { adminRoutes } from './routes/admin.js';
+import { principalRoutes } from './routes/principal.js';
 
 export type AppOptions = {
   logger?: boolean | object;
@@ -77,6 +78,7 @@ export async function buildApp(opts: AppOptions = {}) {
   await app.register(signupRoutes);
   await app.register(meRoutes);
   await app.register(adminRoutes);
+  await app.register(principalRoutes);
 
   return app;
 }

--- a/apps/auth-service/tests/principal.test.ts
+++ b/apps/auth-service/tests/principal.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { buildTestApp, authHeader, seedAuth, sqlMock, mockRedis, TEST_DEVELOPER, TEST_GRANT, TEST_AGENT } from './helpers.js';
+import { signPrincipalSessionToken } from '../src/lib/crypto.js';
+import type { FastifyInstance } from 'fastify';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+// Helper to generate a valid session token for tests
+async function makeSessionToken(principalId = 'user_123', developerId = TEST_DEVELOPER.id) {
+  return signPrincipalSessionToken({ principalId, developerId }, 3600);
+}
+
+function sessionHeader(token: string): Record<string, string> {
+  return { authorization: `Bearer ${token}` };
+}
+
+const GRANT_WITH_AGENT = {
+  ...TEST_GRANT,
+  delegation_depth: 0,
+  agent_name: TEST_AGENT.name,
+  agent_description: TEST_AGENT.description,
+  agent_did: TEST_AGENT.did,
+};
+
+// ─── POST /v1/principal-sessions ─────────────────────────────────────────────
+
+describe('POST /v1/principal-sessions', () => {
+  it('returns 201 with sessionToken and dashboardUrl when grants exist', async () => {
+    seedAuth();
+    // Query for active grants — at least one found
+    sqlMock.mockResolvedValueOnce([TEST_GRANT]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/principal-sessions',
+      headers: authHeader(),
+      payload: { principalId: 'user_123' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ sessionToken: string; dashboardUrl: string; expiresAt: string }>();
+    expect(body.sessionToken).toBeTruthy();
+    expect(body.dashboardUrl).toContain('/permissions?session=');
+    expect(body.expiresAt).toBeTruthy();
+  });
+
+  it('returns 400 when principalId is missing', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/principal-sessions',
+      headers: authHeader(),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ code: string }>().code).toBe('BAD_REQUEST');
+  });
+
+  it('returns 400 for invalid expiresIn format', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/principal-sessions',
+      headers: authHeader(),
+      payload: { principalId: 'user_123', expiresIn: 'invalid' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ code: string }>().code).toBe('BAD_REQUEST');
+  });
+
+  it('returns 404 when no active grants exist for the principal', async () => {
+    seedAuth();
+    // Query for active grants — none found
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/principal-sessions',
+      headers: authHeader(),
+      payload: { principalId: 'user_no_grants' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ code: string }>().code).toBe('NOT_FOUND');
+  });
+
+  it('returns 401 without developer API key', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/principal-sessions',
+      payload: { principalId: 'user_123' },
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('caps expiresIn at 24h', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([TEST_GRANT]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/principal-sessions',
+      headers: authHeader(),
+      payload: { principalId: 'user_123', expiresIn: '48h' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ expiresAt: string }>();
+    const expiresAt = new Date(body.expiresAt).getTime();
+    const maxExpiry = Date.now() + 86400_000 + 5000; // 24h + 5s buffer
+    expect(expiresAt).toBeLessThanOrEqual(maxExpiry);
+  });
+
+  it('defaults to 1h when expiresIn is not provided', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([TEST_GRANT]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/principal-sessions',
+      headers: authHeader(),
+      payload: { principalId: 'user_123' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ expiresAt: string }>();
+    const expiresAt = new Date(body.expiresAt).getTime();
+    const expectedMax = Date.now() + 3600_000 + 5000; // 1h + 5s buffer
+    const expectedMin = Date.now() + 3600_000 - 5000;
+    expect(expiresAt).toBeLessThanOrEqual(expectedMax);
+    expect(expiresAt).toBeGreaterThanOrEqual(expectedMin);
+  });
+});
+
+// ─── GET /v1/principal/grants ────────────────────────────────────────────────
+
+describe('GET /v1/principal/grants', () => {
+  it('returns grants for valid session token', async () => {
+    const token = await makeSessionToken();
+    sqlMock.mockResolvedValueOnce([GRANT_WITH_AGENT]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/principal/grants',
+      headers: sessionHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ grants: Array<{ grantId: string; agentName: string }>; principalId: string }>();
+    expect(body.grants).toHaveLength(1);
+    expect(body.grants[0]!.grantId).toBe(TEST_GRANT.id);
+    expect(body.grants[0]!.agentName).toBe(TEST_AGENT.name);
+    expect(body.principalId).toBe('user_123');
+  });
+
+  it('returns 401 with missing token', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/principal/grants',
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 with expired token', async () => {
+    // Sign a token that's already expired
+    const token = await signPrincipalSessionToken(
+      { principalId: 'user_123', developerId: TEST_DEVELOPER.id },
+      -10, // negative = already expired
+    );
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/principal/grants',
+      headers: sessionHeader(token),
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 with an invalid token', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/principal/grants',
+      headers: sessionHeader('not.a.valid.token'),
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// ─── GET /v1/principal/audit ─────────────────────────────────────────────────
+
+describe('GET /v1/principal/audit', () => {
+  it('returns entries for valid session', async () => {
+    const token = await makeSessionToken();
+    const mockEntry = {
+      id: 'aud_1',
+      agent_id: TEST_AGENT.id,
+      agent_did: TEST_AGENT.did,
+      grant_id: TEST_GRANT.id,
+      principal_id: 'user_123',
+      action: 'read.data',
+      metadata: {},
+      status: 'success',
+      timestamp: new Date().toISOString(),
+    };
+    sqlMock.mockResolvedValueOnce([mockEntry]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/principal/audit',
+      headers: sessionHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ entries: Array<{ entryId: string }> }>();
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0]!.entryId).toBe('aud_1');
+  });
+
+  it('returns 401 with invalid token', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/principal/audit',
+      headers: sessionHeader('bad-token'),
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// ─── DELETE /v1/principal/grants/:id ─────────────────────────────────────────
+
+describe('DELETE /v1/principal/grants/:id', () => {
+  it('returns 204 and revokes grant', async () => {
+    const token = await makeSessionToken();
+    // Ownership check
+    sqlMock.mockResolvedValueOnce([TEST_GRANT]);
+    // revokeGrantCascade: UPDATE grants (revoke root)
+    sqlMock.mockResolvedValueOnce([TEST_GRANT]);
+    // revokeGrantCascade: cascade descendants
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/v1/principal/grants/${TEST_GRANT.id}`,
+      headers: sessionHeader(token),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      `revoked:grant:${TEST_GRANT.id}`,
+      '1',
+      'EX',
+      expect.any(Number),
+    );
+  });
+
+  it('returns 404 when grant does not belong to this principal', async () => {
+    const token = await makeSessionToken('other_user');
+    // Ownership check — no rows found
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/v1/principal/grants/${TEST_GRANT.id}`,
+      headers: sessionHeader(token),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 401 with invalid session', async () => {
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/v1/principal/grants/${TEST_GRANT.id}`,
+      headers: sessionHeader('invalid'),
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// ─── GET /permissions ────────────────────────────────────────────────────────
+
+describe('GET /permissions', () => {
+  it('returns HTML with Manage Permissions', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/permissions',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.body).toContain('Manage Permissions');
+  });
+});

--- a/docs/api-reference/principal-sessions/create-principal-session.mdx
+++ b/docs/api-reference/principal-sessions/create-principal-session.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/principal-sessions
+---

--- a/docs/api-reference/principal-sessions/get-principal-audit.mdx
+++ b/docs/api-reference/principal-sessions/get-principal-audit.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/principal/audit
+---

--- a/docs/api-reference/principal-sessions/list-principal-grants.mdx
+++ b/docs/api-reference/principal-sessions/list-principal-grants.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/principal/grants
+---

--- a/docs/api-reference/principal-sessions/revoke-principal-grant.mdx
+++ b/docs/api-reference/principal-sessions/revoke-principal-grant.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/principal/grants/{id}
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -52,7 +52,8 @@
               "guides/self-hosting",
               "guides/security-best-practices",
               "guides/token-verification",
-              "guides/troubleshooting"
+              "guides/troubleshooting",
+              "guides/end-user-permissions"
             ]
           },
           {
@@ -100,7 +101,8 @@
               "sdks/typescript/anomalies",
               "sdks/typescript/billing",
               "sdks/typescript/scim",
-              "sdks/typescript/sso"
+              "sdks/typescript/sso",
+              "sdks/typescript/principal-sessions"
             ]
           },
           {
@@ -141,7 +143,8 @@
               "sdks/python/anomalies",
               "sdks/python/billing",
               "sdks/python/scim",
-              "sdks/python/sso"
+              "sdks/python/sso",
+              "sdks/python/principal-sessions"
             ]
           },
           {
@@ -325,6 +328,15 @@
               "api-reference/sso/remove-sso-configuration",
               "api-reference/sso/initiate-sso-login",
               "api-reference/sso/sso-callback"
+            ]
+          },
+          {
+            "group": "Principal Sessions",
+            "pages": [
+              "api-reference/principal-sessions/create-principal-session",
+              "api-reference/principal-sessions/list-principal-grants",
+              "api-reference/principal-sessions/get-principal-audit",
+              "api-reference/principal-sessions/revoke-principal-grant"
             ]
           },
           {

--- a/docs/guides/end-user-permissions.mdx
+++ b/docs/guides/end-user-permissions.mdx
@@ -1,0 +1,130 @@
+---
+title: "End-User Permission Dashboard"
+sidebarTitle: "End-User Permissions"
+description: "Give your users a self-service page to view and revoke agent access."
+---
+
+End-users (the people your agents act on behalf of) need visibility and control over which agents have access to their data. The Permission Dashboard lets you generate a short-lived, secure link that your users can open to view and revoke agent access — no API key needed.
+
+## How It Works
+
+1. **Developer generates a session URL** — Your backend calls `POST /v1/principal-sessions` with the user's `principalId` and gets back a short-lived session token embedded in a URL.
+2. **You share the URL with the user** — Via email, in-app notification, settings page link, etc.
+3. **User opens the dashboard** — They see all agents with active access, scopes granted, and a revoke button for each.
+4. **User revokes access** — One click revokes the grant and cascade-revokes any delegated sub-grants.
+
+Session tokens are JWT-based, scoped to a specific principal+developer pair, and expire after 1 hour by default (max 24 hours).
+
+## Generate a Session URL
+
+### Using curl
+
+```bash
+curl -X POST https://api.grantex.dev/v1/principal-sessions \
+  -H "Authorization: Bearer $GRANTEX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"principalId": "user_abc123", "expiresIn": "2h"}'
+```
+
+Response:
+
+```json
+{
+  "sessionToken": "eyJhbGciOiJSUzI1NiIs...",
+  "dashboardUrl": "https://api.grantex.dev/permissions?session=eyJhbGciOiJSUzI1NiIs...",
+  "expiresAt": "2026-03-01T14:00:00.000Z"
+}
+```
+
+### Using the TypeScript SDK
+
+<CodeGroup>
+```typescript TypeScript
+import { Grantex } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+const session = await grantex.principalSessions.create({
+  principalId: 'user_abc123',
+  expiresIn: '2h',   // optional, defaults to "1h", max "24h"
+});
+
+console.log(session.dashboardUrl);
+// → "https://api.grantex.dev/permissions?session=eyJ..."
+
+// Send this URL to your user (email, in-app, etc.)
+```
+
+```python Python
+from grantex import Grantex, CreatePrincipalSessionParams
+
+grantex = Grantex(api_key="your-api-key")
+
+session = grantex.principal_sessions.create(
+    CreatePrincipalSessionParams(
+        principal_id="user_abc123",
+        expires_in="2h",   # optional, defaults to "1h", max "24h"
+    )
+)
+
+print(session.dashboard_url)
+# → "https://api.grantex.dev/permissions?session=eyJ..."
+```
+</CodeGroup>
+
+## Parameters
+
+<ParamField body="principalId" type="string" required>
+  The user's principal ID — the same `userId` / `principalId` used when creating authorization requests.
+</ParamField>
+
+<ParamField body="expiresIn" type="string" default="1h">
+  How long the session token is valid. Format: `"30m"`, `"1h"`, `"24h"`. Capped at 24 hours.
+</ParamField>
+
+## Response
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sessionToken` | `string` | The JWT session token |
+| `dashboardUrl` | `string` | Full URL the user can open in their browser |
+| `expiresAt` | `string` | ISO 8601 expiry timestamp |
+
+## What the User Sees
+
+When the user opens the dashboard URL, they see:
+
+- **Apps with access** — A card for each agent with an active grant, showing the agent name, description, granted scopes, issue date, expiry date, and a "Revoke access" button.
+- **Recent activity** — A table of recent audit log entries for actions taken by agents on their behalf.
+- **Session expired** — If the session token has expired, a clear message asking them to request a new link.
+
+## Revoking Access
+
+When a user clicks "Revoke access" on a grant:
+
+1. The grant is marked as revoked
+2. All delegated sub-grants (child grants from agent-to-agent delegation) are also revoked
+3. Redis revocation keys are set so tokens are rejected immediately
+4. A `grant.revoked` webhook event is fired
+
+This is the same cascade-revoke behavior as the developer-facing `DELETE /v1/grants/:id` endpoint.
+
+## Security Considerations
+
+- **Short-lived tokens** — Session tokens default to 1 hour. Use the shortest duration practical for your use case.
+- **Scoped access** — Session tokens are bound to a specific principal+developer pair. A user cannot see or revoke another user's grants, and cannot see grants from other developers.
+- **Purpose claim** — Session JWTs include a `purpose: "principal_dashboard"` claim that prevents grant tokens from being reused as session tokens (and vice versa).
+- **No API key exposure** — End-users never see or need the developer's API key.
+- **HTTPS only** — Always serve dashboard URLs over HTTPS in production.
+
+## API Endpoints
+
+The permission dashboard uses these endpoints under the hood:
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| `POST` | `/v1/principal-sessions` | Developer API key | Create a session token |
+| `GET` | `/v1/principal/grants` | Session token | List active grants |
+| `GET` | `/v1/principal/audit` | Session token | List recent audit entries |
+| `DELETE` | `/v1/principal/grants/:id` | Session token | Revoke a grant |
+| `GET` | `/permissions` | None (public HTML) | Permission dashboard page |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -61,6 +61,8 @@ tags:
     description: SCIM 2.0 user provisioning and token management
   - name: SSO
     description: OIDC single sign-on configuration and flow
+  - name: Principal Sessions
+    description: End-user permission management via short-lived session tokens
 
 components:
   securitySchemes:
@@ -2596,6 +2598,194 @@ paths:
             text/html:
               schema:
                 type: string
+
+  /v1/principal-sessions:
+    post:
+      operationId: createPrincipalSession
+      tags: [Principal Sessions]
+      summary: Create a principal session
+      description: |
+        Generate a short-lived session token for an end-user to view and manage their agent permissions.
+        The returned `dashboardUrl` can be sent to the user (via email, in-app link, etc.).
+        Requires at least one active grant for the specified principal.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [principalId]
+              properties:
+                principalId:
+                  type: string
+                  description: The end-user's principal ID
+                  example: user_abc123
+                expiresIn:
+                  type: string
+                  description: Session duration (e.g. "1h", "30m", "24h"). Defaults to "1h", capped at "24h".
+                  example: "2h"
+      responses:
+        "201":
+          description: Session created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sessionToken:
+                    type: string
+                    description: Signed JWT session token
+                  dashboardUrl:
+                    type: string
+                    description: Full URL the user can open to manage permissions
+                  expiresAt:
+                    type: string
+                    format: date-time
+                    description: When the session token expires
+        "400":
+          description: Missing principalId or invalid expiresIn
+        "404":
+          description: No active grants for this principal
+
+  /v1/principal/grants:
+    get:
+      operationId: listPrincipalGrants
+      tags: [Principal Sessions]
+      summary: List principal's active grants
+      description: |
+        Returns all active grants for the authenticated principal. Requires a session token
+        (from `POST /v1/principal-sessions`) in the Authorization header.
+      security: []
+      parameters:
+        - name: Authorization
+          in: header
+          required: true
+          schema:
+            type: string
+          description: "Bearer <sessionToken>"
+      responses:
+        "200":
+          description: List of active grants
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  grants:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        grantId:
+                          type: string
+                        agentId:
+                          type: string
+                        agentName:
+                          type: string
+                        agentDescription:
+                          type: string
+                        agentDid:
+                          type: string
+                        scopes:
+                          type: array
+                          items:
+                            type: string
+                        status:
+                          type: string
+                        issuedAt:
+                          type: string
+                          format: date-time
+                        expiresAt:
+                          type: string
+                          format: date-time
+                        delegationDepth:
+                          type: integer
+                  principalId:
+                    type: string
+        "401":
+          description: Missing, invalid, or expired session token
+
+  /v1/principal/audit:
+    get:
+      operationId: getPrincipalAudit
+      tags: [Principal Sessions]
+      summary: Get principal's audit log
+      description: |
+        Returns recent audit entries for the authenticated principal. Requires a session token.
+      security: []
+      parameters:
+        - name: Authorization
+          in: header
+          required: true
+          schema:
+            type: string
+          description: "Bearer <sessionToken>"
+      responses:
+        "200":
+          description: Audit entries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        entryId:
+                          type: string
+                        agentId:
+                          type: string
+                        agentDid:
+                          type: string
+                        grantId:
+                          type: string
+                        principalId:
+                          type: string
+                        action:
+                          type: string
+                        metadata:
+                          type: object
+                        status:
+                          type: string
+                        timestamp:
+                          type: string
+                          format: date-time
+        "401":
+          description: Missing, invalid, or expired session token
+
+  /v1/principal/grants/{id}:
+    delete:
+      operationId: revokePrincipalGrant
+      tags: [Principal Sessions]
+      summary: Revoke a grant
+      description: |
+        Revoke a specific grant. The grant must belong to the authenticated principal and developer.
+        Cascade-revokes all descendant (delegated) grants. Requires a session token.
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The grant ID to revoke
+        - name: Authorization
+          in: header
+          required: true
+          schema:
+            type: string
+          description: "Bearer <sessionToken>"
+      responses:
+        "204":
+          description: Grant revoked
+        "401":
+          description: Missing, invalid, or expired session token
+        "404":
+          description: Grant not found or does not belong to this principal
 
   /dashboard/principal:
     get:

--- a/docs/sdks/python/principal-sessions.mdx
+++ b/docs/sdks/python/principal-sessions.mdx
@@ -1,0 +1,75 @@
+---
+title: "Principal Sessions"
+sidebarTitle: "Principal Sessions"
+description: "Generate session tokens for end-users to view and manage their agent permissions."
+---
+
+## Overview
+
+The `principal_sessions` sub-client lets you create short-lived session tokens for your end-users. These tokens power the [Permission Dashboard](/guides/end-user-permissions) where users can view which agents have access and revoke grants.
+
+```python
+session = grantex.principal_sessions.create(
+    CreatePrincipalSessionParams(
+        principal_id="user_abc123",
+        expires_in="2h",
+    )
+)
+
+# Send session.dashboard_url to the user
+print(session.dashboard_url)
+```
+
+---
+
+## principal_sessions.create()
+
+Create a session token for an end-user. Returns a URL they can open to manage their permissions.
+
+```python
+from grantex import Grantex, CreatePrincipalSessionParams
+
+grantex = Grantex(api_key="your-api-key")
+
+session = grantex.principal_sessions.create(
+    CreatePrincipalSessionParams(
+        principal_id="user_abc123",
+        expires_in="2h",
+    )
+)
+
+print(session.session_token)   # JWT string
+print(session.dashboard_url)   # Full URL with embedded token
+print(session.expires_at)      # '2026-03-01T14:00:00.000Z'
+```
+
+### Parameters: `CreatePrincipalSessionParams`
+
+<ParamField body="principal_id" type="str" required>
+  The end-user's principal ID — the same `user_id` used in `grantex.authorize()`.
+</ParamField>
+
+<ParamField body="expires_in" type="str | None">
+  Session duration. Format: `"30m"`, `"1h"`, `"24h"`. Defaults to `"1h"`, capped at `"24h"`.
+</ParamField>
+
+### Response: `PrincipalSessionResponse`
+
+<ResponseField name="session_token" type="str">
+  The signed JWT session token.
+</ResponseField>
+
+<ResponseField name="dashboard_url" type="str">
+  Full URL the user can open in their browser to view and revoke permissions.
+</ResponseField>
+
+<ResponseField name="expires_at" type="str">
+  ISO 8601 timestamp when the session token expires.
+</ResponseField>
+
+### Errors
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 400 | `BAD_REQUEST` | Missing `principal_id` or invalid `expires_in` format |
+| 404 | `NOT_FOUND` | No active grants exist for this principal |

--- a/docs/sdks/typescript/principal-sessions.mdx
+++ b/docs/sdks/typescript/principal-sessions.mdx
@@ -1,0 +1,67 @@
+---
+title: "Principal Sessions"
+sidebarTitle: "Principal Sessions"
+description: "Generate session tokens for end-users to view and manage their agent permissions."
+---
+
+## Overview
+
+The `principalSessions` sub-client lets you create short-lived session tokens for your end-users. These tokens power the [Permission Dashboard](/guides/end-user-permissions) where users can view which agents have access and revoke grants.
+
+```typescript
+const session = await grantex.principalSessions.create({
+  principalId: 'user_abc123',
+  expiresIn: '2h',
+});
+
+// Send session.dashboardUrl to the user
+console.log(session.dashboardUrl);
+```
+
+---
+
+## principalSessions.create()
+
+Create a session token for an end-user. Returns a URL they can open to manage their permissions.
+
+```typescript
+const session = await grantex.principalSessions.create({
+  principalId: 'user_abc123',
+  expiresIn: '2h',
+});
+
+console.log(session.sessionToken);  // JWT string
+console.log(session.dashboardUrl);  // Full URL with embedded token
+console.log(session.expiresAt);     // '2026-03-01T14:00:00.000Z'
+```
+
+### Parameters: `CreatePrincipalSessionParams`
+
+<ParamField body="principalId" type="string" required>
+  The end-user's principal ID — the same `userId` used in `grantex.authorize()`.
+</ParamField>
+
+<ParamField body="expiresIn" type="string">
+  Session duration. Format: `"30m"`, `"1h"`, `"24h"`. Defaults to `"1h"`, capped at `"24h"`.
+</ParamField>
+
+### Response: `PrincipalSessionResponse`
+
+<ResponseField name="sessionToken" type="string">
+  The signed JWT session token.
+</ResponseField>
+
+<ResponseField name="dashboardUrl" type="string">
+  Full URL the user can open in their browser to view and revoke permissions.
+</ResponseField>
+
+<ResponseField name="expiresAt" type="string">
+  ISO 8601 timestamp when the session token expires.
+</ResponseField>
+
+### Errors
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 400 | `BAD_REQUEST` | Missing `principalId` or invalid `expiresIn` format |
+| 404 | `NOT_FOUND` | No active grants exist for this principal |

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/conformance",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Conformance test suite for the Grantex protocol",
   "type": "module",
   "bin": {

--- a/packages/conformance/src/runner.ts
+++ b/packages/conformance/src/runner.ts
@@ -21,6 +21,7 @@ import { scimSuite } from './suites/scim.js';
 import { ssoSuite } from './suites/sso.js';
 import { anomaliesSuite } from './suites/anomalies.js';
 import { complianceSuite } from './suites/compliance.js';
+import { principalSessionsSuite } from './suites/principal-sessions.js';
 
 const coreSuites: SuiteDefinition[] = [
   healthSuite,
@@ -41,6 +42,7 @@ const optionalSuites: SuiteDefinition[] = [
   ssoSuite,
   anomaliesSuite,
   complianceSuite,
+  principalSessionsSuite,
 ];
 
 async function setupSharedAgent(http: ConformanceHttpClient): Promise<SharedAgent> {

--- a/packages/conformance/src/suites/principal-sessions.ts
+++ b/packages/conformance/src/suites/principal-sessions.ts
@@ -1,0 +1,102 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectString } from '../helpers.js';
+
+export const principalSessionsSuite: SuiteDefinition = {
+  name: 'principal-sessions',
+  description: 'Principal session tokens and end-user permission endpoints',
+  optional: true,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+    const { agentId, agentDid } = ctx.sharedAgent;
+
+    // We need a grant to exist for the principal before creating a session
+    const principalId = `principal-session-${Date.now()}`;
+    const flow = await ctx.flow.executeFullFlow({
+      agentId,
+      agentDid,
+      scopes: ['read', 'write'],
+      principalId,
+    });
+
+    results.push(
+      await test(
+        'POST /v1/principal-sessions returns 201 with sessionToken and dashboardUrl',
+        '§12',
+        async () => {
+          const res = await ctx.http.post<{
+            sessionToken: string;
+            dashboardUrl: string;
+            expiresAt: string;
+          }>('/v1/principal-sessions', {
+            principalId,
+            expiresIn: '1h',
+          });
+          expectStatus(res, 201);
+          expectString(res.body.sessionToken, 'sessionToken');
+          expectString(res.body.dashboardUrl, 'dashboardUrl');
+          expectString(res.body.expiresAt, 'expiresAt');
+
+          if (!res.body.dashboardUrl.includes('/permissions?session=')) {
+            throw new Error(
+              `Expected dashboardUrl to contain /permissions?session=, got: ${res.body.dashboardUrl}`,
+            );
+          }
+        },
+      ),
+    );
+
+    results.push(
+      await test(
+        'POST /v1/principal-sessions returns 400 without principalId',
+        '§12',
+        async () => {
+          const res = await ctx.http.post('/v1/principal-sessions', {});
+          expectStatus(res, 400);
+        },
+      ),
+    );
+
+    results.push(
+      await test(
+        'Session token can be used to GET /v1/principal/grants',
+        '§12',
+        async () => {
+          // Create a session token
+          const sessionRes = await ctx.http.post<{
+            sessionToken: string;
+          }>('/v1/principal-sessions', {
+            principalId,
+          });
+          expectStatus(sessionRes, 201);
+
+          // Use the session token to fetch grants
+          const grantsRes = await ctx.http.doRequestWithToken<{
+            grants: Array<{ grantId: string; agentId: string; scopes: string[] }>;
+            principalId: string;
+          }>('GET', '/v1/principal/grants', sessionRes.body.sessionToken);
+          expectStatus(grantsRes, 200);
+
+          if (!Array.isArray(grantsRes.body.grants)) {
+            throw new Error('Expected grants to be an array');
+          }
+          if (grantsRes.body.principalId !== principalId) {
+            throw new Error(
+              `Expected principalId ${principalId}, got ${grantsRes.body.principalId}`,
+            );
+          }
+          // Should find the grant we created
+          const found = grantsRes.body.grants.some(
+            (g) => g.grantId === flow.grantId,
+          );
+          if (!found) {
+            throw new Error(
+              `Expected to find grant ${flow.grantId} in principal grants`,
+            );
+          }
+        },
+      ),
+    );
+
+    return results;
+  },
+};

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.1.4"
+version = "0.1.5"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -38,6 +38,8 @@ from ._types import (
     ExchangeTokenParams,
     ExchangeTokenResponse,
     RefreshTokenParams,
+    CreatePrincipalSessionParams,
+    PrincipalSessionResponse,
     Grant,
     GrantTokenPayload,
     ListAgentsResponse,
@@ -77,7 +79,7 @@ from ._pkce import PkceChallenge, generate_pkce
 from ._verify import verify_grant_token
 from ._webhook import verify_webhook_signature
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 __all__ = [
     # Main client
@@ -125,6 +127,8 @@ __all__ = [
     "ExchangeTokenParams",
     "ExchangeTokenResponse",
     "RefreshTokenParams",
+    "CreatePrincipalSessionParams",
+    "PrincipalSessionResponse",
     "Grant",
     "GrantTokenPayload",
     "ListAgentsResponse",

--- a/packages/sdk-py/src/grantex/_client.py
+++ b/packages/sdk-py/src/grantex/_client.py
@@ -17,6 +17,7 @@ from .resources._tokens import TokensClient
 from .resources._webhooks import WebhooksClient
 from .resources._billing import BillingClient
 from .resources._policies import PoliciesClient
+from .resources._principal_sessions import PrincipalSessionsClient
 
 _DEFAULT_BASE_URL = "https://api.grantex.dev"
 
@@ -35,6 +36,7 @@ class Grantex:
     anomalies: AnomaliesClient
     scim: ScimClient
     sso: SsoClient
+    principal_sessions: PrincipalSessionsClient
 
     def __init__(
         self,
@@ -67,6 +69,7 @@ class Grantex:
         self.anomalies = AnomaliesClient(self._http)
         self.scim = ScimClient(self._http)
         self.sso = SsoClient(self._http)
+        self.principal_sessions = PrincipalSessionsClient(self._http)
 
     @staticmethod
     def signup(

--- a/packages/sdk-py/src/grantex/_types.py
+++ b/packages/sdk-py/src/grantex/_types.py
@@ -310,6 +310,36 @@ class RefreshTokenParams:
         return {"refreshToken": self.refresh_token, "agentId": self.agent_id}
 
 
+# ─── Principal Sessions ──────────────────────────────────────────────────────
+
+
+@dataclass
+class CreatePrincipalSessionParams:
+    principal_id: str
+    expires_in: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {"principalId": self.principal_id}
+        if self.expires_in is not None:
+            body["expiresIn"] = self.expires_in
+        return body
+
+
+@dataclass(frozen=True)
+class PrincipalSessionResponse:
+    session_token: str
+    dashboard_url: str
+    expires_at: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PrincipalSessionResponse:
+        return cls(
+            session_token=data["sessionToken"],
+            dashboard_url=data["dashboardUrl"],
+            expires_at=data["expiresAt"],
+        )
+
+
 # ─── Audit ────────────────────────────────────────────────────────────────────
 
 

--- a/packages/sdk-py/src/grantex/resources/_principal_sessions.py
+++ b/packages/sdk-py/src/grantex/resources/_principal_sessions.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .._http import HttpClient
+from .._types import CreatePrincipalSessionParams, PrincipalSessionResponse
+
+
+class PrincipalSessionsClient:
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def create(self, params: CreatePrincipalSessionParams) -> PrincipalSessionResponse:
+        data = self._http.post("/v1/principal-sessions", params.to_dict())
+        return PrincipalSessionResponse.from_dict(data)

--- a/packages/sdk-py/tests/test_principal_sessions.py
+++ b/packages/sdk-py/tests/test_principal_sessions.py
@@ -1,0 +1,61 @@
+"""Tests for PrincipalSessionsClient."""
+from __future__ import annotations
+
+import json
+
+import pytest
+import respx
+import httpx
+
+from grantex import Grantex, CreatePrincipalSessionParams
+
+
+@pytest.fixture
+def client() -> Grantex:
+    return Grantex(api_key="test-key")
+
+
+@respx.mock
+def test_create_principal_session(client: Grantex) -> None:
+    payload = {
+        "sessionToken": "eyJ...",
+        "dashboardUrl": "https://api.grantex.dev/permissions?session=eyJ...",
+        "expiresAt": "2026-03-01T00:00:00Z",
+    }
+    route = respx.post("https://api.grantex.dev/v1/principal-sessions").mock(
+        return_value=httpx.Response(201, json=payload)
+    )
+
+    response = client.principal_sessions.create(
+        CreatePrincipalSessionParams(principal_id="user_123", expires_in="2h")
+    )
+
+    assert response.session_token == "eyJ..."
+    assert response.dashboard_url.endswith("/permissions?session=eyJ...")
+    assert response.expires_at == "2026-03-01T00:00:00Z"
+
+    body = json.loads(route.calls[0].request.content)
+    assert body["principalId"] == "user_123"
+    assert body["expiresIn"] == "2h"
+
+
+@respx.mock
+def test_create_principal_session_minimal(client: Grantex) -> None:
+    payload = {
+        "sessionToken": "tok",
+        "dashboardUrl": "url",
+        "expiresAt": "2026-03-01T00:00:00Z",
+    }
+    route = respx.post("https://api.grantex.dev/v1/principal-sessions").mock(
+        return_value=httpx.Response(201, json=payload)
+    )
+
+    response = client.principal_sessions.create(
+        CreatePrincipalSessionParams(principal_id="user_456")
+    )
+
+    assert response.session_token == "tok"
+
+    body = json.loads(route.calls[0].request.content)
+    assert body["principalId"] == "user_456"
+    assert "expiresIn" not in body

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "type": "module",
   "exports": {

--- a/packages/sdk-ts/src/client.ts
+++ b/packages/sdk-ts/src/client.ts
@@ -10,6 +10,7 @@ import { ComplianceClient } from './resources/compliance.js';
 import { AnomaliesClient } from './resources/anomalies.js';
 import { ScimClient } from './resources/scim.js';
 import { SsoClient } from './resources/sso.js';
+import { PrincipalSessionsClient } from './resources/principal-sessions.js';
 import type {
   AuthorizationRequest,
   AuthorizeParams,
@@ -35,6 +36,7 @@ export class Grantex {
   readonly anomalies: AnomaliesClient;
   readonly scim: ScimClient;
   readonly sso: SsoClient;
+  readonly principalSessions: PrincipalSessionsClient;
 
   constructor(options: GrantexClientOptions = {}) {
     const apiKey =
@@ -63,6 +65,7 @@ export class Grantex {
     this.anomalies = new AnomaliesClient(this.#http);
     this.scim = new ScimClient(this.#http);
     this.sso = new SsoClient(this.#http);
+    this.principalSessions = new PrincipalSessionsClient(this.#http);
   }
 
   /**

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -45,6 +45,9 @@ export type {
   ExchangeTokenResponse,
   RefreshTokenParams,
   VerifyTokenResponse,
+  // Principal Sessions
+  CreatePrincipalSessionParams,
+  PrincipalSessionResponse,
   // Audit
   LogAuditParams,
   AuditEntry,

--- a/packages/sdk-ts/src/resources/principal-sessions.ts
+++ b/packages/sdk-ts/src/resources/principal-sessions.ts
@@ -1,0 +1,14 @@
+import type { HttpClient } from '../http.js';
+import type { CreatePrincipalSessionParams, PrincipalSessionResponse } from '../types.js';
+
+export class PrincipalSessionsClient {
+  readonly #http: HttpClient;
+
+  constructor(http: HttpClient) {
+    this.#http = http;
+  }
+
+  create(params: CreatePrincipalSessionParams): Promise<PrincipalSessionResponse> {
+    return this.#http.post<PrincipalSessionResponse>('/v1/principal-sessions', params);
+  }
+}

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -183,6 +183,19 @@ export interface VerifyTokenResponse {
   expiresAt?: string;
 }
 
+// ─── Principal Sessions ──────────────────────────────────────────────────────
+
+export interface CreatePrincipalSessionParams {
+  principalId: string;
+  expiresIn?: string;
+}
+
+export interface PrincipalSessionResponse {
+  sessionToken: string;
+  dashboardUrl: string;
+  expiresAt: string;
+}
+
 // ─── Audit ────────────────────────────────────────────────────────────────────
 
 export interface LogAuditParams {

--- a/packages/sdk-ts/tests/principal-sessions.test.ts
+++ b/packages/sdk-ts/tests/principal-sessions.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Grantex } from '../src/client.js';
+
+function makeFetch(status: number, body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+describe('PrincipalSessionsClient', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('create() POSTs to /v1/principal-sessions', async () => {
+    const mockResponse = {
+      sessionToken: 'eyJ...',
+      dashboardUrl: 'https://api.grantex.dev/permissions?session=eyJ...',
+      expiresAt: '2026-03-01T00:00:00.000Z',
+    };
+    const mockFetch = makeFetch(201, mockResponse);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new Grantex({ apiKey: 'test_key' });
+    const result = await client.principalSessions.create({
+      principalId: 'user_123',
+      expiresIn: '2h',
+    });
+
+    expect(result.sessionToken).toBe('eyJ...');
+    expect(result.dashboardUrl).toContain('/permissions?session=');
+    expect(result.expiresAt).toBeTruthy();
+
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toContain('/v1/principal-sessions');
+    expect(init.method).toBe('POST');
+    const sentBody = JSON.parse(init.body as string);
+    expect(sentBody.principalId).toBe('user_123');
+    expect(sentBody.expiresIn).toBe('2h');
+  });
+
+  it('create() sends only principalId when expiresIn is omitted', async () => {
+    const mockFetch = makeFetch(201, {
+      sessionToken: 'tok',
+      dashboardUrl: 'url',
+      expiresAt: '2026-03-01T00:00:00.000Z',
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new Grantex({ apiKey: 'test_key' });
+    await client.principalSessions.create({ principalId: 'user_456' });
+
+    const [, init] = mockFetch.mock.calls[0]!;
+    const sentBody = JSON.parse(init.body as string);
+    expect(sentBody.principalId).toBe('user_456');
+  });
+});


### PR DESCRIPTION
## Summary

- Add self-service permission dashboard for end-users to view and revoke agent access without needing a developer API key
- Developers generate short-lived session JWTs via `POST /v1/principal-sessions` (API/SDK) and share the dashboard URL with their users
- Extract cascade-revoke logic into shared `lib/revoke.ts` helper used by both developer and principal grant revocation

## Changes

**Auth service:**
- `signPrincipalSessionToken()` / `verifyPrincipalSessionToken()` in `crypto.ts` — RS256 JWTs with `purpose: "principal_dashboard"` claim to prevent grant token reuse
- `lib/revoke.ts` — shared `revokeGrantCascade()` extracted from `grants.ts`
- 5 new routes in `routes/principal.ts`: `POST /v1/principal-sessions`, `GET /v1/principal/grants`, `GET /v1/principal/audit`, `DELETE /v1/principal/grants/:id`, `GET /permissions` (HTML page)
- 17 new tests passing

**TypeScript SDK (0.1.5):**
- `principalSessions.create()` with `CreatePrincipalSessionParams` / `PrincipalSessionResponse`

**Python SDK (0.1.5):**
- `principal_sessions.create()` with `CreatePrincipalSessionParams` / `PrincipalSessionResponse`

**Conformance suite (0.1.2):**
- Optional `principal-sessions` suite with 3 tests

**Documentation:**
- New guide: `guides/end-user-permissions.mdx`
- New SDK reference pages for TS and Python
- 4 new API reference pages with OpenAPI specs
- Updated README with permission dashboard in flow diagram + quickstart step 7

## Test plan

- [x] Auth service: 225 passed, typecheck clean, build clean (1 pre-existing pkce test failure)
- [x] TypeScript SDK: 85 passed, typecheck clean
- [x] Python SDK: 95 passed, mypy --strict clean
- [x] Conformance: 27 passed, typecheck clean, build clean
- [ ] Deploy auth service and run conformance with `--include principal-sessions`
- [ ] Open `/permissions?session=<token>` in browser and verify UI
- [ ] Verify new docs pages render on Mintlify
- [ ] Publish: sdk-ts 0.1.5, sdk-py 0.1.5, conformance 0.1.2