### PR TITLE
chore: bump all package versions for keyword publish

### DIFF
--- a/packages/a2a-py/pyproject.toml
+++ b/packages/a2a-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex-a2a"
-version = "0.1.1"
+version = "0.1.2"
 description = "Google A2A protocol bridge for Grantex — inject grant tokens into agent-to-agent communication"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/a2a",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Google A2A protocol bridge for Grantex — inject grant tokens into agent-to-agent communication",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/adapters",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Pre-built service provider adapters for Grantex — Google Calendar, Gmail, Drive, Stripe, Slack, GitHub, Notion, HubSpot, Salesforce, Linear, Jira",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/autogen/package.json
+++ b/packages/autogen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/autogen",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "AutoGen / OpenAI function-calling integration for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev/for/autogen",
   "bugs": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "CLI tool for local Grantex development",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/conformance",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Conformance test suite for the Grantex protocol",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/crewai/pyproject.toml
+++ b/packages/crewai/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex-crewai"
-version = "0.1.3"
+version = "0.1.4"
 description = "CrewAI integration for the Grantex delegated authorization protocol — scope-enforced, audited agent tools"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/destinations/package.json
+++ b/packages/destinations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/destinations",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "license": "Apache-2.0",
   "description": "Event destination connectors for Grantex (Datadog, Splunk, S3, BigQuery, Kafka)",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/express",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Express.js middleware for Grantex grant token verification and scope-based authorization",
   "homepage": "https://grantex.dev/for/express",
   "bugs": {

--- a/packages/fastapi/pyproject.toml
+++ b/packages/fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex-fastapi"
-version = "0.1.2"
+version = "0.1.3"
 description = "FastAPI middleware for Grantex grant token verification and scope-based authorization"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/gateway",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Zero-code reverse-proxy gateway that enforces Grantex grant tokens via YAML config",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/google-adk/pyproject.toml
+++ b/packages/google-adk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex-adk"
-version = "0.1.2"
+version = "0.1.3"
 description = "Google ADK integration for the Grantex delegated authorization protocol — scope-enforced agent tools"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/langchain",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "LangChain integration for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev/for/langchain",
   "bugs": {

--- a/packages/mcp-auth/package.json
+++ b/packages/mcp-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/mcp-auth",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "OAuth 2.1 + PKCE authorization server for MCP servers, powered by Grantex",
   "homepage": "https://grantex.dev/for/mcp",
   "bugs": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/mcp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MCP server for Grantex delegated agent authorization",
   "homepage": "https://grantex.dev/for/mcp",
   "bugs": {

--- a/packages/mpp/package.json
+++ b/packages/mpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/mpp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Grantex agent identity and delegation for MPP (Machine Payments Protocol)",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/openai-agents/pyproject.toml
+++ b/packages/openai-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex-openai-agents"
-version = "0.1.2"
+version = "0.1.3"
 description = "OpenAI Agents SDK integration for the Grantex delegated authorization protocol — scope-enforced, audited agent tools"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.2.2"
+version = "0.2.3"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/vercel-ai",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Vercel AI SDK integration for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev/for/vercel-ai",
   "bugs": {

--- a/packages/x402/package.json
+++ b/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/x402",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Grantex Delegation Tokens for x402 payment flows — agent spend authorization with W3C Verifiable Credentials",
   "homepage": "https://grantex.dev/x402",
   "bugs": {


### PR DESCRIPTION
## Summary
- Patch bump 15 npm packages and 6 PyPI packages to publish expanded keyword metadata to registries

## Version Bumps

**npm (15):**
| Package | Old | New |
|---|---|---|
| `@grantex/sdk` | 0.2.3 | 0.2.4 |
| `@grantex/cli` | 0.1.4 | 0.1.5 |
| `@grantex/mcp` | 0.1.3 | 0.1.4 |
| `@grantex/langchain` | 0.1.4 | 0.1.5 |
| `@grantex/express` | 0.1.3 | 0.1.4 |
| `@grantex/gateway` | 0.1.3 | 0.1.4 |
| `@grantex/conformance` | 0.1.6 | 0.1.7 |
| `@grantex/vercel-ai` | 0.1.3 | 0.1.4 |
| `@grantex/autogen` | 0.1.3 | 0.1.4 |
| `@grantex/mcp-auth` | 0.1.1 | 0.1.2 |
| `@grantex/adapters` | 0.1.3 | 0.1.4 |
| `@grantex/destinations` | 0.1.1 | 0.1.2 |
| `@grantex/a2a` | 0.1.1 | 0.1.2 |
| `@grantex/mpp` | 0.1.0 | 0.1.1 |
| `@grantex/x402` | 0.1.0 | 0.1.1 |

**PyPI (6):**
| Package | Old | New |
|---|---|---|
| `grantex` | 0.2.2 | 0.2.3 |
| `grantex-openai-agents` | 0.1.2 | 0.1.3 |
| `grantex-adk` | 0.1.2 | 0.1.3 |
| `grantex-crewai` | 0.1.3 | 0.1.4 |
| `grantex-fastapi` | 0.1.2 | 0.1.3 |
| `grantex-a2a` | 0.1.1 | 0.1.2 |

## Test plan
- [ ] CI passes (no code changes, version-only bumps)