### PR TITLE
feat: launch prep — PH gallery screenshots, LinkedIn post, readiness checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ build/
 .firebase/
 web/dashboard/
 
+# Generated PH gallery screenshots
+web/ph-gallery/
+
 # Coverage & caches
 coverage/
 .cache/

--- a/LAUNCH_POSTS.md
+++ b/LAUNCH_POSTS.md
@@ -291,6 +291,55 @@ As agents get more capable, proper authorization becomes more critical — not l
 
 ---
 
+## 7. LinkedIn Post
+
+I've been thinking about a problem that keeps coming up in AI agent development: permissions.
+
+When you build an agent that books flights, sends emails, or moves money — how does it prove to downstream services what it's allowed to do? Right now, the answer is usually "hand it your API key and hope for the best."
+
+That's the same mistake the web made before OAuth. And it's going to scale very badly as agents get more capable.
+
+So I built Grantex — an open protocol for delegated authorization of AI agents.
+
+Here's how it works:
+
+1. An agent registers with the scopes it needs (e.g., flights:book, payments:max_500)
+2. The human approves those specific scopes via a consent screen
+3. The agent receives a signed JWT — scoped, time-limited, revocable
+4. Any downstream service can verify that JWT offline via JWKS — no Grantex account needed
+5. Every action gets logged in an append-only audit trail
+
+What makes this different from "just use OAuth":
+
+- Agents get their own cryptographic identity (DID-based), not borrowed user credentials
+- Delegation chains let a parent agent grant narrower permissions to sub-agents, with full depth tracking
+- Real-time revocation — kill a misbehaving agent's access in under a second
+
+What's shipping today:
+
+- Protocol spec v1.0 (frozen, public)
+- SDKs in TypeScript, Python, and Go
+- 8 framework integrations: LangChain, CrewAI, AutoGen, Vercel AI SDK, OpenAI Agents SDK, Google ADK, MCP server (works with Claude Desktop/Cursor/Windsurf), Express.js + FastAPI middleware
+- Auth service, CLI, developer portal, conformance test suite
+- Enterprise features: policy engine, SCIM/SSO, anomaly detection, compliance exports
+
+Everything is open source under Apache 2.0.
+
+If you're building with AI agents — whether it's a single-agent tool or a multi-agent pipeline — I'd love your feedback on the protocol design.
+
+Get started:
+npm install @grantex/sdk
+pip install grantex
+go get github.com/mishrasanjeev/grantex-go
+
+Homepage: https://grantex.dev
+Docs: https://grantex.dev/docs
+GitHub: https://github.com/mishrasanjeev/grantex
+
+#AI #OpenSource #Security #AIAgents #OAuth #Authorization
+
+---
+
 ## Posting Order (recommended)
 
 1. **Dev.to** — publish first so you have a canonical URL for cross-referencing

--- a/scripts/screenshot-gallery.mjs
+++ b/scripts/screenshot-gallery.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+/**
+ * Captures 6 Product Hunt gallery slides from web/ph-gallery.html
+ * as individual 1270×760 PNGs into web/ph-gallery/.
+ *
+ * Usage: npx playwright install chromium && node scripts/screenshot-gallery.mjs
+ */
+
+import { chromium } from 'playwright';
+import { fileURLToPath } from 'url';
+import { dirname, resolve, join } from 'path';
+import { mkdir } from 'fs/promises';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, '..');
+
+const SLIDES = [
+  { index: 1, name: 'slide-1-hero' },
+  { index: 2, name: 'slide-2-problem' },
+  { index: 3, name: 'slide-3-how-it-works' },
+  { index: 4, name: 'slide-4-code-quickstart' },
+  { index: 5, name: 'slide-5-integrations' },
+  { index: 6, name: 'slide-6-open-source' },
+];
+
+const WIDTH = 1270;
+const HEIGHT = 760;
+
+async function main() {
+  const outDir = join(ROOT, 'web', 'ph-gallery');
+  await mkdir(outDir, { recursive: true });
+
+  const galleryPath = join(ROOT, 'web', 'ph-gallery.html');
+  const fileUrl = `file://${galleryPath.replace(/\\/g, '/')}`;
+
+  console.log(`Opening ${fileUrl}`);
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage({
+    viewport: { width: WIDTH + 200, height: HEIGHT + 200 },
+  });
+
+  await page.goto(fileUrl, { waitUntil: 'networkidle' });
+
+  // Wait for fonts to load
+  await page.waitForTimeout(2000);
+
+  const wrappers = await page.locator('.slide-wrapper').all();
+
+  if (wrappers.length !== 6) {
+    console.error(`Expected 6 slides, found ${wrappers.length}`);
+    await browser.close();
+    process.exit(1);
+  }
+
+  for (const slide of SLIDES) {
+    const wrapper = wrappers[slide.index - 1];
+    const slideEl = wrapper.locator('.slide');
+
+    const outPath = join(outDir, `${slide.name}.png`);
+
+    await slideEl.screenshot({
+      path: outPath,
+      type: 'png',
+    });
+
+    console.log(`✓ ${slide.name}.png (${WIDTH}×${HEIGHT})`);
+  }
+
+  await browser.close();
+  console.log(`\nDone — ${SLIDES.length} screenshots saved to web/ph-gallery/`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `scripts/screenshot-gallery.mjs` — Playwright script that captures 6 Product Hunt gallery slides (1270x760 PNGs) from `web/ph-gallery.html`
- Add LinkedIn post draft as Section 7 in `LAUNCH_POSTS.md` (2166 chars, under 3000 limit)
- Add `web/ph-gallery/` to `.gitignore` (generated assets)

## Technical readiness verified
- Auth service health: 200
- All key links live (homepage, docs, signup, GitHub)
- Packages verified on npm (v0.1.5), PyPI (v0.1.5), Go proxy (v0.1.0)
- JWKS endpoint live with RS256 key
- **Conformance suite: 39/39 tests passed** against production

## Test plan
- [ ] Run `npx playwright install chromium && node scripts/screenshot-gallery.mjs` and verify 6 PNGs in `web/ph-gallery/`
- [ ] Verify LinkedIn post in LAUNCH_POSTS.md is under 3000 chars
- [ ] Verify `web/ph-gallery/` is gitignored