### PR TITLE
chore: bump SDK versions to 0.1.6

### DIFF
--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.1.5"
+version = "0.1.6"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -80,7 +80,7 @@ from ._pkce import PkceChallenge, generate_pkce
 from ._verify import verify_grant_token
 from ._webhook import verify_webhook_signature
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 __all__ = [
     # Main client

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Bump `@grantex/sdk` from 0.1.5 → 0.1.6
- Bump `grantex` (Python) from 0.1.5 → 0.1.6

Version bump for rate limit headers feature (PR #116).

## Test plan
- [x] Version-only change — no code changes