### PR TITLE
fix: remove duplicate API Reference tab in docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -20,8 +20,7 @@
         { "tab": "TypeScript SDK", "href": "/sdks/typescript/overview" },
         { "tab": "Python SDK", "href": "/sdks/python/overview" },
         { "tab": "Go SDK", "href": "/sdks/go/overview" },
-        { "tab": "Integrations", "href": "/integrations/overview" },
-        { "tab": "API Reference", "href": "/api-reference" }
+        { "tab": "Integrations", "href": "/integrations/overview" }
       ]
     },
     "tabs": [


### PR DESCRIPTION
## Summary
- The API Reference tab was appearing twice on the Mintlify docs site — once from the explicit entry in `navigation.global.tabs` and once auto-generated from the top-level `openapi` field
- Removed the redundant `global.tabs` entry; the `openapi` field + `navigation.tabs` definition still renders the tab correctly

## Test plan
- [ ] Verify on https://grantex.mintlify.app that only one API Reference tab appears after Mintlify redeploys