### PR TITLE
chore: auto-update sitemap dates + weekly SEO pings

### DIFF
--- a/.github/workflows/deploy-portal.yml
+++ b/.github/workflows/deploy-portal.yml
@@ -40,6 +40,12 @@ jobs:
           mkdir -p web/dashboard
           cp -r apps/portal/dist/* web/dashboard/
 
+      - name: Update sitemap lastmod dates
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+          sed -i "s|<lastmod>[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}</lastmod>|<lastmod>${TODAY}</lastmod>|g" web/sitemap.xml
+          echo "Updated sitemap lastmod dates to ${TODAY}"
+
       - name: Deploy to Firebase Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/seo-ping.yml
+++ b/.github/workflows/seo-ping.yml
@@ -1,0 +1,51 @@
+name: SEO Sitemap Ping
+
+on:
+  schedule:
+    - cron: '0 8 * * 1' # Every Monday at 8am UTC
+  workflow_dispatch:
+
+jobs:
+  ping:
+    name: Ping Search Engines
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Google
+        run: |
+          curl -s "https://www.google.com/ping?sitemap=https://grantex.dev/sitemap.xml"
+          curl -s "https://www.google.com/ping?sitemap=https://docs.grantex.dev/sitemap.xml"
+          echo "Google pinged"
+
+      - name: Ping Bing
+        run: |
+          curl -s "https://www.bing.com/ping?sitemap=https://grantex.dev/sitemap.xml"
+          curl -s "https://www.bing.com/ping?sitemap=https://docs.grantex.dev/sitemap.xml"
+          echo "Bing pinged"
+
+      - name: Ping IndexNow (Bing/Yandex)
+        run: |
+          curl -s -X POST "https://api.indexnow.org/indexnow" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "host": "grantex.dev",
+              "key": "78181e8137ae41ec881a17171a1e9fb2",
+              "urlList": [
+                "https://grantex.dev/",
+                "https://grantex.dev/playground",
+                "https://grantex.dev/report/state-of-agent-security-2026",
+                "https://grantex.dev/for/langchain",
+                "https://grantex.dev/for/crewai",
+                "https://grantex.dev/for/openai-agents",
+                "https://grantex.dev/for/google-adk",
+                "https://grantex.dev/for/vercel-ai",
+                "https://grantex.dev/for/autogen",
+                "https://grantex.dev/for/mcp",
+                "https://grantex.dev/for/express",
+                "https://grantex.dev/for/fastapi",
+                "https://grantex.dev/vs/oauth",
+                "https://grantex.dev/vs/api-keys",
+                "https://grantex.dev/vs/mcp-auth",
+                "https://grantex.dev/vs/securing-ai-agents"
+              ]
+            }' || true
+          echo "IndexNow pinged"


### PR DESCRIPTION
## Summary
- **deploy-portal.yml**: auto-updates all sitemap `lastmod` dates to today's date before each Firebase deploy
- **seo-ping.yml**: weekly cron (Monday 8am UTC) pings Google, Bing, and IndexNow with all 16 sitemap URLs

## Test plan
- [ ] Verify sitemap dates update on next deploy
- [ ] Manually trigger seo-ping workflow to confirm pings succeed