### PR TITLE
feat: add service provider adapters and gateway packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ Service providers implement scope definitions for their APIs. Agents declare whi
 
 | Framework | Package | Install | Status |
 |-----------|---------|---------|--------|
+| **Adapters** | `@grantex/adapters` | `npm install @grantex/adapters` | ✅ Shipped |
+| **Gateway** | `@grantex/gateway` | `npm install @grantex/gateway` | ✅ Shipped |
 | **Express.js** | `@grantex/express` | `npm install @grantex/express` | ✅ Shipped |
 | **FastAPI** | `grantex-fastapi` | `pip install grantex-fastapi` | ✅ Shipped |
 | **LangChain** | `@grantex/langchain` | `npm install @grantex/langchain` | ✅ Shipped |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -211,6 +211,13 @@
             ]
           },
           {
+            "group": "Service Providers",
+            "pages": [
+              "integrations/adapters",
+              "integrations/gateway"
+            ]
+          },
+          {
             "group": "Framework Integrations",
             "pages": [
               "integrations/express",

--- a/docs/integrations/adapters.mdx
+++ b/docs/integrations/adapters.mdx
@@ -1,0 +1,196 @@
+---
+title: "Service Provider Adapters"
+sidebarTitle: "Adapters"
+description: "Pre-built integrations that translate Grantex grants into real API calls."
+---
+
+## Overview
+
+`@grantex/adapters` provides pre-built adapters for popular APIs — Google Calendar, Gmail, Stripe, and Slack. Each adapter verifies grant tokens offline (JWKS), checks scopes, enforces constraints, and calls the upstream API.
+
+```bash
+npm install @grantex/adapters @grantex/sdk
+```
+
+## Google Calendar
+
+Scopes: `calendar:read`, `calendar:write`
+
+```typescript
+import { GoogleCalendarAdapter } from '@grantex/adapters';
+
+const calendar = new GoogleCalendarAdapter({
+  jwksUri: 'https://your-auth-server/.well-known/jwks.json',
+  credentials: process.env.GOOGLE_ACCESS_TOKEN,
+});
+
+// List events (requires calendar:read)
+const events = await calendar.listEvents(grantToken, {
+  timeMin: new Date().toISOString(),
+  maxResults: 10,
+});
+
+// Create event (requires calendar:write)
+const created = await calendar.createEvent(grantToken, {
+  summary: 'Team Sync',
+  start: { dateTime: '2026-03-01T10:00:00Z' },
+  end: { dateTime: '2026-03-01T11:00:00Z' },
+});
+```
+
+## Gmail
+
+Scopes: `email:read`, `email:send`
+
+```typescript
+import { GmailAdapter } from '@grantex/adapters';
+
+const gmail = new GmailAdapter({ jwksUri, credentials });
+
+// List messages (requires email:read)
+const messages = await gmail.listMessages(grantToken, { q: 'from:alice' });
+
+// Send message (requires email:send)
+await gmail.sendMessage(grantToken, {
+  to: 'bob@example.com',
+  subject: 'Hello',
+  body: 'Hi Bob!',
+});
+```
+
+## Stripe
+
+Scopes: `payments:read`, `payments:initiate`
+
+Supports constraint enforcement — `payments:initiate:max_500` limits payments to $500.
+
+```typescript
+import { StripeAdapter } from '@grantex/adapters';
+
+const stripe = new StripeAdapter({
+  jwksUri,
+  credentials: process.env.STRIPE_SECRET_KEY,
+});
+
+// List payment intents (requires payments:read)
+const intents = await stripe.listPaymentIntents(grantToken, { limit: 10 });
+
+// Create payment intent (requires payments:initiate)
+// If grant has payments:initiate:max_500, amount must be <= $500
+await stripe.createPaymentIntent(grantToken, {
+  amount: 10000, // $100 in cents
+  currency: 'usd',
+});
+```
+
+## Slack
+
+Scopes: `notifications:send`, `notifications:read`
+
+```typescript
+import { SlackAdapter } from '@grantex/adapters';
+
+const slack = new SlackAdapter({
+  jwksUri,
+  credentials: process.env.SLACK_BOT_TOKEN,
+});
+
+// Send message (requires notifications:send)
+await slack.sendMessage(grantToken, {
+  channel: 'C123ABC',
+  text: 'Hello from agent!',
+});
+
+// List messages (requires notifications:read)
+const history = await slack.listMessages(grantToken, {
+  channel: 'C123ABC',
+  limit: 20,
+});
+```
+
+## Constraint Enforcement
+
+Scopes can include constraints that adapters enforce automatically:
+
+| Constraint | Meaning | Example |
+|-----------|---------|---------|
+| `max_N` | Value must be &lt;= N | `payments:initiate:max_500` — max $500 |
+| `min_N` | Value must be &gt;= N | `payments:initiate:min_10` — min $10 |
+| `limit_N` | Count must be &lt;= N | `api:calls:limit_1000` — max 1000 calls |
+
+```typescript
+import { parseScope, enforceConstraint } from '@grantex/adapters';
+
+const parsed = parseScope('payments:initiate:max_500');
+// { baseScope: 'payments:initiate', constraint: { type: 'max', value: 500 } }
+
+const result = enforceConstraint(parsed, 600);
+// { allowed: false, reason: 'Value 600 exceeds maximum 500' }
+```
+
+## Dynamic Credentials
+
+Pass an async function instead of a static string:
+
+```typescript
+const calendar = new GoogleCalendarAdapter({
+  jwksUri,
+  credentials: async () => {
+    return await refreshGoogleToken(serviceAccountId);
+  },
+});
+```
+
+## Audit Logging
+
+Connect adapters to Grantex audit:
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey, baseUrl });
+
+const stripe = new StripeAdapter({
+  jwksUri,
+  credentials: stripeKey,
+  auditLogger: (params) => grantex.audit.log(params),
+});
+```
+
+## Building Custom Adapters
+
+Extend `BaseAdapter` to integrate any API:
+
+```typescript
+import { BaseAdapter } from '@grantex/adapters';
+import type { AdapterConfig, AdapterResult } from '@grantex/adapters';
+
+class MyApiAdapter extends BaseAdapter {
+  constructor(config: AdapterConfig) {
+    super(config);
+  }
+
+  async getData(token: string): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'myapi:read');
+    const credential = await this.resolveCredential();
+
+    const data = await this.callUpstream('https://api.myservice.com/data', {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${credential}` },
+    });
+
+    await this.logAudit(grant, 'myapi:getData', 'success');
+    return this.wrapResult(grant, data);
+  }
+}
+```
+
+## Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `TOKEN_INVALID` | Grant token verification failed |
+| `SCOPE_MISSING` | Grant doesn't include required scope |
+| `CONSTRAINT_VIOLATED` | Value exceeds scope constraint |
+| `UPSTREAM_ERROR` | Upstream API returned an error |
+| `CREDENTIAL_ERROR` | Failed to resolve credentials |

--- a/docs/integrations/gateway.mdx
+++ b/docs/integrations/gateway.mdx
@@ -1,0 +1,187 @@
+---
+title: "Grantex Gateway"
+sidebarTitle: "Gateway"
+description: "Zero-code reverse-proxy that enforces grant tokens in front of any API."
+---
+
+## Overview
+
+`@grantex/gateway` is a standalone reverse-proxy that enforces Grantex grant tokens in front of any upstream API. Define routes and required scopes in a YAML config — no code required.
+
+```bash
+npm install @grantex/gateway @grantex/sdk
+```
+
+## Quick Start
+
+**1. Create `gateway.yaml`:**
+
+```yaml
+upstream: https://api.internal.example.com
+jwksUri: https://your-auth-server/.well-known/jwks.json
+port: 8080
+upstreamHeaders:
+  X-Internal-Auth: "secret-key"
+routes:
+  - path: /calendar/**
+    methods: [GET]
+    requiredScopes: [calendar:read]
+  - path: /calendar/**
+    methods: [POST, PUT, PATCH]
+    requiredScopes: [calendar:write]
+  - path: /payments/**
+    methods: [POST]
+    requiredScopes: [payments:initiate]
+```
+
+**2. Start the gateway:**
+
+```bash
+npx @grantex/gateway --config gateway.yaml
+```
+
+**3. Make requests with grant tokens:**
+
+```bash
+curl -H "Authorization: Bearer <grant-token>" \
+  http://localhost:8080/calendar/events
+```
+
+## How It Works
+
+```
+Client → Gateway (verify token + check scopes) → Upstream API
+```
+
+1. **Route matching** — finds the first route matching the request method + path
+2. **Token verification** — extracts Bearer token and verifies offline via JWKS
+3. **Scope checking** — ensures the grant includes all required scopes
+4. **Proxy** — strips Authorization header, adds upstream headers + `X-Grantex-*` context, forwards to upstream
+5. **Response** — returns the upstream response to the client
+
+## YAML Config Reference
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `upstream` | string | Yes | — | Base URL of the upstream API |
+| `jwksUri` | string | Yes | — | JWKS endpoint for offline verification |
+| `port` | number | No | 8080 | Listen port |
+| `upstreamHeaders` | object | No | — | Headers added to every upstream request |
+| `grantexApiKey` | string | No | — | API key for audit logging |
+| `routes` | array | Yes | — | Route definitions |
+
+### Route Definition
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | string | URL pattern. `*` matches one segment, `**` matches any depth |
+| `methods` | string[] | HTTP methods (GET, POST, PUT, PATCH, DELETE) |
+| `requiredScopes` | string[] | Scopes that must be present in the grant |
+
+### Path Matching
+
+| Pattern | Matches | Does Not Match |
+|---------|---------|----------------|
+| `/users/*` | `/users/123` | `/users/123/profile` |
+| `/calendar/**` | `/calendar/events`, `/calendar/events/123/attendees` | `/api/calendar` |
+| `/health` | `/health` | `/health/check` |
+
+## Context Headers
+
+The gateway adds these headers to every upstream request:
+
+| Header | Value |
+|--------|-------|
+| `X-Grantex-Principal` | Principal ID (end-user) |
+| `X-Grantex-Agent` | Agent DID |
+| `X-Grantex-GrantId` | Grant ID |
+
+Your upstream API can use these to apply fine-grained business logic without re-verifying the token.
+
+## Error Responses
+
+All errors return JSON with `error` and `message` fields:
+
+| Status | Error Code | When |
+|--------|-----------|------|
+| 404 | `ROUTE_NOT_FOUND` | No route matches the request |
+| 401 | `TOKEN_MISSING` | No Bearer token in Authorization header |
+| 401 | `TOKEN_INVALID` | Token signature verification failed |
+| 401 | `TOKEN_EXPIRED` | Token has expired |
+| 403 | `SCOPE_INSUFFICIENT` | Grant doesn't include required scopes |
+| 502 | `UPSTREAM_ERROR` | Upstream API is unreachable |
+
+## CLI Usage
+
+```bash
+# Start with config file
+npx @grantex/gateway --config gateway.yaml
+
+# Short flag
+npx @grantex/gateway -c gateway.yaml
+
+# Default: looks for gateway.yaml in current directory
+npx @grantex/gateway
+```
+
+## Library API
+
+Use the gateway programmatically in your own server:
+
+```typescript
+import { createGatewayServer, loadConfig } from '@grantex/gateway';
+
+const config = loadConfig('./gateway.yaml');
+const server = createGatewayServer(config);
+
+await server.listen({ port: config.port, host: '0.0.0.0' });
+```
+
+## Docker Deployment
+
+```dockerfile
+FROM node:20-slim AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --ignore-scripts
+COPY tsconfig*.json ./
+COPY src/ src/
+RUN npm run build
+
+FROM node:20-slim
+WORKDIR /app
+COPY --from=builder /app/package*.json ./
+RUN npm ci --omit=dev --ignore-scripts
+COPY --from=builder /app/dist/ dist/
+EXPOSE 8080
+ENTRYPOINT ["node", "dist/cli.js"]
+CMD ["--config", "/etc/grantex/gateway.yaml"]
+```
+
+```bash
+docker build -t grantex-gateway .
+docker run -p 8080:8080 -v ./gateway.yaml:/etc/grantex/gateway.yaml grantex-gateway
+```
+
+## Example: Protecting a Calendar API
+
+```yaml
+upstream: https://calendar-api.internal.svc
+jwksUri: https://grantex-auth-dd4mtrt2gq-uc.a.run.app/.well-known/jwks.json
+port: 8080
+upstreamHeaders:
+  X-Service-Key: "calendar-internal-key"
+routes:
+  - path: /calendars/*/events
+    methods: [GET]
+    requiredScopes: [calendar:read]
+  - path: /calendars/*/events
+    methods: [POST]
+    requiredScopes: [calendar:write]
+  - path: /calendars/*/events/*
+    methods: [PUT, PATCH]
+    requiredScopes: [calendar:write]
+  - path: /calendars/*/events/*
+    methods: [DELETE]
+    requiredScopes: [calendar:delete]
+```

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -7,6 +7,12 @@ description: "Grantex integrates with every major AI agent framework."
 ## Available Integrations
 
 <CardGroup cols={2}>
+  <Card title="Service Provider Adapters" icon="puzzle-piece" href="/integrations/adapters">
+    Pre-built integrations for Google Calendar, Gmail, Stripe, and Slack.
+  </Card>
+  <Card title="Grantex Gateway" icon="shield-halved" href="/integrations/gateway">
+    Zero-code reverse-proxy that enforces grant tokens via YAML config.
+  </Card>
   <Card title="Express.js" icon="server" href="/integrations/express">
     Grant token verification and scope-based authorization middleware.
   </Card>
@@ -46,6 +52,8 @@ description: "Grantex integrates with every major AI agent framework."
 
 | Framework | Package | Install | Language |
 |-----------|---------|---------|----------|
+| Adapters | `@grantex/adapters` | `npm install @grantex/adapters` | TypeScript |
+| Gateway | `@grantex/gateway` | `npm install @grantex/gateway` | TypeScript |
 | Express.js | `@grantex/express` | `npm install @grantex/express` | TypeScript |
 | FastAPI | `grantex-fastapi` | `pip install grantex-fastapi` | Python |
 | MCP | `@grantex/mcp` | `npm install -g @grantex/mcp` | TypeScript |

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -1,0 +1,219 @@
+# @grantex/adapters
+
+Pre-built service provider adapters for [Grantex](https://grantex.dev) — translate grant tokens into real API calls for Google Calendar, Gmail, Stripe, and Slack.
+
+## Install
+
+```bash
+npm install @grantex/adapters @grantex/sdk
+```
+
+## Quick Start
+
+```typescript
+import { GoogleCalendarAdapter } from '@grantex/adapters';
+
+const calendar = new GoogleCalendarAdapter({
+  jwksUri: 'https://your-auth-server/.well-known/jwks.json',
+  credentials: process.env.GOOGLE_ACCESS_TOKEN!,
+});
+
+// Agent presents a grant token — adapter verifies it, checks scopes, calls Google API
+const result = await calendar.listEvents(grantToken, {
+  timeMin: new Date().toISOString(),
+  maxResults: 10,
+});
+
+if (result.success) {
+  console.log(result.data); // Google Calendar API response
+}
+```
+
+## Adapters
+
+### Google Calendar
+
+Requires scopes: `calendar:read`, `calendar:write`
+
+```typescript
+import { GoogleCalendarAdapter } from '@grantex/adapters';
+
+const calendar = new GoogleCalendarAdapter({ jwksUri, credentials });
+
+// List events (requires calendar:read)
+await calendar.listEvents(token, { calendarId: 'primary', maxResults: 10 });
+
+// Create event (requires calendar:write)
+await calendar.createEvent(token, {
+  summary: 'Team Sync',
+  start: { dateTime: '2026-03-01T10:00:00Z' },
+  end: { dateTime: '2026-03-01T11:00:00Z' },
+});
+```
+
+### Gmail
+
+Requires scopes: `email:read`, `email:send`
+
+```typescript
+import { GmailAdapter } from '@grantex/adapters';
+
+const gmail = new GmailAdapter({ jwksUri, credentials });
+
+// List messages (requires email:read)
+await gmail.listMessages(token, { q: 'from:alice', maxResults: 5 });
+
+// Send message (requires email:send)
+await gmail.sendMessage(token, {
+  to: 'bob@example.com',
+  subject: 'Hello',
+  body: 'Hi Bob!',
+});
+```
+
+### Stripe
+
+Requires scopes: `payments:read`, `payments:initiate`
+
+Supports constraint enforcement — `payments:initiate:max_500` limits payments to $500.
+
+```typescript
+import { StripeAdapter } from '@grantex/adapters';
+
+const stripe = new StripeAdapter({ jwksUri, credentials: process.env.STRIPE_SECRET_KEY! });
+
+// List payment intents (requires payments:read)
+await stripe.listPaymentIntents(token, { limit: 10 });
+
+// Create payment intent (requires payments:initiate)
+// If grant has payments:initiate:max_500, amount must be <= $500 (50000 cents)
+await stripe.createPaymentIntent(token, {
+  amount: 10000, // $100 in cents
+  currency: 'usd',
+});
+```
+
+### Slack
+
+Requires scopes: `notifications:send`, `notifications:read`
+
+```typescript
+import { SlackAdapter } from '@grantex/adapters';
+
+const slack = new SlackAdapter({ jwksUri, credentials: process.env.SLACK_BOT_TOKEN! });
+
+// Send message (requires notifications:send)
+await slack.sendMessage(token, { channel: 'C123ABC', text: 'Hello from agent!' });
+
+// List messages (requires notifications:read)
+await slack.listMessages(token, { channel: 'C123ABC', limit: 20 });
+```
+
+## Configuration
+
+```typescript
+interface AdapterConfig {
+  jwksUri: string;             // JWKS endpoint for offline token verification
+  credentials: CredentialProvider; // API key/token (string or async function)
+  auditLogger?: AuditLogger;   // Optional audit logging callback
+  clockTolerance?: number;     // JWT clock skew tolerance in seconds
+  timeout?: number;            // Upstream request timeout in ms (default: 30000)
+}
+```
+
+### Dynamic Credentials
+
+```typescript
+const calendar = new GoogleCalendarAdapter({
+  jwksUri,
+  credentials: async () => {
+    // Fetch a fresh access token from your token store
+    return await refreshGoogleToken(serviceAccountId);
+  },
+});
+```
+
+### Audit Logging
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey, baseUrl });
+
+const stripe = new StripeAdapter({
+  jwksUri,
+  credentials: stripeKey,
+  auditLogger: (params) => grantex.audit.log(params),
+});
+```
+
+## Constraint Enforcement
+
+Scopes can include constraints like `payments:initiate:max_500`:
+
+| Constraint | Meaning | Example |
+|-----------|---------|---------|
+| `max_N` | Value must be <= N | `payments:initiate:max_500` — max $500 |
+| `min_N` | Value must be >= N | `payments:initiate:min_10` — min $10 |
+| `limit_N` | Count must be <= N | `api:calls:limit_1000` — max 1000 calls |
+
+## Error Handling
+
+All adapters throw `GrantexAdapterError` with typed error codes:
+
+| Code | Meaning |
+|------|---------|
+| `TOKEN_INVALID` | Grant token verification failed |
+| `SCOPE_MISSING` | Grant doesn't include required scope |
+| `CONSTRAINT_VIOLATED` | Value exceeds scope constraint |
+| `UPSTREAM_ERROR` | Upstream API returned an error |
+| `CREDENTIAL_ERROR` | Failed to resolve credentials |
+
+```typescript
+import { GrantexAdapterError } from '@grantex/adapters';
+
+try {
+  await stripe.createPaymentIntent(token, { amount: 100000, currency: 'usd' });
+} catch (err) {
+  if (err instanceof GrantexAdapterError) {
+    console.error(err.code, err.message);
+  }
+}
+```
+
+## Custom Adapters
+
+Extend `BaseAdapter` to build your own:
+
+```typescript
+import { BaseAdapter } from '@grantex/adapters';
+import type { AdapterConfig, AdapterResult } from '@grantex/adapters';
+
+class MyApiAdapter extends BaseAdapter {
+  constructor(config: AdapterConfig) {
+    super(config);
+  }
+
+  async getData(token: string): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'myapi:read');
+    const credential = await this.resolveCredential();
+
+    const data = await this.callUpstream('https://api.myservice.com/data', {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${credential}` },
+    });
+
+    await this.logAudit(grant, 'myapi:getData', 'success');
+    return this.wrapResult(grant, data);
+  }
+}
+```
+
+## Requirements
+
+- Node.js 18+
+- `@grantex/sdk` >= 0.1.0
+
+## License
+
+Apache-2.0

--- a/packages/adapters/package-lock.json
+++ b/packages/adapters/package-lock.json
@@ -1,0 +1,1875 @@
+{
+  "name": "@grantex/adapters",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@grantex/adapters",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@grantex/sdk": "^0.1.5",
+        "@types/node": "^20.11.0",
+        "typescript": "~5.3.3",
+        "vitest": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@grantex/sdk": ">=0.1.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grantex/sdk": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@grantex/sdk/-/sdk-0.1.5.tgz",
+      "integrity": "sha512-Xc3k+ap0b4dM+LnNF9Dvhw8dnjittC3JFFruvLJvz3XRZTS6pCKTsZH68KWSYz1yCgaqS59Hr8A7dhC+svgTOA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jose": "^5.2.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
+      "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@grantex/adapters",
+  "version": "0.1.0",
+  "description": "Pre-built service provider adapters for Grantex — Google Calendar, Gmail, Stripe, Slack",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "@grantex/sdk": ">=0.1.0"
+  },
+  "devDependencies": {
+    "@grantex/sdk": "^0.1.5",
+    "@types/node": "^20.11.0",
+    "typescript": "~5.3.3",
+    "vitest": "^1.3.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mishrasanjeev/grantex.git",
+    "directory": "packages/adapters"
+  },
+  "keywords": [
+    "grantex",
+    "adapters",
+    "google-calendar",
+    "gmail",
+    "stripe",
+    "slack",
+    "authorization",
+    "ai-agents"
+  ]
+}

--- a/packages/adapters/src/adapters/gmail.ts
+++ b/packages/adapters/src/adapters/gmail.ts
@@ -1,0 +1,82 @@
+import type { AdapterConfig, AdapterResult, ListMessagesParams, SendMessageParams } from '../types.js';
+import { BaseAdapter } from '../base-adapter.js';
+import { GrantexAdapterError } from '../errors.js';
+
+const GMAIL_API = 'https://gmail.googleapis.com/gmail/v1';
+
+export class GmailAdapter extends BaseAdapter {
+  constructor(config: AdapterConfig) {
+    super(config);
+  }
+
+  async listMessages(
+    token: string,
+    params: ListMessagesParams = {},
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'email:read');
+    const credential = await this.resolveCredential();
+
+    const query = new URLSearchParams();
+    if (params.q) query.set('q', params.q);
+    if (params.maxResults) query.set('maxResults', String(params.maxResults));
+    if (params.labelIds) {
+      for (const label of params.labelIds) {
+        query.append('labelIds', label);
+      }
+    }
+
+    const qs = query.toString();
+    const url = `${GMAIL_API}/users/me/messages${qs ? `?${qs}` : ''}`;
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${credential}` },
+      });
+      await this.logAudit(grant, 'email:listMessages', 'success');
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'email:listMessages', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Gmail list failed: ${String(err)}`);
+    }
+  }
+
+  async sendMessage(
+    token: string,
+    params: SendMessageParams,
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'email:send');
+    const credential = await this.resolveCredential();
+
+    const mimeLines = [
+      `To: ${params.to}`,
+      `Subject: ${params.subject}`,
+      ...(params.cc !== undefined ? [`Cc: ${params.cc}`] : []),
+      ...(params.bcc !== undefined ? [`Bcc: ${params.bcc}`] : []),
+      'Content-Type: text/plain; charset=utf-8',
+      '',
+      params.body,
+    ];
+    const raw = Buffer.from(mimeLines.join('\r\n')).toString('base64url');
+
+    const url = `${GMAIL_API}/users/me/messages/send`;
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${credential}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ raw }),
+      });
+      await this.logAudit(grant, 'email:sendMessage', 'success', { to: params.to });
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'email:sendMessage', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Gmail send failed: ${String(err)}`);
+    }
+  }
+}

--- a/packages/adapters/src/adapters/google-calendar.ts
+++ b/packages/adapters/src/adapters/google-calendar.ts
@@ -1,0 +1,77 @@
+import type { AdapterConfig, AdapterResult, ListEventsParams, CreateEventParams } from '../types.js';
+import { BaseAdapter } from '../base-adapter.js';
+import { GrantexAdapterError } from '../errors.js';
+
+const CALENDAR_API = 'https://www.googleapis.com/calendar/v3';
+
+export class GoogleCalendarAdapter extends BaseAdapter {
+  constructor(config: AdapterConfig) {
+    super(config);
+  }
+
+  async listEvents(
+    token: string,
+    params: ListEventsParams = {},
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'calendar:read');
+    const credential = await this.resolveCredential();
+
+    const calendarId = encodeURIComponent(params.calendarId ?? 'primary');
+    const query = new URLSearchParams();
+    if (params.timeMin) query.set('timeMin', params.timeMin);
+    if (params.timeMax) query.set('timeMax', params.timeMax);
+    if (params.maxResults) query.set('maxResults', String(params.maxResults));
+
+    const qs = query.toString();
+    const url = `${CALENDAR_API}/calendars/${calendarId}/events${qs ? `?${qs}` : ''}`;
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${credential}` },
+      });
+      await this.logAudit(grant, 'calendar:listEvents', 'success', { calendarId: params.calendarId ?? 'primary' });
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'calendar:listEvents', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Calendar list failed: ${String(err)}`);
+    }
+  }
+
+  async createEvent(
+    token: string,
+    params: CreateEventParams,
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'calendar:write');
+    const credential = await this.resolveCredential();
+
+    const calendarId = encodeURIComponent(params.calendarId ?? 'primary');
+    const url = `${CALENDAR_API}/calendars/${calendarId}/events`;
+
+    const body = {
+      summary: params.summary,
+      start: params.start,
+      end: params.end,
+      ...(params.description !== undefined ? { description: params.description } : {}),
+      ...(params.attendees !== undefined ? { attendees: params.attendees } : {}),
+    };
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${credential}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      await this.logAudit(grant, 'calendar:createEvent', 'success', { calendarId: params.calendarId ?? 'primary' });
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'calendar:createEvent', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Calendar create failed: ${String(err)}`);
+    }
+  }
+}

--- a/packages/adapters/src/adapters/slack.ts
+++ b/packages/adapters/src/adapters/slack.ts
@@ -1,0 +1,86 @@
+import type { AdapterConfig, AdapterResult, SlackSendMessageParams, SlackListMessagesParams } from '../types.js';
+import { BaseAdapter } from '../base-adapter.js';
+import { GrantexAdapterError } from '../errors.js';
+
+const SLACK_API = 'https://slack.com/api';
+
+export class SlackAdapter extends BaseAdapter {
+  constructor(config: AdapterConfig) {
+    super(config);
+  }
+
+  async sendMessage(
+    token: string,
+    params: SlackSendMessageParams,
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'notifications:send');
+    const credential = await this.resolveCredential();
+
+    const url = `${SLACK_API}/chat.postMessage`;
+
+    const body: Record<string, unknown> = {
+      channel: params.channel,
+      text: params.text,
+    };
+    if (params.thread_ts !== undefined) {
+      body['thread_ts'] = params.thread_ts;
+    }
+
+    try {
+      const data = await this.callUpstream<{ ok: boolean; error?: string }>(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${credential}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+
+      // Slack returns 200 even for errors, check the `ok` field
+      if (!data.ok) {
+        throw new GrantexAdapterError('UPSTREAM_ERROR', `Slack API error: ${data.error ?? 'unknown'}`);
+      }
+
+      await this.logAudit(grant, 'notifications:sendMessage', 'success', { channel: params.channel });
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'notifications:sendMessage', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Slack send failed: ${String(err)}`);
+    }
+  }
+
+  async listMessages(
+    token: string,
+    params: SlackListMessagesParams,
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'notifications:read');
+    const credential = await this.resolveCredential();
+
+    const query = new URLSearchParams();
+    query.set('channel', params.channel);
+    if (params.limit) query.set('limit', String(params.limit));
+    if (params.oldest) query.set('oldest', params.oldest);
+    if (params.latest) query.set('latest', params.latest);
+
+    const url = `${SLACK_API}/conversations.history?${query.toString()}`;
+
+    try {
+      const data = await this.callUpstream<{ ok: boolean; error?: string }>(url, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${credential}` },
+      });
+
+      if (!data.ok) {
+        throw new GrantexAdapterError('UPSTREAM_ERROR', `Slack API error: ${data.error ?? 'unknown'}`);
+      }
+
+      await this.logAudit(grant, 'notifications:listMessages', 'success', { channel: params.channel });
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'notifications:listMessages', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Slack list failed: ${String(err)}`);
+    }
+  }
+}

--- a/packages/adapters/src/adapters/stripe.ts
+++ b/packages/adapters/src/adapters/stripe.ts
@@ -1,0 +1,96 @@
+import type { AdapterConfig, AdapterResult, ListPaymentIntentsParams, CreatePaymentIntentParams } from '../types.js';
+import { BaseAdapter } from '../base-adapter.js';
+import { enforceConstraint } from '../scope-utils.js';
+import { GrantexAdapterError } from '../errors.js';
+
+const STRIPE_API = 'https://api.stripe.com/v1';
+
+export class StripeAdapter extends BaseAdapter {
+  constructor(config: AdapterConfig) {
+    super(config);
+  }
+
+  async listPaymentIntents(
+    token: string,
+    params: ListPaymentIntentsParams = {},
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'payments:read');
+    const credential = await this.resolveCredential();
+
+    const query = new URLSearchParams();
+    if (params.limit) query.set('limit', String(params.limit));
+    if (params.customer) query.set('customer', params.customer);
+    if (params.starting_after) query.set('starting_after', params.starting_after);
+
+    const qs = query.toString();
+    const url = `${STRIPE_API}/payment_intents${qs ? `?${qs}` : ''}`;
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${credential}` },
+      });
+      await this.logAudit(grant, 'payments:listPaymentIntents', 'success');
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'payments:listPaymentIntents', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Stripe list failed: ${String(err)}`);
+    }
+  }
+
+  async createPaymentIntent(
+    token: string,
+    params: CreatePaymentIntentParams,
+  ): Promise<AdapterResult> {
+    const { grant, matchedScope } = await this.verifyAndCheckScope(token, 'payments:initiate');
+    const credential = await this.resolveCredential();
+
+    // Enforce constraint: max_500 means max $500 = max 50000 cents
+    // The constraint value is in dollars, params.amount is in cents
+    if (matchedScope.constraint) {
+      const amountInDollars = params.amount / 100;
+      const result = enforceConstraint(matchedScope, amountInDollars);
+      if (!result.allowed) {
+        await this.logAudit(grant, 'payments:createPaymentIntent', 'blocked', {
+          amount: params.amount,
+          constraint: matchedScope.constraint,
+        });
+        throw new GrantexAdapterError('CONSTRAINT_VIOLATED', result.reason!);
+      }
+    }
+
+    const formData = new URLSearchParams();
+    formData.set('amount', String(params.amount));
+    formData.set('currency', params.currency);
+    if (params.customer) formData.set('customer', params.customer);
+    if (params.description) formData.set('description', params.description);
+    if (params.metadata) {
+      for (const [key, value] of Object.entries(params.metadata)) {
+        formData.set(`metadata[${key}]`, value);
+      }
+    }
+
+    const url = `${STRIPE_API}/payment_intents`;
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${credential}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: formData.toString(),
+      });
+      await this.logAudit(grant, 'payments:createPaymentIntent', 'success', {
+        amount: params.amount,
+        currency: params.currency,
+      });
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'payments:createPaymentIntent', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Stripe create failed: ${String(err)}`);
+    }
+  }
+}

--- a/packages/adapters/src/base-adapter.ts
+++ b/packages/adapters/src/base-adapter.ts
@@ -1,0 +1,123 @@
+import { verifyGrantToken, type VerifiedGrant } from '@grantex/sdk';
+import type { AdapterConfig, AdapterResult, CredentialProvider, AuditLogger } from './types.js';
+import { findMatchingScope, type ParsedScope } from './scope-utils.js';
+import { GrantexAdapterError } from './errors.js';
+
+export abstract class BaseAdapter {
+  protected readonly jwksUri: string;
+  protected readonly credentials: CredentialProvider;
+  protected readonly auditLogger?: AuditLogger;
+  protected readonly clockTolerance?: number;
+  protected readonly timeout: number;
+
+  constructor(config: AdapterConfig) {
+    this.jwksUri = config.jwksUri;
+    this.credentials = config.credentials;
+    this.auditLogger = config.auditLogger;
+    this.clockTolerance = config.clockTolerance;
+    this.timeout = config.timeout ?? 30_000;
+  }
+
+  protected async verifyAndCheckScope(
+    token: string,
+    requiredScope: string,
+  ): Promise<{ grant: VerifiedGrant; matchedScope: ParsedScope }> {
+    let grant: VerifiedGrant;
+    try {
+      grant = await verifyGrantToken(token, {
+        jwksUri: this.jwksUri,
+        ...(this.clockTolerance !== undefined ? { clockTolerance: this.clockTolerance } : {}),
+      });
+    } catch {
+      throw new GrantexAdapterError('TOKEN_INVALID', 'Grant token verification failed');
+    }
+
+    const matchedScope = findMatchingScope(grant.scopes, requiredScope);
+    if (!matchedScope) {
+      throw new GrantexAdapterError(
+        'SCOPE_MISSING',
+        `Grant does not include required scope: ${requiredScope}`,
+      );
+    }
+
+    return { grant, matchedScope };
+  }
+
+  protected async resolveCredential(): Promise<string> {
+    try {
+      if (typeof this.credentials === 'string') {
+        return this.credentials;
+      }
+      return await this.credentials();
+    } catch {
+      throw new GrantexAdapterError('CREDENTIAL_ERROR', 'Failed to resolve credentials');
+    }
+  }
+
+  protected async logAudit(
+    grant: VerifiedGrant,
+    action: string,
+    status: 'success' | 'failure' | 'blocked',
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    if (!this.auditLogger) return;
+    try {
+      await this.auditLogger({
+        agentId: grant.agentDid,
+        grantId: grant.grantId,
+        action,
+        status,
+        ...(metadata !== undefined ? { metadata } : {}),
+      });
+    } catch {
+      // Audit logging is best-effort
+    }
+  }
+
+  protected async callUpstream<T>(
+    url: string,
+    options: RequestInit,
+  ): Promise<T> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      const response = await fetch(url, {
+        ...options,
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        throw new GrantexAdapterError(
+          'UPSTREAM_ERROR',
+          `Upstream API returned ${response.status}: ${body}`,
+        );
+      }
+
+      return (await response.json()) as T;
+    } catch (err) {
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError(
+        'UPSTREAM_ERROR',
+        `Upstream request failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  protected wrapResult<T>(
+    grant: VerifiedGrant,
+    data: T,
+  ): AdapterResult<T> {
+    return { success: true, data, grant };
+  }
+
+  protected wrapError(
+    grant: VerifiedGrant,
+    error: string,
+  ): AdapterResult {
+    return { success: false, error, grant };
+  }
+}

--- a/packages/adapters/src/errors.ts
+++ b/packages/adapters/src/errors.ts
@@ -1,0 +1,16 @@
+export type AdapterErrorCode =
+  | 'SCOPE_MISSING'
+  | 'CONSTRAINT_VIOLATED'
+  | 'TOKEN_INVALID'
+  | 'UPSTREAM_ERROR'
+  | 'CREDENTIAL_ERROR';
+
+export class GrantexAdapterError extends Error {
+  readonly code: AdapterErrorCode;
+
+  constructor(code: AdapterErrorCode, message: string) {
+    super(message);
+    this.code = code;
+    Object.setPrototypeOf(this, GrantexAdapterError.prototype);
+  }
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,0 +1,23 @@
+export { GoogleCalendarAdapter } from './adapters/google-calendar.js';
+export { GmailAdapter } from './adapters/gmail.js';
+export { StripeAdapter } from './adapters/stripe.js';
+export { SlackAdapter } from './adapters/slack.js';
+export { BaseAdapter } from './base-adapter.js';
+export { GrantexAdapterError } from './errors.js';
+export { parseScope, findMatchingScope, enforceConstraint } from './scope-utils.js';
+export type { ParsedScope } from './scope-utils.js';
+export type { AdapterErrorCode } from './errors.js';
+export type {
+  AdapterConfig,
+  AdapterResult,
+  CredentialProvider,
+  AuditLogger,
+  ListEventsParams,
+  CreateEventParams,
+  ListMessagesParams,
+  SendMessageParams,
+  ListPaymentIntentsParams,
+  CreatePaymentIntentParams,
+  SlackSendMessageParams,
+  SlackListMessagesParams,
+} from './types.js';

--- a/packages/adapters/src/scope-utils.ts
+++ b/packages/adapters/src/scope-utils.ts
@@ -1,0 +1,80 @@
+export interface ParsedScope {
+  baseScope: string;
+  constraint?: { type: string; value: number };
+}
+
+export function parseScope(scope: string): ParsedScope {
+  const parts = scope.split(':');
+  if (parts.length < 2) {
+    return { baseScope: scope };
+  }
+
+  const lastPart = parts[parts.length - 1]!;
+  const constraintMatch = lastPart.match(/^(max|min|limit)_(\d+)$/);
+
+  if (constraintMatch) {
+    const baseScope = parts.slice(0, -1).join(':');
+    return {
+      baseScope,
+      constraint: {
+        type: constraintMatch[1]!,
+        value: parseInt(constraintMatch[2]!, 10),
+      },
+    };
+  }
+
+  return { baseScope: scope };
+}
+
+export function findMatchingScope(
+  grantedScopes: string[],
+  requiredScope: string,
+): ParsedScope | null {
+  for (const scope of grantedScopes) {
+    const parsed = parseScope(scope);
+    if (parsed.baseScope === requiredScope) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+export function enforceConstraint(
+  parsed: ParsedScope,
+  actualValue: number,
+): { allowed: boolean; reason?: string } {
+  if (!parsed.constraint) {
+    return { allowed: true };
+  }
+
+  const { type, value } = parsed.constraint;
+
+  switch (type) {
+    case 'max':
+      if (actualValue > value) {
+        return {
+          allowed: false,
+          reason: `Value ${actualValue} exceeds maximum ${value}`,
+        };
+      }
+      return { allowed: true };
+    case 'min':
+      if (actualValue < value) {
+        return {
+          allowed: false,
+          reason: `Value ${actualValue} is below minimum ${value}`,
+        };
+      }
+      return { allowed: true };
+    case 'limit':
+      if (actualValue > value) {
+        return {
+          allowed: false,
+          reason: `Value ${actualValue} exceeds limit ${value}`,
+        };
+      }
+      return { allowed: true };
+    default:
+      return { allowed: true };
+  }
+}

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -1,0 +1,81 @@
+import type { VerifiedGrant, LogAuditParams } from '@grantex/sdk';
+
+export type CredentialProvider = string | (() => string | Promise<string>);
+
+export type AuditLogger = (params: LogAuditParams) => Promise<void>;
+
+export interface AdapterConfig {
+  jwksUri: string;
+  credentials: CredentialProvider;
+  auditLogger?: AuditLogger;
+  clockTolerance?: number;
+  timeout?: number;
+}
+
+export interface AdapterResult<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  grant: VerifiedGrant;
+}
+
+// Google Calendar types
+export interface ListEventsParams {
+  calendarId?: string;
+  timeMin?: string;
+  timeMax?: string;
+  maxResults?: number;
+}
+
+export interface CreateEventParams {
+  calendarId?: string;
+  summary: string;
+  start: { dateTime: string; timeZone?: string };
+  end: { dateTime: string; timeZone?: string };
+  description?: string;
+  attendees?: Array<{ email: string }>;
+}
+
+// Gmail types
+export interface ListMessagesParams {
+  q?: string;
+  maxResults?: number;
+  labelIds?: string[];
+}
+
+export interface SendMessageParams {
+  to: string;
+  subject: string;
+  body: string;
+  cc?: string;
+  bcc?: string;
+}
+
+// Stripe types
+export interface ListPaymentIntentsParams {
+  limit?: number;
+  customer?: string;
+  starting_after?: string;
+}
+
+export interface CreatePaymentIntentParams {
+  amount: number;
+  currency: string;
+  customer?: string;
+  description?: string;
+  metadata?: Record<string, string>;
+}
+
+// Slack types
+export interface SlackSendMessageParams {
+  channel: string;
+  text: string;
+  thread_ts?: string;
+}
+
+export interface SlackListMessagesParams {
+  channel: string;
+  limit?: number;
+  oldest?: string;
+  latest?: string;
+}

--- a/packages/adapters/tests/adapters/gmail.test.ts
+++ b/packages/adapters/tests/adapters/gmail.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VerifiedGrant } from '@grantex/sdk';
+
+vi.mock('@grantex/sdk', () => ({
+  verifyGrantToken: vi.fn(),
+}));
+
+import { verifyGrantToken } from '@grantex/sdk';
+import { GmailAdapter } from '../../src/adapters/gmail.js';
+import { GrantexAdapterError } from '../../src/errors.js';
+
+const MOCK_GRANT: VerifiedGrant = {
+  tokenId: 'tok_1', grantId: 'grnt_1', principalId: 'user_1',
+  agentDid: 'did:grantex:agent:a1', developerId: 'dev_1',
+  scopes: ['email:read', 'email:send'],
+  issuedAt: Math.floor(Date.now() / 1000),
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+};
+
+describe('GmailAdapter', () => {
+  const adapter = new GmailAdapter({
+    jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+    credentials: 'google-oauth-token',
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+  });
+
+  describe('listMessages', () => {
+    it('lists messages with default params', async () => {
+      const messages = { messages: [{ id: 'msg_1' }] };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(messages),
+      }));
+
+      const result = await adapter.listMessages('token');
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(messages);
+
+      const url = vi.mocked(fetch).mock.calls[0]![0] as string;
+      expect(url).toContain('/users/me/messages');
+    });
+
+    it('passes query and label filters', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ messages: [] }),
+      }));
+
+      await adapter.listMessages('token', {
+        q: 'from:alice',
+        maxResults: 5,
+        labelIds: ['INBOX', 'UNREAD'],
+      });
+
+      const url = vi.mocked(fetch).mock.calls[0]![0] as string;
+      expect(url).toContain('q=from');
+      expect(url).toContain('maxResults=5');
+      expect(url).toContain('labelIds=INBOX');
+      expect(url).toContain('labelIds=UNREAD');
+    });
+
+    it('throws SCOPE_MISSING without email:read', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT, scopes: ['email:send'],
+      });
+
+      await expect(adapter.listMessages('token'))
+        .rejects.toThrow(GrantexAdapterError);
+    });
+
+    it('throws UPSTREAM_ERROR on API failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false, status: 401, text: () => Promise.resolve('Unauthorized'),
+      }));
+
+      try {
+        await adapter.listMessages('token');
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('UPSTREAM_ERROR');
+      }
+    });
+  });
+
+  describe('sendMessage', () => {
+    it('sends message successfully', async () => {
+      const sent = { id: 'msg_sent', threadId: 'thr_1' };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(sent),
+      }));
+
+      const result = await adapter.sendMessage('token', {
+        to: 'bob@example.com',
+        subject: 'Hello',
+        body: 'Hi Bob!',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(sent);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[0]).toContain('/users/me/messages/send');
+      expect(fetchCall[1]?.method).toBe('POST');
+      const body = JSON.parse(fetchCall[1]?.body as string);
+      expect(body.raw).toBeDefined();
+    });
+
+    it('includes cc and bcc in MIME', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ id: 'msg_2' }),
+      }));
+
+      await adapter.sendMessage('token', {
+        to: 'bob@example.com',
+        subject: 'Test',
+        body: 'Hello',
+        cc: 'alice@example.com',
+        bcc: 'charlie@example.com',
+      });
+
+      const body = JSON.parse(vi.mocked(fetch).mock.calls[0]![1]?.body as string);
+      const decoded = Buffer.from(body.raw, 'base64url').toString();
+      expect(decoded).toContain('Cc: alice@example.com');
+      expect(decoded).toContain('Bcc: charlie@example.com');
+    });
+
+    it('throws SCOPE_MISSING without email:send', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT, scopes: ['email:read'],
+      });
+
+      await expect(adapter.sendMessage('token', {
+        to: 'bob@example.com', subject: 'Test', body: 'Hi',
+      })).rejects.toThrow(GrantexAdapterError);
+    });
+
+    it('throws TOKEN_INVALID on verification failure', async () => {
+      vi.mocked(verifyGrantToken).mockRejectedValue(new Error('expired'));
+
+      try {
+        await adapter.sendMessage('bad-token', {
+          to: 'bob@example.com', subject: 'Test', body: 'Hi',
+        });
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('TOKEN_INVALID');
+      }
+    });
+  });
+});

--- a/packages/adapters/tests/adapters/google-calendar.test.ts
+++ b/packages/adapters/tests/adapters/google-calendar.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VerifiedGrant } from '@grantex/sdk';
+
+vi.mock('@grantex/sdk', () => ({
+  verifyGrantToken: vi.fn(),
+}));
+
+import { verifyGrantToken } from '@grantex/sdk';
+import { GoogleCalendarAdapter } from '../../src/adapters/google-calendar.js';
+import { GrantexAdapterError } from '../../src/errors.js';
+
+const MOCK_GRANT: VerifiedGrant = {
+  tokenId: 'tok_1', grantId: 'grnt_1', principalId: 'user_1',
+  agentDid: 'did:grantex:agent:a1', developerId: 'dev_1',
+  scopes: ['calendar:read', 'calendar:write'],
+  issuedAt: Math.floor(Date.now() / 1000),
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+};
+
+describe('GoogleCalendarAdapter', () => {
+  const adapter = new GoogleCalendarAdapter({
+    jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+    credentials: 'google-oauth-token',
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+  });
+
+  describe('listEvents', () => {
+    it('lists events with default calendar', async () => {
+      const events = { items: [{ id: 'evt_1', summary: 'Meeting' }] };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(events),
+      }));
+
+      const result = await adapter.listEvents('grant-token');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(events);
+      expect(result.grant).toBe(MOCK_GRANT);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[0]).toContain('/calendars/primary/events');
+    });
+
+    it('passes query parameters', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ items: [] }),
+      }));
+
+      await adapter.listEvents('grant-token', {
+        calendarId: 'work',
+        timeMin: '2026-01-01T00:00:00Z',
+        maxResults: 10,
+      });
+
+      const url = vi.mocked(fetch).mock.calls[0]![0] as string;
+      expect(url).toContain('/calendars/work/events');
+      expect(url).toContain('timeMin=');
+      expect(url).toContain('maxResults=10');
+    });
+
+    it('throws SCOPE_MISSING without calendar:read', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['email:read'],
+      });
+
+      await expect(adapter.listEvents('token'))
+        .rejects.toThrow(GrantexAdapterError);
+    });
+
+    it('throws TOKEN_INVALID on verification failure', async () => {
+      vi.mocked(verifyGrantToken).mockRejectedValue(new Error('expired'));
+
+      try {
+        await adapter.listEvents('bad-token');
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('TOKEN_INVALID');
+      }
+    });
+
+    it('throws UPSTREAM_ERROR on API failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false, status: 403, text: () => Promise.resolve('Forbidden'),
+      }));
+
+      try {
+        await adapter.listEvents('token');
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('UPSTREAM_ERROR');
+      }
+    });
+  });
+
+  describe('createEvent', () => {
+    it('creates event successfully', async () => {
+      const created = { id: 'evt_new', summary: 'Team Sync' };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(created),
+      }));
+
+      const result = await adapter.createEvent('token', {
+        summary: 'Team Sync',
+        start: { dateTime: '2026-03-01T10:00:00Z' },
+        end: { dateTime: '2026-03-01T11:00:00Z' },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(created);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[1]?.method).toBe('POST');
+      const body = JSON.parse(fetchCall[1]?.body as string);
+      expect(body.summary).toBe('Team Sync');
+    });
+
+    it('includes optional fields when provided', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ id: 'evt_2' }),
+      }));
+
+      await adapter.createEvent('token', {
+        summary: 'Test',
+        start: { dateTime: '2026-03-01T10:00:00Z' },
+        end: { dateTime: '2026-03-01T11:00:00Z' },
+        description: 'A test event',
+        attendees: [{ email: 'bob@example.com' }],
+        calendarId: 'team',
+      });
+
+      const body = JSON.parse(vi.mocked(fetch).mock.calls[0]![1]?.body as string);
+      expect(body.description).toBe('A test event');
+      expect(body.attendees).toEqual([{ email: 'bob@example.com' }]);
+    });
+
+    it('throws SCOPE_MISSING without calendar:write', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['calendar:read'],
+      });
+
+      await expect(adapter.createEvent('token', {
+        summary: 'Test',
+        start: { dateTime: '2026-03-01T10:00:00Z' },
+        end: { dateTime: '2026-03-01T11:00:00Z' },
+      })).rejects.toThrow(GrantexAdapterError);
+    });
+  });
+});

--- a/packages/adapters/tests/adapters/slack.test.ts
+++ b/packages/adapters/tests/adapters/slack.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VerifiedGrant } from '@grantex/sdk';
+
+vi.mock('@grantex/sdk', () => ({
+  verifyGrantToken: vi.fn(),
+}));
+
+import { verifyGrantToken } from '@grantex/sdk';
+import { SlackAdapter } from '../../src/adapters/slack.js';
+import { GrantexAdapterError } from '../../src/errors.js';
+
+const MOCK_GRANT: VerifiedGrant = {
+  tokenId: 'tok_1', grantId: 'grnt_1', principalId: 'user_1',
+  agentDid: 'did:grantex:agent:a1', developerId: 'dev_1',
+  scopes: ['notifications:send', 'notifications:read'],
+  issuedAt: Math.floor(Date.now() / 1000),
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+};
+
+describe('SlackAdapter', () => {
+  const adapter = new SlackAdapter({
+    jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+    credentials: 'xoxb-slack-token',
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+  });
+
+  describe('sendMessage', () => {
+    it('sends message successfully', async () => {
+      const slackResp = { ok: true, channel: 'C123', ts: '1234567890.123456' };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(slackResp),
+      }));
+
+      const result = await adapter.sendMessage('token', {
+        channel: 'C123',
+        text: 'Hello from agent!',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(slackResp);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[0]).toContain('chat.postMessage');
+      const body = JSON.parse(fetchCall[1]?.body as string);
+      expect(body.channel).toBe('C123');
+      expect(body.text).toBe('Hello from agent!');
+    });
+
+    it('includes thread_ts when provided', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ ok: true }),
+      }));
+
+      await adapter.sendMessage('token', {
+        channel: 'C123',
+        text: 'Thread reply',
+        thread_ts: '1234567890.123456',
+      });
+
+      const body = JSON.parse(vi.mocked(fetch).mock.calls[0]![1]?.body as string);
+      expect(body.thread_ts).toBe('1234567890.123456');
+    });
+
+    it('throws UPSTREAM_ERROR when Slack returns ok: false', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ ok: false, error: 'channel_not_found' }),
+      }));
+
+      try {
+        await adapter.sendMessage('token', { channel: 'C999', text: 'test' });
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('UPSTREAM_ERROR');
+        expect((err as GrantexAdapterError).message).toContain('channel_not_found');
+      }
+    });
+
+    it('throws SCOPE_MISSING without notifications:send', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT, scopes: ['notifications:read'],
+      });
+
+      await expect(adapter.sendMessage('token', {
+        channel: 'C123', text: 'test',
+      })).rejects.toThrow(GrantexAdapterError);
+    });
+
+    it('throws TOKEN_INVALID on verification failure', async () => {
+      vi.mocked(verifyGrantToken).mockRejectedValue(new Error('expired'));
+
+      try {
+        await adapter.sendMessage('bad-token', { channel: 'C123', text: 'test' });
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('TOKEN_INVALID');
+      }
+    });
+  });
+
+  describe('listMessages', () => {
+    it('lists messages successfully', async () => {
+      const slackResp = { ok: true, messages: [{ text: 'Hello', ts: '123' }] };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(slackResp),
+      }));
+
+      const result = await adapter.listMessages('token', { channel: 'C123' });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(slackResp);
+
+      const url = vi.mocked(fetch).mock.calls[0]![0] as string;
+      expect(url).toContain('conversations.history');
+      expect(url).toContain('channel=C123');
+    });
+
+    it('passes optional filters', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ ok: true, messages: [] }),
+      }));
+
+      await adapter.listMessages('token', {
+        channel: 'C123',
+        limit: 20,
+        oldest: '1000000000.000000',
+        latest: '2000000000.000000',
+      });
+
+      const url = vi.mocked(fetch).mock.calls[0]![0] as string;
+      expect(url).toContain('limit=20');
+      expect(url).toContain('oldest=');
+      expect(url).toContain('latest=');
+    });
+
+    it('throws UPSTREAM_ERROR when Slack returns ok: false', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ ok: false, error: 'missing_scope' }),
+      }));
+
+      try {
+        await adapter.listMessages('token', { channel: 'C123' });
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('UPSTREAM_ERROR');
+        expect((err as GrantexAdapterError).message).toContain('missing_scope');
+      }
+    });
+
+    it('throws SCOPE_MISSING without notifications:read', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT, scopes: ['notifications:send'],
+      });
+
+      await expect(adapter.listMessages('token', { channel: 'C123' }))
+        .rejects.toThrow(GrantexAdapterError);
+    });
+  });
+});

--- a/packages/adapters/tests/adapters/stripe.test.ts
+++ b/packages/adapters/tests/adapters/stripe.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VerifiedGrant } from '@grantex/sdk';
+
+vi.mock('@grantex/sdk', () => ({
+  verifyGrantToken: vi.fn(),
+}));
+
+import { verifyGrantToken } from '@grantex/sdk';
+import { StripeAdapter } from '../../src/adapters/stripe.js';
+import { GrantexAdapterError } from '../../src/errors.js';
+
+const MOCK_GRANT: VerifiedGrant = {
+  tokenId: 'tok_1', grantId: 'grnt_1', principalId: 'user_1',
+  agentDid: 'did:grantex:agent:a1', developerId: 'dev_1',
+  scopes: ['payments:read', 'payments:initiate:max_500'],
+  issuedAt: Math.floor(Date.now() / 1000),
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+};
+
+describe('StripeAdapter', () => {
+  const adapter = new StripeAdapter({
+    jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+    credentials: 'sk_test_123',
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+  });
+
+  describe('listPaymentIntents', () => {
+    it('lists payment intents', async () => {
+      const intents = { data: [{ id: 'pi_1', amount: 5000 }] };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(intents),
+      }));
+
+      const result = await adapter.listPaymentIntents('token');
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(intents);
+
+      const url = vi.mocked(fetch).mock.calls[0]![0] as string;
+      expect(url).toContain('/v1/payment_intents');
+    });
+
+    it('passes query filters', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ data: [] }),
+      }));
+
+      await adapter.listPaymentIntents('token', {
+        limit: 10,
+        customer: 'cus_123',
+      });
+
+      const url = vi.mocked(fetch).mock.calls[0]![0] as string;
+      expect(url).toContain('limit=10');
+      expect(url).toContain('customer=cus_123');
+    });
+
+    it('throws SCOPE_MISSING without payments:read', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT, scopes: ['payments:initiate:max_500'],
+      });
+
+      await expect(adapter.listPaymentIntents('token'))
+        .rejects.toThrow(GrantexAdapterError);
+    });
+  });
+
+  describe('createPaymentIntent', () => {
+    it('creates payment intent within constraint', async () => {
+      const created = { id: 'pi_new', amount: 10000, currency: 'usd' };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(created),
+      }));
+
+      const result = await adapter.createPaymentIntent('token', {
+        amount: 10000, // $100 in cents
+        currency: 'usd',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(created);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[1]?.method).toBe('POST');
+      expect(fetchCall[1]?.headers).toHaveProperty('Content-Type', 'application/x-www-form-urlencoded');
+    });
+
+    it('allows payment at exact max ($500 = 50000 cents)', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ id: 'pi_exact' }),
+      }));
+
+      const result = await adapter.createPaymentIntent('token', {
+        amount: 50000, // exactly $500
+        currency: 'usd',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects payment over max constraint ($600 > $500)', async () => {
+      try {
+        await adapter.createPaymentIntent('token', {
+          amount: 60000, // $600 in cents
+          currency: 'usd',
+        });
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('CONSTRAINT_VIOLATED');
+        expect((err as GrantexAdapterError).message).toContain('600');
+        expect((err as GrantexAdapterError).message).toContain('500');
+      }
+    });
+
+    it('allows any amount when scope has no constraint', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT, scopes: ['payments:read', 'payments:initiate'],
+      });
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ id: 'pi_big' }),
+      }));
+
+      const result = await adapter.createPaymentIntent('token', {
+        amount: 10000000, // $100,000
+        currency: 'usd',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('sends metadata as form-encoded bracket notation', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ id: 'pi_meta' }),
+      }));
+
+      await adapter.createPaymentIntent('token', {
+        amount: 5000,
+        currency: 'usd',
+        metadata: { orderId: 'ord_123', source: 'agent' },
+      });
+
+      const body = vi.mocked(fetch).mock.calls[0]![1]?.body as string;
+      expect(body).toContain('metadata%5BorderId%5D=ord_123');
+      expect(body).toContain('metadata%5Bsource%5D=agent');
+    });
+
+    it('throws SCOPE_MISSING without payments:initiate', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT, scopes: ['payments:read'],
+      });
+
+      await expect(adapter.createPaymentIntent('token', {
+        amount: 1000, currency: 'usd',
+      })).rejects.toThrow(GrantexAdapterError);
+    });
+
+    it('throws UPSTREAM_ERROR on Stripe failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false, status: 402, text: () => Promise.resolve('Card declined'),
+      }));
+
+      try {
+        await adapter.createPaymentIntent('token', {
+          amount: 1000, currency: 'usd',
+        });
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('UPSTREAM_ERROR');
+      }
+    });
+  });
+});

--- a/packages/adapters/tests/base-adapter.test.ts
+++ b/packages/adapters/tests/base-adapter.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VerifiedGrant } from '@grantex/sdk';
+
+vi.mock('@grantex/sdk', () => ({
+  verifyGrantToken: vi.fn(),
+}));
+
+import { verifyGrantToken } from '@grantex/sdk';
+import { BaseAdapter } from '../src/base-adapter.js';
+import { GrantexAdapterError } from '../src/errors.js';
+import type { AdapterConfig } from '../src/types.js';
+
+const MOCK_GRANT: VerifiedGrant = {
+  tokenId: 'tok_123',
+  grantId: 'grnt_123',
+  principalId: 'user_1',
+  agentDid: 'did:grantex:agent:a1',
+  developerId: 'dev_1',
+  scopes: ['calendar:read', 'payments:initiate:max_500'],
+  issuedAt: Math.floor(Date.now() / 1000),
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+};
+
+class TestAdapter extends BaseAdapter {
+  async testVerifyAndCheckScope(token: string, scope: string) {
+    return this.verifyAndCheckScope(token, scope);
+  }
+
+  async testResolveCredential() {
+    return this.resolveCredential();
+  }
+
+  async testLogAudit(
+    grant: VerifiedGrant,
+    action: string,
+    status: 'success' | 'failure' | 'blocked',
+  ) {
+    return this.logAudit(grant, action, status);
+  }
+
+  async testCallUpstream<T>(url: string, options: RequestInit) {
+    return this.callUpstream<T>(url, options);
+  }
+}
+
+describe('BaseAdapter', () => {
+  const baseConfig: AdapterConfig = {
+    jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+    credentials: 'test-api-key',
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('verifyAndCheckScope', () => {
+    it('verifies token and returns grant with matched scope', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+      const adapter = new TestAdapter(baseConfig);
+
+      const result = await adapter.testVerifyAndCheckScope('valid-token', 'calendar:read');
+
+      expect(result.grant).toBe(MOCK_GRANT);
+      expect(result.matchedScope.baseScope).toBe('calendar:read');
+      expect(verifyGrantToken).toHaveBeenCalledWith('valid-token', {
+        jwksUri: baseConfig.jwksUri,
+      });
+    });
+
+    it('passes clockTolerance when configured', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+      const adapter = new TestAdapter({ ...baseConfig, clockTolerance: 30 });
+
+      await adapter.testVerifyAndCheckScope('token', 'calendar:read');
+
+      expect(verifyGrantToken).toHaveBeenCalledWith('token', {
+        jwksUri: baseConfig.jwksUri,
+        clockTolerance: 30,
+      });
+    });
+
+    it('throws TOKEN_INVALID when verification fails', async () => {
+      vi.mocked(verifyGrantToken).mockRejectedValue(new Error('bad token'));
+      const adapter = new TestAdapter(baseConfig);
+
+      await expect(adapter.testVerifyAndCheckScope('bad', 'calendar:read'))
+        .rejects.toThrow(GrantexAdapterError);
+
+      try {
+        await adapter.testVerifyAndCheckScope('bad', 'calendar:read');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('TOKEN_INVALID');
+      }
+    });
+
+    it('throws SCOPE_MISSING when scope not granted', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+      const adapter = new TestAdapter(baseConfig);
+
+      await expect(adapter.testVerifyAndCheckScope('token', 'email:send'))
+        .rejects.toThrow(GrantexAdapterError);
+
+      try {
+        await adapter.testVerifyAndCheckScope('token', 'email:send');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('SCOPE_MISSING');
+      }
+    });
+
+    it('finds scope with constraint', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+      const adapter = new TestAdapter(baseConfig);
+
+      const result = await adapter.testVerifyAndCheckScope('token', 'payments:initiate');
+      expect(result.matchedScope.baseScope).toBe('payments:initiate');
+      expect(result.matchedScope.constraint).toEqual({ type: 'max', value: 500 });
+    });
+  });
+
+  describe('resolveCredential', () => {
+    it('returns string credential directly', async () => {
+      const adapter = new TestAdapter(baseConfig);
+      const cred = await adapter.testResolveCredential();
+      expect(cred).toBe('test-api-key');
+    });
+
+    it('calls function credential provider', async () => {
+      const adapter = new TestAdapter({
+        ...baseConfig,
+        credentials: () => 'dynamic-key',
+      });
+      const cred = await adapter.testResolveCredential();
+      expect(cred).toBe('dynamic-key');
+    });
+
+    it('awaits async credential provider', async () => {
+      const adapter = new TestAdapter({
+        ...baseConfig,
+        credentials: async () => 'async-key',
+      });
+      const cred = await adapter.testResolveCredential();
+      expect(cred).toBe('async-key');
+    });
+
+    it('throws CREDENTIAL_ERROR on failure', async () => {
+      const adapter = new TestAdapter({
+        ...baseConfig,
+        credentials: () => { throw new Error('no cred'); },
+      });
+
+      try {
+        await adapter.testResolveCredential();
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('CREDENTIAL_ERROR');
+      }
+    });
+  });
+
+  describe('logAudit', () => {
+    it('calls auditLogger when provided', async () => {
+      const logger = vi.fn().mockResolvedValue(undefined);
+      const adapter = new TestAdapter({ ...baseConfig, auditLogger: logger });
+
+      await adapter.testLogAudit(MOCK_GRANT, 'test:action', 'success');
+
+      expect(logger).toHaveBeenCalledWith({
+        agentId: MOCK_GRANT.agentDid,
+        grantId: MOCK_GRANT.grantId,
+        action: 'test:action',
+        status: 'success',
+      });
+    });
+
+    it('does nothing when no auditLogger', async () => {
+      const adapter = new TestAdapter(baseConfig);
+      // Should not throw
+      await adapter.testLogAudit(MOCK_GRANT, 'test:action', 'success');
+    });
+
+    it('swallows auditLogger errors', async () => {
+      const logger = vi.fn().mockRejectedValue(new Error('audit fail'));
+      const adapter = new TestAdapter({ ...baseConfig, auditLogger: logger });
+
+      // Should not throw
+      await adapter.testLogAudit(MOCK_GRANT, 'test:action', 'success');
+    });
+  });
+
+  describe('callUpstream', () => {
+    it('makes fetch request and returns JSON', async () => {
+      const mockResponse = { ok: true, json: () => Promise.resolve({ id: '123' }) };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+      const adapter = new TestAdapter(baseConfig);
+      const result = await adapter.testCallUpstream<{ id: string }>('https://api.test.com/data', {
+        method: 'GET',
+      });
+
+      expect(result).toEqual({ id: '123' });
+    });
+
+    it('throws UPSTREAM_ERROR on non-ok response', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('Internal Server Error'),
+      };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+      const adapter = new TestAdapter(baseConfig);
+
+      try {
+        await adapter.testCallUpstream('https://api.test.com/data', { method: 'GET' });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('UPSTREAM_ERROR');
+        expect((err as GrantexAdapterError).message).toContain('500');
+      }
+    });
+
+    it('throws UPSTREAM_ERROR on network failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+
+      const adapter = new TestAdapter(baseConfig);
+
+      try {
+        await adapter.testCallUpstream('https://api.test.com/data', { method: 'GET' });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('UPSTREAM_ERROR');
+        expect((err as GrantexAdapterError).message).toContain('ECONNREFUSED');
+      }
+    });
+  });
+});

--- a/packages/adapters/tests/scope-utils.test.ts
+++ b/packages/adapters/tests/scope-utils.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { parseScope, findMatchingScope, enforceConstraint } from '../src/scope-utils.js';
+
+describe('parseScope', () => {
+  it('parses simple scope without constraint', () => {
+    expect(parseScope('calendar:read')).toEqual({
+      baseScope: 'calendar:read',
+    });
+  });
+
+  it('parses scope with max constraint', () => {
+    expect(parseScope('payments:initiate:max_500')).toEqual({
+      baseScope: 'payments:initiate',
+      constraint: { type: 'max', value: 500 },
+    });
+  });
+
+  it('parses scope with min constraint', () => {
+    expect(parseScope('payments:initiate:min_10')).toEqual({
+      baseScope: 'payments:initiate',
+      constraint: { type: 'min', value: 10 },
+    });
+  });
+
+  it('parses scope with limit constraint', () => {
+    expect(parseScope('api:calls:limit_1000')).toEqual({
+      baseScope: 'api:calls',
+      constraint: { type: 'limit', value: 1000 },
+    });
+  });
+
+  it('returns baseScope as-is for single-part scope', () => {
+    expect(parseScope('admin')).toEqual({ baseScope: 'admin' });
+  });
+
+  it('handles scope with colon but no constraint', () => {
+    expect(parseScope('email:send')).toEqual({
+      baseScope: 'email:send',
+    });
+  });
+
+  it('handles multi-part scope without constraint', () => {
+    expect(parseScope('org:team:manage')).toEqual({
+      baseScope: 'org:team:manage',
+    });
+  });
+
+  it('parses zero constraint value', () => {
+    expect(parseScope('payments:initiate:max_0')).toEqual({
+      baseScope: 'payments:initiate',
+      constraint: { type: 'max', value: 0 },
+    });
+  });
+});
+
+describe('findMatchingScope', () => {
+  it('finds exact match without constraint', () => {
+    const result = findMatchingScope(['calendar:read', 'email:send'], 'calendar:read');
+    expect(result).toEqual({ baseScope: 'calendar:read' });
+  });
+
+  it('finds match with constraint', () => {
+    const result = findMatchingScope(['payments:initiate:max_500'], 'payments:initiate');
+    expect(result).toEqual({
+      baseScope: 'payments:initiate',
+      constraint: { type: 'max', value: 500 },
+    });
+  });
+
+  it('returns null when no match', () => {
+    const result = findMatchingScope(['calendar:read'], 'email:send');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty scopes', () => {
+    const result = findMatchingScope([], 'calendar:read');
+    expect(result).toBeNull();
+  });
+
+  it('returns first matching scope', () => {
+    const result = findMatchingScope(
+      ['payments:initiate:max_100', 'payments:initiate:max_500'],
+      'payments:initiate',
+    );
+    expect(result).toEqual({
+      baseScope: 'payments:initiate',
+      constraint: { type: 'max', value: 100 },
+    });
+  });
+});
+
+describe('enforceConstraint', () => {
+  it('allows when no constraint', () => {
+    const result = enforceConstraint({ baseScope: 'payments:initiate' }, 1000);
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it('allows value under max', () => {
+    const parsed = { baseScope: 'payments:initiate', constraint: { type: 'max', value: 500 } };
+    expect(enforceConstraint(parsed, 200)).toEqual({ allowed: true });
+  });
+
+  it('allows value equal to max', () => {
+    const parsed = { baseScope: 'payments:initiate', constraint: { type: 'max', value: 500 } };
+    expect(enforceConstraint(parsed, 500)).toEqual({ allowed: true });
+  });
+
+  it('rejects value over max', () => {
+    const parsed = { baseScope: 'payments:initiate', constraint: { type: 'max', value: 500 } };
+    const result = enforceConstraint(parsed, 600);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('600');
+    expect(result.reason).toContain('500');
+  });
+
+  it('allows value above min', () => {
+    const parsed = { baseScope: 'payments:initiate', constraint: { type: 'min', value: 10 } };
+    expect(enforceConstraint(parsed, 50)).toEqual({ allowed: true });
+  });
+
+  it('rejects value below min', () => {
+    const parsed = { baseScope: 'payments:initiate', constraint: { type: 'min', value: 10 } };
+    const result = enforceConstraint(parsed, 5);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('5');
+  });
+
+  it('allows value under limit', () => {
+    const parsed = { baseScope: 'api:calls', constraint: { type: 'limit', value: 100 } };
+    expect(enforceConstraint(parsed, 50)).toEqual({ allowed: true });
+  });
+
+  it('rejects value over limit', () => {
+    const parsed = { baseScope: 'api:calls', constraint: { type: 'limit', value: 100 } };
+    const result = enforceConstraint(parsed, 150);
+    expect(result.allowed).toBe(false);
+  });
+
+  it('allows for unknown constraint type', () => {
+    const parsed = { baseScope: 'test', constraint: { type: 'unknown', value: 100 } };
+    expect(enforceConstraint(parsed, 9999)).toEqual({ allowed: true });
+  });
+});

--- a/packages/adapters/tsconfig.build.json
+++ b/packages/adapters/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/packages/adapters/tsconfig.json
+++ b/packages/adapters/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitOverride": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/gateway/Dockerfile
+++ b/packages/gateway/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-slim AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --ignore-scripts
+COPY tsconfig*.json ./
+COPY src/ src/
+RUN npm run build
+
+FROM node:20-slim
+WORKDIR /app
+COPY --from=builder /app/package*.json ./
+RUN npm ci --omit=dev --ignore-scripts
+COPY --from=builder /app/dist/ dist/
+
+EXPOSE 8080
+ENTRYPOINT ["node", "dist/cli.js"]
+CMD ["--config", "/etc/grantex/gateway.yaml"]

--- a/packages/gateway/README.md
+++ b/packages/gateway/README.md
@@ -1,0 +1,125 @@
+# @grantex/gateway
+
+Zero-code reverse-proxy that enforces [Grantex](https://grantex.dev) grant tokens in front of any API via YAML config.
+
+## Install
+
+```bash
+npm install @grantex/gateway @grantex/sdk
+```
+
+## Quick Start
+
+**1. Create `gateway.yaml`:**
+
+```yaml
+upstream: https://api.internal.example.com
+jwksUri: https://your-auth-server/.well-known/jwks.json
+port: 8080
+upstreamHeaders:
+  X-Internal-Auth: "secret-key"
+routes:
+  - path: /calendar/**
+    methods: [GET]
+    requiredScopes: [calendar:read]
+  - path: /calendar/**
+    methods: [POST, PUT, PATCH]
+    requiredScopes: [calendar:write]
+  - path: /payments/**
+    methods: [POST]
+    requiredScopes: [payments:initiate]
+```
+
+**2. Start the gateway:**
+
+```bash
+npx @grantex/gateway --config gateway.yaml
+```
+
+**3. Make requests with grant tokens:**
+
+```bash
+curl -H "Authorization: Bearer <grant-token>" \
+  http://localhost:8080/calendar/events
+```
+
+## How It Works
+
+```
+Client → Gateway (verify token + check scopes) → Upstream API
+```
+
+1. **Route matching** — finds the first route matching the request method + path
+2. **Token verification** — extracts Bearer token and verifies offline via JWKS
+3. **Scope checking** — ensures the grant includes all required scopes for the route
+4. **Proxy** — strips the Authorization header, adds upstream headers + `X-Grantex-*` context headers, forwards to upstream
+5. **Response** — returns the upstream response as-is
+
+## YAML Config Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `upstream` | string | Yes | Base URL of the upstream API |
+| `jwksUri` | string | Yes | JWKS endpoint for offline token verification |
+| `port` | number | No | Listen port (default: 8080) |
+| `upstreamHeaders` | object | No | Headers added to every upstream request |
+| `grantexApiKey` | string | No | API key for audit logging |
+| `routes` | array | Yes | Route definitions (see below) |
+
+### Route Definition
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | string | URL path pattern (`*` = single segment, `**` = any depth) |
+| `methods` | string[] | HTTP methods (GET, POST, PUT, PATCH, DELETE) |
+| `requiredScopes` | string[] | Scopes that must be present in the grant token |
+
+## Context Headers
+
+The gateway adds these headers to upstream requests:
+
+| Header | Value |
+|--------|-------|
+| `X-Grantex-Principal` | Principal ID from the grant token |
+| `X-Grantex-Agent` | Agent DID from the grant token |
+| `X-Grantex-GrantId` | Grant ID from the grant token |
+
+## Error Responses
+
+| Status | Error Code | When |
+|--------|-----------|------|
+| 404 | `ROUTE_NOT_FOUND` | No route matches the request |
+| 401 | `TOKEN_MISSING` | No Bearer token in Authorization header |
+| 401 | `TOKEN_INVALID` | Token signature verification failed |
+| 401 | `TOKEN_EXPIRED` | Token has expired |
+| 403 | `SCOPE_INSUFFICIENT` | Grant doesn't include required scopes |
+| 502 | `UPSTREAM_ERROR` | Upstream API is unreachable |
+
+## Library API
+
+Use the gateway programmatically:
+
+```typescript
+import { createGatewayServer, loadConfig } from '@grantex/gateway';
+
+const config = loadConfig('./gateway.yaml');
+const server = createGatewayServer(config);
+
+await server.listen({ port: config.port });
+```
+
+## Docker
+
+```bash
+docker build -t grantex-gateway packages/gateway/
+docker run -p 8080:8080 -v ./gateway.yaml:/etc/grantex/gateway.yaml grantex-gateway
+```
+
+## Requirements
+
+- Node.js 18+
+- `@grantex/sdk` >= 0.1.0
+
+## License
+
+Apache-2.0

--- a/packages/gateway/gateway.example.yaml
+++ b/packages/gateway/gateway.example.yaml
@@ -1,0 +1,34 @@
+# Grantex Gateway Configuration
+# See https://grantex.dev/docs/integrations/gateway for full reference
+
+upstream: https://api.internal.example.com
+jwksUri: https://grantex-auth-dd4mtrt2gq-uc.a.run.app/.well-known/jwks.json
+port: 8080
+
+# Optional: headers added to every upstream request
+upstreamHeaders:
+  X-Internal-Auth: "your-internal-secret"
+
+# Optional: Grantex API key for audit logging
+# grantexApiKey: gx_key_...
+
+routes:
+  # Calendar read access
+  - path: /calendar/**
+    methods: [GET]
+    requiredScopes: [calendar:read]
+
+  # Calendar write access
+  - path: /calendar/**
+    methods: [POST, PUT, PATCH]
+    requiredScopes: [calendar:write]
+
+  # Payment processing
+  - path: /payments/**
+    methods: [POST]
+    requiredScopes: [payments:initiate]
+
+  # User data read
+  - path: /users/*
+    methods: [GET]
+    requiredScopes: [users:read]

--- a/packages/gateway/package-lock.json
+++ b/packages/gateway/package-lock.json
@@ -1,0 +1,2395 @@
+{
+  "name": "@grantex/gateway",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@grantex/gateway",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fastify": "^4.26.0",
+        "yaml": "^2.3.4"
+      },
+      "bin": {
+        "grantex-gateway": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@grantex/sdk": "^0.1.5",
+        "@types/node": "^20.11.0",
+        "typescript": "~5.3.3",
+        "vitest": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@grantex/sdk": ">=0.1.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.6.0.tgz",
+      "integrity": "sha512-LwdXQJjmMD+GwLOkP7TVC68qa+pSSogeWWmznRJ/coyTcfe9qA05AHFSe1eZFwK6q+xVRpChnvFUkf1iYaSZsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1",
+        "fast-uri": "^2.0.0"
+      }
+    },
+    "node_modules/@fastify/error": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.4.1.tgz",
+      "integrity": "sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.3.0.tgz",
+      "integrity": "sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^5.7.0"
+      }
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.1.1.tgz",
+      "integrity": "sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
+    "node_modules/@grantex/sdk": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@grantex/sdk/-/sdk-0.1.5.tgz",
+      "integrity": "sha512-Xc3k+ap0b4dM+LnNF9Dvhw8dnjittC3JFFruvLJvz3XRZTS6pCKTsZH68KWSYz1yCgaqS59Hr8A7dhC+svgTOA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jose": "^5.2.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
+      "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-8.4.0.tgz",
+      "integrity": "sha512-CDSwaxINFy59iNwhYnkvALBwZiTydGkOecZyPkqBpABYR1KqGEsET0VOOYDwtleZSUIdeY36DC2bSZ24CO1igA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^3.3.0",
+        "fastq": "^1.17.1"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-1.1.0.tgz",
+      "integrity": "sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==",
+      "license": "MIT"
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stringify": {
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.16.1.tgz",
+      "integrity": "sha512-KAdnLvy1yu/XrRtP+LJnxbBGrhN+xXu+gt3EUvZhYGKCr3lFHq/7UFJHHFgmJKoqlh6B40bZLEv7w46B0mqn1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.1.0",
+        "ajv": "^8.10.0",
+        "ajv-formats": "^3.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^2.1.0",
+        "json-schema-ref-resolver": "^1.0.1",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.4.0.tgz",
+      "integrity": "sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==",
+      "license": "MIT"
+    },
+    "node_modules/fastify": {
+      "version": "4.29.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.29.1.tgz",
+      "integrity": "sha512-m2kMNHIG92tSNWv+Z3UeTR9AWLLuo7KctC7mlFPtMEVrfjIhmQhkQnT9v15qA/BfVq3vvj134Y0jl9SBje3jXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^3.5.0",
+        "@fastify/error": "^3.4.0",
+        "@fastify/fast-json-stringify-compiler": "^4.3.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^8.3.0",
+        "fast-content-type-parse": "^1.1.0",
+        "fast-json-stringify": "^5.8.0",
+        "find-my-way": "^8.0.0",
+        "light-my-request": "^5.11.0",
+        "pino": "^9.0.0",
+        "process-warning": "^3.0.0",
+        "proxy-addr": "^2.0.7",
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.7.0",
+        "semver": "^7.5.4",
+        "toad-cache": "^3.3.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
+      "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-1.0.1.tgz",
+      "integrity": "sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/light-my-request": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.14.0.tgz",
+      "integrity": "sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^0.7.0",
+        "process-warning": "^3.0.0",
+        "set-cookie-parser": "^2.4.1"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/pino/node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.4.3.tgz",
+      "integrity": "sha512-0f4Memo5QP7WQyUEAYUO3esD/XjOc3Zjjg5CPsAq1p8sIu0XPeMbHJemKA0BO7tV0X7+A0FoEpbmHXWxPyD3wQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-regex2": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-3.1.0.tgz",
+      "integrity": "sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==",
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.4.0"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@grantex/gateway",
+  "version": "0.1.0",
+  "description": "Zero-code reverse-proxy gateway that enforces Grantex grant tokens via YAML config",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "grantex-gateway": "./dist/cli.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "start": "node dist/cli.js"
+  },
+  "dependencies": {
+    "fastify": "^4.26.0",
+    "yaml": "^2.3.4"
+  },
+  "peerDependencies": {
+    "@grantex/sdk": ">=0.1.0"
+  },
+  "devDependencies": {
+    "@grantex/sdk": "^0.1.5",
+    "@types/node": "^20.11.0",
+    "typescript": "~5.3.3",
+    "vitest": "^1.3.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mishrasanjeev/grantex.git",
+    "directory": "packages/gateway"
+  },
+  "keywords": [
+    "grantex",
+    "gateway",
+    "reverse-proxy",
+    "authorization",
+    "ai-agents",
+    "grant-tokens"
+  ]
+}

--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { loadConfig } from './config.js';
+import { createGatewayServer } from './server.js';
+import { log } from './logger.js';
+
+const args = process.argv.slice(2);
+let configPath = 'gateway.yaml';
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--config' || args[i] === '-c') {
+    const next = args[i + 1];
+    if (next) {
+      configPath = next;
+      i++;
+    }
+  }
+}
+
+try {
+  const config = loadConfig(configPath);
+  const server = createGatewayServer(config);
+
+  server.listen({ port: config.port, host: '0.0.0.0' }, (err, address) => {
+    if (err) {
+      log('error', 'Failed to start gateway', { error: String(err) });
+      process.exit(1);
+    }
+    log('info', `Grantex Gateway listening`, {
+      address,
+      upstream: config.upstream,
+      routes: config.routes.length,
+    });
+  });
+
+  // Graceful shutdown
+  const shutdown = () => {
+    log('info', 'Shutting down gateway');
+    server.close().then(() => process.exit(0));
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+} catch (err) {
+  log('error', 'Failed to start gateway', { error: String(err) });
+  process.exit(1);
+}

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from 'node:fs';
+import { parse as parseYaml } from 'yaml';
+import type { GatewayConfig } from './types.js';
+import { GatewayError } from './errors.js';
+
+export function loadConfig(filePath: string): GatewayConfig {
+  let content: string;
+  try {
+    content = readFileSync(filePath, 'utf-8');
+  } catch {
+    throw new GatewayError('CONFIG_NOT_FOUND', `Config file not found: ${filePath}`, 500);
+  }
+
+  let raw: unknown;
+  try {
+    raw = parseYaml(content);
+  } catch {
+    throw new GatewayError('CONFIG_INVALID', 'Failed to parse YAML config', 500);
+  }
+
+  return validateConfig(raw);
+}
+
+export function validateConfig(raw: unknown): GatewayConfig {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new GatewayError('CONFIG_INVALID', 'Config must be an object', 500);
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  if (typeof obj['upstream'] !== 'string' || !obj['upstream']) {
+    throw new GatewayError('CONFIG_INVALID', 'Config must include a non-empty "upstream" URL', 500);
+  }
+
+  if (typeof obj['jwksUri'] !== 'string' || !obj['jwksUri']) {
+    throw new GatewayError('CONFIG_INVALID', 'Config must include a non-empty "jwksUri"', 500);
+  }
+
+  const port = typeof obj['port'] === 'number' ? obj['port'] : 8080;
+
+  if (!Array.isArray(obj['routes']) || obj['routes'].length === 0) {
+    throw new GatewayError('CONFIG_INVALID', 'Config must include at least one route', 500);
+  }
+
+  const routes = obj['routes'].map((route: unknown, i: number) => {
+    if (typeof route !== 'object' || route === null) {
+      throw new GatewayError('CONFIG_INVALID', `Route ${i} must be an object`, 500);
+    }
+    const r = route as Record<string, unknown>;
+
+    if (typeof r['path'] !== 'string' || !r['path']) {
+      throw new GatewayError('CONFIG_INVALID', `Route ${i} must have a "path"`, 500);
+    }
+
+    if (!Array.isArray(r['methods']) || r['methods'].length === 0) {
+      throw new GatewayError('CONFIG_INVALID', `Route ${i} must have at least one method`, 500);
+    }
+
+    const methods = r['methods'].map((m: unknown) => {
+      if (typeof m !== 'string') {
+        throw new GatewayError('CONFIG_INVALID', `Route ${i} methods must be strings`, 500);
+      }
+      return m.toUpperCase();
+    });
+
+    if (!Array.isArray(r['requiredScopes']) || r['requiredScopes'].length === 0) {
+      throw new GatewayError('CONFIG_INVALID', `Route ${i} must have at least one requiredScope`, 500);
+    }
+
+    const requiredScopes = r['requiredScopes'].map((s: unknown) => {
+      if (typeof s !== 'string') {
+        throw new GatewayError('CONFIG_INVALID', `Route ${i} requiredScopes must be strings`, 500);
+      }
+      return s;
+    });
+
+    return { path: r['path'], methods, requiredScopes };
+  });
+
+  const upstreamHeaders = typeof obj['upstreamHeaders'] === 'object' && obj['upstreamHeaders'] !== null
+    ? Object.fromEntries(
+        Object.entries(obj['upstreamHeaders'] as Record<string, unknown>).map(([k, v]) => [k, String(v)]),
+      )
+    : undefined;
+
+  return {
+    upstream: obj['upstream'] as string,
+    jwksUri: obj['jwksUri'] as string,
+    port,
+    routes,
+    ...(upstreamHeaders !== undefined ? { upstreamHeaders } : {}),
+    ...(typeof obj['grantexApiKey'] === 'string' ? { grantexApiKey: obj['grantexApiKey'] } : {}),
+  };
+}

--- a/packages/gateway/src/errors.ts
+++ b/packages/gateway/src/errors.ts
@@ -1,0 +1,21 @@
+export type GatewayErrorCode =
+  | 'CONFIG_NOT_FOUND'
+  | 'CONFIG_INVALID'
+  | 'ROUTE_NOT_FOUND'
+  | 'TOKEN_MISSING'
+  | 'TOKEN_INVALID'
+  | 'TOKEN_EXPIRED'
+  | 'SCOPE_INSUFFICIENT'
+  | 'UPSTREAM_ERROR';
+
+export class GatewayError extends Error {
+  readonly code: GatewayErrorCode;
+  readonly statusCode: number;
+
+  constructor(code: GatewayErrorCode, message: string, statusCode: number) {
+    super(message);
+    this.code = code;
+    this.statusCode = statusCode;
+    Object.setPrototypeOf(this, GatewayError.prototype);
+  }
+}

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,0 +1,9 @@
+export { createGatewayServer } from './server.js';
+export { loadConfig, validateConfig } from './config.js';
+export { matchRoute } from './matcher.js';
+export { proxyRequest } from './proxy.js';
+export { GatewayError } from './errors.js';
+export { log } from './logger.js';
+export type { GatewayErrorCode } from './errors.js';
+export type { GatewayConfig, RouteDefinition, MatchResult } from './types.js';
+export type { ProxyOptions } from './proxy.js';

--- a/packages/gateway/src/logger.ts
+++ b/packages/gateway/src/logger.ts
@@ -1,0 +1,22 @@
+export interface LogEntry {
+  level: 'info' | 'warn' | 'error';
+  message: string;
+  timestamp: string;
+  [key: string]: unknown;
+}
+
+export function log(level: LogEntry['level'], message: string, extra?: Record<string, unknown>): void {
+  const entry: LogEntry = {
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+    ...extra,
+  };
+  const output = JSON.stringify(entry);
+
+  if (level === 'error') {
+    process.stderr.write(output + '\n');
+  } else {
+    process.stdout.write(output + '\n');
+  }
+}

--- a/packages/gateway/src/matcher.ts
+++ b/packages/gateway/src/matcher.ts
@@ -1,0 +1,54 @@
+import type { RouteDefinition, MatchResult } from './types.js';
+
+/**
+ * Convert a route path pattern to a regex.
+ * Supports:
+ *   - `*` matches a single path segment (no slashes)
+ *   - `**` matches zero or more segments (including slashes)
+ */
+function patternToRegex(pattern: string): RegExp {
+  // Escape special regex chars except * and /
+  let regex = '';
+  let i = 0;
+
+  while (i < pattern.length) {
+    if (pattern[i] === '*' && pattern[i + 1] === '*') {
+      regex += '.*';
+      i += 2;
+      // Skip trailing slash after **
+      if (pattern[i] === '/') i++;
+    } else if (pattern[i] === '*') {
+      regex += '[^/]+';
+      i++;
+    } else if ('.+?^${}()|[]\\'.includes(pattern[i]!)) {
+      regex += '\\' + pattern[i];
+      i++;
+    } else {
+      regex += pattern[i];
+      i++;
+    }
+  }
+
+  return new RegExp(`^${regex}$`);
+}
+
+export function matchRoute(
+  method: string,
+  path: string,
+  routes: RouteDefinition[],
+): MatchResult | null {
+  const upperMethod = method.toUpperCase();
+
+  for (const route of routes) {
+    // Check method first (cheap)
+    if (!route.methods.includes(upperMethod)) continue;
+
+    // Check path pattern
+    const regex = patternToRegex(route.path);
+    if (regex.test(path)) {
+      return { route, params: {} };
+    }
+  }
+
+  return null;
+}

--- a/packages/gateway/src/proxy.ts
+++ b/packages/gateway/src/proxy.ts
@@ -1,0 +1,80 @@
+import type { VerifiedGrant } from '@grantex/sdk';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { GatewayError } from './errors.js';
+
+export interface ProxyOptions {
+  upstream: string;
+  upstreamHeaders?: Record<string, string>;
+  timeout?: number;
+}
+
+export async function proxyRequest(
+  req: FastifyRequest,
+  reply: FastifyReply,
+  grant: VerifiedGrant,
+  options: ProxyOptions,
+): Promise<void> {
+  const targetUrl = `${options.upstream.replace(/\/$/, '')}${req.url}`;
+
+  // Build headers: strip Authorization, add upstream headers + Grantex context
+  const headers: Record<string, string> = {};
+
+  // Forward original headers (except Authorization and Host)
+  const rawHeaders = req.headers;
+  for (const [key, value] of Object.entries(rawHeaders)) {
+    if (key.toLowerCase() === 'authorization') continue;
+    if (key.toLowerCase() === 'host') continue;
+    if (value !== undefined) {
+      headers[key] = Array.isArray(value) ? value.join(', ') : value;
+    }
+  }
+
+  // Add configured upstream headers
+  if (options.upstreamHeaders) {
+    for (const [key, value] of Object.entries(options.upstreamHeaders)) {
+      headers[key] = value;
+    }
+  }
+
+  // Add Grantex context headers
+  headers['X-Grantex-Principal'] = grant.principalId;
+  headers['X-Grantex-Agent'] = grant.agentDid;
+  headers['X-Grantex-GrantId'] = grant.grantId;
+
+  const controller = new AbortController();
+  const timeout = options.timeout ?? 30_000;
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const body = req.method !== 'GET' && req.method !== 'HEAD' ? req.body : undefined;
+
+    const response = await fetch(targetUrl, {
+      method: req.method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+
+    // Forward status code
+    reply.status(response.status);
+
+    // Forward response headers
+    for (const [key, value] of response.headers.entries()) {
+      if (key.toLowerCase() === 'transfer-encoding') continue;
+      reply.header(key, value);
+    }
+
+    // Forward response body
+    const responseBody = await response.text();
+    reply.send(responseBody);
+  } catch (err) {
+    if (err instanceof GatewayError) throw err;
+    throw new GatewayError(
+      'UPSTREAM_ERROR',
+      `Failed to reach upstream: ${err instanceof Error ? err.message : String(err)}`,
+      502,
+    );
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -1,0 +1,108 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { verifyGrantToken, GrantexTokenError } from '@grantex/sdk';
+import type { GatewayConfig } from './types.js';
+import { matchRoute } from './matcher.js';
+import { proxyRequest } from './proxy.js';
+import { GatewayError } from './errors.js';
+import { log } from './logger.js';
+
+export function createGatewayServer(config: GatewayConfig): FastifyInstance {
+  const app = Fastify({ logger: false });
+
+  // Capture raw body for proxying
+  app.addContentTypeParser('*', { parseAs: 'string' }, (_req, body, done) => {
+    done(null, body);
+  });
+  app.addContentTypeParser('application/json', { parseAs: 'string' }, (_req, body, done) => {
+    try {
+      done(null, JSON.parse(body as string));
+    } catch {
+      done(null, body);
+    }
+  });
+
+  // Catch-all route
+  app.all('/*', async (req, reply) => {
+    const method = req.method;
+    const path = req.url.split('?')[0]!;
+
+    // 1. Match route
+    const match = matchRoute(method, path, config.routes);
+    if (!match) {
+      reply.status(404).send({
+        error: 'ROUTE_NOT_FOUND',
+        message: `No route matches ${method} ${path}`,
+      });
+      return;
+    }
+
+    // 2. Extract Bearer token
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      reply.status(401).send({
+        error: 'TOKEN_MISSING',
+        message: 'Authorization header with Bearer token is required',
+      });
+      return;
+    }
+    const token = authHeader.slice(7);
+
+    // 3. Verify grant token
+    try {
+      const grant = await verifyGrantToken(token, {
+        jwksUri: config.jwksUri,
+        requiredScopes: match.route.requiredScopes,
+      });
+
+      log('info', 'Request authorized', {
+        method,
+        path,
+        principal: grant.principalId,
+        agent: grant.agentDid,
+        grantId: grant.grantId,
+      });
+
+      // 4. Proxy to upstream
+      await proxyRequest(req, reply, grant, {
+        upstream: config.upstream,
+        upstreamHeaders: config.upstreamHeaders,
+      });
+    } catch (err) {
+      if (err instanceof GatewayError) {
+        reply.status(err.statusCode).send({
+          error: err.code,
+          message: err.message,
+        });
+        return;
+      }
+
+      if (err instanceof GrantexTokenError) {
+        const isExpired = err.message.toLowerCase().includes('exp');
+        const code = isExpired ? 'TOKEN_EXPIRED' : 'TOKEN_INVALID';
+        const isScopeError = err.message.toLowerCase().includes('scope');
+
+        if (isScopeError) {
+          reply.status(403).send({
+            error: 'SCOPE_INSUFFICIENT',
+            message: err.message,
+          });
+          return;
+        }
+
+        reply.status(401).send({
+          error: code,
+          message: err.message,
+        });
+        return;
+      }
+
+      log('error', 'Unexpected error', { error: String(err) });
+      reply.status(500).send({
+        error: 'INTERNAL_ERROR',
+        message: 'An unexpected error occurred',
+      });
+    }
+  });
+
+  return app;
+}

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -1,0 +1,19 @@
+export interface RouteDefinition {
+  path: string;
+  methods: string[];
+  requiredScopes: string[];
+}
+
+export interface GatewayConfig {
+  upstream: string;
+  jwksUri: string;
+  port: number;
+  upstreamHeaders?: Record<string, string>;
+  routes: RouteDefinition[];
+  grantexApiKey?: string;
+}
+
+export interface MatchResult {
+  route: RouteDefinition;
+  params: Record<string, string>;
+}

--- a/packages/gateway/tests/config.test.ts
+++ b/packages/gateway/tests/config.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { validateConfig } from '../src/config.js';
+import { GatewayError } from '../src/errors.js';
+
+const VALID_CONFIG = {
+  upstream: 'https://api.internal.example.com',
+  jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+  port: 8080,
+  routes: [
+    {
+      path: '/calendar/**',
+      methods: ['GET'],
+      requiredScopes: ['calendar:read'],
+    },
+  ],
+};
+
+describe('validateConfig', () => {
+  it('validates a correct config', () => {
+    const config = validateConfig(VALID_CONFIG);
+    expect(config.upstream).toBe('https://api.internal.example.com');
+    expect(config.jwksUri).toBe('https://auth.example.com/.well-known/jwks.json');
+    expect(config.port).toBe(8080);
+    expect(config.routes).toHaveLength(1);
+    expect(config.routes[0]!.methods).toEqual(['GET']);
+  });
+
+  it('defaults port to 8080', () => {
+    const { port: _, ...noPort } = VALID_CONFIG;
+    const config = validateConfig(noPort);
+    expect(config.port).toBe(8080);
+  });
+
+  it('uppercases methods', () => {
+    const config = validateConfig({
+      ...VALID_CONFIG,
+      routes: [{
+        path: '/api/**',
+        methods: ['get', 'post'],
+        requiredScopes: ['api:read'],
+      }],
+    });
+    expect(config.routes[0]!.methods).toEqual(['GET', 'POST']);
+  });
+
+  it('parses upstream headers', () => {
+    const config = validateConfig({
+      ...VALID_CONFIG,
+      upstreamHeaders: { 'X-Auth': 'secret', 'X-Version': 2 },
+    });
+    expect(config.upstreamHeaders).toEqual({ 'X-Auth': 'secret', 'X-Version': '2' });
+  });
+
+  it('parses grantexApiKey', () => {
+    const config = validateConfig({
+      ...VALID_CONFIG,
+      grantexApiKey: 'gx_key_123',
+    });
+    expect(config.grantexApiKey).toBe('gx_key_123');
+  });
+
+  it('rejects null config', () => {
+    expect(() => validateConfig(null)).toThrow(GatewayError);
+  });
+
+  it('rejects missing upstream', () => {
+    const { upstream: _, ...noUpstream } = VALID_CONFIG;
+    expect(() => validateConfig(noUpstream)).toThrow(GatewayError);
+  });
+
+  it('rejects empty upstream', () => {
+    expect(() => validateConfig({ ...VALID_CONFIG, upstream: '' })).toThrow(GatewayError);
+  });
+
+  it('rejects missing jwksUri', () => {
+    const { jwksUri: _, ...noJwks } = VALID_CONFIG;
+    expect(() => validateConfig(noJwks)).toThrow(GatewayError);
+  });
+
+  it('rejects empty routes', () => {
+    expect(() => validateConfig({ ...VALID_CONFIG, routes: [] })).toThrow(GatewayError);
+  });
+
+  it('rejects missing routes', () => {
+    const { routes: _, ...noRoutes } = VALID_CONFIG;
+    expect(() => validateConfig(noRoutes)).toThrow(GatewayError);
+  });
+
+  it('rejects route without path', () => {
+    expect(() => validateConfig({
+      ...VALID_CONFIG,
+      routes: [{ methods: ['GET'], requiredScopes: ['read'] }],
+    })).toThrow(GatewayError);
+  });
+
+  it('rejects route without methods', () => {
+    expect(() => validateConfig({
+      ...VALID_CONFIG,
+      routes: [{ path: '/api', methods: [], requiredScopes: ['read'] }],
+    })).toThrow(GatewayError);
+  });
+
+  it('rejects route without requiredScopes', () => {
+    expect(() => validateConfig({
+      ...VALID_CONFIG,
+      routes: [{ path: '/api', methods: ['GET'], requiredScopes: [] }],
+    })).toThrow(GatewayError);
+  });
+
+  it('rejects non-string methods', () => {
+    expect(() => validateConfig({
+      ...VALID_CONFIG,
+      routes: [{ path: '/api', methods: [123], requiredScopes: ['read'] }],
+    })).toThrow(GatewayError);
+  });
+
+  it('validates multiple routes', () => {
+    const config = validateConfig({
+      ...VALID_CONFIG,
+      routes: [
+        { path: '/api/read', methods: ['GET'], requiredScopes: ['api:read'] },
+        { path: '/api/write', methods: ['POST', 'PUT'], requiredScopes: ['api:write'] },
+      ],
+    });
+    expect(config.routes).toHaveLength(2);
+  });
+});

--- a/packages/gateway/tests/matcher.test.ts
+++ b/packages/gateway/tests/matcher.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { matchRoute } from '../src/matcher.js';
+import type { RouteDefinition } from '../src/types.js';
+
+const ROUTES: RouteDefinition[] = [
+  { path: '/calendar/**', methods: ['GET'], requiredScopes: ['calendar:read'] },
+  { path: '/calendar/**', methods: ['POST', 'PUT', 'PATCH'], requiredScopes: ['calendar:write'] },
+  { path: '/payments/**', methods: ['POST'], requiredScopes: ['payments:initiate'] },
+  { path: '/users/*', methods: ['GET'], requiredScopes: ['users:read'] },
+  { path: '/health', methods: ['GET'], requiredScopes: ['health:read'] },
+];
+
+describe('matchRoute', () => {
+  it('matches exact path', () => {
+    const result = matchRoute('GET', '/health', ROUTES);
+    expect(result).not.toBeNull();
+    expect(result!.route.requiredScopes).toEqual(['health:read']);
+  });
+
+  it('matches ** glob (single segment)', () => {
+    const result = matchRoute('GET', '/calendar/events', ROUTES);
+    expect(result).not.toBeNull();
+    expect(result!.route.requiredScopes).toEqual(['calendar:read']);
+  });
+
+  it('matches ** glob (nested segments)', () => {
+    const result = matchRoute('GET', '/calendar/events/123/attendees', ROUTES);
+    expect(result).not.toBeNull();
+    expect(result!.route.requiredScopes).toEqual(['calendar:read']);
+  });
+
+  it('matches ** glob (just base path)', () => {
+    const result = matchRoute('GET', '/calendar/', ROUTES);
+    expect(result).not.toBeNull();
+  });
+
+  it('matches * glob (single segment only)', () => {
+    const result = matchRoute('GET', '/users/123', ROUTES);
+    expect(result).not.toBeNull();
+    expect(result!.route.requiredScopes).toEqual(['users:read']);
+  });
+
+  it('does NOT match * glob across segments', () => {
+    const result = matchRoute('GET', '/users/123/profile', ROUTES);
+    expect(result).toBeNull();
+  });
+
+  it('matches correct method', () => {
+    const getResult = matchRoute('GET', '/calendar/events', ROUTES);
+    expect(getResult!.route.requiredScopes).toEqual(['calendar:read']);
+
+    const postResult = matchRoute('POST', '/calendar/events', ROUTES);
+    expect(postResult!.route.requiredScopes).toEqual(['calendar:write']);
+  });
+
+  it('is case-insensitive on method', () => {
+    const result = matchRoute('get', '/health', ROUTES);
+    expect(result).not.toBeNull();
+  });
+
+  it('returns null for unmatched path', () => {
+    const result = matchRoute('GET', '/unknown/path', ROUTES);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for unmatched method', () => {
+    const result = matchRoute('DELETE', '/health', ROUTES);
+    expect(result).toBeNull();
+  });
+
+  it('returns first matching route', () => {
+    const routes: RouteDefinition[] = [
+      { path: '/api/**', methods: ['GET'], requiredScopes: ['first'] },
+      { path: '/api/**', methods: ['GET'], requiredScopes: ['second'] },
+    ];
+    const result = matchRoute('GET', '/api/test', routes);
+    expect(result!.route.requiredScopes).toEqual(['first']);
+  });
+
+  it('matches POST to payments', () => {
+    const result = matchRoute('POST', '/payments/intents', ROUTES);
+    expect(result).not.toBeNull();
+    expect(result!.route.requiredScopes).toEqual(['payments:initiate']);
+  });
+
+  it('does not match GET to payments (only POST configured)', () => {
+    const result = matchRoute('GET', '/payments/intents', ROUTES);
+    expect(result).toBeNull();
+  });
+});

--- a/packages/gateway/tests/proxy.test.ts
+++ b/packages/gateway/tests/proxy.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VerifiedGrant } from '@grantex/sdk';
+import { proxyRequest } from '../src/proxy.js';
+import { GatewayError } from '../src/errors.js';
+
+const MOCK_GRANT: VerifiedGrant = {
+  tokenId: 'tok_1', grantId: 'grnt_1', principalId: 'user_1',
+  agentDid: 'did:grantex:agent:a1', developerId: 'dev_1',
+  scopes: ['calendar:read'],
+  issuedAt: Math.floor(Date.now() / 1000),
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+};
+
+function mockReq(overrides: Record<string, unknown> = {}) {
+  return {
+    url: '/calendar/events',
+    method: 'GET',
+    headers: { 'content-type': 'application/json', authorization: 'Bearer xxx' },
+    body: undefined,
+    ...overrides,
+  } as never;
+}
+
+function mockReply() {
+  const r = {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    body: undefined as unknown,
+    status(code: number) { r.statusCode = code; return r; },
+    header(key: string, value: string) { r.headers[key] = value; return r; },
+    send(body: unknown) { r.body = body; return r; },
+  };
+  return r as never;
+}
+
+describe('proxyRequest', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('proxies GET request to upstream', async () => {
+    const responseHeaders = new Map([['content-type', 'application/json']]);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      headers: { entries: () => responseHeaders.entries() },
+      text: () => Promise.resolve('{"data":"ok"}'),
+    }));
+
+    const req = mockReq();
+    const reply = mockReply();
+
+    await proxyRequest(req, reply, MOCK_GRANT, {
+      upstream: 'https://api.internal.com',
+    });
+
+    const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+    expect(fetchCall[0]).toBe('https://api.internal.com/calendar/events');
+
+    const headers = fetchCall[1]?.headers as Record<string, string>;
+    expect(headers['X-Grantex-Principal']).toBe('user_1');
+    expect(headers['X-Grantex-Agent']).toBe('did:grantex:agent:a1');
+    expect(headers['X-Grantex-GrantId']).toBe('grnt_1');
+    // Authorization should be stripped
+    expect(headers['authorization']).toBeUndefined();
+  });
+
+  it('adds upstream headers', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      headers: { entries: () => [].values() },
+      text: () => Promise.resolve(''),
+    }));
+
+    await proxyRequest(mockReq(), mockReply(), MOCK_GRANT, {
+      upstream: 'https://api.internal.com',
+      upstreamHeaders: { 'X-Internal-Auth': 'secret-key' },
+    });
+
+    const headers = vi.mocked(fetch).mock.calls[0]![1]?.headers as Record<string, string>;
+    expect(headers['X-Internal-Auth']).toBe('secret-key');
+  });
+
+  it('strips trailing slash from upstream', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      headers: { entries: () => [].values() },
+      text: () => Promise.resolve(''),
+    }));
+
+    await proxyRequest(mockReq(), mockReply(), MOCK_GRANT, {
+      upstream: 'https://api.internal.com/',
+    });
+
+    const url = vi.mocked(fetch).mock.calls[0]![0] as string;
+    expect(url).toBe('https://api.internal.com/calendar/events');
+  });
+
+  it('forwards upstream status code', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 201,
+      headers: { entries: () => [].values() },
+      text: () => Promise.resolve('{"created":true}'),
+    }));
+
+    const reply = mockReply();
+    await proxyRequest(mockReq(), reply, MOCK_GRANT, {
+      upstream: 'https://api.internal.com',
+    });
+
+    expect((reply as { statusCode: number }).statusCode).toBe(201);
+  });
+
+  it('forwards POST body', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      headers: { entries: () => [].values() },
+      text: () => Promise.resolve(''),
+    }));
+
+    const req = mockReq({ method: 'POST', body: { summary: 'Meeting' } });
+    await proxyRequest(req, mockReply(), MOCK_GRANT, {
+      upstream: 'https://api.internal.com',
+    });
+
+    const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+    expect(fetchCall[1]?.body).toBe(JSON.stringify({ summary: 'Meeting' }));
+  });
+
+  it('throws UPSTREAM_ERROR on network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+
+    await expect(
+      proxyRequest(mockReq(), mockReply(), MOCK_GRANT, {
+        upstream: 'https://api.internal.com',
+      }),
+    ).rejects.toThrow(GatewayError);
+  });
+
+  it('does not send body for GET requests', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      headers: { entries: () => [].values() },
+      text: () => Promise.resolve(''),
+    }));
+
+    await proxyRequest(mockReq(), mockReply(), MOCK_GRANT, {
+      upstream: 'https://api.internal.com',
+    });
+
+    const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+    expect(fetchCall[1]?.body).toBeUndefined();
+  });
+});

--- a/packages/gateway/tests/server.test.ts
+++ b/packages/gateway/tests/server.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { VerifiedGrant } from '@grantex/sdk';
+
+vi.mock('@grantex/sdk', () => ({
+  verifyGrantToken: vi.fn(),
+  GrantexTokenError: class GrantexTokenError extends Error {
+    constructor(message: string) {
+      super(message);
+      Object.setPrototypeOf(this, GrantexTokenError.prototype);
+    }
+  },
+}));
+
+// Mock proxy to avoid actual HTTP calls
+vi.mock('../src/proxy.js', () => ({
+  proxyRequest: vi.fn(),
+}));
+
+import { verifyGrantToken, GrantexTokenError } from '@grantex/sdk';
+import { proxyRequest } from '../src/proxy.js';
+import { createGatewayServer } from '../src/server.js';
+import type { GatewayConfig } from '../src/types.js';
+
+const MOCK_GRANT: VerifiedGrant = {
+  tokenId: 'tok_1', grantId: 'grnt_1', principalId: 'user_1',
+  agentDid: 'did:grantex:agent:a1', developerId: 'dev_1',
+  scopes: ['calendar:read', 'calendar:write'],
+  issuedAt: Math.floor(Date.now() / 1000),
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+};
+
+const CONFIG: GatewayConfig = {
+  upstream: 'https://api.internal.example.com',
+  jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+  port: 0,
+  routes: [
+    { path: '/calendar/**', methods: ['GET'], requiredScopes: ['calendar:read'] },
+    { path: '/calendar/**', methods: ['POST'], requiredScopes: ['calendar:write'] },
+    { path: '/payments/**', methods: ['POST'], requiredScopes: ['payments:initiate'] },
+  ],
+};
+
+describe('createGatewayServer', () => {
+  let server: ReturnType<typeof createGatewayServer>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    server = createGatewayServer(CONFIG);
+    vi.mocked(proxyRequest).mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it('returns 404 for unmatched route', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/unknown/path',
+      headers: { authorization: 'Bearer valid-token' },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(JSON.parse(response.body).error).toBe('ROUTE_NOT_FOUND');
+  });
+
+  it('returns 401 when no Authorization header', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/calendar/events',
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(JSON.parse(response.body).error).toBe('TOKEN_MISSING');
+  });
+
+  it('returns 401 when Authorization is not Bearer', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/calendar/events',
+      headers: { authorization: 'Basic dXNlcjpwYXNz' },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(JSON.parse(response.body).error).toBe('TOKEN_MISSING');
+  });
+
+  it('returns 401 for invalid token', async () => {
+    vi.mocked(verifyGrantToken).mockRejectedValue(
+      new GrantexTokenError('Invalid signature'),
+    );
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/calendar/events',
+      headers: { authorization: 'Bearer invalid-token' },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(JSON.parse(response.body).error).toBe('TOKEN_INVALID');
+  });
+
+  it('returns 401 for expired token', async () => {
+    vi.mocked(verifyGrantToken).mockRejectedValue(
+      new GrantexTokenError('Token exp claim is in the past'),
+    );
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/calendar/events',
+      headers: { authorization: 'Bearer expired-token' },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(JSON.parse(response.body).error).toBe('TOKEN_EXPIRED');
+  });
+
+  it('returns 403 for insufficient scopes', async () => {
+    vi.mocked(verifyGrantToken).mockRejectedValue(
+      new GrantexTokenError('Missing required scope: payments:initiate'),
+    );
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/payments/intents',
+      headers: { authorization: 'Bearer token-without-payments' },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(JSON.parse(response.body).error).toBe('SCOPE_INSUFFICIENT');
+  });
+
+  it('proxies request on valid token', async () => {
+    vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/calendar/events',
+      headers: { authorization: 'Bearer valid-grant-token' },
+    });
+
+    expect(verifyGrantToken).toHaveBeenCalledWith('valid-grant-token', {
+      jwksUri: CONFIG.jwksUri,
+      requiredScopes: ['calendar:read'],
+    });
+    expect(proxyRequest).toHaveBeenCalled();
+  });
+
+  it('passes correct requiredScopes for POST', async () => {
+    vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+
+    await server.inject({
+      method: 'POST',
+      url: '/calendar/events',
+      headers: {
+        authorization: 'Bearer valid-grant-token',
+        'content-type': 'application/json',
+      },
+      payload: { summary: 'Meeting' },
+    });
+
+    expect(verifyGrantToken).toHaveBeenCalledWith('valid-grant-token', {
+      jwksUri: CONFIG.jwksUri,
+      requiredScopes: ['calendar:write'],
+    });
+  });
+
+  it('returns 500 on unexpected errors', async () => {
+    vi.mocked(verifyGrantToken).mockRejectedValue(new Error('DB connection lost'));
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/calendar/events',
+      headers: { authorization: 'Bearer token' },
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(JSON.parse(response.body).error).toBe('INTERNAL_ERROR');
+  });
+
+  it('handles DELETE method against unmatched route', async () => {
+    const response = await server.inject({
+      method: 'DELETE',
+      url: '/calendar/events/123',
+      headers: { authorization: 'Bearer token' },
+    });
+
+    // No DELETE route configured for /calendar/**
+    expect(response.statusCode).toBe(404);
+  });
+});

--- a/packages/gateway/tsconfig.build.json
+++ b/packages/gateway/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/packages/gateway/tsconfig.json
+++ b/packages/gateway/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitOverride": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/web/index.html
+++ b/web/index.html
@@ -893,6 +893,14 @@
       Drop Grantex into any AI framework or language runtime.
     </p>
     <div class="integrations-grid">
+      <a href="https://www.npmjs.com/package/@grantex/adapters" class="integration-pill" style="text-decoration:none;">
+        <span class="integration-icon">&#x1F9E9;</span>
+        Adapters
+      </a>
+      <a href="https://www.npmjs.com/package/@grantex/gateway" class="integration-pill" style="text-decoration:none;">
+        <span class="integration-icon">&#x1F6E1;</span>
+        Gateway
+      </a>
       <a href="https://www.npmjs.com/package/@grantex/express" class="integration-pill" style="text-decoration:none;">
         <span class="integration-icon" style="font-family:var(--mono);font-size:14px;font-weight:700;">Ex</span>
         Express.js


### PR DESCRIPTION
## Summary

- **`@grantex/adapters`**: Pre-built service provider adapters (Google Calendar, Gmail, Stripe, Slack) that verify grant tokens offline, check scopes, enforce constraints (e.g. `max_500`), and call upstream APIs. Includes `BaseAdapter` for building custom adapters. 72 tests, 0 typecheck errors.
- **`@grantex/gateway`**: Zero-code reverse-proxy that enforces grant tokens in front of any API via YAML config. Glob route matching (`*`, `**`), `X-Grantex-*` context headers, CLI entry point, Dockerfile. 46 tests, 0 typecheck errors.
- Docs: new `adapters.mdx` and `gateway.mdx` pages, "Service Providers" nav group in `docs.json`, integration overview cards/table rows, README rows, landing page pills.

## Test plan

- [x] `cd packages/adapters && npm run typecheck` — 0 errors
- [x] `cd packages/adapters && npm test` — 72 tests pass
- [x] `cd packages/gateway && npm run typecheck` — 0 errors
- [x] `cd packages/gateway && npm test` — 46 tests pass
- [x] Both `npm run build` produce `dist/`
- [x] `node packages/gateway/dist/cli.js --config packages/gateway/gateway.example.yaml` starts listening
- [x] `docs/docs.json` validates as JSON