### PR TITLE
chore: bump SDK, adapters, mcp-auth, Python SDK versions

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grantex/adapters",
-  "version": "0.1.1",
-  "description": "Pre-built service provider adapters for Grantex — Google Calendar, Gmail, Stripe, Slack",
+  "version": "0.1.2",
+  "description": "Pre-built service provider adapters for Grantex — Google Calendar, Gmail, Drive, Stripe, Slack, GitHub, Notion, HubSpot, Salesforce, Linear, Jira",
   "type": "module",
   "exports": {
     ".": {
@@ -45,8 +45,15 @@
     "adapters",
     "google-calendar",
     "gmail",
+    "google-drive",
     "stripe",
     "slack",
+    "github",
+    "notion",
+    "hubspot",
+    "salesforce",
+    "linear",
+    "jira",
     "authorization",
     "ai-agents"
   ]

--- a/packages/mcp-auth/package.json
+++ b/packages/mcp-auth/package.json
@@ -17,7 +17,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@grantex/sdk": "^0.1.6",
+    "@grantex/sdk": "^0.1.8",
     "fastify": "^5.2.1"
   },
   "devDependencies": {

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.1.7"
+version = "0.1.8"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- `@grantex/sdk` 0.1.7 → 0.1.8 (vault client)
- `@grantex/adapters` 0.1.1 → 0.1.2 (7 new adapters, updated description + keywords)
- `@grantex/mcp-auth` 0.1.0 (new package, first publish)
- `grantex` (Python) 0.1.7 → 0.1.8 (vault client)