### PR TITLE
chore: bump @grantex/sdk 0.2.0, grantex (py) 0.2.0

### DIFF
--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.1.9"
+version = "0.2.0"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- Bump `@grantex/sdk` from 0.1.9 to 0.2.0
- Bump `grantex` (Python) from 0.1.9 to 0.2.0

New packages at 0.1.0 (no bump needed):
- `@grantex/a2a` 0.1.0
- `grantex-a2a` 0.1.0

## Test plan

- [x] No code changes, version bumps only