### PR TITLE
fix: point docs links to docs.grantex.dev

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -622,7 +622,7 @@
         grant<span>ex</span>
       </a>
       <ul class="nav-links">
-        <li><a href="/docs"
+        <li><a href="https://docs.grantex.dev"
                onclick="gtag('event','docs_click',{event_category:'nav'})">Docs</a></li>
         <li><a href="https://github.com/mishrasanjeev/grantex"
                onclick="gtag('event','github_click',{event_category:'nav'})">GitHub</a></li>
@@ -659,7 +659,7 @@
         </svg>
         Try the playground
       </a>
-      <a href="/docs" class="btn btn-secondary"
+      <a href="https://docs.grantex.dev" class="btn btn-secondary"
          onclick="gtag('event','docs_click',{event_category:'hero'})">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
           <path d="M1 2.5A2.5 2.5 0 013.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 011 11.5v-9zm3.5-1a1 1 0 00-1 1v6.06A2.5 2.5 0 013.5 8.5H11V1.5H4.5zM5 4h4.75a.75.75 0 010 1.5H5A.75.75 0 015 4zm0 2.5h4.75a.75.75 0 010 1.5H5A.75.75 0 015 6.5z"/>
@@ -1332,7 +1332,7 @@
     <div class="footer-inner">
       <span class="footer-logo">grantex</span>
       <ul class="footer-links">
-        <li><a href="/docs">Docs</a></li>
+        <li><a href="https://docs.grantex.dev">Docs</a></li>
         <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
         <li><a href="https://pypi.org/project/grantex/">PyPI</a></li>
         <li><a href="https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/">IETF Draft</a></li>


### PR DESCRIPTION
## Summary
- Update all 3 docs links on the landing page (nav, hero button, footer) from `/docs` to `https://docs.grantex.dev`

## Test plan
- [ ] Verify nav "Docs" link opens docs.grantex.dev
- [ ] Verify hero "Documentation" button opens docs.grantex.dev
- [ ] Verify footer "Docs" link opens docs.grantex.dev