### PR TITLE
chore: improve SEO — HSTS, manifest, sitemap, DID redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -4,7 +4,8 @@
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "redirects": [
       { "source": "/docs", "destination": "https://docs.grantex.dev", "type": 301 },
-      { "source": "/docs/:path*", "destination": "https://docs.grantex.dev/:path*", "type": 301 }
+      { "source": "/docs/:path*", "destination": "https://docs.grantex.dev/:path*", "type": 301 },
+      { "source": "/.well-known/did.json", "destination": "https://grantex-auth-dd4mtrt2gq-uc.a.run.app/.well-known/did.json", "type": 302 }
     ],
     "rewrites": [
       { "source": "/dashboard/**", "destination": "/dashboard/index.html" },
@@ -25,7 +26,9 @@
         "headers": [
           { "key": "X-Frame-Options",           "value": "DENY" },
           { "key": "X-Content-Type-Options",    "value": "nosniff" },
-          { "key": "Referrer-Policy",           "value": "strict-origin-when-cross-origin" }
+          { "key": "Referrer-Policy",           "value": "strict-origin-when-cross-origin" },
+          { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
+          { "key": "Permissions-Policy",        "value": "camera=(), microphone=(), geolocation=()" }
         ]
       }
     ]

--- a/web/index.html
+++ b/web/index.html
@@ -9,6 +9,8 @@
   <meta name="description" content="Open delegated authorization protocol for AI agents. W3C Verifiable Credentials, FIDO2/WebAuthn passkeys, SD-JWT selective disclosure, and DID infrastructure — built on JWT and OAuth 2.0.">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="canonical" href="https://grantex.dev/">
+  <link rel="manifest" href="/manifest.json">
+  <meta name="google-site-verification" content="78181e8137ae41ec881a17171a1e9fb2">
 
   <!-- OpenGraph -->
   <meta property="og:title" content="Grantex — OAuth 2.0 for AI Agents">

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "Grantex",
+  "short_name": "Grantex",
+  "description": "Open delegated authorization protocol for AI agents",
+  "start_url": "/",
+  "display": "browser",
+  "background_color": "#0f172a",
+  "theme_color": "#6366f1",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any"
+    }
+  ]
+}

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -2,91 +2,91 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://grantex.dev/</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://grantex.dev/playground</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/langchain</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/crewai</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/openai-agents</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/google-adk</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/vercel-ai</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/autogen</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/mcp</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/express</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/fastapi</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://grantex.dev/vs/oauth</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/vs/api-keys</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/vs/mcp-auth</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/vs/securing-ai-agents</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>


### PR DESCRIPTION
## Summary
- Add `google-site-verification` meta tag (redundant to existing file verification)
- Add HSTS (`max-age=63072000; includeSubDomains; preload`) and `Permissions-Policy` headers
- Add `web/manifest.json` with PWA metadata + `<link rel="manifest">` in index.html
- Update all sitemap `lastmod` dates to 2026-03-12
- Add `/.well-known/did.json` 302 redirect to auth service for DID spec compliance

## Test plan
- [ ] Verify `https://grantex.dev/.well-known/did.json` resolves after deploy
- [ ] Check HSTS header in browser devtools Network tab
- [ ] Validate sitemap at https://www.xml-sitemaps.com/validate-xml-sitemap.html
- [ ] Confirm GSC meta tag shows in page source