### PR TITLE
feat: expose rate limit headers in all three SDKs

### DIFF
--- a/docs/guides/rate-limits.mdx
+++ b/docs/guides/rate-limits.mdx
@@ -41,23 +41,97 @@ When you exceed a rate limit, the API returns a `429 Too Many Requests` status w
 
 The `Retry-After` header tells you exactly how long to wait.
 
+## Reading Rate Limits from SDKs
+
+All three SDKs automatically parse rate limit headers from every response. You can read them via `client.lastRateLimit` (TypeScript/Python) or `client.LastRateLimit()` (Go).
+
+### After a Successful Call
+
+<CodeGroup>
+```typescript TypeScript
+import { Grantex } from '@grantex/sdk';
+
+const client = new Grantex({ apiKey: 'gx_...' });
+const agents = await client.agents.list();
+
+const rl = client.lastRateLimit;
+if (rl) {
+  console.log(`${rl.remaining}/${rl.limit} requests left, resets at ${rl.reset}`);
+}
+```
+
+```python Python
+from grantex import Grantex
+
+client = Grantex(api_key="gx_...")
+agents = client.agents.list()
+
+rl = client.last_rate_limit
+if rl:
+    print(f"{rl.remaining}/{rl.limit} requests left, resets at {rl.reset}")
+```
+
+```go Go
+client := grantex.NewClient("gx_...")
+agents, _ := client.Agents.List(ctx)
+
+if rl := client.LastRateLimit(); rl != nil {
+    fmt.Printf("%d/%d requests left, resets at %d\n", rl.Remaining, rl.Limit, rl.Reset)
+}
+```
+</CodeGroup>
+
+### Handling 429 Errors
+
+When a `429` is returned, the error object includes rate limit info with the `retryAfter` value:
+
+<CodeGroup>
+```typescript TypeScript
+import { GrantexApiError } from '@grantex/sdk';
+
+try {
+  await client.tokens.verify(token);
+} catch (err) {
+  if (err instanceof GrantexApiError && err.rateLimit?.retryAfter) {
+    console.log(`Rate limited — retry in ${err.rateLimit.retryAfter}s`);
+  }
+}
+```
+
+```python Python
+from grantex import GrantexApiError
+
+try:
+    client.tokens.verify(token)
+except GrantexApiError as err:
+    if err.rate_limit and err.rate_limit.retry_after:
+        print(f"Rate limited — retry in {err.rate_limit.retry_after}s")
+```
+
+```go Go
+var apiErr *grantex.APIError
+if errors.As(err, &apiErr) && apiErr.RateLimit != nil && apiErr.RateLimit.RetryAfter > 0 {
+    fmt.Printf("Rate limited — retry in %ds\n", apiErr.RateLimit.RetryAfter)
+}
+```
+</CodeGroup>
+
 ## Retry Strategy
 
 Use exponential backoff with jitter to avoid thundering-herd problems when multiple clients hit the limit simultaneously.
 
 <CodeGroup>
 ```typescript TypeScript
+import { GrantexApiError } from '@grantex/sdk';
+
 async function withRetry<T>(fn: () => Promise<T>, maxRetries = 3): Promise<T> {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       return await fn();
     } catch (err: unknown) {
-      const status = (err as { status?: number }).status;
-      const retryAfter = (err as { headers?: Record<string, string> }).headers?.['retry-after'];
+      if (!(err instanceof GrantexApiError) || err.statusCode !== 429 || attempt === maxRetries) throw err;
 
-      if (status !== 429 || attempt === maxRetries) throw err;
-
-      const base = retryAfter ? parseInt(retryAfter, 10) * 1000 : 2 ** attempt * 1000;
+      const base = (err.rateLimit?.retryAfter ?? 2 ** attempt) * 1000;
       const jitter = Math.random() * 500;
       await new Promise((r) => setTimeout(r, base + jitter));
     }
@@ -76,10 +150,10 @@ def with_retry(fn, max_retries=3):
         try:
             return fn()
         except GrantexApiError as err:
-            if err.status != 429 or attempt == max_retries:
+            if err.status_code != 429 or attempt == max_retries:
                 raise
 
-            base = float(err.headers.get("retry-after", 2 ** attempt))
+            base = float(err.rate_limit.retry_after if err.rate_limit and err.rate_limit.retry_after else 2 ** attempt)
             jitter = random.uniform(0, 0.5)
             time.sleep(base + jitter)
 ```
@@ -91,9 +165,9 @@ import (
 	"errors"
 	"math"
 	"math/rand"
-	"net/http"
-	"strconv"
 	"time"
+
+	grantex "github.com/mishrasanjeev/grantex-go"
 )
 
 func withRetry[T any](fn func() (T, error), maxRetries int) (T, error) {
@@ -104,19 +178,14 @@ func withRetry[T any](fn func() (T, error), maxRetries int) (T, error) {
 			return result, nil
 		}
 
-		var httpErr interface{ StatusCode() int }
-		if !errors.As(err, &httpErr) || httpErr.StatusCode() != http.StatusTooManyRequests || attempt == maxRetries {
+		var apiErr *grantex.APIError
+		if !errors.As(err, &apiErr) || apiErr.StatusCode != 429 || attempt == maxRetries {
 			return zero, err
 		}
 
 		base := math.Pow(2, float64(attempt))
-		// Use Retry-After header if available
-		if ra, ok := err.(interface{ Header(string) string }); ok {
-			if s := ra.Header("Retry-After"); s != "" {
-				if v, e := strconv.ParseFloat(s, 64); e == nil {
-					base = v
-				}
-			}
+		if apiErr.RateLimit != nil && apiErr.RateLimit.RetryAfter > 0 {
+			base = float64(apiErr.RateLimit.RetryAfter)
 		}
 		jitter := rand.Float64() * 0.5
 		time.Sleep(time.Duration((base+jitter)*1000) * time.Millisecond)

--- a/packages/go-sdk/errors.go
+++ b/packages/go-sdk/errors.go
@@ -12,6 +12,7 @@ type APIError struct {
 	Code       string
 	RequestID  string
 	Message    string
+	RateLimit  *RateLimit
 }
 
 func (e *APIError) Error() string {

--- a/packages/go-sdk/grantex.go
+++ b/packages/go-sdk/grantex.go
@@ -100,6 +100,11 @@ func Signup(ctx context.Context, params SignupParams, opts ...Option) (*SignupRe
 	return unmarshal[SignupResponse](h.post(ctx, "/v1/developers/signup", params))
 }
 
+// LastRateLimit returns the rate limit metadata from the most recent API response, or nil if unavailable.
+func (c *Client) LastRateLimit() *RateLimit {
+	return c.http.lastRateLimit
+}
+
 // Authorize creates an authorization request for a user to grant permissions to an agent.
 func (c *Client) Authorize(ctx context.Context, params AuthorizeParams) (*AuthorizationRequest, error) {
 	return unmarshal[AuthorizationRequest](c.http.post(ctx, "/v1/authorize", params))

--- a/packages/go-sdk/http.go
+++ b/packages/go-sdk/http.go
@@ -7,15 +7,48 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
 const sdkVersion = "0.1.0"
 
+func parseRateLimitHeaders(header http.Header) *RateLimit {
+	limitStr := header.Get("X-RateLimit-Limit")
+	remainingStr := header.Get("X-RateLimit-Remaining")
+	resetStr := header.Get("X-RateLimit-Reset")
+
+	if limitStr == "" || remainingStr == "" || resetStr == "" {
+		return nil
+	}
+
+	limit, err1 := strconv.Atoi(limitStr)
+	remaining, err2 := strconv.Atoi(remainingStr)
+	reset, err3 := strconv.ParseInt(resetStr, 10, 64)
+	if err1 != nil || err2 != nil || err3 != nil {
+		return nil
+	}
+
+	rl := &RateLimit{
+		Limit:     limit,
+		Remaining: remaining,
+		Reset:     reset,
+	}
+
+	if ra := header.Get("Retry-After"); ra != "" {
+		if v, err := strconv.Atoi(ra); err == nil {
+			rl.RetryAfter = v
+		}
+	}
+
+	return rl
+}
+
 type httpClient struct {
-	baseURL string
-	apiKey  string
-	client  *http.Client
+	baseURL       string
+	apiKey        string
+	client        *http.Client
+	lastRateLimit *RateLimit
 }
 
 func (h *httpClient) get(ctx context.Context, path string) ([]byte, error) {
@@ -72,6 +105,8 @@ func (h *httpClient) do(ctx context.Context, method, path string, body interface
 		return nil, &NetworkError{Message: "failed to read response body", Cause: err}
 	}
 
+	h.lastRateLimit = parseRateLimitHeaders(resp.Header)
+
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		if resp.StatusCode == http.StatusNoContent || len(respBody) == 0 {
 			return nil, nil
@@ -79,13 +114,14 @@ func (h *httpClient) do(ctx context.Context, method, path string, body interface
 		return respBody, nil
 	}
 
-	return nil, h.parseError(resp.StatusCode, respBody)
+	return nil, h.parseError(resp.StatusCode, respBody, h.lastRateLimit)
 }
 
-func (h *httpClient) parseError(statusCode int, body []byte) error {
+func (h *httpClient) parseError(statusCode int, body []byte, rl *RateLimit) error {
 	apiErr := &APIError{
 		StatusCode: statusCode,
 		Body:       json.RawMessage(body),
+		RateLimit:  rl,
 	}
 
 	var parsed struct {

--- a/packages/go-sdk/http_test.go
+++ b/packages/go-sdk/http_test.go
@@ -288,3 +288,89 @@ func TestUnmarshalPassthroughError(t *testing.T) {
 		t.Error("expected passthrough error")
 	}
 }
+
+func TestHTTPClientRateLimitHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "100")
+		w.Header().Set("X-RateLimit-Remaining", "97")
+		w.Header().Set("X-RateLimit-Reset", "1709337600")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer server.Close()
+
+	h := &httpClient{baseURL: server.URL, apiKey: "test-key", client: http.DefaultClient}
+	_, err := h.get(context.Background(), "/test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if h.lastRateLimit == nil {
+		t.Fatal("expected lastRateLimit to be set")
+	}
+	if h.lastRateLimit.Limit != 100 {
+		t.Errorf("expected Limit 100, got %d", h.lastRateLimit.Limit)
+	}
+	if h.lastRateLimit.Remaining != 97 {
+		t.Errorf("expected Remaining 97, got %d", h.lastRateLimit.Remaining)
+	}
+	if h.lastRateLimit.Reset != 1709337600 {
+		t.Errorf("expected Reset 1709337600, got %d", h.lastRateLimit.Reset)
+	}
+	if h.lastRateLimit.RetryAfter != 0 {
+		t.Errorf("expected RetryAfter 0, got %d", h.lastRateLimit.RetryAfter)
+	}
+}
+
+func TestHTTPClientRateLimitOn429(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "20")
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", "1709337600")
+		w.Header().Set("Retry-After", "42")
+		w.WriteHeader(http.StatusTooManyRequests)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Rate limit exceeded"})
+	}))
+	defer server.Close()
+
+	h := &httpClient{baseURL: server.URL, apiKey: "test-key", client: http.DefaultClient}
+	_, err := h.get(context.Background(), "/test")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected APIError, got %T", err)
+	}
+	if apiErr.StatusCode != 429 {
+		t.Errorf("expected 429, got %d", apiErr.StatusCode)
+	}
+	if apiErr.RateLimit == nil {
+		t.Fatal("expected RateLimit on error")
+	}
+	if apiErr.RateLimit.RetryAfter != 42 {
+		t.Errorf("expected RetryAfter 42, got %d", apiErr.RateLimit.RetryAfter)
+	}
+	if apiErr.RateLimit.Remaining != 0 {
+		t.Errorf("expected Remaining 0, got %d", apiErr.RateLimit.Remaining)
+	}
+}
+
+func TestHTTPClientNoRateLimitHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer server.Close()
+
+	h := &httpClient{baseURL: server.URL, apiKey: "test-key", client: http.DefaultClient}
+	_, err := h.get(context.Background(), "/test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if h.lastRateLimit != nil {
+		t.Error("expected lastRateLimit to be nil when headers are missing")
+	}
+}

--- a/packages/go-sdk/types.go
+++ b/packages/go-sdk/types.go
@@ -1,5 +1,15 @@
 package grantex
 
+// --- Rate Limits ---
+
+// RateLimit contains rate limit metadata parsed from response headers.
+type RateLimit struct {
+	Limit      int
+	Remaining  int
+	Reset      int64
+	RetryAfter int // 0 = not present
+}
+
 // --- Signup ---
 
 // SignupParams are the parameters for developer registration.

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -11,6 +11,7 @@ from ._errors import (
     GrantexTokenError,
 )
 from ._types import (
+    RateLimit,
     Agent,
     RotateKeyResponse,
     SignupParams,
@@ -101,6 +102,8 @@ __all__ = [
     "GrantexAuthError",
     "GrantexTokenError",
     "GrantexNetworkError",
+    # Rate Limits
+    "RateLimit",
     # Types
     "Agent",
     "Anomaly",

--- a/packages/sdk-py/src/grantex/_client.py
+++ b/packages/sdk-py/src/grantex/_client.py
@@ -5,7 +5,7 @@ import os
 import httpx
 
 from ._http import HttpClient
-from ._types import AuthorizationRequest, AuthorizeParams, RotateKeyResponse, SignupParams, SignupResponse
+from ._types import AuthorizationRequest, AuthorizeParams, RateLimit, RotateKeyResponse, SignupParams, SignupResponse
 from .resources._agents import AgentsClient
 from .resources._audit import AuditClient
 from .resources._anomalies import AnomaliesClient
@@ -37,6 +37,10 @@ class Grantex:
     scim: ScimClient
     sso: SsoClient
     principal_sessions: PrincipalSessionsClient
+
+    @property
+    def last_rate_limit(self) -> RateLimit | None:
+        return self._http.last_rate_limit
 
     def __init__(
         self,

--- a/packages/sdk-py/src/grantex/_errors.py
+++ b/packages/sdk-py/src/grantex/_errors.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ._types import RateLimit
 
 
 class GrantexError(Exception):
@@ -17,12 +20,14 @@ class GrantexApiError(GrantexError):
         body: Any = None,
         request_id: str | None = None,
         code: str | None = None,
+        rate_limit: RateLimit | None = None,
     ) -> None:
         super().__init__(message)
         self.status_code = status_code
         self.body = body
         self.request_id = request_id
         self.code = code
+        self.rate_limit = rate_limit
 
 
 class GrantexAuthError(GrantexApiError):

--- a/packages/sdk-py/src/grantex/_http.py
+++ b/packages/sdk-py/src/grantex/_http.py
@@ -5,9 +5,27 @@ from typing import Any
 import httpx
 
 from ._errors import GrantexApiError, GrantexAuthError, GrantexNetworkError
+from ._types import RateLimit
 
 _SDK_VERSION = "0.1.0"
 _DEFAULT_TIMEOUT = 30.0
+
+
+def _parse_rate_limit_headers(headers: httpx.Headers) -> RateLimit | None:
+    limit = headers.get("x-ratelimit-limit")
+    remaining = headers.get("x-ratelimit-remaining")
+    reset = headers.get("x-ratelimit-reset")
+
+    if limit is None or remaining is None or reset is None:
+        return None
+
+    retry_after_raw = headers.get("retry-after")
+    return RateLimit(
+        limit=int(limit),
+        remaining=int(remaining),
+        reset=int(reset),
+        retry_after=int(retry_after_raw) if retry_after_raw is not None else None,
+    )
 
 
 class HttpClient:
@@ -20,6 +38,7 @@ class HttpClient:
         timeout: float = _DEFAULT_TIMEOUT,
     ) -> None:
         self._base_url = base_url.rstrip("/")
+        self._last_rate_limit: RateLimit | None = None
         self._client = httpx.Client(
             headers={
                 "Authorization": f"Bearer {api_key}",
@@ -28,6 +47,10 @@ class HttpClient:
             },
             timeout=timeout,
         )
+
+    @property
+    def last_rate_limit(self) -> RateLimit | None:
+        return self._last_rate_limit
 
     def get(self, path: str) -> Any:
         return self._request("GET", path)
@@ -62,6 +85,7 @@ class HttpClient:
             ) from exc
 
         request_id: str | None = response.headers.get("x-request-id")
+        self._last_rate_limit = _parse_rate_limit_headers(response.headers)
 
         if not response.is_success:
             body_data: Any = None
@@ -75,10 +99,12 @@ class HttpClient:
 
             if response.status_code in (401, 403):
                 raise GrantexAuthError(
-                    message, response.status_code, body_data, request_id, error_code
+                    message, response.status_code, body_data, request_id, error_code,
+                    self._last_rate_limit,
                 )
             raise GrantexApiError(
-                message, response.status_code, body_data, request_id, error_code
+                message, response.status_code, body_data, request_id, error_code,
+                self._last_rate_limit,
             )
 
         if response.status_code == 204:

--- a/packages/sdk-py/src/grantex/_types.py
+++ b/packages/sdk-py/src/grantex/_types.py
@@ -4,6 +4,17 @@ from dataclasses import dataclass
 from typing import Any
 
 
+# ─── Rate Limits ──────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RateLimit:
+    limit: int
+    remaining: int
+    reset: int
+    retry_after: int | None = None
+
+
 # ─── Signup ───────────────────────────────────────────────────────────────────
 
 

--- a/packages/sdk-py/tests/test_rate_limit.py
+++ b/packages/sdk-py/tests/test_rate_limit.py
@@ -1,0 +1,75 @@
+"""Tests for rate limit header parsing."""
+from __future__ import annotations
+
+import pytest
+import respx
+import httpx
+
+from grantex import Grantex, GrantexApiError, RateLimit
+
+
+@pytest.fixture
+def client() -> Grantex:
+    return Grantex(api_key="test-key")
+
+
+@respx.mock
+def test_last_rate_limit_populated_on_success(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(
+            200,
+            json={"agents": [], "total": 0, "page": 1, "pageSize": 20},
+            headers={
+                "x-ratelimit-limit": "100",
+                "x-ratelimit-remaining": "97",
+                "x-ratelimit-reset": "1709337600",
+            },
+        )
+    )
+
+    client.agents.list()
+
+    assert client.last_rate_limit is not None
+    assert client.last_rate_limit == RateLimit(
+        limit=100, remaining=97, reset=1709337600
+    )
+
+
+@respx.mock
+def test_rate_limit_on_429_with_retry_after(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(
+            429,
+            json={"message": "Rate limit exceeded"},
+            headers={
+                "x-ratelimit-limit": "20",
+                "x-ratelimit-remaining": "0",
+                "x-ratelimit-reset": "1709337600",
+                "retry-after": "42",
+            },
+        )
+    )
+
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.list()
+
+    err = exc_info.value
+    assert err.status_code == 429
+    assert err.rate_limit is not None
+    assert err.rate_limit == RateLimit(
+        limit=20, remaining=0, reset=1709337600, retry_after=42
+    )
+
+
+@respx.mock
+def test_last_rate_limit_none_when_headers_missing(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(
+            200,
+            json={"agents": [], "total": 0, "page": 1, "pageSize": 20},
+        )
+    )
+
+    client.agents.list()
+
+    assert client.last_rate_limit is None

--- a/packages/sdk-ts/src/client.ts
+++ b/packages/sdk-ts/src/client.ts
@@ -15,6 +15,7 @@ import type {
   AuthorizationRequest,
   AuthorizeParams,
   GrantexClientOptions,
+  RateLimit,
   RotateKeyResponse,
   SignupParams,
   SignupResponse,
@@ -37,6 +38,10 @@ export class Grantex {
   readonly scim: ScimClient;
   readonly sso: SsoClient;
   readonly principalSessions: PrincipalSessionsClient;
+
+  get lastRateLimit(): RateLimit | undefined {
+    return this.#http.lastRateLimit;
+  }
 
   constructor(options: GrantexClientOptions = {}) {
     const apiKey =

--- a/packages/sdk-ts/src/errors.ts
+++ b/packages/sdk-ts/src/errors.ts
@@ -1,3 +1,5 @@
+import type { RateLimit } from './types.js';
+
 export class GrantexError extends Error {
   constructor(message: string) {
     super(message);
@@ -12,6 +14,7 @@ export class GrantexApiError extends GrantexError {
   readonly body: unknown;
   readonly code: string | undefined;
   readonly requestId: string | undefined;
+  readonly rateLimit: RateLimit | undefined;
 
   constructor(
     message: string,
@@ -19,6 +22,7 @@ export class GrantexApiError extends GrantexError {
     body: unknown,
     requestId?: string,
     code?: string,
+    rateLimit?: RateLimit,
   ) {
     super(message);
     this.name = 'GrantexApiError';
@@ -26,6 +30,7 @@ export class GrantexApiError extends GrantexError {
     this.body = body;
     this.code = code;
     this.requestId = requestId;
+    this.rateLimit = rateLimit;
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }
@@ -37,8 +42,9 @@ export class GrantexAuthError extends GrantexApiError {
     body: unknown,
     requestId?: string,
     code?: string,
+    rateLimit?: RateLimit,
   ) {
-    super(message, statusCode, body, requestId, code);
+    super(message, statusCode, body, requestId, code, rateLimit);
     this.name = 'GrantexAuthError';
     Object.setPrototypeOf(this, new.target.prototype);
   }

--- a/packages/sdk-ts/src/http.ts
+++ b/packages/sdk-ts/src/http.ts
@@ -1,7 +1,26 @@
 import { GrantexApiError, GrantexAuthError, GrantexNetworkError } from './errors.js';
+import type { RateLimit } from './types.js';
 
 const SDK_VERSION = '0.1.0';
 const DEFAULT_TIMEOUT_MS = 30_000;
+
+function parseRateLimitHeaders(headers: Headers): RateLimit | undefined {
+  const limit = headers.get('x-ratelimit-limit');
+  const remaining = headers.get('x-ratelimit-remaining');
+  const reset = headers.get('x-ratelimit-reset');
+
+  if (limit === null || remaining === null || reset === null) {
+    return undefined;
+  }
+
+  const retryAfterRaw = headers.get('retry-after');
+  return {
+    limit: Number(limit),
+    remaining: Number(remaining),
+    reset: Number(reset),
+    ...(retryAfterRaw !== null ? { retryAfter: Number(retryAfterRaw) } : {}),
+  };
+}
 
 export interface HttpClientOptions {
   baseUrl: string;
@@ -13,11 +32,16 @@ export class HttpClient {
   readonly #baseUrl: string;
   readonly #apiKey: string;
   readonly #timeout: number;
+  #lastRateLimit: RateLimit | undefined;
 
   constructor(options: HttpClientOptions) {
     this.#baseUrl = options.baseUrl.replace(/\/$/, '');
     this.#apiKey = options.apiKey;
     this.#timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  get lastRateLimit(): RateLimit | undefined {
+    return this.#lastRateLimit;
   }
 
   async get<T>(path: string): Promise<T> {
@@ -77,6 +101,7 @@ export class HttpClient {
     }
 
     const requestId = response.headers.get('x-request-id') ?? undefined;
+    this.#lastRateLimit = parseRateLimitHeaders(response.headers);
 
     if (!response.ok) {
       let responseBody: unknown;
@@ -96,10 +121,11 @@ export class HttpClient {
           responseBody,
           requestId,
           errorCode,
+          this.#lastRateLimit,
         );
       }
 
-      throw new GrantexApiError(message, response.status, responseBody, requestId, errorCode);
+      throw new GrantexApiError(message, response.status, responseBody, requestId, errorCode, this.#lastRateLimit);
     }
 
     if (response.status === 204) {

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -21,6 +21,7 @@ export {
 
 // Types
 export type {
+  RateLimit,
   GrantexClientOptions,
   // Signup
   SignupParams,

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -1,3 +1,12 @@
+// ─── Rate Limits ─────────────────────────────────────────────────────────────
+
+export interface RateLimit {
+  limit: number;
+  remaining: number;
+  reset: number;
+  retryAfter?: number;
+}
+
 // ─── Client configuration ────────────────────────────────────────────────────
 
 export interface GrantexClientOptions {

--- a/packages/sdk-ts/tests/rate-limit.test.ts
+++ b/packages/sdk-ts/tests/rate-limit.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Grantex, GrantexApiError } from '../src/index.js';
+
+function mockFetch(status: number, body: unknown, headers: Record<string, string> = {}) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(headers),
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Rate limit headers', () => {
+  it('populates lastRateLimit on successful response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch(200, { agents: [], total: 0, page: 1, pageSize: 20 }, {
+        'x-ratelimit-limit': '100',
+        'x-ratelimit-remaining': '97',
+        'x-ratelimit-reset': '1709337600',
+      }),
+    );
+
+    const client = new Grantex({ apiKey: 'test-key' });
+    await client.agents.list();
+
+    expect(client.lastRateLimit).toEqual({
+      limit: 100,
+      remaining: 97,
+      reset: 1709337600,
+    });
+  });
+
+  it('attaches rateLimit with retryAfter to GrantexApiError on 429', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch(429, { message: 'Rate limit exceeded' }, {
+        'x-ratelimit-limit': '20',
+        'x-ratelimit-remaining': '0',
+        'x-ratelimit-reset': '1709337600',
+        'retry-after': '42',
+      }),
+    );
+
+    const client = new Grantex({ apiKey: 'test-key' });
+
+    try {
+      await client.agents.list();
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(GrantexApiError);
+      const apiErr = err as GrantexApiError;
+      expect(apiErr.statusCode).toBe(429);
+      expect(apiErr.rateLimit).toEqual({
+        limit: 20,
+        remaining: 0,
+        reset: 1709337600,
+        retryAfter: 42,
+      });
+    }
+  });
+
+  it('returns undefined lastRateLimit when headers are missing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch(200, { agents: [], total: 0, page: 1, pageSize: 20 }, {}),
+    );
+
+    const client = new Grantex({ apiKey: 'test-key' });
+    await client.agents.list();
+
+    expect(client.lastRateLimit).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Parse `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, and `Retry-After` response headers in the TypeScript, Python, and Go SDKs
- Expose via `client.lastRateLimit` (TS/Python) and `client.LastRateLimit()` (Go) for quota visibility after any API call
- Attach `rateLimit` / `rate_limit` / `RateLimit` to API error objects — especially useful on 429s for `retryAfter`
- Update docs rate-limits guide with SDK usage examples and improved retry strategy code

## Test plan
- [x] `cd packages/sdk-ts && npm run typecheck && npm test` — 0 errors, 88 tests pass (3 new)
- [x] `cd packages/sdk-py && pytest` — 98 tests pass (3 new)
- [x] `cd packages/go-sdk && go vet ./... && go test ./...` — clean, all pass (3 new)
- [x] Auth service unchanged — no tests to run
- [x] Fully backward-compatible — no existing return types changed