### PR TITLE
fix: cascade delete dependent rows when deleting an agent

### DIFF
--- a/apps/auth-service/src/routes/agents.ts
+++ b/apps/auth-service/src/routes/agents.ts
@@ -118,13 +118,27 @@ export async function agentsRoutes(app: FastifyInstance): Promise<void> {
   // DELETE /v1/agents/:id
   app.delete<{ Params: { id: string } }>('/v1/agents/:id', async (request, reply) => {
     const sql = getSql();
-    const result = await sql`
-      DELETE FROM agents
-      WHERE id = ${request.params.id} AND developer_id = ${request.developer.id}
+    const agentId = request.params.id;
+    const developerId = request.developer.id;
+
+    // Verify agent exists and belongs to this developer
+    const rows = await sql`
+      SELECT id FROM agents WHERE id = ${agentId} AND developer_id = ${developerId}
     `;
-    if (result.count === 0) {
+    if (rows.length === 0) {
       return reply.status(404).send({ message: 'Agent not found', code: 'NOT_FOUND', requestId: request.id });
     }
+
+    // Cascade delete: dependents first, then agent
+    const grantSubquery = sql`SELECT id FROM grants WHERE agent_id = ${agentId} AND developer_id = ${developerId}`;
+    await sql`DELETE FROM budget_transactions WHERE grant_id IN (${grantSubquery})`;
+    await sql`DELETE FROM budget_allocations WHERE grant_id IN (${grantSubquery})`;
+    await sql`DELETE FROM refresh_tokens WHERE grant_id IN (${grantSubquery})`;
+    await sql`DELETE FROM grant_tokens WHERE grant_id IN (${grantSubquery})`;
+    await sql`DELETE FROM grants WHERE agent_id = ${agentId} AND developer_id = ${developerId}`;
+    await sql`DELETE FROM auth_requests WHERE agent_id = ${agentId} AND developer_id = ${developerId}`;
+    await sql`DELETE FROM agents WHERE id = ${agentId} AND developer_id = ${developerId}`;
+
     return reply.status(204).send();
   });
 }

--- a/apps/auth-service/tests/agents.test.ts
+++ b/apps/auth-service/tests/agents.test.ts
@@ -165,7 +165,14 @@ describe('PATCH /v1/agents/:id', () => {
 describe('DELETE /v1/agents/:id', () => {
   it('deletes agent and returns 204', async () => {
     seedAuth();
-    sqlMock.mockResolvedValueOnce({ count: 1 });
+    sqlMock.mockResolvedValueOnce([{ id: TEST_AGENT.id }]); // SELECT existence check
+    sqlMock.mockResolvedValueOnce([]); // DELETE budget_transactions
+    sqlMock.mockResolvedValueOnce([]); // DELETE budget_allocations
+    sqlMock.mockResolvedValueOnce([]); // DELETE refresh_tokens
+    sqlMock.mockResolvedValueOnce([]); // DELETE grant_tokens
+    sqlMock.mockResolvedValueOnce([]); // DELETE grants
+    sqlMock.mockResolvedValueOnce([]); // DELETE auth_requests
+    sqlMock.mockResolvedValueOnce([]); // DELETE agents
 
     const res = await app.inject({
       method: 'DELETE',
@@ -178,7 +185,7 @@ describe('DELETE /v1/agents/:id', () => {
 
   it('returns 404 when agent not found', async () => {
     seedAuth();
-    sqlMock.mockResolvedValueOnce({ count: 0 });
+    sqlMock.mockResolvedValueOnce([]); // SELECT existence check → empty
 
     const res = await app.inject({
       method: 'DELETE',


### PR DESCRIPTION
## Summary

- `DELETE /v1/agents/:id` now cascades to dependent tables before deleting the agent
- Deletes: budget_transactions, budget_allocations, refresh_tokens, grant_tokens, grants, auth_requests
- Previously returned 500 with FK constraint violation when agent had any auth requests or grants

## Test plan

- [x] All 362 auth service tests pass
- [x] Typecheck passes
- [x] Deployed to Cloud Run and verified: successfully deleted `playground-agent` that previously failed