### PR TITLE
fix: eliminate API key data flow in CLI config show

### DIFF
--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -32,10 +32,8 @@ export function configCommand(): Command {
       }
 
       console.log(`URL      ${config.baseUrl}`);
-      const masked = config.apiKey.length > 12
-        ? config.apiKey.slice(0, 8) + '…' + config.apiKey.slice(-4)
-        : '****';
-      console.log(`API key  ${masked}`);
+      const prefix = config.apiKey.startsWith('gx_test_') ? 'gx_test_' : 'gx_live_';
+      console.log(`API key  ${prefix}${'*'.repeat(8)}`);
 
       if (process.env['GRANTEX_URL'] || process.env['GRANTEX_KEY']) {
         console.log(chalk.dim('(env vars take precedence over config file)'));


### PR DESCRIPTION
## Summary
- CodeQL re-flagged alert #54 because `.slice()` on the key still carries taint
- Now uses static prefix detection (`startsWith`) + fixed `********` — no part of the actual key is logged

## Test plan
- [x] Output shows `gx_live_********` or `gx_test_********`