### PR TITLE
feat: v2.0 Platform — Vault, MCP Auth, 7 Adapters, Webhook Log

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ Service providers implement scope definitions for their APIs. Agents declare whi
 | Framework | Package | Install | Status |
 |-----------|---------|---------|--------|
 | **Adapters** | `@grantex/adapters` | `npm install @grantex/adapters` | ✅ Shipped |
+| **MCP Auth Server** | `@grantex/mcp-auth` | `npm install @grantex/mcp-auth` | ✅ Shipped |
 | **Gateway** | `@grantex/gateway` | `npm install @grantex/gateway` | ✅ Shipped |
 | **Express.js** | `@grantex/express` | `npm install @grantex/express` | ✅ Shipped |
 | **FastAPI** | `grantex-fastapi` | `pip install grantex-fastapi` | ✅ Shipped |
@@ -569,6 +570,9 @@ Walk through all 7 steps of the protocol: register an agent, authorize, exchange
 | [`crewai-agent`](examples/crewai-agent) | CrewAI agent with Grantex authorization | `python main.py` |
 | [`openai-agents`](examples/openai-agents) | OpenAI Agents SDK integration | `python main.py` |
 | [`google-adk`](examples/google-adk) | Google ADK agent with Grantex tools | `python main.py` |
+| [`gateway-proxy`](examples/gateway-proxy) | Gateway reverse proxy with YAML config and scope enforcement | `npm start` |
+| [`adapter-google-calendar`](examples/adapter-google-calendar) | GoogleCalendarAdapter with grant token verification | `npm start` |
+| [`multi-agent-delegation`](examples/multi-agent-delegation) | Parent/child delegation with cascade revocation | `npm start` |
 
 ---
 
@@ -615,6 +619,7 @@ All milestones through v1.0 are complete. See [ROADMAP.md](https://github.com/mi
 | **v0.2 — Integrations** | LangChain, AutoGen, webhooks, Stripe billing, CLI | ✅ Complete |
 | **v0.3 — Enterprise** | CrewAI, Vercel AI, compliance exports, policy engine, SCIM/SSO, anomaly detection | ✅ Complete |
 | **v1.0 — Stable Protocol** | Protocol spec finalized (v1.0), security audit, SOC2, standards submission | ✅ Complete |
+| **v2.0 — Platform** | MCP Auth Server, Credential Vault, 7 new adapters, webhook delivery log, examples | ✅ Complete |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,43 +48,20 @@
 
 ---
 
-## Now — v2.0 Platform
-
-Making Grantex the default authorization layer for every AI agent.
-
-### MCP Authorization Server
-- [ ] Drop-in OAuth 2.1 + PKCE auth provider for any MCP server
-- [ ] Dynamic client registration support
-- [ ] Resource indicators (RFC 8707) support
-
-### Credential Vault
-- [ ] Secure per-user credential store for third-party OAuth tokens
-- [ ] Agents exchange Grantex grant token for upstream service credential
-- [ ] Support for OAuth, API key, and custom credential types
-- [ ] Automatic token refresh for stored credentials
-
-### Service Provider Adapters
-- [ ] Google Drive (`files:read`, `files:write`)
-- [ ] GitHub (`repos:read`, `repos:write`, `issues:read`, `issues:write`)
-- [ ] Notion (`pages:read`, `pages:write`)
-- [ ] HubSpot (`contacts:read`, `contacts:write`)
-- [ ] Salesforce (`crm:read`, `crm:write`)
-- [ ] Linear (`issues:read`, `issues:write`)
-- [ ] Jira (`issues:read`, `issues:write`)
-
-### Quality & Completeness
-- [ ] Complete MCP tool coverage (token refresh, principal sessions, agent CRUD)
-- [ ] Conformance suites for token refresh and principal sessions
-- [ ] Portal pages for SSO configuration and SCIM token management
-- [ ] Webhook delivery history and retry log in portal
-- [ ] Go quickstart example
-- [ ] Gateway, adapters, and multi-agent delegation examples
-
-**Target: End of April 2026**
+### v2.0 Platform
+- [x] MCP Authorization Server — OAuth 2.1 + PKCE, dynamic client registration, RFC 8414 metadata
+- [x] Credential Vault — encrypted per-user credential store, grant-token-based exchange
+- [x] 7 new service provider adapters: Google Drive, GitHub, Notion, HubSpot, Salesforce, Linear, Jira
+- [x] Webhook delivery log — backend endpoint + portal page with status filtering
+- [x] Complete MCP tool coverage (token refresh, principal sessions, agent CRUD)
+- [x] Conformance suites for token refresh and principal sessions
+- [x] Portal pages for SSO configuration and SCIM token management
+- [x] Go quickstart example
+- [x] Gateway proxy, adapter, and multi-agent delegation examples
 
 ---
 
-## Next — v2.1 Enterprise Scale
+## Now — v2.1 Enterprise Scale
 
 Features that make Grantex indispensable for regulated, high-scale environments.
 

--- a/apps/auth-service/src/config.ts
+++ b/apps/auth-service/src/config.ts
@@ -25,6 +25,7 @@ export const config = {
   stripeWebhookSecret: process.env['STRIPE_WEBHOOK_SECRET'] ?? null,
   stripePricePro: process.env['STRIPE_PRICE_PRO'] ?? null,
   stripePriceEnterprise: process.env['STRIPE_PRICE_ENTERPRISE'] ?? null,
+  vaultEncryptionKey: process.env['VAULT_ENCRYPTION_KEY'] ?? null,
   adminApiKey: optional('ADMIN_API_KEY', ''),
 } as const;
 

--- a/apps/auth-service/src/db/migrations/012_credential_vault.sql
+++ b/apps/auth-service/src/db/migrations/012_credential_vault.sql
@@ -1,0 +1,20 @@
+-- Credential vault for encrypted per-user credential storage
+CREATE TABLE IF NOT EXISTS vault_credentials (
+  id            TEXT PRIMARY KEY,
+  developer_id  TEXT NOT NULL,
+  principal_id  TEXT NOT NULL,
+  service       TEXT NOT NULL,
+  credential_type TEXT NOT NULL DEFAULT 'oauth2',
+  access_token  TEXT NOT NULL,
+  refresh_token TEXT,
+  token_expires_at TIMESTAMPTZ,
+  metadata      JSONB NOT NULL DEFAULT '{}',
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_vault_credentials_unique
+  ON vault_credentials (developer_id, principal_id, service);
+
+CREATE INDEX IF NOT EXISTS idx_vault_credentials_principal
+  ON vault_credentials (developer_id, principal_id);

--- a/apps/auth-service/src/lib/crypto.ts
+++ b/apps/auth-service/src/lib/crypto.ts
@@ -106,6 +106,25 @@ export async function signGrantToken(
   return builder.sign(privateKey);
 }
 
+export async function verifyGrantToken(
+  token: string,
+): Promise<{ sub: string; dev: string; scp: string[] }> {
+  const { publicKey } = getKeyPair();
+  const { payload } = await jwtVerify(token, publicKey, {
+    issuer: config.jwtIssuer,
+    algorithms: ['RS256'],
+  });
+
+  const sub = payload.sub;
+  const dev = payload['dev'] as string | undefined;
+  const scp = payload['scp'] as string[] | undefined;
+  if (!sub || !dev || !scp) {
+    throw new Error('Missing required grant token claims');
+  }
+
+  return { sub, dev, scp };
+}
+
 export async function buildJwks(): Promise<{ keys: Record<string, unknown>[] }> {
   const { publicKey, kid } = getKeyPair();
   const jwk = await exportJWK(publicKey);

--- a/apps/auth-service/src/lib/ids.ts
+++ b/apps/auth-service/src/lib/ids.ts
@@ -13,3 +13,4 @@ export const newPolicyId = (): string => `pol_${ulid()}`;
 export const newAnomalyId = (): string => `anm_${ulid()}`;
 export const newScimTokenId = (): string => `scimtok_${ulid()}`;
 export const newScimUserId = (): string => `scimuser_${ulid()}`;
+export const newVaultCredentialId = (): string => `vault_${ulid()}`;

--- a/apps/auth-service/src/lib/vault-crypto.ts
+++ b/apps/auth-service/src/lib/vault-crypto.ts
@@ -1,0 +1,40 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+import { config } from '../config.js';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+const TAG_LENGTH = 16;
+
+function getKey(): Buffer {
+  const key = config.vaultEncryptionKey;
+  if (!key) {
+    throw new Error('VAULT_ENCRYPTION_KEY is not configured');
+  }
+  return Buffer.from(key, 'hex');
+}
+
+export function encrypt(plaintext: string): string {
+  const key = getKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: TAG_LENGTH });
+
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  // Format: base64(iv + tag + ciphertext)
+  return Buffer.concat([iv, tag, encrypted]).toString('base64');
+}
+
+export function decrypt(ciphertext: string): string {
+  const key = getKey();
+  const data = Buffer.from(ciphertext, 'base64');
+
+  const iv = data.subarray(0, IV_LENGTH);
+  const tag = data.subarray(IV_LENGTH, IV_LENGTH + TAG_LENGTH);
+  const encrypted = data.subarray(IV_LENGTH + TAG_LENGTH);
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: TAG_LENGTH });
+  decipher.setAuthTag(tag);
+
+  return decipher.update(encrypted) + decipher.final('utf8');
+}

--- a/apps/auth-service/src/routes/vault.ts
+++ b/apps/auth-service/src/routes/vault.ts
@@ -1,0 +1,201 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { getSql } from '../db/client.js';
+import { newVaultCredentialId } from '../lib/ids.js';
+import { encrypt, decrypt } from '../lib/vault-crypto.js';
+import { verifyGrantToken } from '../lib/crypto.js';
+
+interface StoreCredentialBody {
+  principalId: string;
+  service: string;
+  credentialType?: string;
+  accessToken: string;
+  refreshToken?: string;
+  tokenExpiresAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface ExchangeCredentialBody {
+  service: string;
+}
+
+function toCredentialResponse(row: Record<string, unknown>) {
+  return {
+    id: row['id'],
+    principalId: row['principal_id'],
+    service: row['service'],
+    credentialType: row['credential_type'],
+    tokenExpiresAt: row['token_expires_at'] ?? null,
+    metadata: row['metadata'] ?? {},
+    createdAt: row['created_at'],
+    updatedAt: row['updated_at'],
+  };
+}
+
+export async function vaultRoutes(app: FastifyInstance): Promise<void> {
+  // POST /v1/vault/credentials — store encrypted credential
+  app.post<{ Body: StoreCredentialBody }>('/v1/vault/credentials', async (request, reply) => {
+    const { principalId, service, credentialType, accessToken, refreshToken, tokenExpiresAt, metadata } = request.body;
+
+    if (!principalId || !service || !accessToken) {
+      return reply.status(400).send({
+        message: 'principalId, service, and accessToken are required',
+        code: 'BAD_REQUEST',
+        requestId: request.id,
+      });
+    }
+
+    const sql = getSql();
+    const developerId = request.developer.id;
+    const id = newVaultCredentialId();
+
+    const encryptedAccess = encrypt(accessToken);
+    const encryptedRefresh = refreshToken ? encrypt(refreshToken) : null;
+
+    await sql`
+      INSERT INTO vault_credentials (id, developer_id, principal_id, service, credential_type, access_token, refresh_token, token_expires_at, metadata)
+      VALUES (
+        ${id}, ${developerId}, ${principalId}, ${service},
+        ${credentialType ?? 'oauth2'}, ${encryptedAccess}, ${encryptedRefresh},
+        ${tokenExpiresAt ?? null}, ${JSON.stringify(metadata ?? {})}
+      )
+      ON CONFLICT (developer_id, principal_id, service) DO UPDATE SET
+        access_token = ${encryptedAccess},
+        refresh_token = ${encryptedRefresh},
+        credential_type = ${credentialType ?? 'oauth2'},
+        token_expires_at = ${tokenExpiresAt ?? null},
+        metadata = ${JSON.stringify(metadata ?? {})},
+        updated_at = NOW()
+    `;
+
+    return reply.status(201).send({
+      id,
+      principalId,
+      service,
+      credentialType: credentialType ?? 'oauth2',
+      createdAt: new Date().toISOString(),
+    });
+  });
+
+  // GET /v1/vault/credentials — list credentials (metadata only)
+  app.get('/v1/vault/credentials', async (request, reply) => {
+    const sql = getSql();
+    const query = request.query as Record<string, string>;
+    const developerId = request.developer.id;
+
+    const principalId = query['principalId'] ?? null;
+    const service = query['service'] ?? null;
+
+    const rows = await sql`
+      SELECT id, principal_id, service, credential_type, token_expires_at, metadata, created_at, updated_at
+      FROM vault_credentials
+      WHERE developer_id = ${developerId}
+        AND (${principalId}::text IS NULL OR principal_id = ${principalId ?? ''})
+        AND (${service}::text IS NULL OR service = ${service ?? ''})
+      ORDER BY created_at DESC
+    `;
+
+    return reply.send({ credentials: rows.map(toCredentialResponse) });
+  });
+
+  // GET /v1/vault/credentials/:id — get credential metadata (no raw token)
+  app.get<{ Params: { id: string } }>('/v1/vault/credentials/:id', async (request, reply) => {
+    const sql = getSql();
+    const rows = await sql`
+      SELECT id, principal_id, service, credential_type, token_expires_at, metadata, created_at, updated_at
+      FROM vault_credentials
+      WHERE id = ${request.params.id} AND developer_id = ${request.developer.id}
+    `;
+    const cred = rows[0];
+    if (!cred) {
+      return reply.status(404).send({
+        message: 'Credential not found',
+        code: 'NOT_FOUND',
+        requestId: request.id,
+      });
+    }
+    return reply.send(toCredentialResponse(cred));
+  });
+
+  // DELETE /v1/vault/credentials/:id — delete credential
+  app.delete<{ Params: { id: string } }>('/v1/vault/credentials/:id', async (request, reply) => {
+    const sql = getSql();
+    const rows = await sql`
+      DELETE FROM vault_credentials
+      WHERE id = ${request.params.id} AND developer_id = ${request.developer.id}
+      RETURNING id
+    `;
+    if (!rows[0]) {
+      return reply.status(404).send({
+        message: 'Credential not found',
+        code: 'NOT_FOUND',
+        requestId: request.id,
+      });
+    }
+    return reply.status(204).send();
+  });
+
+  // POST /v1/vault/credentials/exchange — exchange grant token for upstream credential
+  app.post<{ Body: ExchangeCredentialBody }>(
+    '/v1/vault/credentials/exchange',
+    { config: { skipAuth: true } },
+    async (request, reply) => {
+      const auth = request.headers.authorization;
+      if (!auth || !auth.startsWith('Bearer ')) {
+        return reply.status(401).send({
+          message: 'Missing grant token',
+          code: 'UNAUTHORIZED',
+          requestId: request.id,
+        });
+      }
+
+      const grantToken = auth.slice(7);
+      let claims: { sub: string; dev: string; scp: string[] };
+      try {
+        claims = await verifyGrantToken(grantToken);
+      } catch {
+        return reply.status(401).send({
+          message: 'Invalid or expired grant token',
+          code: 'UNAUTHORIZED',
+          requestId: request.id,
+        });
+      }
+
+      const { service } = request.body;
+      if (!service) {
+        return reply.status(400).send({
+          message: 'service is required',
+          code: 'BAD_REQUEST',
+          requestId: request.id,
+        });
+      }
+
+      const sql = getSql();
+      const rows = await sql`
+        SELECT id, access_token, refresh_token, token_expires_at, credential_type, metadata
+        FROM vault_credentials
+        WHERE developer_id = ${claims.dev}
+          AND principal_id = ${claims.sub}
+          AND service = ${service}
+      `;
+
+      const cred = rows[0];
+      if (!cred) {
+        return reply.status(404).send({
+          message: 'No credential found for this principal and service',
+          code: 'NOT_FOUND',
+          requestId: request.id,
+        });
+      }
+
+      const accessToken = decrypt(cred['access_token'] as string);
+
+      return reply.send({
+        accessToken,
+        service,
+        credentialType: cred['credential_type'],
+        tokenExpiresAt: cred['token_expires_at'] ?? null,
+        metadata: cred['metadata'] ?? {},
+      });
+    },
+  );
+}

--- a/apps/auth-service/src/routes/webhooks.ts
+++ b/apps/auth-service/src/routes/webhooks.ts
@@ -93,6 +93,68 @@ export async function webhooksRoutes(app: FastifyInstance): Promise<void> {
     });
   });
 
+  // GET /v1/webhooks/:id/deliveries
+  app.get<{ Params: { id: string } }>('/v1/webhooks/:id/deliveries', async (request, reply) => {
+    const sql = getSql();
+    const developerId = request.developer.id;
+    const webhookId = request.params.id;
+
+    // Verify webhook ownership
+    const whRows = await sql`
+      SELECT id FROM webhooks
+      WHERE id = ${webhookId} AND developer_id = ${developerId}
+    `;
+    if (!whRows[0]) {
+      return reply.status(404).send({
+        message: 'Webhook not found',
+        code: 'NOT_FOUND',
+        requestId: request.id,
+      });
+    }
+
+    const query = request.query as Record<string, string>;
+    const status = query['status'] ?? null;
+    const page = Math.max(1, parseInt(query['page'] ?? '1', 10));
+    const pageSize = Math.min(100, Math.max(1, parseInt(query['pageSize'] ?? '20', 10)));
+    const offset = (page - 1) * pageSize;
+
+    const countRows = await sql<{ count: string }[]>`
+      SELECT COUNT(*) AS count FROM webhook_deliveries
+      WHERE webhook_id = ${webhookId}
+        AND (${status}::text IS NULL OR status = ${status ?? ''})
+    `;
+    const total = parseInt(countRows[0]?.count ?? '0', 10);
+
+    const rows = await sql`
+      SELECT id, event_id, event_type, status, attempts, max_attempts, url,
+             last_error, created_at, delivered_at
+      FROM webhook_deliveries
+      WHERE webhook_id = ${webhookId}
+        AND (${status}::text IS NULL OR status = ${status ?? ''})
+      ORDER BY created_at DESC
+      LIMIT ${pageSize} OFFSET ${offset}
+    `;
+
+    return reply.send({
+      deliveries: rows.map(r => ({
+        id: r['id'],
+        webhookId,
+        eventId: r['event_id'],
+        eventType: r['event_type'],
+        status: r['status'],
+        attempts: r['attempts'],
+        maxAttempts: r['max_attempts'],
+        url: r['url'],
+        lastError: r['last_error'] ?? null,
+        createdAt: r['created_at'],
+        deliveredAt: r['delivered_at'] ?? null,
+      })),
+      total,
+      page,
+      pageSize,
+    });
+  });
+
   // DELETE /v1/webhooks/:id
   app.delete<{ Params: { id: string } }>('/v1/webhooks/:id', async (request, reply) => {
     const sql = getSql();

--- a/apps/auth-service/src/server.ts
+++ b/apps/auth-service/src/server.ts
@@ -26,6 +26,7 @@ import { meRoutes } from './routes/me.js';
 import { healthRoutes } from './routes/health.js';
 import { adminRoutes } from './routes/admin.js';
 import { principalRoutes } from './routes/principal.js';
+import { vaultRoutes } from './routes/vault.js';
 
 export type AppOptions = {
   logger?: boolean | object;
@@ -79,6 +80,7 @@ export async function buildApp(opts: AppOptions = {}) {
   await app.register(meRoutes);
   await app.register(adminRoutes);
   await app.register(principalRoutes);
+  await app.register(vaultRoutes);
 
   return app;
 }

--- a/apps/auth-service/tests/vault.test.ts
+++ b/apps/auth-service/tests/vault.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { buildTestApp, authHeader, seedAuth, sqlMock } from './helpers.js';
+import type { FastifyInstance } from 'fastify';
+
+// Mock vault-crypto module
+vi.mock('../src/lib/vault-crypto.js', () => ({
+  encrypt: vi.fn((val: string) => `encrypted:${val}`),
+  decrypt: vi.fn((val: string) => val.replace('encrypted:', '')),
+}));
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+describe('POST /v1/vault/credentials', () => {
+  it('stores a credential and returns metadata', async () => {
+    seedAuth();
+    // INSERT ... ON CONFLICT
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/vault/credentials',
+      headers: authHeader(),
+      payload: {
+        principalId: 'user_123',
+        service: 'google',
+        accessToken: 'ya29.access_token',
+        refreshToken: 'rt_refresh',
+        metadata: { email: 'test@example.com' },
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.principalId).toBe('user_123');
+    expect(body.service).toBe('google');
+    expect(body.credentialType).toBe('oauth2');
+    expect(body.id).toMatch(/^vault_/);
+    expect(body).not.toHaveProperty('accessToken');
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/vault/credentials',
+      headers: authHeader(),
+      payload: { principalId: 'user_123' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('BAD_REQUEST');
+  });
+});
+
+describe('GET /v1/vault/credentials', () => {
+  it('lists credentials without raw tokens', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([
+      {
+        id: 'vault_1',
+        principal_id: 'user_123',
+        service: 'google',
+        credential_type: 'oauth2',
+        token_expires_at: '2026-04-01T00:00:00Z',
+        metadata: { email: 'test@example.com' },
+        created_at: '2026-03-01T00:00:00Z',
+        updated_at: '2026-03-01T00:00:00Z',
+      },
+    ]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/vault/credentials',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.credentials).toHaveLength(1);
+    expect(body.credentials[0].id).toBe('vault_1');
+    expect(body.credentials[0].service).toBe('google');
+    expect(body.credentials[0]).not.toHaveProperty('accessToken');
+    expect(body.credentials[0]).not.toHaveProperty('access_token');
+  });
+
+  it('filters by principalId and service', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/vault/credentials?principalId=user_123&service=google',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().credentials).toEqual([]);
+  });
+});
+
+describe('GET /v1/vault/credentials/:id', () => {
+  it('returns credential metadata', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([
+      {
+        id: 'vault_1',
+        principal_id: 'user_123',
+        service: 'google',
+        credential_type: 'oauth2',
+        token_expires_at: null,
+        metadata: {},
+        created_at: '2026-03-01T00:00:00Z',
+        updated_at: '2026-03-01T00:00:00Z',
+      },
+    ]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/vault/credentials/vault_1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().id).toBe('vault_1');
+  });
+
+  it('returns 404 for non-existent credential', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/vault/credentials/vault_nonexistent',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('NOT_FOUND');
+  });
+});
+
+describe('DELETE /v1/vault/credentials/:id', () => {
+  it('deletes a credential', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ id: 'vault_1' }]);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/v1/vault/credentials/vault_1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+  });
+
+  it('returns 404 for non-existent credential', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/v1/vault/credentials/vault_nonexistent',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('POST /v1/vault/credentials/exchange', () => {
+  it('exchanges grant token for upstream credential', async () => {
+    // No seedAuth needed — skipAuth is true
+    // Mock the grant token verification
+    const { signGrantToken } = await import('../src/lib/crypto.js');
+    const token = await signGrantToken({
+      sub: 'user_123',
+      agt: 'did:grantex:ag_01',
+      dev: 'dev_TEST',
+      scp: ['google:read'],
+      jti: 'tok_VAULT01',
+      grnt: 'grnt_VAULT01',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    sqlMock.mockResolvedValueOnce([
+      {
+        id: 'vault_1',
+        access_token: 'encrypted:ya29.real_token',
+        refresh_token: null,
+        token_expires_at: '2026-04-01T00:00:00Z',
+        credential_type: 'oauth2',
+        metadata: {},
+      },
+    ]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/vault/credentials/exchange',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { service: 'google' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.accessToken).toBe('ya29.real_token');
+    expect(body.service).toBe('google');
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/vault/credentials/exchange',
+      payload: { service: 'google' },
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 400 without service', async () => {
+    const { signGrantToken } = await import('../src/lib/crypto.js');
+    const token = await signGrantToken({
+      sub: 'user_123',
+      agt: 'did:grantex:ag_01',
+      dev: 'dev_TEST',
+      scp: ['google:read'],
+      jti: 'tok_VAULT02',
+      grnt: 'grnt_VAULT02',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/vault/credentials/exchange',
+      headers: { authorization: `Bearer ${token}` },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 when no credential found', async () => {
+    const { signGrantToken } = await import('../src/lib/crypto.js');
+    const token = await signGrantToken({
+      sub: 'user_123',
+      agt: 'did:grantex:ag_01',
+      dev: 'dev_TEST',
+      scp: ['google:read'],
+      jti: 'tok_VAULT03',
+      grnt: 'grnt_VAULT03',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/vault/credentials/exchange',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { service: 'nonexistent' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/apps/auth-service/tests/webhookDeliveries.test.ts
+++ b/apps/auth-service/tests/webhookDeliveries.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { buildTestApp, authHeader, seedAuth, sqlMock } from './helpers.js';
+import type { FastifyInstance } from 'fastify';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+const MOCK_DELIVERY = {
+  id: 'whd_01',
+  event_id: 'evt_01',
+  event_type: 'grant.created',
+  status: 'delivered',
+  attempts: 1,
+  max_attempts: 5,
+  url: 'https://example.com/webhook',
+  last_error: null,
+  created_at: '2026-03-01T00:00:00Z',
+  delivered_at: '2026-03-01T00:00:01Z',
+};
+
+describe('GET /v1/webhooks/:id/deliveries', () => {
+  it('returns deliveries for an owned webhook', async () => {
+    seedAuth();
+    // Webhook ownership check
+    sqlMock.mockResolvedValueOnce([{ id: 'wh_01' }]);
+    // Count
+    sqlMock.mockResolvedValueOnce([{ count: '1' }]);
+    // Deliveries
+    sqlMock.mockResolvedValueOnce([MOCK_DELIVERY]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/webhooks/wh_01/deliveries',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.deliveries).toHaveLength(1);
+    expect(body.deliveries[0].id).toBe('whd_01');
+    expect(body.deliveries[0].webhookId).toBe('wh_01');
+    expect(body.deliveries[0].eventType).toBe('grant.created');
+    expect(body.deliveries[0].status).toBe('delivered');
+    expect(body.deliveries[0].deliveredAt).toBe('2026-03-01T00:00:01Z');
+    expect(body.total).toBe(1);
+    expect(body.page).toBe(1);
+    expect(body.pageSize).toBe(20);
+  });
+
+  it('returns 404 for non-existent webhook', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/webhooks/wh_nonexistent/deliveries',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('NOT_FOUND');
+  });
+
+  it('filters by status', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ id: 'wh_01' }]);
+    sqlMock.mockResolvedValueOnce([{ count: '0' }]);
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/webhooks/wh_01/deliveries?status=failed',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().deliveries).toEqual([]);
+  });
+
+  it('supports pagination parameters', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ id: 'wh_01' }]);
+    sqlMock.mockResolvedValueOnce([{ count: '50' }]);
+    sqlMock.mockResolvedValueOnce([MOCK_DELIVERY]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/webhooks/wh_01/deliveries?page=2&pageSize=10',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.page).toBe(2);
+    expect(body.pageSize).toBe(10);
+    expect(body.total).toBe(50);
+  });
+
+  it('clamps pageSize to max 100', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ id: 'wh_01' }]);
+    sqlMock.mockResolvedValueOnce([{ count: '0' }]);
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/webhooks/wh_01/deliveries?pageSize=500',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().pageSize).toBe(100);
+  });
+
+  it('returns empty deliveries array when none exist', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ id: 'wh_01' }]);
+    sqlMock.mockResolvedValueOnce([{ count: '0' }]);
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/webhooks/wh_01/deliveries',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.deliveries).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+
+  it('maps failed delivery fields correctly', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ id: 'wh_01' }]);
+    sqlMock.mockResolvedValueOnce([{ count: '1' }]);
+    sqlMock.mockResolvedValueOnce([{
+      ...MOCK_DELIVERY,
+      status: 'failed',
+      attempts: 5,
+      last_error: 'Connection refused',
+      delivered_at: null,
+    }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/webhooks/wh_01/deliveries',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const d = res.json().deliveries[0];
+    expect(d.status).toBe('failed');
+    expect(d.attempts).toBe(5);
+    expect(d.lastError).toBe('Connection refused');
+    expect(d.deliveredAt).toBeNull();
+  });
+
+  it('returns 401 without auth header', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/webhooks/wh_01/deliveries',
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/apps/auth-service/vitest.config.ts
+++ b/apps/auth-service/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       STRIPE_WEBHOOK_SECRET: 'whsec_fake',
       STRIPE_PRICE_PRO: 'price_pro_fake',
       STRIPE_PRICE_ENTERPRISE: 'price_enterprise_fake',
+      VAULT_ENCRYPTION_KEY: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
     },
   },
 });

--- a/apps/portal/src/api/webhooks.ts
+++ b/apps/portal/src/api/webhooks.ts
@@ -26,3 +26,39 @@ export function createWebhook(data: {
 export function deleteWebhook(id: string): Promise<void> {
   return api.del(`/v1/webhooks/${encodeURIComponent(id)}`);
 }
+
+// Webhook deliveries
+
+export interface WebhookDelivery {
+  id: string;
+  webhookId: string;
+  eventId: string;
+  eventType: string;
+  status: 'pending' | 'delivered' | 'failed';
+  attempts: number;
+  maxAttempts: number;
+  url: string;
+  lastError: string | null;
+  createdAt: string;
+  deliveredAt: string | null;
+}
+
+export interface ListDeliveriesResponse {
+  deliveries: WebhookDelivery[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export async function listDeliveries(
+  webhookId: string,
+  opts?: { page?: number; pageSize?: number; status?: string },
+): Promise<ListDeliveriesResponse> {
+  const params = new URLSearchParams();
+  if (opts?.page) params.set('page', String(opts.page));
+  if (opts?.pageSize) params.set('pageSize', String(opts.pageSize));
+  if (opts?.status) params.set('status', opts.status);
+  const qs = params.toString();
+  const path = `/v1/webhooks/${encodeURIComponent(webhookId)}/deliveries${qs ? `?${qs}` : ''}`;
+  return api.get<ListDeliveriesResponse>(path);
+}

--- a/apps/portal/src/pages/webhooks/WebhookDeliveries.tsx
+++ b/apps/portal/src/pages/webhooks/WebhookDeliveries.tsx
@@ -1,0 +1,202 @@
+import { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import {
+  listDeliveries,
+  type WebhookDelivery,
+} from '../../api/webhooks';
+import { useToast } from '../../store/toast';
+import { Card } from '../../components/ui/Card';
+import { Button } from '../../components/ui/Button';
+import { Table } from '../../components/ui/Table';
+import { Spinner } from '../../components/ui/Spinner';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { formatDate, truncateId } from '../../lib/format';
+
+const STATUS_STYLES: Record<string, string> = {
+  delivered: 'bg-green-500/10 text-green-400 border-green-500/20',
+  pending: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  failed: 'bg-red-500/10 text-red-400 border-red-500/20',
+};
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border ${STATUS_STYLES[status] ?? 'bg-gx-card text-gx-muted border-gx-border'}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+export function WebhookDeliveries() {
+  const { id: webhookId } = useParams<{ id: string }>();
+  const [deliveries, setDeliveries] = useState<WebhookDelivery[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [statusFilter, setStatusFilter] = useState<string>('');
+  const pageSize = 20;
+  const { show } = useToast();
+
+  useEffect(() => {
+    if (!webhookId) return;
+    setLoading(true);
+    listDeliveries(webhookId, {
+      page,
+      pageSize,
+      ...(statusFilter ? { status: statusFilter } : {}),
+    })
+      .then((res) => {
+        setDeliveries(res.deliveries);
+        setTotal(res.total);
+      })
+      .catch(() => show('Failed to load deliveries', 'error'))
+      .finally(() => setLoading(false));
+  }, [webhookId, page, statusFilter, show]);
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <Link
+            to="/dashboard/webhooks"
+            className="text-gx-muted hover:text-gx-text transition-colors text-sm"
+          >
+            Webhooks
+          </Link>
+          <span className="text-gx-muted">/</span>
+          <h1 className="text-xl font-semibold text-gx-text">Deliveries</h1>
+          <span className="font-mono text-xs text-gx-muted">
+            {webhookId ? truncateId(webhookId) : ''}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {['', 'delivered', 'pending', 'failed'].map((s) => (
+            <button
+              key={s}
+              onClick={() => {
+                setStatusFilter(s);
+                setPage(1);
+              }}
+              className={`px-3 py-1.5 rounded-md border text-xs transition-colors ${
+                statusFilter === s
+                  ? 'border-gx-accent bg-gx-accent/10 text-gx-accent'
+                  : 'border-gx-border text-gx-muted hover:border-gx-muted'
+              }`}
+            >
+              {s || 'All'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <Card className="p-0">
+        {deliveries.length === 0 ? (
+          <EmptyState
+            title="No deliveries"
+            description={
+              statusFilter
+                ? `No ${statusFilter} deliveries found.`
+                : 'No webhook deliveries recorded yet.'
+            }
+          />
+        ) : (
+          <div className="p-4">
+            <Table
+              data={deliveries}
+              rowKey={(d) => d.id}
+              columns={[
+                {
+                  key: 'id',
+                  header: 'ID',
+                  render: (d) => (
+                    <span className="font-mono text-xs text-gx-accent2">
+                      {truncateId(d.id)}
+                    </span>
+                  ),
+                },
+                {
+                  key: 'eventType',
+                  header: 'Event',
+                  render: (d) => (
+                    <span className="font-mono text-xs text-gx-text">{d.eventType}</span>
+                  ),
+                },
+                {
+                  key: 'status',
+                  header: 'Status',
+                  render: (d) => <StatusBadge status={d.status} />,
+                },
+                {
+                  key: 'attempts',
+                  header: 'Attempts',
+                  render: (d) => (
+                    <span className="text-xs text-gx-muted">
+                      {d.attempts}/{d.maxAttempts}
+                    </span>
+                  ),
+                },
+                {
+                  key: 'error',
+                  header: 'Error',
+                  render: (d) => (
+                    <span className="text-xs text-red-400 truncate max-w-xs block">
+                      {d.lastError ?? '-'}
+                    </span>
+                  ),
+                },
+                {
+                  key: 'created',
+                  header: 'Created',
+                  render: (d) => (
+                    <span className="text-gx-muted text-xs">{formatDate(d.createdAt)}</span>
+                  ),
+                },
+              ]}
+            />
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between mt-4 pt-4 border-t border-gx-border">
+                <span className="text-xs text-gx-muted">
+                  {total} total deliveries
+                </span>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={page <= 1}
+                    onClick={() => setPage((p) => p - 1)}
+                  >
+                    Previous
+                  </Button>
+                  <span className="text-xs text-gx-muted">
+                    Page {page} of {totalPages}
+                  </span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={page >= totalPages}
+                    onClick={() => setPage((p) => p + 1)}
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/apps/portal/src/pages/webhooks/WebhookList.tsx
+++ b/apps/portal/src/pages/webhooks/WebhookList.tsx
@@ -16,6 +16,7 @@ import { ConfirmDialog } from '../../components/ui/ConfirmDialog';
 import { Modal } from '../../components/ui/Modal';
 import { Input } from '../../components/ui/Input';
 import { CopyButton } from '../../components/ui/CopyButton';
+import { Link } from 'react-router-dom';
 import { formatDate, truncateId } from '../../lib/format';
 
 const EVENT_OPTIONS = ['grant.created', 'grant.revoked', 'token.issued'];
@@ -148,16 +149,25 @@ export function WebhookList() {
                   header: '',
                   className: 'text-right',
                   render: (w) => (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setDeleteTarget(w);
-                      }}
-                    >
-                      Delete
-                    </Button>
+                    <div className="flex items-center justify-end gap-2">
+                      <Link
+                        to={`/dashboard/webhooks/${w.id}/deliveries`}
+                        className="text-xs text-gx-accent hover:underline"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        Deliveries
+                      </Link>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setDeleteTarget(w);
+                        }}
+                      >
+                        Delete
+                      </Button>
+                    </div>
                   ),
                 },
               ]}

--- a/apps/portal/src/routes.tsx
+++ b/apps/portal/src/routes.tsx
@@ -19,6 +19,7 @@ import { SettingsPage } from './pages/settings/SettingsPage';
 import { SsoConfigPage } from './pages/settings/SsoConfigPage';
 import { ScimTokensPage } from './pages/settings/ScimTokensPage';
 import { WebhookList } from './pages/webhooks/WebhookList';
+import { WebhookDeliveries } from './pages/webhooks/WebhookDeliveries';
 import { AdminPage } from './pages/admin/AdminPage';
 import { NotFound } from './pages/NotFound';
 import { RequireAuth } from './RequireAuth';
@@ -44,6 +45,7 @@ export const routes: RouteObject[] = [
       { path: '/dashboard/audit', element: <AuditLog /> },
       { path: '/dashboard/audit/:id', element: <AuditDetail /> },
       { path: '/dashboard/webhooks', element: <WebhookList /> },
+      { path: '/dashboard/webhooks/:id/deliveries', element: <WebhookDeliveries /> },
       { path: '/dashboard/policies', element: <PolicyList /> },
       { path: '/dashboard/policies/new', element: <PolicyForm /> },
       { path: '/dashboard/policies/:id/edit', element: <PolicyForm /> },

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -8,7 +8,13 @@ description: "Grantex integrates with every major AI agent framework."
 
 <CardGroup cols={2}>
   <Card title="Service Provider Adapters" icon="puzzle-piece" href="/integrations/adapters">
-    Pre-built integrations for Google Calendar, Gmail, Stripe, and Slack.
+    Pre-built integrations for 11 services: Google Calendar, Gmail, Drive, Stripe, Slack, GitHub, Notion, HubSpot, Salesforce, Linear, Jira.
+  </Card>
+  <Card title="Credential Vault" icon="vault" href="/integrations/vault">
+    Encrypted per-user credential store. Agents exchange grant tokens for upstream service credentials.
+  </Card>
+  <Card title="MCP Auth Server" icon="lock" href="/integrations/mcp-auth">
+    Drop-in OAuth 2.1 + PKCE authorization provider for any MCP server.
   </Card>
   <Card title="Grantex Gateway" icon="shield-halved" href="/integrations/gateway">
     Zero-code reverse-proxy that enforces grant tokens via YAML config.
@@ -53,6 +59,7 @@ description: "Grantex integrates with every major AI agent framework."
 | Framework | Package | Install | Language |
 |-----------|---------|---------|----------|
 | Adapters | `@grantex/adapters` | `npm install @grantex/adapters` | TypeScript |
+| MCP Auth Server | `@grantex/mcp-auth` | `npm install @grantex/mcp-auth` | TypeScript |
 | Gateway | `@grantex/gateway` | `npm install @grantex/gateway` | TypeScript |
 | Express.js | `@grantex/express` | `npm install @grantex/express` | TypeScript |
 | FastAPI | `grantex-fastapi` | `pip install grantex-fastapi` | Python |

--- a/examples/adapter-google-calendar/README.md
+++ b/examples/adapter-google-calendar/README.md
@@ -1,0 +1,23 @@
+# Adapter Example — Google Calendar
+
+Demonstrates using the `GoogleCalendarAdapter` from `@grantex/adapters` with grant tokens.
+
+## Setup
+
+```bash
+# Start the auth service
+docker compose up
+
+# Install and run
+cd examples/adapter-google-calendar
+npm install && npm start
+```
+
+## What it does
+
+1. Registers an agent with `calendar:read` and `calendar:write` scopes
+2. Obtains a grant token via sandbox auto-approval
+3. Uses the `GoogleCalendarAdapter` to list and create events
+4. Demonstrates scope enforcement — a read-only token is blocked from creating events
+
+The adapter handles grant token verification, scope checking, and audit logging automatically.

--- a/examples/adapter-google-calendar/package.json
+++ b/examples/adapter-google-calendar/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "grantex-example-adapter-google-calendar",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "npx tsx src/index.ts"
+  },
+  "dependencies": {
+    "@grantex/adapters": "^0.1.1",
+    "@grantex/sdk": "^0.1.6"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/examples/adapter-google-calendar/src/index.ts
+++ b/examples/adapter-google-calendar/src/index.ts
@@ -1,0 +1,125 @@
+/**
+ * Grantex Adapter Example — Google Calendar
+ *
+ * Demonstrates using the GoogleCalendarAdapter with a grant token:
+ *   1. Register an agent with calendar scopes
+ *   2. Authorize and get a grant token (sandbox auto-approve)
+ *   3. Use the adapter to list events and create an event
+ *   4. The adapter verifies the grant token and enforces scopes
+ *
+ * Prerequisites:
+ *   docker compose up          # from repo root
+ *   cd examples/adapter-google-calendar
+ *   npm install && npm start
+ *
+ * Note: This example uses a mock credential. In production, you would
+ * store the user's Google OAuth token in the Grantex Credential Vault
+ * and use vault.exchange() to retrieve it.
+ */
+
+import { Grantex } from '@grantex/sdk';
+import { GoogleCalendarAdapter } from '@grantex/adapters';
+
+const BASE_URL = process.env['GRANTEX_URL'] ?? 'http://localhost:3001';
+const API_KEY = process.env['GRANTEX_API_KEY'] ?? 'sandbox-api-key-local';
+const JWKS_URI = `${BASE_URL}/.well-known/jwks.json`;
+
+async function main(): Promise<void> {
+  const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
+
+  // ── 1. Register an agent with calendar scopes ──────────────────────
+  const agent = await grantex.agents.register({
+    name: 'calendar-agent',
+    description: 'Agent that reads and writes calendar events',
+    scopes: ['calendar:read', 'calendar:write'],
+  });
+  console.log('Agent registered:', agent.id);
+
+  // ── 2. Authorize — sandbox mode auto-approves ─────────────────────
+  const authRequest = await grantex.authorize({
+    agentId: agent.id,
+    userId: 'user-alice',
+    scopes: ['calendar:read', 'calendar:write'],
+  });
+
+  const code = (authRequest as unknown as Record<string, unknown>)['code'] as string;
+  if (!code) {
+    console.error('No code returned — are you using the sandbox API key?');
+    process.exit(1);
+  }
+
+  const token = await grantex.tokens.exchange({ code, agentId: agent.id });
+  console.log('Grant token obtained, scopes:', token.scopes.join(', '));
+
+  // ── 3. Create the adapter ─────────────────────────────────────────
+  // In production, credentials would come from the Vault:
+  //   const cred = await grantex.vault.exchange(token.grantToken, { service: 'google' });
+  //   const credential = cred.accessToken;
+  const adapter = new GoogleCalendarAdapter({
+    jwksUri: JWKS_URI,
+    credentials: 'mock-google-oauth-token',
+    auditLogger: async (params) => {
+      console.log(`  [audit] ${params.action} — ${params.status}`);
+    },
+  });
+
+  // ── 4. List events ─────────────────────────────────────────────────
+  console.log('\nListing calendar events...');
+  try {
+    const result = await adapter.listEvents(token.grantToken, {
+      calendarId: 'primary',
+      maxResults: 10,
+    });
+    console.log('  Success:', result.success);
+    console.log('  Data:', JSON.stringify(result.data, null, 2));
+  } catch (err) {
+    // Expected: upstream call will fail with mock credential
+    console.log('  Expected error (mock credential):', (err as Error).message);
+  }
+
+  // ── 5. Create an event ─────────────────────────────────────────────
+  console.log('\nCreating a calendar event...');
+  try {
+    const result = await adapter.createEvent(token.grantToken, {
+      summary: 'Team Planning',
+      start: { dateTime: '2026-03-15T10:00:00Z' },
+      end: { dateTime: '2026-03-15T11:00:00Z' },
+      description: 'Weekly planning session',
+      attendees: [{ email: 'bob@example.com' }],
+    });
+    console.log('  Success:', result.success);
+  } catch (err) {
+    console.log('  Expected error (mock credential):', (err as Error).message);
+  }
+
+  // ── 6. Demonstrate scope enforcement ───────────────────────────────
+  console.log('\nScope enforcement demo:');
+
+  // Get a token with only calendar:read scope
+  const readOnlyAuth = await grantex.authorize({
+    agentId: agent.id,
+    userId: 'user-bob',
+    scopes: ['calendar:read'],
+  });
+  const readOnlyCode = (readOnlyAuth as unknown as Record<string, unknown>)['code'] as string;
+  const readOnlyToken = await grantex.tokens.exchange({ code: readOnlyCode, agentId: agent.id });
+  console.log('  Read-only token scopes:', readOnlyToken.scopes.join(', '));
+
+  try {
+    // This should fail — createEvent requires calendar:write
+    await adapter.createEvent(readOnlyToken.grantToken, {
+      summary: 'Unauthorized Event',
+      start: { dateTime: '2026-03-15T14:00:00Z' },
+      end: { dateTime: '2026-03-15T15:00:00Z' },
+    });
+  } catch (err) {
+    console.log('  Correctly blocked:', (err as Error).message);
+  }
+
+  console.log('\nDone! Adapter example complete.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/gateway-proxy/README.md
+++ b/examples/gateway-proxy/README.md
@@ -1,0 +1,31 @@
+# Gateway Proxy Example
+
+Demonstrates the Grantex gateway as a reverse proxy with scope enforcement.
+
+## Setup
+
+```bash
+# Start the auth service
+docker compose up
+
+# Install and run
+cd examples/gateway-proxy
+npm install
+npm start
+```
+
+## What it does
+
+1. Starts a mock upstream API server on port 4001
+2. Registers an agent and obtains a grant token with `calendar:read` and `email:read` scopes
+3. Makes requests through the gateway (port 4000) — authorized requests pass through, unauthorized requests are rejected
+
+## Running the Gateway
+
+In a separate terminal:
+
+```bash
+npx grantex-gateway gateway.yaml
+```
+
+The gateway reads `gateway.yaml` and enforces grant token scopes on each route.

--- a/examples/gateway-proxy/gateway.yaml
+++ b/examples/gateway-proxy/gateway.yaml
@@ -1,0 +1,35 @@
+# Grantex Gateway — YAML Configuration Example
+#
+# This config proxies requests to a local mock API server,
+# enforcing Grantex grant tokens with scope validation.
+
+listen:
+  port: 4000
+  host: "0.0.0.0"
+
+jwksUri: "http://localhost:3001/.well-known/jwks.json"
+
+routes:
+  - path: "/api/calendar/**"
+    upstream: "http://localhost:4001"
+    requiredScopes:
+      - "calendar:read"
+    methods: ["GET"]
+
+  - path: "/api/calendar/events"
+    upstream: "http://localhost:4001"
+    requiredScopes:
+      - "calendar:write"
+    methods: ["POST"]
+
+  - path: "/api/email/**"
+    upstream: "http://localhost:4001"
+    requiredScopes:
+      - "email:read"
+    methods: ["GET"]
+
+  - path: "/api/email/send"
+    upstream: "http://localhost:4001"
+    requiredScopes:
+      - "email:send"
+    methods: ["POST"]

--- a/examples/gateway-proxy/package.json
+++ b/examples/gateway-proxy/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "grantex-example-gateway-proxy",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "npx tsx src/index.ts"
+  },
+  "dependencies": {
+    "@grantex/gateway": "^0.1.1",
+    "@grantex/sdk": "^0.1.6"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/examples/gateway-proxy/src/index.ts
+++ b/examples/gateway-proxy/src/index.ts
@@ -1,0 +1,128 @@
+/**
+ * Grantex Gateway Proxy Example
+ *
+ * Demonstrates:
+ *   1. A mock upstream API server
+ *   2. The Grantex gateway proxying requests with scope enforcement
+ *   3. Agents making requests through the gateway with grant tokens
+ *
+ * Prerequisites:
+ *   docker compose up          # from repo root
+ *   cd examples/gateway-proxy
+ *   npm install && npm start
+ */
+
+import { createServer } from 'node:http';
+import { Grantex, verifyGrantToken } from '@grantex/sdk';
+
+const BASE_URL = process.env['GRANTEX_URL'] ?? 'http://localhost:3001';
+const API_KEY = process.env['GRANTEX_API_KEY'] ?? 'sandbox-api-key-local';
+const GATEWAY_PORT = 4000;
+const UPSTREAM_PORT = 4001;
+
+// ── Mock upstream API server ────────────────────────────────────────────
+
+const upstreamServer = createServer((req, res) => {
+  console.log(`  [upstream] ${req.method} ${req.url}`);
+
+  if (req.url?.startsWith('/api/calendar')) {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      events: [
+        { id: 'evt_1', summary: 'Team standup', time: '10:00 AM' },
+        { id: 'evt_2', summary: 'Design review', time: '2:00 PM' },
+      ],
+    }));
+    return;
+  }
+
+  if (req.url?.startsWith('/api/email')) {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ messages: [{ id: 'msg_1', subject: 'Hello!' }] }));
+    return;
+  }
+
+  res.writeHead(404);
+  res.end('Not found');
+});
+
+async function main(): Promise<void> {
+  const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
+
+  // ── 1. Start mock upstream server ──────────────────────────────────
+  await new Promise<void>((resolve) => {
+    upstreamServer.listen(UPSTREAM_PORT, () => {
+      console.log(`Mock upstream API listening on :${UPSTREAM_PORT}`);
+      resolve();
+    });
+  });
+
+  // ── 2. Register an agent and get a grant token ─────────────────────
+  const agent = await grantex.agents.register({
+    name: 'gateway-demo-agent',
+    description: 'Agent for gateway proxy example',
+    scopes: ['calendar:read', 'calendar:write', 'email:read', 'email:send'],
+  });
+  console.log('Agent registered:', agent.id);
+
+  const authRequest = await grantex.authorize({
+    agentId: agent.id,
+    userId: 'demo-user-001',
+    scopes: ['calendar:read', 'email:read'],
+  });
+
+  const code = (authRequest as unknown as Record<string, unknown>)['code'] as string;
+  if (!code) {
+    console.error('No code returned — are you using the sandbox API key?');
+    process.exit(1);
+  }
+
+  const token = await grantex.tokens.exchange({ code, agentId: agent.id });
+  console.log('Grant token obtained, scopes:', token.scopes.join(', '));
+
+  // ── 3. Make requests through the gateway ───────────────────────────
+  console.log('\n--- Requests through Gateway (port', GATEWAY_PORT, ') ---\n');
+
+  // Request with valid scope
+  console.log('GET /api/calendar/events (has calendar:read scope):');
+  try {
+    const res = await fetch(`http://localhost:${GATEWAY_PORT}/api/calendar/events`, {
+      headers: { Authorization: `Bearer ${token.grantToken}` },
+    });
+    console.log(`  Status: ${res.status}`);
+    if (res.ok) {
+      const body = await res.json();
+      console.log('  Body:', JSON.stringify(body, null, 2));
+    }
+  } catch (err) {
+    console.log(`  Gateway not running (start separately with: npx grantex-gateway gateway.yaml)`);
+  }
+
+  // Request that should be rejected (no email:send scope)
+  console.log('\nPOST /api/email/send (does NOT have email:send scope):');
+  try {
+    const res = await fetch(`http://localhost:${GATEWAY_PORT}/api/email/send`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token.grantToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ to: 'bob@example.com', subject: 'Test' }),
+    });
+    console.log(`  Status: ${res.status} (expected 403 — scope not granted)`);
+  } catch (err) {
+    console.log(`  Gateway not running (start separately with: npx grantex-gateway gateway.yaml)`);
+  }
+
+  // ── Cleanup ────────────────────────────────────────────────────────
+  upstreamServer.close();
+  console.log('\nDone! Gateway proxy example complete.');
+  console.log('To run the full flow, start the gateway in another terminal:');
+  console.log('  npx grantex-gateway gateway.yaml');
+}
+
+main().catch((err) => {
+  console.error(err);
+  upstreamServer.close();
+  process.exit(1);
+});

--- a/examples/multi-agent-delegation/README.md
+++ b/examples/multi-agent-delegation/README.md
@@ -1,0 +1,22 @@
+# Multi-Agent Delegation Example
+
+Demonstrates the Grantex delegation chain pattern (SPEC §9) with cascade revocation.
+
+## Setup
+
+```bash
+# Start the auth service
+docker compose up
+
+# Install and run
+cd examples/multi-agent-delegation
+npm install && npm start
+```
+
+## What it does
+
+1. Registers a parent agent (orchestrator) and a child agent (calendar worker)
+2. Parent agent obtains a grant token with broad scopes
+3. Parent delegates a subset of scopes (`calendar:read` only) to the child
+4. Verifies the child token shows delegation metadata (`delegationDepth`, `parentAgentDid`)
+5. Revokes the parent grant — cascade revocation automatically revokes the child grant

--- a/examples/multi-agent-delegation/package.json
+++ b/examples/multi-agent-delegation/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "grantex-example-multi-agent-delegation",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "npx tsx src/index.ts"
+  },
+  "dependencies": {
+    "@grantex/sdk": "^0.1.6"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/examples/multi-agent-delegation/src/index.ts
+++ b/examples/multi-agent-delegation/src/index.ts
@@ -1,0 +1,113 @@
+/**
+ * Grantex Multi-Agent Delegation Example
+ *
+ * Demonstrates the delegation chain pattern (SPEC §9):
+ *   1. Register a parent agent and a child agent
+ *   2. Parent agent gets a grant token with broad scopes
+ *   3. Parent delegates a subset of scopes to the child agent
+ *   4. Child agent's token is verified with delegation metadata
+ *   5. Revoking the parent grant cascade-revokes the child
+ *
+ * Prerequisites:
+ *   docker compose up          # from repo root
+ *   cd examples/multi-agent-delegation
+ *   npm install && npm start
+ */
+
+import { Grantex, verifyGrantToken } from '@grantex/sdk';
+
+const BASE_URL = process.env['GRANTEX_URL'] ?? 'http://localhost:3001';
+const API_KEY = process.env['GRANTEX_API_KEY'] ?? 'sandbox-api-key-local';
+const JWKS_URI = `${BASE_URL}/.well-known/jwks.json`;
+
+async function main(): Promise<void> {
+  const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
+
+  // ── 1. Register parent and child agents ────────────────────────────
+  const parentAgent = await grantex.agents.register({
+    name: 'orchestrator-agent',
+    description: 'Parent agent that coordinates tasks across sub-agents',
+    scopes: ['calendar:read', 'calendar:write', 'email:read', 'email:send'],
+  });
+  console.log('Parent agent registered:', parentAgent.id);
+
+  const childAgent = await grantex.agents.register({
+    name: 'calendar-worker',
+    description: 'Specialized agent for calendar operations only',
+    scopes: ['calendar:read', 'calendar:write'],
+  });
+  console.log('Child agent registered:', childAgent.id);
+
+  // ── 2. Parent agent gets a grant token ─────────────────────────────
+  const parentAuth = await grantex.authorize({
+    agentId: parentAgent.id,
+    userId: 'user-alice',
+    scopes: ['calendar:read', 'calendar:write', 'email:read', 'email:send'],
+  });
+
+  const parentCode = (parentAuth as unknown as Record<string, unknown>)['code'] as string;
+  if (!parentCode) {
+    console.error('No code returned — are you using the sandbox API key?');
+    process.exit(1);
+  }
+
+  const parentToken = await grantex.tokens.exchange({
+    code: parentCode,
+    agentId: parentAgent.id,
+  });
+  console.log('\nParent grant token:');
+  console.log('  grantId:', parentToken.grantId);
+  console.log('  scopes:', parentToken.scopes.join(', '));
+
+  // ── 3. Parent delegates to child with subset of scopes ────────────
+  console.log('\nDelegating calendar scopes to child agent...');
+  const delegatedToken = await grantex.grants.delegate({
+    grantToken: parentToken.grantToken,
+    agentId: childAgent.id,
+    scopes: ['calendar:read'],  // Only a subset of parent's scopes
+  });
+  console.log('Child grant token:');
+  console.log('  grantId:', delegatedToken.grantId);
+  console.log('  scopes:', delegatedToken.scopes.join(', '));
+
+  // ── 4. Verify the child token — shows delegation metadata ─────────
+  console.log('\nVerifying child token offline...');
+  const childVerified = await verifyGrantToken(delegatedToken.grantToken, {
+    jwksUri: JWKS_URI,
+  });
+  console.log('Child token claims:');
+  console.log('  principalId:', childVerified.principalId);
+  console.log('  agentDid:', childVerified.agentDid);
+  console.log('  scopes:', childVerified.scopes.join(', '));
+  console.log('  delegationDepth:', childVerified.delegationDepth);
+  if (childVerified.parentAgentDid) {
+    console.log('  parentAgentDid:', childVerified.parentAgentDid);
+  }
+  if (childVerified.parentGrantId) {
+    console.log('  parentGrantId:', childVerified.parentGrantId);
+  }
+
+  // ── 5. Both tokens are valid ───────────────────────────────────────
+  const parentCheck = await grantex.tokens.verify(parentToken.grantToken);
+  const childCheck = await grantex.tokens.verify(delegatedToken.grantToken);
+  console.log('\nBefore revocation:');
+  console.log('  Parent token valid:', parentCheck.valid);
+  console.log('  Child token valid:', childCheck.valid);
+
+  // ── 6. Revoke parent → cascades to child ──────────────────────────
+  console.log('\nRevoking parent grant (cascade)...');
+  await grantex.grants.revoke(parentToken.grantId);
+
+  const parentCheckAfter = await grantex.tokens.verify(parentToken.grantToken);
+  const childCheckAfter = await grantex.tokens.verify(delegatedToken.grantToken);
+  console.log('After parent revocation:');
+  console.log('  Parent token valid:', parentCheckAfter.valid, '(expected: false)');
+  console.log('  Child token valid:', childCheckAfter.valid, '(expected: false — cascade revoked)');
+
+  console.log('\nDone! Multi-agent delegation lifecycle complete.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/adapters/src/adapters/github.ts
+++ b/packages/adapters/src/adapters/github.ts
@@ -1,0 +1,82 @@
+import { BaseAdapter } from '../base-adapter.js';
+import { GrantexAdapterError } from '../errors.js';
+import type { AdapterConfig, AdapterResult, ListRepositoriesParams, CreateIssueParams } from '../types.js';
+
+const GITHUB_API = 'https://api.github.com';
+
+export class GitHubAdapter extends BaseAdapter {
+  constructor(config: AdapterConfig) {
+    super(config);
+  }
+
+  async listRepositories(
+    token: string,
+    params: ListRepositoriesParams = {},
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'repos:read');
+    const credential = await this.resolveCredential();
+
+    const query = new URLSearchParams();
+    if (params.sort) query.set('sort', params.sort);
+    if (params.direction) query.set('direction', params.direction);
+    if (params.per_page) query.set('per_page', String(params.per_page));
+    if (params.page) query.set('page', String(params.page));
+
+    const qs = query.toString();
+    const url = `${GITHUB_API}/user/repos${qs ? `?${qs}` : ''}`;
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${credential}`,
+          Accept: 'application/vnd.github+json',
+        },
+      });
+      await this.logAudit(grant, 'repos:listRepositories', 'success');
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'repos:listRepositories', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `GitHub list failed: ${String(err)}`);
+    }
+  }
+
+  async createIssue(
+    token: string,
+    params: CreateIssueParams,
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'issues:write');
+    const credential = await this.resolveCredential();
+
+    const url = `${GITHUB_API}/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/issues`;
+
+    const body: Record<string, unknown> = {
+      title: params.title,
+      ...(params.body !== undefined ? { body: params.body } : {}),
+      ...(params.labels !== undefined ? { labels: params.labels } : {}),
+      ...(params.assignees !== undefined ? { assignees: params.assignees } : {}),
+    };
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${credential}`,
+          Accept: 'application/vnd.github+json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      await this.logAudit(grant, 'issues:createIssue', 'success', {
+        owner: params.owner,
+        repo: params.repo,
+      });
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'issues:createIssue', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `GitHub create issue failed: ${String(err)}`);
+    }
+  }
+}

--- a/packages/adapters/src/adapters/google-drive.ts
+++ b/packages/adapters/src/adapters/google-drive.ts
@@ -1,0 +1,85 @@
+import { BaseAdapter } from '../base-adapter.js';
+import { GrantexAdapterError } from '../errors.js';
+import type { AdapterConfig, AdapterResult, ListFilesParams, UploadFileParams } from '../types.js';
+
+const DRIVE_API = 'https://www.googleapis.com/drive/v3';
+
+export class GoogleDriveAdapter extends BaseAdapter {
+  constructor(config: AdapterConfig) {
+    super(config);
+  }
+
+  async listFiles(
+    token: string,
+    params: ListFilesParams = {},
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'files:read');
+    const credential = await this.resolveCredential();
+
+    const query = new URLSearchParams();
+    if (params.q) query.set('q', params.q);
+    if (params.pageSize) query.set('pageSize', String(params.pageSize));
+    if (params.pageToken) query.set('pageToken', params.pageToken);
+    if (params.fields) query.set('fields', params.fields);
+
+    const qs = query.toString();
+    const url = `${DRIVE_API}/files${qs ? `?${qs}` : ''}`;
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${credential}` },
+      });
+      await this.logAudit(grant, 'files:listFiles', 'success');
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'files:listFiles', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Drive list failed: ${String(err)}`);
+    }
+  }
+
+  async uploadFile(
+    token: string,
+    params: UploadFileParams,
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'files:write');
+    const credential = await this.resolveCredential();
+
+    const metadata: Record<string, unknown> = {
+      name: params.name,
+      mimeType: params.mimeType,
+      ...(params.parents !== undefined ? { parents: params.parents } : {}),
+      ...(params.description !== undefined ? { description: params.description } : {}),
+    };
+
+    const url = 'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart';
+
+    const boundary = 'grantex_boundary';
+    const body =
+      `--${boundary}\r\n` +
+      'Content-Type: application/json; charset=UTF-8\r\n\r\n' +
+      JSON.stringify(metadata) +
+      `\r\n--${boundary}\r\n` +
+      `Content-Type: ${params.mimeType}\r\n\r\n` +
+      String(params.content) +
+      `\r\n--${boundary}--`;
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${credential}`,
+          'Content-Type': `multipart/related; boundary=${boundary}`,
+        },
+        body,
+      });
+      await this.logAudit(grant, 'files:uploadFile', 'success', { name: params.name });
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'files:uploadFile', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Drive upload failed: ${String(err)}`);
+    }
+  }
+}

--- a/packages/adapters/src/adapters/hubspot.ts
+++ b/packages/adapters/src/adapters/hubspot.ts
@@ -1,0 +1,80 @@
+import { BaseAdapter } from '../base-adapter.js';
+import { GrantexAdapterError } from '../errors.js';
+import type { AdapterConfig, AdapterResult, ListContactsParams, CreateContactParams } from '../types.js';
+
+const HUBSPOT_API = 'https://api.hubapi.com';
+
+export class HubSpotAdapter extends BaseAdapter {
+  constructor(config: AdapterConfig) {
+    super(config);
+  }
+
+  async listContacts(
+    token: string,
+    params: ListContactsParams = {},
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'contacts:read');
+    const credential = await this.resolveCredential();
+
+    const query = new URLSearchParams();
+    if (params.limit) query.set('limit', String(params.limit));
+    if (params.after) query.set('after', params.after);
+    if (params.properties) {
+      for (const prop of params.properties) {
+        query.append('properties', prop);
+      }
+    }
+
+    const qs = query.toString();
+    const url = `${HUBSPOT_API}/crm/v3/objects/contacts${qs ? `?${qs}` : ''}`;
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${credential}` },
+      });
+      await this.logAudit(grant, 'contacts:listContacts', 'success');
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'contacts:listContacts', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `HubSpot list failed: ${String(err)}`);
+    }
+  }
+
+  async createContact(
+    token: string,
+    params: CreateContactParams,
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'contacts:write');
+    const credential = await this.resolveCredential();
+
+    const url = `${HUBSPOT_API}/crm/v3/objects/contacts`;
+
+    const properties: Record<string, string> = {
+      email: params.email,
+      ...(params.firstname !== undefined ? { firstname: params.firstname } : {}),
+      ...(params.lastname !== undefined ? { lastname: params.lastname } : {}),
+      ...(params.phone !== undefined ? { phone: params.phone } : {}),
+      ...(params.company !== undefined ? { company: params.company } : {}),
+      ...(params.properties !== undefined ? params.properties : {}),
+    };
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${credential}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ properties }),
+      });
+      await this.logAudit(grant, 'contacts:createContact', 'success', { email: params.email });
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'contacts:createContact', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `HubSpot create failed: ${String(err)}`);
+    }
+  }
+}

--- a/packages/adapters/src/adapters/jira.ts
+++ b/packages/adapters/src/adapters/jira.ts
@@ -1,0 +1,98 @@
+import { BaseAdapter } from '../base-adapter.js';
+import { GrantexAdapterError } from '../errors.js';
+import type { AdapterResult, SearchIssuesParams, JiraCreateIssueParams, JiraAdapterConfig } from '../types.js';
+
+export class JiraAdapter extends BaseAdapter {
+  readonly #baseUrl: string;
+
+  constructor(config: JiraAdapterConfig) {
+    super(config);
+    this.#baseUrl = config.baseUrl.replace(/\/$/, '');
+  }
+
+  async searchIssues(
+    token: string,
+    params: SearchIssuesParams,
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'issues:read');
+    const credential = await this.resolveCredential();
+
+    const url = `${this.#baseUrl}/rest/api/3/search`;
+
+    const body: Record<string, unknown> = {
+      jql: params.jql,
+      ...(params.maxResults !== undefined ? { maxResults: params.maxResults } : {}),
+      ...(params.startAt !== undefined ? { startAt: params.startAt } : {}),
+      ...(params.fields !== undefined ? { fields: params.fields } : {}),
+    };
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${credential}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      await this.logAudit(grant, 'issues:searchIssues', 'success');
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'issues:searchIssues', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Jira search failed: ${String(err)}`);
+    }
+  }
+
+  async createIssue(
+    token: string,
+    params: JiraCreateIssueParams,
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'issues:write');
+    const credential = await this.resolveCredential();
+
+    const url = `${this.#baseUrl}/rest/api/3/issue`;
+
+    const fields: Record<string, unknown> = {
+      project: { key: params.projectKey },
+      summary: params.summary,
+      issuetype: { name: params.issueType },
+      ...(params.description !== undefined
+        ? {
+            description: {
+              type: 'doc',
+              version: 1,
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: params.description }],
+                },
+              ],
+            },
+          }
+        : {}),
+      ...(params.priority !== undefined ? { priority: { name: params.priority } } : {}),
+      ...(params.assignee !== undefined ? { assignee: { id: params.assignee } } : {}),
+      ...(params.labels !== undefined ? { labels: params.labels } : {}),
+    };
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${credential}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ fields }),
+      });
+      await this.logAudit(grant, 'issues:createIssue', 'success', {
+        projectKey: params.projectKey,
+      });
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'issues:createIssue', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Jira create failed: ${String(err)}`);
+    }
+  }
+}

--- a/packages/adapters/src/adapters/linear.ts
+++ b/packages/adapters/src/adapters/linear.ts
@@ -1,0 +1,99 @@
+import { BaseAdapter } from '../base-adapter.js';
+import { GrantexAdapterError } from '../errors.js';
+import type { AdapterConfig, AdapterResult, ListIssuesParams, LinearCreateIssueParams } from '../types.js';
+
+const LINEAR_API = 'https://api.linear.app/graphql';
+
+export class LinearAdapter extends BaseAdapter {
+  constructor(config: AdapterConfig) {
+    super(config);
+  }
+
+  async listIssues(
+    token: string,
+    params: ListIssuesParams = {},
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'issues:read');
+    const credential = await this.resolveCredential();
+
+    const variables: Record<string, unknown> = {
+      ...(params.first !== undefined ? { first: params.first } : {}),
+      ...(params.after !== undefined ? { after: params.after } : {}),
+      ...(params.filter !== undefined ? { filter: params.filter } : {}),
+    };
+
+    if (params.teamId) {
+      variables['filter'] = {
+        ...(typeof variables['filter'] === 'object' && variables['filter'] !== null
+          ? variables['filter'] as Record<string, unknown>
+          : {}),
+        team: { id: { eq: params.teamId } },
+      };
+    }
+
+    const query = `query ListIssues($first: Int, $after: String, $filter: IssueFilter) {
+      issues(first: $first, after: $after, filter: $filter) {
+        nodes { id identifier title state { name } priority assignee { name } createdAt updatedAt }
+        pageInfo { hasNextPage endCursor }
+      }
+    }`;
+
+    try {
+      const data = await this.callUpstream(LINEAR_API, {
+        method: 'POST',
+        headers: {
+          Authorization: credential,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ query, variables }),
+      });
+      await this.logAudit(grant, 'issues:listIssues', 'success');
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'issues:listIssues', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Linear list failed: ${String(err)}`);
+    }
+  }
+
+  async createIssue(
+    token: string,
+    params: LinearCreateIssueParams,
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'issues:write');
+    const credential = await this.resolveCredential();
+
+    const input: Record<string, unknown> = {
+      teamId: params.teamId,
+      title: params.title,
+      ...(params.description !== undefined ? { description: params.description } : {}),
+      ...(params.priority !== undefined ? { priority: params.priority } : {}),
+      ...(params.assigneeId !== undefined ? { assigneeId: params.assigneeId } : {}),
+      ...(params.labelIds !== undefined ? { labelIds: params.labelIds } : {}),
+    };
+
+    const query = `mutation CreateIssue($input: IssueCreateInput!) {
+      issueCreate(input: $input) {
+        success
+        issue { id identifier title state { name } priority createdAt }
+      }
+    }`;
+
+    try {
+      const data = await this.callUpstream(LINEAR_API, {
+        method: 'POST',
+        headers: {
+          Authorization: credential,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ query, variables: { input } }),
+      });
+      await this.logAudit(grant, 'issues:createIssue', 'success', { teamId: params.teamId });
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'issues:createIssue', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Linear create failed: ${String(err)}`);
+    }
+  }
+}

--- a/packages/adapters/src/adapters/notion.ts
+++ b/packages/adapters/src/adapters/notion.ts
@@ -1,0 +1,82 @@
+import { BaseAdapter } from '../base-adapter.js';
+import { GrantexAdapterError } from '../errors.js';
+import type { AdapterConfig, AdapterResult, QueryDatabaseParams, CreatePageParams } from '../types.js';
+
+const NOTION_API = 'https://api.notion.com/v1';
+
+export class NotionAdapter extends BaseAdapter {
+  constructor(config: AdapterConfig) {
+    super(config);
+  }
+
+  async queryDatabase(
+    token: string,
+    params: QueryDatabaseParams,
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'pages:read');
+    const credential = await this.resolveCredential();
+
+    const url = `${NOTION_API}/databases/${encodeURIComponent(params.database_id)}/query`;
+
+    const body: Record<string, unknown> = {
+      ...(params.filter !== undefined ? { filter: params.filter } : {}),
+      ...(params.sorts !== undefined ? { sorts: params.sorts } : {}),
+      ...(params.page_size !== undefined ? { page_size: params.page_size } : {}),
+      ...(params.start_cursor !== undefined ? { start_cursor: params.start_cursor } : {}),
+    };
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${credential}`,
+          'Content-Type': 'application/json',
+          'Notion-Version': '2022-06-28',
+        },
+        body: JSON.stringify(body),
+      });
+      await this.logAudit(grant, 'pages:queryDatabase', 'success', {
+        databaseId: params.database_id,
+      });
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'pages:queryDatabase', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Notion query failed: ${String(err)}`);
+    }
+  }
+
+  async createPage(
+    token: string,
+    params: CreatePageParams,
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'pages:write');
+    const credential = await this.resolveCredential();
+
+    const url = `${NOTION_API}/pages`;
+
+    const body: Record<string, unknown> = {
+      parent: params.parent,
+      properties: params.properties,
+      ...(params.children !== undefined ? { children: params.children } : {}),
+    };
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${credential}`,
+          'Content-Type': 'application/json',
+          'Notion-Version': '2022-06-28',
+        },
+        body: JSON.stringify(body),
+      });
+      await this.logAudit(grant, 'pages:createPage', 'success');
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'pages:createPage', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Notion create page failed: ${String(err)}`);
+    }
+  }
+}

--- a/packages/adapters/src/adapters/salesforce.ts
+++ b/packages/adapters/src/adapters/salesforce.ts
@@ -1,0 +1,62 @@
+import { BaseAdapter } from '../base-adapter.js';
+import { GrantexAdapterError } from '../errors.js';
+import type { AdapterResult, QueryRecordsParams, CreateRecordParams, SalesforceAdapterConfig } from '../types.js';
+
+export class SalesforceAdapter extends BaseAdapter {
+  readonly #instanceUrl: string;
+
+  constructor(config: SalesforceAdapterConfig) {
+    super(config);
+    this.#instanceUrl = config.instanceUrl.replace(/\/$/, '');
+  }
+
+  async queryRecords(
+    token: string,
+    params: QueryRecordsParams,
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'crm:read');
+    const credential = await this.resolveCredential();
+
+    const url = `${this.#instanceUrl}/services/data/v59.0/query?q=${encodeURIComponent(params.query)}`;
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${credential}` },
+      });
+      await this.logAudit(grant, 'crm:queryRecords', 'success');
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'crm:queryRecords', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Salesforce query failed: ${String(err)}`);
+    }
+  }
+
+  async createRecord(
+    token: string,
+    params: CreateRecordParams,
+  ): Promise<AdapterResult> {
+    const { grant } = await this.verifyAndCheckScope(token, 'crm:write');
+    const credential = await this.resolveCredential();
+
+    const url = `${this.#instanceUrl}/services/data/v59.0/sobjects/${encodeURIComponent(params.sobject)}`;
+
+    try {
+      const data = await this.callUpstream(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${credential}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(params.fields),
+      });
+      await this.logAudit(grant, 'crm:createRecord', 'success', { sobject: params.sobject });
+      return this.wrapResult(grant, data);
+    } catch (err) {
+      await this.logAudit(grant, 'crm:createRecord', 'failure');
+      if (err instanceof GrantexAdapterError) throw err;
+      throw new GrantexAdapterError('UPSTREAM_ERROR', `Salesforce create failed: ${String(err)}`);
+    }
+  }
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -2,6 +2,13 @@ export { GoogleCalendarAdapter } from './adapters/google-calendar.js';
 export { GmailAdapter } from './adapters/gmail.js';
 export { StripeAdapter } from './adapters/stripe.js';
 export { SlackAdapter } from './adapters/slack.js';
+export { GoogleDriveAdapter } from './adapters/google-drive.js';
+export { GitHubAdapter } from './adapters/github.js';
+export { NotionAdapter } from './adapters/notion.js';
+export { HubSpotAdapter } from './adapters/hubspot.js';
+export { SalesforceAdapter } from './adapters/salesforce.js';
+export { LinearAdapter } from './adapters/linear.js';
+export { JiraAdapter } from './adapters/jira.js';
 export { BaseAdapter } from './base-adapter.js';
 export { GrantexAdapterError } from './errors.js';
 export { parseScope, findMatchingScope, enforceConstraint } from './scope-utils.js';
@@ -20,4 +27,27 @@ export type {
   CreatePaymentIntentParams,
   SlackSendMessageParams,
   SlackListMessagesParams,
+  // Google Drive
+  ListFilesParams,
+  UploadFileParams,
+  // GitHub
+  ListRepositoriesParams,
+  CreateIssueParams,
+  // Notion
+  QueryDatabaseParams,
+  CreatePageParams,
+  // HubSpot
+  ListContactsParams,
+  CreateContactParams,
+  // Salesforce
+  SalesforceAdapterConfig,
+  QueryRecordsParams,
+  CreateRecordParams,
+  // Linear
+  ListIssuesParams,
+  LinearCreateIssueParams,
+  // Jira
+  JiraAdapterConfig,
+  SearchIssuesParams,
+  JiraCreateIssueParams,
 } from './types.js';

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -79,3 +79,120 @@ export interface SlackListMessagesParams {
   oldest?: string;
   latest?: string;
 }
+
+// Google Drive types
+export interface ListFilesParams {
+  q?: string;
+  pageSize?: number;
+  pageToken?: string;
+  fields?: string;
+}
+
+export interface UploadFileParams {
+  name: string;
+  mimeType: string;
+  content: string | Buffer;
+  parents?: string[];
+  description?: string;
+}
+
+// GitHub types
+export interface ListRepositoriesParams {
+  sort?: 'created' | 'updated' | 'pushed' | 'full_name';
+  direction?: 'asc' | 'desc';
+  per_page?: number;
+  page?: number;
+}
+
+export interface CreateIssueParams {
+  owner: string;
+  repo: string;
+  title: string;
+  body?: string;
+  labels?: string[];
+  assignees?: string[];
+}
+
+// Notion types
+export interface QueryDatabaseParams {
+  database_id: string;
+  filter?: Record<string, unknown>;
+  sorts?: Array<Record<string, unknown>>;
+  page_size?: number;
+  start_cursor?: string;
+}
+
+export interface CreatePageParams {
+  parent: { database_id: string } | { page_id: string };
+  properties: Record<string, unknown>;
+  children?: Array<Record<string, unknown>>;
+}
+
+// HubSpot types
+export interface ListContactsParams {
+  limit?: number;
+  after?: string;
+  properties?: string[];
+}
+
+export interface CreateContactParams {
+  email: string;
+  firstname?: string;
+  lastname?: string;
+  phone?: string;
+  company?: string;
+  properties?: Record<string, string>;
+}
+
+// Salesforce types
+export interface SalesforceAdapterConfig extends AdapterConfig {
+  instanceUrl: string;
+}
+
+export interface QueryRecordsParams {
+  query: string;
+}
+
+export interface CreateRecordParams {
+  sobject: string;
+  fields: Record<string, unknown>;
+}
+
+// Linear types
+export interface ListIssuesParams {
+  teamId?: string;
+  first?: number;
+  after?: string;
+  filter?: Record<string, unknown>;
+}
+
+export interface LinearCreateIssueParams {
+  teamId: string;
+  title: string;
+  description?: string;
+  priority?: number;
+  assigneeId?: string;
+  labelIds?: string[];
+}
+
+// Jira types
+export interface JiraAdapterConfig extends AdapterConfig {
+  baseUrl: string;
+}
+
+export interface SearchIssuesParams {
+  jql: string;
+  maxResults?: number;
+  startAt?: number;
+  fields?: string[];
+}
+
+export interface JiraCreateIssueParams {
+  projectKey: string;
+  summary: string;
+  issueType: string;
+  description?: string;
+  priority?: string;
+  assignee?: string;
+  labels?: string[];
+}

--- a/packages/adapters/tests/adapters/github.test.ts
+++ b/packages/adapters/tests/adapters/github.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VerifiedGrant } from '@grantex/sdk';
+
+vi.mock('@grantex/sdk', () => ({
+  verifyGrantToken: vi.fn(),
+}));
+
+import { verifyGrantToken } from '@grantex/sdk';
+import { GitHubAdapter } from '../../src/adapters/github.js';
+import { GrantexAdapterError } from '../../src/errors.js';
+
+const MOCK_GRANT: VerifiedGrant = {
+  tokenId: 'tok_1', grantId: 'grnt_1', principalId: 'user_1',
+  agentDid: 'did:grantex:agent:a1', developerId: 'dev_1',
+  scopes: ['repos:read', 'issues:write'],
+  issuedAt: Math.floor(Date.now() / 1000),
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+};
+
+describe('GitHubAdapter', () => {
+  const adapter = new GitHubAdapter({
+    jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+    credentials: 'ghp_test_token',
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+  });
+
+  describe('listRepositories', () => {
+    it('lists repositories successfully', async () => {
+      const repos = [{ id: 1, name: 'my-repo', full_name: 'user/my-repo' }];
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(repos),
+      }));
+
+      const result = await adapter.listRepositories('grant-token');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(repos);
+      expect(result.grant).toBe(MOCK_GRANT);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[0]).toContain('/user/repos');
+    });
+
+    it('passes query parameters', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve([]),
+      }));
+
+      await adapter.listRepositories('grant-token', {
+        sort: 'updated',
+        direction: 'desc',
+        per_page: 50,
+      });
+
+      const url = vi.mocked(fetch).mock.calls[0]![0] as string;
+      expect(url).toContain('sort=updated');
+      expect(url).toContain('direction=desc');
+      expect(url).toContain('per_page=50');
+    });
+
+    it('throws SCOPE_MISSING without repos:read', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['email:read'],
+      });
+
+      await expect(adapter.listRepositories('token'))
+        .rejects.toThrow(GrantexAdapterError);
+    });
+
+    it('throws TOKEN_INVALID on verification failure', async () => {
+      vi.mocked(verifyGrantToken).mockRejectedValue(new Error('expired'));
+
+      try {
+        await adapter.listRepositories('bad-token');
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('TOKEN_INVALID');
+      }
+    });
+
+    it('throws UPSTREAM_ERROR on API failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false, status: 401, text: () => Promise.resolve('Unauthorized'),
+      }));
+
+      try {
+        await adapter.listRepositories('token');
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('UPSTREAM_ERROR');
+      }
+    });
+  });
+
+  describe('createIssue', () => {
+    it('creates issue successfully', async () => {
+      const created = { id: 42, number: 1, title: 'Bug report' };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(created),
+      }));
+
+      const result = await adapter.createIssue('token', {
+        owner: 'octocat',
+        repo: 'hello-world',
+        title: 'Bug report',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(created);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[1]?.method).toBe('POST');
+      expect(fetchCall[0]).toContain('/repos/octocat/hello-world/issues');
+    });
+
+    it('includes optional fields when provided', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ id: 43 }),
+      }));
+
+      await adapter.createIssue('token', {
+        owner: 'octocat',
+        repo: 'hello-world',
+        title: 'Feature request',
+        body: 'Please add this',
+        labels: ['enhancement'],
+        assignees: ['octocat'],
+      });
+
+      const body = JSON.parse(vi.mocked(fetch).mock.calls[0]![1]?.body as string);
+      expect(body.body).toBe('Please add this');
+      expect(body.labels).toEqual(['enhancement']);
+      expect(body.assignees).toEqual(['octocat']);
+    });
+
+    it('throws SCOPE_MISSING without issues:write', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['repos:read'],
+      });
+
+      await expect(adapter.createIssue('token', {
+        owner: 'octocat',
+        repo: 'hello-world',
+        title: 'Test',
+      })).rejects.toThrow(GrantexAdapterError);
+    });
+  });
+});

--- a/packages/adapters/tests/adapters/google-drive.test.ts
+++ b/packages/adapters/tests/adapters/google-drive.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VerifiedGrant } from '@grantex/sdk';
+
+vi.mock('@grantex/sdk', () => ({
+  verifyGrantToken: vi.fn(),
+}));
+
+import { verifyGrantToken } from '@grantex/sdk';
+import { GoogleDriveAdapter } from '../../src/adapters/google-drive.js';
+import { GrantexAdapterError } from '../../src/errors.js';
+
+const MOCK_GRANT: VerifiedGrant = {
+  tokenId: 'tok_1', grantId: 'grnt_1', principalId: 'user_1',
+  agentDid: 'did:grantex:agent:a1', developerId: 'dev_1',
+  scopes: ['files:read', 'files:write'],
+  issuedAt: Math.floor(Date.now() / 1000),
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+};
+
+describe('GoogleDriveAdapter', () => {
+  const adapter = new GoogleDriveAdapter({
+    jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+    credentials: 'google-oauth-token',
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+  });
+
+  describe('listFiles', () => {
+    it('lists files successfully', async () => {
+      const files = { files: [{ id: 'f1', name: 'doc.txt' }] };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(files),
+      }));
+
+      const result = await adapter.listFiles('grant-token');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(files);
+      expect(result.grant).toBe(MOCK_GRANT);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[0]).toContain('/drive/v3/files');
+    });
+
+    it('passes query parameters', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ files: [] }),
+      }));
+
+      await adapter.listFiles('grant-token', {
+        q: 'name contains "report"',
+        pageSize: 25,
+        fields: 'files(id,name)',
+      });
+
+      const url = vi.mocked(fetch).mock.calls[0]![0] as string;
+      expect(url).toContain('q=');
+      expect(url).toContain('pageSize=25');
+      expect(url).toContain('fields=');
+    });
+
+    it('throws SCOPE_MISSING without files:read', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['email:read'],
+      });
+
+      await expect(adapter.listFiles('token'))
+        .rejects.toThrow(GrantexAdapterError);
+    });
+
+    it('throws TOKEN_INVALID on verification failure', async () => {
+      vi.mocked(verifyGrantToken).mockRejectedValue(new Error('expired'));
+
+      try {
+        await adapter.listFiles('bad-token');
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('TOKEN_INVALID');
+      }
+    });
+
+    it('throws UPSTREAM_ERROR on API failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false, status: 403, text: () => Promise.resolve('Forbidden'),
+      }));
+
+      try {
+        await adapter.listFiles('token');
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('UPSTREAM_ERROR');
+      }
+    });
+  });
+
+  describe('uploadFile', () => {
+    it('uploads file successfully', async () => {
+      const created = { id: 'f_new', name: 'upload.txt' };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(created),
+      }));
+
+      const result = await adapter.uploadFile('token', {
+        name: 'upload.txt',
+        mimeType: 'text/plain',
+        content: 'Hello world',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(created);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[1]?.method).toBe('POST');
+      expect(fetchCall[0]).toContain('uploadType=multipart');
+    });
+
+    it('includes optional fields when provided', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ id: 'f2' }),
+      }));
+
+      await adapter.uploadFile('token', {
+        name: 'report.pdf',
+        mimeType: 'application/pdf',
+        content: 'pdf-content',
+        parents: ['folder_1'],
+        description: 'Monthly report',
+      });
+
+      const body = vi.mocked(fetch).mock.calls[0]![1]?.body as string;
+      expect(body).toContain('"parents":["folder_1"]');
+      expect(body).toContain('"description":"Monthly report"');
+    });
+
+    it('throws SCOPE_MISSING without files:write', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['files:read'],
+      });
+
+      await expect(adapter.uploadFile('token', {
+        name: 'test.txt',
+        mimeType: 'text/plain',
+        content: 'data',
+      })).rejects.toThrow(GrantexAdapterError);
+    });
+  });
+});

--- a/packages/adapters/tests/adapters/hubspot.test.ts
+++ b/packages/adapters/tests/adapters/hubspot.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VerifiedGrant } from '@grantex/sdk';
+
+vi.mock('@grantex/sdk', () => ({
+  verifyGrantToken: vi.fn(),
+}));
+
+import { verifyGrantToken } from '@grantex/sdk';
+import { HubSpotAdapter } from '../../src/adapters/hubspot.js';
+import { GrantexAdapterError } from '../../src/errors.js';
+
+const MOCK_GRANT: VerifiedGrant = {
+  tokenId: 'tok_1', grantId: 'grnt_1', principalId: 'user_1',
+  agentDid: 'did:grantex:agent:a1', developerId: 'dev_1',
+  scopes: ['contacts:read', 'contacts:write'],
+  issuedAt: Math.floor(Date.now() / 1000),
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+};
+
+describe('HubSpotAdapter', () => {
+  const adapter = new HubSpotAdapter({
+    jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+    credentials: 'hubspot-api-key',
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+  });
+
+  describe('listContacts', () => {
+    it('lists contacts successfully', async () => {
+      const contacts = { results: [{ id: '1', properties: { email: 'a@b.com' } }] };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(contacts),
+      }));
+
+      const result = await adapter.listContacts('grant-token');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(contacts);
+      expect(result.grant).toBe(MOCK_GRANT);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[0]).toContain('/crm/v3/objects/contacts');
+    });
+
+    it('passes query parameters', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ results: [] }),
+      }));
+
+      await adapter.listContacts('grant-token', {
+        limit: 20,
+        after: 'cursor_abc',
+        properties: ['email', 'firstname'],
+      });
+
+      const url = vi.mocked(fetch).mock.calls[0]![0] as string;
+      expect(url).toContain('limit=20');
+      expect(url).toContain('after=cursor_abc');
+      expect(url).toContain('properties=email');
+      expect(url).toContain('properties=firstname');
+    });
+
+    it('throws SCOPE_MISSING without contacts:read', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['email:read'],
+      });
+
+      await expect(adapter.listContacts('token'))
+        .rejects.toThrow(GrantexAdapterError);
+    });
+
+    it('throws TOKEN_INVALID on verification failure', async () => {
+      vi.mocked(verifyGrantToken).mockRejectedValue(new Error('expired'));
+
+      try {
+        await adapter.listContacts('bad-token');
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('TOKEN_INVALID');
+      }
+    });
+
+    it('throws UPSTREAM_ERROR on API failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false, status: 429, text: () => Promise.resolve('Rate limited'),
+      }));
+
+      try {
+        await adapter.listContacts('token');
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('UPSTREAM_ERROR');
+      }
+    });
+  });
+
+  describe('createContact', () => {
+    it('creates contact successfully', async () => {
+      const created = { id: '2', properties: { email: 'new@example.com' } };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(created),
+      }));
+
+      const result = await adapter.createContact('token', {
+        email: 'new@example.com',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(created);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[1]?.method).toBe('POST');
+      const body = JSON.parse(fetchCall[1]?.body as string);
+      expect(body.properties.email).toBe('new@example.com');
+    });
+
+    it('includes optional fields when provided', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ id: '3' }),
+      }));
+
+      await adapter.createContact('token', {
+        email: 'jane@example.com',
+        firstname: 'Jane',
+        lastname: 'Doe',
+        phone: '+1234567890',
+        company: 'Acme Inc',
+      });
+
+      const body = JSON.parse(vi.mocked(fetch).mock.calls[0]![1]?.body as string);
+      expect(body.properties.firstname).toBe('Jane');
+      expect(body.properties.lastname).toBe('Doe');
+      expect(body.properties.phone).toBe('+1234567890');
+      expect(body.properties.company).toBe('Acme Inc');
+    });
+
+    it('throws SCOPE_MISSING without contacts:write', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['contacts:read'],
+      });
+
+      await expect(adapter.createContact('token', {
+        email: 'test@example.com',
+      })).rejects.toThrow(GrantexAdapterError);
+    });
+  });
+});

--- a/packages/adapters/tests/adapters/jira.test.ts
+++ b/packages/adapters/tests/adapters/jira.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VerifiedGrant } from '@grantex/sdk';
+
+vi.mock('@grantex/sdk', () => ({
+  verifyGrantToken: vi.fn(),
+}));
+
+import { verifyGrantToken } from '@grantex/sdk';
+import { JiraAdapter } from '../../src/adapters/jira.js';
+import { GrantexAdapterError } from '../../src/errors.js';
+
+const MOCK_GRANT: VerifiedGrant = {
+  tokenId: 'tok_1', grantId: 'grnt_1', principalId: 'user_1',
+  agentDid: 'did:grantex:agent:a1', developerId: 'dev_1',
+  scopes: ['issues:read', 'issues:write'],
+  issuedAt: Math.floor(Date.now() / 1000),
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+};
+
+describe('JiraAdapter', () => {
+  const adapter = new JiraAdapter({
+    jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+    credentials: 'base64-encoded-credentials',
+    baseUrl: 'https://myteam.atlassian.net',
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+  });
+
+  describe('searchIssues', () => {
+    it('searches issues successfully', async () => {
+      const issues = { total: 1, issues: [{ key: 'PROJ-1', fields: { summary: 'Bug' } }] };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(issues),
+      }));
+
+      const result = await adapter.searchIssues('grant-token', {
+        jql: 'project = PROJ',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(issues);
+      expect(result.grant).toBe(MOCK_GRANT);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[0]).toContain('myteam.atlassian.net/rest/api/3/search');
+      expect(fetchCall[1]?.method).toBe('POST');
+    });
+
+    it('passes search parameters', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ total: 0, issues: [] }),
+      }));
+
+      await adapter.searchIssues('grant-token', {
+        jql: 'status = Open',
+        maxResults: 50,
+        startAt: 10,
+        fields: ['summary', 'status'],
+      });
+
+      const body = JSON.parse(vi.mocked(fetch).mock.calls[0]![1]?.body as string);
+      expect(body.jql).toBe('status = Open');
+      expect(body.maxResults).toBe(50);
+      expect(body.startAt).toBe(10);
+      expect(body.fields).toEqual(['summary', 'status']);
+    });
+
+    it('uses Basic auth header', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ total: 0, issues: [] }),
+      }));
+
+      await adapter.searchIssues('grant-token', { jql: 'project = PROJ' });
+
+      const headers = vi.mocked(fetch).mock.calls[0]![1]?.headers as Record<string, string>;
+      expect(headers['Authorization']).toBe('Basic base64-encoded-credentials');
+    });
+
+    it('throws SCOPE_MISSING without issues:read', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['email:read'],
+      });
+
+      await expect(adapter.searchIssues('token', { jql: 'project = PROJ' }))
+        .rejects.toThrow(GrantexAdapterError);
+    });
+
+    it('throws TOKEN_INVALID on verification failure', async () => {
+      vi.mocked(verifyGrantToken).mockRejectedValue(new Error('expired'));
+
+      try {
+        await adapter.searchIssues('bad-token', { jql: 'project = PROJ' });
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('TOKEN_INVALID');
+      }
+    });
+
+    it('throws UPSTREAM_ERROR on API failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false, status: 400, text: () => Promise.resolve('Bad JQL'),
+      }));
+
+      try {
+        await adapter.searchIssues('token', { jql: 'INVALID' });
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('UPSTREAM_ERROR');
+      }
+    });
+  });
+
+  describe('createIssue', () => {
+    it('creates issue successfully', async () => {
+      const created = { id: '10001', key: 'PROJ-2', self: 'https://myteam.atlassian.net/rest/api/3/issue/10001' };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(created),
+      }));
+
+      const result = await adapter.createIssue('token', {
+        projectKey: 'PROJ',
+        summary: 'New bug report',
+        issueType: 'Bug',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(created);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[1]?.method).toBe('POST');
+      expect(fetchCall[0]).toContain('/rest/api/3/issue');
+      const body = JSON.parse(fetchCall[1]?.body as string);
+      expect(body.fields.project.key).toBe('PROJ');
+      expect(body.fields.summary).toBe('New bug report');
+      expect(body.fields.issuetype.name).toBe('Bug');
+    });
+
+    it('includes optional fields when provided', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ key: 'PROJ-3' }),
+      }));
+
+      await adapter.createIssue('token', {
+        projectKey: 'PROJ',
+        summary: 'Feature request',
+        issueType: 'Story',
+        description: 'Implement dark mode',
+        priority: 'High',
+        assignee: 'user123',
+        labels: ['enhancement', 'ui'],
+      });
+
+      const body = JSON.parse(vi.mocked(fetch).mock.calls[0]![1]?.body as string);
+      expect(body.fields.description.type).toBe('doc');
+      expect(body.fields.description.content[0].content[0].text).toBe('Implement dark mode');
+      expect(body.fields.priority.name).toBe('High');
+      expect(body.fields.assignee.id).toBe('user123');
+      expect(body.fields.labels).toEqual(['enhancement', 'ui']);
+    });
+
+    it('throws SCOPE_MISSING without issues:write', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['issues:read'],
+      });
+
+      await expect(adapter.createIssue('token', {
+        projectKey: 'PROJ',
+        summary: 'Test',
+        issueType: 'Task',
+      })).rejects.toThrow(GrantexAdapterError);
+    });
+  });
+});

--- a/packages/adapters/tests/adapters/linear.test.ts
+++ b/packages/adapters/tests/adapters/linear.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VerifiedGrant } from '@grantex/sdk';
+
+vi.mock('@grantex/sdk', () => ({
+  verifyGrantToken: vi.fn(),
+}));
+
+import { verifyGrantToken } from '@grantex/sdk';
+import { LinearAdapter } from '../../src/adapters/linear.js';
+import { GrantexAdapterError } from '../../src/errors.js';
+
+const MOCK_GRANT: VerifiedGrant = {
+  tokenId: 'tok_1', grantId: 'grnt_1', principalId: 'user_1',
+  agentDid: 'did:grantex:agent:a1', developerId: 'dev_1',
+  scopes: ['issues:read', 'issues:write'],
+  issuedAt: Math.floor(Date.now() / 1000),
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+};
+
+describe('LinearAdapter', () => {
+  const adapter = new LinearAdapter({
+    jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+    credentials: 'lin_api_key',
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+  });
+
+  describe('listIssues', () => {
+    it('lists issues successfully', async () => {
+      const issues = { data: { issues: { nodes: [{ id: 'iss_1', title: 'Bug' }] } } };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(issues),
+      }));
+
+      const result = await adapter.listIssues('grant-token');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(issues);
+      expect(result.grant).toBe(MOCK_GRANT);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[0]).toBe('https://api.linear.app/graphql');
+      expect(fetchCall[1]?.method).toBe('POST');
+    });
+
+    it('passes GraphQL variables with teamId filter', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ data: { issues: { nodes: [] } } }),
+      }));
+
+      await adapter.listIssues('grant-token', {
+        teamId: 'team_abc',
+        first: 25,
+      });
+
+      const body = JSON.parse(vi.mocked(fetch).mock.calls[0]![1]?.body as string);
+      expect(body.query).toContain('ListIssues');
+      expect(body.variables.first).toBe(25);
+      expect(body.variables.filter.team.id.eq).toBe('team_abc');
+    });
+
+    it('throws SCOPE_MISSING without issues:read', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['email:read'],
+      });
+
+      await expect(adapter.listIssues('token'))
+        .rejects.toThrow(GrantexAdapterError);
+    });
+
+    it('throws TOKEN_INVALID on verification failure', async () => {
+      vi.mocked(verifyGrantToken).mockRejectedValue(new Error('expired'));
+
+      try {
+        await adapter.listIssues('bad-token');
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('TOKEN_INVALID');
+      }
+    });
+
+    it('throws UPSTREAM_ERROR on API failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false, status: 500, text: () => Promise.resolve('Internal Server Error'),
+      }));
+
+      try {
+        await adapter.listIssues('token');
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('UPSTREAM_ERROR');
+      }
+    });
+  });
+
+  describe('createIssue', () => {
+    it('creates issue successfully', async () => {
+      const created = { data: { issueCreate: { success: true, issue: { id: 'iss_new' } } } };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(created),
+      }));
+
+      const result = await adapter.createIssue('token', {
+        teamId: 'team_abc',
+        title: 'New feature',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(created);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[0]).toBe('https://api.linear.app/graphql');
+      const body = JSON.parse(fetchCall[1]?.body as string);
+      expect(body.query).toContain('CreateIssue');
+      expect(body.variables.input.teamId).toBe('team_abc');
+      expect(body.variables.input.title).toBe('New feature');
+    });
+
+    it('includes optional fields when provided', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ data: { issueCreate: { success: true } } }),
+      }));
+
+      await adapter.createIssue('token', {
+        teamId: 'team_abc',
+        title: 'Urgent fix',
+        description: 'Fix the login bug',
+        priority: 1,
+        assigneeId: 'user_xyz',
+        labelIds: ['label_1'],
+      });
+
+      const body = JSON.parse(vi.mocked(fetch).mock.calls[0]![1]?.body as string);
+      expect(body.variables.input.description).toBe('Fix the login bug');
+      expect(body.variables.input.priority).toBe(1);
+      expect(body.variables.input.assigneeId).toBe('user_xyz');
+      expect(body.variables.input.labelIds).toEqual(['label_1']);
+    });
+
+    it('throws SCOPE_MISSING without issues:write', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['issues:read'],
+      });
+
+      await expect(adapter.createIssue('token', {
+        teamId: 'team_abc',
+        title: 'Test',
+      })).rejects.toThrow(GrantexAdapterError);
+    });
+  });
+});

--- a/packages/adapters/tests/adapters/notion.test.ts
+++ b/packages/adapters/tests/adapters/notion.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VerifiedGrant } from '@grantex/sdk';
+
+vi.mock('@grantex/sdk', () => ({
+  verifyGrantToken: vi.fn(),
+}));
+
+import { verifyGrantToken } from '@grantex/sdk';
+import { NotionAdapter } from '../../src/adapters/notion.js';
+import { GrantexAdapterError } from '../../src/errors.js';
+
+const MOCK_GRANT: VerifiedGrant = {
+  tokenId: 'tok_1', grantId: 'grnt_1', principalId: 'user_1',
+  agentDid: 'did:grantex:agent:a1', developerId: 'dev_1',
+  scopes: ['pages:read', 'pages:write'],
+  issuedAt: Math.floor(Date.now() / 1000),
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+};
+
+describe('NotionAdapter', () => {
+  const adapter = new NotionAdapter({
+    jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+    credentials: 'ntn_test_secret',
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+  });
+
+  describe('queryDatabase', () => {
+    it('queries database successfully', async () => {
+      const results = { results: [{ id: 'page_1', object: 'page' }] };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(results),
+      }));
+
+      const result = await adapter.queryDatabase('grant-token', {
+        database_id: 'db_123',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(results);
+      expect(result.grant).toBe(MOCK_GRANT);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[0]).toContain('/databases/db_123/query');
+      expect((fetchCall[1]?.headers as Record<string, string>)['Notion-Version']).toBe('2022-06-28');
+    });
+
+    it('passes filter and sort parameters', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ results: [] }),
+      }));
+
+      await adapter.queryDatabase('grant-token', {
+        database_id: 'db_123',
+        filter: { property: 'Status', select: { equals: 'Done' } },
+        sorts: [{ property: 'Created', direction: 'descending' }],
+        page_size: 10,
+      });
+
+      const body = JSON.parse(vi.mocked(fetch).mock.calls[0]![1]?.body as string);
+      expect(body.filter).toEqual({ property: 'Status', select: { equals: 'Done' } });
+      expect(body.sorts).toHaveLength(1);
+      expect(body.page_size).toBe(10);
+    });
+
+    it('throws SCOPE_MISSING without pages:read', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['email:read'],
+      });
+
+      await expect(adapter.queryDatabase('token', { database_id: 'db_1' }))
+        .rejects.toThrow(GrantexAdapterError);
+    });
+
+    it('throws TOKEN_INVALID on verification failure', async () => {
+      vi.mocked(verifyGrantToken).mockRejectedValue(new Error('expired'));
+
+      try {
+        await adapter.queryDatabase('bad-token', { database_id: 'db_1' });
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('TOKEN_INVALID');
+      }
+    });
+
+    it('throws UPSTREAM_ERROR on API failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false, status: 404, text: () => Promise.resolve('Not Found'),
+      }));
+
+      try {
+        await adapter.queryDatabase('token', { database_id: 'db_1' });
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('UPSTREAM_ERROR');
+      }
+    });
+  });
+
+  describe('createPage', () => {
+    it('creates page successfully', async () => {
+      const created = { id: 'page_new', object: 'page' };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(created),
+      }));
+
+      const result = await adapter.createPage('token', {
+        parent: { database_id: 'db_123' },
+        properties: { Name: { title: [{ text: { content: 'New Page' } }] } },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(created);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[1]?.method).toBe('POST');
+      expect(fetchCall[0]).toContain('/v1/pages');
+    });
+
+    it('includes children blocks when provided', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ id: 'page_2' }),
+      }));
+
+      await adapter.createPage('token', {
+        parent: { database_id: 'db_123' },
+        properties: { Name: { title: [{ text: { content: 'Test' } }] } },
+        children: [{ object: 'block', type: 'paragraph', paragraph: { rich_text: [] } }],
+      });
+
+      const body = JSON.parse(vi.mocked(fetch).mock.calls[0]![1]?.body as string);
+      expect(body.children).toHaveLength(1);
+    });
+
+    it('throws SCOPE_MISSING without pages:write', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['pages:read'],
+      });
+
+      await expect(adapter.createPage('token', {
+        parent: { database_id: 'db_123' },
+        properties: {},
+      })).rejects.toThrow(GrantexAdapterError);
+    });
+  });
+});

--- a/packages/adapters/tests/adapters/salesforce.test.ts
+++ b/packages/adapters/tests/adapters/salesforce.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VerifiedGrant } from '@grantex/sdk';
+
+vi.mock('@grantex/sdk', () => ({
+  verifyGrantToken: vi.fn(),
+}));
+
+import { verifyGrantToken } from '@grantex/sdk';
+import { SalesforceAdapter } from '../../src/adapters/salesforce.js';
+import { GrantexAdapterError } from '../../src/errors.js';
+
+const MOCK_GRANT: VerifiedGrant = {
+  tokenId: 'tok_1', grantId: 'grnt_1', principalId: 'user_1',
+  agentDid: 'did:grantex:agent:a1', developerId: 'dev_1',
+  scopes: ['crm:read', 'crm:write'],
+  issuedAt: Math.floor(Date.now() / 1000),
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+};
+
+describe('SalesforceAdapter', () => {
+  const adapter = new SalesforceAdapter({
+    jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+    credentials: 'sf-access-token',
+    instanceUrl: 'https://myorg.salesforce.com',
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+  });
+
+  describe('queryRecords', () => {
+    it('queries records successfully', async () => {
+      const records = { totalSize: 1, records: [{ Id: '001', Name: 'Acme' }] };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(records),
+      }));
+
+      const result = await adapter.queryRecords('grant-token', {
+        query: 'SELECT Id, Name FROM Account LIMIT 10',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(records);
+      expect(result.grant).toBe(MOCK_GRANT);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[0]).toContain('myorg.salesforce.com');
+      expect(fetchCall[0]).toContain('/services/data/v59.0/query');
+      expect(fetchCall[0]).toContain('q=');
+    });
+
+    it('strips trailing slash from instance URL', async () => {
+      const adapterSlash = new SalesforceAdapter({
+        jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+        credentials: 'sf-token',
+        instanceUrl: 'https://myorg.salesforce.com/',
+      });
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve({ totalSize: 0, records: [] }),
+      }));
+
+      await adapterSlash.queryRecords('grant-token', { query: 'SELECT Id FROM Account' });
+
+      const url = vi.mocked(fetch).mock.calls[0]![0] as string;
+      expect(url).not.toContain('.com//');
+    });
+
+    it('throws SCOPE_MISSING without crm:read', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['email:read'],
+      });
+
+      await expect(adapter.queryRecords('token', { query: 'SELECT Id FROM Account' }))
+        .rejects.toThrow(GrantexAdapterError);
+    });
+
+    it('throws TOKEN_INVALID on verification failure', async () => {
+      vi.mocked(verifyGrantToken).mockRejectedValue(new Error('expired'));
+
+      try {
+        await adapter.queryRecords('bad-token', { query: 'SELECT Id FROM Account' });
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('TOKEN_INVALID');
+      }
+    });
+
+    it('throws UPSTREAM_ERROR on API failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false, status: 400, text: () => Promise.resolve('Bad Request'),
+      }));
+
+      try {
+        await adapter.queryRecords('token', { query: 'INVALID' });
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as GrantexAdapterError).code).toBe('UPSTREAM_ERROR');
+      }
+    });
+  });
+
+  describe('createRecord', () => {
+    it('creates record successfully', async () => {
+      const created = { id: '001abc', success: true };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: () => Promise.resolve(created),
+      }));
+
+      const result = await adapter.createRecord('token', {
+        sobject: 'Account',
+        fields: { Name: 'New Corp', Industry: 'Technology' },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(created);
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+      expect(fetchCall[1]?.method).toBe('POST');
+      expect(fetchCall[0]).toContain('/sobjects/Account');
+      const body = JSON.parse(fetchCall[1]?.body as string);
+      expect(body.Name).toBe('New Corp');
+    });
+
+    it('throws SCOPE_MISSING without crm:write', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue({
+        ...MOCK_GRANT,
+        scopes: ['crm:read'],
+      });
+
+      await expect(adapter.createRecord('token', {
+        sobject: 'Account',
+        fields: { Name: 'Test' },
+      })).rejects.toThrow(GrantexAdapterError);
+    });
+  });
+});

--- a/packages/mcp-auth/package-lock.json
+++ b/packages/mcp-auth/package-lock.json
@@ -1,0 +1,2480 @@
+{
+  "name": "@grantex/mcp-auth",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@grantex/mcp-auth",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grantex/sdk": "^0.1.6",
+        "fastify": "^5.2.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.3.3",
+        "vitest": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
+      "integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz",
+      "integrity": "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^6.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
+      "integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+      "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@grantex/sdk": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@grantex/sdk/-/sdk-0.1.6.tgz",
+      "integrity": "sha512-sj2hLnLFdIN7Q/8XiRTnbXydrE7Sk2gm+goiLln9g36UA4yB4DkwtRs3XKLAfzwioPHSnXhp548O/u4jq+XgJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jose": "^5.2.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
+      "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.2.0.tgz",
+      "integrity": "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stringify": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.3.0.tgz",
+      "integrity": "sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.7.4.tgz",
+      "integrity": "sha512-e6l5NsRdaEP8rdD8VR0ErJASeyaRbzXYpmkrpr2SuvuMq6Si3lvsaVy5C+7gLanEkvjpMDzBXWE5HPeb/hgTxA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^6.0.0",
+        "find-my-way": "^9.0.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^10.1.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.5.0.tgz",
+      "integrity": "sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
+      "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
+      "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/packages/mcp-auth/package.json
+++ b/packages/mcp-auth/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@grantex/mcp-auth",
+  "version": "0.1.0",
+  "description": "OAuth 2.1 + PKCE authorization server for MCP servers, powered by Grantex",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist", "README.md"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@grantex/sdk": "^0.1.6",
+    "fastify": "^5.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.3.3",
+    "vitest": "^1.3.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "keywords": ["grantex", "mcp", "oauth", "pkce", "authorization-server"],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mishrasanjeev/grantex"
+  }
+}

--- a/packages/mcp-auth/src/endpoints/authorize.ts
+++ b/packages/mcp-auth/src/endpoints/authorize.ts
@@ -1,0 +1,115 @@
+import type { FastifyInstance } from 'fastify';
+import type { McpAuthConfig, ClientStore, CodeStore } from '../types.js';
+import { generateCode } from '../lib/codes.js';
+
+interface AuthorizeQuery {
+  response_type: string;
+  client_id: string;
+  redirect_uri: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  scope?: string;
+  state?: string;
+  resource?: string;
+}
+
+export function registerAuthorizeEndpoint(
+  app: FastifyInstance,
+  config: McpAuthConfig,
+  clientStore: ClientStore,
+  codeStore: CodeStore,
+): void {
+  app.get<{ Querystring: AuthorizeQuery }>('/authorize', async (request, reply) => {
+    const {
+      response_type,
+      client_id,
+      redirect_uri,
+      code_challenge,
+      code_challenge_method,
+      scope,
+      state,
+      resource,
+    } = request.query;
+
+    // Validate response_type
+    if (response_type !== 'code') {
+      return reply.status(400).send({
+        error: 'unsupported_response_type',
+        error_description: 'Only response_type=code is supported',
+      });
+    }
+
+    // Validate PKCE (mandatory)
+    if (!code_challenge || code_challenge_method !== 'S256') {
+      return reply.status(400).send({
+        error: 'invalid_request',
+        error_description: 'PKCE is required. Provide code_challenge with method S256.',
+      });
+    }
+
+    // Validate client
+    const client = await clientStore.get(client_id);
+    if (!client) {
+      return reply.status(400).send({
+        error: 'invalid_client',
+        error_description: 'Unknown client_id',
+      });
+    }
+
+    // Validate redirect_uri
+    if (!client.redirectUris.includes(redirect_uri)) {
+      return reply.status(400).send({
+        error: 'invalid_request',
+        error_description: 'redirect_uri not registered for this client',
+      });
+    }
+
+    // Validate resource indicator
+    if (resource && config.allowedResources && config.allowedResources.length > 0) {
+      if (!config.allowedResources.includes(resource)) {
+        return reply.status(400).send({
+          error: 'invalid_target',
+          error_description: 'Resource not in allow-list',
+        });
+      }
+    }
+
+    // Create Grantex auth request
+    const scopes = scope ? scope.split(' ') : config.scopes;
+    let grantexAuth;
+    try {
+      grantexAuth = await config.grantex.authorize({
+        agentId: config.agentId,
+        userId: client_id, // Use client_id as principal for MCP flow
+        scopes,
+      });
+    } catch (err) {
+      return reply.status(502).send({
+        error: 'server_error',
+        error_description: `Grantex authorization failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+
+    // Generate authorization code and store
+    const code = generateCode();
+    const codeExpiration = config.codeExpirationSeconds ?? 600;
+    await codeStore.set(code, {
+      code,
+      clientId: client_id,
+      redirectUri: redirect_uri,
+      codeChallenge: code_challenge,
+      codeChallengeMethod: 'S256',
+      scopes,
+      ...(resource !== undefined ? { resource } : {}),
+      grantexAuthRequestId: grantexAuth.authRequestId,
+      expiresAt: Date.now() + codeExpiration * 1000,
+    });
+
+    // Redirect to client with authorization code
+    const redirectUrl = new URL(redirect_uri);
+    redirectUrl.searchParams.set('code', code);
+    if (state) redirectUrl.searchParams.set('state', state);
+
+    return reply.redirect(redirectUrl.toString());
+  });
+}

--- a/packages/mcp-auth/src/endpoints/metadata.ts
+++ b/packages/mcp-auth/src/endpoints/metadata.ts
@@ -1,0 +1,22 @@
+import type { FastifyInstance } from 'fastify';
+import type { McpAuthConfig } from '../types.js';
+
+export function registerMetadataEndpoint(app: FastifyInstance, config: McpAuthConfig): void {
+  app.get('/.well-known/oauth-authorization-server', async (_request, reply) => {
+    const issuer = config.issuer.replace(/\/$/, '');
+    return reply.send({
+      issuer,
+      authorization_endpoint: `${issuer}/authorize`,
+      token_endpoint: `${issuer}/token`,
+      registration_endpoint: `${issuer}/register`,
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      code_challenge_methods_supported: ['S256'],
+      token_endpoint_auth_methods_supported: ['client_secret_post', 'none'],
+      scopes_supported: config.scopes,
+      ...(config.allowedResources !== undefined && config.allowedResources.length > 0
+        ? { resource_indicators_supported: true }
+        : {}),
+    });
+  });
+}

--- a/packages/mcp-auth/src/endpoints/register.ts
+++ b/packages/mcp-auth/src/endpoints/register.ts
@@ -1,0 +1,39 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import type { ClientStore, RegisterClientRequest } from '../types.js';
+
+export function registerRegisterEndpoint(app: FastifyInstance, clientStore: ClientStore): void {
+  app.post<{ Body: RegisterClientRequest }>('/register', async (request, reply) => {
+    const { redirect_uris, grant_types, client_name } = request.body ?? {};
+
+    if (!redirect_uris || !Array.isArray(redirect_uris) || redirect_uris.length === 0) {
+      return reply.status(400).send({
+        error: 'invalid_client_metadata',
+        error_description: 'redirect_uris is required and must be a non-empty array',
+      });
+    }
+
+    const clientId = randomUUID();
+    const clientSecret = randomBytes(32).toString('hex');
+    const resolvedGrantTypes = grant_types ?? ['authorization_code'];
+
+    const registration = {
+      clientId,
+      clientSecret,
+      redirectUris: redirect_uris,
+      grantTypes: resolvedGrantTypes,
+      ...(client_name !== undefined ? { clientName: client_name } : {}),
+      createdAt: new Date().toISOString(),
+    };
+
+    await clientStore.set(clientId, registration);
+
+    return reply.status(201).send({
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uris,
+      grant_types: resolvedGrantTypes,
+      ...(client_name !== undefined ? { client_name } : {}),
+    });
+  });
+}

--- a/packages/mcp-auth/src/endpoints/token.ts
+++ b/packages/mcp-auth/src/endpoints/token.ts
@@ -1,0 +1,158 @@
+import type { FastifyInstance } from 'fastify';
+import type { McpAuthConfig, ClientStore, CodeStore } from '../types.js';
+import { verifyCodeChallenge } from '../lib/pkce.js';
+
+interface TokenBody {
+  grant_type: string;
+  code?: string;
+  redirect_uri?: string;
+  client_id?: string;
+  client_secret?: string;
+  code_verifier?: string;
+  refresh_token?: string;
+}
+
+export function registerTokenEndpoint(
+  app: FastifyInstance,
+  config: McpAuthConfig,
+  clientStore: ClientStore,
+  codeStore: CodeStore,
+): void {
+  app.post<{ Body: TokenBody }>('/token', async (request, reply) => {
+    const { grant_type, code, redirect_uri, client_id, code_verifier, refresh_token } = request.body ?? {};
+
+    if (grant_type === 'authorization_code') {
+      if (!code || !redirect_uri || !client_id || !code_verifier) {
+        return reply.status(400).send({
+          error: 'invalid_request',
+          error_description: 'code, redirect_uri, client_id, and code_verifier are required',
+        });
+      }
+
+      // Validate client
+      const client = await clientStore.get(client_id);
+      if (!client) {
+        return reply.status(401).send({
+          error: 'invalid_client',
+          error_description: 'Unknown client_id',
+        });
+      }
+
+      // Look up authorization code
+      const authCode = await codeStore.get(code);
+      if (!authCode) {
+        return reply.status(400).send({
+          error: 'invalid_grant',
+          error_description: 'Invalid or expired authorization code',
+        });
+      }
+
+      // Delete code immediately (single-use)
+      await codeStore.delete(code);
+
+      // Verify code belongs to client
+      if (authCode.clientId !== client_id) {
+        return reply.status(400).send({
+          error: 'invalid_grant',
+          error_description: 'Code was not issued to this client',
+        });
+      }
+
+      // Verify redirect_uri
+      if (authCode.redirectUri !== redirect_uri) {
+        return reply.status(400).send({
+          error: 'invalid_grant',
+          error_description: 'redirect_uri mismatch',
+        });
+      }
+
+      // Verify PKCE
+      if (!verifyCodeChallenge(code_verifier, authCode.codeChallenge)) {
+        return reply.status(400).send({
+          error: 'invalid_grant',
+          error_description: 'PKCE verification failed',
+        });
+      }
+
+      // Exchange with Grantex (use the stored auth code from Grantex)
+      let tokenResponse;
+      try {
+        tokenResponse = await config.grantex.tokens.exchange({
+          code: authCode.grantexCode ?? authCode.grantexAuthRequestId,
+          agentId: config.agentId,
+        });
+      } catch (err) {
+        return reply.status(502).send({
+          error: 'server_error',
+          error_description: `Grantex token exchange failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+
+      return reply.send({
+        access_token: tokenResponse.grantToken,
+        token_type: 'bearer',
+        expires_in: Math.floor(
+          (new Date(tokenResponse.expiresAt).getTime() - Date.now()) / 1000,
+        ),
+        scope: tokenResponse.scopes.join(' '),
+        ...(tokenResponse.refreshToken !== undefined
+          ? { refresh_token: tokenResponse.refreshToken }
+          : {}),
+      });
+    }
+
+    if (grant_type === 'refresh_token') {
+      if (!refresh_token || !client_id) {
+        return reply.status(400).send({
+          error: 'invalid_request',
+          error_description: 'refresh_token and client_id are required',
+        });
+      }
+
+      const client = await clientStore.get(client_id);
+      if (!client) {
+        return reply.status(401).send({
+          error: 'invalid_client',
+          error_description: 'Unknown client_id',
+        });
+      }
+
+      if (!client.grantTypes.includes('refresh_token')) {
+        return reply.status(400).send({
+          error: 'unauthorized_client',
+          error_description: 'Client is not authorized for refresh_token grant type',
+        });
+      }
+
+      let tokenResponse;
+      try {
+        tokenResponse = await config.grantex.tokens.refresh({
+          refreshToken: refresh_token,
+          agentId: config.agentId,
+        });
+      } catch (err) {
+        return reply.status(400).send({
+          error: 'invalid_grant',
+          error_description: `Refresh failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+
+      return reply.send({
+        access_token: tokenResponse.grantToken,
+        token_type: 'bearer',
+        expires_in: Math.floor(
+          (new Date(tokenResponse.expiresAt).getTime() - Date.now()) / 1000,
+        ),
+        scope: tokenResponse.scopes.join(' '),
+        ...(tokenResponse.refreshToken !== undefined
+          ? { refresh_token: tokenResponse.refreshToken }
+          : {}),
+      });
+    }
+
+    return reply.status(400).send({
+      error: 'unsupported_grant_type',
+      error_description: `Grant type "${grant_type}" is not supported`,
+    });
+  });
+}

--- a/packages/mcp-auth/src/index.ts
+++ b/packages/mcp-auth/src/index.ts
@@ -1,0 +1,12 @@
+export { createMcpAuthServer } from './server.js';
+export { InMemoryClientStore } from './lib/clients.js';
+export { InMemoryCodeStore } from './lib/codes.js';
+export { verifyCodeChallenge } from './lib/pkce.js';
+export type {
+  McpAuthConfig,
+  ClientRegistration,
+  RegisterClientRequest,
+  AuthorizationCode,
+  ClientStore,
+  CodeStore,
+} from './types.js';

--- a/packages/mcp-auth/src/lib/clients.ts
+++ b/packages/mcp-auth/src/lib/clients.ts
@@ -1,0 +1,17 @@
+import type { ClientStore, ClientRegistration } from '../types.js';
+
+export class InMemoryClientStore implements ClientStore {
+  readonly #clients = new Map<string, ClientRegistration>();
+
+  async get(clientId: string): Promise<ClientRegistration | undefined> {
+    return this.#clients.get(clientId);
+  }
+
+  async set(clientId: string, registration: ClientRegistration): Promise<void> {
+    this.#clients.set(clientId, registration);
+  }
+
+  async delete(clientId: string): Promise<boolean> {
+    return this.#clients.delete(clientId);
+  }
+}

--- a/packages/mcp-auth/src/lib/codes.ts
+++ b/packages/mcp-auth/src/lib/codes.ts
@@ -1,0 +1,28 @@
+import { randomBytes } from 'node:crypto';
+import type { CodeStore, AuthorizationCode } from '../types.js';
+
+export class InMemoryCodeStore implements CodeStore {
+  readonly #codes = new Map<string, AuthorizationCode>();
+
+  async get(code: string): Promise<AuthorizationCode | undefined> {
+    const data = this.#codes.get(code);
+    if (!data) return undefined;
+    if (Date.now() > data.expiresAt) {
+      this.#codes.delete(code);
+      return undefined;
+    }
+    return data;
+  }
+
+  async set(code: string, data: AuthorizationCode): Promise<void> {
+    this.#codes.set(code, data);
+  }
+
+  async delete(code: string): Promise<boolean> {
+    return this.#codes.delete(code);
+  }
+}
+
+export function generateCode(): string {
+  return randomBytes(32).toString('base64url');
+}

--- a/packages/mcp-auth/src/lib/pkce.ts
+++ b/packages/mcp-auth/src/lib/pkce.ts
@@ -1,0 +1,11 @@
+import { createHash } from 'node:crypto';
+
+export function verifyCodeChallenge(
+  codeVerifier: string,
+  codeChallenge: string,
+): boolean {
+  const computed = createHash('sha256')
+    .update(codeVerifier)
+    .digest('base64url');
+  return computed === codeChallenge;
+}

--- a/packages/mcp-auth/src/server.ts
+++ b/packages/mcp-auth/src/server.ts
@@ -1,0 +1,25 @@
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import { InMemoryClientStore } from './lib/clients.js';
+import { InMemoryCodeStore } from './lib/codes.js';
+import { registerMetadataEndpoint } from './endpoints/metadata.js';
+import { registerRegisterEndpoint } from './endpoints/register.js';
+import { registerAuthorizeEndpoint } from './endpoints/authorize.js';
+import { registerTokenEndpoint } from './endpoints/token.js';
+import type { McpAuthConfig } from './types.js';
+
+export async function createMcpAuthServer(
+  config: McpAuthConfig,
+): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+
+  const clientStore = config.clientStore ?? new InMemoryClientStore();
+  const codeStore = new InMemoryCodeStore();
+
+  registerMetadataEndpoint(app, config);
+  registerRegisterEndpoint(app, clientStore);
+  registerAuthorizeEndpoint(app, config, clientStore, codeStore);
+  registerTokenEndpoint(app, config, clientStore, codeStore);
+
+  return app;
+}

--- a/packages/mcp-auth/src/types.ts
+++ b/packages/mcp-auth/src/types.ts
@@ -1,0 +1,60 @@
+import type { Grantex } from '@grantex/sdk';
+
+export interface McpAuthConfig {
+  /** Grantex SDK client instance */
+  grantex: Grantex;
+  /** Agent ID to use for Grantex authorization */
+  agentId: string;
+  /** Scopes to request from Grantex */
+  scopes: string[];
+  /** Base URL for this auth server (used in metadata) */
+  issuer: string;
+  /** Allowed redirect URIs (optional - if empty, all are allowed) */
+  allowedRedirectUris?: string[];
+  /** Allowed resource indicators (RFC 8707) */
+  allowedResources?: string[];
+  /** Custom client store (defaults to in-memory) */
+  clientStore?: ClientStore;
+  /** Code expiration in seconds (default: 600) */
+  codeExpirationSeconds?: number;
+}
+
+export interface ClientRegistration {
+  clientId: string;
+  clientSecret?: string;
+  redirectUris: string[];
+  grantTypes: string[];
+  clientName?: string;
+  createdAt: string;
+}
+
+export interface RegisterClientRequest {
+  redirect_uris: string[];
+  grant_types?: string[];
+  client_name?: string;
+}
+
+export interface AuthorizationCode {
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  codeChallengeMethod: 'S256';
+  scopes: string[];
+  resource?: string;
+  grantexAuthRequestId: string;
+  grantexCode?: string;
+  expiresAt: number;
+}
+
+export interface ClientStore {
+  get(clientId: string): Promise<ClientRegistration | undefined>;
+  set(clientId: string, registration: ClientRegistration): Promise<void>;
+  delete(clientId: string): Promise<boolean>;
+}
+
+export interface CodeStore {
+  get(code: string): Promise<AuthorizationCode | undefined>;
+  set(code: string, data: AuthorizationCode): Promise<void>;
+  delete(code: string): Promise<boolean>;
+}

--- a/packages/mcp-auth/tests/authorize.test.ts
+++ b/packages/mcp-auth/tests/authorize.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import { createMcpAuthServer } from '../src/server.js';
+import { InMemoryClientStore } from '../src/lib/clients.js';
+import type { McpAuthConfig } from '../src/types.js';
+
+function computeS256Challenge(verifier: string): string {
+  return createHash('sha256').update(verifier).digest('base64url');
+}
+
+const TEST_CLIENT_ID = 'test-client-id';
+const TEST_REDIRECT_URI = 'https://app.example.com/callback';
+const TEST_VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+const TEST_CHALLENGE = computeS256Challenge(TEST_VERIFIER);
+
+function createMockGrantex() {
+  return {
+    authorize: vi.fn().mockResolvedValue({
+      authRequestId: 'auth-req-1',
+      consentUrl: 'https://example.com/consent',
+      agentId: 'agent-1',
+      principalId: 'principal-1',
+      scopes: ['read', 'write'],
+      expiresIn: '600s',
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      status: 'pending' as const,
+      createdAt: new Date().toISOString(),
+    }),
+    tokens: {
+      exchange: vi.fn().mockResolvedValue({
+        grantToken: 'gt_test',
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+        scopes: ['read', 'write'],
+        refreshToken: 'rt_test',
+        grantId: 'grant-1',
+      }),
+      refresh: vi.fn().mockResolvedValue({
+        grantToken: 'gt_refreshed',
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+        scopes: ['read', 'write'],
+        refreshToken: 'rt_new',
+        grantId: 'grant-1',
+      }),
+    },
+  };
+}
+
+async function createTestApp(overrides: Partial<McpAuthConfig> = {}) {
+  const clientStore = new InMemoryClientStore();
+  await clientStore.set(TEST_CLIENT_ID, {
+    clientId: TEST_CLIENT_ID,
+    clientSecret: 'test-secret',
+    redirectUris: [TEST_REDIRECT_URI],
+    grantTypes: ['authorization_code'],
+    createdAt: new Date().toISOString(),
+  });
+
+  const mockGrantex = createMockGrantex();
+
+  const app = await createMcpAuthServer({
+    grantex: mockGrantex as unknown as McpAuthConfig['grantex'],
+    agentId: 'agent-1',
+    scopes: ['read', 'write'],
+    issuer: 'https://auth.example.com',
+    clientStore,
+    ...overrides,
+  });
+
+  return { app, mockGrantex, clientStore };
+}
+
+describe('authorize endpoint', () => {
+  let app: FastifyInstance;
+  let mockGrantex: ReturnType<typeof createMockGrantex>;
+
+  beforeEach(async () => {
+    const testCtx = await createTestApp();
+    app = testCtx.app;
+    mockGrantex = testCtx.mockGrantex;
+  });
+
+  it('returns 400 for unsupported response_type', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/authorize',
+      query: {
+        response_type: 'token',
+        client_id: TEST_CLIENT_ID,
+        redirect_uri: TEST_REDIRECT_URI,
+        code_challenge: TEST_CHALLENGE,
+        code_challenge_method: 'S256',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body.error).toBe('unsupported_response_type');
+  });
+
+  it('returns 400 when PKCE is missing', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/authorize',
+      query: {
+        response_type: 'code',
+        client_id: TEST_CLIENT_ID,
+        redirect_uri: TEST_REDIRECT_URI,
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body.error).toBe('invalid_request');
+    expect(body.error_description).toContain('PKCE');
+  });
+
+  it('returns 400 for unknown client_id', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/authorize',
+      query: {
+        response_type: 'code',
+        client_id: 'unknown-client',
+        redirect_uri: TEST_REDIRECT_URI,
+        code_challenge: TEST_CHALLENGE,
+        code_challenge_method: 'S256',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body.error).toBe('invalid_client');
+  });
+
+  it('returns 400 for unregistered redirect_uri', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/authorize',
+      query: {
+        response_type: 'code',
+        client_id: TEST_CLIENT_ID,
+        redirect_uri: 'https://evil.example.com/callback',
+        code_challenge: TEST_CHALLENGE,
+        code_challenge_method: 'S256',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body.error).toBe('invalid_request');
+    expect(body.error_description).toContain('redirect_uri');
+  });
+
+  it('returns 400 for invalid resource indicator', async () => {
+    const { app: appWithResources } = await createTestApp({
+      allowedResources: ['https://api.example.com'],
+    });
+
+    const response = await appWithResources.inject({
+      method: 'GET',
+      url: '/authorize',
+      query: {
+        response_type: 'code',
+        client_id: TEST_CLIENT_ID,
+        redirect_uri: TEST_REDIRECT_URI,
+        code_challenge: TEST_CHALLENGE,
+        code_challenge_method: 'S256',
+        resource: 'https://evil.example.com/api',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body.error).toBe('invalid_target');
+  });
+
+  it('redirects with code on success', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/authorize',
+      query: {
+        response_type: 'code',
+        client_id: TEST_CLIENT_ID,
+        redirect_uri: TEST_REDIRECT_URI,
+        code_challenge: TEST_CHALLENGE,
+        code_challenge_method: 'S256',
+      },
+    });
+
+    expect(response.statusCode).toBe(302);
+    const location = response.headers['location'] as string;
+    expect(location).toBeDefined();
+    const url = new URL(location);
+    expect(url.origin + url.pathname).toBe(TEST_REDIRECT_URI);
+    expect(url.searchParams.get('code')).toBeTruthy();
+  });
+
+  it('calls grantex.authorize with correct params', async () => {
+    await app.inject({
+      method: 'GET',
+      url: '/authorize',
+      query: {
+        response_type: 'code',
+        client_id: TEST_CLIENT_ID,
+        redirect_uri: TEST_REDIRECT_URI,
+        code_challenge: TEST_CHALLENGE,
+        code_challenge_method: 'S256',
+        scope: 'read write',
+      },
+    });
+
+    expect(mockGrantex.authorize).toHaveBeenCalledWith({
+      agentId: 'agent-1',
+      userId: TEST_CLIENT_ID,
+      scopes: ['read', 'write'],
+    });
+  });
+
+  it('passes state through to redirect', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/authorize',
+      query: {
+        response_type: 'code',
+        client_id: TEST_CLIENT_ID,
+        redirect_uri: TEST_REDIRECT_URI,
+        code_challenge: TEST_CHALLENGE,
+        code_challenge_method: 'S256',
+        state: 'my-state-value',
+      },
+    });
+
+    expect(response.statusCode).toBe(302);
+    const location = response.headers['location'] as string;
+    const url = new URL(location);
+    expect(url.searchParams.get('state')).toBe('my-state-value');
+  });
+});

--- a/packages/mcp-auth/tests/metadata.test.ts
+++ b/packages/mcp-auth/tests/metadata.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { createMcpAuthServer } from '../src/server.js';
+import type { McpAuthConfig } from '../src/types.js';
+
+function createMockGrantex() {
+  return {
+    authorize: async () => ({
+      authRequestId: 'auth-req-1',
+      consentUrl: 'https://example.com/consent',
+      agentId: 'agent-1',
+      principalId: 'principal-1',
+      scopes: ['read', 'write'],
+      expiresIn: '600s',
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      status: 'pending' as const,
+      createdAt: new Date().toISOString(),
+    }),
+    tokens: {
+      exchange: async () => ({
+        grantToken: 'gt_test',
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+        scopes: ['read', 'write'],
+        refreshToken: 'rt_test',
+        grantId: 'grant-1',
+      }),
+      refresh: async () => ({
+        grantToken: 'gt_refreshed',
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+        scopes: ['read', 'write'],
+        refreshToken: 'rt_new',
+        grantId: 'grant-1',
+      }),
+    },
+  } as unknown as McpAuthConfig['grantex'];
+}
+
+describe('metadata endpoint', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = await createMcpAuthServer({
+      grantex: createMockGrantex(),
+      agentId: 'agent-1',
+      scopes: ['read', 'write'],
+      issuer: 'https://auth.example.com',
+    });
+  });
+
+  it('returns well-known metadata with correct fields', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/.well-known/oauth-authorization-server',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).toHaveProperty('issuer');
+    expect(body).toHaveProperty('authorization_endpoint');
+    expect(body).toHaveProperty('token_endpoint');
+    expect(body).toHaveProperty('registration_endpoint');
+    expect(body).toHaveProperty('response_types_supported');
+    expect(body).toHaveProperty('grant_types_supported');
+    expect(body).toHaveProperty('code_challenge_methods_supported');
+    expect(body).toHaveProperty('token_endpoint_auth_methods_supported');
+    expect(body).toHaveProperty('scopes_supported');
+  });
+
+  it('returns correct issuer and endpoints', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/.well-known/oauth-authorization-server',
+    });
+
+    const body = response.json();
+    expect(body.issuer).toBe('https://auth.example.com');
+    expect(body.authorization_endpoint).toBe('https://auth.example.com/authorize');
+    expect(body.token_endpoint).toBe('https://auth.example.com/token');
+    expect(body.registration_endpoint).toBe('https://auth.example.com/register');
+  });
+
+  it('includes scopes_supported from config', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/.well-known/oauth-authorization-server',
+    });
+
+    const body = response.json();
+    expect(body.scopes_supported).toEqual(['read', 'write']);
+  });
+
+  it('includes resource_indicators_supported when allowedResources configured', async () => {
+    const appWithResources = await createMcpAuthServer({
+      grantex: createMockGrantex(),
+      agentId: 'agent-1',
+      scopes: ['read'],
+      issuer: 'https://auth.example.com',
+      allowedResources: ['https://api.example.com'],
+    });
+
+    const response = await appWithResources.inject({
+      method: 'GET',
+      url: '/.well-known/oauth-authorization-server',
+    });
+
+    const body = response.json();
+    expect(body.resource_indicators_supported).toBe(true);
+  });
+
+  it('omits resource_indicators_supported when no allowedResources', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/.well-known/oauth-authorization-server',
+    });
+
+    const body = response.json();
+    expect(body).not.toHaveProperty('resource_indicators_supported');
+  });
+});

--- a/packages/mcp-auth/tests/pkce.test.ts
+++ b/packages/mcp-auth/tests/pkce.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { verifyCodeChallenge } from '../src/lib/pkce.js';
+
+function computeS256Challenge(verifier: string): string {
+  return createHash('sha256').update(verifier).digest('base64url');
+}
+
+describe('verifyCodeChallenge', () => {
+  it('returns true for a valid S256 challenge', () => {
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = computeS256Challenge(verifier);
+    expect(verifyCodeChallenge(verifier, challenge)).toBe(true);
+  });
+
+  it('returns false for an invalid verifier', () => {
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = computeS256Challenge(verifier);
+    expect(verifyCodeChallenge('wrong-verifier', challenge)).toBe(false);
+  });
+
+  it('handles short verifier strings', () => {
+    const verifier = 'abc';
+    const challenge = computeS256Challenge(verifier);
+    expect(verifyCodeChallenge(verifier, challenge)).toBe(true);
+  });
+
+  it('handles long verifier strings', () => {
+    const verifier = 'a'.repeat(128);
+    const challenge = computeS256Challenge(verifier);
+    expect(verifyCodeChallenge(verifier, challenge)).toBe(true);
+  });
+});

--- a/packages/mcp-auth/tests/register.test.ts
+++ b/packages/mcp-auth/tests/register.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { createMcpAuthServer } from '../src/server.js';
+import type { McpAuthConfig } from '../src/types.js';
+
+function createMockGrantex() {
+  return {
+    authorize: async () => ({
+      authRequestId: 'auth-req-1',
+      consentUrl: 'https://example.com/consent',
+      agentId: 'agent-1',
+      principalId: 'principal-1',
+      scopes: ['read'],
+      expiresIn: '600s',
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      status: 'pending' as const,
+      createdAt: new Date().toISOString(),
+    }),
+    tokens: {
+      exchange: async () => ({
+        grantToken: 'gt_test',
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+        scopes: ['read'],
+        refreshToken: 'rt_test',
+        grantId: 'grant-1',
+      }),
+      refresh: async () => ({
+        grantToken: 'gt_refreshed',
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+        scopes: ['read'],
+        refreshToken: 'rt_new',
+        grantId: 'grant-1',
+      }),
+    },
+  } as unknown as McpAuthConfig['grantex'];
+}
+
+describe('register endpoint', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = await createMcpAuthServer({
+      grantex: createMockGrantex(),
+      agentId: 'agent-1',
+      scopes: ['read'],
+      issuer: 'https://auth.example.com',
+    });
+  });
+
+  it('registers a client with redirect_uris', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/register',
+      payload: {
+        redirect_uris: ['https://app.example.com/callback'],
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const body = response.json();
+    expect(body.redirect_uris).toEqual(['https://app.example.com/callback']);
+  });
+
+  it('returns client_id and client_secret', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/register',
+      payload: {
+        redirect_uris: ['https://app.example.com/callback'],
+      },
+    });
+
+    const body = response.json();
+    expect(body).toHaveProperty('client_id');
+    expect(body).toHaveProperty('client_secret');
+    expect(typeof body.client_id).toBe('string');
+    expect(typeof body.client_secret).toBe('string');
+    expect(body.client_id.length).toBeGreaterThan(0);
+    expect(body.client_secret.length).toBeGreaterThan(0);
+  });
+
+  it('returns 400 when redirect_uris is missing', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/register',
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body.error).toBe('invalid_client_metadata');
+  });
+
+  it('returns 400 when redirect_uris is empty array', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/register',
+      payload: {
+        redirect_uris: [],
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body.error).toBe('invalid_client_metadata');
+  });
+
+  it('sets default grant_types to authorization_code', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/register',
+      payload: {
+        redirect_uris: ['https://app.example.com/callback'],
+      },
+    });
+
+    const body = response.json();
+    expect(body.grant_types).toEqual(['authorization_code']);
+  });
+});

--- a/packages/mcp-auth/tests/token.test.ts
+++ b/packages/mcp-auth/tests/token.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import { createMcpAuthServer } from '../src/server.js';
+import { InMemoryClientStore } from '../src/lib/clients.js';
+import type { McpAuthConfig } from '../src/types.js';
+
+const TEST_CLIENT_ID = 'test-client-id';
+const TEST_REDIRECT_URI = 'https://app.example.com/callback';
+const TEST_VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+const TEST_CHALLENGE = createHash('sha256').update(TEST_VERIFIER).digest('base64url');
+
+function createMockGrantex() {
+  return {
+    authorize: vi.fn().mockResolvedValue({
+      authRequestId: 'auth-req-1',
+      consentUrl: 'https://example.com/consent',
+      agentId: 'agent-1',
+      principalId: 'principal-1',
+      scopes: ['read', 'write'],
+      expiresIn: '600s',
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      status: 'pending' as const,
+      createdAt: new Date().toISOString(),
+    }),
+    tokens: {
+      exchange: vi.fn().mockResolvedValue({
+        grantToken: 'gt_test_token',
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+        scopes: ['read', 'write'],
+        refreshToken: 'rt_test_refresh',
+        grantId: 'grant-1',
+      }),
+      refresh: vi.fn().mockResolvedValue({
+        grantToken: 'gt_refreshed_token',
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+        scopes: ['read', 'write'],
+        refreshToken: 'rt_new_refresh',
+        grantId: 'grant-1',
+      }),
+    },
+  };
+}
+
+async function setupWithCode() {
+  const clientStore = new InMemoryClientStore();
+  await clientStore.set(TEST_CLIENT_ID, {
+    clientId: TEST_CLIENT_ID,
+    clientSecret: 'test-secret',
+    redirectUris: [TEST_REDIRECT_URI],
+    grantTypes: ['authorization_code', 'refresh_token'],
+    createdAt: new Date().toISOString(),
+  });
+
+  const mockGrantex = createMockGrantex();
+
+  const app = await createMcpAuthServer({
+    grantex: mockGrantex as unknown as McpAuthConfig['grantex'],
+    agentId: 'agent-1',
+    scopes: ['read', 'write'],
+    issuer: 'https://auth.example.com',
+    clientStore,
+  });
+
+  // Issue an authorization code via the authorize endpoint
+  const authResponse = await app.inject({
+    method: 'GET',
+    url: '/authorize',
+    query: {
+      response_type: 'code',
+      client_id: TEST_CLIENT_ID,
+      redirect_uri: TEST_REDIRECT_URI,
+      code_challenge: TEST_CHALLENGE,
+      code_challenge_method: 'S256',
+      scope: 'read write',
+    },
+  });
+
+  const location = authResponse.headers['location'] as string;
+  const redirectUrl = new URL(location);
+  const code = redirectUrl.searchParams.get('code')!;
+
+  return { app, mockGrantex, code };
+}
+
+describe('token endpoint', () => {
+  it('returns 400 for unsupported grant_type', async () => {
+    const { app } = await setupWithCode();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/token',
+      payload: {
+        grant_type: 'client_credentials',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body.error).toBe('unsupported_grant_type');
+  });
+
+  it('returns 400 when required fields missing', async () => {
+    const { app } = await setupWithCode();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/token',
+      payload: {
+        grant_type: 'authorization_code',
+        code: 'some-code',
+        // Missing redirect_uri, client_id, code_verifier
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body.error).toBe('invalid_request');
+  });
+
+  it('returns 401 for unknown client_id', async () => {
+    const { app, code } = await setupWithCode();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/token',
+      payload: {
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: TEST_REDIRECT_URI,
+        client_id: 'unknown-client',
+        code_verifier: TEST_VERIFIER,
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    const body = response.json();
+    expect(body.error).toBe('invalid_client');
+  });
+
+  it('returns 400 for invalid/expired code', async () => {
+    const { app } = await setupWithCode();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/token',
+      payload: {
+        grant_type: 'authorization_code',
+        code: 'nonexistent-code',
+        redirect_uri: TEST_REDIRECT_URI,
+        client_id: TEST_CLIENT_ID,
+        code_verifier: TEST_VERIFIER,
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body.error).toBe('invalid_grant');
+  });
+
+  it('returns 400 for PKCE verification failure', async () => {
+    const { app, code } = await setupWithCode();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/token',
+      payload: {
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: TEST_REDIRECT_URI,
+        client_id: TEST_CLIENT_ID,
+        code_verifier: 'wrong-verifier-value',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body.error).toBe('invalid_grant');
+    expect(body.error_description).toContain('PKCE');
+  });
+
+  it('returns access_token on success', async () => {
+    const { app, code } = await setupWithCode();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/token',
+      payload: {
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: TEST_REDIRECT_URI,
+        client_id: TEST_CLIENT_ID,
+        code_verifier: TEST_VERIFIER,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.access_token).toBe('gt_test_token');
+    expect(body.token_type).toBe('bearer');
+    expect(body.expires_in).toBeGreaterThan(0);
+    expect(body.scope).toBe('read write');
+  });
+
+  it('returns refresh_token when available', async () => {
+    const { app, code } = await setupWithCode();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/token',
+      payload: {
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: TEST_REDIRECT_URI,
+        client_id: TEST_CLIENT_ID,
+        code_verifier: TEST_VERIFIER,
+      },
+    });
+
+    const body = response.json();
+    expect(body.refresh_token).toBe('rt_test_refresh');
+  });
+
+  it('handles refresh_token grant type', async () => {
+    const { app } = await setupWithCode();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/token',
+      payload: {
+        grant_type: 'refresh_token',
+        refresh_token: 'rt_test_refresh',
+        client_id: TEST_CLIENT_ID,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.access_token).toBe('gt_refreshed_token');
+    expect(body.token_type).toBe('bearer');
+    expect(body.refresh_token).toBe('rt_new_refresh');
+  });
+});

--- a/packages/mcp-auth/tsconfig.build.json
+++ b/packages/mcp-auth/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/mcp-auth/tsconfig.json
+++ b/packages/mcp-auth/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -75,6 +75,14 @@ from ._types import (
     CreateSsoConfigParams,
     SsoLoginResponse,
     SsoCallbackResponse,
+    # Vault
+    StoreCredentialParams,
+    StoreCredentialResponse,
+    VaultCredential,
+    ListVaultCredentialsParams,
+    ListVaultCredentialsResponse,
+    ExchangeCredentialParams,
+    ExchangeCredentialResponse,
 )
 from ._pkce import PkceChallenge, generate_pkce
 from ._verify import verify_grant_token
@@ -165,6 +173,14 @@ __all__ = [
     "CreateSsoConfigParams",
     "SsoLoginResponse",
     "SsoCallbackResponse",
+    # Vault
+    "StoreCredentialParams",
+    "StoreCredentialResponse",
+    "VaultCredential",
+    "ListVaultCredentialsParams",
+    "ListVaultCredentialsResponse",
+    "ExchangeCredentialParams",
+    "ExchangeCredentialResponse",
     # Version
     "__version__",
 ]

--- a/packages/sdk-py/src/grantex/_client.py
+++ b/packages/sdk-py/src/grantex/_client.py
@@ -18,6 +18,7 @@ from .resources._webhooks import WebhooksClient
 from .resources._billing import BillingClient
 from .resources._policies import PoliciesClient
 from .resources._principal_sessions import PrincipalSessionsClient
+from .resources._vault import VaultClient
 
 _DEFAULT_BASE_URL = "https://api.grantex.dev"
 
@@ -37,6 +38,7 @@ class Grantex:
     scim: ScimClient
     sso: SsoClient
     principal_sessions: PrincipalSessionsClient
+    vault: VaultClient
 
     @property
     def last_rate_limit(self) -> RateLimit | None:
@@ -74,6 +76,7 @@ class Grantex:
         self.scim = ScimClient(self._http)
         self.sso = SsoClient(self._http)
         self.principal_sessions = PrincipalSessionsClient(self._http)
+        self.vault = VaultClient(self._http, base_url)
 
     @staticmethod
     def signup(

--- a/packages/sdk-py/src/grantex/_types.py
+++ b/packages/sdk-py/src/grantex/_types.py
@@ -1150,3 +1150,116 @@ class SsoCallbackResponse:
             name=data.get("name"),
             sub=data.get("sub"),
         )
+
+
+# ── Credential Vault ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class StoreCredentialParams:
+    principal_id: str
+    service: str
+    access_token: str
+    credential_type: str | None = None
+    refresh_token: str | None = None
+    token_expires_at: str | None = None
+    metadata: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "principalId": self.principal_id,
+            "service": self.service,
+            "accessToken": self.access_token,
+            **({"credentialType": self.credential_type} if self.credential_type is not None else {}),
+            **({"refreshToken": self.refresh_token} if self.refresh_token is not None else {}),
+            **({"tokenExpiresAt": self.token_expires_at} if self.token_expires_at is not None else {}),
+            **({"metadata": self.metadata} if self.metadata is not None else {}),
+        }
+
+
+@dataclass(frozen=True)
+class StoreCredentialResponse:
+    id: str
+    principal_id: str
+    service: str
+    credential_type: str
+    created_at: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "StoreCredentialResponse":
+        return cls(
+            id=data["id"],
+            principal_id=data["principalId"],
+            service=data["service"],
+            credential_type=data["credentialType"],
+            created_at=data["createdAt"],
+        )
+
+
+@dataclass(frozen=True)
+class VaultCredential:
+    id: str
+    principal_id: str
+    service: str
+    credential_type: str
+    token_expires_at: str | None
+    metadata: dict[str, Any]
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "VaultCredential":
+        return cls(
+            id=data["id"],
+            principal_id=data["principalId"],
+            service=data["service"],
+            credential_type=data["credentialType"],
+            token_expires_at=data.get("tokenExpiresAt"),
+            metadata=data.get("metadata", {}),
+            created_at=data["createdAt"],
+            updated_at=data["updatedAt"],
+        )
+
+
+@dataclass
+class ListVaultCredentialsParams:
+    principal_id: str | None = None
+    service: str | None = None
+
+
+@dataclass(frozen=True)
+class ListVaultCredentialsResponse:
+    credentials: tuple[VaultCredential, ...]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ListVaultCredentialsResponse":
+        return cls(
+            credentials=tuple(VaultCredential.from_dict(c) for c in data["credentials"]),
+        )
+
+
+@dataclass
+class ExchangeCredentialParams:
+    service: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"service": self.service}
+
+
+@dataclass(frozen=True)
+class ExchangeCredentialResponse:
+    access_token: str
+    service: str
+    credential_type: str
+    token_expires_at: str | None
+    metadata: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ExchangeCredentialResponse":
+        return cls(
+            access_token=data["accessToken"],
+            service=data["service"],
+            credential_type=data["credentialType"],
+            token_expires_at=data.get("tokenExpiresAt"),
+            metadata=data.get("metadata", {}),
+        )

--- a/packages/sdk-py/src/grantex/resources/_vault.py
+++ b/packages/sdk-py/src/grantex/resources/_vault.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from .._http import HttpClient
+from .._types import (
+    ExchangeCredentialParams,
+    ExchangeCredentialResponse,
+    ListVaultCredentialsParams,
+    ListVaultCredentialsResponse,
+    StoreCredentialParams,
+    StoreCredentialResponse,
+    VaultCredential,
+)
+
+
+class VaultClient:
+    def __init__(self, http: HttpClient, base_url: str) -> None:
+        self._http = http
+        self._base_url = base_url.rstrip("/")
+
+    def store(self, params: StoreCredentialParams) -> StoreCredentialResponse:
+        """Store an encrypted credential in the vault (upserts on principal+service)."""
+        data = self._http.post("/v1/vault/credentials", params.to_dict())
+        return StoreCredentialResponse.from_dict(data)
+
+    def list(self, params: ListVaultCredentialsParams | None = None) -> ListVaultCredentialsResponse:
+        """List credential metadata (no raw tokens)."""
+        query_parts: list[str] = []
+        if params is not None:
+            if params.principal_id is not None:
+                query_parts.append(f"principalId={params.principal_id}")
+            if params.service is not None:
+                query_parts.append(f"service={params.service}")
+        qs = "&".join(query_parts)
+        path = f"/v1/vault/credentials?{qs}" if qs else "/v1/vault/credentials"
+        data = self._http.get(path)
+        return ListVaultCredentialsResponse.from_dict(data)
+
+    def get(self, credential_id: str) -> VaultCredential:
+        """Get credential metadata by ID (no raw token)."""
+        data = self._http.get(f"/v1/vault/credentials/{credential_id}")
+        return VaultCredential.from_dict(data)
+
+    def delete(self, credential_id: str) -> None:
+        """Delete a credential from the vault."""
+        self._http.delete(f"/v1/vault/credentials/{credential_id}")
+
+    def exchange(
+        self,
+        grant_token: str,
+        params: ExchangeCredentialParams,
+    ) -> ExchangeCredentialResponse:
+        """Exchange a grant token for an upstream credential.
+
+        Uses the grant token (not the API key) as the Bearer token.
+        """
+        url = f"{self._base_url}/v1/vault/credentials/exchange"
+        response = httpx.post(
+            url,
+            json=params.to_dict(),
+            headers={
+                "Authorization": f"Bearer {grant_token}",
+                "Accept": "application/json",
+            },
+        )
+        if not response.is_success:
+            body: dict[str, Any] | None = None
+            try:
+                body = response.json()
+            except Exception:
+                pass
+            message = (
+                body["message"]
+                if isinstance(body, dict) and isinstance(body.get("message"), str)
+                else f"HTTP {response.status_code}"
+            )
+            raise ValueError(message)
+        return ExchangeCredentialResponse.from_dict(response.json())

--- a/packages/sdk-py/tests/test_vault.py
+++ b/packages/sdk-py/tests/test_vault.py
@@ -1,0 +1,135 @@
+"""Tests for the VaultClient resource."""
+from __future__ import annotations
+
+import json
+
+import httpx
+import respx
+
+from grantex import (
+    Grantex,
+    StoreCredentialParams,
+    ExchangeCredentialParams,
+    ListVaultCredentialsParams,
+)
+
+BASE_URL = "https://api.grantex.dev"
+
+MOCK_CREDENTIAL = {
+    "id": "vault_01",
+    "principalId": "user_123",
+    "service": "google",
+    "credentialType": "oauth2",
+    "tokenExpiresAt": "2026-04-01T00:00:00Z",
+    "metadata": {"email": "test@example.com"},
+    "createdAt": "2026-03-01T00:00:00Z",
+    "updatedAt": "2026-03-01T00:00:00Z",
+}
+
+
+@respx.mock
+def test_store_credential() -> None:
+    respx.post(f"{BASE_URL}/v1/vault/credentials").mock(
+        return_value=httpx.Response(201, json={
+            "id": "vault_01",
+            "principalId": "user_123",
+            "service": "google",
+            "credentialType": "oauth2",
+            "createdAt": "2026-03-01T00:00:00Z",
+        })
+    )
+
+    client = Grantex(api_key="test_key", base_url=BASE_URL)
+    result = client.vault.store(StoreCredentialParams(
+        principal_id="user_123",
+        service="google",
+        access_token="ya29.access_token",
+        refresh_token="rt_refresh",
+    ))
+
+    assert result.id == "vault_01"
+    assert result.service == "google"
+    assert result.credential_type == "oauth2"
+
+    request = respx.calls.last.request
+    body = json.loads(request.content)
+    assert body["principalId"] == "user_123"
+    assert body["accessToken"] == "ya29.access_token"
+
+
+@respx.mock
+def test_list_credentials_with_filters() -> None:
+    respx.get(f"{BASE_URL}/v1/vault/credentials?principalId=user_123&service=google").mock(
+        return_value=httpx.Response(200, json={"credentials": [MOCK_CREDENTIAL]})
+    )
+
+    client = Grantex(api_key="test_key", base_url=BASE_URL)
+    result = client.vault.list(ListVaultCredentialsParams(
+        principal_id="user_123",
+        service="google",
+    ))
+
+    assert len(result.credentials) == 1
+    assert result.credentials[0].service == "google"
+
+
+@respx.mock
+def test_get_credential() -> None:
+    respx.get(f"{BASE_URL}/v1/vault/credentials/vault_01").mock(
+        return_value=httpx.Response(200, json=MOCK_CREDENTIAL)
+    )
+
+    client = Grantex(api_key="test_key", base_url=BASE_URL)
+    result = client.vault.get("vault_01")
+
+    assert result.id == "vault_01"
+    assert result.principal_id == "user_123"
+
+
+@respx.mock
+def test_delete_credential() -> None:
+    respx.delete(f"{BASE_URL}/v1/vault/credentials/vault_01").mock(
+        return_value=httpx.Response(204)
+    )
+
+    client = Grantex(api_key="test_key", base_url=BASE_URL)
+    client.vault.delete("vault_01")
+
+
+@respx.mock
+def test_exchange_credential() -> None:
+    respx.post(f"{BASE_URL}/v1/vault/credentials/exchange").mock(
+        return_value=httpx.Response(200, json={
+            "accessToken": "ya29.real_token",
+            "service": "google",
+            "credentialType": "oauth2",
+            "tokenExpiresAt": "2026-04-01T00:00:00Z",
+            "metadata": {},
+        })
+    )
+
+    client = Grantex(api_key="test_key", base_url=BASE_URL)
+    result = client.vault.exchange(
+        "grant.jwt.token",
+        ExchangeCredentialParams(service="google"),
+    )
+
+    assert result.access_token == "ya29.real_token"
+    assert result.service == "google"
+
+    request = respx.calls.last.request
+    assert request.headers["authorization"] == "Bearer grant.jwt.token"
+    body = json.loads(request.content)
+    assert body["service"] == "google"
+
+
+@respx.mock
+def test_list_credentials_without_filters() -> None:
+    respx.get(f"{BASE_URL}/v1/vault/credentials").mock(
+        return_value=httpx.Response(200, json={"credentials": []})
+    )
+
+    client = Grantex(api_key="test_key", base_url=BASE_URL)
+    result = client.vault.list()
+
+    assert len(result.credentials) == 0

--- a/packages/sdk-ts/src/client.ts
+++ b/packages/sdk-ts/src/client.ts
@@ -11,6 +11,7 @@ import { AnomaliesClient } from './resources/anomalies.js';
 import { ScimClient } from './resources/scim.js';
 import { SsoClient } from './resources/sso.js';
 import { PrincipalSessionsClient } from './resources/principal-sessions.js';
+import { VaultClient } from './resources/vault.js';
 import type {
   AuthorizationRequest,
   AuthorizeParams,
@@ -38,6 +39,7 @@ export class Grantex {
   readonly scim: ScimClient;
   readonly sso: SsoClient;
   readonly principalSessions: PrincipalSessionsClient;
+  readonly vault: VaultClient;
 
   get lastRateLimit(): RateLimit | undefined {
     return this.#http.lastRateLimit;
@@ -71,6 +73,7 @@ export class Grantex {
     this.scim = new ScimClient(this.#http);
     this.sso = new SsoClient(this.#http);
     this.principalSessions = new PrincipalSessionsClient(this.#http);
+    this.vault = new VaultClient(this.#http, options.baseUrl ?? DEFAULT_BASE_URL);
   }
 
   /**

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -95,6 +95,14 @@ export type {
   CreateSsoConfigParams,
   SsoLoginResponse,
   SsoCallbackResponse,
+  // Vault
+  StoreCredentialParams,
+  StoreCredentialResponse,
+  VaultCredential,
+  ListVaultCredentialsParams,
+  ListVaultCredentialsResponse,
+  ExchangeCredentialParams,
+  ExchangeCredentialResponse,
   // Compliance
   ComplianceSummary,
   ComplianceExportGrantsParams,

--- a/packages/sdk-ts/src/resources/vault.ts
+++ b/packages/sdk-ts/src/resources/vault.ts
@@ -1,0 +1,77 @@
+import type { HttpClient } from '../http.js';
+import type {
+  ExchangeCredentialParams,
+  ExchangeCredentialResponse,
+  ListVaultCredentialsParams,
+  ListVaultCredentialsResponse,
+  StoreCredentialParams,
+  StoreCredentialResponse,
+  VaultCredential,
+} from '../types.js';
+
+export class VaultClient {
+  readonly #http: HttpClient;
+  readonly #baseUrl: string;
+
+  constructor(http: HttpClient, baseUrl: string) {
+    this.#http = http;
+    this.#baseUrl = baseUrl.replace(/\/$/, '');
+  }
+
+  /** Store an encrypted credential in the vault (upserts on principal+service). */
+  store(params: StoreCredentialParams): Promise<StoreCredentialResponse> {
+    return this.#http.post<StoreCredentialResponse>('/v1/vault/credentials', params);
+  }
+
+  /** List credential metadata (no raw tokens). */
+  list(params: ListVaultCredentialsParams = {}): Promise<ListVaultCredentialsResponse> {
+    const query = new URLSearchParams();
+    if (params.principalId) query.set('principalId', params.principalId);
+    if (params.service) query.set('service', params.service);
+    const qs = query.toString();
+    return this.#http.get<ListVaultCredentialsResponse>(
+      `/v1/vault/credentials${qs ? `?${qs}` : ''}`,
+    );
+  }
+
+  /** Get credential metadata by ID (no raw token). */
+  get(credentialId: string): Promise<VaultCredential> {
+    return this.#http.get<VaultCredential>(`/v1/vault/credentials/${credentialId}`);
+  }
+
+  /** Delete a credential from the vault. */
+  delete(credentialId: string): Promise<void> {
+    return this.#http.delete(`/v1/vault/credentials/${credentialId}`);
+  }
+
+  /**
+   * Exchange a grant token for an upstream credential.
+   * Uses the grant token (not the API key) as the Bearer token.
+   */
+  async exchange(
+    grantToken: string,
+    params: ExchangeCredentialParams,
+  ): Promise<ExchangeCredentialResponse> {
+    const url = `${this.#baseUrl}/v1/vault/credentials/exchange`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${grantToken}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(params),
+    });
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => null);
+      const message =
+        body && typeof body === 'object' && 'message' in body
+          ? String((body as Record<string, unknown>)['message'])
+          : `HTTP ${response.status}`;
+      throw new Error(message);
+    }
+
+    return response.json() as Promise<ExchangeCredentialResponse>;
+  }
+}

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -558,3 +558,55 @@ export interface SsoCallbackResponse {
   sub: string | null;
   developerId: string;
 }
+
+// ─── Credential Vault ───────────────────────────────────────────────────────
+
+export interface StoreCredentialParams {
+  principalId: string;
+  service: string;
+  credentialType?: string;
+  accessToken: string;
+  refreshToken?: string;
+  tokenExpiresAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface VaultCredential {
+  id: string;
+  principalId: string;
+  service: string;
+  credentialType: string;
+  tokenExpiresAt: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface StoreCredentialResponse {
+  id: string;
+  principalId: string;
+  service: string;
+  credentialType: string;
+  createdAt: string;
+}
+
+export interface ListVaultCredentialsParams {
+  principalId?: string;
+  service?: string;
+}
+
+export interface ListVaultCredentialsResponse {
+  credentials: VaultCredential[];
+}
+
+export interface ExchangeCredentialParams {
+  service: string;
+}
+
+export interface ExchangeCredentialResponse {
+  accessToken: string;
+  service: string;
+  credentialType: string;
+  tokenExpiresAt: string | null;
+  metadata: Record<string, unknown>;
+}

--- a/packages/sdk-ts/tests/vault.test.ts
+++ b/packages/sdk-ts/tests/vault.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { Grantex } from '../src/client.js';
+
+function makeFetch(status: number, body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+const MOCK_CREDENTIAL = {
+  id: 'vault_01',
+  principalId: 'user_123',
+  service: 'google',
+  credentialType: 'oauth2',
+  tokenExpiresAt: '2026-04-01T00:00:00Z',
+  metadata: { email: 'test@example.com' },
+  createdAt: '2026-03-01T00:00:00Z',
+  updatedAt: '2026-03-01T00:00:00Z',
+};
+
+describe('VaultClient', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('store() POSTs to /v1/vault/credentials', async () => {
+    const mockFetch = makeFetch(201, {
+      id: 'vault_01',
+      principalId: 'user_123',
+      service: 'google',
+      credentialType: 'oauth2',
+      createdAt: '2026-03-01T00:00:00Z',
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.vault.store({
+      principalId: 'user_123',
+      service: 'google',
+      accessToken: 'ya29.access_token',
+      refreshToken: 'rt_refresh',
+    });
+
+    expect(result.id).toBe('vault_01');
+    expect(result.service).toBe('google');
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/vault\/credentials$/);
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
+    expect(body.principalId).toBe('user_123');
+    expect(body.accessToken).toBe('ya29.access_token');
+  });
+
+  it('list() GETs /v1/vault/credentials with filters', async () => {
+    const mockFetch = makeFetch(200, { credentials: [MOCK_CREDENTIAL] });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.vault.list({ principalId: 'user_123', service: 'google' });
+
+    expect(result.credentials).toHaveLength(1);
+    expect(result.credentials[0]!.service).toBe('google');
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toContain('principalId=user_123');
+    expect(url).toContain('service=google');
+  });
+
+  it('get() GETs /v1/vault/credentials/:id', async () => {
+    const mockFetch = makeFetch(200, MOCK_CREDENTIAL);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.vault.get('vault_01');
+
+    expect(result.id).toBe('vault_01');
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/vault\/credentials\/vault_01$/);
+    expect(init.method).toBe('GET');
+  });
+
+  it('delete() DELETEs /v1/vault/credentials/:id', async () => {
+    const mockFetch = makeFetch(204, null);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    await expect(grantex.vault.delete('vault_01')).resolves.toBeUndefined();
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/vault\/credentials\/vault_01$/);
+    expect(init.method).toBe('DELETE');
+  });
+
+  it('exchange() POSTs to /v1/vault/credentials/exchange with grant token', async () => {
+    const mockFetch = makeFetch(200, {
+      accessToken: 'ya29.real_token',
+      service: 'google',
+      credentialType: 'oauth2',
+      tokenExpiresAt: '2026-04-01T00:00:00Z',
+      metadata: {},
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.vault.exchange('grant.jwt.token', { service: 'google' });
+
+    expect(result.accessToken).toBe('ya29.real_token');
+    expect(result.service).toBe('google');
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/vault\/credentials\/exchange$/);
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer grant.jwt.token');
+    const body = JSON.parse(init.body as string);
+    expect(body.service).toBe('google');
+  });
+
+  it('exchange() uses grant token auth, not API key', async () => {
+    const mockFetch = makeFetch(200, {
+      accessToken: 'token',
+      service: 'github',
+      credentialType: 'oauth2',
+      tokenExpiresAt: null,
+      metadata: {},
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'my_api_key' });
+    await grantex.vault.exchange('my.grant.token', { service: 'github' });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    // Exchange should use the grant token, not the API key
+    expect(headers['Authorization']).toBe('Bearer my.grant.token');
+    expect(headers['Authorization']).not.toContain('my_api_key');
+  });
+
+  it('list() works without filters', async () => {
+    const mockFetch = makeFetch(200, { credentials: [] });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.vault.list();
+
+    expect(result.credentials).toEqual([]);
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toMatch(/\/v1\/vault\/credentials$/);
+  });
+});

--- a/web/index.html
+++ b/web/index.html
@@ -895,7 +895,11 @@
     <div class="integrations-grid">
       <a href="https://www.npmjs.com/package/@grantex/adapters" class="integration-pill" style="text-decoration:none;">
         <span class="integration-icon">&#x1F9E9;</span>
-        Adapters
+        Adapters (11)
+      </a>
+      <a href="https://www.npmjs.com/package/@grantex/mcp-auth" class="integration-pill" style="text-decoration:none;">
+        <span class="integration-icon">&#x1F510;</span>
+        MCP Auth Server
       </a>
       <a href="https://www.npmjs.com/package/@grantex/gateway" class="integration-pill" style="text-decoration:none;">
         <span class="integration-icon">&#x1F6E1;</span>
@@ -1198,6 +1202,20 @@
             <div>
               <h4>On-premise Docker</h4>
               <p>Self-host the entire stack with our production Docker Compose configuration.</p>
+            </div>
+          </div>
+          <div class="enterprise-feature">
+            <span class="check">&#x2713;</span>
+            <div>
+              <h4>Credential Vault</h4>
+              <p>Encrypted per-user credential store. Agents exchange grant tokens for upstream service credentials.</p>
+            </div>
+          </div>
+          <div class="enterprise-feature">
+            <span class="check">&#x2713;</span>
+            <div>
+              <h4>MCP Auth Server</h4>
+              <p>Drop-in OAuth 2.1 + PKCE authorization for any MCP server with dynamic client registration.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Implements all remaining v2.0 platform features:

- **Credential Vault** — Encrypted per-user credential store (AES-256-GCM) with grant-token-based exchange endpoint. SDK clients for TypeScript and Python.
- **MCP Authorization Server** (`@grantex/mcp-auth`) — Drop-in OAuth 2.1 + PKCE authorization provider for any MCP server. Dynamic client registration (RFC 7591), server metadata (RFC 8414).
- **7 new service provider adapters** — Google Drive, GitHub, Notion, HubSpot, Salesforce, Linear, Jira (11 total).
- **Webhook delivery log** — `GET /v1/webhooks/:id/deliveries` with pagination + status filter. Portal page with color-coded status badges.
- **3 new examples** — gateway-proxy, adapter-google-calendar, multi-agent-delegation.
- **Docs & roadmap** updated across all surfaces (Mintlify, README, landing page, integrations overview).

## Test Results

| Package | Tests |
|---------|-------|
| TypeScript SDK | 95 |
| Adapters | 128 |
| Auth Service | 246 |
| MCP Auth Server | 30 |
| Python SDK | 104 |
| **Total** | **603** |

All typechecks pass. All packages build cleanly.

## Test plan

- [ ] Verify CI passes (auth-service, sdk-ts, sdk-py jobs)
- [ ] Deploy auth service to Cloud Run (vault migration + env var)
- [ ] Deploy portal to Firebase Hosting
- [ ] Publish `@grantex/mcp-auth` to npm
- [ ] Bump `@grantex/sdk`, `@grantex/adapters`, `grantex` (Python) versions