### PR TITLE
fix: add GET /v1/budget/allocations endpoint

### DIFF
--- a/apps/auth-service/src/lib/budget.ts
+++ b/apps/auth-service/src/lib/budget.ts
@@ -156,6 +156,20 @@ function mapAllocationRow(row: Record<string, unknown>): BudgetAllocation {
   };
 }
 
+export async function listBudgetAllocations(
+  sql: ReturnType<typeof postgres>,
+  developerId: string,
+): Promise<BudgetAllocation[]> {
+  const rows = await sql`
+    SELECT id, grant_id, developer_id, initial_budget, remaining_budget, currency, created_at, updated_at
+    FROM budget_allocations
+    WHERE developer_id = ${developerId}
+    ORDER BY created_at DESC
+  `;
+
+  return rows.map(mapAllocationRow);
+}
+
 export class InsufficientBudgetError extends Error {
   constructor(grantId: string) {
     super(`Insufficient budget for grant ${grantId}`);

--- a/apps/auth-service/src/routes/budget.ts
+++ b/apps/auth-service/src/routes/budget.ts
@@ -4,6 +4,7 @@ import {
   createBudgetAllocation,
   debitBudget,
   getBudgetBalance,
+  listBudgetAllocations,
   listBudgetTransactions,
   InsufficientBudgetError,
 } from '../lib/budget.js';
@@ -22,6 +23,13 @@ interface DebitBody {
 }
 
 export async function budgetRoutes(app: FastifyInstance): Promise<void> {
+  // GET /v1/budget/allocations — list all budget allocations for the developer
+  app.get('/v1/budget/allocations', async (request, reply) => {
+    const sql = getSql();
+    const allocations = await listBudgetAllocations(sql, request.developer.id);
+    return reply.send({ allocations });
+  });
+
   // POST /v1/budget/allocate — create a budget allocation for a grant
   app.post<{ Body: AllocateBody }>('/v1/budget/allocate', async (request, reply) => {
     const { grantId, initialBudget, currency } = request.body;


### PR DESCRIPTION
## Summary
- Adds `GET /v1/budget/allocations` endpoint to the auth service — returns all budget allocations for the authenticated developer
- Fixes the portal Budgets page which was getting a 404 when loading

## Test plan
- [x] 362 auth-service tests pass
- [x] Typecheck passes
- [ ] Deploy to Cloud Run and verify portal Budgets page loads