### PR TITLE
chore: bump all package versions for v2.3 release

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grantex/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grantex/cli",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@grantex/sdk": "^0.1.1",
@@ -15,22 +15,6 @@
       },
       "bin": {
         "grantex": "dist/index.js"
-      },
-      "devDependencies": {
-        "@types/node": "^20.11.0",
-        "typescript": "^5.3.3",
-        "vitest": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "../sdk-ts": {
-      "name": "@grantex/sdk",
-      "version": "0.1.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jose": "^5.2.4"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -484,8 +468,16 @@
       }
     },
     "node_modules/@grantex/sdk": {
-      "resolved": "../sdk-ts",
-      "link": true
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@grantex/sdk/-/sdk-0.1.9.tgz",
+      "integrity": "sha512-9h155JD6KLrEM4rvPz4bLv550bRAy1St1YAU4Nv4qw/aHwQ/HkyWt/XxUrVz/vOcX3icAHV+olVUlu9dyuquyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jose": "^5.2.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
@@ -1273,6 +1265,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "CLI tool for local Grantex development",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/conformance/package-lock.json
+++ b/packages/conformance/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grantex/conformance",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grantex/conformance",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/conformance",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Conformance test suite for the Grantex protocol",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/express/package-lock.json
+++ b/packages/express/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grantex/express",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grantex/express",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@grantex/sdk": "file:../sdk-ts",
@@ -26,7 +26,7 @@
     },
     "../sdk-ts": {
       "name": "@grantex/sdk",
-      "version": "0.1.5",
+      "version": "0.2.3",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -34,6 +34,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
+        "@vitest/coverage-v8": "^1.6.1",
         "typescript": "^5.3.3",
         "vitest": "^1.3.1"
       },

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/express",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Express.js middleware for Grantex grant token verification and scope-based authorization",
   "homepage": "https://grantex.dev/for/express",
   "bugs": {

--- a/packages/gateway/package-lock.json
+++ b/packages/gateway/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grantex/gateway",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grantex/gateway",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "fastify": "^5.7.3",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/gateway",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Zero-code reverse-proxy gateway that enforces Grantex grant tokens via YAML config",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/langchain/package-lock.json
+++ b/packages/langchain/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grantex/langchain",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grantex/langchain",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@grantex/sdk": "file:../sdk-ts",
@@ -25,7 +25,7 @@
     },
     "../sdk-ts": {
       "name": "@grantex/sdk",
-      "version": "0.1.0",
+      "version": "0.2.3",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
+        "@vitest/coverage-v8": "^1.6.1",
         "typescript": "^5.3.3",
         "vitest": "^1.3.1"
       },

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/langchain",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "LangChain integration for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev/for/langchain",
   "bugs": {

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grantex/mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grantex/mcp",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@grantex/sdk": "^0.1.6",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "MCP server for Grantex delegated agent authorization",
   "homepage": "https://grantex.dev/for/mcp",
   "bugs": {

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.2.1"
+version = "0.2.2"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grantex/sdk",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "jose": "^5.2.4"

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev",
   "bugs": {


### PR DESCRIPTION
## Summary
Bump all package versions for the v2.3 Trust & Identity release.

| Package | Old | New |
|---|---|---|
| `@grantex/sdk` | 0.2.2 | 0.2.3 |
| `grantex` (PyPI) | 0.2.1 | 0.2.2 |
| `@grantex/mcp` | 0.1.2 | 0.1.3 |
| `@grantex/cli` | 0.1.3 | 0.1.4 |
| `@grantex/langchain` | 0.1.3 | 0.1.4 |
| `@grantex/express` | 0.1.2 | 0.1.3 |
| `@grantex/gateway` | 0.1.2 | 0.1.3 |
| `@grantex/conformance` | 0.1.5 | 0.1.6 |

## Test plan
- [ ] CI passes
- [ ] Publish npm packages after merge
- [ ] Publish PyPI package after merge