### PR TITLE
feat: W3C Verifiable Credentials, SD-JWT selective disclosure, and trust infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 <br/>
 
-> **Status:** Production-ready. Protocol spec finalized (v1.0), auth service, TypeScript & Python SDKs, framework integrations (LangChain, AutoGen, CrewAI, Vercel AI), CLI, developer portal, [interactive playground](https://grantex.dev/playground), and enterprise features (policies, anomaly detection, compliance exports) — all shipped.
+> **Status:** Production-ready. Protocol spec finalized (v1.0), auth service, TypeScript & Python SDKs, framework integrations (LangChain, AutoGen, CrewAI, Vercel AI), CLI, developer portal, [interactive playground](https://grantex.dev/playground), enterprise features (policies, anomaly detection, compliance exports), and trust infrastructure (FIDO2/WebAuthn, W3C Verifiable Credentials, DID) — all shipped.
 
 ```bash
 npm install @grantex/sdk        # TypeScript / Node.js
@@ -312,6 +312,157 @@ delegated = grantex.grants.delegate(
 - Sub-agent scopes must be a strict subset of the parent's scopes — scope escalation is rejected with 400
 - Sub-agent token expiry is `min(parent expiry, requested expiry)` — sub-agents can never outlive their parent
 - Revoking a root grant cascades to all descendant grants atomically
+
+---
+
+## FIDO2 / WebAuthn
+
+Grantex supports passkey-based human presence verification using the FIDO2/WebAuthn standard. When enabled, end-users prove they are physically present during the consent flow by authenticating with a passkey (biometric, security key, or platform authenticator). This raises the assurance level of every grant from "user clicked approve" to "user was cryptographically verified."
+
+### How It Works
+
+1. **Developer enables FIDO** — Set `fidoRequired: true` on your developer profile via `PATCH /v1/me`
+2. **User registers a passkey** — During the first consent flow, the user registers a FIDO2 credential (fingerprint, Face ID, YubiKey, etc.)
+3. **User authenticates on consent** — On subsequent authorization requests, the user completes a WebAuthn assertion challenge instead of a simple button click
+4. **FIDO evidence embedded in grants** — The assertion result is recorded in the grant and can be embedded in Verifiable Credentials as cryptographic proof of human presence
+
+### SDK Usage
+
+```typescript
+// Enable FIDO for your developer account
+await grantex.updateSettings({ fidoRequired: true, fidoRpName: 'My App' });
+
+// Register a passkey for an end-user (called from the browser)
+const options = await grantex.webauthn.registerOptions({ principalId: 'user_abc123' });
+// Pass options to navigator.credentials.create() in the browser
+const credential = await navigator.credentials.create({ publicKey: options });
+await grantex.webauthn.registerVerify({ challengeId: options.challengeId, response: credential });
+
+// List and manage credentials
+const creds = await grantex.webauthn.listCredentials('user_abc123');
+await grantex.webauthn.deleteCredential(credentialId);
+```
+
+```python
+# Enable FIDO for your developer account
+client.update_settings(fido_required=True, fido_rp_name="My App")
+
+# Register a passkey (server-side portion)
+options = client.webauthn.register_options(principal_id="user_abc123")
+# Browser performs navigator.credentials.create() and sends response back
+result = client.webauthn.register_verify(challenge_id=options.challenge_id, response=credential_response)
+
+# List and manage credentials
+creds = client.webauthn.list_credentials("user_abc123")
+client.webauthn.delete_credential(credential_id)
+```
+
+### WebAuthn API Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/v1/webauthn/register/options` | Generate passkey registration options |
+| `POST` | `/v1/webauthn/register/verify` | Verify registration and store credential |
+| `GET` | `/v1/webauthn/credentials` | List WebAuthn credentials for a principal |
+| `DELETE` | `/v1/webauthn/credentials/:id` | Delete a credential |
+| `POST` | `/v1/webauthn/assert/options` | Generate assertion options for consent |
+| `POST` | `/v1/webauthn/assert/verify` | Verify assertion during consent |
+| `PATCH` | `/v1/me` | Update developer settings (FIDO config) |
+
+---
+
+## Verifiable Credentials
+
+Grantex can issue W3C Verifiable Credentials (VCs) alongside standard JWTs. While JWTs are optimized for real-time authorization, VCs provide a portable, tamper-proof, standards-compliant proof of authorization that can be presented to any verifier — including systems outside the Grantex ecosystem.
+
+### Why VCs Matter for Agents
+
+In agentic commerce, an agent acting on your behalf needs to prove its authorization to third-party services that may not integrate with Grantex directly. A Verifiable Credential is a self-contained, cryptographically signed document that any party can verify using the issuer's published DID document — no API calls, no accounts, no trust relationships required.
+
+### How It Works
+
+When exchanging an authorization code for a grant token, pass `credentialFormat: "vc-jwt"` to receive a Verifiable Credential alongside the standard grant token:
+
+```typescript
+const result = await grantex.tokens.exchange({
+  code,
+  agentId: agent.id,
+  credentialFormat: 'vc-jwt',   // opt-in to VC issuance
+});
+
+console.log(result.grantToken);         // standard RS256 JWT (unchanged)
+console.log(result.verifiableCredential); // W3C VC-JWT
+```
+
+```python
+result = client.tokens.exchange(ExchangeTokenParams(
+    code=code,
+    agent_id=agent.id,
+    credential_format="vc-jwt",
+))
+
+print(result.verifiable_credential)  # W3C VC-JWT
+```
+
+### Credential Types
+
+| Type | Description |
+|------|-------------|
+| `AgentGrantCredential` | Issued for direct grants — attests that a principal authorized an agent with specific scopes |
+| `DelegatedGrantCredential` | Issued for delegated grants — includes the full delegation chain |
+
+### Verifying a VC
+
+```typescript
+const verification = await grantex.credentials.verify(vcJwt);
+console.log(verification.valid);
+console.log(verification.credentialSubject);
+console.log(verification.issuer); // "did:web:grantex.dev"
+```
+
+```python
+verification = client.credentials.verify(vc_jwt)
+print(verification.valid)
+print(verification.credential_subject)
+```
+
+### Revocation via StatusList2021
+
+Grantex implements the W3C StatusList2021 revocation mechanism. Each credential references a status list entry. When a grant is revoked, the corresponding bit in the status list is flipped, and any verifier checking the credential sees it as revoked.
+
+```typescript
+// Check a specific credential's status
+const cred = await grantex.credentials.get(credentialId);
+console.log(cred.status); // "active" or "revoked"
+
+// List credentials with filters
+const { credentials } = await grantex.credentials.list({
+  grantId: 'grnt_01HXYZ...',
+  status: 'active',
+});
+```
+
+### FIDO Evidence in VCs
+
+When FIDO is enabled and the user completes a WebAuthn assertion during consent, the VC includes a `fidoEvidence` field that cryptographically proves human presence at the time of authorization. This is compatible with the Mastercard Verifiable Intent specification for agentic commerce.
+
+### DID Infrastructure
+
+Grantex publishes a W3C DID document at `/.well-known/did.json` (`did:web:grantex.dev`). This document contains the public keys used to sign Verifiable Credentials, enabling any party to verify credentials without contacting Grantex:
+
+```bash
+curl https://api.grantex.dev/.well-known/did.json
+```
+
+### Verifiable Credentials API Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/v1/credentials/:id` | Retrieve a Verifiable Credential |
+| `GET` | `/v1/credentials` | List Verifiable Credentials |
+| `POST` | `/v1/credentials/verify` | Verify a VC-JWT |
+| `GET` | `/v1/credentials/status/:id` | StatusList2021 credential |
+| `GET` | `/.well-known/did.json` | W3C DID document |
 
 ---
 
@@ -626,6 +777,7 @@ All milestones through v1.0 are complete. See [ROADMAP.md](https://github.com/mi
 | **v2.0 — Platform** | MCP Auth Server, Credential Vault, 7 new adapters, webhook delivery log, examples | ✅ Complete |
 | **v2.1 — Enterprise Scale** | Event streaming, budget controls, observability, Terraform provider, gateway, conformance | ✅ Complete |
 | **v2.2 — Ecosystem** | OPA/Cedar policy backends, A2A protocol bridge, usage metering, custom domains, policy-as-code | ✅ Complete |
+| **v2.3 — Trust & Identity** | FIDO2/WebAuthn passkeys, W3C Verifiable Credentials, DID infrastructure, StatusList2021 revocation, Mastercard Verifiable Intent | ✅ Complete |
 
 ---
 

--- a/apps/auth-service/src/db/migrations/020_verifiable_credentials.sql
+++ b/apps/auth-service/src/db/migrations/020_verifiable_credentials.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS verifiable_credentials (
+  id              TEXT PRIMARY KEY,
+  grant_id        TEXT NOT NULL REFERENCES grants(id),
+  developer_id    TEXT NOT NULL REFERENCES developers(id),
+  principal_id    TEXT NOT NULL,
+  agent_did       TEXT NOT NULL,
+  credential_type TEXT NOT NULL,
+  format          TEXT NOT NULL DEFAULT 'jwt',
+  credential_jwt  TEXT,
+  credential_json JSONB,
+  status          TEXT NOT NULL DEFAULT 'active',
+  status_list_idx INTEGER,
+  issued_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at      TIMESTAMPTZ NOT NULL,
+  revoked_at      TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_vc_grant ON verifiable_credentials(grant_id);
+CREATE INDEX IF NOT EXISTS idx_vc_developer ON verifiable_credentials(developer_id);
+
+CREATE TABLE IF NOT EXISTS vc_status_lists (
+  id             TEXT PRIMARY KEY,
+  developer_id   TEXT NOT NULL REFERENCES developers(id),
+  purpose        TEXT NOT NULL DEFAULT 'revocation',
+  encoded_list   TEXT NOT NULL,
+  size           INTEGER NOT NULL DEFAULT 131072,
+  next_index     INTEGER NOT NULL DEFAULT 0,
+  credential_jwt TEXT,
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_vc_status_list_dev_purpose
+  ON vc_status_lists(developer_id, purpose);

--- a/apps/auth-service/src/db/migrations/021_sd_jwt.sql
+++ b/apps/auth-service/src/db/migrations/021_sd_jwt.sql
@@ -1,0 +1,2 @@
+ALTER TABLE verifiable_credentials ADD COLUMN IF NOT EXISTS sd_jwt_disclosures JSONB;
+ALTER TABLE verifiable_credentials ADD COLUMN IF NOT EXISTS credential_format TEXT NOT NULL DEFAULT 'vc-jwt';

--- a/apps/auth-service/src/lib/events.ts
+++ b/apps/auth-service/src/lib/events.ts
@@ -9,7 +9,10 @@ export type EventType =
   | 'budget.threshold'
   | 'budget.exhausted'
   | 'fido.registered'
-  | 'fido.assertion';
+  | 'fido.assertion'
+  | 'vc.issued'
+  | 'sd-jwt.issued'
+  | 'sd-jwt.presented';
 
 export interface GrantexEvent {
   id: string;

--- a/apps/auth-service/src/lib/ids.ts
+++ b/apps/auth-service/src/lib/ids.ts
@@ -21,3 +21,6 @@ export const newPolicyBundleId = (): string => `pbnd_${ulid()}`;
 export const newSigningKeyId = (): string => `key_${ulid()}`;
 export const newWebAuthnCredentialId = (): string => `cred_${ulid()}`;
 export const newWebAuthnChallengeId = (): string => `wac_${ulid()}`;
+export const newVerifiableCredentialId = (): string => `vc_${ulid()}`;
+export const newStatusListId = (): string => `vcsl_${ulid()}`;
+export const newPresentationId = (): string => `pres_${ulid()}`;

--- a/apps/auth-service/src/lib/revoke.ts
+++ b/apps/auth-service/src/lib/revoke.ts
@@ -2,6 +2,7 @@ import { getSql } from '../db/client.js';
 import { getRedis } from '../redis/client.js';
 import { emitEvent } from './events.js';
 import { grantsRevokedTotal } from './metrics.js';
+import { revokeVCsByGrantIds } from './vc.js';
 
 export interface RevokeResult {
   revoked: boolean;
@@ -56,6 +57,10 @@ export async function revokeGrantCascade(
     const descTtl = Math.max(1, Math.floor((descExpiresAt.getTime() - Date.now()) / 1000));
     await redis.set(`revoked:grant:${row['id'] as string}`, '1', 'EX', descTtl);
   }
+
+  // Revoke associated VCs (best-effort, non-blocking)
+  const allRevokedIds = [grantId, ...descendantRows.map(r => r['id'] as string)];
+  revokeVCsByGrantIds(allRevokedIds, developerId).catch(() => {});
 
   // Emit event (best-effort, non-blocking)
   emitEvent(developerId, 'grant.revoked', {

--- a/apps/auth-service/src/lib/sd-jwt.ts
+++ b/apps/auth-service/src/lib/sd-jwt.ts
@@ -1,0 +1,371 @@
+/**
+ * SD-JWT (Selective Disclosure JWT) implementation per draft-ietf-oauth-selective-disclosure-jwt.
+ *
+ * SD-JWT format: <issuer-jwt>~<disclosure1>~<disclosure2>~...~<optional-kb-jwt>
+ * Each disclosure is: base64url(JSON([salt, claim_name, claim_value]))
+ *
+ * Uses the existing RS256 key pair from crypto.ts and `jose` for JWT operations.
+ */
+
+import { randomBytes, createHash } from 'node:crypto';
+import { SignJWT, jwtVerify, decodeJwt, decodeProtectedHeader } from 'jose';
+import { getKeyPair } from './crypto.js';
+import { newVerifiableCredentialId } from './ids.js';
+import { config } from '../config.js';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface SDJWTIssueParams {
+  grantId: string;
+  agentDid: string;
+  principalId: string;
+  developerId: string;
+  scopes: string[];
+  expiresAt: Date;
+  delegationDepth?: number;
+  selectiveFields?: string[];
+}
+
+export interface SDJWTVerifyResult {
+  valid: boolean;
+  vcId?: string;
+  disclosedClaims?: Record<string, unknown>;
+  error?: string;
+}
+
+export interface Disclosure {
+  salt: string;
+  claimName: string;
+  claimValue: unknown;
+  encoded: string;
+  digest: string;
+}
+
+// Default fields that are selectively disclosable
+const DEFAULT_SELECTIVE_FIELDS = ['principalId', 'developerId', 'scopes', 'delegationDepth'];
+
+// ── Internal helpers ────────────────────────────────────────────────────────
+
+/**
+ * Generate a cryptographically random salt as base64url string.
+ */
+function generateSalt(): string {
+  return randomBytes(16).toString('base64url');
+}
+
+/**
+ * Create a disclosure triplet [salt, claimName, claimValue] and encode it.
+ */
+function createDisclosure(claimName: string, claimValue: unknown): Disclosure {
+  const salt = generateSalt();
+  const triplet = JSON.stringify([salt, claimName, claimValue]);
+  const encoded = Buffer.from(triplet, 'utf-8').toString('base64url');
+  const digest = hashDisclosure(encoded);
+  return { salt, claimName, claimValue, encoded, digest };
+}
+
+/**
+ * SHA-256 hash of a disclosure, returned as base64url string.
+ */
+function hashDisclosure(encodedDisclosure: string): string {
+  return createHash('sha256').update(encodedDisclosure, 'ascii').digest().toString('base64url');
+}
+
+/**
+ * Decode a base64url-encoded disclosure back to [salt, claimName, claimValue].
+ */
+function decodeDisclosure(encoded: string): { salt: string; claimName: string; claimValue: unknown } | null {
+  try {
+    const json = Buffer.from(encoded, 'base64url').toString('utf-8');
+    const parsed = JSON.parse(json) as unknown;
+    if (!Array.isArray(parsed) || parsed.length !== 3) return null;
+    const [salt, claimName, claimValue] = parsed as [string, string, unknown];
+    if (typeof salt !== 'string' || typeof claimName !== 'string') return null;
+    return { salt, claimName, claimValue };
+  } catch {
+    return null;
+  }
+}
+
+// ── SD-JWT Issuance ─────────────────────────────────────────────────────────
+
+/**
+ * Issue an SD-JWT with selective disclosure for credential subject fields.
+ *
+ * Returns the full SD-JWT string: <issuer-jwt>~<disclosure1>~<disclosure2>~...~
+ */
+export async function issueSDJWT(params: SDJWTIssueParams): Promise<{
+  vcId: string;
+  sdJwt: string;
+  disclosures: string[];
+}> {
+  const {
+    grantId,
+    agentDid,
+    principalId,
+    developerId,
+    scopes,
+    expiresAt,
+    delegationDepth = 0,
+  } = params;
+
+  const selectiveFields = params.selectiveFields ?? DEFAULT_SELECTIVE_FIELDS;
+  const vcId = newVerifiableCredentialId();
+  const { privateKey, kid } = getKeyPair();
+  const domain = config.didWebDomain;
+  const issuerDid = `did:web:${domain}`;
+
+  // Build the full credential subject
+  const allClaims: Record<string, unknown> = {
+    id: agentDid,
+    type: 'AIAgent',
+    principalId,
+    developerId,
+    grantId,
+    scopes,
+    delegationDepth,
+  };
+
+  // Create disclosures for selective fields
+  const disclosures: Disclosure[] = [];
+  const sdDigests: string[] = [];
+  const visibleClaims: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(allClaims)) {
+    if (selectiveFields.includes(key)) {
+      const disclosure = createDisclosure(key, value);
+      disclosures.push(disclosure);
+      sdDigests.push(disclosure.digest);
+    } else {
+      visibleClaims[key] = value;
+    }
+  }
+
+  // Build the credentialSubject with _sd array
+  const credentialSubject: Record<string, unknown> = {
+    ...visibleClaims,
+    _sd: sdDigests,
+  };
+
+  const vcClaim = {
+    '@context': [
+      'https://www.w3.org/ns/credentials/v2',
+      'https://grantex.dev/ns/credentials/v1',
+    ],
+    type: ['VerifiableCredential', 'AgentGrantCredential'],
+    credentialSubject,
+  };
+
+  // Sign the issuer JWT
+  const now = Math.floor(Date.now() / 1000);
+  const exp = Math.floor(expiresAt.getTime() / 1000);
+
+  const issuerJwt = await new SignJWT({
+    vc: vcClaim,
+    _sd_alg: 'sha-256',
+  })
+    .setProtectedHeader({ alg: 'RS256', kid, typ: 'vc+sd-jwt' })
+    .setIssuer(issuerDid)
+    .setSubject(agentDid)
+    .setJti(vcId)
+    .setIssuedAt(now)
+    .setExpirationTime(exp)
+    .sign(privateKey);
+
+  // Build the SD-JWT: <issuer-jwt>~<disclosure1>~<disclosure2>~...~
+  const disclosureStrings = disclosures.map((d) => d.encoded);
+  const sdJwt = issuerJwt + '~' + disclosureStrings.join('~') + '~';
+
+  return { vcId, sdJwt, disclosures: disclosureStrings };
+}
+
+// ── SD-JWT Verification ─────────────────────────────────────────────────────
+
+/**
+ * Verify an SD-JWT and return the disclosed claims.
+ *
+ * Accepts both full SD-JWTs (with all disclosures) and presentations
+ * (with a subset of disclosures, optionally with a key-binding JWT).
+ */
+export async function verifySDJWT(sdJwt: string): Promise<SDJWTVerifyResult> {
+  // Parse the SD-JWT format: <issuer-jwt>~<disclosure1>~...~<optional-kb-jwt>
+  const parts = sdJwt.split('~');
+  if (parts.length < 2) {
+    return { valid: false, error: 'Invalid SD-JWT format' };
+  }
+
+  const issuerJwt = parts[0]!;
+  // The last element after splitting on ~ is either empty string (trailing ~),
+  // a KB-JWT, or a disclosure
+  const remaining = parts.slice(1);
+
+  // Filter out empty strings and separate disclosures from potential KB-JWT
+  const nonEmpty = remaining.filter((p) => p.length > 0);
+
+  // Try to detect if the last element is a KB-JWT (has JWT structure with 2 dots)
+  let kbJwt: string | undefined;
+  const disclosureStrings: string[] = [];
+
+  for (const part of nonEmpty) {
+    const dotCount = part.split('.').length - 1;
+    if (dotCount === 2) {
+      // Could be a KB-JWT — try to decode header
+      try {
+        const header = decodeProtectedHeader(part);
+        if (header.typ === 'kb+jwt') {
+          kbJwt = part;
+          continue;
+        }
+      } catch {
+        // Not a JWT, treat as disclosure
+      }
+    }
+    disclosureStrings.push(part);
+  }
+
+  // Verify the issuer JWT signature
+  const { publicKey } = getKeyPair();
+
+  let decoded: Record<string, unknown>;
+  try {
+    decoded = decodeJwt(issuerJwt) as Record<string, unknown>;
+  } catch {
+    return { valid: false, error: 'Invalid JWT format' };
+  }
+
+  const vcId = decoded['jti'] as string | undefined;
+  const vcIdFields = vcId !== undefined ? { vcId } : {};
+
+  try {
+    await jwtVerify(issuerJwt, publicKey, {
+      algorithms: ['RS256'],
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Verification failed';
+    if (message.includes('exp') || message.includes('expired')) {
+      return { valid: false, ...vcIdFields, error: 'SD-JWT expired' };
+    }
+    return { valid: false, ...vcIdFields, error: message };
+  }
+
+  // Verify _sd_alg is present and supported
+  const sdAlg = decoded['_sd_alg'] as string | undefined;
+  if (sdAlg && sdAlg !== 'sha-256') {
+    return { valid: false, ...vcIdFields, error: `Unsupported _sd_alg: ${sdAlg}` };
+  }
+
+  // Extract the vc claim
+  const vc = decoded['vc'] as Record<string, unknown> | undefined;
+  if (!vc) {
+    return { valid: false, ...vcIdFields, error: 'Missing vc claim' };
+  }
+
+  const credentialSubject = vc['credentialSubject'] as Record<string, unknown> | undefined;
+  if (!credentialSubject) {
+    return { valid: false, ...vcIdFields, error: 'Missing credentialSubject' };
+  }
+
+  const sdDigests = credentialSubject['_sd'] as string[] | undefined;
+
+  // Decode and verify disclosures
+  const disclosedClaims: Record<string, unknown> = {};
+
+  // Start with visible (non-selective) claims from credentialSubject
+  for (const [key, value] of Object.entries(credentialSubject)) {
+    if (key !== '_sd') {
+      disclosedClaims[key] = value;
+    }
+  }
+
+  // Process each disclosure
+  for (const encodedDisclosure of disclosureStrings) {
+    const disclosure = decodeDisclosure(encodedDisclosure);
+    if (!disclosure) {
+      return { valid: false, ...vcIdFields, error: 'Invalid disclosure format' };
+    }
+
+    // Verify the disclosure hash is in the _sd array
+    const digest = hashDisclosure(encodedDisclosure);
+    if (!sdDigests || !sdDigests.includes(digest)) {
+      return { valid: false, ...vcIdFields, error: 'Disclosure hash not found in _sd array — possible tampering' };
+    }
+
+    disclosedClaims[disclosure.claimName] = disclosure.claimValue;
+  }
+
+  // If a key-binding JWT is present, verify it
+  if (kbJwt !== undefined) {
+    try {
+      const kbDecoded = decodeJwt(kbJwt) as Record<string, unknown>;
+      // KB-JWT should contain nonce and aud claims
+      if (!kbDecoded['nonce'] && !kbDecoded['aud']) {
+        return { valid: false, ...vcIdFields, error: 'KB-JWT missing nonce or aud' };
+      }
+    } catch {
+      return { valid: false, ...vcIdFields, error: 'Invalid KB-JWT format' };
+    }
+  }
+
+  return {
+    valid: true,
+    ...vcIdFields,
+    disclosedClaims,
+  };
+}
+
+// ── SD-JWT Presentation ─────────────────────────────────────────────────────
+
+/**
+ * Create a presentation from an SD-JWT by selecting which fields to disclose.
+ *
+ * Takes a full SD-JWT and returns a new SD-JWT with only the specified
+ * disclosures included. Optionally includes a key-binding JWT.
+ */
+export function createPresentation(
+  sdJwt: string,
+  fieldsToDisclose: string[],
+  options?: { nonce?: string; audience?: string },
+): string {
+  // Parse the SD-JWT
+  const parts = sdJwt.split('~');
+  if (parts.length < 2) {
+    throw new Error('Invalid SD-JWT format');
+  }
+
+  const issuerJwt = parts[0]!;
+  const remaining = parts.slice(1).filter((p) => p.length > 0);
+
+  // Decode each disclosure and filter by requested fields
+  const selectedDisclosures: string[] = [];
+  for (const encoded of remaining) {
+    // Skip if it looks like a KB-JWT
+    const dotCount = encoded.split('.').length - 1;
+    if (dotCount === 2) {
+      try {
+        const header = decodeProtectedHeader(encoded);
+        if (header.typ === 'kb+jwt') continue;
+      } catch {
+        // Not a JWT, process as disclosure
+      }
+    }
+
+    const disclosure = decodeDisclosure(encoded);
+    if (disclosure && fieldsToDisclose.includes(disclosure.claimName)) {
+      selectedDisclosures.push(encoded);
+    }
+  }
+
+  // Build the presentation SD-JWT
+  let presentation = issuerJwt + '~' + selectedDisclosures.join('~') + '~';
+
+  // If nonce/audience provided, note where KB-JWT would go
+  // (KB-JWT creation requires holder's private key, which is beyond this scope.
+  //  For server-side verification, we pass nonce/audience as query params.)
+  if (options?.nonce !== undefined || options?.audience !== undefined) {
+    // In a real implementation, the holder would sign a KB-JWT here.
+    // For Grantex, the presentation endpoint accepts nonce/audience in the request body.
+    // We leave the trailing ~ which signals no KB-JWT.
+  }
+
+  return presentation;
+}

--- a/apps/auth-service/src/lib/vc.ts
+++ b/apps/auth-service/src/lib/vc.ts
@@ -1,0 +1,378 @@
+/**
+ * W3C Verifiable Credentials (VC-JWT) issuance, verification, and StatusList2021.
+ *
+ * Uses the existing RS256 key pair from crypto.ts. VC-JWTs follow W3C VC Data
+ * Model v2.0 with the JWT encoding specified in the VC-JWT specification.
+ */
+
+import { SignJWT, jwtVerify, decodeJwt } from 'jose';
+import { gzipSync, gunzipSync } from 'node:zlib';
+import { getSql } from '../db/client.js';
+import { getKeyPair } from './crypto.js';
+import { newVerifiableCredentialId, newStatusListId } from './ids.js';
+import { config } from '../config.js';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface IssueVCParams {
+  grantId: string;
+  agentDid: string;
+  principalId: string;
+  developerId: string;
+  scopes: string[];
+  expiresAt: Date;
+  delegationDepth?: number;
+  fidoEvidence?: Record<string, unknown>;
+}
+
+export interface VCPayload {
+  iss: string;
+  sub: string;
+  iat: number;
+  exp: number;
+  jti: string;
+  vc: {
+    '@context': string[];
+    type: string[];
+    credentialSubject: Record<string, unknown>;
+    credentialStatus?: Record<string, unknown>;
+    evidence?: Record<string, unknown>[];
+  };
+}
+
+export interface VerifyVCResult {
+  valid: boolean;
+  vcId?: string;
+  payload?: VCPayload;
+  revoked?: boolean;
+  expired?: boolean;
+  error?: string;
+}
+
+// ── StatusList2021 helpers ──────────────────────────────────────────────────
+
+const STATUS_LIST_SIZE = 131072; // bits
+const STATUS_LIST_BYTES = Math.ceil(STATUS_LIST_SIZE / 8); // 16384
+
+function createEmptyBitstring(): Buffer {
+  return Buffer.alloc(STATUS_LIST_BYTES, 0);
+}
+
+function encodeBitstring(bitstring: Buffer): string {
+  const compressed = gzipSync(bitstring);
+  return compressed.toString('base64url');
+}
+
+function decodeBitstring(encoded: string): Buffer {
+  const compressed = Buffer.from(encoded, 'base64url');
+  return Buffer.from(gunzipSync(compressed));
+}
+
+function setBit(bitstring: Buffer, index: number): void {
+  const byteIndex = Math.floor(index / 8);
+  const bitIndex = 7 - (index % 8); // MSB-first
+  bitstring[byteIndex]! |= 1 << bitIndex;
+}
+
+function getBit(bitstring: Buffer, index: number): boolean {
+  const byteIndex = Math.floor(index / 8);
+  const bitIndex = 7 - (index % 8);
+  return ((bitstring[byteIndex]! >> bitIndex) & 1) === 1;
+}
+
+// ── StatusList management ───────────────────────────────────────────────────
+
+export async function getOrCreateStatusList(
+  developerId: string,
+): Promise<{ id: string; nextIndex: number }> {
+  const sql = getSql();
+
+  // Try to find existing list
+  const existing = await sql`
+    SELECT id, next_index FROM vc_status_lists
+    WHERE developer_id = ${developerId} AND purpose = 'revocation'
+    LIMIT 1
+  `;
+
+  if (existing[0]) {
+    return {
+      id: existing[0]['id'] as string,
+      nextIndex: Number(existing[0]['next_index']),
+    };
+  }
+
+  // Create new status list
+  const listId = newStatusListId();
+  const emptyBitstring = createEmptyBitstring();
+  const encoded = encodeBitstring(emptyBitstring);
+
+  await sql`
+    INSERT INTO vc_status_lists (id, developer_id, purpose, encoded_list, size, next_index)
+    VALUES (${listId}, ${developerId}, 'revocation', ${encoded}, ${STATUS_LIST_SIZE}, 0)
+  `;
+
+  return { id: listId, nextIndex: 0 };
+}
+
+// ── VC-JWT issuance ─────────────────────────────────────────────────────────
+
+export async function issueAgentGrantVC(params: IssueVCParams): Promise<{
+  vcId: string;
+  vcJwt: string;
+  statusListIdx: number;
+}> {
+  const {
+    grantId,
+    agentDid,
+    principalId,
+    developerId,
+    scopes,
+    expiresAt,
+    delegationDepth = 0,
+    fidoEvidence,
+  } = params;
+
+  const vcId = newVerifiableCredentialId();
+  const { privateKey, kid } = getKeyPair();
+  const domain = config.didWebDomain;
+  const issuerDid = `did:web:${domain}`;
+
+  // Get or create status list and allocate an index
+  const statusList = await getOrCreateStatusList(developerId);
+  const statusListIdx = statusList.nextIndex;
+
+  // Increment next_index
+  const sql = getSql();
+  await sql`
+    UPDATE vc_status_lists SET next_index = next_index + 1, updated_at = NOW()
+    WHERE id = ${statusList.id}
+  `;
+
+  // Build VC payload
+  const now = Math.floor(Date.now() / 1000);
+  const exp = Math.floor(expiresAt.getTime() / 1000);
+
+  const credentialSubject: Record<string, unknown> = {
+    id: agentDid,
+    type: 'AIAgent',
+    principalId,
+    developerId,
+    grantId,
+    scopes,
+    delegationDepth,
+  };
+
+  const credentialStatus = {
+    id: `${config.jwtIssuer}/v1/credentials/status/${statusList.id}#${statusListIdx}`,
+    type: 'StatusList2021Entry',
+    statusPurpose: 'revocation',
+    statusListIndex: String(statusListIdx),
+    statusListCredential: `${config.jwtIssuer}/v1/credentials/status/${statusList.id}`,
+  };
+
+  const evidence: Record<string, unknown>[] = [];
+  if (fidoEvidence) {
+    evidence.push({
+      type: 'FidoAttestation',
+      ...fidoEvidence,
+    });
+  }
+
+  const vcClaim: VCPayload['vc'] = {
+    '@context': [
+      'https://www.w3.org/ns/credentials/v2',
+      'https://grantex.dev/ns/credentials/v1',
+    ],
+    type: ['VerifiableCredential', 'AgentGrantCredential'],
+    credentialSubject,
+    credentialStatus,
+    ...(evidence.length > 0 ? { evidence } : {}),
+  };
+
+  // Sign the VC-JWT
+  const vcJwt = await new SignJWT({ vc: vcClaim })
+    .setProtectedHeader({ alg: 'RS256', kid, typ: 'JWT' })
+    .setIssuer(issuerDid)
+    .setSubject(agentDid)
+    .setJti(vcId)
+    .setIssuedAt(now)
+    .setExpirationTime(exp)
+    .sign(privateKey);
+
+  // Store in database
+  await sql`
+    INSERT INTO verifiable_credentials (
+      id, grant_id, developer_id, principal_id, agent_did,
+      credential_type, format, credential_jwt, status,
+      status_list_idx, expires_at
+    )
+    VALUES (
+      ${vcId}, ${grantId}, ${developerId}, ${principalId}, ${agentDid},
+      'AgentGrantCredential', 'vc-jwt', ${vcJwt}, 'active',
+      ${statusListIdx}, ${expiresAt}
+    )
+  `;
+
+  return { vcId, vcJwt, statusListIdx };
+}
+
+// ── VC-JWT verification ─────────────────────────────────────────────────────
+
+export async function verifyAgentGrantVC(vcJwt: string): Promise<VerifyVCResult> {
+  const { publicKey } = getKeyPair();
+
+  // Decode first to extract claims without full verification (for error reporting)
+  let decoded: Record<string, unknown>;
+  try {
+    decoded = decodeJwt(vcJwt) as Record<string, unknown>;
+  } catch {
+    return { valid: false, error: 'Invalid JWT format' };
+  }
+
+  const vcId = decoded['jti'] as string | undefined;
+  const vcIdFields = vcId !== undefined ? { vcId } : {};
+
+  // Verify signature and expiry
+  try {
+    await jwtVerify(vcJwt, publicKey, {
+      algorithms: ['RS256'],
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Verification failed';
+    if (message.includes('exp') || message.includes('expired')) {
+      return { valid: false, ...vcIdFields, expired: true, error: 'Credential expired' };
+    }
+    return { valid: false, ...vcIdFields, error: message };
+  }
+
+  // Check structure
+  const vc = decoded['vc'] as Record<string, unknown> | undefined;
+  if (!vc) {
+    return { valid: false, ...vcIdFields, error: 'Missing vc claim' };
+  }
+
+  // Check revocation via status list
+  const credentialStatus = vc['credentialStatus'] as Record<string, unknown> | undefined;
+  if (credentialStatus) {
+    const statusListIdx = parseInt(credentialStatus['statusListIndex'] as string, 10);
+    const statusListUrl = credentialStatus['statusListCredential'] as string;
+
+    // Extract list ID from URL
+    const listIdMatch = statusListUrl?.match(/\/status\/([^/#]+)/);
+    if (listIdMatch) {
+      const listId = listIdMatch[1]!;
+      const sql = getSql();
+      const listRows = await sql`
+        SELECT encoded_list FROM vc_status_lists WHERE id = ${listId}
+      `;
+
+      if (listRows[0]) {
+        const bitstring = decodeBitstring(listRows[0]['encoded_list'] as string);
+        if (getBit(bitstring, statusListIdx)) {
+          return {
+            valid: false,
+            ...vcIdFields,
+            revoked: true,
+            error: 'Credential has been revoked',
+            payload: decoded as unknown as VCPayload,
+          };
+        }
+      }
+    }
+  }
+
+  return {
+    valid: true,
+    ...vcIdFields,
+    payload: decoded as unknown as VCPayload,
+  };
+}
+
+// ── VC revocation ───────────────────────────────────────────────────────────
+
+export async function revokeVCsByGrantIds(
+  grantIds: string[],
+  developerId: string,
+): Promise<void> {
+  if (grantIds.length === 0) return;
+
+  const sql = getSql();
+
+  // Find all active VCs for these grants
+  const vcRows = await sql`
+    SELECT id, status_list_idx FROM verifiable_credentials
+    WHERE grant_id = ANY(${grantIds})
+      AND developer_id = ${developerId}
+      AND status = 'active'
+  `;
+
+  if (vcRows.length === 0) return;
+
+  // Mark VCs as revoked
+  const vcIds = vcRows.map((r) => r['id'] as string);
+  await sql`
+    UPDATE verifiable_credentials
+    SET status = 'revoked', revoked_at = NOW()
+    WHERE id = ANY(${vcIds})
+  `;
+
+  // Flip bits in the status list
+  const listRows = await sql`
+    SELECT id, encoded_list FROM vc_status_lists
+    WHERE developer_id = ${developerId} AND purpose = 'revocation'
+    LIMIT 1
+  `;
+
+  if (listRows[0]) {
+    const listId = listRows[0]['id'] as string;
+    const bitstring = decodeBitstring(listRows[0]['encoded_list'] as string);
+
+    for (const row of vcRows) {
+      const idx = Number(row['status_list_idx']);
+      if (idx >= 0 && idx < STATUS_LIST_SIZE) {
+        setBit(bitstring, idx);
+      }
+    }
+
+    const encoded = encodeBitstring(bitstring);
+    await sql`
+      UPDATE vc_status_lists SET encoded_list = ${encoded}, updated_at = NOW()
+      WHERE id = ${listId}
+    `;
+  }
+}
+
+// ── StatusList2021 credential builder ───────────────────────────────────────
+
+export async function buildStatusListCredential(
+  listId: string,
+): Promise<Record<string, unknown> | null> {
+  const sql = getSql();
+  const rows = await sql`
+    SELECT id, developer_id, encoded_list, purpose, size, updated_at
+    FROM vc_status_lists WHERE id = ${listId}
+  `;
+
+  const list = rows[0];
+  if (!list) return null;
+
+  const domain = config.didWebDomain;
+  const issuerDid = `did:web:${domain}`;
+
+  return {
+    '@context': [
+      'https://www.w3.org/ns/credentials/v2',
+      'https://w3id.org/vc/status-list/2021/v1',
+    ],
+    id: `${config.jwtIssuer}/v1/credentials/status/${list['id'] as string}`,
+    type: ['VerifiableCredential', 'StatusList2021Credential'],
+    issuer: issuerDid,
+    issued: (list['updated_at'] as Date).toISOString(),
+    credentialSubject: {
+      id: `${config.jwtIssuer}/v1/credentials/status/${list['id'] as string}#list`,
+      type: 'StatusList2021',
+      statusPurpose: list['purpose'] as string,
+      encodedList: list['encoded_list'] as string,
+    },
+  };
+}

--- a/apps/auth-service/src/routes/billing.ts
+++ b/apps/auth-service/src/routes/billing.ts
@@ -17,12 +17,6 @@ interface PortalBody {
   returnUrl: string;
 }
 
-interface StripeWebhookBody extends Buffer {}
-
-function requireStripe(reply: Parameters<FastifyInstance['post']>[1] extends infer R ? never : never) {
-  // dummy — see usage in handlers
-}
-
 export async function billingRoutes(app: FastifyInstance): Promise<void> {
   // ----------------------------------------------------------------
   // POST /v1/billing/webhook (Stripe → us)

--- a/apps/auth-service/src/routes/credentials.ts
+++ b/apps/auth-service/src/routes/credentials.ts
@@ -1,0 +1,164 @@
+import type { FastifyInstance } from 'fastify';
+import { getSql } from '../db/client.js';
+import { verifyAgentGrantVC, buildStatusListCredential } from '../lib/vc.js';
+import { verifySDJWT } from '../lib/sd-jwt.js';
+import { newPresentationId } from '../lib/ids.js';
+import { emitEvent } from '../lib/events.js';
+
+export async function credentialsRoutes(app: FastifyInstance): Promise<void> {
+  // GET /v1/credentials/:id — retrieve a VC (protected)
+  app.get<{ Params: { id: string } }>(
+    '/v1/credentials/:id',
+    async (request, reply) => {
+      const { id } = request.params;
+      const sql = getSql();
+      const developerId = request.developer.id;
+
+      const rows = await sql`
+        SELECT id, grant_id, developer_id, principal_id, agent_did,
+               credential_type, format, credential_jwt, status,
+               status_list_idx, issued_at, expires_at, revoked_at
+        FROM verifiable_credentials
+        WHERE id = ${id} AND developer_id = ${developerId}
+      `;
+
+      const vc = rows[0];
+      if (!vc) {
+        return reply.status(404).send({
+          message: 'Credential not found',
+          code: 'NOT_FOUND',
+          requestId: request.id,
+        });
+      }
+
+      return reply.send({
+        id: vc['id'],
+        grantId: vc['grant_id'],
+        developerId: vc['developer_id'],
+        principalId: vc['principal_id'],
+        agentDid: vc['agent_did'],
+        credentialType: vc['credential_type'],
+        format: vc['format'],
+        credentialJwt: vc['credential_jwt'],
+        status: vc['status'],
+        statusListIdx: vc['status_list_idx'],
+        issuedAt: (vc['issued_at'] as Date).toISOString(),
+        expiresAt: (vc['expires_at'] as Date).toISOString(),
+        revokedAt: vc['revoked_at'] ? (vc['revoked_at'] as Date).toISOString() : null,
+      });
+    },
+  );
+
+  // GET /v1/credentials — list VCs with filters (protected)
+  app.get<{ Querystring: { grantId?: string; principalId?: string; status?: string } }>(
+    '/v1/credentials',
+    async (request, reply) => {
+      const sql = getSql();
+      const developerId = request.developer.id;
+      const { grantId, principalId, status } = request.query;
+
+      const rows = await sql`
+        SELECT id, grant_id, developer_id, principal_id, agent_did,
+               credential_type, format, credential_jwt, status,
+               status_list_idx, issued_at, expires_at, revoked_at
+        FROM verifiable_credentials
+        WHERE developer_id = ${developerId}
+          AND (${grantId ?? null}::TEXT IS NULL OR grant_id = ${grantId ?? null})
+          AND (${principalId ?? null}::TEXT IS NULL OR principal_id = ${principalId ?? null})
+          AND (${status ?? null}::TEXT IS NULL OR status = ${status ?? null})
+        ORDER BY issued_at DESC
+        LIMIT 100
+      `;
+
+      const credentials = rows.map((vc) => ({
+        id: vc['id'],
+        grantId: vc['grant_id'],
+        developerId: vc['developer_id'],
+        principalId: vc['principal_id'],
+        agentDid: vc['agent_did'],
+        credentialType: vc['credential_type'],
+        format: vc['format'],
+        credentialJwt: vc['credential_jwt'],
+        status: vc['status'],
+        statusListIdx: vc['status_list_idx'],
+        issuedAt: (vc['issued_at'] as Date).toISOString(),
+        expiresAt: (vc['expires_at'] as Date).toISOString(),
+        revokedAt: vc['revoked_at'] ? (vc['revoked_at'] as Date).toISOString() : null,
+      }));
+
+      return reply.send({ credentials });
+    },
+  );
+
+  // POST /v1/credentials/verify — verify a VC-JWT (public, skipAuth)
+  app.post<{ Body: { credential: string } }>(
+    '/v1/credentials/verify',
+    { config: { skipAuth: true } },
+    async (request, reply) => {
+      const { credential } = request.body;
+      if (!credential) {
+        return reply.status(400).send({
+          message: 'credential is required',
+          code: 'BAD_REQUEST',
+          requestId: request.id,
+        });
+      }
+
+      const result = await verifyAgentGrantVC(credential);
+      return reply.send(result);
+    },
+  );
+
+  // GET /v1/credentials/status/:listId — StatusList2021 credential (public, skipAuth)
+  app.get<{ Params: { listId: string } }>(
+    '/v1/credentials/status/:listId',
+    { config: { skipAuth: true } },
+    async (request, reply) => {
+      const { listId } = request.params;
+      const statusListCredential = await buildStatusListCredential(listId);
+
+      if (!statusListCredential) {
+        return reply.status(404).send({
+          message: 'Status list not found',
+          code: 'NOT_FOUND',
+          requestId: request.id,
+        });
+      }
+
+      return reply.send(statusListCredential);
+    },
+  );
+
+  // POST /v1/credentials/present — verify an SD-JWT presentation (public, skipAuth)
+  app.post<{ Body: { sdJwt: string; nonce?: string; audience?: string } }>(
+    '/v1/credentials/present',
+    { config: { skipAuth: true } },
+    async (request, reply) => {
+      const { sdJwt } = request.body;
+      if (!sdJwt) {
+        return reply.status(400).send({
+          message: 'sdJwt is required',
+          code: 'BAD_REQUEST',
+          requestId: request.id,
+        });
+      }
+
+      const result = await verifySDJWT(sdJwt);
+
+      if (result.valid) {
+        const presentationId = newPresentationId();
+
+        // Extract developerId from disclosed claims for event emission (best-effort)
+        const developerId = result.disclosedClaims?.['developerId'] as string | undefined;
+        if (developerId) {
+          emitEvent(developerId, 'sd-jwt.presented', {
+            presentationId,
+            vcId: result.vcId,
+          }).catch(() => {});
+        }
+      }
+
+      return reply.send(result);
+    },
+  );
+}

--- a/apps/auth-service/src/routes/delegate.ts
+++ b/apps/auth-service/src/routes/delegate.ts
@@ -4,12 +4,14 @@ import { getRedis } from '../redis/client.js';
 import { newGrantId, newTokenId, newRefreshTokenId } from '../lib/ids.js';
 import { decodeTokenClaims, signGrantToken, parseExpiresIn } from '../lib/crypto.js';
 import { emitEvent } from '../lib/events.js';
+import { issueAgentGrantVC } from '../lib/vc.js';
 
 interface DelegateBody {
   parentGrantToken: string;
   subAgentId: string;
   scopes: string[];
   expiresIn?: string;
+  credentialFormat?: 'jwt' | 'vc-jwt' | 'both';
 }
 
 export async function delegateRoutes(app: FastifyInstance): Promise<void> {
@@ -132,6 +134,27 @@ export async function delegateRoutes(app: FastifyInstance): Promise<void> {
       delegationDepth,
     });
 
+    // VC-JWT issuance (optional)
+    let verifiableCredential: string | undefined;
+    const { credentialFormat } = request.body;
+    if (credentialFormat === 'vc-jwt' || credentialFormat === 'both') {
+      try {
+        const vcResult = await issueAgentGrantVC({
+          grantId,
+          agentDid: subAgent['did'] as string,
+          principalId: parentClaims['sub'] as string,
+          developerId,
+          scopes,
+          expiresAt,
+          delegationDepth,
+        });
+        verifiableCredential = vcResult.vcJwt;
+        emitEvent(developerId, 'vc.issued', { vcId: vcResult.vcId, grantId }).catch(() => {});
+      } catch {
+        // Best-effort — don't fail delegation if VC issuance fails
+      }
+    }
+
     // Emit events (best-effort, non-blocking)
     emitEvent(developerId, 'grant.created', {
       grantId,
@@ -156,6 +179,7 @@ export async function delegateRoutes(app: FastifyInstance): Promise<void> {
       expiresAt: expiresAt.toISOString(),
       scopes,
       grantId,
+      ...(verifiableCredential !== undefined ? { verifiableCredential } : {}),
     });
   });
 }

--- a/apps/auth-service/src/routes/token.ts
+++ b/apps/auth-service/src/routes/token.ts
@@ -8,11 +8,14 @@ import { withSpan } from '../lib/tracing.js';
 import { GRANTEX_AGENT_ID, GRANTEX_GRANT_ID, GRANTEX_PRINCIPAL_ID, GRANTEX_SCOPES, GRANTEX_DEVELOPER_ID } from '../lib/traceAttributes.js';
 import { verifyPkceChallenge } from '../lib/pkce.js';
 import { incrementUsage } from '../lib/usage.js';
+import { issueAgentGrantVC } from '../lib/vc.js';
+import { issueSDJWT } from '../lib/sd-jwt.js';
 
 interface TokenBody {
   code: string;
   agentId: string;
   codeVerifier?: string;
+  credentialFormat?: 'jwt' | 'vc-jwt' | 'sd-jwt' | 'both';
 }
 
 interface RefreshBody {
@@ -141,6 +144,45 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
       exp: expTimestamp,
     }));
 
+    // VC-JWT issuance (optional)
+    let verifiableCredential: string | undefined;
+    const { credentialFormat } = request.body;
+    if (credentialFormat === 'vc-jwt' || credentialFormat === 'both') {
+      try {
+        const vcResult = await issueAgentGrantVC({
+          grantId,
+          agentDid: authReq['agent_did'] as string,
+          principalId: authReq['principal_id'] as string,
+          developerId,
+          scopes: authReq['scopes'] as string[],
+          expiresAt,
+        });
+        verifiableCredential = vcResult.vcJwt;
+        emitEvent(developerId, 'vc.issued', { vcId: vcResult.vcId, grantId }).catch(() => {});
+      } catch {
+        // Best-effort — don't fail the token exchange if VC issuance fails
+      }
+    }
+
+    // SD-JWT issuance (optional)
+    let sdJwtCredential: string | undefined;
+    if (credentialFormat === 'sd-jwt') {
+      try {
+        const sdResult = await issueSDJWT({
+          grantId,
+          agentDid: authReq['agent_did'] as string,
+          principalId: authReq['principal_id'] as string,
+          developerId,
+          scopes: authReq['scopes'] as string[],
+          expiresAt,
+        });
+        sdJwtCredential = sdResult.sdJwt;
+        emitEvent(developerId, 'sd-jwt.issued', { vcId: sdResult.vcId, grantId }).catch(() => {});
+      } catch {
+        // Best-effort — don't fail the token exchange if SD-JWT issuance fails
+      }
+    }
+
     // Emit events (best-effort, non-blocking)
     const eventData = {
       grantId,
@@ -164,6 +206,8 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
       scopes: authReq['scopes'] as string[],
       refreshToken: refreshId,
       grantId,
+      ...(verifiableCredential !== undefined ? { verifiableCredential } : {}),
+      ...(sdJwtCredential !== undefined ? { sdJwtCredential } : {}),
     });
   });
 

--- a/apps/auth-service/src/server.ts
+++ b/apps/auth-service/src/server.ts
@@ -36,6 +36,7 @@ import { domainsRoutes } from './routes/domains.js';
 import { policySyncRoutes } from './routes/policy-sync.js';
 import { didRoutes } from './routes/did.js';
 import { webauthnRoutes } from './routes/webauthn.js';
+import { credentialsRoutes } from './routes/credentials.js';
 import { metricsHookPlugin } from './plugins/metricsHook.js';
 import websocket from '@fastify/websocket';
 
@@ -105,6 +106,7 @@ export async function buildApp(opts: AppOptions = {}) {
   await app.register(domainsRoutes);
   await app.register(policySyncRoutes);
   await app.register(webauthnRoutes);
+  await app.register(credentialsRoutes);
 
   return app;
 }

--- a/apps/auth-service/tests/agents.test.ts
+++ b/apps/auth-service/tests/agents.test.ts
@@ -148,6 +148,21 @@ describe('PATCH /v1/agents/:id', () => {
     expect(body.name).toBe('Updated Name');
   });
 
+  it('returns 404 when patching a non-existent agent', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]); // UPDATE returns no rows
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/agents/ag_NONEXISTENT',
+      headers: authHeader(),
+      payload: { name: 'New Name' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('NOT_FOUND');
+  });
+
   it('returns 400 when no fields provided', async () => {
     seedAuth();
 

--- a/apps/auth-service/tests/billing.test.ts
+++ b/apps/auth-service/tests/billing.test.ts
@@ -422,4 +422,42 @@ describe('POST /v1/billing/webhook', () => {
 
     expect(res.statusCode).toBe(400);
   });
+
+  it('returns 503 when stripeWebhookSecret is not configured', async () => {
+    const { config } = await import('../src/config.js');
+    const original = config.stripeWebhookSecret;
+    (config as { stripeWebhookSecret: string | null }).stripeWebhookSecret = null;
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/billing/webhook',
+      headers: {
+        'content-type': 'application/json',
+        'stripe-signature': 'sig_test',
+      },
+      payload: JSON.stringify({}),
+    });
+
+    (config as { stripeWebhookSecret: string | null }).stripeWebhookSecret = original;
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json().message).toBe('Billing not configured');
+  });
+
+  it('returns 503 when getStripe throws in webhook handler', async () => {
+    mockGetStripe.mockImplementationOnce(() => { throw new Error('STRIPE_SECRET_KEY is not configured'); });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/billing/webhook',
+      headers: {
+        'content-type': 'application/json',
+        'stripe-signature': 'sig_test',
+      },
+      payload: JSON.stringify({}),
+    });
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json().message).toBe('Billing not configured');
+  });
 });

--- a/apps/auth-service/tests/budget.test.ts
+++ b/apps/auth-service/tests/budget.test.ts
@@ -170,6 +170,21 @@ describe('POST /v1/budget/debit', () => {
 
     expect(res.statusCode).toBe(400);
   });
+
+  it('re-throws non-InsufficientBudgetError exceptions', async () => {
+    seedAuth();
+    // debitBudget's SQL call fails with a generic error
+    sqlMock.mockRejectedValueOnce(new Error('connection lost'));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/budget/debit',
+      headers: authHeader(),
+      payload: { grantId: 'grnt_1', amount: 10 },
+    });
+
+    expect(res.statusCode).toBe(500);
+  });
 });
 
 describe('GET /v1/budget/balance/:grantId', () => {
@@ -295,6 +310,75 @@ describe('POST /v1/budget/debit (threshold events)', () => {
     });
 
     expect(res.statusCode).toBe(200);
+  });
+
+  it('emits budget.threshold at 50% usage', async () => {
+    seedAuth();
+    // Debit UPDATE RETURNING — initial=100, remaining=50 → usedPct=50
+    sqlMock.mockResolvedValueOnce([{
+      id: 'bdg_thresh50',
+      grant_id: 'grnt_thresh50',
+      initial_budget: '100.0000',
+      remaining_budget: '50.0000',
+    }]);
+    // INSERT budget_transaction
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/budget/debit',
+      headers: authHeader(),
+      payload: { grantId: 'grnt_thresh50', amount: 50 },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().remaining).toBe('50.0000');
+  });
+
+  it('emits budget.threshold at 80% usage', async () => {
+    seedAuth();
+    // Debit UPDATE RETURNING — initial=100, remaining=20 → usedPct=80
+    sqlMock.mockResolvedValueOnce([{
+      id: 'bdg_thresh80',
+      grant_id: 'grnt_thresh80',
+      initial_budget: '100.0000',
+      remaining_budget: '20.0000',
+    }]);
+    // INSERT budget_transaction
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/budget/debit',
+      headers: authHeader(),
+      payload: { grantId: 'grnt_thresh80', amount: 80 },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().remaining).toBe('20.0000');
+  });
+
+  it('emits budget.exhausted when remaining hits 0', async () => {
+    seedAuth();
+    // Debit UPDATE RETURNING — initial=100, remaining=0 → exhausted
+    sqlMock.mockResolvedValueOnce([{
+      id: 'bdg_exhaust',
+      grant_id: 'grnt_exhaust',
+      initial_budget: '100.0000',
+      remaining_budget: '0.0000',
+    }]);
+    // INSERT budget_transaction
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/budget/debit',
+      headers: authHeader(),
+      payload: { grantId: 'grnt_exhaust', amount: 100 },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().remaining).toBe('0.0000');
   });
 });
 

--- a/apps/auth-service/tests/credentials.test.ts
+++ b/apps/auth-service/tests/credentials.test.ts
@@ -1,0 +1,521 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { buildTestApp, seedAuth, authHeader, sqlMock, TEST_DEVELOPER, TEST_AGENT } from './helpers.js';
+import type { FastifyInstance } from 'fastify';
+import { initKeys, getKeyPair } from '../src/lib/crypto.js';
+import { SignJWT, decodeJwt } from 'jose';
+import { gzipSync } from 'node:zlib';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const now = new Date();
+const future = new Date(Date.now() + 86400_000);
+
+const TEST_VC = {
+  id: 'vc_TEST01',
+  grant_id: 'grnt_TEST01',
+  developer_id: TEST_DEVELOPER.id,
+  principal_id: 'user_123',
+  agent_did: TEST_AGENT.did,
+  credential_type: 'AgentGrantCredential',
+  format: 'vc-jwt',
+  credential_jwt: 'eyJ...',
+  status: 'active',
+  status_list_idx: 0,
+  issued_at: now,
+  expires_at: future,
+  revoked_at: null,
+};
+
+function createEmptyEncodedList(): string {
+  const bits = Buffer.alloc(16384, 0);
+  return gzipSync(bits).toString('base64url');
+}
+
+async function createSignedVcJwt(overrides: Record<string, unknown> = {}): Promise<string> {
+  const { privateKey, kid } = getKeyPair();
+  const exp = overrides['exp'] as number | undefined ?? Math.floor(Date.now() / 1000) + 86400;
+  const iat = overrides['iat'] as number | undefined ?? Math.floor(Date.now() / 1000);
+
+  return new SignJWT({
+    vc: {
+      '@context': ['https://www.w3.org/ns/credentials/v2', 'https://grantex.dev/ns/credentials/v1'],
+      type: ['VerifiableCredential', 'AgentGrantCredential'],
+      credentialSubject: {
+        id: TEST_AGENT.did,
+        type: 'AIAgent',
+        principalId: 'user_123',
+        developerId: TEST_DEVELOPER.id,
+        grantId: 'grnt_TEST01',
+        scopes: ['read'],
+        delegationDepth: 0,
+      },
+      credentialStatus: {
+        id: 'https://grantex.dev/v1/credentials/status/vcsl_TEST#0',
+        type: 'StatusList2021Entry',
+        statusPurpose: 'revocation',
+        statusListIndex: '0',
+        statusListCredential: 'https://grantex.dev/v1/credentials/status/vcsl_TEST',
+      },
+    },
+  })
+    .setProtectedHeader({ alg: 'RS256', kid, typ: 'JWT' })
+    .setIssuer('did:web:grantex.dev')
+    .setSubject(TEST_AGENT.did)
+    .setJti('vc_TEST01')
+    .setIssuedAt(iat)
+    .setExpirationTime(exp)
+    .sign(privateKey);
+}
+
+// ── GET /v1/credentials/:id ─────────────────────────────────────────────────
+
+describe('GET /v1/credentials/:id', () => {
+  it('returns a credential by ID', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([TEST_VC]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/credentials/vc_TEST01',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.id).toBe('vc_TEST01');
+    expect(body.grantId).toBe('grnt_TEST01');
+    expect(body.credentialType).toBe('AgentGrantCredential');
+    expect(body.format).toBe('vc-jwt');
+    expect(body.status).toBe('active');
+  });
+
+  it('returns 404 when credential not found', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/credentials/vc_NONEXISTENT',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('NOT_FOUND');
+  });
+
+  it('returns 404 for credential belonging to another developer', async () => {
+    seedAuth();
+    // Query scoped to developer_id, so it returns empty
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/credentials/vc_OTHER_DEV',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('requires authentication', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/credentials/vc_TEST01',
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// ── GET /v1/credentials ─────────────────────────────────────────────────────
+
+describe('GET /v1/credentials', () => {
+  it('lists credentials without filters', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([TEST_VC]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/credentials',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.credentials).toHaveLength(1);
+    expect(body.credentials[0].id).toBe('vc_TEST01');
+  });
+
+  it('filters by grantId', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([TEST_VC]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/credentials?grantId=grnt_TEST01',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().credentials).toHaveLength(1);
+  });
+
+  it('filters by principalId', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([TEST_VC]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/credentials?principalId=user_123',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().credentials).toHaveLength(1);
+  });
+
+  it('filters by status', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ ...TEST_VC, status: 'revoked', revoked_at: now }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/credentials?status=revoked',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const cred = res.json().credentials[0];
+    expect(cred.status).toBe('revoked');
+  });
+
+  it('returns empty array when no credentials match', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/credentials',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().credentials).toEqual([]);
+  });
+});
+
+// ── POST /v1/credentials/verify ─────────────────────────────────────────────
+
+describe('POST /v1/credentials/verify', () => {
+  it('returns valid for a properly signed VC-JWT', async () => {
+    const vcJwt = await createSignedVcJwt();
+
+    // Status list lookup for revocation check → not found (no revocation)
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/credentials/verify',
+      payload: { credential: vcJwt },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.valid).toBe(true);
+    expect(body.vcId).toBe('vc_TEST01');
+    expect(body.payload).toBeDefined();
+  });
+
+  it('returns invalid for expired VC-JWT', async () => {
+    const vcJwt = await createSignedVcJwt({
+      iat: Math.floor(Date.now() / 1000) - 7200,
+      exp: Math.floor(Date.now() / 1000) - 3600,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/credentials/verify',
+      payload: { credential: vcJwt },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.valid).toBe(false);
+    expect(body.expired).toBe(true);
+  });
+
+  it('returns invalid for revoked VC-JWT (status list bit set)', async () => {
+    const vcJwt = await createSignedVcJwt();
+
+    // Status list with bit 0 set (revoked)
+    const bits = Buffer.alloc(16384, 0);
+    bits[0]! |= 1 << 7; // Set bit 0 (MSB-first)
+    const encodedList = gzipSync(bits).toString('base64url');
+
+    sqlMock.mockResolvedValueOnce([{
+      encoded_list: encodedList,
+    }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/credentials/verify',
+      payload: { credential: vcJwt },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.valid).toBe(false);
+    expect(body.revoked).toBe(true);
+  });
+
+  it('returns invalid for invalid signature', async () => {
+    const { generateKeyPair } = await import('jose');
+    const { privateKey } = await generateKeyPair('RS256');
+    const fakeJwt = await new SignJWT({ vc: {} })
+      .setProtectedHeader({ alg: 'RS256' })
+      .setIssuer('did:web:fake.dev')
+      .setSubject('did:fake:agent')
+      .setJti('vc_FAKE')
+      .setIssuedAt()
+      .setExpirationTime(Math.floor(Date.now() / 1000) + 3600)
+      .sign(privateKey);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/credentials/verify',
+      payload: { credential: fakeJwt },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.valid).toBe(false);
+  });
+
+  it('returns 400 when credential is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/credentials/verify',
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('BAD_REQUEST');
+  });
+
+  it('does not require authentication (skipAuth)', async () => {
+    const vcJwt = await createSignedVcJwt();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/credentials/verify',
+      payload: { credential: vcJwt },
+      // No auth header
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+// ── GET /v1/credentials/status/:listId ──────────────────────────────────────
+
+describe('GET /v1/credentials/status/:listId', () => {
+  it('returns a StatusList2021 credential', async () => {
+    const encodedList = createEmptyEncodedList();
+    sqlMock.mockResolvedValueOnce([{
+      id: 'vcsl_LIST1',
+      developer_id: TEST_DEVELOPER.id,
+      encoded_list: encodedList,
+      purpose: 'revocation',
+      size: 131072,
+      updated_at: now,
+    }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/credentials/status/vcsl_LIST1',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.type).toContain('StatusList2021Credential');
+    expect(body.issuer).toBe('did:web:grantex.dev');
+    expect(body.credentialSubject.type).toBe('StatusList2021');
+    expect(body.credentialSubject.statusPurpose).toBe('revocation');
+    expect(body.credentialSubject.encodedList).toBe(encodedList);
+  });
+
+  it('returns 404 for non-existent status list', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/credentials/status/vcsl_MISSING',
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('NOT_FOUND');
+  });
+
+  it('does not require authentication (skipAuth)', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/credentials/status/vcsl_TEST',
+      // No auth header
+    });
+
+    // 404 not 401 — means auth was skipped
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ── Token exchange with credentialFormat ─────────────────────────────────────
+
+const validAuthRequest = {
+  id: 'areq_VC_TEST',
+  agent_id: TEST_AGENT.id,
+  principal_id: 'user_123',
+  developer_id: TEST_DEVELOPER.id,
+  scopes: ['read', 'write'],
+  expires_in: '24h',
+  expires_at: new Date(Date.now() + 86400_000).toISOString(),
+  status: 'approved',
+  agent_did: TEST_AGENT.did,
+  code_challenge: null,
+};
+
+describe('POST /v1/token with credentialFormat', () => {
+  it('returns only grantToken without credentialFormat (backward compat)', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([validAuthRequest]);  // Auth request lookup
+    sqlMock.mockResolvedValueOnce([]);  // INSERT grants
+    sqlMock.mockResolvedValueOnce([]);  // INSERT grant_tokens
+    sqlMock.mockResolvedValueOnce([]);  // INSERT refresh_tokens
+    sqlMock.mockResolvedValueOnce([]);  // UPDATE auth_requests
+    sqlMock.mockResolvedValueOnce([]);  // Budget check
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token',
+      headers: authHeader(),
+      payload: { code: 'code-compat', agentId: TEST_AGENT.id },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.grantToken).toBeDefined();
+    expect(body.verifiableCredential).toBeUndefined();
+  });
+
+  it('returns verifiableCredential with credentialFormat=vc-jwt', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([validAuthRequest]);  // Auth request lookup
+    sqlMock.mockResolvedValueOnce([]);  // INSERT grants
+    sqlMock.mockResolvedValueOnce([]);  // INSERT grant_tokens
+    sqlMock.mockResolvedValueOnce([]);  // INSERT refresh_tokens
+    sqlMock.mockResolvedValueOnce([]);  // UPDATE auth_requests
+    sqlMock.mockResolvedValueOnce([]);  // Budget check
+
+    // VC issuance SQL calls:
+    sqlMock.mockResolvedValueOnce([{ id: 'vcsl_TOK1', next_index: 0 }]);  // getOrCreateStatusList
+    sqlMock.mockResolvedValueOnce([]);  // UPDATE next_index
+    sqlMock.mockResolvedValueOnce([]);  // INSERT verifiable_credentials
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token',
+      headers: authHeader(),
+      payload: { code: 'code-vc', agentId: TEST_AGENT.id, credentialFormat: 'vc-jwt' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.grantToken).toBeDefined();
+    expect(body.verifiableCredential).toBeDefined();
+    expect(typeof body.verifiableCredential).toBe('string');
+
+    // Verify the VC-JWT structure
+    const vcPayload = decodeJwt(body.verifiableCredential);
+    expect(vcPayload.iss).toBe('did:web:grantex.dev');
+    expect(vcPayload['vc']).toBeDefined();
+  });
+
+  it('returns both grantToken and verifiableCredential with credentialFormat=both', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([validAuthRequest]);  // Auth request lookup
+    sqlMock.mockResolvedValueOnce([]);  // INSERT grants
+    sqlMock.mockResolvedValueOnce([]);  // INSERT grant_tokens
+    sqlMock.mockResolvedValueOnce([]);  // INSERT refresh_tokens
+    sqlMock.mockResolvedValueOnce([]);  // UPDATE auth_requests
+    sqlMock.mockResolvedValueOnce([]);  // Budget check
+
+    // VC issuance SQL calls:
+    sqlMock.mockResolvedValueOnce([{ id: 'vcsl_BOTH', next_index: 5 }]);
+    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token',
+      headers: authHeader(),
+      payload: { code: 'code-both', agentId: TEST_AGENT.id, credentialFormat: 'both' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.grantToken).toBeDefined();
+    expect(body.verifiableCredential).toBeDefined();
+    expect(body.refreshToken).toBeDefined();
+    expect(body.grantId).toBeDefined();
+  });
+});
+
+// ── VC revocation via grant revocation ──────────────────────────────────────
+
+describe('VC revocation cascade', () => {
+  it('revokes VCs when grant is revoked (via revokeVCsByGrantIds)', async () => {
+    // This tests the revokeVCsByGrantIds function directly
+    const { revokeVCsByGrantIds } = await import('../src/lib/vc.js');
+
+    // SELECT active VCs
+    sqlMock.mockResolvedValueOnce([
+      { id: 'vc_CASCADE1', status_list_idx: 0 },
+      { id: 'vc_CASCADE2', status_list_idx: 1 },
+    ]);
+    // UPDATE VCs to revoked
+    sqlMock.mockResolvedValueOnce([]);
+    // SELECT status list
+    const encodedList = createEmptyEncodedList();
+    sqlMock.mockResolvedValueOnce([{
+      id: 'vcsl_CASCADE',
+      encoded_list: encodedList,
+    }]);
+    // UPDATE status list
+    sqlMock.mockResolvedValueOnce([]);
+
+    await revokeVCsByGrantIds(['grnt_CASCADE1'], TEST_DEVELOPER.id);
+
+    // Verify SQL was called the right number of times
+    expect(sqlMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('handles revocation with no matching VCs gracefully', async () => {
+    const { revokeVCsByGrantIds } = await import('../src/lib/vc.js');
+
+    // SELECT active VCs → empty
+    sqlMock.mockResolvedValueOnce([]);
+
+    await revokeVCsByGrantIds(['grnt_NOVCS'], TEST_DEVELOPER.id);
+
+    // Only one SQL call (the SELECT)
+    expect(sqlMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/auth-service/tests/delegate.test.ts
+++ b/apps/auth-service/tests/delegate.test.ts
@@ -149,4 +149,155 @@ describe('POST /v1/grants/delegate', () => {
 
     expect(res.statusCode).toBe(400);
   });
+
+  it('includes verifiableCredential when credentialFormat is vc-jwt', async () => {
+    seedAuth();
+    mockRedis.get.mockResolvedValue(null);
+    // Sub-agent lookup
+    sqlMock.mockResolvedValueOnce([SUB_AGENT]);
+    // INSERT grants
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT grant_tokens
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT refresh_tokens
+    sqlMock.mockResolvedValueOnce([]);
+    // VC issuance: SELECT vc_status_lists (existing list)
+    sqlMock.mockResolvedValueOnce([{ id: 'vcsl_TEST', next_index: 0 }]);
+    // VC issuance: UPDATE vc_status_lists next_index
+    sqlMock.mockResolvedValueOnce([]);
+    // VC issuance: INSERT verifiable_credentials
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/grants/delegate',
+      headers: authHeader(),
+      payload: {
+        parentGrantToken: parentToken,
+        subAgentId: SUB_AGENT.id,
+        scopes: ['read'],
+        expiresIn: '1h',
+        credentialFormat: 'vc-jwt',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{
+      grantToken: string;
+      expiresAt: string;
+      scopes: string[];
+      grantId: string;
+      verifiableCredential: string;
+    }>();
+    expect(typeof body.grantToken).toBe('string');
+    expect(body.scopes).toEqual(['read']);
+    expect(typeof body.grantId).toBe('string');
+    expect(typeof body.verifiableCredential).toBe('string');
+
+    // Verify the VC-JWT is a valid JWT with vc claim
+    const vcClaims = decodeJwt(body.verifiableCredential);
+    expect(vcClaims['vc']).toBeDefined();
+    const vc = vcClaims['vc'] as Record<string, unknown>;
+    expect((vc['type'] as string[])).toContain('AgentGrantCredential');
+    const subject = vc['credentialSubject'] as Record<string, unknown>;
+    expect(subject['id']).toBe(SUB_AGENT.did);
+    expect(subject['scopes']).toEqual(['read']);
+  });
+
+  it('includes verifiableCredential when credentialFormat is both', async () => {
+    seedAuth();
+    mockRedis.get.mockResolvedValue(null);
+    // Sub-agent lookup
+    sqlMock.mockResolvedValueOnce([SUB_AGENT]);
+    // INSERT grants
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT grant_tokens
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT refresh_tokens
+    sqlMock.mockResolvedValueOnce([]);
+    // VC issuance: SELECT vc_status_lists (existing list)
+    sqlMock.mockResolvedValueOnce([{ id: 'vcsl_TEST', next_index: 0 }]);
+    // VC issuance: UPDATE vc_status_lists next_index
+    sqlMock.mockResolvedValueOnce([]);
+    // VC issuance: INSERT verifiable_credentials
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/grants/delegate',
+      headers: authHeader(),
+      payload: {
+        parentGrantToken: parentToken,
+        subAgentId: SUB_AGENT.id,
+        scopes: ['read'],
+        expiresIn: '1h',
+        credentialFormat: 'both',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{
+      grantToken: string;
+      expiresAt: string;
+      scopes: string[];
+      grantId: string;
+      verifiableCredential: string;
+    }>();
+    expect(typeof body.grantToken).toBe('string');
+    expect(typeof body.verifiableCredential).toBe('string');
+
+    // Both the grant JWT and the VC-JWT should be present and different
+    expect(body.grantToken).not.toBe(body.verifiableCredential);
+
+    // Verify grant JWT has delegation claims
+    const grantClaims = decodeJwt(body.grantToken);
+    expect(grantClaims['delegationDepth']).toBe(1);
+
+    // Verify VC-JWT has vc claim
+    const vcClaims = decodeJwt(body.verifiableCredential);
+    expect(vcClaims['vc']).toBeDefined();
+  });
+
+  it('succeeds without verifiableCredential when VC issuance fails (best-effort)', async () => {
+    seedAuth();
+    mockRedis.get.mockResolvedValue(null);
+    // Sub-agent lookup
+    sqlMock.mockResolvedValueOnce([SUB_AGENT]);
+    // INSERT grants
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT grant_tokens
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT refresh_tokens
+    sqlMock.mockResolvedValueOnce([]);
+    // VC issuance: SELECT vc_status_lists — reject to simulate DB failure
+    sqlMock.mockRejectedValueOnce(new Error('status list query failed'));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/grants/delegate',
+      headers: authHeader(),
+      payload: {
+        parentGrantToken: parentToken,
+        subAgentId: SUB_AGENT.id,
+        scopes: ['read'],
+        expiresIn: '1h',
+        credentialFormat: 'vc-jwt',
+      },
+    });
+
+    // Delegation should still succeed
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{
+      grantToken: string;
+      expiresAt: string;
+      scopes: string[];
+      grantId: string;
+      verifiableCredential?: string;
+    }>();
+    expect(typeof body.grantToken).toBe('string');
+    expect(body.scopes).toEqual(['read']);
+    expect(typeof body.grantId).toBe('string');
+    // verifiableCredential should NOT be present since VC issuance failed
+    expect(body.verifiableCredential).toBeUndefined();
+  });
 });

--- a/apps/auth-service/tests/delegate.test.ts
+++ b/apps/auth-service/tests/delegate.test.ts
@@ -137,6 +137,54 @@ describe('POST /v1/grants/delegate', () => {
     expect(res.statusCode).toBe(404);
   });
 
+  it('returns 400 when parentGrantToken is not a valid JWT', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/grants/delegate',
+      headers: authHeader(),
+      payload: {
+        parentGrantToken: 'not-a-valid-jwt',
+        subAgentId: SUB_AGENT.id,
+        scopes: ['read'],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ message: string; code: string }>();
+    expect(body.message).toBe('Invalid parentGrantToken');
+    expect(body.code).toBe('BAD_REQUEST');
+  });
+
+  it('returns 400 when parentGrantToken is missing required claims (jti)', async () => {
+    seedAuth();
+
+    // Create a JWT without jti (and without grnt, scp, exp)
+    const { SignJWT: JoseSignJWT } = await import('jose');
+    const { getKeyPair } = await import('../src/lib/crypto.js');
+    const { privateKey } = getKeyPair();
+    const invalidToken = await new JoseSignJWT({ sub: 'user_123', agt: 'did:test:agent' })
+      .setProtectedHeader({ alg: 'RS256' })
+      .sign(privateKey);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/grants/delegate',
+      headers: authHeader(),
+      payload: {
+        parentGrantToken: invalidToken,
+        subAgentId: SUB_AGENT.id,
+        scopes: ['read'],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ message: string; code: string }>();
+    expect(body.message).toBe('Invalid parentGrantToken claims');
+    expect(body.code).toBe('BAD_REQUEST');
+  });
+
   it('returns 400 when required fields are missing', async () => {
     seedAuth();
 

--- a/apps/auth-service/tests/ed25519-crypto.test.ts
+++ b/apps/auth-service/tests/ed25519-crypto.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import {
   initKeys, initEdKey, getEdKeyPair, buildJwks, signWithEd25519,
 } from '../src/lib/crypto.js';
-import { jwtVerify } from 'jose';
+import { jwtVerify, generateKeyPair, exportPKCS8 } from 'jose';
+import { config } from '../src/config.js';
 
 beforeAll(async () => {
   process.env['AUTO_GENERATE_KEYS'] = 'true';
@@ -79,5 +80,39 @@ describe('signWithEd25519', () => {
     expect(payload.iss).toBe('https://grantex.dev');
     expect(payload.exp).toBeDefined();
     expect(payload.iat).toBeDefined();
+  });
+});
+
+describe('initEdKey with PEM import', () => {
+  it('initializes Ed25519 key pair from a PKCS8 PEM private key', async () => {
+    // Generate a fresh Ed25519 key pair and export the private key as PEM
+    const { privateKey: generatedPrivate } = await generateKeyPair('EdDSA', { crv: 'Ed25519' });
+    const pem = await exportPKCS8(generatedPrivate);
+
+    // Set the config to use the PEM import path
+    (config as { ed25519PrivateKey: string | null }).ed25519PrivateKey = pem;
+
+    try {
+      // Re-initialize — this should take the PEM import branch (lines 148-162)
+      await initEdKey();
+
+      const kp = getEdKeyPair();
+      expect(kp).not.toBeNull();
+      expect(kp!.privateKey).toBeDefined();
+      expect(kp!.publicKey).toBeDefined();
+      expect(kp!.kid).toMatch(/^grantex-ed25519-\d{4}-\d{2}$/);
+
+      // Verify the imported key can sign and verify a JWT
+      const jwt = await signWithEd25519({ pemTest: true });
+      const { payload } = await jwtVerify(jwt, kp!.publicKey, {
+        algorithms: ['EdDSA'],
+      });
+      expect(payload['pemTest']).toBe(true);
+    } finally {
+      // Reset config so other tests are not affected
+      (config as { ed25519PrivateKey: string | null }).ed25519PrivateKey = null;
+      // Re-initialize with auto-generated key
+      await initEdKey();
+    }
   });
 });

--- a/apps/auth-service/tests/policies.test.ts
+++ b/apps/auth-service/tests/policies.test.ts
@@ -165,6 +165,20 @@ describe('PATCH /v1/policies/:id', () => {
 
     expect(res.statusCode).toBe(404);
   });
+
+  it('returns 400 for invalid effect value in PATCH', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/v1/policies/${MOCK_POLICY.id}`,
+      headers: authHeader(),
+      payload: { effect: 'maybe' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('BAD_REQUEST');
+  });
 });
 
 describe('DELETE /v1/policies/:id', () => {

--- a/apps/auth-service/tests/scim.test.ts
+++ b/apps/auth-service/tests/scim.test.ts
@@ -266,6 +266,35 @@ describe('PUT /scim/v2/Users/:id', () => {
   });
 });
 
+describe('PUT /scim/v2/Users/:id (error paths)', () => {
+  it('returns 400 when userName is missing', async () => {
+    seedScimToken();
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/scim/v2/Users/scimuser_01',
+      headers: { authorization: 'Bearer scim-test-token', 'content-type': 'application/json' },
+      payload: { displayName: 'No Username', active: true, emails: [] },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 when user not found', async () => {
+    seedScimToken();
+    sqlMock.mockResolvedValueOnce([]); // no matching user
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/scim/v2/Users/scimuser_missing',
+      headers: { authorization: 'Bearer scim-test-token', 'content-type': 'application/json' },
+      payload: { userName: 'alice@corp.com', displayName: 'Alice', active: true, emails: [] },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
 describe('PATCH /scim/v2/Users/:id', () => {
   it('applies Operations and returns updated user', async () => {
     const deactivated = { ...SCIM_USER_ROW, active: false, updated_at: '2026-02-27T02:00:00Z' };

--- a/apps/auth-service/tests/sd-jwt.test.ts
+++ b/apps/auth-service/tests/sd-jwt.test.ts
@@ -423,6 +423,23 @@ describe('verifySDJWT', () => {
     expect(result.valid).toBe(true);
   });
 
+  it('treats parts with 2 dots but invalid JWT header as disclosures during verify', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+    const issuerJwt = sdJwt.split('~')[0]!;
+
+    // Create a part that has 2 dots but is NOT a valid JWT (invalid base64url header)
+    // decodeProtectedHeader will throw, triggering the catch on line 220-221
+    const fakeJwtLikePart = '!!!.not.valid';
+    const withFake = issuerJwt + '~' + fakeJwtLikePart + '~';
+
+    // It should be treated as a disclosure (not a KB-JWT), and then fail
+    // because it's not a valid disclosure either
+    const result = await verifySDJWT(withFake);
+    expect(result.valid).toBe(false);
+    // It should fail with disclosure error since it's parsed as disclosure
+    expect(result.error).toBe('Invalid disclosure format');
+  });
+
   it('returns invalid for disclosure with wrong array length', async () => {
     const { sdJwt } = await issueSDJWT(defaultParams);
     const issuerJwt = sdJwt.split('~')[0]!;

--- a/apps/auth-service/tests/sd-jwt.test.ts
+++ b/apps/auth-service/tests/sd-jwt.test.ts
@@ -364,6 +364,65 @@ describe('verifySDJWT', () => {
     expect(result.error).toBe('Invalid disclosure format');
   });
 
+  it('returns invalid for KB-JWT missing nonce and aud', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    // Create a KB-JWT with typ=kb+jwt but no nonce or aud
+    const kbHeader = Buffer.from(JSON.stringify({ alg: 'none', typ: 'kb+jwt' })).toString('base64url');
+    const kbPayload = Buffer.from(JSON.stringify({ iat: 12345 })).toString('base64url');
+    const kbJwt = `${kbHeader}.${kbPayload}.`;
+
+    // Append KB-JWT to SD-JWT
+    const withKb = sdJwt.replace(/~$/, '') + '~' + kbJwt + '~';
+    const result = await verifySDJWT(withKb);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('KB-JWT missing nonce or aud');
+  });
+
+  it('returns invalid for malformed KB-JWT', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    // Create something that has a kb+jwt header but invalid JWT payload
+    const kbHeader = Buffer.from(JSON.stringify({ alg: 'none', typ: 'kb+jwt' })).toString('base64url');
+    const kbJwt = `${kbHeader}.!!!invalid!!!.`;
+
+    const withKb = sdJwt.replace(/~$/, '') + '~' + kbJwt + '~';
+    const result = await verifySDJWT(withKb);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid KB-JWT format');
+  });
+
+  it('accepts valid KB-JWT with nonce', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    // Create a valid KB-JWT with nonce
+    const kbHeader = Buffer.from(JSON.stringify({ alg: 'none', typ: 'kb+jwt' })).toString('base64url');
+    const kbPayload = Buffer.from(JSON.stringify({ nonce: 'test-nonce-123', iat: Math.floor(Date.now() / 1000) })).toString('base64url');
+    const kbJwt = `${kbHeader}.${kbPayload}.`;
+
+    const withKb = sdJwt.replace(/~$/, '') + '~' + kbJwt + '~';
+    const result = await verifySDJWT(withKb);
+
+    expect(result.valid).toBe(true);
+    expect(result.disclosedClaims).toBeDefined();
+  });
+
+  it('accepts valid KB-JWT with aud', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    // Create a valid KB-JWT with aud
+    const kbHeader = Buffer.from(JSON.stringify({ alg: 'none', typ: 'kb+jwt' })).toString('base64url');
+    const kbPayload = Buffer.from(JSON.stringify({ aud: 'https://verifier.example.com', iat: Math.floor(Date.now() / 1000) })).toString('base64url');
+    const kbJwt = `${kbHeader}.${kbPayload}.`;
+
+    const withKb = sdJwt.replace(/~$/, '') + '~' + kbJwt + '~';
+    const result = await verifySDJWT(withKb);
+
+    expect(result.valid).toBe(true);
+  });
+
   it('returns invalid for disclosure with wrong array length', async () => {
     const { sdJwt } = await issueSDJWT(defaultParams);
     const issuerJwt = sdJwt.split('~')[0]!;
@@ -443,6 +502,47 @@ describe('createPresentation', () => {
     const parts = presentation.split('~');
     const nonEmptyDisclosures = parts.slice(1).filter((p) => p.length > 0);
     expect(nonEmptyDisclosures).toHaveLength(0);
+  });
+
+  it('strips KB-JWT (typ=kb+jwt) from the SD-JWT during presentation', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    // Craft a fake KB-JWT with typ=kb+jwt
+    const kbHeader = Buffer.from(JSON.stringify({ alg: 'none', typ: 'kb+jwt' })).toString('base64url');
+    const kbPayload = Buffer.from(JSON.stringify({ nonce: 'n', aud: 'a' })).toString('base64url');
+    const kbJwt = `${kbHeader}.${kbPayload}.`;
+
+    // Append the KB-JWT before the trailing ~
+    const withKb = sdJwt.replace(/~$/, '') + '~' + kbJwt + '~';
+
+    const presentation = createPresentation(withKb, ['principalId']);
+    const presentationParts = presentation.split('~').filter((p) => p.length > 0);
+
+    // KB-JWT should not be in the presentation
+    for (const part of presentationParts.slice(1)) {
+      const dots = part.split('.').length - 1;
+      if (dots === 2) {
+        // Should not have kb+jwt type
+        try {
+          const header = JSON.parse(Buffer.from(part.split('.')[0]!, 'base64url').toString('utf-8'));
+          expect(header.typ).not.toBe('kb+jwt');
+        } catch {
+          // Not a JWT, that's fine
+        }
+      }
+    }
+  });
+
+  it('treats parts with 2 dots but non-JWT header as disclosures', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    // Add a disclosure that happens to have 2 dots but is not a valid JWT
+    const fakePartWithDots = 'not.a.jwt';
+    const withFakePart = sdJwt.replace(/~$/, '') + '~' + fakePartWithDots + '~';
+
+    // Should not throw — the part should be treated as a disclosure (and will fail verification since hash won't match)
+    const presentation = createPresentation(withFakePart, ['principalId']);
+    expect(typeof presentation).toBe('string');
   });
 });
 

--- a/apps/auth-service/tests/sd-jwt.test.ts
+++ b/apps/auth-service/tests/sd-jwt.test.ts
@@ -1,0 +1,681 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { buildTestApp, seedAuth, authHeader, sqlMock, TEST_DEVELOPER, TEST_AGENT } from './helpers.js';
+import type { FastifyInstance } from 'fastify';
+import { initKeys, getKeyPair } from '../src/lib/crypto.js';
+import { SignJWT, decodeJwt, generateKeyPair } from 'jose';
+import { createHash } from 'node:crypto';
+import {
+  issueSDJWT,
+  verifySDJWT,
+  createPresentation,
+} from '../src/lib/sd-jwt.js';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  await initKeys();
+  app = await buildTestApp();
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const future = new Date(Date.now() + 86400_000);
+
+const defaultParams = {
+  grantId: 'grnt_SDJWT01',
+  agentDid: 'did:grantex:ag_SDJWT01',
+  principalId: 'user_sd_123',
+  developerId: 'dev_TEST',
+  scopes: ['read', 'write'],
+  expiresAt: future,
+};
+
+function decodeDisclosure(encoded: string): { salt: string; claimName: string; claimValue: unknown } {
+  const json = Buffer.from(encoded, 'base64url').toString('utf-8');
+  const [salt, claimName, claimValue] = JSON.parse(json) as [string, string, unknown];
+  return { salt, claimName, claimValue };
+}
+
+function hashDisclosure(encoded: string): string {
+  return createHash('sha256').update(encoded, 'ascii').digest().toString('base64url');
+}
+
+// ── SD-JWT Issuance ─────────────────────────────────────────────────────────
+
+describe('issueSDJWT', () => {
+  it('creates a valid SD-JWT with default selective fields', async () => {
+    const { vcId, sdJwt, disclosures } = await issueSDJWT(defaultParams);
+
+    expect(vcId).toMatch(/^vc_/);
+    expect(typeof sdJwt).toBe('string');
+
+    // SD-JWT format: <issuer-jwt>~<d1>~<d2>~...~
+    const parts = sdJwt.split('~');
+    expect(parts.length).toBeGreaterThanOrEqual(3); // jwt + at least 1 disclosure + trailing empty
+
+    // Default selective fields: principalId, developerId, scopes, delegationDepth
+    expect(disclosures).toHaveLength(4);
+
+    // Decode the issuer JWT
+    const issuerJwt = parts[0]!;
+    const payload = decodeJwt(issuerJwt);
+
+    expect(payload.iss).toBe('did:web:grantex.dev');
+    expect(payload.sub).toBe('did:grantex:ag_SDJWT01');
+    expect(payload.jti).toBe(vcId);
+    expect(payload['_sd_alg']).toBe('sha-256');
+
+    // Check vc claim
+    const vc = payload['vc'] as Record<string, unknown>;
+    expect(vc['@context']).toContain('https://www.w3.org/ns/credentials/v2');
+    expect(vc['type']).toContain('AgentGrantCredential');
+
+    // Credential subject should have _sd array and visible claims
+    const subject = vc['credentialSubject'] as Record<string, unknown>;
+    expect(subject['id']).toBe('did:grantex:ag_SDJWT01');
+    expect(subject['type']).toBe('AIAgent');
+    expect(subject['grantId']).toBe('grnt_SDJWT01');
+    expect(subject['_sd']).toBeDefined();
+    expect(Array.isArray(subject['_sd'])).toBe(true);
+    expect((subject['_sd'] as string[]).length).toBe(4);
+
+    // Selective fields should NOT be in the visible credentialSubject
+    expect(subject['principalId']).toBeUndefined();
+    expect(subject['developerId']).toBeUndefined();
+    expect(subject['scopes']).toBeUndefined();
+    expect(subject['delegationDepth']).toBeUndefined();
+  });
+
+  it('creates SD-JWT with custom selective fields', async () => {
+    const { disclosures } = await issueSDJWT({
+      ...defaultParams,
+      selectiveFields: ['principalId', 'scopes'],
+    });
+
+    expect(disclosures).toHaveLength(2);
+
+    // Decode disclosures
+    const decoded = disclosures.map(decodeDisclosure);
+    const claimNames = decoded.map((d) => d.claimName).sort();
+    expect(claimNames).toEqual(['principalId', 'scopes']);
+  });
+
+  it('includes delegation depth in selective fields by default', async () => {
+    const { sdJwt, disclosures } = await issueSDJWT({
+      ...defaultParams,
+      delegationDepth: 2,
+    });
+
+    const decoded = disclosures.map(decodeDisclosure);
+    const depthDisclosure = decoded.find((d) => d.claimName === 'delegationDepth');
+    expect(depthDisclosure).toBeDefined();
+    expect(depthDisclosure!.claimValue).toBe(2);
+  });
+
+  it('sets correct JWT header type', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+    const issuerJwt = sdJwt.split('~')[0]!;
+
+    // Decode the protected header
+    const headerB64 = issuerJwt.split('.')[0]!;
+    const header = JSON.parse(Buffer.from(headerB64, 'base64url').toString('utf-8'));
+    expect(header.typ).toBe('vc+sd-jwt');
+    expect(header.alg).toBe('RS256');
+    expect(header.kid).toBeDefined();
+  });
+
+  it('disclosure hashes match the _sd array in the JWT', async () => {
+    const { sdJwt, disclosures } = await issueSDJWT(defaultParams);
+    const issuerJwt = sdJwt.split('~')[0]!;
+    const payload = decodeJwt(issuerJwt);
+
+    const vc = payload['vc'] as Record<string, unknown>;
+    const subject = vc['credentialSubject'] as Record<string, unknown>;
+    const sdArray = subject['_sd'] as string[];
+
+    // Each disclosure's hash should appear in the _sd array
+    for (const disc of disclosures) {
+      const hash = hashDisclosure(disc);
+      expect(sdArray).toContain(hash);
+    }
+  });
+});
+
+// ── SD-JWT Verification (Full Disclosure) ───────────────────────────────────
+
+describe('verifySDJWT', () => {
+  it('succeeds with full disclosure', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    const result = await verifySDJWT(sdJwt);
+
+    expect(result.valid).toBe(true);
+    expect(result.vcId).toMatch(/^vc_/);
+    expect(result.disclosedClaims).toBeDefined();
+
+    // All claims should be disclosed
+    const claims = result.disclosedClaims!;
+    expect(claims['id']).toBe('did:grantex:ag_SDJWT01');
+    expect(claims['type']).toBe('AIAgent');
+    expect(claims['grantId']).toBe('grnt_SDJWT01');
+    expect(claims['principalId']).toBe('user_sd_123');
+    expect(claims['developerId']).toBe('dev_TEST');
+    expect(claims['scopes']).toEqual(['read', 'write']);
+    expect(claims['delegationDepth']).toBe(0);
+  });
+
+  it('succeeds with partial disclosure', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    // Create a presentation with only some disclosures
+    const presentation = createPresentation(sdJwt, ['principalId', 'scopes']);
+    const result = await verifySDJWT(presentation);
+
+    expect(result.valid).toBe(true);
+    expect(result.disclosedClaims).toBeDefined();
+
+    const claims = result.disclosedClaims!;
+    // Visible (non-selective) claims should always be present
+    expect(claims['id']).toBe('did:grantex:ag_SDJWT01');
+    expect(claims['type']).toBe('AIAgent');
+    expect(claims['grantId']).toBe('grnt_SDJWT01');
+
+    // Only the selected disclosures should appear
+    expect(claims['principalId']).toBe('user_sd_123');
+    expect(claims['scopes']).toEqual(['read', 'write']);
+
+    // Non-disclosed selective fields should NOT appear
+    expect(claims['developerId']).toBeUndefined();
+    expect(claims['delegationDepth']).toBeUndefined();
+  });
+
+  it('succeeds with zero disclosures', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    // Create a presentation with no disclosures
+    const presentation = createPresentation(sdJwt, []);
+    const result = await verifySDJWT(presentation);
+
+    expect(result.valid).toBe(true);
+    expect(result.disclosedClaims).toBeDefined();
+
+    const claims = result.disclosedClaims!;
+    // Only visible claims
+    expect(claims['id']).toBe('did:grantex:ag_SDJWT01');
+    expect(claims['type']).toBe('AIAgent');
+    expect(claims['grantId']).toBe('grnt_SDJWT01');
+
+    // No selective claims disclosed
+    expect(claims['principalId']).toBeUndefined();
+    expect(claims['developerId']).toBeUndefined();
+    expect(claims['scopes']).toBeUndefined();
+    expect(claims['delegationDepth']).toBeUndefined();
+  });
+
+  it('returns invalid for invalid SD-JWT format', async () => {
+    const result = await verifySDJWT('not-valid');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid SD-JWT format');
+  });
+
+  it('returns invalid for garbage JWT', async () => {
+    const result = await verifySDJWT('a.b.c~disclosure~');
+    expect(result.valid).toBe(false);
+  });
+
+  it('returns invalid for wrong signature', async () => {
+    const { privateKey: fakeKey } = await generateKeyPair('RS256');
+    const fakeJwt = await new SignJWT({
+      vc: {
+        '@context': ['https://www.w3.org/ns/credentials/v2'],
+        type: ['VerifiableCredential'],
+        credentialSubject: { _sd: [] },
+      },
+      _sd_alg: 'sha-256',
+    })
+      .setProtectedHeader({ alg: 'RS256', typ: 'vc+sd-jwt' })
+      .setIssuer('did:web:fake.dev')
+      .setSubject('did:fake:agent')
+      .setJti('vc_FAKE')
+      .setIssuedAt()
+      .setExpirationTime(Math.floor(Date.now() / 1000) + 3600)
+      .sign(fakeKey);
+
+    const result = await verifySDJWT(fakeJwt + '~');
+    expect(result.valid).toBe(false);
+    expect(result.vcId).toBe('vc_FAKE');
+  });
+
+  it('returns invalid for expired SD-JWT', async () => {
+    const { privateKey, kid } = getKeyPair();
+    const expiredJwt = await new SignJWT({
+      vc: {
+        '@context': ['https://www.w3.org/ns/credentials/v2'],
+        type: ['VerifiableCredential'],
+        credentialSubject: { _sd: [] },
+      },
+      _sd_alg: 'sha-256',
+    })
+      .setProtectedHeader({ alg: 'RS256', kid, typ: 'vc+sd-jwt' })
+      .setIssuer('did:web:grantex.dev')
+      .setSubject('did:test:agent')
+      .setJti('vc_EXPIRED')
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 7200)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 3600)
+      .sign(privateKey);
+
+    const result = await verifySDJWT(expiredJwt + '~');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('SD-JWT expired');
+  });
+
+  it('returns invalid for tampered disclosure', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    // Tamper with a disclosure — modify the base64url content
+    const parts = sdJwt.split('~');
+    const issuerJwt = parts[0]!;
+    const disclosures = parts.slice(1).filter((p) => p.length > 0);
+
+    // Create a fake disclosure that does not match any _sd hash
+    const fakeDisclosure = Buffer.from(
+      JSON.stringify(['fakesalt', 'principalId', 'hacker']),
+      'utf-8',
+    ).toString('base64url');
+
+    const tamperedSdJwt = issuerJwt + '~' + fakeDisclosure + '~';
+    const result = await verifySDJWT(tamperedSdJwt);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Disclosure hash not found');
+  });
+
+  it('returns invalid for unsupported _sd_alg', async () => {
+    const { privateKey, kid } = getKeyPair();
+    const jwt = await new SignJWT({
+      vc: {
+        '@context': ['https://www.w3.org/ns/credentials/v2'],
+        type: ['VerifiableCredential'],
+        credentialSubject: { _sd: [] },
+      },
+      _sd_alg: 'sha-384',
+    })
+      .setProtectedHeader({ alg: 'RS256', kid, typ: 'vc+sd-jwt' })
+      .setIssuer('did:web:grantex.dev')
+      .setSubject('did:test:agent')
+      .setJti('vc_BADALG')
+      .setIssuedAt()
+      .setExpirationTime(Math.floor(Date.now() / 1000) + 3600)
+      .sign(privateKey);
+
+    const result = await verifySDJWT(jwt + '~');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Unsupported _sd_alg');
+  });
+
+  it('returns invalid for missing vc claim', async () => {
+    const { privateKey, kid } = getKeyPair();
+    const jwt = await new SignJWT({ notVc: 'something', _sd_alg: 'sha-256' })
+      .setProtectedHeader({ alg: 'RS256', kid, typ: 'vc+sd-jwt' })
+      .setIssuer('did:web:grantex.dev')
+      .setSubject('did:test:agent')
+      .setJti('vc_NOVC')
+      .setIssuedAt()
+      .setExpirationTime(Math.floor(Date.now() / 1000) + 3600)
+      .sign(privateKey);
+
+    const result = await verifySDJWT(jwt + '~');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Missing vc claim');
+  });
+
+  it('returns invalid for missing credentialSubject', async () => {
+    const { privateKey, kid } = getKeyPair();
+    const jwt = await new SignJWT({
+      vc: {
+        '@context': ['https://www.w3.org/ns/credentials/v2'],
+        type: ['VerifiableCredential'],
+      },
+      _sd_alg: 'sha-256',
+    })
+      .setProtectedHeader({ alg: 'RS256', kid, typ: 'vc+sd-jwt' })
+      .setIssuer('did:web:grantex.dev')
+      .setSubject('did:test:agent')
+      .setJti('vc_NOSUB')
+      .setIssuedAt()
+      .setExpirationTime(Math.floor(Date.now() / 1000) + 3600)
+      .sign(privateKey);
+
+    const result = await verifySDJWT(jwt + '~');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Missing credentialSubject');
+  });
+
+  it('returns invalid for malformed disclosure (non-JSON)', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+    const issuerJwt = sdJwt.split('~')[0]!;
+
+    // Add a disclosure that is not valid base64url JSON
+    const badDisclosure = Buffer.from('not-json', 'utf-8').toString('base64url');
+    const badSdJwt = issuerJwt + '~' + badDisclosure + '~';
+
+    const result = await verifySDJWT(badSdJwt);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid disclosure format');
+  });
+
+  it('returns invalid for disclosure with wrong array length', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+    const issuerJwt = sdJwt.split('~')[0]!;
+
+    // A valid JSON array but with wrong length (2 instead of 3)
+    const badDisclosure = Buffer.from(
+      JSON.stringify(['salt', 'claimName']),
+      'utf-8',
+    ).toString('base64url');
+    const badSdJwt = issuerJwt + '~' + badDisclosure + '~';
+
+    const result = await verifySDJWT(badSdJwt);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid disclosure format');
+  });
+});
+
+// ── SD-JWT Presentation ─────────────────────────────────────────────────────
+
+describe('createPresentation', () => {
+  it('creates a presentation with selected fields', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    const presentation = createPresentation(sdJwt, ['principalId']);
+
+    // Should have issuer JWT + 1 disclosure + trailing ~
+    const parts = presentation.split('~');
+    const nonEmptyDisclosures = parts.slice(1).filter((p) => p.length > 0);
+    expect(nonEmptyDisclosures).toHaveLength(1);
+
+    // Decode the only disclosure
+    const decoded = decodeDisclosure(nonEmptyDisclosures[0]!);
+    expect(decoded.claimName).toBe('principalId');
+    expect(decoded.claimValue).toBe('user_sd_123');
+  });
+
+  it('creates a presentation with multiple fields', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    const presentation = createPresentation(sdJwt, ['principalId', 'scopes']);
+    const parts = presentation.split('~');
+    const nonEmptyDisclosures = parts.slice(1).filter((p) => p.length > 0);
+    expect(nonEmptyDisclosures).toHaveLength(2);
+
+    const decoded = nonEmptyDisclosures.map(decodeDisclosure);
+    const names = decoded.map((d) => d.claimName).sort();
+    expect(names).toEqual(['principalId', 'scopes']);
+  });
+
+  it('creates a presentation with no fields (empty)', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    const presentation = createPresentation(sdJwt, []);
+    const parts = presentation.split('~');
+    const nonEmptyDisclosures = parts.slice(1).filter((p) => p.length > 0);
+    expect(nonEmptyDisclosures).toHaveLength(0);
+  });
+
+  it('preserves the issuer JWT unchanged', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+    const originalIssuerJwt = sdJwt.split('~')[0]!;
+
+    const presentation = createPresentation(sdJwt, ['principalId']);
+    const presentationIssuerJwt = presentation.split('~')[0]!;
+
+    expect(presentationIssuerJwt).toBe(originalIssuerJwt);
+  });
+
+  it('throws for invalid SD-JWT format', () => {
+    expect(() => createPresentation('not-valid', ['field'])).toThrow('Invalid SD-JWT format');
+  });
+
+  it('ignores fields not present in disclosures', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    const presentation = createPresentation(sdJwt, ['nonExistentField']);
+    const parts = presentation.split('~');
+    const nonEmptyDisclosures = parts.slice(1).filter((p) => p.length > 0);
+    expect(nonEmptyDisclosures).toHaveLength(0);
+  });
+});
+
+// ── Roundtrip: Issue → Present → Verify ─────────────────────────────────────
+
+describe('SD-JWT roundtrip', () => {
+  it('issue → full verify → all claims present', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+    const result = await verifySDJWT(sdJwt);
+
+    expect(result.valid).toBe(true);
+    expect(result.disclosedClaims!['principalId']).toBe('user_sd_123');
+    expect(result.disclosedClaims!['developerId']).toBe('dev_TEST');
+    expect(result.disclosedClaims!['scopes']).toEqual(['read', 'write']);
+    expect(result.disclosedClaims!['delegationDepth']).toBe(0);
+    expect(result.disclosedClaims!['grantId']).toBe('grnt_SDJWT01');
+  });
+
+  it('issue → partial present → verify only disclosed claims', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+    const presentation = createPresentation(sdJwt, ['principalId']);
+    const result = await verifySDJWT(presentation);
+
+    expect(result.valid).toBe(true);
+    expect(result.disclosedClaims!['principalId']).toBe('user_sd_123');
+    expect(result.disclosedClaims!['developerId']).toBeUndefined();
+    expect(result.disclosedClaims!['scopes']).toBeUndefined();
+    // Visible claims always present
+    expect(result.disclosedClaims!['grantId']).toBe('grnt_SDJWT01');
+  });
+
+  it('issue → present with nonce/audience → verify succeeds', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+    const presentation = createPresentation(sdJwt, ['principalId'], {
+      nonce: 'test-nonce-123',
+      audience: 'https://verifier.example.com',
+    });
+    const result = await verifySDJWT(presentation);
+
+    expect(result.valid).toBe(true);
+    expect(result.disclosedClaims!['principalId']).toBe('user_sd_123');
+  });
+});
+
+// ── POST /v1/credentials/present (route tests) ─────────────────────────────
+
+describe('POST /v1/credentials/present', () => {
+  it('returns valid for a properly issued SD-JWT', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/credentials/present',
+      payload: { sdJwt },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.valid).toBe(true);
+    expect(body.vcId).toBeDefined();
+    expect(body.disclosedClaims).toBeDefined();
+    expect(body.disclosedClaims.principalId).toBe('user_sd_123');
+  });
+
+  it('returns valid for a partial presentation', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+    const presentation = createPresentation(sdJwt, ['scopes']);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/credentials/present',
+      payload: { sdJwt: presentation },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.valid).toBe(true);
+    expect(body.disclosedClaims.scopes).toEqual(['read', 'write']);
+    expect(body.disclosedClaims.principalId).toBeUndefined();
+  });
+
+  it('returns invalid for tampered SD-JWT', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+    const issuerJwt = sdJwt.split('~')[0]!;
+
+    const fakeDisclosure = Buffer.from(
+      JSON.stringify(['fakesalt', 'principalId', 'tampered']),
+      'utf-8',
+    ).toString('base64url');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/credentials/present',
+      payload: { sdJwt: issuerJwt + '~' + fakeDisclosure + '~' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.valid).toBe(false);
+    expect(body.error).toContain('Disclosure hash not found');
+  });
+
+  it('returns 400 when sdJwt is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/credentials/present',
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('BAD_REQUEST');
+  });
+
+  it('does not require authentication (skipAuth)', async () => {
+    const { sdJwt } = await issueSDJWT(defaultParams);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/credentials/present',
+      payload: { sdJwt },
+      // No auth header
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().valid).toBe(true);
+  });
+
+  it('returns invalid for expired SD-JWT presentation', async () => {
+    const { privateKey, kid } = getKeyPair();
+    const expiredJwt = await new SignJWT({
+      vc: {
+        '@context': ['https://www.w3.org/ns/credentials/v2'],
+        type: ['VerifiableCredential'],
+        credentialSubject: { _sd: [] },
+      },
+      _sd_alg: 'sha-256',
+    })
+      .setProtectedHeader({ alg: 'RS256', kid, typ: 'vc+sd-jwt' })
+      .setIssuer('did:web:grantex.dev')
+      .setSubject('did:test:agent')
+      .setJti('vc_EXPIRED')
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 7200)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 3600)
+      .sign(privateKey);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/credentials/present',
+      payload: { sdJwt: expiredJwt + '~' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.valid).toBe(false);
+    expect(body.error).toBe('SD-JWT expired');
+  });
+});
+
+// ── Token exchange with credentialFormat=sd-jwt ─────────────────────────────
+
+const validAuthRequest = {
+  id: 'areq_SDJWT_TEST',
+  agent_id: TEST_AGENT.id,
+  principal_id: 'user_sd_456',
+  developer_id: TEST_DEVELOPER.id,
+  scopes: ['read', 'write'],
+  expires_in: '24h',
+  expires_at: new Date(Date.now() + 86400_000).toISOString(),
+  status: 'approved',
+  agent_did: TEST_AGENT.did,
+  code_challenge: null,
+};
+
+describe('POST /v1/token with credentialFormat=sd-jwt', () => {
+  it('returns sdJwtCredential when credentialFormat=sd-jwt', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([validAuthRequest]);  // Auth request lookup
+    sqlMock.mockResolvedValueOnce([]);  // INSERT grants
+    sqlMock.mockResolvedValueOnce([]);  // INSERT grant_tokens
+    sqlMock.mockResolvedValueOnce([]);  // INSERT refresh_tokens
+    sqlMock.mockResolvedValueOnce([]);  // UPDATE auth_requests
+    sqlMock.mockResolvedValueOnce([]);  // Budget check
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token',
+      headers: authHeader(),
+      payload: { code: 'code-sdjwt', agentId: TEST_AGENT.id, credentialFormat: 'sd-jwt' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.grantToken).toBeDefined();
+    expect(body.sdJwtCredential).toBeDefined();
+    expect(typeof body.sdJwtCredential).toBe('string');
+
+    // Verify the SD-JWT structure
+    const sdJwtParts = (body.sdJwtCredential as string).split('~');
+    expect(sdJwtParts.length).toBeGreaterThanOrEqual(3);
+
+    // Should not have verifiableCredential (that's for vc-jwt)
+    expect(body.verifiableCredential).toBeUndefined();
+
+    // Verify it can be verified
+    const verifyResult = await verifySDJWT(body.sdJwtCredential as string);
+    expect(verifyResult.valid).toBe(true);
+    expect(verifyResult.disclosedClaims!['principalId']).toBe('user_sd_456');
+  });
+
+  it('does not return sdJwtCredential for credentialFormat=vc-jwt', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([validAuthRequest]);
+    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([]);
+
+    // VC issuance SQL calls
+    sqlMock.mockResolvedValueOnce([{ id: 'vcsl_NTSDJWT', next_index: 0 }]);
+    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token',
+      headers: authHeader(),
+      payload: { code: 'code-vcjwt', agentId: TEST_AGENT.id, credentialFormat: 'vc-jwt' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.verifiableCredential).toBeDefined();
+    expect(body.sdJwtCredential).toBeUndefined();
+  });
+});

--- a/apps/auth-service/tests/security.test.ts
+++ b/apps/auth-service/tests/security.test.ts
@@ -1,0 +1,524 @@
+/**
+ * Security test suite — covers replay attacks, credential stuffing,
+ * challenge TTL enforcement, counter verification, cross-developer isolation,
+ * and other security-critical paths.
+ */
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { buildTestApp, seedAuth, authHeader, sqlMock, mockRedis, TEST_DEVELOPER, TEST_AGENT } from './helpers.js';
+import type { FastifyInstance } from 'fastify';
+import { initKeys, getKeyPair, signGrantToken } from '../src/lib/crypto.js';
+import { SignJWT, generateKeyPair } from 'jose';
+import { gzipSync } from 'node:zlib';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+// ── WebAuthn Security ─────────────────────────────────────────────────────
+
+describe('WebAuthn Security', () => {
+  describe('Challenge replay protection', () => {
+    it('rejects consumed registration challenge', async () => {
+      seedAuth();
+      // Challenge lookup returns empty (consumed = TRUE or expired)
+      sqlMock.mockResolvedValueOnce([]);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/webauthn/register/verify',
+        headers: authHeader(),
+        payload: {
+          challengeId: 'wac_consumed',
+          response: {
+            id: 'test', rawId: 'test', type: 'public-key',
+            response: { clientDataJSON: '', attestationObject: '' },
+            clientExtensionResults: {},
+          },
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().message).toContain('Invalid or expired challenge');
+    });
+
+    it('rejects consumed assertion challenge', async () => {
+      // Challenge lookup returns empty (consumed = TRUE)
+      sqlMock.mockResolvedValueOnce([]);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/webauthn/assert/verify',
+        payload: {
+          challengeId: 'wac_replayed',
+          response: {
+            id: 'cred-id', rawId: 'cred-id', type: 'public-key',
+            response: { clientDataJSON: '', authenticatorData: '', signature: '' },
+            clientExtensionResults: {},
+          },
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().message).toContain('Invalid or expired challenge');
+    });
+  });
+
+  describe('Credential not found during assertion', () => {
+    it('returns 400 when credential ID does not match stored credentials', async () => {
+      // Challenge lookup — valid
+      sqlMock.mockResolvedValueOnce([{
+        challenge: 'valid-challenge',
+        principal_id: 'user_123',
+        developer_id: 'dev_TEST',
+        auth_request_id: 'areq_test',
+      }]);
+      // Consume challenge
+      sqlMock.mockResolvedValueOnce([]);
+      // Credential lookup — not found
+      sqlMock.mockResolvedValueOnce([]);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/webauthn/assert/verify',
+        payload: {
+          challengeId: 'wac_valid',
+          response: {
+            id: 'unknown-credential-id', rawId: 'unknown-credential-id', type: 'public-key',
+            response: { clientDataJSON: '', authenticatorData: '', signature: '' },
+            clientExtensionResults: {},
+          },
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().message).toContain('Credential not found');
+    });
+  });
+
+  describe('Assertion verification failure', () => {
+    it('returns 400 when verifyAuthResponse returns verified: false', async () => {
+      // Import the mocked verifyAuthResponse
+      const webauthnMock = await import('../src/lib/webauthn.js');
+      const verifyAuthResponseMock = vi.mocked(webauthnMock.verifyAuthResponse);
+      verifyAuthResponseMock.mockResolvedValueOnce({
+        verified: false,
+        authenticationInfo: {
+          credentialID: 'bW9jay1jcmVk',
+          newCounter: 1,
+          userVerified: false,
+          credentialDeviceType: 'singleDevice',
+          credentialBackedUp: false,
+          origin: 'https://grantex.dev',
+          rpID: 'grantex.dev',
+        },
+      } as never);
+
+      // Challenge lookup
+      sqlMock.mockResolvedValueOnce([{
+        challenge: 'valid-challenge',
+        principal_id: 'user_123',
+        developer_id: 'dev_TEST',
+        auth_request_id: 'areq_test',
+      }]);
+      // Consume challenge
+      sqlMock.mockResolvedValueOnce([]);
+      // Credential lookup
+      sqlMock.mockResolvedValueOnce([{
+        id: 'cred_1',
+        credential_id: 'bW9jay1jcmVk',
+        public_key: 'AQIDBA',
+        counter: 5,
+        transports: ['internal'],
+      }]);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/webauthn/assert/verify',
+        payload: {
+          challengeId: 'wac_fail_verify',
+          response: {
+            id: 'bW9jay1jcmVk', rawId: 'bW9jay1jcmVk', type: 'public-key',
+            response: { clientDataJSON: '', authenticatorData: '', signature: '' },
+            clientExtensionResults: {},
+          },
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().message).toContain('Assertion verification failed');
+    });
+  });
+
+  describe('Registration verification failure', () => {
+    it('returns 400 when verifyRegResponse returns verified: false', async () => {
+      const webauthnMock = await import('../src/lib/webauthn.js');
+      const verifyRegResponseMock = vi.mocked(webauthnMock.verifyRegResponse);
+      verifyRegResponseMock.mockResolvedValueOnce({
+        verified: false,
+        registrationInfo: undefined,
+      } as never);
+
+      seedAuth();
+      // Challenge lookup — valid
+      sqlMock.mockResolvedValueOnce([{
+        challenge: 'valid-reg-challenge',
+        principal_id: 'user_123',
+      }]);
+      // Consume challenge
+      sqlMock.mockResolvedValueOnce([]);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/webauthn/register/verify',
+        headers: authHeader(),
+        payload: {
+          challengeId: 'wac_fail_reg',
+          response: {
+            id: 'test', rawId: 'test', type: 'public-key',
+            response: { clientDataJSON: '', attestationObject: '' },
+            clientExtensionResults: {},
+          },
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().message).toContain('Registration verification failed');
+    });
+  });
+
+  describe('Assertion with null auth_request_id', () => {
+    it('skips auth request update when auth_request_id is null', async () => {
+      // Challenge lookup — valid but no auth_request_id
+      sqlMock.mockResolvedValueOnce([{
+        challenge: 'valid-challenge',
+        principal_id: 'user_123',
+        developer_id: 'dev_TEST',
+        auth_request_id: null,
+      }]);
+      // Consume challenge
+      sqlMock.mockResolvedValueOnce([]);
+      // Credential lookup
+      sqlMock.mockResolvedValueOnce([{
+        id: 'cred_1',
+        credential_id: 'bW9jay1jcmVk',
+        public_key: 'AQIDBA',
+        counter: 5,
+        transports: ['internal'],
+      }]);
+      // Update counter
+      sqlMock.mockResolvedValueOnce([]);
+      // Note: no auth request update expected since auth_request_id is null
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/webauthn/assert/verify',
+        payload: {
+          challengeId: 'wac_no_areq',
+          response: {
+            id: 'bW9jay1jcmVk', rawId: 'bW9jay1jcmVk', type: 'public-key',
+            response: { clientDataJSON: '', authenticatorData: '', signature: '' },
+            clientExtensionResults: {},
+          },
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().verified).toBe(true);
+      // Only 4 SQL calls (no auth request update)
+      expect(sqlMock).toHaveBeenCalledTimes(4);
+    });
+  });
+});
+
+// ── VC-JWT Security ──────────────────────────────────────────────────────
+
+describe('VC-JWT Security', () => {
+  describe('Credential stuffing / injection', () => {
+    it('rejects garbage JWT input', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/credentials/verify',
+        payload: { credential: 'not-a-jwt-at-all' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().valid).toBe(false);
+      expect(res.json().error).toBe('Invalid JWT format');
+    });
+
+    it('rejects JWT with base64 but invalid JSON', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/credentials/verify',
+        payload: { credential: 'eyJ0eXAiOiJKV1QifQ.invalid.sig' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().valid).toBe(false);
+    });
+
+    it('rejects JWT signed with unknown key', async () => {
+      const { privateKey } = await generateKeyPair('RS256');
+      const fakeJwt = await new SignJWT({
+        vc: {
+          '@context': ['https://www.w3.org/ns/credentials/v2'],
+          type: ['VerifiableCredential'],
+          credentialSubject: { id: 'did:test:agent' },
+        },
+      })
+        .setProtectedHeader({ alg: 'RS256', kid: 'fake-kid' })
+        .setIssuer('did:web:attacker.dev')
+        .setSubject('did:test:agent')
+        .setJti('vc_INJECTED')
+        .setIssuedAt()
+        .setExpirationTime(Math.floor(Date.now() / 1000) + 3600)
+        .sign(privateKey);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/credentials/verify',
+        payload: { credential: fakeJwt },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().valid).toBe(false);
+    });
+
+    it('rejects VC-JWT signed with wrong algorithm (HS256)', async () => {
+      // Try to use a symmetric algorithm against an asymmetric key verifier
+      const { createSecretKey } = await import('node:crypto');
+      const secret = createSecretKey(Buffer.alloc(32, 'secret'));
+
+      const fakeJwt = await new SignJWT({
+        vc: { type: ['VerifiableCredential'] },
+      })
+        .setProtectedHeader({ alg: 'HS256' })
+        .setIssuer('did:web:grantex.dev')
+        .setSubject('did:test:agent')
+        .setJti('vc_HS256')
+        .setIssuedAt()
+        .setExpirationTime(Math.floor(Date.now() / 1000) + 3600)
+        .sign(secret);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/credentials/verify',
+        payload: { credential: fakeJwt },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().valid).toBe(false);
+    });
+  });
+
+  describe('StatusList bit manipulation', () => {
+    it('correctly detects revoked credential at non-zero bit index', async () => {
+      const { privateKey, kid } = getKeyPair();
+      const statusListIdx = 42;
+
+      // Create VC pointing to bit index 42
+      const vcJwt = await new SignJWT({
+        vc: {
+          '@context': ['https://www.w3.org/ns/credentials/v2'],
+          type: ['VerifiableCredential', 'AgentGrantCredential'],
+          credentialSubject: { id: 'did:test:agent', type: 'AIAgent' },
+          credentialStatus: {
+            id: `https://grantex.dev/v1/credentials/status/vcsl_BITTEST#${statusListIdx}`,
+            type: 'StatusList2021Entry',
+            statusPurpose: 'revocation',
+            statusListIndex: String(statusListIdx),
+            statusListCredential: 'https://grantex.dev/v1/credentials/status/vcsl_BITTEST',
+          },
+        },
+      })
+        .setProtectedHeader({ alg: 'RS256', kid, typ: 'JWT' })
+        .setIssuer('did:web:grantex.dev')
+        .setSubject('did:test:agent')
+        .setJti('vc_BIT42')
+        .setIssuedAt()
+        .setExpirationTime(Math.floor(Date.now() / 1000) + 3600)
+        .sign(privateKey);
+
+      // Create status list with bit 42 set
+      const bits = Buffer.alloc(16384, 0);
+      const byteIndex = Math.floor(statusListIdx / 8); // byte 5
+      const bitIndex = 7 - (statusListIdx % 8); // bit within byte, MSB-first
+      bits[byteIndex]! |= 1 << bitIndex;
+      const encodedList = gzipSync(bits).toString('base64url');
+
+      sqlMock.mockResolvedValueOnce([{ encoded_list: encodedList }]);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/credentials/verify',
+        payload: { credential: vcJwt },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().valid).toBe(false);
+      expect(res.json().revoked).toBe(true);
+    });
+
+    it('does not flag credential at adjacent bit index', async () => {
+      const { privateKey, kid } = getKeyPair();
+      const statusListIdx = 43;
+
+      // Create VC pointing to bit index 43
+      const vcJwt = await new SignJWT({
+        vc: {
+          '@context': ['https://www.w3.org/ns/credentials/v2'],
+          type: ['VerifiableCredential', 'AgentGrantCredential'],
+          credentialSubject: { id: 'did:test:agent', type: 'AIAgent' },
+          credentialStatus: {
+            id: `https://grantex.dev/v1/credentials/status/vcsl_ADJ#${statusListIdx}`,
+            type: 'StatusList2021Entry',
+            statusPurpose: 'revocation',
+            statusListIndex: String(statusListIdx),
+            statusListCredential: 'https://grantex.dev/v1/credentials/status/vcsl_ADJ',
+          },
+        },
+      })
+        .setProtectedHeader({ alg: 'RS256', kid, typ: 'JWT' })
+        .setIssuer('did:web:grantex.dev')
+        .setSubject('did:test:agent')
+        .setJti('vc_BIT43')
+        .setIssuedAt()
+        .setExpirationTime(Math.floor(Date.now() / 1000) + 3600)
+        .sign(privateKey);
+
+      // Create status list with bit 42 set (NOT 43)
+      const bits = Buffer.alloc(16384, 0);
+      const byteIdx = Math.floor(42 / 8);
+      const bitIdx = 7 - (42 % 8);
+      bits[byteIdx]! |= 1 << bitIdx;
+      const encodedList = gzipSync(bits).toString('base64url');
+
+      sqlMock.mockResolvedValueOnce([{ encoded_list: encodedList }]);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/credentials/verify',
+        payload: { credential: vcJwt },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().valid).toBe(true);
+    });
+  });
+});
+
+// ── Token Security ──────────────────────────────────────────────────────
+
+describe('Token Security', () => {
+  it('rejects revoked parent grant token in delegation', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const parentToken = await signGrantToken({
+      sub: 'user_123',
+      agt: TEST_AGENT.did,
+      dev: TEST_DEVELOPER.id,
+      scp: ['read', 'write'],
+      jti: 'tok_REVOKED_SEC',
+      grnt: 'grnt_REVOKED_SEC',
+      exp,
+    });
+
+    seedAuth();
+    mockRedis.get.mockResolvedValueOnce('1'); // parent token revoked in Redis
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/grants/delegate',
+      headers: authHeader(),
+      payload: {
+        parentGrantToken: parentToken,
+        subAgentId: 'ag_SUBAGENT',
+        scopes: ['read'],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toMatch(/revoked/);
+  });
+
+  it('rejects delegation with scope escalation', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const parentToken = await signGrantToken({
+      sub: 'user_123',
+      agt: TEST_AGENT.did,
+      dev: TEST_DEVELOPER.id,
+      scp: ['read'],
+      jti: 'tok_SCOPE_SEC',
+      grnt: 'grnt_SCOPE_SEC',
+      exp,
+    });
+
+    seedAuth();
+    mockRedis.get.mockResolvedValue(null);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/grants/delegate',
+      headers: authHeader(),
+      payload: {
+        parentGrantToken: parentToken,
+        subAgentId: 'ag_SUBAGENT',
+        scopes: ['read', 'write', 'admin'], // exceeds parent
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toMatch(/exceed parent/);
+  });
+});
+
+// ── API Key Security ────────────────────────────────────────────────────
+
+describe('API Key Security', () => {
+  const protectedEndpoints = [
+    { method: 'POST' as const, url: '/v1/webauthn/register/options', payload: { principalId: 'user_123' } },
+    { method: 'POST' as const, url: '/v1/webauthn/register/verify', payload: { challengeId: 'test', response: {} } },
+    { method: 'GET' as const, url: '/v1/webauthn/credentials?principalId=user_123' },
+    { method: 'DELETE' as const, url: '/v1/webauthn/credentials/cred_1' },
+    { method: 'GET' as const, url: '/v1/credentials/vc_TEST' },
+    { method: 'GET' as const, url: '/v1/credentials' },
+    { method: 'PATCH' as const, url: '/v1/me', payload: { fidoRequired: true } },
+  ];
+
+  for (const ep of protectedEndpoints) {
+    it(`returns 401 for ${ep.method} ${ep.url} without auth`, async () => {
+      const res = await app.inject({
+        method: ep.method,
+        url: ep.url,
+        ...(ep.payload ? { payload: ep.payload } : {}),
+      });
+
+      expect(res.statusCode).toBe(401);
+    });
+  }
+
+  const publicEndpoints = [
+    { method: 'POST' as const, url: '/v1/webauthn/assert/options', payload: { authRequestId: 'areq_test' } },
+    { method: 'POST' as const, url: '/v1/webauthn/assert/verify', payload: { challengeId: 'wac_test', response: {} } },
+    { method: 'POST' as const, url: '/v1/credentials/verify', payload: { credential: 'test' } },
+    { method: 'GET' as const, url: '/v1/credentials/status/vcsl_TEST' },
+    { method: 'GET' as const, url: '/.well-known/did.json' },
+  ];
+
+  for (const ep of publicEndpoints) {
+    it(`allows ${ep.method} ${ep.url} without auth (public endpoint)`, async () => {
+      // Mock SQL to return something expected
+      sqlMock.mockResolvedValueOnce([]);
+
+      const res = await app.inject({
+        method: ep.method,
+        url: ep.url,
+        ...(ep.payload ? { payload: ep.payload } : {}),
+      });
+
+      // Should NOT be 401
+      expect(res.statusCode).not.toBe(401);
+    });
+  }
+});

--- a/apps/auth-service/tests/token.test.ts
+++ b/apps/auth-service/tests/token.test.ts
@@ -123,4 +123,29 @@ describe('POST /v1/token', () => {
 
     expect(res.statusCode).toBe(400);
   });
+
+  it('succeeds without verifiableCredential when VC issuance fails (best-effort)', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([validAuthRequest]);  // Auth request lookup
+    sqlMock.mockResolvedValueOnce([]);  // INSERT grants
+    sqlMock.mockResolvedValueOnce([]);  // INSERT grant_tokens
+    sqlMock.mockResolvedValueOnce([]);  // INSERT refresh_tokens
+    sqlMock.mockResolvedValueOnce([]);  // UPDATE auth_requests
+    sqlMock.mockResolvedValueOnce([]);  // Budget check (no allocation)
+    // VC issuance: getOrCreateStatusList SQL fails → catch block swallows error
+    sqlMock.mockRejectedValueOnce(new Error('VC status list query failed'));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token',
+      headers: authHeader(),
+      payload: { code: 'code-vc-fail', agentId: TEST_AGENT.id, credentialFormat: 'vc-jwt' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.grantToken).toBeDefined();
+    expect(body.verifiableCredential).toBeUndefined();
+  });
+
 });

--- a/apps/auth-service/tests/tokens.test.ts
+++ b/apps/auth-service/tests/tokens.test.ts
@@ -106,6 +106,18 @@ describe('POST /v1/tokens/verify', () => {
     const body = res.json<{ valid: boolean }>();
     expect(body.valid).toBe(false);
   });
+
+  it('returns 400 when token field is missing', async () => {
+    seedAuth();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/tokens/verify',
+      headers: authHeader(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('BAD_REQUEST');
+  });
 });
 
 describe('POST /v1/tokens/revoke', () => {

--- a/apps/auth-service/tests/vault.test.ts
+++ b/apps/auth-service/tests/vault.test.ts
@@ -266,4 +266,16 @@ describe('POST /v1/vault/credentials/exchange', () => {
 
     expect(res.statusCode).toBe(404);
   });
+
+  it('returns 401 when grant token is expired/invalid', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/vault/credentials/exchange',
+      headers: { authorization: 'Bearer invalid.jwt.token' },
+      payload: { service: 'google' },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('UNAUTHORIZED');
+  });
 });

--- a/apps/auth-service/tests/vc-lib.test.ts
+++ b/apps/auth-service/tests/vc-lib.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initKeys, getKeyPair } from '../src/lib/crypto.js';
+import { sqlMock } from './setup.js';
+
+// Import after mocks are set up by setup.ts
+import {
+  issueAgentGrantVC,
+  verifyAgentGrantVC,
+  getOrCreateStatusList,
+  revokeVCsByGrantIds,
+} from '../src/lib/vc.js';
+
+beforeAll(async () => {
+  await initKeys();
+});
+
+// ── getOrCreateStatusList ───────────────────────────────────────────────────
+
+describe('getOrCreateStatusList', () => {
+  it('creates a new status list when none exists', async () => {
+    // SELECT existing → empty
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT new list
+    sqlMock.mockResolvedValueOnce([]);
+
+    const result = await getOrCreateStatusList('dev_TEST');
+
+    expect(result.id).toMatch(/^vcsl_/);
+    expect(result.nextIndex).toBe(0);
+  });
+
+  it('returns existing status list', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      id: 'vcsl_EXISTING',
+      next_index: 5,
+    }]);
+
+    const result = await getOrCreateStatusList('dev_TEST');
+
+    expect(result.id).toBe('vcsl_EXISTING');
+    expect(result.nextIndex).toBe(5);
+  });
+});
+
+// ── issueAgentGrantVC ───────────────────────────────────────────────────────
+
+describe('issueAgentGrantVC', () => {
+  it('creates a valid VC-JWT structure', async () => {
+    // getOrCreateStatusList: SELECT existing
+    sqlMock.mockResolvedValueOnce([{
+      id: 'vcsl_TEST1',
+      next_index: 0,
+    }]);
+    // UPDATE next_index
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT verifiable_credentials
+    sqlMock.mockResolvedValueOnce([]);
+
+    const result = await issueAgentGrantVC({
+      grantId: 'grnt_TEST1',
+      agentDid: 'did:grantex:ag_TEST',
+      principalId: 'user_123',
+      developerId: 'dev_TEST',
+      scopes: ['read', 'write'],
+      expiresAt: new Date(Date.now() + 86400_000),
+    });
+
+    expect(result.vcId).toMatch(/^vc_/);
+    expect(typeof result.vcJwt).toBe('string');
+    expect(result.statusListIdx).toBe(0);
+
+    // Decode and check the JWT payload
+    const { decodeJwt } = await import('jose');
+    const payload = decodeJwt(result.vcJwt);
+
+    expect(payload.iss).toBe('did:web:grantex.dev');
+    expect(payload.sub).toBe('did:grantex:ag_TEST');
+    expect(payload.jti).toBe(result.vcId);
+    expect(payload['vc']).toBeDefined();
+
+    const vc = payload['vc'] as Record<string, unknown>;
+    expect(vc['@context']).toEqual([
+      'https://www.w3.org/ns/credentials/v2',
+      'https://grantex.dev/ns/credentials/v1',
+    ]);
+    expect(vc['type']).toEqual(['VerifiableCredential', 'AgentGrantCredential']);
+
+    const subject = vc['credentialSubject'] as Record<string, unknown>;
+    expect(subject['id']).toBe('did:grantex:ag_TEST');
+    expect(subject['type']).toBe('AIAgent');
+    expect(subject['principalId']).toBe('user_123');
+    expect(subject['grantId']).toBe('grnt_TEST1');
+    expect(subject['scopes']).toEqual(['read', 'write']);
+    expect(subject['delegationDepth']).toBe(0);
+
+    const status = vc['credentialStatus'] as Record<string, unknown>;
+    expect(status['type']).toBe('StatusList2021Entry');
+    expect(status['statusPurpose']).toBe('revocation');
+  });
+
+  it('includes FIDO evidence when provided', async () => {
+    // getOrCreateStatusList: SELECT existing
+    sqlMock.mockResolvedValueOnce([{
+      id: 'vcsl_TEST2',
+      next_index: 1,
+    }]);
+    // UPDATE next_index
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT verifiable_credentials
+    sqlMock.mockResolvedValueOnce([]);
+
+    const result = await issueAgentGrantVC({
+      grantId: 'grnt_TEST2',
+      agentDid: 'did:grantex:ag_TEST',
+      principalId: 'user_123',
+      developerId: 'dev_TEST',
+      scopes: ['read'],
+      expiresAt: new Date(Date.now() + 86400_000),
+      fidoEvidence: { aaguid: '00000000-0000-0000-0000-000000000000' },
+    });
+
+    const { decodeJwt } = await import('jose');
+    const payload = decodeJwt(result.vcJwt);
+    const vc = payload['vc'] as Record<string, unknown>;
+    const evidence = vc['evidence'] as Record<string, unknown>[];
+
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0]!['type']).toBe('FidoAttestation');
+    expect(evidence[0]!['aaguid']).toBe('00000000-0000-0000-0000-000000000000');
+  });
+});
+
+// ── verifyAgentGrantVC ──────────────────────────────────────────────────────
+
+describe('verifyAgentGrantVC', () => {
+  it('succeeds for a valid VC-JWT', async () => {
+    // Issue a VC first
+    sqlMock.mockResolvedValueOnce([{ id: 'vcsl_V1', next_index: 0 }]);
+    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([]);
+
+    const { vcJwt } = await issueAgentGrantVC({
+      grantId: 'grnt_V1',
+      agentDid: 'did:grantex:ag_V1',
+      principalId: 'user_v1',
+      developerId: 'dev_TEST',
+      scopes: ['read'],
+      expiresAt: new Date(Date.now() + 86400_000),
+    });
+
+    // verifyAgentGrantVC: SELECT status list for revocation check
+    sqlMock.mockResolvedValueOnce([]);
+
+    const result = await verifyAgentGrantVC(vcJwt);
+
+    expect(result.valid).toBe(true);
+    expect(result.vcId).toMatch(/^vc_/);
+    expect(result.payload).toBeDefined();
+  });
+
+  it('returns invalid for garbage input', async () => {
+    const result = await verifyAgentGrantVC('not-a-jwt');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid JWT format');
+  });
+
+  it('returns invalid for a JWT with wrong signature', async () => {
+    // Create a JWT signed with a different key
+    const { generateKeyPair } = await import('jose');
+    const { privateKey } = await generateKeyPair('RS256');
+    const fakeVcJwt = await new (await import('jose')).SignJWT({ vc: {} })
+      .setProtectedHeader({ alg: 'RS256' })
+      .setIssuer('did:web:fake.dev')
+      .setSubject('did:fake:agent')
+      .setJti('vc_FAKE')
+      .setIssuedAt()
+      .setExpirationTime(Math.floor(Date.now() / 1000) + 3600)
+      .sign(privateKey);
+
+    const result = await verifyAgentGrantVC(fakeVcJwt);
+    expect(result.valid).toBe(false);
+    expect(result.vcId).toBe('vc_FAKE');
+  });
+
+  it('returns invalid when vc claim is missing', async () => {
+    const { privateKey, kid } = getKeyPair();
+    const { SignJWT } = await import('jose');
+    const jwt = await new SignJWT({ notVc: 'something' })
+      .setProtectedHeader({ alg: 'RS256', kid })
+      .setIssuer('did:web:grantex.dev')
+      .setSubject('did:test:agent')
+      .setJti('vc_NOVC')
+      .setIssuedAt()
+      .setExpirationTime(Math.floor(Date.now() / 1000) + 3600)
+      .sign(privateKey);
+
+    const result = await verifyAgentGrantVC(jwt);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Missing vc claim');
+  });
+
+  it('returns expired for an expired VC-JWT', async () => {
+    const { privateKey, kid } = getKeyPair();
+    const expiredVcJwt = await new (await import('jose')).SignJWT({
+      vc: {
+        '@context': ['https://www.w3.org/ns/credentials/v2'],
+        type: ['VerifiableCredential'],
+        credentialSubject: { id: 'did:test:agent' },
+      },
+    })
+      .setProtectedHeader({ alg: 'RS256', kid })
+      .setIssuer('did:web:grantex.dev')
+      .setSubject('did:test:agent')
+      .setJti('vc_EXPIRED')
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 7200)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 3600)
+      .sign(privateKey);
+
+    const result = await verifyAgentGrantVC(expiredVcJwt);
+    expect(result.valid).toBe(false);
+    expect(result.expired).toBe(true);
+  });
+});
+
+// ── revokeVCsByGrantIds ─────────────────────────────────────────────────────
+
+describe('revokeVCsByGrantIds', () => {
+  it('does nothing for empty grant IDs', async () => {
+    await revokeVCsByGrantIds([], 'dev_TEST');
+    // No SQL calls expected
+  });
+
+  it('does nothing when no active VCs found', async () => {
+    // SELECT active VCs → empty
+    sqlMock.mockResolvedValueOnce([]);
+
+    await revokeVCsByGrantIds(['grnt_1'], 'dev_TEST');
+  });
+
+  it('flips correct bits in status list', async () => {
+    // SELECT active VCs
+    sqlMock.mockResolvedValueOnce([
+      { id: 'vc_R1', status_list_idx: 3 },
+      { id: 'vc_R2', status_list_idx: 7 },
+    ]);
+    // UPDATE VCs to revoked
+    sqlMock.mockResolvedValueOnce([]);
+    // SELECT status list for bit flipping
+    const { gzipSync } = await import('node:zlib');
+    const emptyBits = Buffer.alloc(16384, 0);
+    const encoded = gzipSync(emptyBits).toString('base64url');
+    sqlMock.mockResolvedValueOnce([{
+      id: 'vcsl_BIT',
+      encoded_list: encoded,
+    }]);
+    // UPDATE status list with flipped bits
+    sqlMock.mockResolvedValueOnce([]);
+
+    await revokeVCsByGrantIds(['grnt_R1'], 'dev_TEST');
+
+    // Verify the UPDATE call was made with updated encoded_list
+    expect(sqlMock).toHaveBeenCalled();
+    // The 4th call (index 3) should be the status list update
+    const lastCallArgs = sqlMock.mock.calls[sqlMock.mock.calls.length - 1];
+    // The SQL template should contain the encoded_list update
+    expect(lastCallArgs).toBeDefined();
+  });
+});

--- a/apps/auth-service/tests/verify-email.test.ts
+++ b/apps/auth-service/tests/verify-email.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { buildTestApp, seedAuth, authHeader, sqlMock } from './helpers.js';
 import type { FastifyInstance } from 'fastify';
 
@@ -47,6 +47,26 @@ describe('POST /v1/signup/verify', () => {
     });
 
     expect(res.statusCode).toBe(401);
+  });
+
+  it('succeeds even when email sending fails', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]); // INSERT email_verification
+
+    // Mock sendEmail to throw
+    const { sendEmail } = await import('../src/lib/email.js');
+    const sendEmailMock = vi.mocked(sendEmail);
+    sendEmailMock.mockRejectedValueOnce(new Error('SMTP connection failed'));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/signup/verify',
+      headers: authHeader(),
+      payload: { email: 'test@example.com' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json().message).toBe('Verification email sent');
   });
 });
 

--- a/apps/auth-service/tests/webauthn-lib.test.ts
+++ b/apps/auth-service/tests/webauthn-lib.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Unmock the real webauthn lib (global setup.ts mocks it)
+vi.unmock('../src/lib/webauthn.js');
+
+// Hoist mocks so they're available in vi.mock factories
+const {
+  mockGenerateRegistrationOptions,
+  mockVerifyRegistrationResponse,
+  mockGenerateAuthenticationOptions,
+  mockVerifyAuthenticationResponse,
+} = vi.hoisted(() => ({
+  mockGenerateRegistrationOptions: vi.fn(),
+  mockVerifyRegistrationResponse: vi.fn(),
+  mockGenerateAuthenticationOptions: vi.fn(),
+  mockVerifyAuthenticationResponse: vi.fn(),
+}));
+
+vi.mock('@simplewebauthn/server', () => ({
+  generateRegistrationOptions: mockGenerateRegistrationOptions,
+  verifyRegistrationResponse: mockVerifyRegistrationResponse,
+  generateAuthenticationOptions: mockGenerateAuthenticationOptions,
+  verifyAuthenticationResponse: mockVerifyAuthenticationResponse,
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    fidoRpId: 'grantex.dev',
+    fidoOrigin: 'https://grantex.dev',
+  },
+}));
+
+import {
+  generateRegOptions,
+  verifyRegResponse,
+  generateAuthOptions,
+  verifyAuthResponse,
+} from '../src/lib/webauthn.js';
+import type { StoredCredential } from '../src/lib/webauthn.js';
+
+beforeEach(() => {
+  mockGenerateRegistrationOptions.mockReset();
+  mockVerifyRegistrationResponse.mockReset();
+  mockGenerateAuthenticationOptions.mockReset();
+  mockVerifyAuthenticationResponse.mockReset();
+});
+
+// ---------------------------------------------------------------
+// generateRegOptions
+// ---------------------------------------------------------------
+describe('generateRegOptions', () => {
+  it('calls generateRegistrationOptions with correct params', async () => {
+    const mockResult = { challenge: 'abc123', rp: { name: 'TestApp', id: 'grantex.dev' } };
+    mockGenerateRegistrationOptions.mockResolvedValueOnce(mockResult);
+
+    const result = await generateRegOptions('user_42', 'TestApp', []);
+
+    expect(result).toEqual(mockResult);
+    expect(mockGenerateRegistrationOptions).toHaveBeenCalledOnce();
+
+    const args = mockGenerateRegistrationOptions.mock.calls[0][0];
+    expect(args.rpName).toBe('TestApp');
+    expect(args.rpID).toBe('grantex.dev');
+    expect(args.userName).toBe('user_42');
+    expect(args.attestationType).toBe('direct');
+    expect(args.authenticatorSelection).toEqual({
+      residentKey: 'preferred',
+      userVerification: 'preferred',
+    });
+    expect(args.excludeCredentials).toEqual([]);
+  });
+
+  it('encodes principalId as userID via TextEncoder', async () => {
+    mockGenerateRegistrationOptions.mockResolvedValueOnce({});
+
+    await generateRegOptions('alice', 'App', []);
+
+    const args = mockGenerateRegistrationOptions.mock.calls[0][0];
+    const expected = new TextEncoder().encode('alice');
+    expect(new Uint8Array(args.userID)).toEqual(expected);
+  });
+
+  it('maps existingCredentials to excludeCredentials', async () => {
+    mockGenerateRegistrationOptions.mockResolvedValueOnce({});
+
+    const creds: StoredCredential[] = [
+      { credentialId: 'cred-aaa', publicKey: 'AQID', counter: 3, transports: ['usb', 'nfc'] },
+      { credentialId: 'cred-bbb', publicKey: 'BAUG', counter: 0, transports: ['internal'] },
+    ];
+
+    await generateRegOptions('user_1', 'App', creds);
+
+    const args = mockGenerateRegistrationOptions.mock.calls[0][0];
+    expect(args.excludeCredentials).toEqual([
+      { id: 'cred-aaa', transports: ['usb', 'nfc'] },
+      { id: 'cred-bbb', transports: ['internal'] },
+    ]);
+  });
+
+  it('handles empty transports in credentials', async () => {
+    mockGenerateRegistrationOptions.mockResolvedValueOnce({});
+
+    const creds: StoredCredential[] = [
+      { credentialId: 'cred-x', publicKey: 'key', counter: 0, transports: [] },
+    ];
+
+    await generateRegOptions('user_2', 'App', creds);
+
+    const args = mockGenerateRegistrationOptions.mock.calls[0][0];
+    expect(args.excludeCredentials).toEqual([
+      { id: 'cred-x', transports: [] },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------
+// verifyRegResponse
+// ---------------------------------------------------------------
+describe('verifyRegResponse', () => {
+  it('calls verifyRegistrationResponse with correct params', async () => {
+    const mockVerification = { verified: true, registrationInfo: { credential: {} } };
+    mockVerifyRegistrationResponse.mockResolvedValueOnce(mockVerification);
+
+    const fakeResponse = {
+      id: 'cred-id',
+      rawId: 'cred-id',
+      type: 'public-key' as const,
+      response: { clientDataJSON: 'abc', attestationObject: 'def' },
+      clientExtensionResults: {},
+    };
+
+    const result = await verifyRegResponse(fakeResponse as any, 'challenge-xyz');
+
+    expect(result).toEqual(mockVerification);
+    expect(mockVerifyRegistrationResponse).toHaveBeenCalledOnce();
+
+    const args = mockVerifyRegistrationResponse.mock.calls[0][0];
+    expect(args.response).toBe(fakeResponse);
+    expect(args.expectedChallenge).toBe('challenge-xyz');
+    expect(args.expectedOrigin).toBe('https://grantex.dev');
+    expect(args.expectedRPID).toBe('grantex.dev');
+  });
+
+  it('returns the upstream result unchanged', async () => {
+    const upstream = { verified: false };
+    mockVerifyRegistrationResponse.mockResolvedValueOnce(upstream);
+
+    const result = await verifyRegResponse({} as any, 'ch');
+
+    expect(result).toBe(upstream);
+  });
+});
+
+// ---------------------------------------------------------------
+// generateAuthOptions
+// ---------------------------------------------------------------
+describe('generateAuthOptions', () => {
+  it('calls generateAuthenticationOptions with correct params', async () => {
+    const mockResult = { challenge: 'auth-challenge', rpId: 'grantex.dev' };
+    mockGenerateAuthenticationOptions.mockResolvedValueOnce(mockResult);
+
+    const result = await generateAuthOptions([]);
+
+    expect(result).toEqual(mockResult);
+    expect(mockGenerateAuthenticationOptions).toHaveBeenCalledOnce();
+
+    const args = mockGenerateAuthenticationOptions.mock.calls[0][0];
+    expect(args.rpID).toBe('grantex.dev');
+    expect(args.userVerification).toBe('preferred');
+    expect(args.allowCredentials).toEqual([]);
+  });
+
+  it('maps credentials to allowCredentials', async () => {
+    mockGenerateAuthenticationOptions.mockResolvedValueOnce({});
+
+    const creds: StoredCredential[] = [
+      { credentialId: 'cred-111', publicKey: 'pk1', counter: 10, transports: ['ble'] },
+      { credentialId: 'cred-222', publicKey: 'pk2', counter: 20, transports: ['usb', 'internal'] },
+    ];
+
+    await generateAuthOptions(creds);
+
+    const args = mockGenerateAuthenticationOptions.mock.calls[0][0];
+    expect(args.allowCredentials).toEqual([
+      { id: 'cred-111', transports: ['ble'] },
+      { id: 'cred-222', transports: ['usb', 'internal'] },
+    ]);
+  });
+
+  it('preserves credential order in allowCredentials', async () => {
+    mockGenerateAuthenticationOptions.mockResolvedValueOnce({});
+
+    const creds: StoredCredential[] = [
+      { credentialId: 'z-last', publicKey: 'k', counter: 0, transports: [] },
+      { credentialId: 'a-first', publicKey: 'k', counter: 0, transports: [] },
+    ];
+
+    await generateAuthOptions(creds);
+
+    const args = mockGenerateAuthenticationOptions.mock.calls[0][0];
+    expect(args.allowCredentials[0].id).toBe('z-last');
+    expect(args.allowCredentials[1].id).toBe('a-first');
+  });
+});
+
+// ---------------------------------------------------------------
+// verifyAuthResponse
+// ---------------------------------------------------------------
+describe('verifyAuthResponse', () => {
+  it('calls verifyAuthenticationResponse with correct params', async () => {
+    const mockResult = { verified: true, authenticationInfo: { newCounter: 6 } };
+    mockVerifyAuthenticationResponse.mockResolvedValueOnce(mockResult);
+
+    const fakeResponse = {
+      id: 'cred-id',
+      rawId: 'cred-id',
+      type: 'public-key' as const,
+      response: { clientDataJSON: 'cd', authenticatorData: 'ad', signature: 'sig' },
+      clientExtensionResults: {},
+    };
+
+    const credential: StoredCredential = {
+      credentialId: 'cred-id',
+      publicKey: 'AQIDBA', // base64url for [1, 2, 3, 4]
+      counter: 5,
+      transports: ['internal'],
+    };
+
+    const result = await verifyAuthResponse(fakeResponse as any, 'challenge-abc', credential);
+
+    expect(result).toEqual(mockResult);
+    expect(mockVerifyAuthenticationResponse).toHaveBeenCalledOnce();
+
+    const args = mockVerifyAuthenticationResponse.mock.calls[0][0];
+    expect(args.response).toBe(fakeResponse);
+    expect(args.expectedChallenge).toBe('challenge-abc');
+    expect(args.expectedOrigin).toBe('https://grantex.dev');
+    expect(args.expectedRPID).toBe('grantex.dev');
+    expect(args.credential.id).toBe('cred-id');
+    expect(args.credential.counter).toBe(5);
+    expect(args.credential.transports).toEqual(['internal']);
+  });
+
+  it('converts base64url publicKey to Uint8Array via Buffer', async () => {
+    mockVerifyAuthenticationResponse.mockResolvedValueOnce({ verified: true });
+
+    // base64url encoding of bytes [1, 2, 3, 4]
+    const credential: StoredCredential = {
+      credentialId: 'cred-buf',
+      publicKey: 'AQIDBA',
+      counter: 0,
+      transports: [],
+    };
+
+    await verifyAuthResponse({} as any, 'ch', credential);
+
+    const args = mockVerifyAuthenticationResponse.mock.calls[0][0];
+    const key = args.credential.publicKey;
+
+    // Should be a Buffer (Uint8Array subclass) with the decoded bytes
+    expect(key).toBeInstanceOf(Uint8Array);
+    expect(Array.from(key)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('handles longer base64url publicKey values', async () => {
+    mockVerifyAuthenticationResponse.mockResolvedValueOnce({ verified: true });
+
+    // 32 bytes of key material
+    const keyBytes = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) keyBytes[i] = i;
+    const b64url = Buffer.from(keyBytes).toString('base64url');
+
+    const credential: StoredCredential = {
+      credentialId: 'cred-long',
+      publicKey: b64url,
+      counter: 100,
+      transports: ['usb'],
+    };
+
+    await verifyAuthResponse({} as any, 'ch', credential);
+
+    const args = mockVerifyAuthenticationResponse.mock.calls[0][0];
+    expect(Array.from(args.credential.publicKey)).toEqual(Array.from(keyBytes));
+  });
+
+  it('returns the upstream result unchanged', async () => {
+    const upstream = { verified: false, authenticationInfo: { newCounter: 0 } };
+    mockVerifyAuthenticationResponse.mockResolvedValueOnce(upstream);
+
+    const credential: StoredCredential = {
+      credentialId: 'c',
+      publicKey: 'AA',
+      counter: 0,
+      transports: [],
+    };
+
+    const result = await verifyAuthResponse({} as any, 'ch', credential);
+
+    expect(result).toBe(upstream);
+  });
+});

--- a/apps/auth-service/tests/webauthn.test.ts
+++ b/apps/auth-service/tests/webauthn.test.ts
@@ -56,6 +56,29 @@ describe('POST /v1/webauthn/register/options', () => {
 
     expect(res.statusCode).toBe(401);
   });
+
+  it('passes existing credentials to generateRegOptions for exclusion', async () => {
+    seedAuth();
+    // Return existing credentials
+    sqlMock.mockResolvedValueOnce([{
+      credential_id: 'existingCredId',
+      public_key: 'existingPK',
+      counter: 5,
+      transports: ['usb', 'ble'],
+    }]);
+    // Insert challenge
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/register/options',
+      headers: authHeader(),
+      payload: { principalId: 'user_with_cred' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().challengeId).toBeDefined();
+  });
 });
 
 // ---------------------------------------------------------------

--- a/apps/auth-service/tests/webhookDelivery.test.ts
+++ b/apps/auth-service/tests/webhookDelivery.test.ts
@@ -106,6 +106,42 @@ describe('startWebhookDeliveryWorker', () => {
     clearInterval(timer);
   });
 
+  it('logs error when initial processDeliveries rejects', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    sqlMock.mockRejectedValueOnce(new Error('DB connection lost'));
+
+    const timer = startWebhookDeliveryWorker(sqlMock as never, 60_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[webhook-delivery] Error on initial run:',
+      expect.any(Error),
+    );
+
+    consoleSpy.mockRestore();
+    clearInterval(timer);
+  });
+
+  it('logs error when interval processDeliveries rejects', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Initial run succeeds
+    sqlMock.mockResolvedValueOnce([]);
+    // Interval run fails
+    sqlMock.mockRejectedValueOnce(new Error('DB connection lost'));
+
+    const timer = startWebhookDeliveryWorker(sqlMock as never, 10_000);
+    await vi.advanceTimersByTimeAsync(0); // initial run
+    await vi.advanceTimersByTimeAsync(10_000); // interval run
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[webhook-delivery] Error processing deliveries:',
+      expect.any(Error),
+    );
+
+    consoleSpy.mockRestore();
+    clearInterval(timer);
+  });
+
   it('runs on the configured interval', async () => {
     // First run (immediate)
     sqlMock.mockResolvedValueOnce([]);

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -3,7 +3,7 @@ title: "API Reference"
 description: "Complete REST API reference for the Grantex Auth Service"
 ---
 
-The Grantex Auth Service exposes a REST API covering agent registration, authorization flows, token management, audit logging, policy enforcement, anomaly detection, compliance exports, SCIM provisioning, SSO, and billing.
+The Grantex Auth Service exposes a REST API covering agent registration, authorization flows, token management, audit logging, policy enforcement, anomaly detection, compliance exports, SCIM provisioning, SSO, billing, FIDO2/WebAuthn passkey management, W3C Verifiable Credentials, and DID infrastructure.
 
 ## Base URLs
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -47,6 +47,15 @@
             ]
           },
           {
+            "group": "Trust & Identity",
+            "pages": [
+              "features/fido-webauthn",
+              "features/verifiable-credentials",
+              "features/sd-jwt",
+              "features/did-infrastructure"
+            ]
+          },
+          {
             "group": "Guides",
             "pages": [
               "guides/rate-limits",
@@ -422,6 +431,32 @@
               "api-reference/consent/get-consent-request-details",
               "api-reference/consent/approve-consent-end-user-action",
               "api-reference/consent/deny-consent-end-user-action"
+            ]
+          },
+          {
+            "group": "WebAuthn / FIDO",
+            "pages": [
+              "api-reference/webauthn/generate-registration-options",
+              "api-reference/webauthn/verify-registration",
+              "api-reference/webauthn/list-credentials",
+              "api-reference/webauthn/delete-credential",
+              "api-reference/webauthn/generate-assertion-options",
+              "api-reference/webauthn/verify-assertion"
+            ]
+          },
+          {
+            "group": "Verifiable Credentials",
+            "pages": [
+              "api-reference/credentials/get-credential",
+              "api-reference/credentials/list-credentials",
+              "api-reference/credentials/verify-credential",
+              "api-reference/credentials/status-list"
+            ]
+          },
+          {
+            "group": "DID",
+            "pages": [
+              "api-reference/did/did-document"
             ]
           }
         ]

--- a/docs/features/did-infrastructure.mdx
+++ b/docs/features/did-infrastructure.mdx
@@ -1,0 +1,269 @@
+---
+title: "DID Infrastructure"
+sidebarTitle: "DID Infrastructure"
+description: "W3C Decentralized Identifier (DID) infrastructure for independent credential verification. Resolve did:web:grantex.dev to verify any Grantex-issued credential."
+---
+
+## Overview
+
+Grantex publishes a W3C Decentralized Identifier (DID) document that enables any party to verify Grantex-issued Verifiable Credentials without contacting the Grantex API. The DID document contains the public keys used to sign VCs and is hosted at a well-known URL following the `did:web` method.
+
+## did:web:grantex.dev
+
+The Grantex DID follows the [did:web method specification](https://w3c-ccg.github.io/did-method-web/). The DID `did:web:grantex.dev` resolves to:
+
+```
+https://grantex.dev/.well-known/did.json
+```
+
+On the auth service, the DID document is served at:
+
+```
+https://api.grantex.dev/.well-known/did.json
+```
+
+Both URLs return the same document. The endpoint is public and requires no authentication.
+
+## DID Document Structure
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/jws-2020/v1"
+  ],
+  "id": "did:web:grantex.dev",
+  "verificationMethod": [
+    {
+      "id": "did:web:grantex.dev#key-1",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:grantex.dev",
+      "publicKeyJwk": {
+        "kty": "RSA",
+        "alg": "RS256",
+        "n": "...",
+        "e": "AQAB",
+        "kid": "key-1",
+        "use": "sig"
+      }
+    },
+    {
+      "id": "did:web:grantex.dev#key-2",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:grantex.dev",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "...",
+        "kid": "key-2",
+        "use": "sig"
+      }
+    }
+  ],
+  "authentication": [
+    "did:web:grantex.dev#key-1"
+  ],
+  "assertionMethod": [
+    "did:web:grantex.dev#key-1",
+    "did:web:grantex.dev#key-2"
+  ],
+  "service": [
+    {
+      "id": "did:web:grantex.dev#grantex-api",
+      "type": "GrantexAuthService",
+      "serviceEndpoint": "https://api.grantex.dev"
+    },
+    {
+      "id": "did:web:grantex.dev#status-list",
+      "type": "StatusList2021Service",
+      "serviceEndpoint": "https://api.grantex.dev/v1/credentials/status"
+    }
+  ]
+}
+```
+
+## Verification Methods
+
+The DID document contains two verification methods:
+
+| Key | Algorithm | Purpose |
+|-----|-----------|---------|
+| `key-1` | RS256 (RSA) | Primary signing key for grant tokens and VCs. Same key published in the JWKS endpoint. |
+| `key-2` | Ed25519 | Secondary signing key for future use with EdDSA-based VCs. |
+
+### Relationship to JWKS
+
+The RS256 key in the DID document is the same key available via the JWKS endpoint (`/.well-known/jwks.json`). The two endpoints serve different ecosystems:
+
+| Endpoint | Format | Used by |
+|----------|--------|---------|
+| `/.well-known/jwks.json` | JSON Web Key Set | JWT libraries verifying grant tokens |
+| `/.well-known/did.json` | DID Document | VC libraries verifying Verifiable Credentials |
+
+Both resolve to the same underlying RSA key pair. If you are only verifying grant tokens (JWTs), use the JWKS endpoint. If you are verifying Verifiable Credentials, use the DID document.
+
+## How Verification Works
+
+When a verifier receives a Grantex-issued Verifiable Credential (VC-JWT), the verification process is:
+
+```
+  Verifier                                      Public Internet
+    │                                                 │
+    │── 1. Decode VC-JWT header ──────────────────────│
+    │   (extract "iss": "did:web:grantex.dev")        │
+    │                                                 │
+    │── 2. Resolve DID ──────────────────────────────►│
+    │   GET https://grantex.dev/.well-known/did.json  │
+    │◄── DID document with public keys ───────────────│
+    │                                                 │
+    │── 3. Extract matching key (by kid) ─────────────│
+    │                                                 │
+    │── 4. Verify JWT signature ──────────────────────│
+    │   (RS256 or Ed25519)                            │
+    │                                                 │
+    │── 5. Check credentialStatus ───────────────────►│
+    │   GET .../v1/credentials/status/:id             │
+    │◄── StatusList2021 bitstring ────────────────────│
+    │                                                 │
+    │── 6. Check bit at statusListIndex ──────────────│
+    │   (0 = active, 1 = revoked)                     │
+    │                                                 │
+    │── Verification complete ────────────────────────│
+```
+
+### Example: Verifying Without the Grantex SDK
+
+Any JWT library can verify Grantex VCs. Here is a minimal example using `jose` (TypeScript) and `PyJWT` (Python):
+
+<CodeGroup>
+```typescript TypeScript
+import * as jose from 'jose';
+
+// 1. Fetch the DID document
+const didDoc = await fetch('https://api.grantex.dev/.well-known/did.json')
+  .then(r => r.json());
+
+// 2. Extract the RS256 key
+const keyEntry = didDoc.verificationMethod.find(
+  (vm: any) => vm.publicKeyJwk.alg === 'RS256'
+);
+const publicKey = await jose.importJWK(keyEntry.publicKeyJwk, 'RS256');
+
+// 3. Verify the VC-JWT
+const { payload } = await jose.jwtVerify(vcJwt, publicKey, {
+  issuer: 'did:web:grantex.dev',
+});
+
+console.log(payload.vc.credentialSubject);
+// { id: 'did:grantex:ag_01...', scopes: ['calendar:read'], ... }
+
+// 4. Check revocation status
+const statusUrl = payload.vc.credentialStatus.statusListCredential;
+const statusList = await fetch(statusUrl).then(r => r.json());
+// Decode the bitstring and check the index
+```
+
+```python Python
+import jwt
+import requests
+
+# 1. Fetch the DID document
+did_doc = requests.get("https://api.grantex.dev/.well-known/did.json").json()
+
+# 2. Extract the RS256 key
+key_entry = next(
+    vm for vm in did_doc["verificationMethod"]
+    if vm["publicKeyJwk"].get("alg") == "RS256"
+)
+public_key = jwt.algorithms.RSAAlgorithm.from_jwk(key_entry["publicKeyJwk"])
+
+# 3. Verify the VC-JWT
+payload = jwt.decode(
+    vc_jwt,
+    public_key,
+    algorithms=["RS256"],
+    issuer="did:web:grantex.dev",
+)
+
+print(payload["vc"]["credentialSubject"])
+
+# 4. Check revocation status
+status_url = payload["vc"]["credentialStatus"]["statusListCredential"]
+status_list = requests.get(status_url).json()
+# Decode the bitstring and check the index
+```
+</CodeGroup>
+
+## Agent DIDs
+
+Every agent registered in Grantex receives a DID in the format `did:grantex:ag_XXXX`. This DID serves as the agent's cryptographic identity and appears in:
+
+- The `agt` claim of grant tokens
+- The `credentialSubject.id` field of Verifiable Credentials
+- Audit log entries
+
+Agent DIDs are issued by Grantex and are not self-sovereign. They identify the agent within the Grantex ecosystem and are resolvable via the Grantex API.
+
+## Service Endpoints
+
+The DID document declares two service endpoints:
+
+### GrantexAuthService
+
+The primary Grantex API endpoint. Verifiers can use this to access the token verification API, JWKS, and other endpoints.
+
+```json
+{
+  "id": "did:web:grantex.dev#grantex-api",
+  "type": "GrantexAuthService",
+  "serviceEndpoint": "https://api.grantex.dev"
+}
+```
+
+### StatusList2021Service
+
+The base URL for StatusList2021 credentials. Verifiers append the status list ID to check revocation.
+
+```json
+{
+  "id": "did:web:grantex.dev#status-list",
+  "type": "StatusList2021Service",
+  "serviceEndpoint": "https://api.grantex.dev/v1/credentials/status"
+}
+```
+
+## Self-Hosting
+
+When self-hosting Grantex, the DID document is served from your own domain. The `did:web` method resolves based on the domain in the DID string:
+
+| DID | Resolves to |
+|-----|-------------|
+| `did:web:grantex.dev` | `https://grantex.dev/.well-known/did.json` |
+| `did:web:auth.example.com` | `https://auth.example.com/.well-known/did.json` |
+
+Configure the `ISSUER_DID` environment variable in your auth service deployment to set the DID that appears in issued VCs. The auth service automatically generates the DID document from the signing key.
+
+## W3C Standards Alignment
+
+| Standard | Grantex Implementation |
+|----------|------------------------|
+| [DID Core v1.0](https://www.w3.org/TR/did-core/) | Full compliance for `did:web` method |
+| [did:web Method](https://w3c-ccg.github.io/did-method-web/) | `/.well-known/did.json` hosting |
+| [JsonWebKey2020](https://w3c-ccg.github.io/lds-jws2020/) | Verification method format |
+| [VC Data Model v2.0](https://www.w3.org/TR/vc-data-model-2.0/) | Credential issuance and verification |
+| [StatusList2021](https://www.w3.org/TR/vc-status-list/) | Revocation checking |
+
+## API Reference
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| `GET` | `/.well-known/did.json` | None (public) | W3C DID document |
+| `GET` | `/.well-known/jwks.json` | None (public) | JSON Web Key Set (same RSA key) |
+| `GET` | `/v1/credentials/status/:id` | None (public) | StatusList2021 credential |
+
+## Next Steps
+
+- [Verifiable Credentials](/features/verifiable-credentials) -- issue and verify W3C VCs
+- [FIDO2 / WebAuthn](/features/fido-webauthn) -- human presence verification
+- [Grant Token](/concepts/grant-token) -- the standard JWT-based grant token
+- [Token Verification](/guides/token-verification) -- offline JWT verification via JWKS

--- a/docs/features/fido-webauthn.mdx
+++ b/docs/features/fido-webauthn.mdx
@@ -1,0 +1,320 @@
+---
+title: "FIDO2 / WebAuthn"
+sidebarTitle: "FIDO2 / WebAuthn"
+description: "Passkey-based human presence verification for agent authorization. Cryptographic proof that a real human approved the grant."
+---
+
+## Overview
+
+Grantex supports FIDO2/WebAuthn passkeys as a human presence verification mechanism during the consent flow. When enabled, end-users authenticate with a biometric, security key, or platform authenticator before a grant is issued. This raises the assurance level from "user clicked approve" to "user was cryptographically verified by their device."
+
+FIDO is opt-in per developer. When `fidoRequired` is set to `true`, all authorization requests for that developer require a WebAuthn assertion before the grant is approved.
+
+## Why FIDO for Agents?
+
+Standard consent flows rely on a button click in a browser. This is vulnerable to session hijacking, UI redressing, and automated approval. A FIDO assertion proves that:
+
+1. The specific device registered by the user is present
+2. The user completed a biometric or physical authentication
+3. The assertion is bound to the specific challenge issued by Grantex
+
+For high-value agent operations (payments, data access, contract signing), this level of assurance is required by emerging standards like the Mastercard Verifiable Intent specification.
+
+## Developer Setup
+
+Enable FIDO for your account using the SDK or REST API:
+
+<CodeGroup>
+```typescript TypeScript
+import { Grantex } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+await grantex.updateSettings({
+  fidoRequired: true,
+  fidoRpName: 'My Application',  // displayed in browser passkey prompts
+});
+```
+
+```python Python
+from grantex import Grantex
+
+client = Grantex(api_key="gx_...")
+
+client.update_settings(
+    fido_required=True,
+    fido_rp_name="My Application",
+)
+```
+
+```bash cURL
+curl -X PATCH https://api.grantex.dev/v1/me \
+  -H "Authorization: Bearer $GRANTEX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"fidoRequired": true, "fidoRpName": "My Application"}'
+```
+</CodeGroup>
+
+<ParamField body="fidoRequired" type="boolean" default="false">
+  When `true`, all authorization requests for this developer require a WebAuthn assertion before the grant is approved.
+</ParamField>
+
+<ParamField body="fidoRpName" type="string">
+  The Relying Party name displayed in the browser's passkey prompt. Typically your application name.
+</ParamField>
+
+## Registration Ceremony
+
+Before a user can authenticate with FIDO, they must register a passkey. This is a one-time process per user per device.
+
+```
+  Browser                          Your Server                     Grantex
+    │                                  │                              │
+    │                                  │─── registerOptions() ───────►│
+    │                                  │◄── challenge + options ──────│
+    │◄── publicKey options ────────────│                              │
+    │                                  │                              │
+    │── navigator.credentials.create() │                              │
+    │── (user touches fingerprint) ────│                              │
+    │                                  │                              │
+    │── attestation response ─────────►│                              │
+    │                                  │─── registerVerify() ────────►│
+    │                                  │◄── credential stored ────────│
+    │◄── success ──────────────────────│                              │
+```
+
+### Step 1: Get Registration Options
+
+<CodeGroup>
+```typescript TypeScript
+const options = await grantex.webauthn.registerOptions({
+  principalId: 'user_abc123',
+});
+
+// options contains:
+// - challengeId: string (server-side reference)
+// - rp: { name, id }
+// - user: { id, name, displayName }
+// - pubKeyCredParams: [{ type: 'public-key', alg: -7 }, ...]
+// - authenticatorSelection: { userVerification: 'required' }
+// - timeout: 60000
+// - challenge: base64url-encoded
+```
+
+```python Python
+options = client.webauthn.register_options(principal_id="user_abc123")
+# Returns WebAuthnRegisterOptions with challengeId, rp, user, etc.
+```
+</CodeGroup>
+
+### Step 2: Create Credential in Browser
+
+Pass the options to the browser's WebAuthn API:
+
+```javascript
+// In the browser
+const credential = await navigator.credentials.create({
+  publicKey: {
+    challenge: base64urlToBuffer(options.challenge),
+    rp: options.rp,
+    user: {
+      id: base64urlToBuffer(options.user.id),
+      name: options.user.name,
+      displayName: options.user.displayName,
+    },
+    pubKeyCredParams: options.pubKeyCredParams,
+    authenticatorSelection: options.authenticatorSelection,
+    timeout: options.timeout,
+  },
+});
+```
+
+### Step 3: Verify and Store
+
+Send the credential response back to your server and forward it to Grantex:
+
+<CodeGroup>
+```typescript TypeScript
+await grantex.webauthn.registerVerify({
+  challengeId: options.challengeId,
+  response: {
+    id: credential.id,
+    rawId: bufferToBase64url(credential.rawId),
+    type: credential.type,
+    response: {
+      clientDataJSON: bufferToBase64url(credential.response.clientDataJSON),
+      attestationObject: bufferToBase64url(credential.response.attestationObject),
+    },
+  },
+});
+```
+
+```python Python
+client.webauthn.register_verify(
+    challenge_id=options.challenge_id,
+    response={
+        "id": credential_id,
+        "rawId": raw_id_b64,
+        "type": "public-key",
+        "response": {
+            "clientDataJSON": client_data_b64,
+            "attestationObject": attestation_b64,
+        },
+    },
+)
+```
+</CodeGroup>
+
+## Assertion Ceremony (Consent Flow)
+
+When FIDO is enabled, the consent flow includes a WebAuthn assertion challenge. This happens automatically in the hosted consent UI, but you can also drive it programmatically.
+
+```
+  Browser                          Grantex Consent UI              Grantex
+    │                                  │                              │
+    │── user opens consent URL ───────►│                              │
+    │                                  │── assertOptions() ──────────►│
+    │                                  │◄── challenge ────────────────│
+    │◄── publicKey get options ────────│                              │
+    │                                  │                              │
+    │── navigator.credentials.get() ──►│                              │
+    │── (user touches fingerprint) ────│                              │
+    │                                  │                              │
+    │── assertion response ───────────►│                              │
+    │                                  │── assertVerify() ───────────►│
+    │                                  │◄── grant approved ───────────│
+    │◄── redirect to callback ─────────│                              │
+```
+
+### Programmatic Assertion
+
+If you build a custom consent UI, use the assertion endpoints directly:
+
+<CodeGroup>
+```typescript TypeScript
+// Get assertion options
+const assertOpts = await grantex.webauthn.assertOptions({
+  principalId: 'user_abc123',
+  authRequestId: 'areq_01HXYZ...',
+});
+
+// Browser performs navigator.credentials.get()
+const assertion = await navigator.credentials.get({
+  publicKey: {
+    challenge: base64urlToBuffer(assertOpts.challenge),
+    allowCredentials: assertOpts.allowCredentials,
+    userVerification: 'required',
+    timeout: 60000,
+  },
+});
+
+// Verify the assertion and approve the grant
+await grantex.webauthn.assertVerify({
+  challengeId: assertOpts.challengeId,
+  response: {
+    id: assertion.id,
+    rawId: bufferToBase64url(assertion.rawId),
+    type: assertion.type,
+    response: {
+      clientDataJSON: bufferToBase64url(assertion.response.clientDataJSON),
+      authenticatorData: bufferToBase64url(assertion.response.authenticatorData),
+      signature: bufferToBase64url(assertion.response.signature),
+    },
+  },
+});
+```
+
+```python Python
+# Get assertion options
+assert_opts = client.webauthn.assert_options(
+    principal_id="user_abc123",
+    auth_request_id="areq_01HXYZ...",
+)
+
+# After browser performs navigator.credentials.get()
+client.webauthn.assert_verify(
+    challenge_id=assert_opts.challenge_id,
+    response={
+        "id": assertion_id,
+        "rawId": raw_id_b64,
+        "type": "public-key",
+        "response": {
+            "clientDataJSON": client_data_b64,
+            "authenticatorData": auth_data_b64,
+            "signature": signature_b64,
+        },
+    },
+)
+```
+</CodeGroup>
+
+## Managing Credentials
+
+Users can have multiple passkeys registered (e.g., laptop fingerprint + phone + YubiKey). Use the credentials endpoints to list and delete them.
+
+<CodeGroup>
+```typescript TypeScript
+// List all credentials for a user
+const credentials = await grantex.webauthn.listCredentials('user_abc123');
+for (const cred of credentials) {
+  console.log(cred.id, cred.createdAt, cred.lastUsedAt);
+}
+
+// Delete a credential
+await grantex.webauthn.deleteCredential('cred_01HXYZ...');
+```
+
+```python Python
+# List all credentials for a user
+credentials = client.webauthn.list_credentials("user_abc123")
+for cred in credentials:
+    print(cred.id, cred.created_at, cred.last_used_at)
+
+# Delete a credential
+client.webauthn.delete_credential("cred_01HXYZ...")
+```
+</CodeGroup>
+
+## FIDO Evidence in Grants
+
+When a grant is approved via FIDO assertion, the grant record includes FIDO evidence metadata:
+
+```json
+{
+  "grantId": "grnt_01HXYZ...",
+  "fidoEvidence": {
+    "credentialId": "cred_01HXYZ...",
+    "authenticatorType": "platform",
+    "userVerified": true,
+    "assertedAt": "2026-03-08T12:00:00Z"
+  }
+}
+```
+
+This evidence is also embedded in Verifiable Credentials when `credentialFormat: "vc-jwt"` is used during token exchange. See [Verifiable Credentials](/features/verifiable-credentials) for details.
+
+## API Reference
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/v1/webauthn/register/options` | Generate passkey registration options |
+| `POST` | `/v1/webauthn/register/verify` | Verify registration and store credential |
+| `GET` | `/v1/webauthn/credentials` | List WebAuthn credentials for a principal |
+| `DELETE` | `/v1/webauthn/credentials/:id` | Delete a credential |
+| `POST` | `/v1/webauthn/assert/options` | Generate assertion options for consent |
+| `POST` | `/v1/webauthn/assert/verify` | Verify assertion during consent |
+| `PATCH` | `/v1/me` | Update developer settings (FIDO config) |
+
+## Security Considerations
+
+- **User verification required**: All FIDO operations set `userVerification: "required"`, ensuring the authenticator performs biometric or PIN verification. `"discouraged"` or `"preferred"` are not accepted.
+- **Challenge expiry**: Registration and assertion challenges expire after 5 minutes. Replaying an expired challenge returns a 400 error.
+- **Credential binding**: Each credential is bound to a specific principal and developer. A credential registered for one developer's consent flow cannot be used for another.
+- **Attestation**: Grantex accepts `"none"`, `"indirect"`, and `"direct"` attestation conveyance. Attestation statements are stored but not currently used for trust decisions.
+- **Fallback behavior**: If FIDO is enabled but the user has no registered credentials, the consent flow prompts them to register a passkey before proceeding.
+
+## Next Steps
+
+- [Verifiable Credentials](/features/verifiable-credentials) -- FIDO evidence embedded in W3C VCs
+- [DID Infrastructure](/features/did-infrastructure) -- how verifiers resolve Grantex's signing keys
+- [End-User Permissions](/guides/end-user-permissions) -- user-facing permission dashboard

--- a/docs/features/sd-jwt.mdx
+++ b/docs/features/sd-jwt.mdx
@@ -1,0 +1,198 @@
+---
+title: "SD-JWT (Selective Disclosure)"
+sidebarTitle: "SD-JWT"
+description: "Selective Disclosure JWTs let agents present only the claims needed for a given transaction, enabling privacy-preserving authorization and Verifiable Intent compatibility."
+---
+
+## Overview
+
+SD-JWT (Selective Disclosure JWT) extends Grantex's Verifiable Credential support with privacy-preserving selective disclosure. Instead of revealing all credential claims to every verifier, agents can choose which fields to disclose per interaction.
+
+<Info>
+SD-JWT builds on the existing VC-JWT infrastructure. Pass `credentialFormat: "sd-jwt"` during token exchange to receive an SD-JWT instead of a standard VC-JWT.
+</Info>
+
+## Why Selective Disclosure?
+
+In agentic commerce, an agent may interact with many services, each needing different information:
+
+- A payment processor needs to verify budget authorization, but doesn't need the principal's identity
+- A content API needs to verify scopes, but doesn't need to know the developer
+- A compliance auditor needs full disclosure of all claims
+
+SD-JWT lets the agent present a tailored credential for each interaction, revealing only what's necessary. This follows the principle of minimal disclosure and aligns with privacy regulations like GDPR.
+
+## How It Works
+
+### SD-JWT Format
+
+An SD-JWT consists of three parts separated by `~`:
+
+```
+<issuer-jwt>~<disclosure1>~<disclosure2>~...~
+```
+
+- **Issuer JWT**: A standard JWT containing visible claims and SHA-256 hashes of selective claims in a `_sd` array
+- **Disclosures**: Base64url-encoded JSON arrays of `[salt, claim_name, claim_value]`
+- **Trailing `~`**: Indicates the end of disclosures
+
+### Issuance Flow
+
+```typescript
+// Request an SD-JWT during token exchange
+const result = await grantex.tokens.exchange({
+  code: authCode,
+  agentId: 'ag_01ABC',
+  credentialFormat: 'sd-jwt',
+});
+
+// result.sdJwtCredential contains the full SD-JWT
+```
+
+### Presentation Flow
+
+When presenting to a verifier, the agent selects which fields to reveal:
+
+```typescript
+// Present only the scopes and grantId (omitting principalId, developerId)
+const result = await grantex.credentials.present({
+  sdJwt: sdJwtCredential,
+  nonce: 'verifier-nonce-123',
+  audience: 'https://api.merchant.com',
+});
+
+// result.disclosedClaims contains only the revealed fields
+```
+
+### Verification
+
+Any party can verify an SD-JWT presentation:
+
+```typescript
+const verification = await grantex.credentials.present({
+  sdJwt: presentedSdJwt,
+});
+
+if (verification.valid) {
+  console.log('Disclosed claims:', verification.disclosedClaims);
+  // Only contains the fields the holder chose to reveal
+}
+```
+
+## Default Selective Fields
+
+By default, the following credential subject fields are selectively disclosable:
+
+| Field | Description | Always visible? |
+|-------|-------------|-----------------|
+| `id` (agentDid) | Agent's DID identifier | Yes |
+| `type` | Credential type (`AIAgent`) | Yes |
+| `grantId` | Grant record ID | Yes |
+| `principalId` | End-user who authorized | No (selective) |
+| `developerId` | Developer organization | No (selective) |
+| `scopes` | Authorized scopes | No (selective) |
+| `delegationDepth` | Delegation chain depth | No (selective) |
+
+## Verifiable Intent Compatibility
+
+SD-JWT enables Grantex credentials to be compatible with Verifiable Intent frameworks like the Mastercard model. By selectively disclosing only the fields relevant to a specific transaction, agents can:
+
+1. **Prove authorization** without revealing identity
+2. **Demonstrate scope** without exposing the full grant
+3. **Verify delegation chains** without leaking organizational structure
+
+## SDK Support
+
+### TypeScript
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_live_...' });
+
+// Issue SD-JWT
+const exchange = await grantex.tokens.exchange({
+  code: authCode,
+  agentId: agentId,
+  credentialFormat: 'sd-jwt',
+});
+
+// Verify presentation
+const result = await grantex.credentials.present({
+  sdJwt: exchange.sdJwtCredential!,
+  nonce: 'verifier-nonce',
+});
+```
+
+### Python
+
+```python
+from grantex import Grantex, SDJWTPresentParams
+
+grantex = Grantex(api_key="gx_live_...")
+
+# Verify an SD-JWT presentation
+result = grantex.credentials.present(
+    SDJWTPresentParams(
+        sd_jwt=sd_jwt_string,
+        nonce="verifier-nonce",
+    )
+)
+
+if result.valid:
+    print(result.disclosed_claims)
+```
+
+## API Reference
+
+### Token Exchange with SD-JWT
+
+```http
+POST /v1/token
+Content-Type: application/json
+Authorization: Bearer gx_live_...
+
+{
+  "code": "auth-code",
+  "agentId": "ag_01ABC",
+  "credentialFormat": "sd-jwt"
+}
+```
+
+Response includes `sdJwtCredential` alongside the standard `grantToken`.
+
+### Verify SD-JWT Presentation
+
+```http
+POST /v1/credentials/present
+Content-Type: application/json
+
+{
+  "sdJwt": "<issuer-jwt>~<disc1>~<disc2>~",
+  "nonce": "optional-verifier-nonce",
+  "audience": "optional-audience"
+}
+```
+
+**Response:**
+
+```json
+{
+  "valid": true,
+  "vcId": "vc_01ABC...",
+  "disclosedClaims": {
+    "id": "did:grantex:ag_01ABC",
+    "type": "AIAgent",
+    "grantId": "grnt_01ABC",
+    "scopes": ["read", "write"]
+  }
+}
+```
+
+## Security Considerations
+
+- Disclosures are salted with 128-bit cryptographic random values to prevent correlation attacks
+- The `_sd` array contains SHA-256 hashes that bind disclosures to the issuer JWT
+- Tampered or fabricated disclosures are detected by hash mismatch
+- The issuer JWT signature covers the `_sd` array, preventing hash substitution
+- SD-JWT verification requires the same public key infrastructure as VC-JWT (Grantex JWKS/DID)

--- a/docs/features/verifiable-credentials.mdx
+++ b/docs/features/verifiable-credentials.mdx
@@ -1,0 +1,315 @@
+---
+title: "Verifiable Credentials"
+sidebarTitle: "Verifiable Credentials"
+description: "W3C Verifiable Credentials issued alongside grant tokens. Portable, tamper-proof proof of agent authorization for any verifier."
+---
+
+## Overview
+
+Grantex can issue W3C Verifiable Credentials (VCs) alongside standard RS256 JWTs. While grant tokens are optimized for real-time authorization (short-lived, revocation-checked, scope-enforced), Verifiable Credentials provide a portable, standards-compliant proof of authorization that any party can verify independently using the Grantex DID document.
+
+<Info>
+Verifiable Credentials are opt-in. Existing token exchange flows continue to work unchanged. Pass `credentialFormat: "vc-jwt"` during token exchange to receive a VC alongside the standard grant token.
+</Info>
+
+## Why Verifiable Credentials?
+
+Grant tokens work well within systems that integrate with Grantex. But in agentic commerce, agents interact with third-party services that may have no relationship with Grantex:
+
+- A payment processor needs proof that the agent is authorized to spend on the user's behalf
+- A contract-signing service needs proof of human consent
+- An insurance API needs proof of delegated authority from a specific principal
+
+Verifiable Credentials solve this by providing a self-contained, cryptographically signed document that any verifier can check using publicly available keys. No Grantex account, no API calls, no trust relationship required.
+
+## W3C Compliance
+
+Grantex VCs conform to:
+
+| Standard | Version | Description |
+|----------|---------|-------------|
+| [VC Data Model](https://www.w3.org/TR/vc-data-model-2.0/) | v2.0 | Credential structure and semantics |
+| [VC-JWT](https://www.w3.org/TR/vc-data-model-2.0/#json-web-token) | -- | JWT encoding of VCs (compact, URL-safe) |
+| [StatusList2021](https://www.w3.org/TR/vc-status-list/) | -- | Bitstring-based revocation mechanism |
+| [DID Core](https://www.w3.org/TR/did-core/) | v1.0 | Issuer identification via `did:web` |
+
+## Issuing a Verifiable Credential
+
+Request a VC during token exchange by setting the `credentialFormat` parameter:
+
+<CodeGroup>
+```typescript TypeScript
+import { Grantex } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+const result = await grantex.tokens.exchange({
+  code,
+  agentId: agent.id,
+  credentialFormat: 'vc-jwt',
+});
+
+console.log(result.grantToken);           // standard RS256 JWT (always present)
+console.log(result.verifiableCredential);  // W3C VC-JWT (present when requested)
+```
+
+```python Python
+from grantex import Grantex, ExchangeTokenParams
+
+client = Grantex(api_key="gx_...")
+
+result = client.tokens.exchange(ExchangeTokenParams(
+    code=code,
+    agent_id=agent.id,
+    credential_format="vc-jwt",
+))
+
+print(result.verifiable_credential)  # W3C VC-JWT
+```
+
+```bash cURL
+curl -X POST https://api.grantex.dev/v1/token \
+  -H "Authorization: Bearer $GRANTEX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"code": "01J...", "agentId": "ag_01...", "credentialFormat": "vc-jwt"}'
+```
+</CodeGroup>
+
+## Credential Types
+
+### AgentGrantCredential
+
+Issued for direct grants (user authorizes an agent directly). The credential subject attests that a specific principal authorized a specific agent with specific scopes.
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://grantex.dev/ns/credentials/v1"
+  ],
+  "type": ["VerifiableCredential", "AgentGrantCredential"],
+  "issuer": "did:web:grantex.dev",
+  "issuanceDate": "2026-03-08T12:00:00Z",
+  "expirationDate": "2026-03-09T12:00:00Z",
+  "credentialSubject": {
+    "id": "did:grantex:ag_01HXYZ123abc",
+    "type": "Agent",
+    "grantId": "grnt_01HXYZ...",
+    "principalId": "user_abc123",
+    "developerId": "org_yourcompany",
+    "scopes": ["calendar:read", "payments:initiate:max_500"],
+    "authorizedAt": "2026-03-08T12:00:00Z"
+  },
+  "credentialStatus": {
+    "id": "https://api.grantex.dev/v1/credentials/status/1#42",
+    "type": "StatusList2021Entry",
+    "statusPurpose": "revocation",
+    "statusListIndex": "42",
+    "statusListCredential": "https://api.grantex.dev/v1/credentials/status/1"
+  }
+}
+```
+
+### DelegatedGrantCredential
+
+Issued for delegated grants (agent delegates to a sub-agent). Includes the full delegation chain for traceability.
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://grantex.dev/ns/credentials/v1"
+  ],
+  "type": ["VerifiableCredential", "DelegatedGrantCredential"],
+  "issuer": "did:web:grantex.dev",
+  "credentialSubject": {
+    "id": "did:grantex:ag_SUB_AGENT",
+    "type": "DelegatedAgent",
+    "grantId": "grnt_01CHILD...",
+    "parentGrantId": "grnt_01ROOT...",
+    "parentAgentDid": "did:grantex:ag_ROOT_AGENT",
+    "delegationDepth": 1,
+    "principalId": "user_abc123",
+    "scopes": ["calendar:read"]
+  }
+}
+```
+
+### FIDO Evidence
+
+When the grant was approved via a FIDO2/WebAuthn assertion, the credential includes cryptographic proof of human presence:
+
+```json
+{
+  "credentialSubject": {
+    "id": "did:grantex:ag_01HXYZ123abc",
+    "type": "Agent",
+    "grantId": "grnt_01HXYZ...",
+    "principalId": "user_abc123",
+    "scopes": ["payments:initiate:max_500"],
+    "fidoEvidence": {
+      "type": "WebAuthnAssertion",
+      "authenticatorType": "platform",
+      "userVerified": true,
+      "assertedAt": "2026-03-08T12:00:00Z"
+    }
+  }
+}
+```
+
+This FIDO evidence is compatible with the **Mastercard Verifiable Intent** specification for agentic commerce, providing the cryptographic human-presence proof that payment networks require.
+
+## Verifying a VC
+
+### Using the Grantex SDK
+
+<CodeGroup>
+```typescript TypeScript
+const verification = await grantex.credentials.verify(vcJwt);
+
+if (verification.valid) {
+  console.log('Issuer:', verification.issuer);
+  console.log('Subject:', verification.credentialSubject);
+  console.log('Scopes:', verification.credentialSubject.scopes);
+  console.log('Status:', verification.status); // "active"
+} else {
+  console.log('Invalid:', verification.reason);
+}
+```
+
+```python Python
+verification = client.credentials.verify(vc_jwt)
+
+if verification.valid:
+    print("Issuer:", verification.issuer)
+    print("Subject:", verification.credential_subject)
+    print("Scopes:", verification.credential_subject["scopes"])
+else:
+    print("Invalid:", verification.reason)
+```
+</CodeGroup>
+
+### Independent Verification
+
+Any party can verify a Grantex VC without the SDK by:
+
+1. Decoding the VC-JWT (standard JWT decode)
+2. Resolving the issuer DID (`did:web:grantex.dev` resolves to `https://grantex.dev/.well-known/did.json`)
+3. Extracting the public key from the DID document
+4. Verifying the JWT signature against the public key
+5. Checking the `credentialStatus` endpoint for revocation
+
+```bash
+# Resolve the DID document
+curl https://api.grantex.dev/.well-known/did.json
+
+# Check revocation status
+curl https://api.grantex.dev/v1/credentials/status/1
+```
+
+No Grantex account or API key is required for verification. The DID document and status list endpoints are public.
+
+## Revocation via StatusList2021
+
+Grantex uses the W3C StatusList2021 standard for credential revocation. Each VC references a position in a bitstring-based status list. When a grant is revoked, the corresponding bit is flipped.
+
+### How It Works
+
+1. Each credential is assigned a `statusListIndex` (a position in the bitstring)
+2. The status list credential is published at a public URL (`/v1/credentials/status/:id`)
+3. When a grant is revoked, Grantex sets the bit at that index
+4. Verifiers fetch the status list and check the bit to determine revocation
+
+### Checking Status
+
+<CodeGroup>
+```typescript TypeScript
+// Via SDK
+const cred = await grantex.credentials.get('vc_01HXYZ...');
+console.log(cred.status);  // "active" or "revoked"
+
+// The SDK also checks status during verify()
+const result = await grantex.credentials.verify(vcJwt);
+console.log(result.status); // "active" or "revoked"
+```
+
+```python Python
+cred = client.credentials.get("vc_01HXYZ...")
+print(cred.status)  # "active" or "revoked"
+
+result = client.credentials.verify(vc_jwt)
+print(result.status)
+```
+</CodeGroup>
+
+### Revocation Timing
+
+When you revoke a grant (via `DELETE /v1/grants/:id`, the permission dashboard, or cascade revocation), the following happens atomically:
+
+1. The grant record is marked as revoked
+2. The Redis revocation key is set (grant token rejected immediately)
+3. The StatusList2021 bit is flipped (VC shows as revoked)
+4. All delegated sub-grants are cascade-revoked (and their VCs)
+
+## Listing Credentials
+
+<CodeGroup>
+```typescript TypeScript
+// List all credentials
+const { credentials } = await grantex.credentials.list();
+
+// Filter by grant
+const { credentials: grantCreds } = await grantex.credentials.list({
+  grantId: 'grnt_01HXYZ...',
+});
+
+// Filter by principal
+const { credentials: userCreds } = await grantex.credentials.list({
+  principalId: 'user_abc123',
+  status: 'active',
+});
+```
+
+```python Python
+# List all credentials
+result = client.credentials.list()
+
+# Filter by grant
+result = client.credentials.list(grant_id="grnt_01HXYZ...")
+
+# Filter by principal and status
+result = client.credentials.list(
+    principal_id="user_abc123",
+    status="active",
+)
+```
+</CodeGroup>
+
+## Mastercard Verifiable Intent
+
+Grantex VCs are designed for compatibility with the Mastercard Verifiable Intent specification for agentic commerce. The key alignment points are:
+
+| Requirement | Grantex Implementation |
+|---|---|
+| Cryptographic human presence proof | FIDO2 WebAuthn assertion evidence in VC |
+| Verifiable agent identity | Agent DID (`did:grantex:ag_...`) as credential subject |
+| Scoped authorization | `scopes` array in credential subject |
+| Revocable credentials | StatusList2021 with real-time revocation |
+| Standard-compliant format | W3C VC Data Model v2.0 + VC-JWT encoding |
+| Independent verification | Public DID document + public status list endpoints |
+
+## API Reference
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/v1/credentials/:id` | Retrieve a specific Verifiable Credential |
+| `GET` | `/v1/credentials` | List credentials with optional filters |
+| `POST` | `/v1/credentials/verify` | Verify a VC-JWT (signature + status + expiry) |
+| `GET` | `/v1/credentials/status/:id` | StatusList2021 credential (public, no auth) |
+
+## Next Steps
+
+- [FIDO2 / WebAuthn](/features/fido-webauthn) -- passkey-based human presence verification
+- [DID Infrastructure](/features/did-infrastructure) -- how the issuer DID works
+- [Grant Token](/concepts/grant-token) -- the standard JWT-based grant token
+- [Multi-Agent Delegation](/concepts/delegation) -- delegation chains in VCs

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -90,6 +90,28 @@ description: "Grantex integrates with every major AI agent framework."
 | Event Destinations | `@grantex/destinations` | `npm install @grantex/destinations` | TypeScript |
 | Terraform Provider | `terraform-provider-grantex` | `source = "mishrasanjeev/grantex"` | Go / HCL |
 
+## Verifiable Intent & Agentic Commerce
+
+Grantex integrates with emerging standards for agentic commerce through W3C Verifiable Credentials and FIDO2/WebAuthn:
+
+<CardGroup cols={2}>
+  <Card title="Verifiable Credentials" icon="certificate" href="/features/verifiable-credentials">
+    Issue W3C VCs alongside grant tokens. Agents present portable, tamper-proof proof of authorization to any verifier -- no Grantex account required.
+  </Card>
+  <Card title="FIDO2 / WebAuthn" icon="fingerprint" href="/features/fido-webauthn">
+    Passkey-based human presence verification. Cryptographic proof that a real human authorized the agent, embedded in grants and VCs.
+  </Card>
+  <Card title="DID Infrastructure" icon="id-card" href="/features/did-infrastructure">
+    W3C DID document at did:web:grantex.dev. Any party can verify Grantex-issued credentials using published public keys.
+  </Card>
+</CardGroup>
+
+These capabilities support the **Mastercard Verifiable Intent** specification and similar agentic commerce frameworks. When an agent needs to prove its authorization to a payment processor, merchant, or third-party API, it presents a Verifiable Credential that the receiving party can verify independently using the Grantex DID document.
+
+<Info>
+Verifiable Credentials are opt-in. Pass `credentialFormat: "vc-jwt"` during token exchange to receive a VC alongside the standard grant token. Existing integrations continue to work unchanged.
+</Info>
+
 ## How Integrations Work
 
 Every integration follows the same pattern:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -64,6 +64,12 @@ tags:
     description: OIDC single sign-on configuration and flow
   - name: Principal Sessions
     description: End-user permission management via short-lived session tokens
+  - name: WebAuthn
+    description: FIDO2/WebAuthn passkey registration, assertion, and credential management
+  - name: Verifiable Credentials
+    description: W3C Verifiable Credential issuance, verification, and StatusList2021 revocation
+  - name: DID
+    description: W3C Decentralized Identifier (DID) document for credential verification
 
 components:
   securitySchemes:
@@ -439,6 +445,37 @@ paths:
                 $ref: "#/components/schemas/Developer"
         "404":
           description: Developer not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    patch:
+      operationId: updateSettings
+      tags: [Authentication]
+      summary: Update developer settings
+      description: Update developer profile settings including FIDO/WebAuthn configuration.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                fidoRequired:
+                  type: boolean
+                  description: Require FIDO2/WebAuthn assertion for all authorization requests
+                fidoRpName:
+                  type: string
+                  description: Relying Party name displayed in browser passkey prompts
+      responses:
+        "200":
+          description: Settings updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Developer"
+        "400":
+          description: Validation error
           content:
             application/json:
               schema:
@@ -948,6 +985,12 @@ paths:
                 codeVerifier:
                   type: string
                   description: PKCE code verifier (required if code_challenge was used)
+                credentialFormat:
+                  type: string
+                  enum: [vc-jwt]
+                  description: |
+                    When set to "vc-jwt", a W3C Verifiable Credential (VC-JWT) is issued alongside the
+                    standard grant token. The VC is a portable, tamper-proof proof of authorization.
               required: [code, agentId]
       responses:
         "201":
@@ -971,6 +1014,9 @@ paths:
                     type: string
                   grantId:
                     type: string
+                  verifiableCredential:
+                    type: string
+                    description: W3C VC-JWT (present when credentialFormat is "vc-jwt")
         "400":
           description: Invalid code, not approved, expired, or PKCE mismatch
           content:
@@ -2873,3 +2919,569 @@ paths:
             text/html:
               schema:
                 type: string
+
+  # ── WebAuthn / FIDO ──────────────────────────────────────────────────
+  /v1/webauthn/register/options:
+    post:
+      operationId: webauthnRegisterOptions
+      tags: [WebAuthn]
+      summary: Generate registration options
+      description: |
+        Generate FIDO2/WebAuthn registration options for a principal. Returns a challenge and
+        PublicKeyCredentialCreationOptions that the browser passes to navigator.credentials.create().
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [principalId]
+              properties:
+                principalId:
+                  type: string
+                  description: The end-user's principal ID
+                  example: user_abc123
+      responses:
+        "200":
+          description: Registration options
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  challengeId:
+                    type: string
+                    description: Server-side challenge reference
+                  challenge:
+                    type: string
+                    description: Base64url-encoded challenge
+                  rp:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      id:
+                        type: string
+                  user:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      displayName:
+                        type: string
+                  pubKeyCredParams:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        alg:
+                          type: integer
+                  authenticatorSelection:
+                    type: object
+                    properties:
+                      userVerification:
+                        type: string
+                        enum: [required]
+                  timeout:
+                    type: integer
+        "400":
+          description: Missing principalId
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/webauthn/register/verify:
+    post:
+      operationId: webauthnRegisterVerify
+      tags: [WebAuthn]
+      summary: Verify registration
+      description: |
+        Verify the attestation response from navigator.credentials.create() and store the credential.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [challengeId, response]
+              properties:
+                challengeId:
+                  type: string
+                  description: The challengeId from registerOptions
+                response:
+                  type: object
+                  description: The credential response from the browser
+                  properties:
+                    id:
+                      type: string
+                    rawId:
+                      type: string
+                    type:
+                      type: string
+                    response:
+                      type: object
+                      properties:
+                        clientDataJSON:
+                          type: string
+                        attestationObject:
+                          type: string
+      responses:
+        "201":
+          description: Credential registered
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  credentialId:
+                    type: string
+                  createdAt:
+                    type: string
+                    format: date-time
+        "400":
+          description: Invalid challenge or attestation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/webauthn/credentials:
+    get:
+      operationId: listWebAuthnCredentials
+      tags: [WebAuthn]
+      summary: List WebAuthn credentials
+      description: List all registered FIDO2 credentials for a principal.
+      parameters:
+        - name: principalId
+          in: query
+          required: true
+          schema:
+            type: string
+          description: The principal ID to list credentials for
+      responses:
+        "200":
+          description: List of credentials
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    principalId:
+                      type: string
+                    authenticatorType:
+                      type: string
+                    createdAt:
+                      type: string
+                      format: date-time
+                    lastUsedAt:
+                      type: string
+                      format: date-time
+
+  /v1/webauthn/credentials/{id}:
+    delete:
+      operationId: deleteWebAuthnCredential
+      tags: [WebAuthn]
+      summary: Delete a credential
+      description: Remove a registered FIDO2 credential.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Credential ID
+      responses:
+        "204":
+          description: Credential deleted
+        "404":
+          description: Credential not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/webauthn/assert/options:
+    post:
+      operationId: webauthnAssertOptions
+      tags: [WebAuthn]
+      summary: Generate assertion options
+      description: |
+        Generate FIDO2/WebAuthn assertion options for the consent flow. Returns a challenge and
+        PublicKeyCredentialRequestOptions that the browser passes to navigator.credentials.get().
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [principalId, authRequestId]
+              properties:
+                principalId:
+                  type: string
+                  description: The end-user's principal ID
+                authRequestId:
+                  type: string
+                  description: The authorization request ID this assertion is for
+      responses:
+        "200":
+          description: Assertion options
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  challengeId:
+                    type: string
+                  challenge:
+                    type: string
+                  allowCredentials:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          type: string
+                  userVerification:
+                    type: string
+                    enum: [required]
+                  timeout:
+                    type: integer
+        "400":
+          description: Missing parameters
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No credentials registered for this principal
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/webauthn/assert/verify:
+    post:
+      operationId: webauthnAssertVerify
+      tags: [WebAuthn]
+      summary: Verify assertion
+      description: |
+        Verify the assertion response from navigator.credentials.get(). On success, the associated
+        authorization request is approved with FIDO evidence attached to the grant.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [challengeId, response]
+              properties:
+                challengeId:
+                  type: string
+                response:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    rawId:
+                      type: string
+                    type:
+                      type: string
+                    response:
+                      type: object
+                      properties:
+                        clientDataJSON:
+                          type: string
+                        authenticatorData:
+                          type: string
+                        signature:
+                          type: string
+      responses:
+        "200":
+          description: Assertion verified, grant approved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  verified:
+                    type: boolean
+                  grantId:
+                    type: string
+                  fidoEvidence:
+                    type: object
+                    properties:
+                      credentialId:
+                        type: string
+                      authenticatorType:
+                        type: string
+                      userVerified:
+                        type: boolean
+                      assertedAt:
+                        type: string
+                        format: date-time
+        "400":
+          description: Invalid assertion
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  # ── Verifiable Credentials ──────────────────────────────────────────
+  /v1/credentials/{id}:
+    get:
+      operationId: getCredential
+      tags: [Verifiable Credentials]
+      summary: Retrieve a Verifiable Credential
+      description: Get a specific Verifiable Credential by ID.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Credential ID
+      responses:
+        "200":
+          description: Verifiable Credential
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  grantId:
+                    type: string
+                  type:
+                    type: string
+                    enum: [AgentGrantCredential, DelegatedGrantCredential]
+                  vcJwt:
+                    type: string
+                    description: The VC-JWT string
+                  status:
+                    type: string
+                    enum: [active, revoked]
+                  issuedAt:
+                    type: string
+                    format: date-time
+                  expiresAt:
+                    type: string
+                    format: date-time
+        "404":
+          description: Credential not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/credentials:
+    get:
+      operationId: listCredentials
+      tags: [Verifiable Credentials]
+      summary: List Verifiable Credentials
+      description: List credentials with optional filters.
+      parameters:
+        - name: grantId
+          in: query
+          schema:
+            type: string
+          description: Filter by grant ID
+        - name: principalId
+          in: query
+          schema:
+            type: string
+          description: Filter by principal ID
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [active, revoked]
+          description: Filter by status
+      responses:
+        "200":
+          description: List of credentials
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  credentials:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        grantId:
+                          type: string
+                        type:
+                          type: string
+                        status:
+                          type: string
+                        issuedAt:
+                          type: string
+                          format: date-time
+                        expiresAt:
+                          type: string
+                          format: date-time
+
+  /v1/credentials/verify:
+    post:
+      operationId: verifyCredential
+      tags: [Verifiable Credentials]
+      summary: Verify a VC-JWT
+      description: |
+        Verify a Verifiable Credential JWT. Checks the signature against the issuer's DID document,
+        validates expiry, and checks the StatusList2021 revocation status.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [vcJwt]
+              properties:
+                vcJwt:
+                  type: string
+                  description: The VC-JWT to verify
+      responses:
+        "200":
+          description: Verification result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  valid:
+                    type: boolean
+                  issuer:
+                    type: string
+                  credentialSubject:
+                    type: object
+                  status:
+                    type: string
+                    enum: [active, revoked]
+                  reason:
+                    type: string
+                    description: Present when valid is false
+
+  /v1/credentials/status/{id}:
+    get:
+      operationId: getStatusList
+      tags: [Verifiable Credentials]
+      summary: StatusList2021 credential
+      description: |
+        Public endpoint returning a StatusList2021 credential (bitstring-based revocation list).
+        No authentication required.
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Status list ID
+      responses:
+        "200":
+          description: StatusList2021 credential
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  "@context":
+                    type: array
+                    items:
+                      type: string
+                  type:
+                    type: array
+                    items:
+                      type: string
+                  issuer:
+                    type: string
+                  issuanceDate:
+                    type: string
+                    format: date-time
+                  credentialSubject:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      type:
+                        type: string
+                      statusPurpose:
+                        type: string
+                      encodedList:
+                        type: string
+                        description: Base64-encoded bitstring
+        "404":
+          description: Status list not found
+
+  # ── DID ──────────────────────────────────────────────────────────────
+  /.well-known/did.json:
+    get:
+      operationId: getDidDocument
+      tags: [DID]
+      summary: W3C DID document
+      description: |
+        Public DID document for did:web:grantex.dev. Contains verification methods (public keys)
+        used to sign Verifiable Credentials. No authentication required.
+      security: []
+      responses:
+        "200":
+          description: DID document
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  "@context":
+                    type: array
+                    items:
+                      type: string
+                  id:
+                    type: string
+                    example: "did:web:grantex.dev"
+                  verificationMethod:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          type: string
+                        controller:
+                          type: string
+                        publicKeyJwk:
+                          type: object
+                  authentication:
+                    type: array
+                    items:
+                      type: string
+                  assertionMethod:
+                    type: array
+                    items:
+                      type: string
+                  service:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          type: string
+                        serviceEndpoint:
+                          type: string

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -90,6 +90,22 @@ from ._types import (
     ListVaultCredentialsResponse,
     ExchangeCredentialParams,
     ExchangeCredentialResponse,
+    # WebAuthn / FIDO
+    WebAuthnRegistrationOptions,
+    WebAuthnRegistrationVerifyParams,
+    WebAuthnCredential,
+    ListWebAuthnCredentialsResponse,
+    # Verifiable Credentials
+    VerifiableCredentialRecord,
+    ListCredentialsParams,
+    ListCredentialsResponse,
+    VCVerificationResult,
+    # SD-JWT
+    SDJWTPresentParams,
+    SDJWTPresentResult,
+    # Developer Settings
+    UpdateDeveloperSettingsParams,
+    UpdateDeveloperSettingsResponse,
 )
 from .resources._events import EventsClient, GrantexEvent as GrantexStreamEvent, StreamOptions
 from ._pkce import PkceChallenge, generate_pkce
@@ -196,6 +212,22 @@ __all__ = [
     "ListVaultCredentialsResponse",
     "ExchangeCredentialParams",
     "ExchangeCredentialResponse",
+    # WebAuthn / FIDO
+    "WebAuthnRegistrationOptions",
+    "WebAuthnRegistrationVerifyParams",
+    "WebAuthnCredential",
+    "ListWebAuthnCredentialsResponse",
+    # Verifiable Credentials
+    "VerifiableCredentialRecord",
+    "ListCredentialsParams",
+    "ListCredentialsResponse",
+    "VCVerificationResult",
+    # SD-JWT
+    "SDJWTPresentParams",
+    "SDJWTPresentResult",
+    # Developer Settings
+    "UpdateDeveloperSettingsParams",
+    "UpdateDeveloperSettingsResponse",
     # Events
     "EventsClient",
     "GrantexStreamEvent",

--- a/packages/sdk-py/src/grantex/_client.py
+++ b/packages/sdk-py/src/grantex/_client.py
@@ -5,7 +5,16 @@ import os
 import httpx
 
 from ._http import HttpClient
-from ._types import AuthorizationRequest, AuthorizeParams, RateLimit, RotateKeyResponse, SignupParams, SignupResponse
+from ._types import (
+    AuthorizationRequest,
+    AuthorizeParams,
+    RateLimit,
+    RotateKeyResponse,
+    SignupParams,
+    SignupResponse,
+    UpdateDeveloperSettingsParams,
+    UpdateDeveloperSettingsResponse,
+)
 from .resources._agents import AgentsClient
 from .resources._audit import AuditClient
 from .resources._anomalies import AnomaliesClient
@@ -23,6 +32,8 @@ from .resources._budgets import BudgetsClient
 from .resources._events import EventsClient
 from .resources._usage import UsageClient
 from .resources._domains import DomainsClient
+from .resources._webauthn import WebAuthnClient
+from .resources._credentials import CredentialsClient
 
 _DEFAULT_BASE_URL = "https://api.grantex.dev"
 
@@ -47,6 +58,8 @@ class Grantex:
     events: EventsClient
     usage: UsageClient
     domains: DomainsClient
+    webauthn: WebAuthnClient
+    credentials: CredentialsClient
 
     @property
     def last_rate_limit(self) -> RateLimit | None:
@@ -89,6 +102,8 @@ class Grantex:
         self.events = EventsClient(base_url, resolved_key)
         self.usage = UsageClient(self._http)
         self.domains = DomainsClient(self._http)
+        self.webauthn = WebAuthnClient(self._http)
+        self.credentials = CredentialsClient(self._http)
 
     @staticmethod
     def signup(
@@ -124,6 +139,13 @@ class Grantex:
         """Rotate the current API key. Returns a new key; the old key is invalidated."""
         data = self._http.post("/v1/keys/rotate")
         return RotateKeyResponse.from_dict(data)
+
+    def update_settings(
+        self, params: UpdateDeveloperSettingsParams
+    ) -> UpdateDeveloperSettingsResponse:
+        """Update developer settings (e.g. FIDO/WebAuthn requirements)."""
+        data = self._http.patch("/v1/me", params.to_dict())
+        return UpdateDeveloperSettingsResponse.from_dict(data)
 
     def authorize(self, params: AuthorizeParams) -> AuthorizationRequest:
         """Initiate the delegated authorization flow for a user.

--- a/packages/sdk-py/src/grantex/_types.py
+++ b/packages/sdk-py/src/grantex/_types.py
@@ -285,11 +285,14 @@ class ExchangeTokenParams:
     code: str
     agent_id: str
     code_verifier: str | None = None
+    credential_format: str | None = None  # 'jwt' | 'vc-jwt' | 'both'
 
     def to_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {"code": self.code, "agentId": self.agent_id}
         if self.code_verifier is not None:
             body["codeVerifier"] = self.code_verifier
+        if self.credential_format is not None:
+            body["credentialFormat"] = self.credential_format
         return body
 
 
@@ -300,6 +303,7 @@ class ExchangeTokenResponse:
     scopes: tuple[str, ...]
     refresh_token: str
     grant_id: str
+    verifiable_credential: str | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ExchangeTokenResponse:
@@ -309,6 +313,7 @@ class ExchangeTokenResponse:
             scopes=tuple(data.get("scopes", [])),
             refresh_token=data["refreshToken"],
             grant_id=data["grantId"],
+            verifiable_credential=data.get("verifiableCredential"),
         )
 
 
@@ -463,6 +468,7 @@ class VerifyGrantTokenOptions:
     required_scopes: list[str] | None = None
     clock_tolerance: int = 0
     audience: str | None = None
+    issuer_did: str | None = None
 
 
 # ─── Raw JWT payload shape ────────────────────────────────────────────────────
@@ -1403,3 +1409,211 @@ class GrantexStreamEvent:
             created_at=d["createdAt"],
             data=d.get("data", {}),
         )
+
+
+# ─── WebAuthn / FIDO ─────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class WebAuthnRegistrationOptions:
+    challenge_id: str
+    public_key: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "WebAuthnRegistrationOptions":
+        return cls(
+            challenge_id=data["challengeId"],
+            public_key=data["publicKey"],
+        )
+
+
+@dataclass
+class WebAuthnRegistrationVerifyParams:
+    challenge_id: str
+    response: dict[str, Any]
+    device_name: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "challengeId": self.challenge_id,
+            "response": self.response,
+        }
+        if self.device_name is not None:
+            body["deviceName"] = self.device_name
+        return body
+
+
+@dataclass(frozen=True)
+class WebAuthnCredential:
+    id: str
+    principal_id: str
+    device_name: str | None
+    backed_up: bool
+    transports: tuple[str, ...]
+    created_at: str
+    last_used_at: str | None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "WebAuthnCredential":
+        return cls(
+            id=data["id"],
+            principal_id=data["principalId"],
+            device_name=data.get("deviceName"),
+            backed_up=data.get("backedUp", False),
+            transports=tuple(data.get("transports", [])),
+            created_at=data["createdAt"],
+            last_used_at=data.get("lastUsedAt"),
+        )
+
+
+@dataclass(frozen=True)
+class ListWebAuthnCredentialsResponse:
+    credentials: tuple[WebAuthnCredential, ...]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ListWebAuthnCredentialsResponse":
+        return cls(
+            credentials=tuple(
+                WebAuthnCredential.from_dict(c)
+                for c in data.get("credentials", [])
+            ),
+        )
+
+
+# ─── Verifiable Credentials ─────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class VerifiableCredentialRecord:
+    id: str
+    grant_id: str
+    credential_type: str
+    format: str
+    credential: str
+    status: str
+    issued_at: str
+    expires_at: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "VerifiableCredentialRecord":
+        return cls(
+            id=data["id"],
+            grant_id=data["grantId"],
+            credential_type=data["credentialType"],
+            format=data["format"],
+            credential=data["credential"],
+            status=data["status"],
+            issued_at=data["issuedAt"],
+            expires_at=data["expiresAt"],
+        )
+
+
+@dataclass
+class ListCredentialsParams:
+    grant_id: str | None = None
+    principal_id: str | None = None
+    status: str | None = None
+
+    def to_query(self) -> dict[str, str]:
+        result: dict[str, str] = {}
+        if self.grant_id is not None:
+            result["grantId"] = self.grant_id
+        if self.principal_id is not None:
+            result["principalId"] = self.principal_id
+        if self.status is not None:
+            result["status"] = self.status
+        return result
+
+
+@dataclass(frozen=True)
+class ListCredentialsResponse:
+    credentials: tuple[VerifiableCredentialRecord, ...]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ListCredentialsResponse":
+        return cls(
+            credentials=tuple(
+                VerifiableCredentialRecord.from_dict(c)
+                for c in data.get("credentials", [])
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class VCVerificationResult:
+    valid: bool
+    credential_type: str | None = None
+    issuer: str | None = None
+    subject: dict[str, Any] | None = None
+    expires_at: str | None = None
+    revoked: bool | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "VCVerificationResult":
+        return cls(
+            valid=data["valid"],
+            credential_type=data.get("credentialType"),
+            issuer=data.get("issuer"),
+            subject=data.get("subject"),
+            expires_at=data.get("expiresAt"),
+            revoked=data.get("revoked"),
+        )
+
+
+# ─── SD-JWT Presentation ─────────────────────────────────────────────────────
+
+
+@dataclass
+class SDJWTPresentParams:
+    sd_jwt: str
+    nonce: str | None = None
+    audience: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {"sdJwt": self.sd_jwt}
+        if self.nonce is not None:
+            body["nonce"] = self.nonce
+        if self.audience is not None:
+            body["audience"] = self.audience
+        return body
+
+
+@dataclass
+class SDJWTPresentResult:
+    valid: bool
+    disclosed_claims: dict[str, Any] | None = None
+    error: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "SDJWTPresentResult":
+        return cls(
+            valid=data["valid"],
+            disclosed_claims=data.get("disclosedClaims"),
+            error=data.get("error"),
+        )
+
+
+# ─── Developer Settings ──────────────────────────────────────────────────────
+
+
+@dataclass
+class UpdateDeveloperSettingsParams:
+    fido_required: bool | None = None
+    fido_rp_name: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.fido_required is not None:
+            body["fidoRequired"] = self.fido_required
+        if self.fido_rp_name is not None:
+            body["fidoRpName"] = self.fido_rp_name
+        return body
+
+
+@dataclass(frozen=True)
+class UpdateDeveloperSettingsResponse:
+    updated: bool
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "UpdateDeveloperSettingsResponse":
+        return cls(updated=data["updated"])

--- a/packages/sdk-py/src/grantex/_verify.py
+++ b/packages/sdk-py/src/grantex/_verify.py
@@ -35,7 +35,12 @@ def verify_grant_token(
             "only RS256 is allowed per SPEC §11"
         )
 
-    signing_key = _fetch_signing_key(options.jwks_uri, header.get("kid"))
+    jwks_uri = options.jwks_uri
+    if options.issuer_did is not None and options.issuer_did.startswith("did:web:"):
+        domain = options.issuer_did.removeprefix("did:web:").replace(":", "/")
+        jwks_uri = f"https://{domain}/.well-known/jwks.json"
+
+    signing_key = _fetch_signing_key(jwks_uri, header.get("kid"))
 
     decode_kwargs: dict[str, Any] = {
         "algorithms": ["RS256"],

--- a/packages/sdk-py/src/grantex/resources/_credentials.py
+++ b/packages/sdk-py/src/grantex/resources/_credentials.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from .._http import HttpClient
+from .._types import (
+    VerifiableCredentialRecord,
+    ListCredentialsParams,
+    ListCredentialsResponse,
+    VCVerificationResult,
+    SDJWTPresentParams,
+    SDJWTPresentResult,
+)
+
+
+class CredentialsClient:
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def get(self, credential_id: str) -> VerifiableCredentialRecord:
+        data = self._http.get(f"/v1/credentials/{credential_id}")
+        return VerifiableCredentialRecord.from_dict(data)
+
+    def list(
+        self, params: ListCredentialsParams | None = None
+    ) -> ListCredentialsResponse:
+        path = "/v1/credentials"
+        if params is not None:
+            query = params.to_query()
+            if query:
+                from urllib.parse import urlencode
+
+                path = f"{path}?{urlencode(query)}"
+        data = self._http.get(path)
+        return ListCredentialsResponse.from_dict(data)
+
+    def verify(self, vc_jwt: str) -> VCVerificationResult:
+        data = self._http.post("/v1/credentials/verify", {"credential": vc_jwt})
+        return VCVerificationResult.from_dict(data)
+
+    def present(self, params: SDJWTPresentParams) -> SDJWTPresentResult:
+        data = self._http.post("/v1/credentials/present", params.to_dict())
+        return SDJWTPresentResult.from_dict(data)

--- a/packages/sdk-py/src/grantex/resources/_webauthn.py
+++ b/packages/sdk-py/src/grantex/resources/_webauthn.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from .._http import HttpClient
+from .._types import (
+    WebAuthnRegistrationOptions,
+    WebAuthnRegistrationVerifyParams,
+    WebAuthnCredential,
+    ListWebAuthnCredentialsResponse,
+)
+
+
+class WebAuthnClient:
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def register_options(self, *, principal_id: str) -> WebAuthnRegistrationOptions:
+        data = self._http.post(
+            "/v1/webauthn/register/options",
+            {"principalId": principal_id},
+        )
+        return WebAuthnRegistrationOptions.from_dict(data)
+
+    def register_verify(
+        self, params: WebAuthnRegistrationVerifyParams
+    ) -> WebAuthnCredential:
+        data = self._http.post("/v1/webauthn/register/verify", params.to_dict())
+        return WebAuthnCredential.from_dict(data)
+
+    def list_credentials(self, principal_id: str) -> ListWebAuthnCredentialsResponse:
+        from urllib.parse import quote
+
+        data = self._http.get(
+            f"/v1/webauthn/credentials?principalId={quote(principal_id, safe='')}"
+        )
+        return ListWebAuthnCredentialsResponse.from_dict(data)
+
+    def delete_credential(self, credential_id: str) -> None:
+        self._http.delete(f"/v1/webauthn/credentials/{credential_id}")

--- a/packages/sdk-py/tests/test_credentials.py
+++ b/packages/sdk-py/tests/test_credentials.py
@@ -1,0 +1,126 @@
+"""Tests for CredentialsClient."""
+from __future__ import annotations
+
+import json
+
+import pytest
+import respx
+import httpx
+
+from grantex import Grantex, ListCredentialsParams, SDJWTPresentParams
+
+MOCK_VC_RECORD = {
+    "id": "vc_01",
+    "grantId": "grant_01",
+    "credentialType": "GrantCredential",
+    "format": "vc+sd-jwt",
+    "credential": "eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9...",
+    "status": "active",
+    "issuedAt": "2026-03-01T00:00:00Z",
+    "expiresAt": "2026-03-02T00:00:00Z",
+}
+
+MOCK_VERIFY_RESULT = {
+    "valid": True,
+    "credentialType": "GrantCredential",
+    "issuer": "did:web:grantex.dev",
+    "subject": {"principalId": "user_abc123", "agentDid": "did:grantex:ag_01"},
+    "expiresAt": "2026-03-02T00:00:00Z",
+    "revoked": False,
+}
+
+
+@pytest.fixture
+def client() -> Grantex:
+    return Grantex(api_key="test-key")
+
+
+@respx.mock
+def test_get_credential(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/credentials/vc_01").mock(
+        return_value=httpx.Response(200, json=MOCK_VC_RECORD)
+    )
+    result = client.credentials.get("vc_01")
+
+    assert result.id == "vc_01"
+    assert result.credential_type == "GrantCredential"
+    assert result.format == "vc+sd-jwt"
+
+
+@respx.mock
+def test_list_with_params(client: Grantex) -> None:
+    respx.get(
+        url__regex=r"/v1/credentials\?.*grantId=grant_01"
+    ).mock(return_value=httpx.Response(200, json={"credentials": [MOCK_VC_RECORD]}))
+
+    result = client.credentials.list(
+        ListCredentialsParams(grant_id="grant_01", status="active")
+    )
+
+    assert len(result.credentials) == 1
+    assert result.credentials[0].grant_id == "grant_01"
+
+
+@respx.mock
+def test_list_without_params(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/credentials").mock(
+        return_value=httpx.Response(200, json={"credentials": []})
+    )
+    result = client.credentials.list()
+    assert len(result.credentials) == 0
+
+
+@respx.mock
+def test_verify_credential(client: Grantex) -> None:
+    route = respx.post("https://api.grantex.dev/v1/credentials/verify").mock(
+        return_value=httpx.Response(200, json=MOCK_VERIFY_RESULT)
+    )
+    result = client.credentials.verify("eyJ...")
+
+    assert result.valid is True
+    assert result.credential_type == "GrantCredential"
+    assert result.issuer == "did:web:grantex.dev"
+    assert result.revoked is False
+
+    body = json.loads(route.calls[0].request.content)
+    assert body == {"credential": "eyJ..."}
+
+
+@respx.mock
+def test_present_sd_jwt(client: Grantex) -> None:
+    mock_result = {
+        "valid": True,
+        "disclosedClaims": {
+            "principalId": "user_abc123",
+            "scopes": ["read"],
+        },
+    }
+    route = respx.post("https://api.grantex.dev/v1/credentials/present").mock(
+        return_value=httpx.Response(200, json=mock_result)
+    )
+    result = client.credentials.present(
+        SDJWTPresentParams(sd_jwt="eyJ...~disc1~disc2~", nonce="abc123")
+    )
+
+    assert result.valid is True
+    assert result.disclosed_claims is not None
+    assert result.disclosed_claims["principalId"] == "user_abc123"
+
+    body = json.loads(route.calls[0].request.content)
+    assert body["sdJwt"] == "eyJ...~disc1~disc2~"
+    assert body["nonce"] == "abc123"
+
+
+@respx.mock
+def test_present_sd_jwt_invalid(client: Grantex) -> None:
+    mock_result = {
+        "valid": False,
+        "error": "Invalid SD-JWT signature",
+    }
+    respx.post("https://api.grantex.dev/v1/credentials/present").mock(
+        return_value=httpx.Response(200, json=mock_result)
+    )
+    result = client.credentials.present(SDJWTPresentParams(sd_jwt="invalid~"))
+
+    assert result.valid is False
+    assert result.error == "Invalid SD-JWT signature"

--- a/packages/sdk-py/tests/test_webauthn.py
+++ b/packages/sdk-py/tests/test_webauthn.py
@@ -1,0 +1,93 @@
+"""Tests for WebAuthnClient."""
+from __future__ import annotations
+
+import json
+
+import pytest
+import respx
+import httpx
+
+from grantex import Grantex
+
+MOCK_REGISTRATION_OPTIONS = {
+    "challengeId": "ch_01",
+    "publicKey": {
+        "rp": {"name": "Grantex", "id": "grantex.dev"},
+        "challenge": "dGVzdC1jaGFsbGVuZ2U",
+        "pubKeyCredParams": [{"type": "public-key", "alg": -7}],
+    },
+}
+
+MOCK_CREDENTIAL = {
+    "id": "cred_01",
+    "principalId": "user_abc123",
+    "deviceName": "YubiKey 5",
+    "backedUp": False,
+    "transports": ["usb"],
+    "createdAt": "2026-03-01T00:00:00Z",
+    "lastUsedAt": None,
+}
+
+
+@pytest.fixture
+def client() -> Grantex:
+    return Grantex(api_key="test-key")
+
+
+@respx.mock
+def test_register_options(client: Grantex) -> None:
+    route = respx.post("https://api.grantex.dev/v1/webauthn/register/options").mock(
+        return_value=httpx.Response(200, json=MOCK_REGISTRATION_OPTIONS)
+    )
+    result = client.webauthn.register_options(principal_id="user_abc123")
+
+    assert result.challenge_id == "ch_01"
+    assert "rp" in result.public_key
+
+    body = json.loads(route.calls[0].request.content)
+    assert body["principalId"] == "user_abc123"
+
+
+@respx.mock
+def test_register_verify(client: Grantex) -> None:
+    route = respx.post("https://api.grantex.dev/v1/webauthn/register/verify").mock(
+        return_value=httpx.Response(200, json=MOCK_CREDENTIAL)
+    )
+    from grantex import WebAuthnRegistrationVerifyParams
+
+    result = client.webauthn.register_verify(
+        WebAuthnRegistrationVerifyParams(
+            challenge_id="ch_01",
+            response={"id": "rawId", "rawId": "rawId", "type": "public-key"},
+            device_name="YubiKey 5",
+        )
+    )
+
+    assert result.id == "cred_01"
+    assert result.principal_id == "user_abc123"
+    assert result.device_name == "YubiKey 5"
+
+    body = json.loads(route.calls[0].request.content)
+    assert body["challengeId"] == "ch_01"
+    assert body["deviceName"] == "YubiKey 5"
+
+
+@respx.mock
+def test_list_credentials(client: Grantex) -> None:
+    respx.get(
+        "https://api.grantex.dev/v1/webauthn/credentials?principalId=user_abc123"
+    ).mock(return_value=httpx.Response(200, json={"credentials": [MOCK_CREDENTIAL]}))
+
+    result = client.webauthn.list_credentials("user_abc123")
+
+    assert len(result.credentials) == 1
+    assert result.credentials[0].device_name == "YubiKey 5"
+
+
+@respx.mock
+def test_delete_credential(client: Grantex) -> None:
+    respx.delete("https://api.grantex.dev/v1/webauthn/credentials/cred_01").mock(
+        return_value=httpx.Response(204)
+    )
+    result = client.webauthn.delete_credential("cred_01")
+    assert result is None

--- a/packages/sdk-ts/src/client.ts
+++ b/packages/sdk-ts/src/client.ts
@@ -16,6 +16,8 @@ import { BudgetsClient } from './resources/budgets.js';
 import { EventsClient } from './resources/events.js';
 import { UsageClient } from './resources/usage.js';
 import { DomainsClient } from './resources/domains.js';
+import { WebAuthnClient } from './resources/webauthn.js';
+import { CredentialsClient } from './resources/credentials.js';
 import type {
   AuthorizationRequest,
   AuthorizeParams,
@@ -24,6 +26,8 @@ import type {
   RotateKeyResponse,
   SignupParams,
   SignupResponse,
+  UpdateDeveloperSettingsParams,
+  UpdateDeveloperSettingsResponse,
 } from './types.js';
 
 const DEFAULT_BASE_URL = 'https://api.grantex.dev';
@@ -48,6 +52,8 @@ export class Grantex {
   readonly events: EventsClient;
   readonly usage: UsageClient;
   readonly domains: DomainsClient;
+  readonly webauthn: WebAuthnClient;
+  readonly credentials: CredentialsClient;
 
   get lastRateLimit(): RateLimit | undefined {
     return this.#http.lastRateLimit;
@@ -86,6 +92,8 @@ export class Grantex {
     this.events = new EventsClient(this.#http);
     this.usage = new UsageClient(this.#http);
     this.domains = new DomainsClient(this.#http);
+    this.webauthn = new WebAuthnClient(this.#http);
+    this.credentials = new CredentialsClient(this.#http);
   }
 
   /**
@@ -135,5 +143,12 @@ export class Grantex {
    */
   rotateKey(): Promise<RotateKeyResponse> {
     return this.#http.post<RotateKeyResponse>('/v1/keys/rotate');
+  }
+
+  /**
+   * Update developer settings (e.g. FIDO/WebAuthn requirements).
+   */
+  updateSettings(params: UpdateDeveloperSettingsParams): Promise<UpdateDeveloperSettingsResponse> {
+    return this.#http.patch<UpdateDeveloperSettingsResponse>('/v1/me', params);
   }
 }

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -132,4 +132,20 @@ export type {
   DomainEntry,
   ListDomainsResponse,
   VerifyDomainResponse,
+  // WebAuthn / FIDO
+  WebAuthnRegistrationOptions,
+  WebAuthnRegistrationVerifyParams,
+  WebAuthnCredential,
+  ListWebAuthnCredentialsResponse,
+  // Verifiable Credentials
+  VerifiableCredentialRecord,
+  ListCredentialsParams,
+  ListCredentialsResponse,
+  VCVerificationResult,
+  // SD-JWT
+  SDJWTPresentParams,
+  SDJWTPresentResult,
+  // Developer Settings
+  UpdateDeveloperSettingsParams,
+  UpdateDeveloperSettingsResponse,
 } from './types.js';

--- a/packages/sdk-ts/src/resources/credentials.ts
+++ b/packages/sdk-ts/src/resources/credentials.ts
@@ -1,0 +1,40 @@
+import type { HttpClient } from '../http.js';
+import type {
+  VerifiableCredentialRecord,
+  ListCredentialsParams,
+  ListCredentialsResponse,
+  VCVerificationResult,
+  SDJWTPresentParams,
+  SDJWTPresentResult,
+} from '../types.js';
+
+export class CredentialsClient {
+  readonly #http: HttpClient;
+
+  constructor(http: HttpClient) {
+    this.#http = http;
+  }
+
+  get(credentialId: string): Promise<VerifiableCredentialRecord> {
+    return this.#http.get<VerifiableCredentialRecord>(`/v1/credentials/${credentialId}`);
+  }
+
+  list(params?: ListCredentialsParams): Promise<ListCredentialsResponse> {
+    const searchParams = new URLSearchParams();
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        if (value !== undefined) searchParams.set(key, String(value));
+      }
+    }
+    const qs = searchParams.toString();
+    return this.#http.get<ListCredentialsResponse>(`/v1/credentials${qs ? `?${qs}` : ''}`);
+  }
+
+  verify(vcJwt: string): Promise<VCVerificationResult> {
+    return this.#http.post<VCVerificationResult>('/v1/credentials/verify', { credential: vcJwt });
+  }
+
+  present(params: SDJWTPresentParams): Promise<SDJWTPresentResult> {
+    return this.#http.post<SDJWTPresentResult>('/v1/credentials/present', params);
+  }
+}

--- a/packages/sdk-ts/src/resources/webauthn.ts
+++ b/packages/sdk-ts/src/resources/webauthn.ts
@@ -1,0 +1,33 @@
+import type { HttpClient } from '../http.js';
+import type {
+  WebAuthnRegistrationOptions,
+  WebAuthnRegistrationVerifyParams,
+  WebAuthnCredential,
+  ListWebAuthnCredentialsResponse,
+} from '../types.js';
+
+export class WebAuthnClient {
+  readonly #http: HttpClient;
+
+  constructor(http: HttpClient) {
+    this.#http = http;
+  }
+
+  registerOptions(params: { principalId: string }): Promise<WebAuthnRegistrationOptions> {
+    return this.#http.post<WebAuthnRegistrationOptions>('/v1/webauthn/register/options', params);
+  }
+
+  registerVerify(params: WebAuthnRegistrationVerifyParams): Promise<WebAuthnCredential> {
+    return this.#http.post<WebAuthnCredential>('/v1/webauthn/register/verify', params);
+  }
+
+  listCredentials(principalId: string): Promise<ListWebAuthnCredentialsResponse> {
+    return this.#http.get<ListWebAuthnCredentialsResponse>(
+      `/v1/webauthn/credentials?principalId=${encodeURIComponent(principalId)}`,
+    );
+  }
+
+  deleteCredential(credentialId: string): Promise<void> {
+    return this.#http.delete<void>(`/v1/webauthn/credentials/${credentialId}`);
+  }
+}

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -169,6 +169,8 @@ export interface ExchangeTokenParams {
   agentId: string;
   /** PKCE code verifier (from generatePkce()) — required if codeChallenge was sent in authorize */
   codeVerifier?: string;
+  /** Request a verifiable credential alongside the grant token */
+  credentialFormat?: 'jwt' | 'vc-jwt' | 'both';
 }
 
 export interface ExchangeTokenResponse {
@@ -177,6 +179,8 @@ export interface ExchangeTokenResponse {
   scopes: string[];
   refreshToken: string;
   grantId: string;
+  /** SD-JWT verifiable credential (present when credentialFormat was requested) */
+  verifiableCredential?: string;
 }
 
 export interface RefreshTokenParams {
@@ -280,6 +284,8 @@ export interface VerifyGrantTokenOptions {
   jwksUri: string;
   requiredScopes?: string[];
   audience?: string;
+  /** Resolve a did:web DID to derive the JWKS URL instead of using jwksUri directly */
+  issuerDid?: string;
   /** @internal override clock for testing */
   clockTolerance?: number;
 }
@@ -725,4 +731,86 @@ export interface ListDomainsResponse {
 export interface VerifyDomainResponse {
   verified: boolean;
   message: string;
+}
+
+// ─── WebAuthn / FIDO ─────────────────────────────────────────────────────────
+
+export interface WebAuthnRegistrationOptions {
+  challengeId: string;
+  publicKey: Record<string, unknown>;
+}
+
+export interface WebAuthnRegistrationVerifyParams {
+  challengeId: string;
+  response: Record<string, unknown>;
+  deviceName?: string;
+}
+
+export interface WebAuthnCredential {
+  id: string;
+  principalId: string;
+  deviceName: string | null;
+  backedUp: boolean;
+  transports: string[];
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
+export interface ListWebAuthnCredentialsResponse {
+  credentials: WebAuthnCredential[];
+}
+
+// ─── Verifiable Credentials ─────────────────────────────────────────────────
+
+export interface VerifiableCredentialRecord {
+  id: string;
+  grantId: string;
+  credentialType: string;
+  format: string;
+  credential: string;
+  status: string;
+  issuedAt: string;
+  expiresAt: string;
+}
+
+export interface ListCredentialsParams {
+  grantId?: string;
+  principalId?: string;
+  status?: string;
+}
+
+export interface ListCredentialsResponse {
+  credentials: VerifiableCredentialRecord[];
+}
+
+export interface VCVerificationResult {
+  valid: boolean;
+  credentialType?: string;
+  issuer?: string;
+  subject?: Record<string, unknown>;
+  expiresAt?: string;
+  revoked?: boolean;
+}
+
+export interface SDJWTPresentParams {
+  sdJwt: string;
+  nonce?: string;
+  audience?: string;
+}
+
+export interface SDJWTPresentResult {
+  valid: boolean;
+  disclosedClaims?: Record<string, unknown>;
+  error?: string;
+}
+
+// ─── Developer Settings ──────────────────────────────────────────────────────
+
+export interface UpdateDeveloperSettingsParams {
+  fidoRequired?: boolean;
+  fidoRpName?: string;
+}
+
+export interface UpdateDeveloperSettingsResponse {
+  updated: boolean;
 }

--- a/packages/sdk-ts/src/verify.ts
+++ b/packages/sdk-ts/src/verify.ts
@@ -12,7 +12,12 @@ export async function verifyGrantToken(
   token: string,
   options: VerifyGrantTokenOptions,
 ): Promise<VerifiedGrant> {
-  const jwks = createRemoteJWKSet(new URL(options.jwksUri));
+  let jwksUri = options.jwksUri;
+  if (options.issuerDid?.startsWith('did:web:')) {
+    const domain = options.issuerDid.replace('did:web:', '').replaceAll(':', '/');
+    jwksUri = `https://${domain}/.well-known/jwks.json`;
+  }
+  const jwks = createRemoteJWKSet(new URL(jwksUri));
 
   let payload: GrantTokenPayload;
   try {

--- a/packages/sdk-ts/tests/credentials.test.ts
+++ b/packages/sdk-ts/tests/credentials.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Grantex } from '../src/client.js';
+
+const MOCK_VC_RECORD = {
+  id: 'vc_01',
+  grantId: 'grant_01',
+  credentialType: 'GrantCredential',
+  format: 'vc+sd-jwt',
+  credential: 'eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9...',
+  status: 'active',
+  issuedAt: '2026-03-01T00:00:00Z',
+  expiresAt: '2026-03-02T00:00:00Z',
+};
+
+const MOCK_VERIFY_RESULT = {
+  valid: true,
+  credentialType: 'GrantCredential',
+  issuer: 'did:web:grantex.dev',
+  subject: { principalId: 'user_abc123', agentDid: 'did:grantex:ag_01' },
+  expiresAt: '2026-03-02T00:00:00Z',
+  revoked: false,
+};
+
+function makeFetch(status: number, body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+describe('CredentialsClient', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('get() GETs /v1/credentials/:id', async () => {
+    const mockFetch = makeFetch(200, MOCK_VC_RECORD);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.credentials.get('vc_01');
+
+    expect(result.id).toBe('vc_01');
+    expect(result.credentialType).toBe('GrantCredential');
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toMatch(/\/v1\/credentials\/vc_01$/);
+  });
+
+  it('list() GETs /v1/credentials with query params', async () => {
+    const mockFetch = makeFetch(200, { credentials: [MOCK_VC_RECORD] });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.credentials.list({ grantId: 'grant_01', status: 'active' });
+
+    expect(result.credentials).toHaveLength(1);
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toContain('/v1/credentials?');
+    expect(url).toContain('grantId=grant_01');
+    expect(url).toContain('status=active');
+  });
+
+  it('list() without params sends GET without query string', async () => {
+    const mockFetch = makeFetch(200, { credentials: [] });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.credentials.list();
+
+    expect(result.credentials).toHaveLength(0);
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toMatch(/\/v1\/credentials$/);
+  });
+
+  it('verify() POSTs to /v1/credentials/verify', async () => {
+    const mockFetch = makeFetch(200, MOCK_VERIFY_RESULT);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.credentials.verify('eyJ...');
+
+    expect(result.valid).toBe(true);
+    expect(result.credentialType).toBe('GrantCredential');
+    expect(result.issuer).toBe('did:web:grantex.dev');
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/credentials\/verify$/);
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({ credential: 'eyJ...' });
+  });
+
+  it('present() POSTs to /v1/credentials/present', async () => {
+    const mockPresentResult = {
+      valid: true,
+      disclosedClaims: { principalId: 'user_abc', scopes: ['read'] },
+    };
+    const mockFetch = makeFetch(200, mockPresentResult);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.credentials.present({
+      sdJwt: 'eyJ...~disc1~disc2~',
+      nonce: 'test-nonce',
+      audience: 'https://api.example.com',
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.disclosedClaims).toEqual({ principalId: 'user_abc', scopes: ['read'] });
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/credentials\/present$/);
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
+    expect(body.sdJwt).toBe('eyJ...~disc1~disc2~');
+    expect(body.nonce).toBe('test-nonce');
+    expect(body.audience).toBe('https://api.example.com');
+  });
+
+  it('present() returns error for invalid SD-JWT', async () => {
+    const mockFetch = makeFetch(200, { valid: false, error: 'Invalid SD-JWT' });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.credentials.present({ sdJwt: 'invalid~' });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid SD-JWT');
+  });
+});

--- a/packages/sdk-ts/tests/signup.test.ts
+++ b/packages/sdk-ts/tests/signup.test.ts
@@ -93,3 +93,23 @@ describe('Grantex.rotateKey()', () => {
     expect(init.method).toBe('POST');
   });
 });
+
+describe('Grantex.updateSettings()', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('PATCHes /v1/me with settings', async () => {
+    const mockFetch = makeFetch(200, { updated: true });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.updateSettings({ fidoRequired: true, fidoRpName: 'MyApp' });
+
+    expect(result.updated).toBe(true);
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/me$/);
+    expect(init.method).toBe('PATCH');
+    const body = JSON.parse(init.body as string);
+    expect(body.fidoRequired).toBe(true);
+    expect(body.fidoRpName).toBe('MyApp');
+  });
+});

--- a/packages/sdk-ts/tests/verify.test.ts
+++ b/packages/sdk-ts/tests/verify.test.ts
@@ -156,6 +156,41 @@ describe('verifyGrantToken', () => {
       expect.objectContaining({ audience: 'https://myapp.example.com' }),
     );
   });
+
+  it('resolves did:web issuerDid to JWKS URI', async () => {
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: VALID_PAYLOAD,
+      protectedHeader: { alg: 'RS256' },
+    } as never);
+
+    const result = await verifyGrantToken('fake.token.here', {
+      jwksUri: 'https://fallback.example.com/.well-known/jwks.json',
+      issuerDid: 'did:web:grantex.dev',
+    });
+
+    // The DID should resolve to https://grantex.dev/.well-known/jwks.json
+    expect(jose.createRemoteJWKSet).toHaveBeenCalledWith(
+      new URL('https://grantex.dev/.well-known/jwks.json'),
+    );
+    expect(result.grantId).toBe('grant_01');
+  });
+
+  it('resolves did:web issuerDid with path segments', async () => {
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: VALID_PAYLOAD,
+      protectedHeader: { alg: 'RS256' },
+    } as never);
+
+    await verifyGrantToken('fake.token.here', {
+      jwksUri: 'https://fallback.example.com/.well-known/jwks.json',
+      issuerDid: 'did:web:example.com:api:v1',
+    });
+
+    // Colons after the method-specific-id prefix become path separators
+    expect(jose.createRemoteJWKSet).toHaveBeenCalledWith(
+      new URL('https://example.com/api/v1/.well-known/jwks.json'),
+    );
+  });
 });
 
 describe('mapOnlineVerifyToVerifiedGrant', () => {

--- a/packages/sdk-ts/tests/webauthn.test.ts
+++ b/packages/sdk-ts/tests/webauthn.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Grantex } from '../src/client.js';
+
+const MOCK_REGISTRATION_OPTIONS = {
+  challengeId: 'ch_01',
+  publicKey: {
+    rp: { name: 'Grantex', id: 'grantex.dev' },
+    challenge: 'dGVzdC1jaGFsbGVuZ2U',
+    pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+  },
+};
+
+const MOCK_CREDENTIAL = {
+  id: 'cred_01',
+  principalId: 'user_abc123',
+  deviceName: 'YubiKey 5',
+  backedUp: false,
+  transports: ['usb'],
+  createdAt: '2026-03-01T00:00:00Z',
+  lastUsedAt: null,
+};
+
+function makeFetch(status: number, body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+describe('WebAuthnClient', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('registerOptions() POSTs to /v1/webauthn/register/options', async () => {
+    const mockFetch = makeFetch(200, MOCK_REGISTRATION_OPTIONS);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.webauthn.registerOptions({ principalId: 'user_abc123' });
+
+    expect(result.challengeId).toBe('ch_01');
+    expect(result.publicKey).toBeDefined();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/webauthn\/register\/options$/);
+    expect(init.method).toBe('POST');
+  });
+
+  it('registerVerify() POSTs to /v1/webauthn/register/verify', async () => {
+    const mockFetch = makeFetch(200, MOCK_CREDENTIAL);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.webauthn.registerVerify({
+      challengeId: 'ch_01',
+      response: { id: 'rawId', rawId: 'rawId', type: 'public-key' },
+      deviceName: 'YubiKey 5',
+    });
+
+    expect(result.id).toBe('cred_01');
+    expect(result.principalId).toBe('user_abc123');
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/webauthn\/register\/verify$/);
+    expect(init.method).toBe('POST');
+  });
+
+  it('listCredentials() GETs /v1/webauthn/credentials with principalId query', async () => {
+    const mockFetch = makeFetch(200, { credentials: [MOCK_CREDENTIAL] });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    const result = await grantex.webauthn.listCredentials('user_abc123');
+
+    expect(result.credentials).toHaveLength(1);
+    expect(result.credentials[0]!.deviceName).toBe('YubiKey 5');
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toMatch(/\/v1\/webauthn\/credentials\?principalId=user_abc123$/);
+  });
+
+  it('deleteCredential() DELETEs /v1/webauthn/credentials/:id', async () => {
+    vi.stubGlobal('fetch', makeFetch(204, null));
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    await expect(grantex.webauthn.deleteCredential('cred_01')).resolves.toBeUndefined();
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v1\/webauthn\/credentials\/cred_01$/);
+    expect(init.method).toBe('DELETE');
+  });
+});


### PR DESCRIPTION
## Summary

- **W3C Verifiable Credentials (VC-JWT)**: Full issuance, verification, and StatusList2021 revocation. VCs issued alongside grant tokens via `credentialFormat` parameter on token exchange and delegation
- **SD-JWT Selective Disclosure**: Privacy-preserving credential presentations per draft-ietf-oauth-selective-disclosure-jwt. Agents reveal only the claims needed per interaction (principalId, developerId, scopes, delegationDepth are selectively disclosable)
- **DID Infrastructure**: `did:web:grantex.dev` document served at `/.well-known/did.json` with Ed25519 + RSA key support
- **FIDO2/WebAuthn**: Challenge replay protection, credential management, and assertion verification via @simplewebauthn/server
- **SDK updates**: TypeScript, Python, and Go SDKs updated with `credentials.present()`, `credentials.get/list/verify()`, `webauthn.*` methods, and new types (`SDJWTPresentParams`, `SDJWTPresentResult`, etc.)
- **Security tests**: 26 dedicated security tests covering WebAuthn replay, VC credential stuffing, StatusList bit manipulation, delegation security, and API key enforcement
- **Documentation**: 4 new Mintlify docs pages (FIDO/WebAuthn, Verifiable Credentials, SD-JWT, DID Infrastructure), OpenAPI spec updates, and navigation updates
- **Coverage**: 677 auth-service tests, 158 TS SDK tests, 127 Python SDK tests — all passing at 99.07% statement coverage

## Test plan

- [x] Auth service tests pass (677 tests across 62 files)
- [x] TypeScript SDK tests pass (158 tests)
- [x] Python SDK tests pass (127 tests)
- [x] Security test suite validates WebAuthn replay protection, VC tampering detection, StatusList isolation
- [x] SD-JWT issuance, verification, and presentation tests (35 tests)
- [x] Typecheck passes for auth-service and SDK packages