### PR TITLE
chore: MPP SEO — sitemap, meta tags, JSON-LD, and /for/mpp landing page

### DIFF
--- a/.github/workflows/seo-ping.yml
+++ b/.github/workflows/seo-ping.yml
@@ -31,6 +31,8 @@ jobs:
               "key": "78181e8137ae41ec881a17171a1e9fb2",
               "urlList": [
                 "https://grantex.dev/",
+                "https://grantex.dev/mpp-demo/",
+                "https://grantex.dev/for/mpp",
                 "https://grantex.dev/playground",
                 "https://grantex.dev/report/state-of-agent-security-2026",
                 "https://grantex.dev/for/langchain",

--- a/web/for/index.html
+++ b/web/for/index.html
@@ -606,6 +606,59 @@ async def list_emails(
     metaTitle: 'Grantex for FastAPI — JWT Middleware for AI Agent Authorization',
     metaDesc: 'Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.',
   },
+  mpp: {
+    name: 'MPP (Machine Payments Protocol)',
+    badge: 'MPP + Grantex',
+    title: 'Agent Identity for <span class="highlight">Machine Payments</span>',
+    desc: 'MPP defines how AI agents pay for services. Grantex adds the missing identity layer — verifiable agent passports that let merchants know exactly who authorized every payment, with offline verification in under 50ms.',
+    docsUrl: 'https://docs.grantex.dev/features/mpp-agent-passport',
+    installUrl: 'https://docs.grantex.dev/guides/mpp-integration',
+    install: 'npm install @grantex/mpp @grantex/sdk',
+    problemBad: 'When an agent makes an MPP payment, the source is just a wallet address. No human name, no org, no authorization chain. For $0.10 API calls nobody cares. For $500 B2B procurement, it\'s a compliance blocker.',
+    problemGood: 'Every MPP payment carries an AgentPassportCredential — a W3C VC 2.0 credential with the human principal, org DID, spending limits, and allowed categories. Merchants verify in <50ms, offline.',
+    howTitle: 'How Grantex Works with MPP',
+    steps: [
+      ['Install the package', 'npm install @grantex/mpp — agent-side middleware + merchant-side verification in one package.'],
+      ['Issue an agent passport', 'Call grantex.passports.issue() with categories (inference, compute, data), spending limits, and expiry.'],
+      ['Attach to MPP requests', 'createMppPassportMiddleware() injects the X-Grantex-Passport header on every outgoing fetch.'],
+      ['Verify on the merchant side', 'requireAgentPassport() Express middleware — one line to verify identity, categories, and amounts.'],
+      ['Check the trust registry', 'lookupOrgTrust() returns verified org status (basic, verified, SOC 2) from the public registry.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createMppPassportMiddleware, requireAgentPassport } from '@grantex/mpp';
+
+// Agent side: issue passport and attach to requests
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const passport = await grantex.passports.issue({
+  agentId: 'ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  allowedMPPCategories: ['inference', 'compute'],
+  maxTransactionAmount: { amount: 50, currency: 'USDC' },
+  expiresIn: '24h',
+});
+
+const middleware = createMppPassportMiddleware({ passport });
+const enriched = await middleware(new Request(url));
+// X-Grantex-Passport header attached
+
+// Merchant side: one-line verification
+app.use('/api/inference', requireAgentPassport({
+  requiredCategories: ['inference'],
+  maxAmount: 10,
+}));
+// req.agentPassport → { humanDID, orgDID, categories, maxAmount, ... }`,
+    features: [
+      ['AgentPassportCredential', 'W3C VC 2.0 with agent DID, human principal, org, categories, spending limits, and delegation depth.'],
+      ['<50ms Verification', 'Offline verification using cached JWKS. No API roundtrip to Grantex servers needed.'],
+      ['9 MPP Categories', 'inference, compute, data, storage, search, media, delivery, browser, general — each maps to a Grantex scope.'],
+      ['StatusList2021 Revocation', 'Revoke any passport instantly. Bit-flip propagation, no polling required.'],
+      ['Trust Registry', 'Public org trust lookup by DID. DNS-TXT, manual, or SOC 2 verification levels.'],
+      ['Auto-Refresh', 'Middleware proactively refreshes passports before expiry via onRefresh callback.'],
+    ],
+    ctaFramework: 'MPP',
+    metaTitle: 'Grantex for MPP — Agent Identity for Machine Payments Protocol',
+    metaDesc: 'Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.',
+  },
 };
 
 // Determine framework from URL

--- a/web/index.html
+++ b/web/index.html
@@ -6,13 +6,14 @@
 
   <!-- SEO -->
   <title>Grantex — OAuth 2.0 for AI Agents</title>
-  <meta name="description" content="Open delegated authorization protocol for AI agents. W3C Verifiable Credentials, FIDO2/WebAuthn passkeys, SD-JWT selective disclosure, and DID infrastructure — built on JWT and OAuth 2.0.">
+  <meta name="description" content="Open delegated authorization protocol for AI agents. MPP agent identity for machine payments, W3C Verifiable Credentials, FIDO2/WebAuthn passkeys, SD-JWT selective disclosure, and DID infrastructure — built on JWT and OAuth 2.0.">
+  <meta name="keywords" content="Grantex, MPP, Machine Payments Protocol, AI agent identity, OAuth for AI agents, agent authorization, W3C Verifiable Credentials, agent passport, agentic commerce, MPP OAuth, agent delegation, DID, FIDO2, WebAuthn, JWT, machine-to-machine payments, USDC payments, AI agent payments, Tempo payments">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="canonical" href="https://grantex.dev/">
 
   <!-- OpenGraph -->
   <meta property="og:title" content="Grantex — OAuth 2.0 for AI Agents">
-  <meta property="og:description" content="Open delegated authorization protocol for AI agents. W3C Verifiable Credentials, FIDO2/WebAuthn passkeys, SD-JWT selective disclosure, and DID infrastructure — built on JWT and OAuth 2.0.">
+  <meta property="og:description" content="Open delegated authorization protocol for AI agents. MPP agent identity for machine payments, W3C Verifiable Credentials, FIDO2/WebAuthn passkeys — built on JWT and OAuth 2.0.">
   <meta property="og:url" content="https://grantex.dev/">
   <meta property="og:image" content="https://grantex.dev/og-image.png">
   <meta property="og:type" content="website">
@@ -21,7 +22,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Grantex — OAuth 2.0 for AI Agents">
-  <meta name="twitter:description" content="Open delegated authorization protocol for AI agents. W3C Verifiable Credentials, FIDO2/WebAuthn passkeys, SD-JWT selective disclosure, and DID infrastructure — built on JWT and OAuth 2.0.">
+  <meta name="twitter:description" content="Open delegated authorization protocol for AI agents. MPP agent identity for machine payments, W3C Verifiable Credentials, FIDO2/WebAuthn passkeys — built on JWT and OAuth 2.0.">
   <meta name="twitter:image" content="https://grantex.dev/og-image.png">
 
   <!-- JSON-LD Structured Data -->
@@ -124,8 +125,51 @@
           "@type": "Answer",
           "text": "SD-JWT allows credential holders to selectively disclose only the claims a verifier needs. Instead of revealing all grant details, agents can present minimal information — for example, showing scopes without revealing the principal's identity."
         }
+      },
+      {
+        "@type": "Question",
+        "name": "What is MPP agent identity?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "MPP (Machine Payments Protocol) defines how AI agents pay for services. Grantex adds the missing identity layer with AgentPassportCredential — a W3C VC 2.0 credential that lets merchants verify who authorized a payment, what the agent can buy, and spending limits. Verification takes under 50ms and works offline."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How does Grantex work with MPP machine payments?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "A human issues an AgentPassportCredential for their agent via Grantex. The agent attaches this credential as an X-Grantex-Passport header alongside standard MPP payment headers. Merchants verify the passport in under 50ms using cached JWKS — confirming the human principal, organization, allowed categories (inference, compute, data), and spending limits before fulfilling the request."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is an AgentPassportCredential?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "An AgentPassportCredential is a W3C Verifiable Credential (VC 2.0) that binds agent identity, human delegation, MPP payment categories, and spending limits into a single offline-verifiable document. It includes the agent DID, human principal DID, organization DID, allowed MPP categories, max transaction amount, and StatusList2021 revocation."
+        }
       }
     ]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Grantex MPP Agent Identity",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Any",
+    "url": "https://grantex.dev/mpp-demo/",
+    "description": "Agent identity and delegation for the Machine Payments Protocol (MPP). Verifiable agent passports for agentic commerce with offline merchant verification in under 50ms.",
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "isPartOf": {
+      "@type": "SoftwareApplication",
+      "name": "Grantex",
+      "url": "https://grantex.dev"
+    }
   }
   </script>
 

--- a/web/mpp-demo/index.html
+++ b/web/mpp-demo/index.html
@@ -3,7 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Grantex × MPP Demo — Agent Identity for Agentic Commerce</title>
+  <title>Grantex × MPP Demo — Agent Identity for Machine Payments</title>
+  <meta name="description" content="Interactive demo: issue AgentPassportCredentials, simulate MPP payment flows with identity verification, and verify passports as a merchant. Grantex adds verifiable agent identity to the Machine Payments Protocol.">
+  <meta name="keywords" content="Grantex, MPP, Machine Payments Protocol, agent identity, AgentPassportCredential, agentic commerce, MPP OAuth, AI agent payments, Tempo, USDC, merchant verification, W3C Verifiable Credentials">
+  <link rel="canonical" href="https://grantex.dev/mpp-demo/">
+  <meta property="og:title" content="Grantex × MPP Demo — Agent Identity for Machine Payments">
+  <meta property="og:description" content="Interactive demo: issue agent passports, simulate MPP payment flows, and verify passports as a merchant.">
+  <meta property="og:url" content="https://grantex.dev/mpp-demo/">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Grantex × MPP Demo — Agent Identity for Machine Payments">
   <style>
     :root {
       --bg: #0a0a0a;

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -2,9 +2,21 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://grantex.dev/</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-03-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://grantex.dev/mpp-demo/</loc>
+    <lastmod>2026-03-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://grantex.dev/for/mpp</loc>
+    <lastmod>2026-03-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/playground</loc>
@@ -100,4 +112,6 @@
   <url><loc>https://docs.grantex.dev/features/verifiable-credentials</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://docs.grantex.dev/features/sd-jwt</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://docs.grantex.dev/features/did-infrastructure</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://docs.grantex.dev/features/mpp-agent-passport</loc><lastmod>2026-03-20</lastmod><changefreq>weekly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://docs.grantex.dev/guides/mpp-integration</loc><lastmod>2026-03-20</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
 </urlset>


### PR DESCRIPTION
## Summary

SEO additions to drive traffic for Grantex + MPP + MPP OAuth searches:

- **Sitemap**: 4 new URLs (mpp-demo, /for/mpp, 2 doc pages), updated lastmod
- **Meta tags**: MPP keywords in landing page description, og, twitter tags + dedicated keywords meta tag
- **JSON-LD**: 3 new FAQ entries (MPP identity, MPP+Grantex, AgentPassportCredential) + SoftwareApplication for MPP
- **MPP demo page**: meta description, keywords, canonical, og tags for crawlers
- **`/for/mpp`**: New framework landing page targeting "Grantex MPP", "MPP OAuth", "agent identity for machine payments"
- **SEO ping**: `/mpp-demo/` and `/for/mpp` added to IndexNow weekly ping

## Test plan
- [ ] Verify sitemap at grantex.dev/sitemap.xml after deploy
- [ ] Verify /for/mpp renders correctly
- [ ] Trigger SEO ping after deploy