### PR TITLE
fix: mask API key in CLI config show output

### DIFF
--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -32,7 +32,10 @@ export function configCommand(): Command {
       }
 
       console.log(`URL      ${config.baseUrl}`);
-      console.log(`API key  ${config.apiKey}`);
+      const masked = config.apiKey.length > 12
+        ? config.apiKey.slice(0, 8) + '…' + config.apiKey.slice(-4)
+        : '****';
+      console.log(`API key  ${masked}`);
 
       if (process.env['GRANTEX_URL'] || process.env['GRANTEX_KEY']) {
         console.log(chalk.dim('(env vars take precedence over config file)'));


### PR DESCRIPTION
## Summary
- Mask API key in `grantex config show` — displays `gx_live_…Ab3z` instead of the full key
- Resolves CodeQL alert #1 (clear-text logging of sensitive information)

## Test plan
- [x] Verified CLI typecheck passes