### PR TITLE
fix: align PKCE test mocks with plan-limit queries

### DIFF
--- a/apps/auth-service/tests/pkce.test.ts
+++ b/apps/auth-service/tests/pkce.test.ts
@@ -32,6 +32,8 @@ describe('PKCE — POST /v1/authorize', () => {
   it('accepts codeChallenge and codeChallengeMethod S256', async () => {
     const { challenge } = generateTestPkce();
     seedAuth();
+    sqlMock.mockResolvedValueOnce([]);                       // subscriptions (plan limit)
+    sqlMock.mockResolvedValueOnce([{ count: '0' }]);         // grant count (plan limit)
     sqlMock.mockResolvedValueOnce([{ id: TEST_AGENT.id }]); // agent lookup
     sqlMock.mockResolvedValueOnce([]);                       // policy lookup
     sqlMock.mockResolvedValueOnce([]);                       // insert


### PR DESCRIPTION
## Summary
- The authorize route's plan-limit-enforcement queries (subscription lookup + grant count) shifted the SQL mock queue in `pkce.test.ts`, causing the agent lookup to receive an empty array and return 404 instead of 201
- Added 2 missing mock responses before the agent lookup mock

## Test plan
- [x] `npm test` — all 226 auth-service tests passing (25 files)
- [x] PKCE test specifically: all 6 tests passing