### PR TITLE
fix: add issues:write permission to monitor-mentions workflow

### DIFF
--- a/.github/workflows/monitor-mentions.yml
+++ b/.github/workflows/monitor-mentions.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 9 * * *' # Daily at 9am UTC
   workflow_dispatch:
 
+permissions:
+  issues: write
+  contents: read
+
 jobs:
   monitor:
     name: Check for Grantex mentions


### PR DESCRIPTION
The GITHUB_TOKEN needs explicit issues:write permission to create/comment on issues.