### PR TITLE
feat: add rate limit headers conformance suite

### DIFF
--- a/docs/integrations/conformance-results.mdx
+++ b/docs/integrations/conformance-results.mdx
@@ -9,14 +9,14 @@ description: "Latest conformance test results for the Grantex production server.
 The Grantex hosted service at `grantex-auth-dd4mtrt2gq-uc.a.run.app` is continuously validated against the full conformance suite. Below are the latest results.
 
 <Info>
-**42 passed, 0 failed** — 39 core + 3 optional principal-sessions tests in ~79s
+**45 passed, 0 failed** — 42 core + 3 optional principal-sessions tests in ~80s
 </Info>
 
-Last run: **February 28, 2026** | Conformance suite version: **0.1.2**
+Last run: **March 1, 2026** | Conformance suite version: **0.1.3**
 
 ---
 
-## Core Suites (39 tests)
+## Core Suites (42 tests)
 
 ### health — Health check and JWKS endpoints
 
@@ -101,6 +101,14 @@ Last run: **February 28, 2026** | Conformance suite version: **0.1.2**
 | JWKS only contains RS256 keys | Pass | §14 |
 | Delegation scope enforcement prevents escalation | Pass | §14 |
 | Audit log is append-only (PUT/DELETE return 404 or 405) | Pass | §14 |
+
+### rate-limit-headers — Rate limit headers presence and format
+
+| Test | Status | Spec |
+|------|--------|------|
+| Rate limit headers on authenticated endpoint | Pass | §14 |
+| Rate limit headers on token verify endpoint | Pass | §14 |
+| JWKS endpoint exempt from rate limits | Pass | §14 |
 
 ---
 

--- a/docs/integrations/conformance.mdx
+++ b/docs/integrations/conformance.mdx
@@ -9,7 +9,7 @@ description: "Validate that your Grantex server implementation is spec-compliant
 `@grantex/conformance` is a black-box test suite that validates any Grantex protocol server implementation. It makes real HTTP requests against a live endpoint and checks that responses match the [protocol specification](/protocol/specification).
 
 <Card title="Latest Production Results" icon="chart-bar" href="/integrations/conformance-results">
-  60 passed, 2 skipped, 0 failed — 62 total tests. See the full breakdown.
+  63 passed, 2 skipped, 0 failed — 65 total tests. See the full breakdown.
 </Card>
 
 Use it to:
@@ -90,7 +90,7 @@ Options:
 
 ## Core Suites
 
-The suite ships with **37 tests** across 9 core suites. These cover every MUST requirement in the specification.
+The suite ships with **40 tests** across 10 core suites. These cover every MUST requirement in the specification.
 
 | Suite | Tests | Spec | What it validates |
 |-------|-------|------|-------------------|
@@ -103,6 +103,7 @@ The suite ships with **37 tests** across 9 core suites. These cover every MUST r
 | `delegation` | 5 | [§9](/protocol/specification#delegation) | Delegation with JWT claims, scope enforcement, depth limits, cascade revocation |
 | `audit` | 5 | [§8](/protocol/specification#audit) | Audit log creation, hash chain integrity, entry retrieval, hash computation |
 | `security` | 5 | [§14](/protocol/specification#security) | Auth enforcement, JWKS algorithm checks, scope escalation prevention, audit immutability |
+| `rate-limit-headers` | 3 | [§14](/protocol/specification#security) | Rate limit header presence and format, JWKS endpoint exemption |
 
 ## Optional Extensions
 

--- a/packages/conformance/README.md
+++ b/packages/conformance/README.md
@@ -54,7 +54,7 @@ grantex-conformance --base-url http://localhost:3001 --api-key sk_test_xxx \
 grantex-conformance --base-url http://localhost:3001 --api-key sk_test_xxx --format json
 ```
 
-## Core Suites (37 tests)
+## Core Suites (40 tests)
 
 | Suite | Tests | Description |
 |-------|-------|-------------|
@@ -67,6 +67,7 @@ grantex-conformance --base-url http://localhost:3001 --api-key sk_test_xxx --for
 | `delegation` | 5 | Grant delegation, JWT claims, scope enforcement, depth limits, cascade revocation |
 | `audit` | 5 | Audit log creation, hash chain integrity, entry retrieval |
 | `security` | 5 | Auth enforcement, JWKS algorithm, scope escalation prevention, audit immutability |
+| `rate-limit-headers` | 3 | Rate limit header presence and format, JWKS endpoint exemption |
 
 ## Optional Extensions
 

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/conformance",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Conformance test suite for the Grantex protocol",
   "type": "module",
   "bin": {

--- a/packages/conformance/src/helpers.ts
+++ b/packages/conformance/src/helpers.ts
@@ -88,3 +88,22 @@ export function expectIncludes(arr: unknown[], value: unknown, field: string): v
     );
   }
 }
+
+export function expectHeader(res: HttpResponse, name: string): string {
+  const value = res.headers[name.toLowerCase()];
+  if (value === undefined || value === '') {
+    throw new AssertionError(`Expected header "${name}" to be present`);
+  }
+  return value;
+}
+
+export function expectNumericHeader(res: HttpResponse, name: string): number {
+  const value = expectHeader(res, name);
+  const num = Number(value);
+  if (isNaN(num)) {
+    throw new AssertionError(
+      `Expected header "${name}" to be numeric, got "${value}"`,
+    );
+  }
+  return num;
+}

--- a/packages/conformance/src/http-client.ts
+++ b/packages/conformance/src/http-client.ts
@@ -1,6 +1,6 @@
 import type { HttpResponse } from './types.js';
 
-const USER_AGENT = '@grantex/conformance/0.1.0';
+const USER_AGENT = '@grantex/conformance/0.1.3';
 
 export class ConformanceHttpClient {
   constructor(
@@ -91,6 +91,11 @@ export class ConformanceHttpClient {
 
     const durationMs = Date.now() - start;
 
+    const responseHeaders: Record<string, string> = {};
+    res.headers.forEach((value, key) => {
+      responseHeaders[key] = value;
+    });
+
     const rawText = await res.text();
     let parsed: T;
     try {
@@ -99,6 +104,6 @@ export class ConformanceHttpClient {
       parsed = rawText as T;
     }
 
-    return { status: res.status, body: parsed, rawText, durationMs };
+    return { status: res.status, headers: responseHeaders, body: parsed, rawText, durationMs };
   }
 }

--- a/packages/conformance/src/runner.ts
+++ b/packages/conformance/src/runner.ts
@@ -13,6 +13,7 @@ import { grantsSuite } from './suites/grants.js';
 import { delegationSuite } from './suites/delegation.js';
 import { auditSuite } from './suites/audit.js';
 import { securitySuite } from './suites/security.js';
+import { rateLimitHeadersSuite } from './suites/rate-limit-headers.js';
 
 // Optional suites
 import { policiesSuite } from './suites/policies.js';
@@ -33,6 +34,7 @@ const coreSuites: SuiteDefinition[] = [
   delegationSuite,
   auditSuite,
   securitySuite,
+  rateLimitHeadersSuite,
 ];
 
 const optionalSuites: SuiteDefinition[] = [

--- a/packages/conformance/src/suites/rate-limit-headers.ts
+++ b/packages/conformance/src/suites/rate-limit-headers.ts
@@ -1,0 +1,58 @@
+import type { SuiteDefinition, SuiteContext, TestResult } from '../types.js';
+import { test, expectStatus, expectNumericHeader } from '../helpers.js';
+
+const YEAR_2020_EPOCH = 1577836800;
+
+export const rateLimitHeadersSuite: SuiteDefinition = {
+  name: 'rate-limit-headers',
+  description: 'Rate limit headers presence and format',
+  optional: false,
+  run: async (ctx: SuiteContext): Promise<TestResult[]> => {
+    const results: TestResult[] = [];
+
+    results.push(
+      await test('Rate limit headers on authenticated endpoint', '§14', async () => {
+        const res = await ctx.http.get('/v1/agents');
+        expectStatus(res, 200);
+
+        expectNumericHeader(res, 'x-ratelimit-limit');
+        expectNumericHeader(res, 'x-ratelimit-remaining');
+        const reset = expectNumericHeader(res, 'x-ratelimit-reset');
+
+        if (reset < YEAR_2020_EPOCH) {
+          throw new Error(
+            `Expected x-ratelimit-reset to be a plausible unix timestamp (> ${YEAR_2020_EPOCH}), got ${reset}`,
+          );
+        }
+      }),
+    );
+
+    results.push(
+      await test('Rate limit headers on token verify endpoint', '§14', async () => {
+        const res = await ctx.http.post('/v1/tokens/verify', {
+          token: 'invalid-token-for-header-check',
+        });
+
+        expectNumericHeader(res, 'x-ratelimit-limit');
+        expectNumericHeader(res, 'x-ratelimit-remaining');
+        expectNumericHeader(res, 'x-ratelimit-reset');
+      }),
+    );
+
+    results.push(
+      await test('JWKS endpoint exempt from rate limits', '§14', async () => {
+        const res = await ctx.http.requestPublic('GET', '/.well-known/jwks.json');
+        expectStatus(res, 200);
+
+        const hasRateLimit = res.headers['x-ratelimit-limit'] !== undefined;
+        if (hasRateLimit) {
+          throw new Error(
+            'Expected JWKS endpoint to be exempt from rate limits, but x-ratelimit-limit header was present',
+          );
+        }
+      }),
+    );
+
+    return results;
+  },
+};

--- a/packages/conformance/src/types.ts
+++ b/packages/conformance/src/types.ts
@@ -9,6 +9,7 @@ export interface RunConfig {
 
 export interface HttpResponse<T = unknown> {
   status: number;
+  headers: Record<string, string>;
   body: T;
   rawText: string;
   durationMs: number;

--- a/packages/conformance/tests/helpers.test.ts
+++ b/packages/conformance/tests/helpers.test.ts
@@ -15,7 +15,7 @@ import {
 import type { HttpResponse } from '../src/types.js';
 
 function mockResponse<T>(status: number, body: T): HttpResponse<T> {
-  return { status, body, rawText: JSON.stringify(body), durationMs: 10 };
+  return { status, headers: {}, body, rawText: JSON.stringify(body), durationMs: 10 };
 }
 
 describe('test()', () => {


### PR DESCRIPTION
## Summary
- Add `headers: Record<string, string>` to the conformance `HttpResponse` type and capture response headers in the HTTP client
- Add `expectHeader()` and `expectNumericHeader()` assertion helpers
- New **rate-limit-headers** core suite (3 tests): validates `x-ratelimit-limit/remaining/reset` on authenticated endpoints, token verify, and JWKS exemption
- Bump `@grantex/conformance` to 0.1.3
- Update docs (conformance guide, results page, README)

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 27/27 passing
- [x] `npm run build` — clean