### PR TITLE
feat: FIDO2/WebAuthn + DID infrastructure (Phases 1 & 3)

### DIFF
--- a/apps/auth-service/package-lock.json
+++ b/apps/auth-service/package-lock.json
@@ -18,6 +18,8 @@
         "@opentelemetry/resources": "^1.30.1",
         "@opentelemetry/sdk-node": "^0.57.2",
         "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@simplewebauthn/server": "^11.0.0",
+        "@simplewebauthn/types": "^11.0.0",
         "dotenv": "^16.4.5",
         "fastify": "^5.7.3",
         "ioredis": "^5.3.2",
@@ -754,6 +756,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@ioredis/commands": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
@@ -831,6 +839,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
     },
     "node_modules/@lukeed/ms": {
       "version": "2.0.2",
@@ -2231,6 +2245,64 @@
         "@opentelemetry/api": "^1.1.0"
       }
     },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.6.0.tgz",
+      "integrity": "sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz",
+      "integrity": "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz",
+      "integrity": "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
+      "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -2651,6 +2723,33 @@
         "win32"
       ]
     },
+    "node_modules/@simplewebauthn/server": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-11.0.0.tgz",
+      "integrity": "sha512-zu8dxKcPiRUNSN2kmrnNOzNbRI8VaR/rL4ENCHUfC6PEE7SAAdIql9g5GBOd/wOVZolIsaZz3ccFxuGoVP0iaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.3.10",
+        "@peculiar/asn1-ecc": "^2.3.8",
+        "@peculiar/asn1-rsa": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-x509": "^2.3.8",
+        "@simplewebauthn/types": "^11.0.0",
+        "cross-fetch": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@simplewebauthn/types": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/types/-/types-11.0.0.tgz",
+      "integrity": "sha512-b2o0wC5u2rWts31dTgBkAtSNKGX0cvL6h8QedNsKmj8O4QoLFQFR3DBVBUlpyVEhYKA+mXGUaXbcOc4JdQ3HzA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -2957,6 +3056,20 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
+      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -3143,6 +3256,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -4496,6 +4618,24 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
@@ -5040,6 +5180,12 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.1.0",

--- a/apps/auth-service/package.json
+++ b/apps/auth-service/package.json
@@ -24,6 +24,8 @@
     "@opentelemetry/resources": "^1.30.1",
     "@opentelemetry/sdk-node": "^0.57.2",
     "@opentelemetry/semantic-conventions": "^1.40.0",
+    "@simplewebauthn/server": "^11.0.0",
+    "@simplewebauthn/types": "^11.0.0",
     "dotenv": "^16.4.5",
     "fastify": "^5.7.3",
     "ioredis": "^5.3.2",

--- a/apps/auth-service/src/config.ts
+++ b/apps/auth-service/src/config.ts
@@ -40,6 +40,14 @@ export const config = {
   // Email (Resend)
   emailApiKey: process.env['RESEND_API_KEY'] ?? null,
   emailFrom: optional('EMAIL_FROM', 'Grantex <noreply@grantex.dev>'),
+  // Ed25519 key for VC Data Integrity proofs (optional)
+  ed25519PrivateKey: process.env['ED25519_PRIVATE_KEY'] ?? null,
+  // DID Web domain
+  didWebDomain: optional('DID_WEB_DOMAIN', 'grantex.dev'),
+  // FIDO/WebAuthn
+  fidoRpId: optional('FIDO_RP_ID', 'grantex.dev'),
+  fidoRpName: optional('FIDO_RP_NAME', 'Grantex'),
+  fidoOrigin: optional('FIDO_ORIGIN', 'https://grantex.dev'),
 } as const;
 
 if (!config.rsaPrivateKey && !config.autoGenerateKeys) {

--- a/apps/auth-service/src/db/migrations/018_webauthn.sql
+++ b/apps/auth-service/src/db/migrations/018_webauthn.sql
@@ -1,0 +1,47 @@
+-- WebAuthn credential storage (FIDO2 passkeys)
+CREATE TABLE IF NOT EXISTS webauthn_credentials (
+  id                TEXT PRIMARY KEY,
+  principal_id      TEXT NOT NULL,
+  developer_id      TEXT NOT NULL REFERENCES developers(id),
+  credential_id     TEXT NOT NULL,
+  public_key        TEXT NOT NULL,
+  counter           BIGINT NOT NULL DEFAULT 0,
+  transports        TEXT[] DEFAULT '{}',
+  aaguid            TEXT,
+  attestation_fmt   TEXT,
+  device_name       TEXT,
+  backed_up         BOOLEAN NOT NULL DEFAULT FALSE,
+  last_used_at      TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webauthn_cred_uniq
+  ON webauthn_credentials (developer_id, credential_id);
+
+CREATE INDEX IF NOT EXISTS idx_webauthn_cred_principal
+  ON webauthn_credentials (principal_id, developer_id);
+
+-- WebAuthn challenges (transient, 5-min TTL)
+CREATE TABLE IF NOT EXISTS webauthn_challenges (
+  id             TEXT PRIMARY KEY,
+  challenge      TEXT NOT NULL,
+  principal_id   TEXT NOT NULL,
+  developer_id   TEXT NOT NULL REFERENCES developers(id),
+  ceremony_type  TEXT NOT NULL,
+  auth_request_id TEXT,
+  expires_at     TIMESTAMPTZ NOT NULL,
+  consumed       BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_webauthn_challenges_expiry
+  ON webauthn_challenges (expires_at) WHERE consumed = FALSE;
+
+-- Developer-level FIDO settings
+ALTER TABLE developers ADD COLUMN IF NOT EXISTS fido_required BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE developers ADD COLUMN IF NOT EXISTS fido_rp_name TEXT;
+
+-- Track FIDO assertion on grants and auth requests
+ALTER TABLE grants ADD COLUMN IF NOT EXISTS fido_verified BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE grants ADD COLUMN IF NOT EXISTS fido_credential_id TEXT;
+ALTER TABLE auth_requests ADD COLUMN IF NOT EXISTS fido_verified BOOLEAN NOT NULL DEFAULT FALSE;

--- a/apps/auth-service/src/db/migrations/019_did_keys.sql
+++ b/apps/auth-service/src/db/migrations/019_did_keys.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS signing_keys (
+  id            TEXT PRIMARY KEY,
+  kid           TEXT NOT NULL UNIQUE,
+  algorithm     TEXT NOT NULL,
+  purpose       TEXT NOT NULL,
+  private_key   TEXT NOT NULL,
+  public_key    TEXT NOT NULL,
+  public_jwk    JSONB NOT NULL,
+  status        TEXT NOT NULL DEFAULT 'active',
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  rotated_at    TIMESTAMPTZ
+);

--- a/apps/auth-service/src/index.ts
+++ b/apps/auth-service/src/index.ts
@@ -1,6 +1,6 @@
 import { initTracing } from './lib/tracing.js';
 import { config } from './config.js';
-import { initKeys } from './lib/crypto.js';
+import { initKeys, initEdKey } from './lib/crypto.js';
 import { getSql } from './db/client.js';
 import { runMigrations } from './db/migrate.js';
 import { getRedis } from './redis/client.js';
@@ -16,6 +16,9 @@ async function main() {
 
   // Initialize RSA keys
   await initKeys();
+
+  // Initialize Ed25519 key (optional — for DID / VC support)
+  await initEdKey();
 
   // Initialize DB connection
   const sql = getSql();

--- a/apps/auth-service/src/lib/crypto.ts
+++ b/apps/auth-service/src/lib/crypto.ts
@@ -127,19 +127,86 @@ export async function verifyGrantToken(
   return { sub, dev, scp };
 }
 
+// ─── Ed25519 key support (optional — for VC Data Integrity proofs) ────────────
+
+export interface EdKeyPair {
+  privateKey: KeyLike;
+  publicKey: KeyLike;
+  kid: string;
+}
+
+let _edKeyPair: EdKeyPair | null = null;
+
+function buildEdKid(): string {
+  const now = new Date();
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+  return `grantex-ed25519-${year}-${month}`;
+}
+
+export async function initEdKey(): Promise<void> {
+  if (config.ed25519PrivateKey) {
+    const pem = config.ed25519PrivateKey.replace(/\\n/g, '\n');
+    const privateKey = await importPKCS8(pem, 'EdDSA');
+    const jwk = await exportJWK(privateKey);
+    if (!jwk.crv || !jwk.x) throw new Error('Cannot extract Ed25519 public key components');
+    const { createPublicKey } = await import('node:crypto');
+    const nodePk = createPublicKey({
+      key: { kty: jwk.kty as string, crv: jwk.crv, x: jwk.x },
+      format: 'jwk',
+    });
+    const spkiPem = nodePk.export({ type: 'spki', format: 'pem' }) as string;
+    const publicKey = await importSPKI(spkiPem, 'EdDSA');
+    _edKeyPair = { privateKey, publicKey, kid: buildEdKid() };
+    return;
+  }
+
+  // Auto-generate Ed25519 key pair
+  const { privateKey, publicKey } = await generateKeyPair('EdDSA', { crv: 'Ed25519' });
+  _edKeyPair = { privateKey, publicKey, kid: buildEdKid() };
+}
+
+export function getEdKeyPair(): EdKeyPair | null {
+  return _edKeyPair;
+}
+
+export async function signWithEd25519(payload: Record<string, unknown>): Promise<string> {
+  if (!_edKeyPair) throw new Error('Ed25519 key not initialized — call initEdKey() first');
+  const { privateKey, kid } = _edKeyPair;
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'EdDSA', kid })
+    .setIssuer(config.jwtIssuer)
+    .setIssuedAt()
+    .setExpirationTime(Math.floor(Date.now() / 1000) + 3600)
+    .sign(privateKey);
+}
+
+// ─── End Ed25519 ─────────────────────────────────────────────────────────────
+
 export async function buildJwks(): Promise<{ keys: Record<string, unknown>[] }> {
   const { publicKey, kid } = getKeyPair();
   const jwk = await exportJWK(publicKey);
-  return {
-    keys: [
-      {
-        ...jwk,
-        alg: 'RS256',
-        use: 'sig',
-        kid,
-      },
-    ],
-  };
+  const keys: Record<string, unknown>[] = [
+    {
+      ...jwk,
+      alg: 'RS256',
+      use: 'sig',
+      kid,
+    },
+  ];
+
+  // Include Ed25519 key if initialized
+  if (_edKeyPair) {
+    const edJwk = await exportJWK(_edKeyPair.publicKey);
+    keys.push({
+      ...edJwk,
+      alg: 'EdDSA',
+      use: 'sig',
+      kid: _edKeyPair.kid,
+    });
+  }
+
+  return { keys };
 }
 
 export function decodeTokenClaims(jwt: string): Record<string, unknown> {

--- a/apps/auth-service/src/lib/events.ts
+++ b/apps/auth-service/src/lib/events.ts
@@ -7,7 +7,9 @@ export type EventType =
   | 'grant.revoked'
   | 'token.issued'
   | 'budget.threshold'
-  | 'budget.exhausted';
+  | 'budget.exhausted'
+  | 'fido.registered'
+  | 'fido.assertion';
 
 export interface GrantexEvent {
   id: string;

--- a/apps/auth-service/src/lib/ids.ts
+++ b/apps/auth-service/src/lib/ids.ts
@@ -18,3 +18,6 @@ export const newBudgetAllocationId = (): string => `bdg_${ulid()}`;
 export const newBudgetTransactionId = (): string => `btx_${ulid()}`;
 export const newUsageDailyId = (): string => `usg_${ulid()}`;
 export const newPolicyBundleId = (): string => `pbnd_${ulid()}`;
+export const newSigningKeyId = (): string => `key_${ulid()}`;
+export const newWebAuthnCredentialId = (): string => `cred_${ulid()}`;
+export const newWebAuthnChallengeId = (): string => `wac_${ulid()}`;

--- a/apps/auth-service/src/lib/webauthn.ts
+++ b/apps/auth-service/src/lib/webauthn.ts
@@ -1,0 +1,86 @@
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} from '@simplewebauthn/server';
+import type {
+  RegistrationResponseJSON,
+  AuthenticationResponseJSON,
+  AuthenticatorTransportFuture,
+} from '@simplewebauthn/types';
+import { config } from '../config.js';
+
+export interface StoredCredential {
+  credentialId: string;
+  publicKey: string; // base64url
+  counter: number;
+  transports: string[];
+}
+
+export async function generateRegOptions(
+  principalId: string,
+  rpName: string,
+  existingCredentials: StoredCredential[],
+) {
+  return generateRegistrationOptions({
+    rpName,
+    rpID: config.fidoRpId,
+    userName: principalId,
+    userID: new TextEncoder().encode(principalId),
+    attestationType: 'direct',
+    authenticatorSelection: {
+      residentKey: 'preferred',
+      userVerification: 'preferred',
+    },
+    excludeCredentials: existingCredentials.map((c) => ({
+      id: c.credentialId,
+      transports: c.transports as AuthenticatorTransportFuture[],
+    })),
+  });
+}
+
+export async function verifyRegResponse(
+  response: RegistrationResponseJSON,
+  expectedChallenge: string,
+) {
+  return verifyRegistrationResponse({
+    response,
+    expectedChallenge,
+    expectedOrigin: config.fidoOrigin,
+    expectedRPID: config.fidoRpId,
+  });
+}
+
+export async function generateAuthOptions(
+  credentials: StoredCredential[],
+) {
+  return generateAuthenticationOptions({
+    rpID: config.fidoRpId,
+    allowCredentials: credentials.map((c) => ({
+      id: c.credentialId,
+      transports: c.transports as AuthenticatorTransportFuture[],
+    })),
+    userVerification: 'preferred',
+  });
+}
+
+export async function verifyAuthResponse(
+  response: AuthenticationResponseJSON,
+  expectedChallenge: string,
+  credential: StoredCredential,
+) {
+  const uint8Key = Buffer.from(credential.publicKey, 'base64url');
+  return verifyAuthenticationResponse({
+    response,
+    expectedChallenge,
+    expectedOrigin: config.fidoOrigin,
+    expectedRPID: config.fidoRpId,
+    credential: {
+      id: credential.credentialId,
+      publicKey: uint8Key,
+      counter: credential.counter,
+      transports: credential.transports as AuthenticatorTransportFuture[],
+    },
+  });
+}

--- a/apps/auth-service/src/routes/consent.ts
+++ b/apps/auth-service/src/routes/consent.ts
@@ -181,11 +181,14 @@ export async function consentRoutes(app: FastifyInstance): Promise<void> {
         agent_name: string;
         agent_description: string | null;
         agent_did: string;
+        fido_required: boolean;
       }[]>`
         SELECT ar.id, ar.scopes, ar.expires_at, ar.status, ar.redirect_uri, ar.state,
-               a.name AS agent_name, a.description AS agent_description, a.did AS agent_did
+               a.name AS agent_name, a.description AS agent_description, a.did AS agent_did,
+               d.fido_required
         FROM auth_requests ar
         JOIN agents a ON a.id = ar.agent_id
+        JOIN developers d ON d.id = ar.developer_id
         WHERE ar.id = ${request.params.id}
       `;
 
@@ -208,6 +211,7 @@ export async function consentRoutes(app: FastifyInstance): Promise<void> {
         scopeDescriptions: row.scopes.map(describeScope),
         expiresAt: row.expires_at,
         status: row.status,
+        fidoRequired: Boolean(row.fido_required),
       });
     },
   );
@@ -226,11 +230,34 @@ export async function consentRoutes(app: FastifyInstance): Promise<void> {
         WHERE id = ${request.params.id}
           AND status = 'pending'
           AND expires_at > NOW()
+          AND (
+            NOT EXISTS (
+              SELECT 1 FROM developers d
+              WHERE d.id = auth_requests.developer_id AND d.fido_required = TRUE
+            )
+            OR fido_verified = TRUE
+          )
         RETURNING id, code, redirect_uri, state
       `;
 
       const row = rows[0];
       if (!row) {
+        // Distinguish FIDO_REQUIRED from expired/processed
+        const fidoCheck = await sql`
+          SELECT d.fido_required, ar.fido_verified, ar.status, ar.expires_at
+          FROM auth_requests ar
+          JOIN developers d ON d.id = ar.developer_id
+          WHERE ar.id = ${request.params.id}
+        `;
+        const fc = fidoCheck[0];
+        if (fc && fc['fido_required'] && !fc['fido_verified']
+            && fc['status'] === 'pending' && new Date(fc['expires_at'] as string) > new Date()) {
+          return reply.status(403).send({
+            message: 'FIDO verification required before approval',
+            code: 'FIDO_REQUIRED',
+            requestId: request.id,
+          });
+        }
         return reply.status(410).send({ message: 'Auth request expired or already processed', code: 'GONE', requestId: request.id });
       }
 

--- a/apps/auth-service/src/routes/did.ts
+++ b/apps/auth-service/src/routes/did.ts
@@ -1,0 +1,63 @@
+import type { FastifyInstance } from 'fastify';
+import { buildJwks, getEdKeyPair } from '../lib/crypto.js';
+import { exportJWK } from 'jose';
+import { config } from '../config.js';
+
+export async function didRoutes(app: FastifyInstance): Promise<void> {
+  // GET /.well-known/did.json — serve DID document (public)
+  app.get('/.well-known/did.json', { config: { skipAuth: true } }, async (_request, reply) => {
+    const domain = config.didWebDomain;
+    const didId = `did:web:${domain}`;
+    const jwks = await buildJwks();
+
+    const verificationMethods: Record<string, unknown>[] = [];
+
+    // RS256 key (always present)
+    const rsaKey = jwks.keys.find((k) => k['alg'] === 'RS256');
+    if (rsaKey) {
+      verificationMethods.push({
+        id: `${didId}#${rsaKey['kid'] as string}`,
+        type: 'JsonWebKey2020',
+        controller: didId,
+        publicKeyJwk: rsaKey,
+      });
+    }
+
+    // Ed25519 key (optional)
+    const edKeyPair = getEdKeyPair();
+    if (edKeyPair) {
+      const edJwk = await exportJWK(edKeyPair.publicKey);
+      verificationMethods.push({
+        id: `${didId}#${edKeyPair.kid}`,
+        type: 'JsonWebKey2020',
+        controller: didId,
+        publicKeyJwk: { ...edJwk, alg: 'EdDSA', use: 'sig', kid: edKeyPair.kid },
+      });
+    }
+
+    const doc = {
+      '@context': [
+        'https://www.w3.org/ns/did/v1',
+        'https://w3id.org/security/suites/jws-2020/v1',
+      ],
+      id: didId,
+      verificationMethod: verificationMethods,
+      authentication: verificationMethods.map((m) => m['id']),
+      assertionMethod: verificationMethods.map((m) => m['id']),
+      service: [
+        {
+          id: `${didId}#jwks`,
+          type: 'JsonWebKeySet',
+          serviceEndpoint: `https://${domain}/.well-known/jwks.json`,
+        },
+        {
+          id: `${didId}#grant-protocol`,
+          type: 'GrantexProtocol',
+          serviceEndpoint: `https://api.${domain}/v1`,
+        },
+      ],
+    };
+
+    return reply.send(doc);
+  });
+}

--- a/apps/auth-service/src/routes/me.ts
+++ b/apps/auth-service/src/routes/me.ts
@@ -41,4 +41,36 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
       createdAt: dev.created_at,
     });
   });
+
+  // PATCH /v1/me — update developer settings (e.g. FIDO)
+  app.patch<{ Body: { fidoRequired?: boolean; fidoRpName?: string } }>(
+    '/v1/me',
+    async (request, reply) => {
+      const sql = getSql();
+      const developerId = request.developer.id;
+      const { fidoRequired, fidoRpName } = request.body;
+
+      if (fidoRequired === undefined && fidoRpName === undefined) {
+        return reply.status(400).send({ message: 'No fields to update', code: 'BAD_REQUEST', requestId: request.id });
+      }
+
+      if (fidoRequired !== undefined && fidoRpName !== undefined) {
+        await sql`
+          UPDATE developers
+          SET fido_required = ${fidoRequired}, fido_rp_name = ${fidoRpName}
+          WHERE id = ${developerId}
+        `;
+      } else if (fidoRequired !== undefined) {
+        await sql`
+          UPDATE developers SET fido_required = ${fidoRequired} WHERE id = ${developerId}
+        `;
+      } else {
+        await sql`
+          UPDATE developers SET fido_rp_name = ${fidoRpName!} WHERE id = ${developerId}
+        `;
+      }
+
+      return reply.send({ updated: true });
+    },
+  );
 }

--- a/apps/auth-service/src/routes/webauthn.ts
+++ b/apps/auth-service/src/routes/webauthn.ts
@@ -1,0 +1,300 @@
+import type { FastifyInstance } from 'fastify';
+import { getSql } from '../db/client.js';
+import { newWebAuthnCredentialId, newWebAuthnChallengeId } from '../lib/ids.js';
+import { generateRegOptions, verifyRegResponse, generateAuthOptions, verifyAuthResponse } from '../lib/webauthn.js';
+import { emitEvent } from '../lib/events.js';
+import { isoBase64URL } from '@simplewebauthn/server/helpers';
+import type { RegistrationResponseJSON, AuthenticationResponseJSON } from '@simplewebauthn/types';
+
+export async function webauthnRoutes(app: FastifyInstance): Promise<void> {
+  // POST /v1/webauthn/register/options — generate registration options (protected)
+  app.post<{ Body: { principalId: string } }>(
+    '/v1/webauthn/register/options',
+    async (request, reply) => {
+      const { principalId } = request.body;
+      if (!principalId) {
+        return reply.status(400).send({ message: 'principalId is required', code: 'BAD_REQUEST', requestId: request.id });
+      }
+
+      const sql = getSql();
+      const developerId = request.developer.id;
+      const rpName = request.developer.name || 'Grantex';
+
+      // Fetch existing credentials for exclusion
+      const existingRows = await sql`
+        SELECT credential_id, public_key, counter, transports
+        FROM webauthn_credentials
+        WHERE principal_id = ${principalId} AND developer_id = ${developerId}
+      `;
+
+      const existing = existingRows.map((r) => ({
+        credentialId: r['credential_id'] as string,
+        publicKey: r['public_key'] as string,
+        counter: Number(r['counter']),
+        transports: (r['transports'] as string[]) ?? [],
+      }));
+
+      const options = await generateRegOptions(principalId, rpName, existing);
+
+      // Store challenge
+      const challengeId = newWebAuthnChallengeId();
+      const expiresAt = new Date(Date.now() + 5 * 60 * 1000); // 5 minutes
+      await sql`
+        INSERT INTO webauthn_challenges (id, challenge, principal_id, developer_id, ceremony_type, expires_at)
+        VALUES (${challengeId}, ${options.challenge}, ${principalId}, ${developerId}, 'registration', ${expiresAt})
+      `;
+
+      return reply.send({ challengeId, publicKey: options });
+    },
+  );
+
+  // POST /v1/webauthn/register/verify — verify registration response (protected)
+  app.post<{ Body: { challengeId: string; response: RegistrationResponseJSON; deviceName?: string } }>(
+    '/v1/webauthn/register/verify',
+    async (request, reply) => {
+      const { challengeId, response, deviceName } = request.body;
+      if (!challengeId || !response) {
+        return reply.status(400).send({ message: 'challengeId and response are required', code: 'BAD_REQUEST', requestId: request.id });
+      }
+
+      const sql = getSql();
+      const developerId = request.developer.id;
+
+      // Look up and consume challenge
+      const challengeRows = await sql`
+        SELECT challenge, principal_id FROM webauthn_challenges
+        WHERE id = ${challengeId} AND developer_id = ${developerId}
+          AND ceremony_type = 'registration' AND consumed = FALSE AND expires_at > NOW()
+      `;
+      const challengeRow = challengeRows[0];
+      if (!challengeRow) {
+        return reply.status(400).send({ message: 'Invalid or expired challenge', code: 'BAD_REQUEST', requestId: request.id });
+      }
+
+      await sql`UPDATE webauthn_challenges SET consumed = TRUE WHERE id = ${challengeId}`;
+
+      const verification = await verifyRegResponse(response, challengeRow['challenge'] as string);
+      if (!verification.verified || !verification.registrationInfo) {
+        return reply.status(400).send({ message: 'Registration verification failed', code: 'BAD_REQUEST', requestId: request.id });
+      }
+
+      const { credential, credentialBackedUp } = verification.registrationInfo;
+      const credId = newWebAuthnCredentialId();
+
+      await sql`
+        INSERT INTO webauthn_credentials (id, principal_id, developer_id, credential_id, public_key, counter, transports, aaguid, backed_up, device_name)
+        VALUES (
+          ${credId},
+          ${challengeRow['principal_id'] as string},
+          ${developerId},
+          ${credential.id},
+          ${isoBase64URL.fromBuffer(credential.publicKey)},
+          ${credential.counter},
+          ${(credential.transports ?? []) as string[]},
+          ${verification.registrationInfo.aaguid ?? null},
+          ${credentialBackedUp},
+          ${deviceName ?? null}
+        )
+      `;
+
+      emitEvent(developerId, 'fido.registered', {
+        principalId: challengeRow['principal_id'] as string,
+        credentialId: credId,
+      }).catch(() => {});
+
+      return reply.status(201).send({
+        id: credId,
+        principalId: challengeRow['principal_id'] as string,
+        deviceName: deviceName ?? null,
+        backedUp: credentialBackedUp,
+        transports: credential.transports ?? [],
+        createdAt: new Date().toISOString(),
+      });
+    },
+  );
+
+  // GET /v1/webauthn/credentials — list credentials for a principal (protected)
+  app.get<{ Querystring: { principalId: string } }>(
+    '/v1/webauthn/credentials',
+    async (request, reply) => {
+      const principalId = request.query.principalId;
+      if (!principalId) {
+        return reply.status(400).send({ message: 'principalId query param is required', code: 'BAD_REQUEST', requestId: request.id });
+      }
+
+      const sql = getSql();
+      const rows = await sql`
+        SELECT id, principal_id, device_name, backed_up, transports, created_at, last_used_at
+        FROM webauthn_credentials
+        WHERE principal_id = ${principalId} AND developer_id = ${request.developer.id}
+        ORDER BY created_at DESC
+      `;
+
+      return reply.send({
+        credentials: rows.map((r) => ({
+          id: r['id'],
+          principalId: r['principal_id'],
+          deviceName: r['device_name'] ?? null,
+          backedUp: r['backed_up'],
+          transports: r['transports'] ?? [],
+          createdAt: r['created_at'],
+          lastUsedAt: r['last_used_at'] ?? null,
+        })),
+      });
+    },
+  );
+
+  // DELETE /v1/webauthn/credentials/:id — remove a credential (protected)
+  app.delete<{ Params: { id: string } }>(
+    '/v1/webauthn/credentials/:id',
+    async (request, reply) => {
+      const sql = getSql();
+      const rows = await sql`
+        DELETE FROM webauthn_credentials
+        WHERE id = ${request.params.id} AND developer_id = ${request.developer.id}
+        RETURNING id
+      `;
+      if (!rows[0]) {
+        return reply.status(404).send({ message: 'Credential not found', code: 'NOT_FOUND', requestId: request.id });
+      }
+      return reply.status(204).send();
+    },
+  );
+
+  // POST /v1/webauthn/assert/options — generate assertion options (PUBLIC, used from consent page)
+  app.post<{ Body: { authRequestId: string } }>(
+    '/v1/webauthn/assert/options',
+    { config: { skipAuth: true } },
+    async (request, reply) => {
+      const { authRequestId } = request.body;
+      if (!authRequestId) {
+        return reply.status(400).send({ message: 'authRequestId is required', code: 'BAD_REQUEST', requestId: request.id });
+      }
+
+      const sql = getSql();
+
+      // Look up auth request to get principal and developer
+      const arRows = await sql`
+        SELECT ar.principal_id, ar.developer_id, d.fido_required
+        FROM auth_requests ar
+        JOIN developers d ON d.id = ar.developer_id
+        WHERE ar.id = ${authRequestId} AND ar.status = 'pending' AND ar.expires_at > NOW()
+      `;
+      const ar = arRows[0];
+      if (!ar) {
+        return reply.status(404).send({ message: 'Auth request not found or expired', code: 'NOT_FOUND', requestId: request.id });
+      }
+
+      if (!ar['fido_required']) {
+        return reply.status(400).send({ message: 'FIDO not required for this developer', code: 'BAD_REQUEST', requestId: request.id });
+      }
+
+      const principalId = ar['principal_id'] as string;
+      const developerId = ar['developer_id'] as string;
+
+      // Fetch credentials
+      const credRows = await sql`
+        SELECT credential_id, public_key, counter, transports
+        FROM webauthn_credentials
+        WHERE principal_id = ${principalId} AND developer_id = ${developerId}
+      `;
+
+      if (credRows.length === 0) {
+        return reply.status(400).send({ message: 'No FIDO credentials registered for this principal', code: 'BAD_REQUEST', requestId: request.id });
+      }
+
+      const credentials = credRows.map((r) => ({
+        credentialId: r['credential_id'] as string,
+        publicKey: r['public_key'] as string,
+        counter: Number(r['counter']),
+        transports: (r['transports'] as string[]) ?? [],
+      }));
+
+      const options = await generateAuthOptions(credentials);
+
+      // Store challenge
+      const challengeId = newWebAuthnChallengeId();
+      const expiresAt = new Date(Date.now() + 5 * 60 * 1000);
+      await sql`
+        INSERT INTO webauthn_challenges (id, challenge, principal_id, developer_id, ceremony_type, auth_request_id, expires_at)
+        VALUES (${challengeId}, ${options.challenge}, ${principalId}, ${developerId}, 'assertion', ${authRequestId}, ${expiresAt})
+      `;
+
+      return reply.send({ challengeId, publicKey: options });
+    },
+  );
+
+  // POST /v1/webauthn/assert/verify — verify assertion (PUBLIC, used from consent page)
+  app.post<{ Body: { challengeId: string; response: AuthenticationResponseJSON } }>(
+    '/v1/webauthn/assert/verify',
+    { config: { skipAuth: true } },
+    async (request, reply) => {
+      const { challengeId, response } = request.body;
+      if (!challengeId || !response) {
+        return reply.status(400).send({ message: 'challengeId and response are required', code: 'BAD_REQUEST', requestId: request.id });
+      }
+
+      const sql = getSql();
+
+      // Look up challenge
+      const challengeRows = await sql`
+        SELECT challenge, principal_id, developer_id, auth_request_id FROM webauthn_challenges
+        WHERE id = ${challengeId} AND ceremony_type = 'assertion' AND consumed = FALSE AND expires_at > NOW()
+      `;
+      const challengeRow = challengeRows[0];
+      if (!challengeRow) {
+        return reply.status(400).send({ message: 'Invalid or expired challenge', code: 'BAD_REQUEST', requestId: request.id });
+      }
+
+      await sql`UPDATE webauthn_challenges SET consumed = TRUE WHERE id = ${challengeId}`;
+
+      // Find the credential being used
+      const credentialId = response.id;
+      const credRows = await sql`
+        SELECT id, credential_id, public_key, counter, transports
+        FROM webauthn_credentials
+        WHERE credential_id = ${credentialId}
+          AND principal_id = ${challengeRow['principal_id'] as string}
+          AND developer_id = ${challengeRow['developer_id'] as string}
+      `;
+      const credRow = credRows[0];
+      if (!credRow) {
+        return reply.status(400).send({ message: 'Credential not found', code: 'BAD_REQUEST', requestId: request.id });
+      }
+
+      const storedCred = {
+        credentialId: credRow['credential_id'] as string,
+        publicKey: credRow['public_key'] as string,
+        counter: Number(credRow['counter']),
+        transports: (credRow['transports'] as string[]) ?? [],
+      };
+
+      const verification = await verifyAuthResponse(response, challengeRow['challenge'] as string, storedCred);
+      if (!verification.verified) {
+        return reply.status(400).send({ message: 'Assertion verification failed', code: 'BAD_REQUEST', requestId: request.id });
+      }
+
+      // Update counter and last_used_at
+      await sql`
+        UPDATE webauthn_credentials
+        SET counter = ${verification.authenticationInfo.newCounter}, last_used_at = NOW()
+        WHERE id = ${credRow['id'] as string}
+      `;
+
+      // Mark auth request as FIDO verified
+      const authRequestId = challengeRow['auth_request_id'] as string;
+      if (authRequestId) {
+        await sql`
+          UPDATE auth_requests SET fido_verified = TRUE WHERE id = ${authRequestId}
+        `;
+      }
+
+      emitEvent(challengeRow['developer_id'] as string, 'fido.assertion', {
+        principalId: challengeRow['principal_id'] as string,
+        authRequestId,
+      }).catch(() => {});
+
+      return reply.send({ verified: true });
+    },
+  );
+}

--- a/apps/auth-service/src/server.ts
+++ b/apps/auth-service/src/server.ts
@@ -34,6 +34,8 @@ import { usageRoutes } from './routes/usage.js';
 import { verifyEmailRoutes } from './routes/verify-email.js';
 import { domainsRoutes } from './routes/domains.js';
 import { policySyncRoutes } from './routes/policy-sync.js';
+import { didRoutes } from './routes/did.js';
+import { webauthnRoutes } from './routes/webauthn.js';
 import { metricsHookPlugin } from './plugins/metricsHook.js';
 import websocket from '@fastify/websocket';
 
@@ -70,6 +72,7 @@ export async function buildApp(opts: AppOptions = {}) {
 
   // Public routes (no auth required)
   await app.register(jwksRoutes);
+  await app.register(didRoutes);
   await app.register(healthRoutes);
   await app.register(consentRoutes);
   await app.register(dashboardRoutes);
@@ -101,6 +104,7 @@ export async function buildApp(opts: AppOptions = {}) {
   await app.register(verifyEmailRoutes);
   await app.register(domainsRoutes);
   await app.register(policySyncRoutes);
+  await app.register(webauthnRoutes);
 
   return app;
 }

--- a/apps/auth-service/tests/did.test.ts
+++ b/apps/auth-service/tests/did.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { buildTestApp } from './helpers.js';
+import { initEdKey } from '../src/lib/crypto.js';
+import type { FastifyInstance } from 'fastify';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  await initEdKey();
+  app = await buildTestApp();
+});
+
+describe('GET /.well-known/did.json', () => {
+  it('returns 200 with a valid DID document (no auth required)', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/.well-known/did.json',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body['@context']).toBeDefined();
+    expect(body['@context']).toContain('https://www.w3.org/ns/did/v1');
+    expect(body['@context']).toContain('https://w3id.org/security/suites/jws-2020/v1');
+  });
+
+  it('contains did:web:grantex.dev as the id', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/.well-known/did.json',
+    });
+
+    const body = res.json();
+    expect(body.id).toBe('did:web:grantex.dev');
+  });
+
+  it('includes the RS256 verification method', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/.well-known/did.json',
+    });
+
+    const body = res.json();
+    const methods = body.verificationMethod as Array<Record<string, unknown>>;
+    expect(methods.length).toBeGreaterThanOrEqual(1);
+
+    const rsaMethod = methods.find((m) => {
+      const jwk = m['publicKeyJwk'] as Record<string, unknown>;
+      return jwk['alg'] === 'RS256';
+    });
+    expect(rsaMethod).toBeDefined();
+    expect(rsaMethod!['type']).toBe('JsonWebKey2020');
+    expect(rsaMethod!['controller']).toBe('did:web:grantex.dev');
+    expect((rsaMethod!['id'] as string).startsWith('did:web:grantex.dev#')).toBe(true);
+  });
+
+  it('has populated authentication and assertionMethod arrays', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/.well-known/did.json',
+    });
+
+    const body = res.json();
+    expect(body.authentication).toBeDefined();
+    expect(Array.isArray(body.authentication)).toBe(true);
+    expect(body.authentication.length).toBeGreaterThanOrEqual(1);
+
+    expect(body.assertionMethod).toBeDefined();
+    expect(Array.isArray(body.assertionMethod)).toBe(true);
+    expect(body.assertionMethod.length).toBeGreaterThanOrEqual(1);
+
+    // authentication and assertionMethod should reference verificationMethod ids
+    const methodIds = (body.verificationMethod as Array<Record<string, unknown>>).map(
+      (m) => m['id'],
+    );
+    for (const authId of body.authentication) {
+      expect(methodIds).toContain(authId);
+    }
+    for (const assertId of body.assertionMethod) {
+      expect(methodIds).toContain(assertId);
+    }
+  });
+
+  it('lists service endpoints', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/.well-known/did.json',
+    });
+
+    const body = res.json();
+    expect(body.service).toBeDefined();
+    expect(Array.isArray(body.service)).toBe(true);
+    expect(body.service.length).toBe(2);
+
+    const jwksService = body.service.find(
+      (s: Record<string, unknown>) => s['type'] === 'JsonWebKeySet',
+    );
+    expect(jwksService).toBeDefined();
+    expect(jwksService['serviceEndpoint']).toBe('https://grantex.dev/.well-known/jwks.json');
+    expect(jwksService['id']).toBe('did:web:grantex.dev#jwks');
+
+    const protocolService = body.service.find(
+      (s: Record<string, unknown>) => s['type'] === 'GrantexProtocol',
+    );
+    expect(protocolService).toBeDefined();
+    expect(protocolService['serviceEndpoint']).toBe('https://api.grantex.dev/v1');
+    expect(protocolService['id']).toBe('did:web:grantex.dev#grant-protocol');
+  });
+
+  it('does not require Authorization header', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/.well-known/did.json',
+      // No authorization header
+    });
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/apps/auth-service/tests/ed25519-crypto.test.ts
+++ b/apps/auth-service/tests/ed25519-crypto.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  initKeys, initEdKey, getEdKeyPair, buildJwks, signWithEd25519,
+} from '../src/lib/crypto.js';
+import { jwtVerify } from 'jose';
+
+beforeAll(async () => {
+  process.env['AUTO_GENERATE_KEYS'] = 'true';
+  process.env['DATABASE_URL'] = 'postgres://test:test@localhost:5432/test';
+  process.env['REDIS_URL'] = 'redis://localhost:6379';
+  await initKeys();
+  await initEdKey();
+});
+
+describe('initEdKey / getEdKeyPair', () => {
+  it('generates an Ed25519 key pair when no config key is set', () => {
+    const kp = getEdKeyPair();
+    expect(kp).not.toBeNull();
+    expect(kp!.privateKey).toBeDefined();
+    expect(kp!.publicKey).toBeDefined();
+    expect(kp!.kid).toMatch(/^grantex-ed25519-\d{4}-\d{2}$/);
+  });
+
+  it('returns the key pair after init', () => {
+    const kp = getEdKeyPair();
+    expect(kp).not.toBeNull();
+    expect(kp!.privateKey).toBeDefined();
+    expect(kp!.publicKey).toBeDefined();
+  });
+});
+
+describe('buildJwks with Ed25519', () => {
+  it('includes both RSA and Ed25519 keys', async () => {
+    const jwks = await buildJwks();
+    expect(jwks.keys.length).toBeGreaterThanOrEqual(2);
+
+    const rsaKey = jwks.keys.find((k) => k['alg'] === 'RS256');
+    expect(rsaKey).toBeDefined();
+    expect(rsaKey!['kty']).toBe('RSA');
+    expect(rsaKey!['use']).toBe('sig');
+
+    const edKey = jwks.keys.find((k) => k['alg'] === 'EdDSA');
+    expect(edKey).toBeDefined();
+    expect(edKey!['kty']).toBe('OKP');
+    expect(edKey!['crv']).toBe('Ed25519');
+    expect(edKey!['use']).toBe('sig');
+    expect(edKey!['kid']).toMatch(/^grantex-ed25519-\d{4}-\d{2}$/);
+  });
+
+  it('does not expose Ed25519 private key components', async () => {
+    const jwks = await buildJwks();
+    const edKey = jwks.keys.find((k) => k['alg'] === 'EdDSA');
+    expect(edKey).toBeDefined();
+    expect(edKey!['d']).toBeUndefined();
+  });
+});
+
+describe('signWithEd25519', () => {
+  it('produces a valid JWT signed with EdDSA', async () => {
+    const jwt = await signWithEd25519({ foo: 'bar', purpose: 'test' });
+    expect(typeof jwt).toBe('string');
+    expect(jwt.split('.')).toHaveLength(3);
+
+    // Verify the header uses EdDSA algorithm
+    const header = JSON.parse(Buffer.from(jwt.split('.')[0]!, 'base64url').toString());
+    expect(header.alg).toBe('EdDSA');
+    expect(header.kid).toMatch(/^grantex-ed25519-\d{4}-\d{2}$/);
+  });
+
+  it('can be verified with the Ed25519 public key', async () => {
+    const kp = getEdKeyPair()!;
+    const jwt = await signWithEd25519({ test: 'value' });
+
+    const { payload } = await jwtVerify(jwt, kp.publicKey, {
+      algorithms: ['EdDSA'],
+    });
+
+    expect(payload['test']).toBe('value');
+    expect(payload.iss).toBe('https://grantex.dev');
+    expect(payload.exp).toBeDefined();
+    expect(payload.iat).toBeDefined();
+  });
+});

--- a/apps/auth-service/tests/setup.ts
+++ b/apps/auth-service/tests/setup.ts
@@ -138,6 +138,65 @@ vi.mock('../src/lib/domains.js', () => ({
   verifyDomainDns: vi.fn().mockResolvedValue(false),
 }));
 
+// Mock WebAuthn — prevents real crypto operations in tests
+vi.mock('../src/lib/webauthn.js', () => ({
+  generateRegOptions: vi.fn().mockResolvedValue({
+    challenge: 'mock-challenge-base64url',
+    rp: { name: 'Grantex', id: 'grantex.dev' },
+    user: { id: 'dXNlcl8xMjM', name: 'user_123', displayName: '' },
+    pubKeyCredParams: [{ alg: -7, type: 'public-key' }],
+    excludeCredentials: [],
+    authenticatorSelection: { residentKey: 'preferred', userVerification: 'preferred' },
+    attestation: 'direct',
+  }),
+  verifyRegResponse: vi.fn().mockResolvedValue({
+    verified: true,
+    registrationInfo: {
+      fmt: 'packed',
+      aaguid: '00000000-0000-0000-0000-000000000000',
+      credential: {
+        id: 'bW9jay1jcmVkLWlk',
+        publicKey: new Uint8Array([1, 2, 3, 4]),
+        counter: 0,
+        transports: ['internal'],
+      },
+      credentialType: 'public-key',
+      attestationObject: new Uint8Array([]),
+      userVerified: true,
+      credentialDeviceType: 'multiDevice',
+      credentialBackedUp: true,
+      origin: 'https://grantex.dev',
+      rpID: 'grantex.dev',
+    },
+  }),
+  generateAuthOptions: vi.fn().mockResolvedValue({
+    challenge: 'mock-auth-challenge-base64url',
+    rpId: 'grantex.dev',
+    allowCredentials: [],
+    userVerification: 'preferred',
+  }),
+  verifyAuthResponse: vi.fn().mockResolvedValue({
+    verified: true,
+    authenticationInfo: {
+      credentialID: 'bW9jay1jcmVkLWlk',
+      newCounter: 1,
+      userVerified: true,
+      credentialDeviceType: 'multiDevice',
+      credentialBackedUp: true,
+      origin: 'https://grantex.dev',
+      rpID: 'grantex.dev',
+    },
+  }),
+}));
+
+// Mock isoBase64URL from @simplewebauthn/server/helpers
+vi.mock('@simplewebauthn/server/helpers', () => ({
+  isoBase64URL: {
+    fromBuffer: vi.fn((buf: Uint8Array) => Buffer.from(buf).toString('base64url')),
+    toBuffer: vi.fn((str: string) => Buffer.from(str, 'base64url')),
+  },
+}));
+
 // ------------------------------------------------------------------
 // Reset all mocks before each test
 // ------------------------------------------------------------------

--- a/apps/auth-service/tests/webauthn.test.ts
+++ b/apps/auth-service/tests/webauthn.test.ts
@@ -1,0 +1,539 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { buildTestApp, seedAuth, authHeader, sqlMock, TEST_DEVELOPER } from './helpers.js';
+import type { FastifyInstance } from 'fastify';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+// ---------------------------------------------------------------
+// POST /v1/webauthn/register/options
+// ---------------------------------------------------------------
+describe('POST /v1/webauthn/register/options', () => {
+  it('returns 400 when principalId is missing', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/register/options',
+      headers: authHeader(),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('BAD_REQUEST');
+  });
+
+  it('returns registration options and challengeId', async () => {
+    seedAuth();
+    // Existing credentials query
+    sqlMock.mockResolvedValueOnce([]);
+    // Insert challenge
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/register/options',
+      headers: authHeader(),
+      payload: { principalId: 'user_123' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.challengeId).toBeDefined();
+    expect(body.publicKey).toBeDefined();
+    expect(body.publicKey.challenge).toBeDefined();
+  });
+
+  it('requires auth (returns 401 without API key)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/register/options',
+      payload: { principalId: 'user_123' },
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------
+// POST /v1/webauthn/register/verify
+// ---------------------------------------------------------------
+describe('POST /v1/webauthn/register/verify', () => {
+  it('returns 400 when challengeId is missing', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/register/verify',
+      headers: authHeader(),
+      payload: { response: {} },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('BAD_REQUEST');
+  });
+
+  it('returns 400 when response is missing', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/register/verify',
+      headers: authHeader(),
+      payload: { challengeId: 'wac_test' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('BAD_REQUEST');
+  });
+
+  it('returns 400 for invalid/expired challenge', async () => {
+    seedAuth();
+    // Challenge lookup returns empty
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/register/verify',
+      headers: authHeader(),
+      payload: {
+        challengeId: 'wac_nonexistent',
+        response: { id: 'test', rawId: 'test', type: 'public-key', response: { clientDataJSON: '', attestationObject: '' }, clientExtensionResults: {} },
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('Invalid or expired challenge');
+  });
+
+  it('creates credential on successful registration', async () => {
+    seedAuth();
+    // Challenge lookup
+    sqlMock.mockResolvedValueOnce([{ challenge: 'mock-challenge', principal_id: 'user_123' }]);
+    // Consume challenge
+    sqlMock.mockResolvedValueOnce([]);
+    // Insert credential
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/register/verify',
+      headers: authHeader(),
+      payload: {
+        challengeId: 'wac_test',
+        response: { id: 'test', rawId: 'test', type: 'public-key', response: { clientDataJSON: '', attestationObject: '' }, clientExtensionResults: {} },
+        deviceName: 'My YubiKey',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.id).toMatch(/^cred_/);
+    expect(body.principalId).toBe('user_123');
+    expect(body.deviceName).toBe('My YubiKey');
+    expect(body.backedUp).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------
+// GET /v1/webauthn/credentials
+// ---------------------------------------------------------------
+describe('GET /v1/webauthn/credentials', () => {
+  it('returns 400 when principalId is missing', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/webauthn/credentials',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('BAD_REQUEST');
+  });
+
+  it('returns empty credentials list', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/webauthn/credentials?principalId=user_123',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().credentials).toEqual([]);
+  });
+
+  it('returns credentials for a principal', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([
+      {
+        id: 'cred_1',
+        principal_id: 'user_123',
+        device_name: 'My YubiKey',
+        backed_up: true,
+        transports: ['usb'],
+        created_at: '2026-03-08T00:00:00Z',
+        last_used_at: null,
+      },
+    ]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/webauthn/credentials?principalId=user_123',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const creds = res.json().credentials;
+    expect(creds).toHaveLength(1);
+    expect(creds[0].id).toBe('cred_1');
+    expect(creds[0].deviceName).toBe('My YubiKey');
+    expect(creds[0].backedUp).toBe(true);
+    expect(creds[0].transports).toEqual(['usb']);
+  });
+});
+
+// ---------------------------------------------------------------
+// DELETE /v1/webauthn/credentials/:id
+// ---------------------------------------------------------------
+describe('DELETE /v1/webauthn/credentials/:id', () => {
+  it('deletes a credential', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ id: 'cred_1' }]);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/v1/webauthn/credentials/cred_1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+  });
+
+  it('returns 404 for unknown credential', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/v1/webauthn/credentials/cred_nonexistent',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('NOT_FOUND');
+  });
+});
+
+// ---------------------------------------------------------------
+// POST /v1/webauthn/assert/options (public)
+// ---------------------------------------------------------------
+describe('POST /v1/webauthn/assert/options', () => {
+  it('returns 400 when authRequestId is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/assert/options',
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('BAD_REQUEST');
+  });
+
+  it('returns 404 for unknown auth request', async () => {
+    // Auth request lookup
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/assert/options',
+      payload: { authRequestId: 'areq_nonexistent' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 400 when FIDO not required for developer', async () => {
+    // Auth request lookup — fido_required is false
+    sqlMock.mockResolvedValueOnce([{
+      principal_id: 'user_123',
+      developer_id: 'dev_TEST',
+      fido_required: false,
+    }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/assert/options',
+      payload: { authRequestId: 'areq_test' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('FIDO not required');
+  });
+
+  it('returns 400 when principal has no FIDO credentials', async () => {
+    // Auth request lookup — fido_required is true
+    sqlMock.mockResolvedValueOnce([{
+      principal_id: 'user_123',
+      developer_id: 'dev_TEST',
+      fido_required: true,
+    }]);
+    // Credentials lookup — empty
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/assert/options',
+      payload: { authRequestId: 'areq_test' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('No FIDO credentials');
+  });
+
+  it('returns assertion options when FIDO is required and credentials exist', async () => {
+    // Auth request lookup
+    sqlMock.mockResolvedValueOnce([{
+      principal_id: 'user_123',
+      developer_id: 'dev_TEST',
+      fido_required: true,
+    }]);
+    // Credentials lookup
+    sqlMock.mockResolvedValueOnce([{
+      credential_id: 'bW9jay1jcmVk',
+      public_key: 'AQIDBA',
+      counter: 5,
+      transports: ['internal'],
+    }]);
+    // Insert challenge
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/assert/options',
+      payload: { authRequestId: 'areq_test' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.challengeId).toBeDefined();
+    expect(body.publicKey).toBeDefined();
+    expect(body.publicKey.challenge).toBeDefined();
+  });
+
+  it('does not require auth (public endpoint)', async () => {
+    // Auth request lookup — no match
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/assert/options',
+      payload: { authRequestId: 'areq_test' },
+    });
+
+    // Should get 404 (not found), not 401 (unauthorized)
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------
+// POST /v1/webauthn/assert/verify (public)
+// ---------------------------------------------------------------
+describe('POST /v1/webauthn/assert/verify', () => {
+  it('returns 400 when challengeId is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/assert/verify',
+      payload: { response: {} },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid/expired challenge', async () => {
+    // Challenge lookup — empty
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/assert/verify',
+      payload: {
+        challengeId: 'wac_expired',
+        response: { id: 'cred-id', rawId: 'cred-id', type: 'public-key', response: { clientDataJSON: '', authenticatorData: '', signature: '' }, clientExtensionResults: {} },
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('Invalid or expired challenge');
+  });
+
+  it('returns verified: true on successful assertion', async () => {
+    // Challenge lookup
+    sqlMock.mockResolvedValueOnce([{
+      challenge: 'mock-auth-challenge',
+      principal_id: 'user_123',
+      developer_id: 'dev_TEST',
+      auth_request_id: 'areq_test',
+    }]);
+    // Consume challenge
+    sqlMock.mockResolvedValueOnce([]);
+    // Credential lookup
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cred_1',
+      credential_id: 'bW9jay1jcmVk',
+      public_key: 'AQIDBA',
+      counter: 5,
+      transports: ['internal'],
+    }]);
+    // Update counter
+    sqlMock.mockResolvedValueOnce([]);
+    // Update auth request fido_verified
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/assert/verify',
+      payload: {
+        challengeId: 'wac_test',
+        response: { id: 'bW9jay1jcmVk', rawId: 'bW9jay1jcmVk', type: 'public-key', response: { clientDataJSON: '', authenticatorData: '', signature: '' }, clientExtensionResults: {} },
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().verified).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------
+// PATCH /v1/me (FIDO settings)
+// ---------------------------------------------------------------
+describe('PATCH /v1/me', () => {
+  it('returns 400 when no fields provided', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/me',
+      headers: authHeader(),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('BAD_REQUEST');
+  });
+
+  it('updates fidoRequired', async () => {
+    seedAuth();
+    // Update query
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/me',
+      headers: authHeader(),
+      payload: { fidoRequired: true },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().updated).toBe(true);
+  });
+
+  it('updates fidoRpName', async () => {
+    seedAuth();
+    // Update query
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/me',
+      headers: authHeader(),
+      payload: { fidoRpName: 'My App' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().updated).toBe(true);
+  });
+
+  it('updates both fields at once', async () => {
+    seedAuth();
+    // Update query
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/me',
+      headers: authHeader(),
+      payload: { fidoRequired: true, fidoRpName: 'My App' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().updated).toBe(true);
+  });
+
+  it('requires auth', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/me',
+      payload: { fidoRequired: true },
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------
+// Consent FIDO enforcement
+// ---------------------------------------------------------------
+describe('POST /v1/consent/:id/approve (FIDO enforcement)', () => {
+  it('returns 403 when FIDO required but not verified', async () => {
+    // UPDATE returns no rows (FIDO gate blocks it)
+    sqlMock.mockResolvedValueOnce([]);
+    // Follow-up FIDO check query
+    sqlMock.mockResolvedValueOnce([{
+      fido_required: true,
+      fido_verified: false,
+      status: 'pending',
+      expires_at: new Date(Date.now() + 86400_000).toISOString(),
+    }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/consent/areq_test/approve',
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json().code).toBe('FIDO_REQUIRED');
+  });
+
+  it('allows approval when FIDO not required', async () => {
+    // UPDATE succeeds (FIDO not required, so WHERE clause passes)
+    sqlMock.mockResolvedValueOnce([{ id: 'areq_test', code: 'TESTCODE', redirect_uri: null, state: null }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/consent/areq_test/approve',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().code).toBeDefined();
+  });
+
+  it('allows approval when FIDO required and verified', async () => {
+    // UPDATE succeeds (fido_verified=TRUE satisfies the WHERE clause)
+    sqlMock.mockResolvedValueOnce([{ id: 'areq_test', code: 'TESTCODE', redirect_uri: null, state: null }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/consent/areq_test/approve',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().code).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **Phase 1 — FIDO2/WebAuthn**: Grantex as a WebAuthn Relying Party using `@simplewebauthn/server` v11. Opt-in per developer via `fido_required` setting. 6 new endpoints for passkey registration, assertion, and credential management. Consent flow enforces FIDO verification when enabled.
- **Phase 3 — DID Infrastructure**: `did:web:grantex.dev` DID document served at `/.well-known/did.json`. Ed25519 key support alongside existing RS256 (additive, no changes to existing JWT flow). JWKS extended with both key types.

### New endpoints
| Endpoint | Auth | Purpose |
|----------|------|---------|
| `POST /v1/webauthn/register/options` | API key | Generate passkey registration options |
| `POST /v1/webauthn/register/verify` | API key | Verify registration, store credential |
| `GET /v1/webauthn/credentials` | API key | List credentials for a principal |
| `DELETE /v1/webauthn/credentials/:id` | API key | Remove a registered credential |
| `POST /v1/webauthn/assert/options` | Public | Generate assertion options (consent page) |
| `POST /v1/webauthn/assert/verify` | Public | Verify assertion (consent page) |
| `PATCH /v1/me` | API key | Update developer FIDO settings |
| `GET /.well-known/did.json` | Public | W3C DID document |

### Backward compatibility
- All existing JWT flows untouched (RS256 signing/verification unchanged)
- FIDO is opt-in per developer (`fido_required` defaults to `false`)
- Ed25519 key is additive — JWKS array extended, not replaced
- New DB columns all have safe defaults
- 564 tests pass, typecheck clean

## Test plan
- [x] All 564 auth-service tests pass
- [x] Typecheck passes
- [ ] Verify FIDO registration ceremony end-to-end
- [ ] Verify DID document resolves correctly at `/.well-known/did.json`
- [ ] Verify JWKS includes both RS256 + Ed25519 keys