### PR TITLE
docs: MPP Agent Identity — landing page, README, and Mintlify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,39 @@ curl https://api.grantex.dev/.well-known/did.json
 
 MPP (Machine Payments Protocol) defines how AI agents pay for services via HTTP 402 flows. Grantex adds the missing identity layer: an `AgentPassportCredential` (W3C VC 2.0) that lets any merchant verify *who* authorized a payment, *what* the agent is allowed to buy, and *how much* it can spend — all in <50ms, offline-capable.
 
-**Issue a passport:**
+### Why Agent Passports?
+
+When an agent makes an MPP payment today, the `source` field is a wallet address — no human name, no organization, no authorization chain. For $0.10 API calls, nobody cares. For $500 B2B procurement, this is a compliance blocker. Visa and Mastercard are building proprietary agent identity networks (Trusted Agent Protocol, AgentPay), but these are closed and non-interoperable.
+
+Grantex passports are the open, standards-based answer: a W3C VC 2.0 credential signed with Ed25519, carrying the full delegation chain from human to agent, with StatusList2021 revocation and a public trust registry.
+
+### How It Works
+
+```
+Human → issues AgentPassportCredential → Agent stores in wallet
+Agent → makes MPP request + attaches X-Grantex-Passport header
+Merchant → verifyPassport() in <50ms → knows human, org, scopes, limits
+```
+
+### Credential Structure
+
+| Field | Description |
+|-------|-------------|
+| `id` | `urn:grantex:passport:<ulid>` |
+| `issuer` | `did:web:grantex.dev` |
+| `credentialSubject.id` | Agent DID (`did:grantex:ag_...`) |
+| `credentialSubject.humanPrincipal` | DID of the authorizing human |
+| `credentialSubject.organizationDID` | Org DID (`did:web:<domain>`) |
+| `credentialSubject.grantId` | Links to underlying Grantex grant |
+| `credentialSubject.allowedMPPCategories` | `inference`, `compute`, `data`, `storage`, `search`, `media`, `delivery`, `browser`, `general` |
+| `credentialSubject.maxTransactionAmount` | `{ amount, currency }` ceiling per transaction |
+| `credentialSubject.delegationDepth` | Inherited from grant delegation chain |
+| `credentialStatus` | StatusList2021 revocation entry |
+| `proof` | Ed25519Signature2020 |
+
+### Issue a Passport
+
+**TypeScript:**
 
 ```typescript
 import { Grantex } from '@grantex/sdk';
@@ -490,9 +522,26 @@ const passport = await grantex.passports.issue({
   paymentRails: ['tempo'],
   expiresIn: '24h',
 });
+// passport.passportId   → "urn:grantex:passport:01HXYZ..."
+// passport.encodedCredential → base64url for X-Grantex-Passport header
 ```
 
-**Attach to MPP requests:**
+**cURL:**
+
+```bash
+curl -X POST https://api.grantex.dev/v1/passport/issue \
+  -H "Authorization: Bearer $GRANTEX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "ag_01HXYZ...",
+    "grantId": "grnt_01HXYZ...",
+    "allowedMPPCategories": ["inference", "compute"],
+    "maxTransactionAmount": { "amount": 50, "currency": "USDC" },
+    "expiresIn": "24h"
+  }'
+```
+
+### Attach to MPP Requests
 
 ```typescript
 import { createMppPassportMiddleware } from '@grantex/mpp';
@@ -500,26 +549,89 @@ import { createMppPassportMiddleware } from '@grantex/mpp';
 const middleware = createMppPassportMiddleware({ passport });
 const enrichedRequest = await middleware(new Request(url, init));
 // enrichedRequest now has X-Grantex-Passport header
+const response = await fetch(enrichedRequest);
 ```
 
-**Verify on the merchant side:**
+### Verify on the Merchant Side
+
+**Standalone verification:**
 
 ```typescript
-import { verifyPassport, requireAgentPassport } from '@grantex/mpp';
+import { verifyPassport } from '@grantex/mpp';
 
-// Standalone verification
 const verified = await verifyPassport(encodedCredential, {
   requiredCategories: ['inference'],
   maxAmount: 10,
 });
-
-// Or as Express middleware
-app.use('/api/paid-resource', requireAgentPassport({
-  requiredCategories: ['inference'],
-}));
+// verified.humanDID        → "did:grantex:user_alice"
+// verified.organizationDID → "did:web:acme.com"
+// verified.allowedCategories → ["inference", "compute"]
+// verified.maxTransactionAmount → { amount: 50, currency: "USDC" }
 ```
 
-See [`packages/mpp/`](packages/mpp/) for full docs. Demo: [grantex.dev/mpp-demo](https://grantex.dev/mpp-demo).
+**Express middleware (one-liner):**
+
+```typescript
+import { requireAgentPassport } from '@grantex/mpp';
+
+app.use('/api/inference', requireAgentPassport({
+  requiredCategories: ['inference'],
+  maxAmount: 10,
+}));
+// req.agentPassport is populated on valid requests
+// 403 with typed error code on invalid requests
+```
+
+### Trust Registry
+
+Query any organization's verified trust level — no authentication required:
+
+```bash
+curl https://api.grantex.dev/v1/trust-registry/did:web:grantex.dev
+# {"organizationDID":"did:web:grantex.dev","trustLevel":"soc2","domains":["grantex.dev"]}
+```
+
+```typescript
+import { lookupOrgTrust } from '@grantex/mpp';
+
+const record = await lookupOrgTrust('did:web:acme.com');
+// record.trustLevel → "verified" | "soc2" | "basic"
+// record.verificationMethod → "dns-txt" | "manual" | "soc2"
+```
+
+### Revocation
+
+Revoking a passport flips a StatusList2021 bit — propagates instantly:
+
+```typescript
+await grantex.passports.revoke('urn:grantex:passport:01HXYZ...');
+// Subsequent verifyPassport() calls return PASSPORT_REVOKED
+```
+
+### Error Codes
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `PASSPORT_EXPIRED` | 403 | Credential `validUntil` has passed |
+| `PASSPORT_REVOKED` | 403 | StatusList2021 bit is set |
+| `INVALID_SIGNATURE` | 403 | Signature verification failed |
+| `UNTRUSTED_ISSUER` | 403 | Issuer DID not in trusted list |
+| `CATEGORY_MISMATCH` | 403 | Categories don't cover required service |
+| `AMOUNT_EXCEEDED` | 403 | Max amount below required threshold |
+| `MISSING_PASSPORT` | 403 | No `X-Grantex-Passport` header |
+| `MALFORMED_CREDENTIAL` | 403 | Invalid base64url or missing VC fields |
+
+### MPP Agent Identity API Endpoints
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| `POST` | `/v1/passport/issue` | API key | Issue AgentPassportCredential |
+| `GET` | `/v1/passport/:id` | API key | Retrieve passport by ID |
+| `POST` | `/v1/passport/:id/revoke` | API key | Revoke passport (StatusList2021) |
+| `GET` | `/v1/trust-registry/:orgDID` | None | Look up org trust record (public) |
+| `GET` | `/v1/trust-registry` | API key | List all trust records (admin) |
+
+See [`packages/mpp/`](packages/mpp/) for full package docs. Demo: [grantex.dev/mpp-demo](https://grantex.dev/mpp-demo).
 
 </details>
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -52,7 +52,8 @@
               "features/fido-webauthn",
               "features/verifiable-credentials",
               "features/sd-jwt",
-              "features/did-infrastructure"
+              "features/did-infrastructure",
+              "features/mpp-agent-passport"
             ]
           },
           {
@@ -80,7 +81,8 @@
               "guides/cedar-integration",
               "guides/policy-as-code",
               "guides/usage-metering",
-              "guides/custom-domains"
+              "guides/custom-domains",
+              "guides/mpp-integration"
             ]
           },
           {
@@ -135,7 +137,8 @@
               "sdks/typescript/budgets",
               "sdks/typescript/events",
               "sdks/typescript/usage",
-              "sdks/typescript/domains"
+              "sdks/typescript/domains",
+              "sdks/typescript/passports"
             ]
           },
           {

--- a/docs/features/mpp-agent-passport.mdx
+++ b/docs/features/mpp-agent-passport.mdx
@@ -1,0 +1,133 @@
+---
+title: "MPP Agent Passport"
+sidebarTitle: "MPP Agent Passport"
+description: "W3C Verifiable Credential for agent identity in machine-to-machine payments via the Machine Payments Protocol (MPP)."
+---
+
+## Overview
+
+The **Machine Payments Protocol (MPP)** defines how AI agents pay for services via HTTP 402 flows and streaming sessions. MPP solves payment mechanics but has a structural gap: **no identity layer**.
+
+When an agent makes an MPP payment, the `source` field is a wallet address — no human name, no organization, no authorization chain. For low-value API calls this is fine. For B2B procurement and regulated transactions, it's a compliance blocker.
+
+Grantex fills this gap with the `AgentPassportCredential` — a W3C VC 2.0 credential that binds agent identity, human delegation, spending limits, and payment categories into a single offline-verifiable document.
+
+<Info>
+  The `@grantex/mpp` package provides both agent-side middleware (attach passports to outgoing requests) and merchant-side verification (validate passports on incoming requests) in a single package.
+</Info>
+
+## How It Works
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  1. Human issues AgentPassportCredential via Grantex             │
+│     → W3C VC 2.0 with Ed25519 proof, StatusList2021 revocation  │
+│     → Contains: agentDID, humanDID, orgDID, categories, limits  │
+└─────────────────────────┬────────────────────────────────────────┘
+                          ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  2. Agent makes MPP request to merchant                          │
+│     → Authorization: Payment <mpp-token>                         │
+│     → X-Grantex-Passport: <base64url-encoded-vc>                │
+└─────────────────────────┬────────────────────────────────────────┘
+                          ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  3. Merchant verifies passport in <50ms (offline-capable)        │
+│     → Checks signature, expiry, categories, amount limits        │
+│     → Returns VerifiedPassport with full identity chain           │
+└─────────────────────────┬────────────────────────────────────────┘
+                          ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  4. Merchant fulfills request — knows exactly who authorized it  │
+│     → Audit entry: passportId, agentDID, humanDID, amount        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## AgentPassportCredential Structure
+
+The credential follows the W3C Verifiable Credentials Data Model v2.0:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `@context` | `string[]` | `["https://www.w3.org/ns/credentials/v2", "https://grantex.dev/contexts/mpp/v1"]` |
+| `type` | `string[]` | `["VerifiableCredential", "AgentPassportCredential"]` |
+| `id` | `string` | `urn:grantex:passport:<ulid>` |
+| `issuer` | `string` | `did:web:grantex.dev` |
+| `validFrom` | `string` | ISO 8601 issuance timestamp |
+| `validUntil` | `string` | ISO 8601 expiry (max 30 days) |
+| `credentialSubject.id` | `string` | Agent DID (`did:grantex:ag_...`) |
+| `credentialSubject.humanPrincipal` | `string` | DID of the authorizing human |
+| `credentialSubject.organizationDID` | `string` | Org DID (`did:web:<domain>`) |
+| `credentialSubject.grantId` | `string` | Underlying Grantex grant ID |
+| `credentialSubject.allowedMPPCategories` | `string[]` | Permitted MPP service categories |
+| `credentialSubject.maxTransactionAmount` | `object` | `{ amount: number, currency: string }` |
+| `credentialSubject.paymentRails` | `string[]` | Payment networks (e.g., `["tempo"]`) |
+| `credentialSubject.delegationDepth` | `number` | From grant delegation chain |
+| `credentialStatus` | `object` | StatusList2021 revocation entry |
+| `proof` | `object` | Ed25519Signature2020 |
+
+## MPP Category Scopes
+
+Each MPP category maps to a Grantex scope. The agent's grant must include the corresponding scope:
+
+| MPP Category | Grantex Scope |
+|-------------|---------------|
+| `inference` | `payments:mpp:inference` |
+| `compute` | `payments:mpp:compute` |
+| `data` | `payments:mpp:data` |
+| `storage` | `payments:mpp:storage` |
+| `search` | `payments:mpp:search` |
+| `media` | `payments:mpp:media` |
+| `delivery` | `payments:mpp:delivery` |
+| `browser` | `payments:mpp:browser` |
+| `general` | `payments:mpp:general` |
+
+## Trust Registry
+
+The trust registry is a public endpoint that maps organization DIDs to verified trust records:
+
+```bash
+curl https://api.grantex.dev/v1/trust-registry/did:web:grantex.dev
+```
+
+```json
+{
+  "organizationDID": "did:web:grantex.dev",
+  "verifiedAt": "2026-03-20T03:11:31.447Z",
+  "verificationMethod": "soc2",
+  "trustLevel": "soc2",
+  "domains": ["grantex.dev"]
+}
+```
+
+Trust levels: `basic` (self-declared), `verified` (DNS-TXT proof), `soc2` (SOC 2 audit verified).
+
+## Verification Error Codes
+
+| Code | Description |
+|------|-------------|
+| `PASSPORT_EXPIRED` | Credential `validUntil` has passed |
+| `PASSPORT_REVOKED` | StatusList2021 bit is set |
+| `INVALID_SIGNATURE` | Ed25519/RS256 signature verification failed |
+| `UNTRUSTED_ISSUER` | Issuer DID not in the trusted issuers list |
+| `CATEGORY_MISMATCH` | Passport categories don't cover the required service |
+| `AMOUNT_EXCEEDED` | Passport max amount below required threshold |
+| `MISSING_PASSPORT` | No `X-Grantex-Passport` header provided |
+| `MALFORMED_CREDENTIAL` | Invalid base64url encoding or missing VC fields |
+
+## API Endpoints
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| `POST` | `/v1/passport/issue` | API key | Issue an AgentPassportCredential |
+| `GET` | `/v1/passport/:id` | API key | Retrieve passport by ID |
+| `POST` | `/v1/passport/:id/revoke` | API key | Revoke passport (flips StatusList2021 bit) |
+| `GET` | `/v1/trust-registry/:orgDID` | None | Look up org trust record (public) |
+| `GET` | `/v1/trust-registry` | API key | List all trust records (admin) |
+
+## Next Steps
+
+- **[MPP Integration Guide](/guides/mpp-integration)** — step-by-step setup for agents and merchants
+- **[Verifiable Credentials](/features/verifiable-credentials)** — the underlying VC infrastructure
+- **[DID Infrastructure](/features/did-infrastructure)** — how agent DIDs work
+- **[Delegation](/concepts/delegation)** — multi-agent delegation chains

--- a/docs/guides/mpp-integration.mdx
+++ b/docs/guides/mpp-integration.mdx
@@ -1,0 +1,188 @@
+---
+title: "MPP Integration Guide"
+sidebarTitle: "MPP Integration"
+description: "Step-by-step guide to adding Grantex agent identity to MPP payment flows — for both agents and merchants."
+---
+
+## Overview
+
+This guide walks through integrating Grantex agent passports with the Machine Payments Protocol (MPP). You'll learn how to:
+
+1. **Agent side** — Issue passports and attach them to outgoing MPP requests
+2. **Merchant side** — Verify passports on incoming requests with one line of code
+3. **Trust registry** — Look up organization trust levels before fulfilling requests
+
+## Prerequisites
+
+- A Grantex account with an API key ([sign up free](https://grantex.dev/dashboard/signup))
+- A registered agent with an active grant that includes `payments:mpp:*` scopes
+- Node.js 18+ for the TypeScript SDK
+
+## Installation
+
+```bash
+npm install @grantex/sdk @grantex/mpp
+```
+
+## Agent Side: Issue and Attach Passports
+
+### Step 1: Issue a Passport
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Issue a passport for your agent
+const passport = await grantex.passports.issue({
+  agentId: 'ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  allowedMPPCategories: ['inference', 'compute'],
+  maxTransactionAmount: { amount: 50, currency: 'USDC' },
+  paymentRails: ['tempo'],
+  expiresIn: '24h',  // max: 720h (30 days)
+});
+
+console.log(passport.passportId);
+// "urn:grantex:passport:01HXYZ..."
+```
+
+<Warning>
+  The grant must include the corresponding `payments:mpp:*` scopes for each category.
+  For example, requesting `['inference', 'compute']` requires the grant to have
+  `payments:mpp:inference` and `payments:mpp:compute` scopes.
+</Warning>
+
+### Step 2: Attach to MPP Requests
+
+Use the middleware to automatically inject the `X-Grantex-Passport` header:
+
+```typescript
+import { createMppPassportMiddleware } from '@grantex/mpp';
+
+const middleware = createMppPassportMiddleware({
+  passport,
+  autoRefreshThreshold: 300, // warn 5 min before expiry
+});
+
+// Wrap every outgoing fetch
+const request = new Request('https://merchant.example.com/api/inference', {
+  method: 'GET',
+  headers: { 'Authorization': 'Payment <mpp-token>' },
+});
+
+const enrichedRequest = await middleware(request);
+const response = await fetch(enrichedRequest);
+// enrichedRequest has X-Grantex-Passport header attached
+```
+
+## Merchant Side: Verify Passports
+
+### Option A: Express Middleware (Recommended)
+
+One line to protect any route:
+
+```typescript
+import express from 'express';
+import { requireAgentPassport } from '@grantex/mpp';
+
+const app = express();
+
+// Protect inference endpoints — require inference category
+app.use('/api/inference', requireAgentPassport({
+  requiredCategories: ['inference'],
+  maxAmount: 10,
+}));
+
+app.get('/api/inference', (req, res) => {
+  // req.agentPassport is populated
+  console.log(req.agentPassport.humanDID);        // "did:grantex:user_alice"
+  console.log(req.agentPassport.organizationDID);  // "did:web:acme.com"
+  console.log(req.agentPassport.allowedCategories); // ["inference", "compute"]
+
+  res.json({ result: 'inference complete' });
+});
+```
+
+Invalid passports return `403` with a typed error code:
+
+```json
+{
+  "error": "CATEGORY_MISMATCH",
+  "message": "Passport does not cover required categories: storage"
+}
+```
+
+### Option B: Standalone Verification
+
+```typescript
+import { verifyPassport } from '@grantex/mpp';
+
+const encodedPassport = req.headers['x-grantex-passport'];
+
+try {
+  const verified = await verifyPassport(encodedPassport, {
+    trustedIssuers: ['did:web:grantex.dev'],
+    requiredCategories: ['inference'],
+    maxAmount: 10,
+    checkRevocation: false,  // true for online revocation check
+  });
+
+  console.log(verified.valid);          // true
+  console.log(verified.humanDID);       // "did:grantex:user_alice"
+  console.log(verified.agentDID);       // "did:grantex:ag_01HXYZ..."
+  console.log(verified.grantId);        // "grnt_01HXYZ..."
+  console.log(verified.delegationDepth); // 0
+} catch (err) {
+  // err.code is a typed PassportErrorCode
+  console.error(err.code, err.message);
+}
+```
+
+## Trust Registry Lookup
+
+Before fulfilling a high-value request, check the organization's trust level:
+
+```typescript
+import { lookupOrgTrust } from '@grantex/mpp';
+
+const record = await lookupOrgTrust(verified.organizationDID);
+
+if (!record || record.trustLevel === 'basic') {
+  // Require additional verification for unverified orgs
+  return res.status(403).json({ error: 'ORG_NOT_VERIFIED' });
+}
+
+// record.trustLevel: "basic" | "verified" | "soc2"
+// record.verificationMethod: "dns-txt" | "manual" | "soc2"
+```
+
+Results are cached in-memory for 1 hour by default.
+
+## Revoking Passports
+
+Instantly revoke a passport — flips the StatusList2021 bit:
+
+```typescript
+const result = await grantex.passports.revoke('urn:grantex:passport:01HXYZ...');
+// { revoked: true, revokedAt: "2026-03-20T..." }
+```
+
+After revocation, any `verifyPassport()` call with `checkRevocation: true` will throw `PASSPORT_REVOKED`.
+
+## Verification Options Reference
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `jwksUri` | `string` | `https://api.grantex.dev/.well-known/jwks.json` | JWKS endpoint for signature verification |
+| `trustedIssuers` | `string[]` | `['did:web:grantex.dev']` | Allowed issuer DIDs |
+| `requiredCategories` | `MPPCategory[]` | `undefined` | Required MPP categories |
+| `maxAmount` | `number` | `undefined` | Minimum passport amount ceiling |
+| `checkRevocation` | `boolean` | `false` | Online revocation check via StatusList2021 |
+| `revocationEndpoint` | `string` | — | Required when `checkRevocation: true` |
+
+## Next Steps
+
+- **[MPP Agent Passport](/features/mpp-agent-passport)** — credential specification and trust registry details
+- **[Budget Controls](/guides/budget-controls)** — combine passports with budget enforcement
+- **[Event Streaming](/guides/event-streaming)** — subscribe to `passport.issued` and `passport.revoked` events

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -88,6 +88,7 @@ description: "Grantex integrates with every major AI agent framework."
 | CLI | `@grantex/cli` | `npm install -g @grantex/cli` | TypeScript |
 | Conformance Suite | `@grantex/conformance` | `npm install -g @grantex/conformance` | TypeScript |
 | Event Destinations | `@grantex/destinations` | `npm install @grantex/destinations` | TypeScript |
+| MPP Agent Identity | `@grantex/mpp` | `npm install @grantex/mpp` | TypeScript |
 | Terraform Provider | `terraform-provider-grantex` | `source = "mishrasanjeev/grantex"` | Go / HCL |
 
 ## Verifiable Intent & Agentic Commerce
@@ -103,6 +104,9 @@ Grantex integrates with emerging standards for agentic commerce through W3C Veri
   </Card>
   <Card title="DID Infrastructure" icon="id-card" href="/features/did-infrastructure">
     W3C DID document at did:web:grantex.dev. Any party can verify Grantex-issued credentials using published public keys.
+  </Card>
+  <Card title="MPP Agent Passport" icon="passport" href="/features/mpp-agent-passport">
+    Agent identity for machine payments. Issue W3C VC 2.0 passports with spending limits, category restrictions, and offline merchant verification in &lt;50ms.
   </Card>
 </CardGroup>
 

--- a/docs/sdks/typescript/passports.mdx
+++ b/docs/sdks/typescript/passports.mdx
@@ -1,0 +1,156 @@
+---
+title: "Passports"
+sidebarTitle: "Passports"
+description: "Issue, retrieve, revoke, and list AgentPassportCredentials for MPP agent identity."
+---
+
+## Overview
+
+The `passports` sub-client manages AgentPassportCredentials — W3C VC 2.0 credentials that bind agent identity, human delegation, and spending limits for machine payment flows.
+
+```typescript
+const passport = await grantex.passports.issue({ ... });
+const record   = await grantex.passports.get('urn:grantex:passport:01HXYZ...');
+const result   = await grantex.passports.revoke('urn:grantex:passport:01HXYZ...');
+```
+
+---
+
+## passports.issue()
+
+Issue a new AgentPassportCredential for an agent with an active grant.
+
+```typescript
+const passport = await grantex.passports.issue({
+  agentId: 'ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  allowedMPPCategories: ['inference', 'compute'],
+  maxTransactionAmount: { amount: 50, currency: 'USDC' },
+  paymentRails: ['tempo'],
+  expiresIn: '24h',
+});
+
+console.log(passport.passportId);        // "urn:grantex:passport:01HXYZ..."
+console.log(passport.encodedCredential); // base64url for X-Grantex-Passport header
+console.log(passport.expiresAt);         // "2026-03-21T03:13:48.150Z"
+```
+
+### Parameters
+
+<ParamField body="agentId" type="string" required>
+  Grantex agent ID (`ag_...`). Must belong to the developer.
+</ParamField>
+
+<ParamField body="grantId" type="string" required>
+  Active Grantex grant ID (`grnt_...`). Must include `payments:mpp:*` scopes for each requested category.
+</ParamField>
+
+<ParamField body="allowedMPPCategories" type="string[]" required>
+  MPP service categories: `inference`, `compute`, `data`, `storage`, `search`, `media`, `delivery`, `browser`, `general`.
+</ParamField>
+
+<ParamField body="maxTransactionAmount" type="object" required>
+  Maximum per-transaction amount: `{ amount: number, currency: 'USDC' }`.
+</ParamField>
+
+<ParamField body="paymentRails" type="string[]" default="['tempo']">
+  Payment networks to include in the credential.
+</ParamField>
+
+<ParamField body="expiresIn" type="string" default="24h">
+  Expiry duration (e.g., `1h`, `8h`, `24h`, `30d`). Maximum: `720h` (30 days).
+</ParamField>
+
+<ParamField body="parentPassportId" type="string">
+  For delegated sub-agent passports — links to the parent passport.
+</ParamField>
+
+### Response: `IssuedPassportResponse`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `passportId` | `string` | `urn:grantex:passport:<ulid>` |
+| `credential` | `object` | Full AgentPassportCredential JSON |
+| `encodedCredential` | `string` | Base64url-encoded credential for headers |
+| `expiresAt` | `string` | ISO 8601 expiry timestamp |
+
+### Errors
+
+| Code | HTTP | Cause |
+|------|------|-------|
+| `INVALID_AGENT` | 400 | Agent not found or not owned by developer |
+| `INVALID_GRANT` | 400 | Grant not found, revoked, or not owned by agent |
+| `SCOPE_INSUFFICIENT` | 400 | Grant doesn't include required `payments:mpp:*` scopes |
+| `AMOUNT_EXCEEDS_BUDGET` | 400 | Max amount exceeds remaining budget allocation |
+| `INVALID_EXPIRY` | 422 | Expiry exceeds 720 hours |
+
+---
+
+## passports.get()
+
+Retrieve a passport by its ID. Returns the full credential JSON plus current status.
+
+```typescript
+const record = await grantex.passports.get('urn:grantex:passport:01HXYZ...');
+
+console.log(record.status); // "active" | "revoked" | "expired"
+```
+
+### Parameters
+
+<ParamField body="passportId" type="string" required>
+  The passport URN identifier.
+</ParamField>
+
+---
+
+## passports.revoke()
+
+Revoke a passport immediately. Flips the StatusList2021 bit so offline verifiers see the revocation.
+
+```typescript
+const result = await grantex.passports.revoke('urn:grantex:passport:01HXYZ...');
+
+console.log(result.revoked);   // true
+console.log(result.revokedAt); // "2026-03-20T03:14:15.261Z"
+```
+
+### Parameters
+
+<ParamField body="passportId" type="string" required>
+  The passport URN identifier.
+</ParamField>
+
+### Response: `RevokePassportResponse`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `revoked` | `boolean` | Always `true` on success |
+| `revokedAt` | `string` | ISO 8601 revocation timestamp |
+
+---
+
+## passports.list()
+
+List passports with optional filters.
+
+```typescript
+const passports = await grantex.passports.list({
+  agentId: 'ag_01HXYZ...',
+  status: 'active',
+});
+```
+
+### Parameters
+
+<ParamField body="agentId" type="string">
+  Filter by agent ID.
+</ParamField>
+
+<ParamField body="grantId" type="string">
+  Filter by grant ID.
+</ParamField>
+
+<ParamField body="status" type="string">
+  Filter by status: `active`, `revoked`, or `expired`.
+</ParamField>

--- a/web/index.html
+++ b/web/index.html
@@ -974,6 +974,131 @@
   </div>
 </section>
 
+<!-- ── MPP Agent Identity ──────────────────────────────────────────────────── -->
+<section id="mpp" style="background: linear-gradient(180deg, rgba(63,185,80,0.04) 0%, transparent 60%);">
+  <div class="container">
+    <div class="section-label">New — Agentic Commerce</div>
+    <h2 class="section-title">Agent Identity for Machine Payments</h2>
+    <p class="section-sub">
+      MPP defines how agents pay for services. Grantex adds the missing identity layer —
+      so merchants know exactly who authorized every payment.
+    </p>
+
+    <div class="cards">
+      <div class="card" style="border-left: 3px solid var(--accent);">
+        <span class="card-icon">&#x1F4B3;</span>
+        <h3>AgentPassportCredential</h3>
+        <p>
+          W3C VC 2.0 credential binding agent identity, human delegation, spending limits,
+          and payment categories into a single offline-verifiable document.
+        </p>
+      </div>
+      <div class="card" style="border-left: 3px solid var(--accent2);">
+        <span class="card-icon">&#x26A1;</span>
+        <h3>&lt;50ms Merchant Verification</h3>
+        <p>
+          Merchants verify passports offline using cached JWKS — no API roundtrip needed.
+          Ed25519 signature, expiry, category, and amount checks in a single call.
+        </p>
+      </div>
+      <div class="card" style="border-left: 3px solid #d2a8ff;">
+        <span class="card-icon">&#x1F3E6;</span>
+        <h3>Public Trust Registry</h3>
+        <p>
+          Look up any organization's verified trust level by DID. DNS-TXT, SOC 2,
+          or manual verification — all queryable without authentication.
+        </p>
+      </div>
+    </div>
+
+    <!-- Flow diagram -->
+    <div style="max-width:780px;margin:48px auto 0;">
+      <div style="font-size:12px;font-family:var(--mono);text-transform:uppercase;letter-spacing:1.5px;color:var(--accent);margin-bottom:20px;">Payment flow with identity</div>
+      <div class="flow">
+        <div class="flow-step">
+          <div class="step-num">1</div>
+          <div class="step-body">
+            <h3>Human issues passport</h3>
+            <p>Principal authorizes agent via Grantex → receives <code>AgentPassportCredential</code> with
+            spending limit, categories (inference, compute, data), and Ed25519 proof.</p>
+          </div>
+        </div>
+        <div class="flow-step">
+          <div class="step-num">2</div>
+          <div class="step-body">
+            <h3>Agent makes MPP payment</h3>
+            <p>Agent sends <code>Authorization: Payment</code> header (standard MPP) plus
+            <code>X-Grantex-Passport</code> header with the base64url-encoded credential.</p>
+          </div>
+        </div>
+        <div class="flow-step">
+          <div class="step-num">3</div>
+          <div class="step-body">
+            <h3>Merchant verifies identity</h3>
+            <p>One function call: <code>verifyPassport()</code> checks signature, expiry, categories, and
+            amount in &lt;50ms. Returns the human principal, org DID, and delegation chain.</p>
+          </div>
+        </div>
+        <div class="flow-step">
+          <div class="step-num">4</div>
+          <div class="step-body">
+            <h3>Full audit trail</h3>
+            <p>Every passport issuance, verification, and revocation is logged. Revocation flips a
+            StatusList2021 bit — propagates instantly, no polling.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Code example -->
+    <div style="max-width:680px;margin:48px auto 0;">
+      <div style="font-size:12px;font-family:var(--mono);text-transform:uppercase;letter-spacing:1.5px;color:var(--accent2);margin-bottom:12px;">Merchant-side verification</div>
+      <div class="code-block" style="border:1px solid var(--border);border-radius:var(--radius);">
+        <pre><span class="kw">import</span> <span class="op">{</span> <span class="id">requireAgentPassport</span> <span class="op">}</span> <span class="kw">from</span> <span class="str">'@grantex/mpp'</span><span class="op">;</span>
+
+<span class="cm">// One line to protect any Express route</span>
+<span class="id">app</span><span class="op">.</span><span class="fn">use</span><span class="op">(</span><span class="str">'/api/inference'</span><span class="op">,</span> <span class="fn">requireAgentPassport</span><span class="op">({</span>
+  <span class="id">requiredCategories</span><span class="op">:</span> <span class="op">[</span><span class="str">'inference'</span><span class="op">],</span>
+  <span class="id">maxAmount</span><span class="op">:</span> <span class="str">10</span><span class="op">,</span>
+<span class="op">}));</span>
+
+<span class="cm">// req.agentPassport is now populated:</span>
+<span class="cm">//   humanDID:    "did:grantex:user_alice"</span>
+<span class="cm">//   orgDID:      "did:web:acme.com"</span>
+<span class="cm">//   categories:  ["inference", "compute"]</span>
+<span class="cm">//   maxAmount:   50 USDC</span>
+<span class="cm">//   delegation:  depth 0 (direct grant)</span></pre>
+      </div>
+    </div>
+
+    <!-- Install + CTA -->
+    <div style="text-align:center;margin-top:40px;">
+      <div class="install-commands" style="justify-content:center;margin-bottom:20px;">
+        <div class="install-cmd" onclick="navigator.clipboard.writeText('npm install @grantex/mpp')">
+          <span class="install-label">npm</span>
+          <code>npm install @grantex/mpp</code>
+          <span class="install-copy">Copy</span>
+        </div>
+      </div>
+      <div style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap;">
+        <a href="https://docs.grantex.dev/features/mpp-agent-passport" class="btn btn-primary"
+           onclick="gtag('event','mpp_docs_click',{event_category:'mpp'})">
+          Read the docs &rarr;
+        </a>
+        <a href="/mpp-demo" class="btn btn-secondary"
+           onclick="gtag('event','mpp_demo_click',{event_category:'mpp'})">
+          Try the demo
+        </a>
+        <a href="https://api.grantex.dev/v1/trust-registry/did:web:grantex.dev" class="btn btn-secondary"
+           onclick="gtag('event','trust_registry_click',{event_category:'mpp'})">
+          Query trust registry
+        </a>
+      </div>
+    </div>
+
+  </div>
+</section>
+
 <!-- ── Integrations ───────────────────────────────────────────────────────── -->
 <section id="integrations">
   <div class="container">


### PR DESCRIPTION
## Summary

- **Landing page** (`web/index.html`): New visual MPP section between Quickstart and Integrations — 3 feature cards, 4-step flow diagram, code example, install command, and CTAs
- **README.md**: Expanded MPP Agent Identity section to match VC/SD-JWT richness — adds credential structure table, trust registry, revocation, error codes, API endpoints, cURL examples
- **Mintlify docs**: 3 new pages + navigation updates:
  - `features/mpp-agent-passport.mdx` — full credential spec, categories, trust registry, error codes
  - `guides/mpp-integration.mdx` — step-by-step for agents and merchants
  - `sdks/typescript/passports.mdx` — SDK reference with ParamField docs
  - Updated `docs.json` nav (Trust & Identity, Guides, TS SDK Resources)
  - Updated `integrations/overview.mdx` (new card + table row)

## Test plan

- [x] Landing page renders correctly (no broken HTML)
- [x] README renders with proper markdown tables and code blocks
- [x] Mintlify docs have correct frontmatter and navigation links
- [ ] Verify landing page at grantex.dev after deploy
- [ ] Verify Mintlify docs at docs.grantex.dev after deploy