### PR TITLE
feat: add FastAPI integration (grantex-fastapi)

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ Service providers implement scope definitions for their APIs. Agents declare whi
 | Framework | Package | Install | Status |
 |-----------|---------|---------|--------|
 | **Express.js** | `@grantex/express` | `npm install @grantex/express` | ✅ Shipped |
+| **FastAPI** | `grantex-fastapi` | `pip install grantex-fastapi` | ✅ Shipped |
 | **LangChain** | `@grantex/langchain` | `npm install @grantex/langchain` | ✅ Shipped |
 | **AutoGen / OpenAI** | `@grantex/autogen` | `npm install @grantex/autogen` | ✅ Shipped |
 | **CrewAI** | `grantex-crewai` | `pip install grantex-crewai` | ✅ Shipped |
@@ -417,6 +418,22 @@ app.use('/api', requireGrantToken({ jwksUri: JWKS_URI }));
 app.get('/api/calendar', requireScopes('calendar:read'), (req, res) => {
   res.json({ principalId: req.grant.principalId, scopes: req.grant.scopes });
 });
+```
+
+**FastAPI** — dependency injection with scope enforcement:
+
+```python
+from fastapi import Depends, FastAPI
+from grantex import VerifiedGrant
+from grantex_fastapi import GrantexAuth, GrantexFastAPIError, grantex_exception_handler
+
+app = FastAPI()
+app.add_exception_handler(GrantexFastAPIError, grantex_exception_handler)
+grantex = GrantexAuth(jwks_uri="https://grantex-auth-dd4mtrt2gq-uc.a.run.app/.well-known/jwks.json")
+
+@app.get("/api/calendar")
+async def calendar(grant: VerifiedGrant = Depends(grantex.scopes("calendar:read"))):
+    return {"principalId": grant.principal_id}
 ```
 
 **LangChain** — scope-enforced tools + audit callbacks:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -168,6 +168,7 @@
             "group": "Framework Integrations",
             "pages": [
               "integrations/express",
+              "integrations/fastapi",
               "integrations/mcp",
               "integrations/langchain",
               "integrations/vercel-ai",

--- a/docs/integrations/fastapi.mdx
+++ b/docs/integrations/fastapi.mdx
@@ -1,0 +1,289 @@
+---
+title: "FastAPI"
+sidebarTitle: "FastAPI"
+description: "Grant token verification and scope-based authorization for FastAPI using dependency injection."
+---
+
+## Install
+
+```bash
+pip install grantex-fastapi
+```
+
+## Quick Start
+
+One dependency protects your entire API:
+
+```python
+from fastapi import Depends, FastAPI
+from grantex import VerifiedGrant
+from grantex_fastapi import GrantexAuth, GrantexFastAPIError, grantex_exception_handler
+
+app = FastAPI()
+app.add_exception_handler(GrantexFastAPIError, grantex_exception_handler)
+
+JWKS_URI = "https://grantex-auth-dd4mtrt2gq-uc.a.run.app/.well-known/jwks.json"
+grantex = GrantexAuth(jwks_uri=JWKS_URI)
+
+@app.get("/api/calendar")
+async def calendar(grant: VerifiedGrant = Depends(grantex.scopes("calendar:read"))):
+    return {"principalId": grant.principal_id, "scopes": list(grant.scopes)}
+```
+
+After verification succeeds, `grant` is a fully typed `VerifiedGrant` dataclass with the principal, agent, scopes, and timestamps.
+
+---
+
+## How It Works
+
+```
+Client → Authorization: Bearer <grantToken> → FastAPI app
+                                                 │
+                                         Depends(grantex)
+                                            │         │
+                                       Valid JWT?   Invalid/Missing?
+                                            │         │
+                                   Return VerifiedGrant   Raise GrantexFastAPIError
+                                            │                    │
+                                      .scopes() check      grantex_exception_handler
+                                       │           │              │
+                                  Has scopes?   Missing?     JSON error response
+                                       │           │
+                                  Return grant   Raise 403
+```
+
+1. `GrantexAuth` extracts the Bearer token from the `Authorization` header
+2. It verifies the RS256 signature against the Grantex JWKS endpoint
+3. On success, a `VerifiedGrant` is returned and injected into your handler
+4. `.scopes()` optionally checks that the grant contains all required scopes
+5. Errors are converted to JSON responses by `grantex_exception_handler`
+
+---
+
+## Token Verification Only
+
+Use `Depends(grantex)` to verify the token without checking scopes:
+
+```python
+@app.get("/api/me")
+async def me(grant: VerifiedGrant = Depends(grantex)):
+    return {"principalId": grant.principal_id, "agentDid": grant.agent_did}
+```
+
+---
+
+## Scope Enforcement
+
+### Via dependency (recommended)
+
+Use `Depends(grantex.scopes(...))` to verify the token AND check scopes in one step:
+
+```python
+# Single scope
+@app.get("/api/calendar")
+async def calendar(grant: VerifiedGrant = Depends(grantex.scopes("calendar:read"))):
+    return {"events": get_calendar_events(grant.principal_id)}
+
+# Multiple scopes — all required
+@app.post("/api/email/send")
+async def send_email(grant: VerifiedGrant = Depends(grantex.scopes("email:read", "email:send"))):
+    return {"sent": True}
+```
+
+### Via function call
+
+Check scopes inside the route handler with `require_scopes()`:
+
+```python
+from grantex_fastapi import require_scopes
+
+@app.get("/api/data")
+async def data(grant: VerifiedGrant = Depends(grantex)):
+    require_scopes(grant, "data:read")
+    return {"data": get_data(grant.principal_id)}
+```
+
+---
+
+## Custom Token Extraction
+
+By default, the middleware reads the `Authorization: Bearer <token>` header. Override this with `token_extractor`:
+
+<CodeGroup>
+
+```python Cookie
+from fastapi import Request
+
+def extract_from_cookie(request: Request) -> str | None:
+    return request.cookies.get("grant_token")
+
+grantex = GrantexAuth(jwks_uri=JWKS_URI, token_extractor=extract_from_cookie)
+```
+
+```python Custom Header
+def extract_from_header(request: Request) -> str | None:
+    return request.headers.get("x-grant-token")
+
+grantex = GrantexAuth(jwks_uri=JWKS_URI, token_extractor=extract_from_header)
+```
+
+```python Query Parameter
+def extract_from_query(request: Request) -> str | None:
+    return request.query_params.get("token")
+
+grantex = GrantexAuth(jwks_uri=JWKS_URI, token_extractor=extract_from_query)
+```
+
+</CodeGroup>
+
+---
+
+## Error Handling
+
+Register the built-in exception handler to return JSON error responses:
+
+```python
+app.add_exception_handler(GrantexFastAPIError, grantex_exception_handler)
+```
+
+Or write a custom handler:
+
+```python
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from grantex_fastapi import GrantexFastAPIError
+
+@app.exception_handler(GrantexFastAPIError)
+async def custom_handler(request: Request, exc: GrantexFastAPIError) -> JSONResponse:
+    if exc.code == "TOKEN_EXPIRED":
+        return JSONResponse(
+            status_code=401,
+            content={"error": "session_expired", "message": "Please re-authorize."},
+        )
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"error": exc.code, "message": str(exc)},
+    )
+```
+
+### Error Codes
+
+| Code | HTTP Status | When |
+|------|-------------|------|
+| `TOKEN_MISSING` | 401 | No token found in the request |
+| `TOKEN_INVALID` | 401 | JWT signature or format is invalid |
+| `TOKEN_EXPIRED` | 401 | JWT `exp` claim is in the past |
+| `SCOPE_INSUFFICIENT` | 403 | Token is missing one or more required scopes |
+
+---
+
+## `grant` Reference
+
+The `VerifiedGrant` dataclass contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `token_id` | `str` | JWT `jti` claim — unique token identifier |
+| `grant_id` | `str` | Grantex grant record ID |
+| `principal_id` | `str` | End-user who authorized the agent |
+| `agent_did` | `str` | Agent's decentralized identifier |
+| `developer_id` | `str` | Developer organization ID |
+| `scopes` | `tuple[str, ...]` | Scopes the agent was granted |
+| `issued_at` | `int` | Token issued-at (seconds since epoch) |
+| `expires_at` | `int` | Token expiry (seconds since epoch) |
+| `parent_agent_did` | `str \| None` | Parent agent DID (delegated grants only) |
+| `parent_grant_id` | `str \| None` | Parent grant ID (delegated grants only) |
+| `delegation_depth` | `int \| None` | Delegation depth (0 = root grant) |
+
+---
+
+## Full Example
+
+A complete FastAPI application protected by Grantex:
+
+```python
+from fastapi import Depends, FastAPI
+from grantex import VerifiedGrant
+from grantex_fastapi import GrantexAuth, GrantexFastAPIError, grantex_exception_handler
+
+app = FastAPI(title="My Agent API")
+app.add_exception_handler(GrantexFastAPIError, grantex_exception_handler)
+
+grantex = GrantexAuth(
+    jwks_uri="https://grantex-auth-dd4mtrt2gq-uc.a.run.app/.well-known/jwks.json",
+    clock_tolerance=5,
+)
+
+
+# Public health check
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+# Token verification only
+@app.get("/api/me")
+async def me(grant: VerifiedGrant = Depends(grantex)):
+    return {
+        "principalId": grant.principal_id,
+        "agentDid": grant.agent_did,
+        "scopes": list(grant.scopes),
+    }
+
+
+# Scope enforcement
+@app.get("/api/calendar")
+async def calendar(grant: VerifiedGrant = Depends(grantex.scopes("calendar:read"))):
+    return {"events": get_calendar_events(grant.principal_id)}
+
+
+@app.post("/api/calendar/events")
+async def create_event(grant: VerifiedGrant = Depends(grantex.scopes("calendar:write"))):
+    return {"created": True}
+
+
+@app.post("/api/email/send")
+async def send_email(
+    grant: VerifiedGrant = Depends(grantex.scopes("email:read", "email:send")),
+):
+    return {"sent": True}
+
+
+def get_calendar_events(principal_id: str) -> list[dict]:
+    return [{"id": "1", "title": "Team standup", "principalId": principal_id}]
+```
+
+---
+
+## API Reference
+
+### `GrantexAuth(jwks_uri, *, clock_tolerance=0, audience=None, token_extractor=None)`
+
+Creates a Grantex authentication dependency.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `jwks_uri` | `str` | *required* | JWKS endpoint URL for token verification |
+| `clock_tolerance` | `int` | `0` | Seconds of clock skew tolerance |
+| `audience` | `str \| None` | `None` | Expected JWT `aud` claim |
+| `token_extractor` | `Callable[[Request], str \| None] \| None` | `None` | Custom function to extract the token |
+
+### `grantex.scopes(*required_scopes)`
+
+Returns a dependency that verifies the token AND checks all required scopes.
+
+### `require_scopes(grant, *scopes)`
+
+Standalone function that checks scopes on an already-verified grant. Raises `GrantexFastAPIError` with `SCOPE_INSUFFICIENT` if any scope is missing.
+
+### `grantex_exception_handler(request, exc)`
+
+Starlette exception handler that converts `GrantexFastAPIError` to a JSON response.
+
+---
+
+## Requirements
+
+- Python 3.9+
+- FastAPI >= 0.100.0
+- `grantex` >= 0.1.0

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -10,6 +10,9 @@ description: "Grantex integrates with every major AI agent framework."
   <Card title="Express.js" icon="server" href="/integrations/express">
     Grant token verification and scope-based authorization middleware.
   </Card>
+  <Card title="FastAPI" icon="bolt-lightning" href="/integrations/fastapi">
+    Dependency injection for grant token verification and scope checks.
+  </Card>
   <Card title="MCP Server" icon="plug" href="/integrations/mcp">
     13 tools for Claude Desktop, Cursor, and Windsurf.
   </Card>
@@ -44,6 +47,7 @@ description: "Grantex integrates with every major AI agent framework."
 | Framework | Package | Install | Language |
 |-----------|---------|---------|----------|
 | Express.js | `@grantex/express` | `npm install @grantex/express` | TypeScript |
+| FastAPI | `grantex-fastapi` | `pip install grantex-fastapi` | Python |
 | MCP | `@grantex/mcp` | `npm install -g @grantex/mcp` | TypeScript |
 | LangChain | `@grantex/langchain` | `npm install @grantex/langchain` | TypeScript |
 | Vercel AI SDK | `@grantex/vercel-ai` | `npm install @grantex/vercel-ai` | TypeScript |

--- a/packages/fastapi/README.md
+++ b/packages/fastapi/README.md
@@ -1,0 +1,143 @@
+# grantex-fastapi
+
+FastAPI dependency injection for [Grantex](https://grantex.dev) grant token verification and scope-based authorization.
+
+Verify Grantex JWTs and enforce scopes on any FastAPI route with a single `Depends()`.
+
+## Install
+
+```bash
+pip install grantex-fastapi
+```
+
+## Quick Start
+
+```python
+from fastapi import Depends, FastAPI
+from grantex import VerifiedGrant
+from grantex_fastapi import GrantexAuth, GrantexFastAPIError, grantex_exception_handler
+
+app = FastAPI()
+app.add_exception_handler(GrantexFastAPIError, grantex_exception_handler)
+
+JWKS_URI = "https://grantex-auth-dd4mtrt2gq-uc.a.run.app/.well-known/jwks.json"
+grantex = GrantexAuth(jwks_uri=JWKS_URI)
+
+# Verify token — grant is injected automatically
+@app.get("/api/calendar")
+async def calendar(grant: VerifiedGrant = Depends(grantex.scopes("calendar:read"))):
+    return {"principalId": grant.principal_id, "scopes": list(grant.scopes)}
+```
+
+## How It Works
+
+`GrantexAuth` is a callable class that acts as a FastAPI dependency:
+
+1. Extracts the Bearer token from the `Authorization` header
+2. Verifies the RS256 signature against the Grantex JWKS endpoint
+3. Returns a typed `VerifiedGrant` object with principal, agent, scopes, and timestamps
+4. The `.scopes()` method adds scope enforcement on top
+
+## Token Verification Only
+
+Use `Depends(grantex)` to verify the token without checking scopes:
+
+```python
+@app.get("/api/me")
+async def me(grant: VerifiedGrant = Depends(grantex)):
+    return {"principalId": grant.principal_id, "agentDid": grant.agent_did}
+```
+
+## Scope Enforcement
+
+Use `Depends(grantex.scopes(...))` to verify the token AND check scopes:
+
+```python
+# Single scope
+@app.get("/api/calendar")
+async def calendar(grant: VerifiedGrant = Depends(grantex.scopes("calendar:read"))):
+    ...
+
+# Multiple scopes — all required
+@app.post("/api/email/send")
+async def send_email(grant: VerifiedGrant = Depends(grantex.scopes("email:read", "email:send"))):
+    ...
+```
+
+Or check scopes inside the handler:
+
+```python
+from grantex_fastapi import require_scopes
+
+@app.get("/api/data")
+async def data(grant: VerifiedGrant = Depends(grantex)):
+    require_scopes(grant, "data:read")
+    ...
+```
+
+## Custom Token Extraction
+
+```python
+from fastapi import Request
+
+def extract_from_cookie(request: Request) -> str | None:
+    return request.cookies.get("grant_token")
+
+grantex = GrantexAuth(jwks_uri=JWKS_URI, token_extractor=extract_from_cookie)
+```
+
+## Custom Error Handling
+
+Register the built-in exception handler for JSON error responses:
+
+```python
+app.add_exception_handler(GrantexFastAPIError, grantex_exception_handler)
+```
+
+Or write your own:
+
+```python
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from grantex_fastapi import GrantexFastAPIError
+
+@app.exception_handler(GrantexFastAPIError)
+async def custom_handler(request: Request, exc: GrantexFastAPIError) -> JSONResponse:
+    if exc.code == "TOKEN_EXPIRED":
+        return JSONResponse(status_code=401, content={"error": "Session expired"})
+    return JSONResponse(status_code=exc.status_code, content={"error": exc.code})
+```
+
+## Error Codes
+
+| Code | Status | Meaning |
+|------|--------|---------|
+| `TOKEN_MISSING` | 401 | No token found in request |
+| `TOKEN_INVALID` | 401 | Token signature or format is invalid |
+| `TOKEN_EXPIRED` | 401 | Token has expired |
+| `SCOPE_INSUFFICIENT` | 403 | Token lacks required scopes |
+
+## `grant` Object
+
+The `VerifiedGrant` dataclass contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `token_id` | `str` | JWT `jti` claim |
+| `grant_id` | `str` | Grant record ID |
+| `principal_id` | `str` | End-user who authorized the agent |
+| `agent_did` | `str` | Agent's DID |
+| `developer_id` | `str` | Developer org ID |
+| `scopes` | `tuple[str, ...]` | Granted scopes |
+| `issued_at` | `int` | Token issued-at (epoch seconds) |
+| `expires_at` | `int` | Token expiry (epoch seconds) |
+
+## Requirements
+
+- Python 3.9+
+- FastAPI >= 0.100.0
+- `grantex` >= 0.1.0
+
+## License
+
+Apache-2.0

--- a/packages/fastapi/pyproject.toml
+++ b/packages/fastapi/pyproject.toml
@@ -1,0 +1,54 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "grantex-fastapi"
+version = "0.1.0"
+description = "FastAPI middleware for Grantex grant token verification and scope-based authorization"
+readme = "README.md"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.9"
+keywords = ["grantex", "fastapi", "middleware", "authorization", "oauth", "jwt", "ai-agents"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Framework :: FastAPI",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Security",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+    "grantex>=0.1.0",
+    "fastapi>=0.100.0",
+]
+
+[project.urls]
+Homepage = "https://grantex.dev"
+Documentation = "https://grantex.dev/docs/integrations/fastapi"
+Repository = "https://github.com/mishrasanjeev/grantex"
+Issues = "https://github.com/mishrasanjeev/grantex/issues"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23.0",
+    "httpx>=0.25.0",
+    "mypy>=1.8",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/grantex_fastapi"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.mypy]
+strict = true
+python_version = "3.9"

--- a/packages/fastapi/src/grantex_fastapi/__init__.py
+++ b/packages/fastapi/src/grantex_fastapi/__init__.py
@@ -1,0 +1,15 @@
+"""FastAPI middleware for Grantex grant token verification and scope-based authorization."""
+
+from __future__ import annotations
+
+from ._errors import GrantexFastAPIError
+from ._middleware import GrantexAuth, grantex_exception_handler, require_scopes
+
+__all__ = [
+    "GrantexAuth",
+    "GrantexFastAPIError",
+    "grantex_exception_handler",
+    "require_scopes",
+]
+
+__version__ = "0.1.0"

--- a/packages/fastapi/src/grantex_fastapi/_errors.py
+++ b/packages/fastapi/src/grantex_fastapi/_errors.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Literal
+
+ErrorCode = Literal[
+    "TOKEN_MISSING",
+    "TOKEN_INVALID",
+    "TOKEN_EXPIRED",
+    "SCOPE_INSUFFICIENT",
+]
+
+
+class GrantexFastAPIError(Exception):
+    """Raised when grant token verification or scope checking fails."""
+
+    def __init__(self, code: ErrorCode, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.code: ErrorCode = code
+        self.status_code = status_code

--- a/packages/fastapi/src/grantex_fastapi/_middleware.py
+++ b/packages/fastapi/src/grantex_fastapi/_middleware.py
@@ -1,0 +1,147 @@
+"""FastAPI dependency-injection helpers for Grantex grant token verification."""
+
+from typing import Any, Callable, Optional
+
+from fastapi import Depends, Request
+from fastapi.responses import JSONResponse
+from grantex import GrantexTokenError, VerifiedGrant, VerifyGrantTokenOptions, verify_grant_token
+
+from ._errors import ErrorCode, GrantexFastAPIError
+
+
+def _extract_bearer_token(request: Request) -> Optional[str]:
+    """Extract a Bearer token from the Authorization header."""
+    header = request.headers.get("authorization")
+    if not header:
+        return None
+    parts = header.split(" ", 1)
+    if len(parts) != 2 or parts[0] != "Bearer":
+        return None
+    return parts[1]
+
+
+class GrantexAuth:
+    """Factory that produces FastAPI dependencies for Grantex token verification.
+
+    Usage::
+
+        from grantex_fastapi import GrantexAuth
+
+        grantex = GrantexAuth(
+            jwks_uri="https://grantex-auth-dd4mtrt2gq-uc.a.run.app/.well-known/jwks.json",
+        )
+
+        @app.get("/api/calendar")
+        async def calendar(grant: VerifiedGrant = Depends(grantex)):
+            return {"principalId": grant.principal_id, "scopes": grant.scopes}
+
+    The instance is callable, so you can use ``Depends(grantex)`` directly.
+    It can also produce scope-checking sub-dependencies via
+    ``Depends(grantex.scopes("calendar:read"))``.
+    """
+
+    def __init__(
+        self,
+        jwks_uri: str,
+        *,
+        clock_tolerance: int = 0,
+        audience: Optional[str] = None,
+        token_extractor: Optional[Callable[[Request], Optional[str]]] = None,
+    ) -> None:
+        self._jwks_uri = jwks_uri
+        self._clock_tolerance = clock_tolerance
+        self._audience = audience
+        self._token_extractor = token_extractor
+
+    async def __call__(self, request: Request) -> VerifiedGrant:
+        """FastAPI dependency that verifies the grant token and returns a VerifiedGrant."""
+        return self._verify(request)
+
+    def _verify(self, request: Request) -> VerifiedGrant:
+        """Core verification logic shared by __call__ and scopes()."""
+        if self._token_extractor is not None:
+            token = self._token_extractor(request)
+        else:
+            token = _extract_bearer_token(request)
+
+        if not token:
+            raise GrantexFastAPIError(
+                "TOKEN_MISSING",
+                'No grant token found. Send a Grantex JWT in the Authorization header as "Bearer <token>".',
+                401,
+            )
+
+        opts = VerifyGrantTokenOptions(
+            jwks_uri=self._jwks_uri,
+            clock_tolerance=self._clock_tolerance,
+            audience=self._audience,
+        )
+
+        try:
+            return verify_grant_token(token, opts)
+        except GrantexTokenError as exc:
+            msg = str(exc)
+            is_expired = "exp" in msg.lower()
+            code: ErrorCode = "TOKEN_EXPIRED" if is_expired else "TOKEN_INVALID"
+            raise GrantexFastAPIError(code, msg, 401) from exc
+
+    def scopes(self, *required_scopes: str) -> Callable[..., Any]:
+        """Return a dependency that verifies the token AND checks scopes.
+
+        Usage::
+
+            @app.get("/api/calendar")
+            async def calendar(grant: VerifiedGrant = Depends(grantex.scopes("calendar:read"))):
+                ...
+
+            # Multiple scopes — all required
+            @app.post("/api/email/send")
+            async def send(grant: VerifiedGrant = Depends(grantex.scopes("email:read", "email:send"))):
+                ...
+        """
+        parent = self
+
+        async def _dependency(request: Request) -> VerifiedGrant:
+            grant = parent._verify(request)
+            missing = [s for s in required_scopes if s not in grant.scopes]
+            if missing:
+                raise GrantexFastAPIError(
+                    "SCOPE_INSUFFICIENT",
+                    f"Grant token is missing required scopes: {', '.join(missing)}",
+                    403,
+                )
+            return grant
+
+        return _dependency
+
+
+def require_scopes(grant: VerifiedGrant, *scopes: str) -> None:
+    """Standalone scope check — call inside a route handler.
+
+    Usage::
+
+        @app.get("/api/data")
+        async def data(grant: VerifiedGrant = Depends(grantex)):
+            require_scopes(grant, "data:read")
+            ...
+    """
+    missing = [s for s in scopes if s not in grant.scopes]
+    if missing:
+        raise GrantexFastAPIError(
+            "SCOPE_INSUFFICIENT",
+            f"Grant token is missing required scopes: {', '.join(missing)}",
+            403,
+        )
+
+
+def grantex_exception_handler(request: Request, exc: GrantexFastAPIError) -> JSONResponse:
+    """Default exception handler for GrantexFastAPIError.
+
+    Register with::
+
+        app.add_exception_handler(GrantexFastAPIError, grantex_exception_handler)
+    """
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"error": exc.code, "message": str(exc)},
+    )

--- a/packages/fastapi/tests/test_middleware.py
+++ b/packages/fastapi/tests/test_middleware.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import Depends, FastAPI, Request
+from fastapi.testclient import TestClient
+from grantex import VerifiedGrant
+
+from grantex_fastapi import GrantexAuth, GrantexFastAPIError, grantex_exception_handler, require_scopes
+
+
+JWKS_URI = "https://example.com/.well-known/jwks.json"
+
+MOCK_GRANT = VerifiedGrant(
+    token_id="tok_01",
+    grant_id="grnt_01",
+    principal_id="user_123",
+    agent_did="did:grantex:ag_01",
+    developer_id="dev_01",
+    scopes=("calendar:read", "email:read"),
+    issued_at=1709100000,
+    expires_at=1709200000,
+)
+
+
+def _make_app(
+    grantex: GrantexAuth,
+    scopes: Optional[tuple[str, ...]] = None,
+) -> FastAPI:
+    """Create a minimal FastAPI app for testing."""
+    app = FastAPI()
+    app.add_exception_handler(GrantexFastAPIError, grantex_exception_handler)  # type: ignore[arg-type]
+
+    if scopes:
+        dep = grantex.scopes(*scopes)
+    else:
+        dep = grantex  # type: ignore[assignment]
+
+    @app.get("/api/test")
+    async def test_route(grant: VerifiedGrant = Depends(dep)) -> dict[str, Any]:
+        return {
+            "principalId": grant.principal_id,
+            "scopes": list(grant.scopes),
+        }
+
+    return app
+
+
+# ─── Token verification ─────────────────────────────────────────────────────
+
+
+class TestGrantexAuth:
+    @patch("grantex_fastapi._middleware.verify_grant_token")
+    def test_valid_token(self, mock_verify: MagicMock) -> None:
+        mock_verify.return_value = MOCK_GRANT
+        grantex = GrantexAuth(jwks_uri=JWKS_URI)
+        app = _make_app(grantex)
+        client = TestClient(app)
+
+        resp = client.get("/api/test", headers={"Authorization": "Bearer valid.jwt.token"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["principalId"] == "user_123"
+        assert data["scopes"] == ["calendar:read", "email:read"]
+
+    def test_missing_token(self) -> None:
+        grantex = GrantexAuth(jwks_uri=JWKS_URI)
+        app = _make_app(grantex)
+        client = TestClient(app)
+
+        resp = client.get("/api/test")
+
+        assert resp.status_code == 401
+        data = resp.json()
+        assert data["error"] == "TOKEN_MISSING"
+
+    def test_non_bearer_auth(self) -> None:
+        grantex = GrantexAuth(jwks_uri=JWKS_URI)
+        app = _make_app(grantex)
+        client = TestClient(app)
+
+        resp = client.get("/api/test", headers={"Authorization": "Basic dXNlcjpwYXNz"})
+
+        assert resp.status_code == 401
+        assert resp.json()["error"] == "TOKEN_MISSING"
+
+    @patch("grantex_fastapi._middleware.verify_grant_token")
+    def test_invalid_token(self, mock_verify: MagicMock) -> None:
+        from grantex import GrantexTokenError
+
+        mock_verify.side_effect = GrantexTokenError("Grant token verification failed: invalid signature")
+        grantex = GrantexAuth(jwks_uri=JWKS_URI)
+        app = _make_app(grantex)
+        client = TestClient(app)
+
+        resp = client.get("/api/test", headers={"Authorization": "Bearer bad.token.here"})
+
+        assert resp.status_code == 401
+        assert resp.json()["error"] == "TOKEN_INVALID"
+
+    @patch("grantex_fastapi._middleware.verify_grant_token")
+    def test_expired_token(self, mock_verify: MagicMock) -> None:
+        from grantex import GrantexTokenError
+
+        mock_verify.side_effect = GrantexTokenError(
+            'Grant token verification failed: Signature has expired'
+        )
+        grantex = GrantexAuth(jwks_uri=JWKS_URI)
+        app = _make_app(grantex)
+        client = TestClient(app)
+
+        resp = client.get("/api/test", headers={"Authorization": "Bearer expired.token"})
+
+        assert resp.status_code == 401
+        assert resp.json()["error"] == "TOKEN_EXPIRED"
+
+    @patch("grantex_fastapi._middleware.verify_grant_token")
+    def test_clock_tolerance_and_audience_passed(self, mock_verify: MagicMock) -> None:
+        mock_verify.return_value = MOCK_GRANT
+        grantex = GrantexAuth(jwks_uri=JWKS_URI, clock_tolerance=10, audience="my-app")
+        app = _make_app(grantex)
+        client = TestClient(app)
+
+        resp = client.get("/api/test", headers={"Authorization": "Bearer some.token"})
+
+        assert resp.status_code == 200
+        opts = mock_verify.call_args[0][1]
+        assert opts.jwks_uri == JWKS_URI
+        assert opts.clock_tolerance == 10
+        assert opts.audience == "my-app"
+
+    @patch("grantex_fastapi._middleware.verify_grant_token")
+    def test_custom_token_extractor(self, mock_verify: MagicMock) -> None:
+        mock_verify.return_value = MOCK_GRANT
+
+        def extract_from_header(request: Request) -> Optional[str]:
+            return request.headers.get("X-Grant-Token")
+
+        grantex = GrantexAuth(jwks_uri=JWKS_URI, token_extractor=extract_from_header)
+        app = _make_app(grantex)
+        client = TestClient(app)
+
+        resp = client.get("/api/test", headers={"X-Grant-Token": "custom.header.token"})
+
+        assert resp.status_code == 200
+        mock_verify.assert_called_once()
+        assert mock_verify.call_args[0][0] == "custom.header.token"
+
+    def test_custom_extractor_returns_none(self) -> None:
+        grantex = GrantexAuth(jwks_uri=JWKS_URI, token_extractor=lambda r: None)
+        app = _make_app(grantex)
+        client = TestClient(app)
+
+        resp = client.get("/api/test", headers={"Authorization": "Bearer ignored"})
+
+        assert resp.status_code == 401
+        assert resp.json()["error"] == "TOKEN_MISSING"
+
+
+# ─── Scope checking via .scopes() dependency ────────────────────────────────
+
+
+class TestScopesDependency:
+    @patch("grantex_fastapi._middleware.verify_grant_token")
+    def test_scopes_pass(self, mock_verify: MagicMock) -> None:
+        mock_verify.return_value = MOCK_GRANT
+        grantex = GrantexAuth(jwks_uri=JWKS_URI)
+        app = _make_app(grantex, scopes=("calendar:read",))
+        client = TestClient(app)
+
+        resp = client.get("/api/test", headers={"Authorization": "Bearer valid.token"})
+
+        assert resp.status_code == 200
+
+    @patch("grantex_fastapi._middleware.verify_grant_token")
+    def test_multiple_scopes_pass(self, mock_verify: MagicMock) -> None:
+        mock_verify.return_value = MOCK_GRANT
+        grantex = GrantexAuth(jwks_uri=JWKS_URI)
+        app = _make_app(grantex, scopes=("calendar:read", "email:read"))
+        client = TestClient(app)
+
+        resp = client.get("/api/test", headers={"Authorization": "Bearer valid.token"})
+
+        assert resp.status_code == 200
+
+    @patch("grantex_fastapi._middleware.verify_grant_token")
+    def test_missing_scope(self, mock_verify: MagicMock) -> None:
+        mock_verify.return_value = MOCK_GRANT
+        grantex = GrantexAuth(jwks_uri=JWKS_URI)
+        app = _make_app(grantex, scopes=("calendar:write",))
+        client = TestClient(app)
+
+        resp = client.get("/api/test", headers={"Authorization": "Bearer valid.token"})
+
+        assert resp.status_code == 403
+        data = resp.json()
+        assert data["error"] == "SCOPE_INSUFFICIENT"
+        assert "calendar:write" in data["message"]
+
+    @patch("grantex_fastapi._middleware.verify_grant_token")
+    def test_multiple_missing_scopes(self, mock_verify: MagicMock) -> None:
+        mock_verify.return_value = MOCK_GRANT
+        grantex = GrantexAuth(jwks_uri=JWKS_URI)
+        app = _make_app(grantex, scopes=("calendar:write", "email:write"))
+        client = TestClient(app)
+
+        resp = client.get("/api/test", headers={"Authorization": "Bearer valid.token"})
+
+        assert resp.status_code == 403
+        data = resp.json()
+        assert "calendar:write" in data["message"]
+        assert "email:write" in data["message"]
+
+    def test_scope_check_without_token(self) -> None:
+        grantex = GrantexAuth(jwks_uri=JWKS_URI)
+        app = _make_app(grantex, scopes=("calendar:read",))
+        client = TestClient(app)
+
+        resp = client.get("/api/test")
+
+        assert resp.status_code == 401
+        assert resp.json()["error"] == "TOKEN_MISSING"
+
+
+# ─── require_scopes standalone ───────────────────────────────────────────────
+
+
+class TestRequireScopes:
+    def test_passes_when_scopes_present(self) -> None:
+        require_scopes(MOCK_GRANT, "calendar:read")
+
+    def test_passes_for_multiple_present_scopes(self) -> None:
+        require_scopes(MOCK_GRANT, "calendar:read", "email:read")
+
+    def test_raises_for_missing_scope(self) -> None:
+        with pytest.raises(GrantexFastAPIError) as exc_info:
+            require_scopes(MOCK_GRANT, "calendar:write")
+        assert exc_info.value.code == "SCOPE_INSUFFICIENT"
+        assert exc_info.value.status_code == 403
+
+    def test_raises_with_all_missing_scopes_listed(self) -> None:
+        with pytest.raises(GrantexFastAPIError) as exc_info:
+            require_scopes(MOCK_GRANT, "calendar:write", "email:write")
+        msg = str(exc_info.value)
+        assert "calendar:write" in msg
+        assert "email:write" in msg
+
+
+# ─── GrantexFastAPIError ─────────────────────────────────────────────────────
+
+
+class TestError:
+    def test_properties(self) -> None:
+        err = GrantexFastAPIError("TOKEN_INVALID", "bad token", 401)
+        assert err.code == "TOKEN_INVALID"
+        assert err.status_code == 401
+        assert str(err) == "bad token"
+        assert isinstance(err, Exception)
+
+    def test_exception_handler_returns_json(self) -> None:
+        app = FastAPI()
+        app.add_exception_handler(GrantexFastAPIError, grantex_exception_handler)  # type: ignore[arg-type]
+
+        @app.get("/err")
+        async def err_route() -> None:
+            raise GrantexFastAPIError("TOKEN_EXPIRED", "Token expired", 401)
+
+        client = TestClient(app)
+        resp = client.get("/err")
+        assert resp.status_code == 401
+        assert resp.json() == {"error": "TOKEN_EXPIRED", "message": "Token expired"}

--- a/web/index.html
+++ b/web/index.html
@@ -888,6 +888,10 @@
         <span class="integration-icon" style="font-family:var(--mono);font-size:14px;font-weight:700;">Ex</span>
         Express.js
       </a>
+      <a href="https://pypi.org/project/grantex-fastapi/" class="integration-pill" style="text-decoration:none;">
+        <span class="integration-icon">&#x26A1;</span>
+        FastAPI
+      </a>
       <a href="https://www.npmjs.com/package/@grantex/langchain" class="integration-pill" style="text-decoration:none;">
         <span class="integration-icon">&#x1F997;</span>
         LangChain


### PR DESCRIPTION
## Summary

- New `grantex-fastapi` package (0.1.0) with FastAPI dependency injection for grant token verification and scope-based authorization
- `GrantexAuth` callable class — use `Depends(grantex)` for token verification, `Depends(grantex.scopes("calendar:read"))` for scope enforcement
- `require_scopes()` standalone helper for in-handler scope checks
- `grantex_exception_handler` for automatic JSON error responses
- Custom token extraction, clock tolerance, audience validation
- 19 tests, mypy strict clean
- Documentation across all surfaces: Mintlify docs, README, landing page, integrations overview

## What's included

### Dependencies
- **`Depends(grantex)`** — Verifies Grantex grant tokens, injects `VerifiedGrant` into handler
- **`Depends(grantex.scopes(...))`** — Verifies token AND checks all required scopes
- **`require_scopes(grant, ...)`** — Standalone scope check for use inside handlers
- **`grantex_exception_handler`** — Converts `GrantexFastAPIError` to JSON responses

### Error codes
- `TOKEN_MISSING` (401), `TOKEN_INVALID` (401), `TOKEN_EXPIRED` (401), `SCOPE_INSUFFICIENT` (403)

### Documentation
- `docs/integrations/fastapi.mdx` — full guide with examples
- Updated `docs/integrations/overview.mdx`, `docs/docs.json`, `README.md`, `web/index.html`

### Gotcha
- `from __future__ import annotations` breaks FastAPI dependency injection (Request type becomes a string annotation). The middleware module omits this import.

## Test plan

- [x] `pytest -v` — 19 tests passing
- [x] `mypy --strict src/grantex_fastapi` — 0 errors
- [x] `python -m build` — clean build