### PR TITLE
fix: resolve Google Search Console indexing issues

### DIFF
--- a/.github/workflows/seo-ping.yml
+++ b/.github/workflows/seo-ping.yml
@@ -31,7 +31,7 @@ jobs:
               "key": "78181e8137ae41ec881a17171a1e9fb2",
               "urlList": [
                 "https://grantex.dev/",
-                "https://grantex.dev/mpp-demo/",
+                "https://grantex.dev/mpp-demo",
                 "https://grantex.dev/for/mpp",
                 "https://grantex.dev/playground",
                 "https://grantex.dev/report/state-of-agent-security-2026",

--- a/firebase.json
+++ b/firebase.json
@@ -2,6 +2,8 @@
   "hosting": {
     "public": "web",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "cleanUrls": true,
+    "trailingSlash": false,
     "redirects": [
       { "source": "/docs", "destination": "https://docs.grantex.dev", "type": 301 },
       { "source": "/docs/:path*", "destination": "https://docs.grantex.dev/:path*", "type": 301 }
@@ -11,14 +13,40 @@
       { "source": "/playground", "destination": "/playground.html" },
       { "source": "/for/:framework", "destination": "/for/index.html" },
       { "source": "/vs/:topic", "destination": "/vs/index.html" },
-      { "source": "/report/state-of-agent-security-2026", "destination": "/report/state-of-agent-security-2026.html" },
-      { "source": "**", "destination": "/index.html" }
+      { "source": "/report/state-of-agent-security-2026", "destination": "/report/state-of-agent-security-2026.html" }
     ],
     "headers": [
       {
         "source": "**/*.@(js|css|woff2)",
         "headers": [
-          { "key": "Cache-Control", "value": "max-age=31536000,immutable" }
+          { "key": "Cache-Control", "value": "public,max-age=31536000,immutable" }
+        ]
+      },
+      {
+        "source": "sitemap.xml",
+        "headers": [
+          { "key": "Cache-Control", "value": "public,max-age=3600" },
+          { "key": "Content-Type", "value": "application/xml" }
+        ]
+      },
+      {
+        "source": "robots.txt",
+        "headers": [
+          { "key": "Cache-Control", "value": "public,max-age=86400" }
+        ]
+      },
+      {
+        "source": "public/contexts/**",
+        "headers": [
+          { "key": "Cache-Control", "value": "public,max-age=86400" },
+          { "key": "Content-Type", "value": "application/ld+json" },
+          { "key": "Access-Control-Allow-Origin", "value": "*" }
+        ]
+      },
+      {
+        "source": "**/*.html",
+        "headers": [
+          { "key": "Cache-Control", "value": "public,max-age=300,s-maxage=3600" }
         ]
       },
       {
@@ -26,7 +54,8 @@
         "headers": [
           { "key": "X-Frame-Options",           "value": "DENY" },
           { "key": "X-Content-Type-Options",    "value": "nosniff" },
-          { "key": "Referrer-Policy",           "value": "strict-origin-when-cross-origin" }
+          { "key": "Referrer-Policy",           "value": "strict-origin-when-cross-origin" },
+          { "key": "X-Robots-Tag",              "value": "index,follow" }
         ]
       }
     ]

--- a/web/404.html
+++ b/web/404.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page Not Found — Grantex</title>
+  <meta name="robots" content="noindex">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      background: #0d1117; color: #e6edf3;
+      min-height: 100vh; display: flex; align-items: center; justify-content: center;
+      padding: 24px; text-align: center;
+    }
+    .box { max-width: 480px; }
+    h1 { font-size: 72px; font-weight: 700; color: #3fb950; margin-bottom: 12px; }
+    h2 { font-size: 20px; font-weight: 600; margin-bottom: 16px; }
+    p { font-size: 15px; color: #8b949e; line-height: 1.6; margin-bottom: 24px; }
+    a {
+      display: inline-block; padding: 10px 24px; background: #3fb950; color: #0d1117;
+      text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 14px;
+    }
+    a:hover { opacity: 0.9; }
+    .links { margin-top: 20px; font-size: 13px; }
+    .links a { background: none; color: #58a6ff; padding: 0; font-weight: 400; }
+  </style>
+</head>
+<body>
+  <div class="box">
+    <h1>404</h1>
+    <h2>Page not found</h2>
+    <p>The page you're looking for doesn't exist. It may have been moved or removed.</p>
+    <a href="/">Back to Grantex</a>
+    <div class="links">
+      <a href="https://docs.grantex.dev">Docs</a> &middot;
+      <a href="https://github.com/mishrasanjeev/grantex">GitHub</a> &middot;
+      <a href="/playground">Playground</a> &middot;
+      <a href="/mpp-demo">MPP Demo</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/web/mpp-demo/index.html
+++ b/web/mpp-demo/index.html
@@ -6,10 +6,10 @@
   <title>Grantex × MPP Demo — Agent Identity for Machine Payments</title>
   <meta name="description" content="Interactive demo: issue AgentPassportCredentials, simulate MPP payment flows with identity verification, and verify passports as a merchant. Grantex adds verifiable agent identity to the Machine Payments Protocol.">
   <meta name="keywords" content="Grantex, MPP, Machine Payments Protocol, agent identity, AgentPassportCredential, agentic commerce, MPP OAuth, AI agent payments, Tempo, USDC, merchant verification, W3C Verifiable Credentials">
-  <link rel="canonical" href="https://grantex.dev/mpp-demo/">
+  <link rel="canonical" href="https://grantex.dev/mpp-demo">
   <meta property="og:title" content="Grantex × MPP Demo — Agent Identity for Machine Payments">
   <meta property="og:description" content="Interactive demo: issue agent passports, simulate MPP payment flows, and verify passports as a merchant.">
-  <meta property="og:url" content="https://grantex.dev/mpp-demo/">
+  <meta property="og:url" content="https://grantex.dev/mpp-demo">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Grantex × MPP Demo — Agent Identity for Machine Payments">

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -7,7 +7,7 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://grantex.dev/mpp-demo/</loc>
+    <loc>https://grantex.dev/mpp-demo</loc>
     <lastmod>2026-03-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>


### PR DESCRIPTION
## Summary

Fixes for the 14 not-indexed pages in GSC coverage report:

- **3 redirect pages**: Remove trailing slash redirects (set `trailingSlash: false`)
- **1 x 404 page**: Add proper `404.html` with `noindex` (was serving homepage as 200)
- **8 discovered-not-indexed**: Remove catch-all `** → /index.html` rewrite that made every URL return homepage content (massive duplicate content signal)
- **Cache headers**: sitemap (1h), robots (24h), HTML (5min client, 1h CDN)
- **X-Robots-Tag**: `index,follow` on all pages
- Fix canonical URLs to no-trailing-slash form in sitemap + mpp-demo