### PR TITLE
fix: install sdk-ts before mpp build in E2E workflow

### DIFF
--- a/.github/workflows/e2e-mpp.yml
+++ b/.github/workflows/e2e-mpp.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           node-version: 20
 
+      - name: Install and build SDK (peer dependency)
+        working-directory: packages/sdk-ts
+        run: npm ci && npm run build
+
       - name: Install MPP package
         working-directory: packages/mpp
         run: npm ci


### PR DESCRIPTION
Same fix as CI — build sdk-ts before mpp so the peer dep types are available.