### PR TITLE
feat: bump free tier to 200 agents and increase all plan limits

### DIFF
--- a/apps/auth-service/src/lib/plans.ts
+++ b/apps/auth-service/src/lib/plans.ts
@@ -11,9 +11,9 @@ export interface PlanLimits {
 }
 
 export const PLAN_LIMITS: Record<PlanName, PlanLimits> = {
-  free:       { agents: 3,        webhooks: 1,        grants: 50,       auditEntries: 1_000,   policies: 5,   tokenExchangesPerMonth: 1_000,   authorizationsPerMonth: 1_000   },
-  pro:        { agents: 25,       webhooks: 10,       grants: 500,      auditEntries: 50_000,  policies: 50,  tokenExchangesPerMonth: 100_000, authorizationsPerMonth: 100_000 },
-  enterprise: { agents: Infinity, webhooks: Infinity, grants: Infinity, auditEntries: Infinity, policies: Infinity, tokenExchangesPerMonth: Infinity, authorizationsPerMonth: Infinity },
+  free:       { agents: 200,      webhooks: 5,         grants: 500,       auditEntries: 10_000,   policies: 10,   tokenExchangesPerMonth: 10_000,   authorizationsPerMonth: 10_000   },
+  pro:        { agents: 1_000,    webhooks: 50,        grants: 10_000,    auditEntries: 500_000,  policies: 200,  tokenExchangesPerMonth: 1_000_000, authorizationsPerMonth: 1_000_000 },
+  enterprise: { agents: Infinity, webhooks: Infinity,  grants: Infinity,  auditEntries: Infinity, policies: Infinity, tokenExchangesPerMonth: Infinity, authorizationsPerMonth: Infinity },
 };
 
 export const PLAN_DISPLAY: Record<PlanName, string> = {

--- a/apps/auth-service/tests/agents.test.ts
+++ b/apps/auth-service/tests/agents.test.ts
@@ -32,7 +32,7 @@ describe('POST /v1/agents', () => {
   it('returns 402 when plan agent limit is reached', async () => {
     seedAuth();
     sqlMock.mockResolvedValueOnce([{ plan: 'free' }]); // subscription → free plan
-    sqlMock.mockResolvedValueOnce([{ count: '3' }]);    // 3 agents already (free limit)
+    sqlMock.mockResolvedValueOnce([{ count: '200' }]);   // 200 agents already (free limit)
 
     const res = await app.inject({
       method: 'POST',

--- a/apps/auth-service/tests/audit.test.ts
+++ b/apps/auth-service/tests/audit.test.ts
@@ -66,7 +66,7 @@ describe('POST /v1/audit/log', () => {
   it('returns 402 when plan audit entry limit is reached', async () => {
     seedAuth();
     sqlMock.mockResolvedValueOnce([{ plan: 'free' }]);   // subscription → free plan
-    sqlMock.mockResolvedValueOnce([{ count: '1000' }]);  // audit count → at limit
+    sqlMock.mockResolvedValueOnce([{ count: '10000' }]); // audit count → at limit
 
     const res = await app.inject({
       method: 'POST',

--- a/apps/auth-service/tests/authorize.test.ts
+++ b/apps/auth-service/tests/authorize.test.ts
@@ -55,7 +55,7 @@ describe('POST /v1/authorize', () => {
   it('returns 402 when plan grant limit is reached', async () => {
     seedAuth();
     sqlMock.mockResolvedValueOnce([{ plan: 'free' }]);  // subscription → free plan
-    sqlMock.mockResolvedValueOnce([{ count: '50' }]);   // grant count → at limit
+    sqlMock.mockResolvedValueOnce([{ count: '500' }]);  // grant count → at limit
 
     const res = await app.inject({
       method: 'POST',

--- a/apps/auth-service/tests/policies.test.ts
+++ b/apps/auth-service/tests/policies.test.ts
@@ -47,7 +47,7 @@ describe('POST /v1/policies', () => {
   it('returns 402 when plan policy limit is reached', async () => {
     seedAuth();
     sqlMock.mockResolvedValueOnce([{ plan: 'free' }]);  // subscription → free plan
-    sqlMock.mockResolvedValueOnce([{ count: '5' }]);    // policy count → at limit
+    sqlMock.mockResolvedValueOnce([{ count: '10' }]);   // policy count → at limit
 
     const res = await app.inject({
       method: 'POST',

--- a/apps/auth-service/tests/webhooks.test.ts
+++ b/apps/auth-service/tests/webhooks.test.ts
@@ -52,7 +52,7 @@ describe('POST /v1/webhooks', () => {
   it('returns 402 when plan webhook limit is reached', async () => {
     seedAuth();
     sqlMock.mockResolvedValueOnce([{ plan: 'free' }]); // subscription → free plan
-    sqlMock.mockResolvedValueOnce([{ count: '1' }]);    // 1 webhook already (free limit)
+    sqlMock.mockResolvedValueOnce([{ count: '5' }]);    // 5 webhooks already (free limit)
 
     const res = await app.inject({
       method: 'POST',

--- a/apps/portal/src/pages/billing/BillingPage.tsx
+++ b/apps/portal/src/pages/billing/BillingPage.tsx
@@ -13,13 +13,13 @@ const PLANS = [
     name: 'free',
     label: 'Free',
     price: '$0',
-    features: ['5 agents', '100 grants', '1,000 audit entries', 'Community support'],
+    features: ['200 agents', '500 grants', '10,000 audit entries', '10 policies', 'Community support'],
   },
   {
     name: 'pro',
     label: 'Pro',
     price: '$49/mo',
-    features: ['50 agents', '10,000 grants', '100,000 audit entries', 'Priority support', 'SOC 2 evidence packs'],
+    features: ['1,000 agents', '10,000 grants', '500,000 audit entries', '200 policies', 'Priority support', 'SOC 2 evidence packs'],
   },
   {
     name: 'enterprise',

--- a/docs/guides/troubleshooting.mdx
+++ b/docs/guides/troubleshooting.mdx
@@ -80,7 +80,7 @@ A `402 Payment Required` response means you've hit a resource limit for your cur
 
 ```json
 {
-  "message": "Agent limit reached (free plan: 3)",
+  "message": "Agent limit reached (free plan: 200)",
   "code": "PLAN_LIMIT_EXCEEDED",
   "requestId": "..."
 }

--- a/docs/guides/usage-metering.mdx
+++ b/docs/guides/usage-metering.mdx
@@ -70,5 +70,10 @@ for day in history.entries:
 
 | Metric | Free | Pro | Enterprise |
 |---|---|---|---|
-| Token exchanges/month | 1,000 | 100,000 | Unlimited |
-| Authorizations/month | 1,000 | 100,000 | Unlimited |
+| Agents | 200 | 1,000 | Unlimited |
+| Grants | 500 | 10,000 | Unlimited |
+| Policies | 10 | 200 | Unlimited |
+| Audit entries | 10,000 | 500,000 | Unlimited |
+| Token exchanges/month | 10,000 | 1,000,000 | Unlimited |
+| Authorizations/month | 10,000 | 1,000,000 | Unlimited |
+| Webhooks | 5 | 50 | Unlimited |

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -17,7 +17,7 @@ const JWKS_URI = `${BASE_URL}/.well-known/jwks.json`;
 let grantex: Grantex;
 let apiKey: string;
 
-// Shared agents (free plan allows 3 — reuse across suites)
+// Shared agents (free plan allows 200 — reuse across suites)
 let mainAgent: { agentId: string; did: string };
 let delegateAgent: { agentId: string; did: string };
 
@@ -59,7 +59,7 @@ beforeAll(async () => {
   apiKey = account.apiKey;
   grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
 
-  // Pre-register shared agents (stays within free plan limit of 3)
+  // Pre-register shared agents (stays within free plan limit of 200)
   const [agent1, agent2, agent3] = await Promise.all([
     grantex.agents.register({ name: `e2e-main-${Date.now()}`, scopes: ['calendar:read', 'email:send', 'files:read'] }),
     grantex.agents.register({ name: `e2e-parent-${Date.now()}`, scopes: ['calendar:read', 'email:send'] }),


### PR DESCRIPTION
## Summary

Increases plan limits across all tiers to be more generous for developers.

| Metric | Free (old → new) | Pro (old → new) |
|---|---|---|
| Agents | 3 → **200** | 25 → **1,000** |
| Grants | 50 → **500** | 500 → **10,000** |
| Audit entries | 1,000 → **10,000** | 50,000 → **500,000** |
| Policies | 5 → **10** | 50 → **200** |
| Webhooks | 1 → **5** | 10 → **50** |
| Token exchanges/mo | 1,000 → **10,000** | 100,000 → **1,000,000** |
| Authorizations/mo | 1,000 → **10,000** | 100,000 → **1,000,000** |

Enterprise: unchanged (unlimited everything).

## Files changed

- `apps/auth-service/src/lib/plans.ts` — plan limits
- `apps/portal/src/pages/billing/BillingPage.tsx` — billing UI
- `docs/guides/troubleshooting.mdx` — error message example
- `docs/guides/usage-metering.mdx` — plan limits table
- 5 test files updated with new limit values

## Test plan

- [x] 703 auth-service tests pass
- [x] TypeScript compiles clean