### PR TITLE
chore: sync Go SDK v0.1.3 with 6 new resource services

### DIFF
--- a/packages/go-sdk/budgets.go
+++ b/packages/go-sdk/budgets.go
@@ -1,0 +1,95 @@
+package grantex
+
+import (
+	"context"
+	"fmt"
+)
+
+// BudgetsService handles budget allocation and tracking.
+type BudgetsService struct {
+	http *httpClient
+}
+
+// AllocateBudgetParams contains the parameters for allocating a budget.
+type AllocateBudgetParams struct {
+	GrantID       string  `json:"grantId"`
+	InitialBudget float64 `json:"initialBudget"`
+}
+
+// BudgetAllocation represents a budget allocation record.
+type BudgetAllocation struct {
+	ID              string `json:"id"`
+	GrantID         string `json:"grantId"`
+	DeveloperID     string `json:"developerId"`
+	InitialBudget   string `json:"initialBudget"`
+	RemainingBudget string `json:"remainingBudget"`
+	Currency        string `json:"currency"`
+	CreatedAt       string `json:"createdAt"`
+	UpdatedAt       string `json:"updatedAt"`
+}
+
+// DebitBudgetParams contains the parameters for debiting a budget.
+type DebitBudgetParams struct {
+	GrantID     string  `json:"grantId"`
+	Amount      float64 `json:"amount"`
+	Description string  `json:"description,omitempty"`
+}
+
+// DebitBudgetResponse is the response from a budget debit operation.
+type DebitBudgetResponse struct {
+	Remaining     string `json:"remaining"`
+	TransactionID string `json:"transactionId"`
+}
+
+// BudgetTransaction represents a single budget transaction.
+type BudgetTransaction struct {
+	ID           string                 `json:"id"`
+	GrantID      string                 `json:"grantId"`
+	AllocationID string                 `json:"allocationId"`
+	Amount       string                 `json:"amount"`
+	Description  string                 `json:"description"`
+	Metadata     map[string]interface{} `json:"metadata"`
+	CreatedAt    string                 `json:"createdAt"`
+}
+
+type listAllocationsResponse struct {
+	Allocations []BudgetAllocation `json:"allocations"`
+}
+
+type listTransactionsResponse struct {
+	Transactions []BudgetTransaction `json:"transactions"`
+	Total        int                 `json:"total"`
+}
+
+// Allocate creates a new budget allocation for a grant.
+func (s *BudgetsService) Allocate(ctx context.Context, params AllocateBudgetParams) (*BudgetAllocation, error) {
+	return unmarshal[BudgetAllocation](s.http.post(ctx, "/v1/budget/allocate", params))
+}
+
+// Debit debits an amount from a grant's budget.
+func (s *BudgetsService) Debit(ctx context.Context, params DebitBudgetParams) (*DebitBudgetResponse, error) {
+	return unmarshal[DebitBudgetResponse](s.http.post(ctx, "/v1/budget/debit", params))
+}
+
+// Balance retrieves the current budget balance for a grant.
+func (s *BudgetsService) Balance(ctx context.Context, grantID string) (*BudgetAllocation, error) {
+	return unmarshal[BudgetAllocation](s.http.get(ctx, fmt.Sprintf("/v1/budget/balance/%s", grantID)))
+}
+
+// Allocations lists all budget allocations.
+func (s *BudgetsService) Allocations(ctx context.Context) ([]BudgetAllocation, error) {
+	resp, err := unmarshal[listAllocationsResponse](s.http.get(ctx, "/v1/budget/allocations"))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Allocations, nil
+}
+
+// Transactions lists budget transactions for a grant.
+func (s *BudgetsService) Transactions(ctx context.Context, grantID string) ([]BudgetTransaction, error) {
+	resp, err := unmarshal[listTransactionsResponse](s.http.get(ctx, fmt.Sprintf("/v1/budget/transactions/%s", grantID)))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Transactions, nil
+}

--- a/packages/go-sdk/budgets_test.go
+++ b/packages/go-sdk/budgets_test.go
@@ -1,0 +1,159 @@
+package grantex
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBudgetsAllocate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/budget/allocate" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		var params AllocateBudgetParams
+		json.NewDecoder(r.Body).Decode(&params)
+		if params.GrantID != "grant-1" {
+			t.Errorf("expected grantId grant-1, got %s", params.GrantID)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(BudgetAllocation{
+			ID:              "alloc-1",
+			GrantID:         "grant-1",
+			DeveloperID:     "dev-1",
+			InitialBudget:   "100.00",
+			RemainingBudget: "100.00",
+			Currency:        "USD",
+			CreatedAt:       "2026-03-01T00:00:00Z",
+			UpdatedAt:       "2026-03-01T00:00:00Z",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	alloc, err := client.Budgets.Allocate(context.Background(), AllocateBudgetParams{
+		GrantID:       "grant-1",
+		InitialBudget: 100.00,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if alloc.ID != "alloc-1" {
+		t.Errorf("expected alloc-1, got %s", alloc.ID)
+	}
+	if alloc.InitialBudget != "100.00" {
+		t.Errorf("expected 100.00, got %s", alloc.InitialBudget)
+	}
+}
+
+func TestBudgetsDebit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/budget/debit" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(DebitBudgetResponse{
+			Remaining:     "90.00",
+			TransactionID: "tx-1",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	result, err := client.Budgets.Debit(context.Background(), DebitBudgetParams{
+		GrantID:     "grant-1",
+		Amount:      10.00,
+		Description: "API call",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Remaining != "90.00" {
+		t.Errorf("expected 90.00, got %s", result.Remaining)
+	}
+	if result.TransactionID != "tx-1" {
+		t.Errorf("expected tx-1, got %s", result.TransactionID)
+	}
+}
+
+func TestBudgetsBalance(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/budget/balance/grant-1" || r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(BudgetAllocation{
+			ID:              "alloc-1",
+			GrantID:         "grant-1",
+			InitialBudget:   "100.00",
+			RemainingBudget: "75.50",
+			Currency:        "USD",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	alloc, err := client.Budgets.Balance(context.Background(), "grant-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if alloc.RemainingBudget != "75.50" {
+		t.Errorf("expected 75.50, got %s", alloc.RemainingBudget)
+	}
+}
+
+func TestBudgetsAllocations(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/budget/allocations" || r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(listAllocationsResponse{
+			Allocations: []BudgetAllocation{
+				{ID: "alloc-1", GrantID: "grant-1"},
+				{ID: "alloc-2", GrantID: "grant-2"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	allocs, err := client.Budgets.Allocations(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(allocs) != 2 {
+		t.Errorf("expected 2 allocations, got %d", len(allocs))
+	}
+}
+
+func TestBudgetsTransactions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/budget/transactions/grant-1" || r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(listTransactionsResponse{
+			Transactions: []BudgetTransaction{
+				{ID: "tx-1", GrantID: "grant-1", Amount: "10.00"},
+				{ID: "tx-2", GrantID: "grant-1", Amount: "5.00"},
+			},
+			Total: 2,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	txns, err := client.Budgets.Transactions(context.Background(), "grant-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(txns) != 2 {
+		t.Errorf("expected 2 transactions, got %d", len(txns))
+	}
+	if txns[0].Amount != "10.00" {
+		t.Errorf("expected 10.00, got %s", txns[0].Amount)
+	}
+}

--- a/packages/go-sdk/credentials.go
+++ b/packages/go-sdk/credentials.go
@@ -1,0 +1,90 @@
+package grantex
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// CredentialsService handles Verifiable Credential operations.
+type CredentialsService struct {
+	http *httpClient
+}
+
+// VerifiableCredentialRecord represents a Verifiable Credential record.
+type VerifiableCredentialRecord struct {
+	ID           string   `json:"id"`
+	Type         []string `json:"type"`
+	Issuer       string   `json:"issuer"`
+	Subject      string   `json:"subject"`
+	GrantID      string   `json:"grantId"`
+	Status       string   `json:"status"`
+	IssuanceDate string   `json:"issuanceDate"`
+	JWT          string   `json:"jwt"`
+}
+
+// ListCredentialsParams contains optional filters for listing credentials.
+type ListCredentialsParams struct {
+	GrantID string
+	Status  string
+}
+
+// VCVerificationResult is the result of verifying a Verifiable Credential.
+type VCVerificationResult struct {
+	Valid             bool                   `json:"valid"`
+	CredentialSubject map[string]interface{} `json:"credentialSubject"`
+	Issuer            string                 `json:"issuer"`
+	Error             string                 `json:"error,omitempty"`
+}
+
+// SDJWTPresentParams contains the parameters for creating an SD-JWT presentation.
+type SDJWTPresentParams struct {
+	SDJWT           string   `json:"sdJwt"`
+	DisclosedClaims []string `json:"disclosedClaims"`
+}
+
+// SDJWTPresentResult is the result of creating an SD-JWT presentation.
+type SDJWTPresentResult struct {
+	Presentation string `json:"presentation"`
+}
+
+type listCredentialsResponse struct {
+	Credentials []VerifiableCredentialRecord `json:"credentials"`
+}
+
+// Get retrieves a Verifiable Credential by ID.
+func (s *CredentialsService) Get(ctx context.Context, id string) (*VerifiableCredentialRecord, error) {
+	return unmarshal[VerifiableCredentialRecord](s.http.get(ctx, fmt.Sprintf("/v1/credentials/%s", id)))
+}
+
+// List retrieves Verifiable Credentials with optional filters.
+func (s *CredentialsService) List(ctx context.Context, params *ListCredentialsParams) ([]VerifiableCredentialRecord, error) {
+	path := "/v1/credentials"
+	if params != nil {
+		q := url.Values{}
+		if params.GrantID != "" {
+			q.Set("grantId", params.GrantID)
+		}
+		if params.Status != "" {
+			q.Set("status", params.Status)
+		}
+		if qs := q.Encode(); qs != "" {
+			path += "?" + qs
+		}
+	}
+	resp, err := unmarshal[listCredentialsResponse](s.http.get(ctx, path))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Credentials, nil
+}
+
+// Verify verifies a VC-JWT.
+func (s *CredentialsService) Verify(ctx context.Context, vcJWT string) (*VCVerificationResult, error) {
+	return unmarshal[VCVerificationResult](s.http.post(ctx, "/v1/credentials/verify", map[string]string{"vcJwt": vcJWT}))
+}
+
+// Present creates an SD-JWT presentation with selective disclosure.
+func (s *CredentialsService) Present(ctx context.Context, params SDJWTPresentParams) (*SDJWTPresentResult, error) {
+	return unmarshal[SDJWTPresentResult](s.http.post(ctx, "/v1/credentials/present", params))
+}

--- a/packages/go-sdk/credentials_test.go
+++ b/packages/go-sdk/credentials_test.go
@@ -1,0 +1,158 @@
+package grantex
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCredentialsGet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/credentials/vc-1" || r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(VerifiableCredentialRecord{
+			ID:           "vc-1",
+			Type:         []string{"VerifiableCredential", "GrantCredential"},
+			Issuer:       "did:web:grantex.dev",
+			Subject:      "did:key:z6Mk...",
+			GrantID:      "grant-1",
+			Status:       "active",
+			IssuanceDate: "2026-03-01T00:00:00Z",
+			JWT:          "eyJ...",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	vc, err := client.Credentials.Get(context.Background(), "vc-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vc.ID != "vc-1" {
+		t.Errorf("expected vc-1, got %s", vc.ID)
+	}
+	if vc.Issuer != "did:web:grantex.dev" {
+		t.Errorf("expected did:web:grantex.dev, got %s", vc.Issuer)
+	}
+	if len(vc.Type) != 2 {
+		t.Errorf("expected 2 types, got %d", len(vc.Type))
+	}
+}
+
+func TestCredentialsList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/credentials" || r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(listCredentialsResponse{
+			Credentials: []VerifiableCredentialRecord{
+				{ID: "vc-1", Status: "active"},
+				{ID: "vc-2", Status: "active"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	creds, err := client.Credentials.List(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(creds) != 2 {
+		t.Errorf("expected 2 credentials, got %d", len(creds))
+	}
+}
+
+func TestCredentialsListWithParams(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("grantId") != "grant-1" {
+			t.Errorf("expected grantId=grant-1, got %s", r.URL.Query().Get("grantId"))
+		}
+		if r.URL.Query().Get("status") != "active" {
+			t.Errorf("expected status=active, got %s", r.URL.Query().Get("status"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(listCredentialsResponse{
+			Credentials: []VerifiableCredentialRecord{
+				{ID: "vc-1", GrantID: "grant-1", Status: "active"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	creds, err := client.Credentials.List(context.Background(), &ListCredentialsParams{
+		GrantID: "grant-1",
+		Status:  "active",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(creds) != 1 {
+		t.Errorf("expected 1 credential, got %d", len(creds))
+	}
+}
+
+func TestCredentialsVerify(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/credentials/verify" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(VCVerificationResult{
+			Valid: true,
+			CredentialSubject: map[string]interface{}{
+				"grantId": "grant-1",
+			},
+			Issuer: "did:web:grantex.dev",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	result, err := client.Credentials.Verify(context.Background(), "eyJ...")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Valid {
+		t.Error("expected credential to be valid")
+	}
+	if result.Issuer != "did:web:grantex.dev" {
+		t.Errorf("expected did:web:grantex.dev, got %s", result.Issuer)
+	}
+}
+
+func TestCredentialsPresent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/credentials/present" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		var params SDJWTPresentParams
+		json.NewDecoder(r.Body).Decode(&params)
+		if params.SDJWT != "sd-jwt-token" {
+			t.Errorf("expected sd-jwt-token, got %s", params.SDJWT)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(SDJWTPresentResult{
+			Presentation: "presentation-jwt",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	result, err := client.Credentials.Present(context.Background(), SDJWTPresentParams{
+		SDJWT:           "sd-jwt-token",
+		DisclosedClaims: []string{"grantId", "scopes"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Presentation != "presentation-jwt" {
+		t.Errorf("expected presentation-jwt, got %s", result.Presentation)
+	}
+}

--- a/packages/go-sdk/domains.go
+++ b/packages/go-sdk/domains.go
@@ -1,0 +1,60 @@
+package grantex
+
+import (
+	"context"
+	"fmt"
+)
+
+// DomainsService handles custom domain management.
+type DomainsService struct {
+	http *httpClient
+}
+
+// CreateDomainParams contains the parameters for creating a custom domain.
+type CreateDomainParams struct {
+	Domain string `json:"domain"`
+}
+
+// Domain represents a custom domain record.
+type Domain struct {
+	ID                string `json:"id"`
+	Domain            string `json:"domain"`
+	Verified          bool   `json:"verified"`
+	VerificationToken string `json:"verificationToken"`
+	Instructions      string `json:"instructions"`
+	CreatedAt         string `json:"createdAt"`
+}
+
+// VerifyDomainResponse is the response from a domain verification operation.
+type VerifyDomainResponse struct {
+	Verified bool `json:"verified"`
+}
+
+type listDomainsResponse struct {
+	Domains []Domain `json:"domains"`
+}
+
+// Create registers a new custom domain.
+func (s *DomainsService) Create(ctx context.Context, params CreateDomainParams) (*Domain, error) {
+	return unmarshal[Domain](s.http.post(ctx, "/v1/domains", params))
+}
+
+// List retrieves all registered custom domains.
+func (s *DomainsService) List(ctx context.Context) ([]Domain, error) {
+	resp, err := unmarshal[listDomainsResponse](s.http.get(ctx, "/v1/domains"))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Domains, nil
+}
+
+// Verify triggers DNS verification for a domain.
+func (s *DomainsService) Verify(ctx context.Context, id string) (*VerifyDomainResponse, error) {
+	return unmarshal[VerifyDomainResponse](s.http.post(ctx, fmt.Sprintf("/v1/domains/%s/verify", id), nil))
+}
+
+// Delete removes a custom domain.
+func (s *DomainsService) Delete(ctx context.Context, id string) error {
+	_, err := s.http.del(ctx, fmt.Sprintf("/v1/domains/%s", id))
+	return err
+}

--- a/packages/go-sdk/domains_test.go
+++ b/packages/go-sdk/domains_test.go
@@ -1,0 +1,112 @@
+package grantex
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDomainsCreate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/domains" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		var params CreateDomainParams
+		json.NewDecoder(r.Body).Decode(&params)
+		if params.Domain != "example.com" {
+			t.Errorf("expected example.com, got %s", params.Domain)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Domain{
+			ID:                "dom-1",
+			Domain:            "example.com",
+			Verified:          false,
+			VerificationToken: "verify-token-123",
+			Instructions:      "Add a TXT record...",
+			CreatedAt:         "2026-03-01T00:00:00Z",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	domain, err := client.Domains.Create(context.Background(), CreateDomainParams{
+		Domain: "example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if domain.ID != "dom-1" {
+		t.Errorf("expected dom-1, got %s", domain.ID)
+	}
+	if domain.Verified {
+		t.Error("expected domain to not be verified")
+	}
+	if domain.VerificationToken != "verify-token-123" {
+		t.Errorf("expected verify-token-123, got %s", domain.VerificationToken)
+	}
+}
+
+func TestDomainsList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/domains" || r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(listDomainsResponse{
+			Domains: []Domain{
+				{ID: "dom-1", Domain: "example.com", Verified: true},
+				{ID: "dom-2", Domain: "api.example.com", Verified: false},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	domains, err := client.Domains.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(domains) != 2 {
+		t.Errorf("expected 2 domains, got %d", len(domains))
+	}
+}
+
+func TestDomainsVerify(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/domains/dom-1/verify" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(VerifyDomainResponse{
+			Verified: true,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	result, err := client.Domains.Verify(context.Background(), "dom-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Verified {
+		t.Error("expected domain to be verified")
+	}
+}
+
+func TestDomainsDelete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/domains/dom-1" || r.Method != http.MethodDelete {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	err := client.Domains.Delete(context.Background(), "dom-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/packages/go-sdk/events.go
+++ b/packages/go-sdk/events.go
@@ -1,0 +1,55 @@
+package grantex
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// EventsService handles real-time event streaming.
+type EventsService struct {
+	http *httpClient
+}
+
+// Event represents a server-sent event.
+type Event struct {
+	Type    string                 `json:"type"`
+	Payload map[string]interface{} `json:"payload"`
+}
+
+// Stream opens an SSE connection and sends events to the provided channel.
+// It blocks until the context is cancelled or the connection is closed.
+func (s *EventsService) Stream(ctx context.Context, ch chan<- Event) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", s.http.baseURL+"/v1/events/stream", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+s.http.apiKey)
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := s.http.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data: ") {
+			data := strings.TrimPrefix(line, "data: ")
+			var evt Event
+			if err := json.Unmarshal([]byte(data), &evt); err == nil {
+				ch <- evt
+			}
+		}
+	}
+	return scanner.Err()
+}

--- a/packages/go-sdk/events_test.go
+++ b/packages/go-sdk/events_test.go
@@ -1,0 +1,68 @@
+package grantex
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEventsStream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/events/stream" || r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("Accept") != "text/event-stream" {
+			t.Errorf("expected Accept: text/event-stream, got %s", r.Header.Get("Accept"))
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("expected http.Flusher")
+		}
+		fmt.Fprintf(w, "data: {\"type\":\"grant.created\",\"payload\":{\"grantId\":\"g-1\"}}\n\n")
+		flusher.Flush()
+		fmt.Fprintf(w, "data: {\"type\":\"token.exchanged\",\"payload\":{\"tokenId\":\"t-1\"}}\n\n")
+		flusher.Flush()
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	ch := make(chan Event, 10)
+
+	err := client.Events.Stream(context.Background(), ch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(ch) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(ch))
+	}
+
+	evt1 := <-ch
+	if evt1.Type != "grant.created" {
+		t.Errorf("expected grant.created, got %s", evt1.Type)
+	}
+
+	evt2 := <-ch
+	if evt2.Type != "token.exchanged" {
+		t.Errorf("expected token.exchanged, got %s", evt2.Type)
+	}
+}
+
+func TestEventsStreamUnauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := NewClient("bad-key", WithBaseURL(server.URL))
+	ch := make(chan Event, 10)
+
+	err := client.Events.Stream(context.Background(), ch)
+	if err == nil {
+		t.Fatal("expected error for unauthorized request")
+	}
+}

--- a/packages/go-sdk/grantex.go
+++ b/packages/go-sdk/grantex.go
@@ -34,6 +34,12 @@ type Client struct {
 	SCIM              *SCIMService
 	SSO               *SSOService
 	PrincipalSessions *PrincipalSessionsService
+	Budgets           *BudgetsService
+	Events            *EventsService
+	Usage             *UsageService
+	Domains           *DomainsService
+	WebAuthn          *WebAuthnService
+	Credentials       *CredentialsService
 
 	http *httpClient
 }
@@ -72,6 +78,12 @@ func NewClient(apiKey string, opts ...Option) *Client {
 	c.SCIM = &SCIMService{http: h}
 	c.SSO = &SSOService{http: h}
 	c.PrincipalSessions = &PrincipalSessionsService{http: h}
+	c.Budgets = &BudgetsService{http: h}
+	c.Events = &EventsService{http: h}
+	c.Usage = &UsageService{http: h}
+	c.Domains = &DomainsService{http: h}
+	c.WebAuthn = &WebAuthnService{http: h}
+	c.Credentials = &CredentialsService{http: h}
 
 	return c
 }

--- a/packages/go-sdk/usage.go
+++ b/packages/go-sdk/usage.go
@@ -1,0 +1,48 @@
+package grantex
+
+import (
+	"context"
+	"fmt"
+)
+
+// UsageService handles usage metering operations.
+type UsageService struct {
+	http *httpClient
+}
+
+// UsageResponse represents the current usage metrics.
+type UsageResponse struct {
+	DeveloperID    string `json:"developerId"`
+	Period         string `json:"period"`
+	TokenExchanges int    `json:"tokenExchanges"`
+	Authorizations int    `json:"authorizations"`
+	Verifications  int    `json:"verifications"`
+	TotalRequests  int    `json:"totalRequests"`
+}
+
+// UsageHistoryEntry represents a single day's usage metrics.
+type UsageHistoryEntry struct {
+	Date           string `json:"date"`
+	TokenExchanges int    `json:"tokenExchanges"`
+	Authorizations int    `json:"authorizations"`
+	Verifications  int    `json:"verifications"`
+	TotalRequests  int    `json:"totalRequests"`
+}
+
+type usageHistoryResponse struct {
+	Entries []UsageHistoryEntry `json:"entries"`
+}
+
+// Current retrieves the current period's usage metrics.
+func (s *UsageService) Current(ctx context.Context) (*UsageResponse, error) {
+	return unmarshal[UsageResponse](s.http.get(ctx, "/v1/usage"))
+}
+
+// History retrieves usage history for the specified number of days.
+func (s *UsageService) History(ctx context.Context, days int) ([]UsageHistoryEntry, error) {
+	resp, err := unmarshal[usageHistoryResponse](s.http.get(ctx, fmt.Sprintf("/v1/usage/history?days=%d", days)))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Entries, nil
+}

--- a/packages/go-sdk/usage_test.go
+++ b/packages/go-sdk/usage_test.go
@@ -1,0 +1,70 @@
+package grantex
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUsageCurrent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/usage" || r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(UsageResponse{
+			DeveloperID:    "dev-1",
+			Period:         "2026-03",
+			TokenExchanges: 150,
+			Authorizations: 42,
+			Verifications:  300,
+			TotalRequests:  492,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	usage, err := client.Usage.Current(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usage.DeveloperID != "dev-1" {
+		t.Errorf("expected dev-1, got %s", usage.DeveloperID)
+	}
+	if usage.TotalRequests != 492 {
+		t.Errorf("expected 492, got %d", usage.TotalRequests)
+	}
+}
+
+func TestUsageHistory(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/usage/history" || r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		if r.URL.Query().Get("days") != "7" {
+			t.Errorf("expected days=7, got %s", r.URL.Query().Get("days"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(usageHistoryResponse{
+			Entries: []UsageHistoryEntry{
+				{Date: "2026-03-01", TokenExchanges: 20, TotalRequests: 50},
+				{Date: "2026-03-02", TokenExchanges: 25, TotalRequests: 60},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	entries, err := client.Usage.History(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Date != "2026-03-01" {
+		t.Errorf("expected 2026-03-01, got %s", entries[0].Date)
+	}
+}

--- a/packages/go-sdk/webauthn.go
+++ b/packages/go-sdk/webauthn.go
@@ -1,0 +1,67 @@
+package grantex
+
+import (
+	"context"
+	"fmt"
+)
+
+// WebAuthnService handles FIDO2/WebAuthn credential management.
+type WebAuthnService struct {
+	http *httpClient
+}
+
+// WebAuthnRegisterOptionsParams contains the parameters for requesting registration options.
+type WebAuthnRegisterOptionsParams struct {
+	PrincipalID string `json:"principalId"`
+}
+
+// WebAuthnRegistrationOptions contains the challenge and options for WebAuthn registration.
+type WebAuthnRegistrationOptions struct {
+	ChallengeID string                 `json:"challengeId"`
+	Options     map[string]interface{} `json:"options"`
+}
+
+// WebAuthnRegisterVerifyParams contains the parameters for verifying a registration response.
+type WebAuthnRegisterVerifyParams struct {
+	ChallengeID string      `json:"challengeId"`
+	Response    interface{} `json:"response"`
+}
+
+// WebAuthnCredential represents a registered FIDO2 credential.
+type WebAuthnCredential struct {
+	ID           string   `json:"id"`
+	CredentialID string   `json:"credentialId"`
+	PublicKey    string   `json:"publicKey"`
+	Counter      int      `json:"counter"`
+	Transports   []string `json:"transports"`
+	CreatedAt    string   `json:"createdAt"`
+}
+
+type listWebAuthnCredentialsResponse struct {
+	Credentials []WebAuthnCredential `json:"credentials"`
+}
+
+// RegisterOptions requests WebAuthn registration options for a principal.
+func (s *WebAuthnService) RegisterOptions(ctx context.Context, params WebAuthnRegisterOptionsParams) (*WebAuthnRegistrationOptions, error) {
+	return unmarshal[WebAuthnRegistrationOptions](s.http.post(ctx, "/v1/webauthn/register/options", params))
+}
+
+// RegisterVerify verifies a WebAuthn registration response.
+func (s *WebAuthnService) RegisterVerify(ctx context.Context, params WebAuthnRegisterVerifyParams) (*WebAuthnCredential, error) {
+	return unmarshal[WebAuthnCredential](s.http.post(ctx, "/v1/webauthn/register/verify", params))
+}
+
+// ListCredentials lists all WebAuthn credentials for a principal.
+func (s *WebAuthnService) ListCredentials(ctx context.Context, principalID string) ([]WebAuthnCredential, error) {
+	resp, err := unmarshal[listWebAuthnCredentialsResponse](s.http.get(ctx, fmt.Sprintf("/v1/webauthn/credentials?principalId=%s", principalID)))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Credentials, nil
+}
+
+// DeleteCredential removes a WebAuthn credential by ID.
+func (s *WebAuthnService) DeleteCredential(ctx context.Context, id string) error {
+	_, err := s.http.del(ctx, fmt.Sprintf("/v1/webauthn/credentials/%s", id))
+	return err
+}

--- a/packages/go-sdk/webauthn_test.go
+++ b/packages/go-sdk/webauthn_test.go
@@ -1,0 +1,120 @@
+package grantex
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWebAuthnRegisterOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/webauthn/register/options" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		var params WebAuthnRegisterOptionsParams
+		json.NewDecoder(r.Body).Decode(&params)
+		if params.PrincipalID != "user-1" {
+			t.Errorf("expected principalId user-1, got %s", params.PrincipalID)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(WebAuthnRegistrationOptions{
+			ChallengeID: "challenge-1",
+			Options: map[string]interface{}{
+				"rp": map[string]interface{}{
+					"name": "Grantex",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	opts, err := client.WebAuthn.RegisterOptions(context.Background(), WebAuthnRegisterOptionsParams{
+		PrincipalID: "user-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.ChallengeID != "challenge-1" {
+		t.Errorf("expected challenge-1, got %s", opts.ChallengeID)
+	}
+}
+
+func TestWebAuthnRegisterVerify(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/webauthn/register/verify" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(WebAuthnCredential{
+			ID:           "cred-1",
+			CredentialID: "cred-id-abc",
+			PublicKey:    "pk-xyz",
+			Counter:      0,
+			Transports:   []string{"usb", "ble"},
+			CreatedAt:    "2026-03-01T00:00:00Z",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	cred, err := client.WebAuthn.RegisterVerify(context.Background(), WebAuthnRegisterVerifyParams{
+		ChallengeID: "challenge-1",
+		Response:    map[string]string{"attestationObject": "abc"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cred.ID != "cred-1" {
+		t.Errorf("expected cred-1, got %s", cred.ID)
+	}
+	if cred.CredentialID != "cred-id-abc" {
+		t.Errorf("expected cred-id-abc, got %s", cred.CredentialID)
+	}
+}
+
+func TestWebAuthnListCredentials(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/webauthn/credentials" || r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		if r.URL.Query().Get("principalId") != "user-1" {
+			t.Errorf("expected principalId=user-1, got %s", r.URL.Query().Get("principalId"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(listWebAuthnCredentialsResponse{
+			Credentials: []WebAuthnCredential{
+				{ID: "cred-1", CredentialID: "cred-id-1"},
+				{ID: "cred-2", CredentialID: "cred-id-2"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	creds, err := client.WebAuthn.ListCredentials(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(creds) != 2 {
+		t.Errorf("expected 2 credentials, got %d", len(creds))
+	}
+}
+
+func TestWebAuthnDeleteCredential(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/webauthn/credentials/cred-1" || r.Method != http.MethodDelete {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	err := client.WebAuthn.DeleteCredential(context.Background(), "cred-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Sync Go SDK monorepo mirror with standalone `grantex-go` repo v0.1.3
- Adds 6 new resource services: Budgets, Events, Usage, Domains, WebAuthn, Credentials
- 12 new files (6 source + 6 test), updated `grantex.go` Client struct

## Test plan
- [x] All tests pass in standalone repo (`go test ./...`)
- [x] v0.1.3 published and indexed on `proxy.golang.org`