### PR TITLE
fix: resolve 4 CodeQL code scanning alerts

### DIFF
--- a/apps/auth-service/src/routes/domains.ts
+++ b/apps/auth-service/src/routes/domains.ts
@@ -2,7 +2,6 @@ import { randomUUID } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import { getSql } from '../db/client.js';
 import { verifyDomainDns } from '../lib/domains.js';
-import { isPlanName, PLAN_LIMITS } from '../lib/plans.js';
 
 export async function domainsRoutes(app: FastifyInstance): Promise<void> {
   // POST /v1/domains — register a custom domain
@@ -79,7 +78,7 @@ export async function domainsRoutes(app: FastifyInstance): Promise<void> {
   });
 
   // POST /v1/domains/:id/verify — verify domain DNS
-  app.post<{ Params: { id: string } }>('/v1/domains/:id/verify', async (request, reply) => {
+  app.post<{ Params: { id: string } }>('/v1/domains/:id/verify', { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } }, async (request, reply) => {
     const sql = getSql();
 
     const rows = await sql`

--- a/apps/auth-service/tests/domains.test.ts
+++ b/apps/auth-service/tests/domains.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { buildTestApp, seedAuth, authHeader, sqlMock } from './helpers.js';
 import type { FastifyInstance } from 'fastify';
 

--- a/apps/auth-service/tests/policy-backend.test.ts
+++ b/apps/auth-service/tests/policy-backend.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { buildTestApp, seedAuth, authHeader, sqlMock } from './helpers.js';
 import type { FastifyInstance } from 'fastify';
 


### PR DESCRIPTION
## Summary
- Remove unused imports (`beforeEach`, `vi`) from `policy-backend.test.ts` (alert #58)
- Remove unused import (`vi`) from `domains.test.ts` (alert #57)
- Remove unused imports (`PLAN_LIMITS`, `isPlanName`) from `domains.ts` (alert #56)
- Add rate limit (10/min) to `POST /v1/domains/:id/verify` route (alert #55 — missing rate limiting, high severity)

## Test plan
- [x] Typecheck passes
- [x] 23/23 tests pass in affected test files