### PR TITLE
feat(cli): add missing commands, --json flag, and full API coverage

### DIFF
--- a/docs/integrations/cli.mdx
+++ b/docs/integrations/cli.mdx
@@ -26,16 +26,66 @@ grantex config show
 
 Config is saved to `~/.grantex/config.json`. Environment variables override the config file.
 
+## JSON Output
+
+All commands support `--json` for machine-readable output. This is useful for scripting, piping into `jq`, or when using the CLI from AI coding assistants (Claude Code, Cursor, Codex, etc.).
+
+```bash
+grantex --json agents list
+grantex --json tokens verify <jwt-token>
+grantex --json grants list --status active | jq '.[].id'
+```
+
+To disable colored output, set the `NO_COLOR=1` environment variable.
+
 ## Commands
+
+### Authorize (Core Flow)
+
+```bash
+# Start an authorization request
+grantex authorize --agent ag_01ABC... --principal user@example.com --scopes email:read,calendar:write
+
+# With PKCE
+grantex authorize --agent ag_01ABC... --principal user@example.com --scopes email:read \
+  --code-challenge <base64url-sha256-challenge>
+
+# With redirect URI
+grantex authorize --agent ag_01ABC... --principal user@example.com --scopes email:read \
+  --redirect-uri https://myapp.com/callback
+
+# With custom expiry
+grantex authorize --agent ag_01ABC... --principal user@example.com --scopes email:read \
+  --expires-in 1h
+```
 
 ### Agents
 
 ```bash
 grantex agents list
-grantex agents register --name travel-booker --scopes calendar:read,payments:initiate
+grantex agents register --name travel-booker --description "Books travel" --scopes calendar:read,payments:initiate
 grantex agents get ag_01ABC...
 grantex agents update ag_01ABC... --name new-name --scopes calendar:read,email:send
 grantex agents delete ag_01ABC...
+```
+
+### Tokens
+
+```bash
+# Exchange authorization code for a grant token
+grantex tokens exchange --code <auth-code> --agent-id ag_01ABC...
+
+# Exchange with PKCE verifier
+grantex tokens exchange --code <auth-code> --agent-id ag_01ABC... --code-verifier <verifier>
+
+# Verify a grant token (online check)
+grantex tokens verify <jwt-token>
+
+# Refresh a grant token
+grantex tokens refresh --refresh-token <token> --agent-id ag_01ABC...
+
+# Revoke a token by JTI
+grantex tokens revoke <jti>
 ```
 
 ### Grants
@@ -43,14 +93,43 @@ grantex agents delete ag_01ABC...
 ```bash
 grantex grants list
 grantex grants list --agent ag_01ABC... --status active
+grantex grants get grnt_01XYZ...
 grantex grants revoke grnt_01XYZ...
+
+# Delegate a grant to a sub-agent
+grantex grants delegate --grant-token <parent-jwt> --agent-id ag_CHILD... --scopes email:read
+grantex grants delegate --grant-token <parent-jwt> --agent-id ag_CHILD... --scopes email:read --expires-in 1h
 ```
 
-### Tokens
+### Budgets
 
 ```bash
-grantex tokens verify <jwt-token>
-grantex tokens revoke <jti>
+grantex budgets allocate --grant-id grnt_01XYZ... --amount 100.00
+grantex budgets allocate --grant-id grnt_01XYZ... --amount 50 --currency EUR
+grantex budgets debit --grant-id grnt_01XYZ... --amount 25.50 --description "API call"
+grantex budgets balance grnt_01XYZ...
+grantex budgets transactions grnt_01XYZ...
+```
+
+### Usage
+
+```bash
+grantex usage current
+grantex usage history
+grantex usage history --days 7
+```
+
+### Events
+
+```bash
+# Stream real-time events (Ctrl+C to stop)
+grantex events stream
+
+# Filter by event type
+grantex events stream --types grant.created,token.issued
+
+# JSON output (one JSON object per line, ideal for piping)
+grantex --json events stream
 ```
 
 ### Audit Log
@@ -58,6 +137,7 @@ grantex tokens revoke <jti>
 ```bash
 grantex audit list
 grantex audit list --agent ag_01ABC... --action payment.initiated --since 2026-01-01
+grantex audit list --grant grnt_01XYZ... --principal user@example.com
 ```
 
 ### Webhooks
@@ -69,6 +149,33 @@ grantex webhooks delete wh_01XYZ...
 ```
 
 Supported events: `grant.created`, `grant.revoked`, `token.issued`.
+
+### Policies
+
+```bash
+grantex policies list
+grantex policies get pol_01ABC...
+grantex policies create --name "Allow Email Bot" --effect allow --agent-id ag_01ABC... --scopes email:read
+grantex policies create --name "Block After Hours" --effect deny --time-start 18:00 --time-end 08:00
+grantex policies update pol_01ABC... --priority 50
+grantex policies delete pol_01ABC...
+```
+
+### Domains
+
+```bash
+grantex domains list
+grantex domains add --domain auth.mycompany.com
+grantex domains verify dom_01ABC...
+grantex domains delete dom_01ABC...
+```
+
+### Principal Sessions
+
+```bash
+grantex principal-sessions create --principal-id user@example.com
+grantex principal-sessions create --principal-id user@example.com --expires-in 1h
+```
 
 ### Compliance
 
@@ -94,6 +201,62 @@ grantex anomalies detect
 grantex anomalies list
 grantex anomalies list --unacknowledged
 grantex anomalies acknowledge anom_01XYZ...
+```
+
+### Billing
+
+```bash
+grantex billing status
+grantex billing checkout pro --success-url https://myapp.com/success --cancel-url https://myapp.com/cancel
+grantex billing portal --return-url https://myapp.com/settings
+```
+
+### SCIM
+
+```bash
+# Token management
+grantex scim tokens list
+grantex scim tokens create --label "Okta Integration"
+grantex scim tokens revoke tok_01ABC...
+
+# User provisioning
+grantex scim users list
+grantex scim users get usr_01ABC...
+```
+
+### SSO
+
+```bash
+grantex sso get
+grantex sso configure --issuer-url https://accounts.google.com --client-id CLIENT_ID \
+  --client-secret CLIENT_SECRET --redirect-uri https://myapp.com/callback
+grantex sso delete
+grantex sso login-url my-org
+```
+
+## Full Workflow Example
+
+```bash
+# 1. Configure
+grantex config set --url http://localhost:3001 --key sandbox-api-key-local
+
+# 2. Register an agent
+grantex agents register --name "Email Reader" --description "Reads emails" --scopes email:read,email:send
+
+# 3. Start authorization (sandbox auto-approves, returns code directly)
+grantex authorize --agent ag_01ABC... --principal user@example.com --scopes email:read
+
+# 4. Exchange the code for a token
+grantex tokens exchange --code <code-from-step-3> --agent-id ag_01ABC...
+
+# 5. Verify the token
+grantex tokens verify <jwt-from-step-4>
+
+# 6. Check audit trail
+grantex audit list --agent ag_01ABC...
+
+# 7. Revoke when done
+grantex grants revoke grnt_01XYZ...
 ```
 
 ## Local Development

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "CLI tool for local Grantex development",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { requireClient } from '../client.js';
-import { printTable, printRecord, shortDate } from '../format.js';
+import { printTable, printRecord, shortDate, isJsonMode } from '../format.js';
 
 export function agentsCommand(): Command {
   const cmd = new Command('agents').description('Manage registered agents');
@@ -20,6 +20,7 @@ export function agentsCommand(): Command {
           CREATED: shortDate(a.createdAt),
         })),
         ['ID', 'NAME', 'DID', 'CREATED'],
+        agents.map((a) => ({ ...a })),
       );
     });
 
@@ -36,6 +37,10 @@ export function agentsCommand(): Command {
         description: opts.description,
         scopes: opts.scopes.split(',').map((s) => s.trim()),
       });
+      if (isJsonMode()) {
+        console.log(JSON.stringify(agent, null, 2));
+        return;
+      }
       console.log(chalk.green('✓') + ` Agent registered: ${agent.id}`);
       printRecord({
         id: agent.id,
@@ -52,6 +57,10 @@ export function agentsCommand(): Command {
     .action(async (agentId: string) => {
       const client = await requireClient();
       const agent = await client.agents.get(agentId);
+      if (isJsonMode()) {
+        console.log(JSON.stringify(agent, null, 2));
+        return;
+      }
       printRecord({
         id: agent.id,
         name: agent.name,
@@ -63,11 +72,35 @@ export function agentsCommand(): Command {
     });
 
   cmd
+    .command('update <agentId>')
+    .description('Update an agent')
+    .option('--name <name>', 'New agent name')
+    .option('--description <desc>', 'New agent description')
+    .option('--scopes <scopes>', 'New comma-separated scopes')
+    .action(async (agentId: string, opts: { name?: string; description?: string; scopes?: string }) => {
+      const client = await requireClient();
+      const updates: Record<string, unknown> = {};
+      if (opts.name !== undefined) updates.name = opts.name;
+      if (opts.description !== undefined) updates.description = opts.description;
+      if (opts.scopes !== undefined) updates.scopes = opts.scopes.split(',').map((s) => s.trim());
+      const agent = await client.agents.update(agentId, updates);
+      if (isJsonMode()) {
+        console.log(JSON.stringify(agent, null, 2));
+        return;
+      }
+      console.log(chalk.green('✓') + ` Agent ${agentId} updated.`);
+    });
+
+  cmd
     .command('delete <agentId>')
     .description('Delete an agent')
     .action(async (agentId: string) => {
       const client = await requireClient();
       await client.agents.delete(agentId);
+      if (isJsonMode()) {
+        console.log(JSON.stringify({ deleted: agentId }));
+        return;
+      }
       console.log(chalk.green('✓') + ` Agent ${agentId} deleted.`);
     });
 

--- a/packages/cli/src/commands/anomalies.ts
+++ b/packages/cli/src/commands/anomalies.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { requireClient } from '../client.js';
-import { printTable, shortDate } from '../format.js';
+import { printTable, shortDate, isJsonMode } from '../format.js';
 import type { Anomaly } from '@grantex/sdk';
 
 const SEVERITY_COLOR: Record<string, (s: string) => string> = {
@@ -33,6 +33,7 @@ export function anomaliesCommand(): Command {
       printTable(
         result.anomalies.map(formatRow),
         ['ID', 'TYPE', 'SEVERITY', 'AGENT', 'DESCRIPTION'],
+        result.anomalies.map((a) => ({ ...a })),
       );
     });
 
@@ -49,6 +50,7 @@ export function anomaliesCommand(): Command {
       printTable(
         result.anomalies.map(formatRow),
         ['ID', 'TYPE', 'SEVERITY', 'AGENT', 'DESCRIPTION'],
+        result.anomalies.map((a) => ({ ...a })),
       );
     });
 

--- a/packages/cli/src/commands/anomalies.ts
+++ b/packages/cli/src/commands/anomalies.ts
@@ -24,6 +24,11 @@ export function anomaliesCommand(): Command {
       const client = await requireClient();
       const result = await client.anomalies.detect();
 
+      if (isJsonMode()) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+
       if (result.total === 0) {
         console.log(chalk.green('✓') + ' No anomalies detected.');
         return;
@@ -33,7 +38,6 @@ export function anomaliesCommand(): Command {
       printTable(
         result.anomalies.map(formatRow),
         ['ID', 'TYPE', 'SEVERITY', 'AGENT', 'DESCRIPTION'],
-        result.anomalies.map((a) => ({ ...a })),
       );
     });
 
@@ -60,6 +64,10 @@ export function anomaliesCommand(): Command {
     .action(async (anomalyId: string) => {
       const client = await requireClient();
       await client.anomalies.acknowledge(anomalyId);
+      if (isJsonMode()) {
+        console.log(JSON.stringify({ acknowledged: anomalyId }));
+        return;
+      }
       console.log(chalk.green('✓') + ` Anomaly ${anomalyId} acknowledged.`);
     });
 

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,9 +1,10 @@
 import { Command } from 'commander';
+import chalk from 'chalk';
 import { requireClient } from '../client.js';
-import { printTable, shortDate } from '../format.js';
+import { printTable, printRecord, shortDate, isJsonMode } from '../format.js';
 
 export function auditCommand(): Command {
-  const cmd = new Command('audit').description('View the audit log');
+  const cmd = new Command('audit').description('View and manage the audit log');
 
   cmd
     .command('list')
@@ -43,6 +44,82 @@ export function auditCommand(): Command {
           ['ID', 'AGENT', 'ACTION', 'STATUS', 'TIMESTAMP'],
           entries.map((e) => ({ ...e })),
         );
+      },
+    );
+
+  cmd
+    .command('get <entryId>')
+    .description('Get a single audit entry by ID')
+    .action(async (entryId: string) => {
+      const client = await requireClient();
+      const entry = await client.audit.get(entryId);
+      if (isJsonMode()) {
+        console.log(JSON.stringify(entry, null, 2));
+        return;
+      }
+      printRecord({
+        entryId: entry.entryId,
+        agentId: entry.agentId,
+        agentDid: entry.agentDid ?? '',
+        grantId: entry.grantId ?? '',
+        principalId: entry.principalId ?? '',
+        action: entry.action,
+        status: entry.status,
+        hash: entry.hash ?? '',
+        previousHash: entry.prevHash ?? '',
+        timestamp: shortDate(entry.timestamp),
+        metadata: JSON.stringify(entry.metadata ?? {}),
+      });
+    });
+
+  cmd
+    .command('log')
+    .description('Log a new audit entry')
+    .requiredOption('--agent-id <agentId>', 'Agent ID')
+    .requiredOption('--agent-did <agentDid>', 'Agent DID (e.g. did:grantex:ag_...)')
+    .requiredOption('--grant-id <grantId>', 'Grant ID')
+    .requiredOption('--principal-id <principalId>', 'Principal ID')
+    .requiredOption('--action <action>', 'Action name (e.g. email.read, payment.initiated)')
+    .option('--status <status>', 'Status: success, failure, or blocked')
+    .option('--metadata <json>', 'JSON metadata object')
+    .action(
+      async (opts: {
+        agentId: string;
+        agentDid: string;
+        grantId: string;
+        principalId: string;
+        action: string;
+        status?: string;
+        metadata?: string;
+      }) => {
+        const client = await requireClient();
+
+        let metadata: Record<string, unknown> | undefined;
+        if (opts.metadata !== undefined) {
+          try {
+            metadata = JSON.parse(opts.metadata) as Record<string, unknown>;
+          } catch {
+            console.error('Error: --metadata must be valid JSON.');
+            process.exit(1);
+          }
+        }
+
+        const entry = await client.audit.log({
+          agentId: opts.agentId,
+          agentDid: opts.agentDid,
+          grantId: opts.grantId,
+          principalId: opts.principalId,
+          action: opts.action,
+          ...(opts.status !== undefined ? { status: opts.status as 'success' | 'failure' | 'blocked' } : {}),
+          ...(metadata !== undefined ? { metadata } : {}),
+        });
+
+        if (isJsonMode()) {
+          console.log(JSON.stringify(entry, null, 2));
+          return;
+        }
+
+        console.log(chalk.green('✓') + ` Audit entry logged: ${entry.entryId}`);
       },
     );
 

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -41,6 +41,7 @@ export function auditCommand(): Command {
             TIMESTAMP: shortDate(e.timestamp),
           })),
           ['ID', 'AGENT', 'ACTION', 'STATUS', 'TIMESTAMP'],
+          entries.map((e) => ({ ...e })),
         );
       },
     );

--- a/packages/cli/src/commands/authorize.ts
+++ b/packages/cli/src/commands/authorize.ts
@@ -1,0 +1,55 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { requireClient } from '../client.js';
+import { printRecord, shortDate, isJsonMode } from '../format.js';
+
+export function authorizeCommand(): Command {
+  const cmd = new Command('authorize').description('Start an authorization request');
+
+  cmd
+    .requiredOption('--agent <agentId>', 'Agent ID to authorize')
+    .requiredOption('--principal <principalId>', 'Principal (user) identifier')
+    .requiredOption('--scopes <scopes>', 'Comma-separated scopes to request')
+    .option('--redirect-uri <uri>', 'Redirect URI for callback')
+    .option('--expires-in <duration>', 'Expiry duration (e.g. 1h, 24h)')
+    .option('--code-challenge <challenge>', 'PKCE S256 code challenge')
+    .action(
+      async (opts: {
+        agent: string;
+        principal: string;
+        scopes: string;
+        redirectUri?: string;
+        expiresIn?: string;
+        codeChallenge?: string;
+      }) => {
+        const client = await requireClient();
+        const res = await client.authorize({
+          agentId: opts.agent,
+          userId: opts.principal,
+          scopes: opts.scopes.split(',').map((s) => s.trim()),
+          ...(opts.redirectUri !== undefined ? { redirectUri: opts.redirectUri } : {}),
+          ...(opts.expiresIn !== undefined ? { expiresIn: opts.expiresIn } : {}),
+          ...(opts.codeChallenge !== undefined ? { codeChallenge: opts.codeChallenge, codeChallengeMethod: 'S256' } : {}),
+        });
+
+        if (isJsonMode()) {
+          console.log(JSON.stringify(res, null, 2));
+          return;
+        }
+
+        console.log(chalk.green('✓') + ` Authorization request created.`);
+        const display: Record<string, string> = {
+          authRequestId: res.authRequestId,
+          consentUrl: res.consentUrl,
+          expiresAt: shortDate(res.expiresAt),
+        };
+        if ('code' in res && res.code) {
+          display.code = res.code as string;
+          console.log(chalk.yellow('  (sandbox auto-approved — code returned directly)'));
+        }
+        printRecord(display);
+      },
+    );
+
+  return cmd;
+}

--- a/packages/cli/src/commands/billing.ts
+++ b/packages/cli/src/commands/billing.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { requireClient } from '../client.js';
-import { printRecord } from '../format.js';
+import { printRecord, isJsonMode } from '../format.js';
 
 export function billingCommand(): Command {
   const cmd = new Command('billing').description('Manage subscription and billing');
@@ -12,11 +12,14 @@ export function billingCommand(): Command {
     .action(async () => {
       const client = await requireClient();
       const sub = await client.billing.getSubscription();
-      printRecord({
-        plan: sub.plan,
-        status: sub.status,
-        currentPeriodEnd: sub.currentPeriodEnd ?? '—',
-      });
+      printRecord(
+        {
+          plan: sub.plan,
+          status: sub.status,
+          currentPeriodEnd: sub.currentPeriodEnd ?? '—',
+        },
+        { ...sub },
+      );
     });
 
   cmd
@@ -31,6 +34,10 @@ export function billingCommand(): Command {
         successUrl: opts.successUrl,
         cancelUrl: opts.cancelUrl,
       });
+      if (isJsonMode()) {
+        console.log(JSON.stringify({ checkoutUrl }));
+        return;
+      }
       console.log(chalk.green('✓') + ' Checkout URL:');
       console.log(checkoutUrl);
     });
@@ -42,6 +49,10 @@ export function billingCommand(): Command {
     .action(async (opts: { returnUrl: string }) => {
       const client = await requireClient();
       const { portalUrl } = await client.billing.createPortal({ returnUrl: opts.returnUrl });
+      if (isJsonMode()) {
+        console.log(JSON.stringify({ portalUrl }));
+        return;
+      }
       console.log(chalk.green('✓') + ' Portal URL:');
       console.log(portalUrl);
     });

--- a/packages/cli/src/commands/budgets.ts
+++ b/packages/cli/src/commands/budgets.ts
@@ -1,0 +1,92 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { requireClient } from '../client.js';
+import { printTable, printRecord, shortDate, isJsonMode } from '../format.js';
+
+export function budgetsCommand(): Command {
+  const cmd = new Command('budgets').description('Manage budget allocations and spend tracking');
+
+  cmd
+    .command('allocate')
+    .description('Allocate a budget to a grant')
+    .requiredOption('--grant-id <grantId>', 'Grant to attach the budget to')
+    .requiredOption('--amount <amount>', 'Budget amount', parseFloat)
+    .option('--currency <currency>', 'Currency code (default: USD)')
+    .action(async (opts: { grantId: string; amount: number; currency?: string }) => {
+      const client = await requireClient();
+      const res = await client.budgets.allocate({
+        grantId: opts.grantId,
+        initialBudget: opts.amount,
+        ...(opts.currency !== undefined ? { currency: opts.currency } : {}),
+      });
+      if (isJsonMode()) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      console.log(chalk.green('✓') + ' Budget allocated.');
+      printRecord({
+        id: res.id,
+        grantId: res.grantId,
+        initialBudget: String(res.initialBudget),
+        remainingBudget: String(res.remainingBudget),
+      });
+    });
+
+  cmd
+    .command('debit')
+    .description('Debit an amount from a grant budget')
+    .requiredOption('--grant-id <grantId>', 'Grant to debit from')
+    .requiredOption('--amount <amount>', 'Amount to debit', parseFloat)
+    .option('--description <desc>', 'Transaction description')
+    .action(async (opts: { grantId: string; amount: number; description?: string }) => {
+      const client = await requireClient();
+      const res = await client.budgets.debit({
+        grantId: opts.grantId,
+        amount: opts.amount,
+        ...(opts.description !== undefined ? { description: opts.description } : {}),
+      });
+      if (isJsonMode()) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      console.log(chalk.green('✓') + ` Debited. Remaining: ${res.remaining}`);
+    });
+
+  cmd
+    .command('balance <grantId>')
+    .description('Get current budget balance for a grant')
+    .action(async (grantId: string) => {
+      const client = await requireClient();
+      const res = await client.budgets.balance(grantId);
+      if (isJsonMode()) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      printRecord({
+        grantId: res.grantId,
+        initialBudget: String(res.initialBudget),
+        remainingBudget: String(res.remainingBudget),
+        currency: res.currency ?? 'USD',
+      });
+    });
+
+  cmd
+    .command('transactions <grantId>')
+    .description('List budget transactions for a grant')
+    .action(async (grantId: string) => {
+      const client = await requireClient();
+      const res = await client.budgets.transactions(grantId);
+      printTable(
+        res.transactions.map((t) => ({
+          ID: t.id,
+          AMOUNT: t.amount,
+          DESCRIPTION: t.description,
+          CREATED: shortDate(t.createdAt),
+        })),
+        ['ID', 'AMOUNT', 'DESCRIPTION', 'CREATED'],
+        res.transactions.map((t) => ({ ...t })),
+      );
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/compliance.ts
+++ b/packages/cli/src/commands/compliance.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { writeFileSync } from 'fs';
 import { requireClient } from '../client.js';
-import { printRecord, shortDate } from '../format.js';
+import { printRecord, shortDate, isJsonMode } from '../format.js';
 import type { Grant, AuditEntry } from '@grantex/sdk';
 
 export function complianceCommand(): Command {
@@ -18,6 +18,10 @@ export function complianceCommand(): Command {
         ...(opts.since ? { since: opts.since } : {}),
         ...(opts.until ? { until: opts.until } : {}),
       });
+      if (isJsonMode()) {
+        console.log(JSON.stringify(s, null, 2));
+        return;
+      }
       printRecord({
         'Generated at': shortDate(s.generatedAt),
         'Plan':         s.plan,
@@ -55,7 +59,8 @@ export function complianceCommand(): Command {
             : {}),
         });
 
-        const output = renderGrants(result.grants, opts.format);
+        const fmt = isJsonMode() ? 'json' : opts.format;
+        const output = renderGrants(result.grants, fmt);
         writeOutput(output, opts.output);
       },
     );
@@ -88,7 +93,8 @@ export function complianceCommand(): Command {
             : {}),
         });
 
-        const output = renderAudit(result.entries, opts.format);
+        const fmt = isJsonMode() ? 'json' : opts.format;
+        const output = renderAudit(result.entries, fmt);
         writeOutput(output, opts.output);
       },
     );
@@ -110,6 +116,11 @@ export function complianceCommand(): Command {
           ...(opts.since ? { since: opts.since } : {}),
           ...(opts.until ? { until: opts.until } : {}),
         });
+
+        if (isJsonMode()) {
+          console.log(JSON.stringify(pack, null, 2));
+          return;
+        }
 
         const defaultFile = `evidence-pack-${new Date().toISOString().slice(0, 10)}.json`;
         const outFile = opts.output ?? defaultFile;

--- a/packages/cli/src/commands/domains.ts
+++ b/packages/cli/src/commands/domains.ts
@@ -1,0 +1,78 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { requireClient } from '../client.js';
+import { printTable, printRecord, isJsonMode } from '../format.js';
+
+export function domainsCommand(): Command {
+  const cmd = new Command('domains').description('Manage custom domains');
+
+  cmd
+    .command('list')
+    .description('List custom domains')
+    .action(async () => {
+      const client = await requireClient();
+      const res = await client.domains.list();
+      printTable(
+        res.domains.map((d) => ({
+          ID: d.id,
+          DOMAIN: d.domain,
+          VERIFIED: d.verified ? 'yes' : 'no',
+        })),
+        ['ID', 'DOMAIN', 'VERIFIED'],
+        res.domains.map((d) => ({ ...d })),
+      );
+    });
+
+  cmd
+    .command('add')
+    .description('Add a custom domain')
+    .requiredOption('--domain <domain>', 'Domain name (e.g. auth.mycompany.com)')
+    .action(async (opts: { domain: string }) => {
+      const client = await requireClient();
+      const res = await client.domains.create({ domain: opts.domain });
+      if (isJsonMode()) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      console.log(chalk.green('✓') + ` Domain added: ${res.domain}`);
+      printRecord({
+        id: res.id,
+        domain: res.domain,
+        verified: String(res.verified),
+        verificationToken: res.verificationToken,
+        instructions: res.instructions,
+      });
+    });
+
+  cmd
+    .command('verify <domainId>')
+    .description('Verify domain ownership via DNS TXT record')
+    .action(async (domainId: string) => {
+      const client = await requireClient();
+      const res = await client.domains.verify(domainId);
+      if (isJsonMode()) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      if (res.verified) {
+        console.log(chalk.green('✓') + ' Domain verified successfully.');
+      } else {
+        console.log(chalk.yellow('⚠') + ' Domain not yet verified. Check your DNS TXT record.');
+      }
+    });
+
+  cmd
+    .command('delete <domainId>')
+    .description('Remove a custom domain')
+    .action(async (domainId: string) => {
+      const client = await requireClient();
+      await client.domains.delete(domainId);
+      if (isJsonMode()) {
+        console.log(JSON.stringify({ deleted: domainId }));
+        return;
+      }
+      console.log(chalk.green('✓') + ` Domain ${domainId} deleted.`);
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/events.ts
+++ b/packages/cli/src/commands/events.ts
@@ -1,0 +1,39 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { requireClient } from '../client.js';
+import { isJsonMode } from '../format.js';
+
+export function eventsCommand(): Command {
+  const cmd = new Command('events').description('Stream real-time authorization events');
+
+  cmd
+    .command('stream')
+    .description('Stream events via SSE (Ctrl+C to stop)')
+    .option('--types <types>', 'Comma-separated event types to filter')
+    .action(async (opts: { types?: string }) => {
+      const client = await requireClient();
+      const options: Record<string, unknown> = {};
+      if (opts.types !== undefined) {
+        options.types = opts.types.split(',').map((t) => t.trim());
+      }
+
+      if (!isJsonMode()) {
+        console.log(chalk.cyan('⟳') + ' Streaming events (Ctrl+C to stop)...\n');
+      }
+
+      for await (const event of client.events.stream(options)) {
+        if (isJsonMode()) {
+          console.log(JSON.stringify(event));
+        } else {
+          const type = event.type ?? 'unknown';
+          const ts = event.createdAt ?? new Date().toISOString();
+          console.log(
+            chalk.gray(`[${ts}]`) + ' ' + chalk.bold(type) + ' ' +
+            JSON.stringify(event.data, null, 0),
+          );
+        }
+      }
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/grants.ts
+++ b/packages/cli/src/commands/grants.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { requireClient } from '../client.js';
-import { printTable, shortDate } from '../format.js';
+import { printTable, printRecord, shortDate, isJsonMode } from '../format.js';
 
 export function grantsCommand(): Command {
   const cmd = new Command('grants').description('View and manage grants');
@@ -29,7 +29,29 @@ export function grantsCommand(): Command {
           EXPIRES: shortDate(g.expiresAt),
         })),
         ['ID', 'AGENT', 'PRINCIPAL', 'STATUS', 'SCOPES', 'EXPIRES'],
+        grants.map((g) => ({ ...g })),
       );
+    });
+
+  cmd
+    .command('get <grantId>')
+    .description('Get details for a single grant')
+    .action(async (grantId: string) => {
+      const client = await requireClient();
+      const grant = await client.grants.get(grantId);
+      if (isJsonMode()) {
+        console.log(JSON.stringify(grant, null, 2));
+        return;
+      }
+      printRecord({
+        id: grant.id,
+        agentId: grant.agentId,
+        principalId: grant.principalId,
+        status: grant.status,
+        scopes: grant.scopes.join(', '),
+        issuedAt: shortDate(grant.issuedAt),
+        expiresAt: shortDate(grant.expiresAt),
+      });
     });
 
   cmd
@@ -38,8 +60,49 @@ export function grantsCommand(): Command {
     .action(async (grantId: string) => {
       const client = await requireClient();
       await client.grants.revoke(grantId);
+      if (isJsonMode()) {
+        console.log(JSON.stringify({ revoked: grantId }));
+        return;
+      }
       console.log(chalk.green('✓') + ` Grant ${grantId} revoked.`);
     });
+
+  cmd
+    .command('delegate')
+    .description('Create a delegated sub-grant from an existing grant token')
+    .requiredOption('--grant-token <jwt>', 'Parent grant token (JWT)')
+    .requiredOption('--agent-id <agentId>', 'Child agent to delegate to')
+    .requiredOption('--scopes <scopes>', 'Comma-separated scopes (must be subset of parent)')
+    .option('--expires-in <duration>', 'Expiry duration (e.g. 1h, must be <= parent)')
+    .action(
+      async (opts: {
+        grantToken: string;
+        agentId: string;
+        scopes: string;
+        expiresIn?: string;
+      }) => {
+        const client = await requireClient();
+        const res = await client.grants.delegate({
+          parentGrantToken: opts.grantToken,
+          subAgentId: opts.agentId,
+          scopes: opts.scopes.split(',').map((s) => s.trim()),
+          ...(opts.expiresIn !== undefined ? { expiresIn: opts.expiresIn } : {}),
+        });
+
+        if (isJsonMode()) {
+          console.log(JSON.stringify(res, null, 2));
+          return;
+        }
+
+        console.log(chalk.green('✓') + ' Grant delegated successfully.');
+        printRecord({
+          grantToken: res.grantToken.slice(0, 40) + '...',
+          grantId: res.grantId,
+          scopes: res.scopes.join(', '),
+          expiresAt: shortDate(res.expiresAt),
+        });
+      },
+    );
 
   return cmd;
 }

--- a/packages/cli/src/commands/me.ts
+++ b/packages/cli/src/commands/me.ts
@@ -1,0 +1,56 @@
+import { Command } from 'commander';
+import { defaultConfigPath, loadConfig, resolveConfig } from '../config.js';
+import { printRecord, shortDate, isJsonMode } from '../format.js';
+
+export function meCommand(): Command {
+  const cmd = new Command('me').description('Show your developer profile and settings');
+
+  cmd.action(async () => {
+    const fileConfig = await loadConfig(defaultConfigPath());
+    const config = resolveConfig(fileConfig);
+
+    if (!config) {
+      console.error(
+        'Error: Grantex is not configured.\n' +
+          'Run:  grantex config set --url <url> --key <api-key>\n' +
+          'Or set the GRANTEX_URL and GRANTEX_KEY environment variables.',
+      );
+      process.exit(1);
+    }
+
+    const res = await fetch(`${config.baseUrl.replace(/\/$/, '')}/v1/me`, {
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        Accept: 'application/json',
+      },
+    });
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      const msg = body && typeof body === 'object' && 'message' in body
+        ? String((body as Record<string, unknown>).message)
+        : `HTTP ${res.status}`;
+      console.error(`Error: ${msg}`);
+      process.exit(1);
+    }
+
+    const me = (await res.json()) as Record<string, unknown>;
+
+    if (isJsonMode()) {
+      console.log(JSON.stringify(me, null, 2));
+      return;
+    }
+
+    printRecord({
+      id: String(me.id ?? ''),
+      name: String(me.name ?? ''),
+      email: String(me.email ?? ''),
+      mode: String(me.mode ?? ''),
+      plan: String(me.plan ?? 'free'),
+      fidoRequired: String(me.fidoRequired ?? false),
+      createdAt: me.createdAt ? shortDate(String(me.createdAt)) : '',
+    });
+  });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/policies.ts
+++ b/packages/cli/src/commands/policies.ts
@@ -31,6 +31,10 @@ export function policiesCommand(): Command {
     .action(async (policyId: string) => {
       const client = await requireClient();
       const p = await client.policies.get(policyId);
+      if (isJsonMode()) {
+        console.log(JSON.stringify(p, null, 2));
+        return;
+      }
       printRecord({
         id: p.id,
         name: p.name,

--- a/packages/cli/src/commands/policies.ts
+++ b/packages/cli/src/commands/policies.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { requireClient } from '../client.js';
-import { printTable, printRecord, shortDate } from '../format.js';
+import { printTable, printRecord, shortDate, isJsonMode } from '../format.js';
 
 export function policiesCommand(): Command {
   const cmd = new Command('policies').description('Manage authorization policies');
@@ -21,6 +21,7 @@ export function policiesCommand(): Command {
           CREATED: shortDate(p.createdAt),
         })),
         ['ID', 'NAME', 'EFFECT', 'PRIORITY', 'CREATED'],
+        policies.map((p) => ({ ...p })),
       );
     });
 
@@ -76,6 +77,10 @@ export function policiesCommand(): Command {
         ...(opts.timeStart !== undefined ? { timeOfDayStart: opts.timeStart } : {}),
         ...(opts.timeEnd !== undefined ? { timeOfDayEnd: opts.timeEnd } : {}),
       });
+      if (isJsonMode()) {
+        console.log(JSON.stringify(policy, null, 2));
+        return;
+      }
       console.log(chalk.green('✓') + ` Policy created: ${policy.id}`);
     });
 
@@ -92,6 +97,10 @@ export function policiesCommand(): Command {
         ...(opts.effect !== undefined ? { effect: opts.effect as 'allow' | 'deny' } : {}),
         ...(opts.priority !== undefined ? { priority: parseInt(opts.priority, 10) } : {}),
       });
+      if (isJsonMode()) {
+        console.log(JSON.stringify(policy, null, 2));
+        return;
+      }
       console.log(chalk.green('✓') + ` Policy updated: ${policy.id}`);
     });
 
@@ -101,6 +110,10 @@ export function policiesCommand(): Command {
     .action(async (policyId: string) => {
       const client = await requireClient();
       await client.policies.delete(policyId);
+      if (isJsonMode()) {
+        console.log(JSON.stringify({ deleted: policyId }));
+        return;
+      }
       console.log(chalk.green('✓') + ` Policy ${policyId} deleted.`);
     });
 

--- a/packages/cli/src/commands/principal-sessions.ts
+++ b/packages/cli/src/commands/principal-sessions.ts
@@ -1,0 +1,35 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { requireClient } from '../client.js';
+import { printRecord, shortDate, isJsonMode } from '../format.js';
+
+export function principalSessionsCommand(): Command {
+  const cmd = new Command('principal-sessions').description('Manage end-user principal sessions');
+
+  cmd
+    .command('create')
+    .description('Create a session token for an end-user')
+    .requiredOption('--principal-id <principalId>', 'Principal (user) identifier')
+    .option('--expires-in <duration>', 'Session duration (e.g. 1h, 24h)')
+    .action(async (opts: { principalId: string; expiresIn?: string }) => {
+      const client = await requireClient();
+      const res = await client.principalSessions.create({
+        principalId: opts.principalId,
+        ...(opts.expiresIn !== undefined ? { expiresIn: opts.expiresIn } : {}),
+      });
+
+      if (isJsonMode()) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+
+      console.log(chalk.green('✓') + ' Principal session created.');
+      printRecord({
+        sessionToken: res.sessionToken,
+        dashboardUrl: res.dashboardUrl,
+        expiresAt: shortDate(res.expiresAt),
+      });
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/scim.ts
+++ b/packages/cli/src/commands/scim.ts
@@ -48,6 +48,10 @@ export function scimCommand(): Command {
     .action(async (tokenId: string) => {
       const client = await requireClient();
       await client.scim.revokeToken(tokenId);
+      if (isJsonMode()) {
+        console.log(JSON.stringify({ revoked: tokenId }));
+        return;
+      }
       console.log(chalk.green('✓') + ` SCIM token ${tokenId} revoked.`);
     });
 
@@ -85,6 +89,10 @@ export function scimCommand(): Command {
     .action(async (userId: string) => {
       const client = await requireClient();
       const u = await client.scim.getUser(userId);
+      if (isJsonMode()) {
+        console.log(JSON.stringify(u, null, 2));
+        return;
+      }
       printRecord({
         id: u.id,
         userName: u.userName,

--- a/packages/cli/src/commands/scim.ts
+++ b/packages/cli/src/commands/scim.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { requireClient } from '../client.js';
-import { printTable, printRecord, shortDate } from '../format.js';
+import { printTable, printRecord, shortDate, isJsonMode } from '../format.js';
 
 export function scimCommand(): Command {
   const cmd = new Command('scim').description('Manage SCIM provisioning');
@@ -23,6 +23,7 @@ export function scimCommand(): Command {
           'LAST USED': t.lastUsedAt ? shortDate(t.lastUsedAt) : '—',
         })),
         ['ID', 'LABEL', 'CREATED', 'LAST USED'],
+        list.map((t) => ({ ...t })),
       );
     });
 
@@ -33,6 +34,10 @@ export function scimCommand(): Command {
     .action(async (opts: { label: string }) => {
       const client = await requireClient();
       const result = await client.scim.createToken({ label: opts.label });
+      if (isJsonMode()) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
       console.log(chalk.green('✓') + ` SCIM token created: ${result.id}`);
       console.log(`Token: ${chalk.bold(result.token)}  (shown once — store it securely)`);
     });
@@ -70,6 +75,7 @@ export function scimCommand(): Command {
           ACTIVE: u.active ? 'yes' : 'no',
         })),
         ['ID', 'USERNAME', 'DISPLAY', 'ACTIVE'],
+        result.Resources.map((u) => ({ ...u })),
       );
     });
 

--- a/packages/cli/src/commands/sso.ts
+++ b/packages/cli/src/commands/sso.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { requireClient } from '../client.js';
-import { printRecord, shortDate } from '../format.js';
+import { printRecord, shortDate, isJsonMode } from '../format.js';
 
 export function ssoCommand(): Command {
   const cmd = new Command('sso').description('Manage SSO configuration');
@@ -12,12 +12,15 @@ export function ssoCommand(): Command {
     .action(async () => {
       const client = await requireClient();
       const config = await client.sso.getConfig();
-      printRecord({
-        issuerUrl: config.issuerUrl,
-        clientId: config.clientId,
-        redirectUri: config.redirectUri,
-        updatedAt: shortDate(config.updatedAt),
-      });
+      printRecord(
+        {
+          issuerUrl: config.issuerUrl,
+          clientId: config.clientId,
+          redirectUri: config.redirectUri,
+          updatedAt: shortDate(config.updatedAt),
+        },
+        { ...config },
+      );
     });
 
   cmd
@@ -53,6 +56,10 @@ export function ssoCommand(): Command {
     .action(async (org: string) => {
       const client = await requireClient();
       const { authorizeUrl } = await client.sso.getLoginUrl(org);
+      if (isJsonMode()) {
+        console.log(JSON.stringify({ authorizeUrl }));
+        return;
+      }
       console.log(authorizeUrl);
     });
 

--- a/packages/cli/src/commands/tokens.ts
+++ b/packages/cli/src/commands/tokens.ts
@@ -1,10 +1,39 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { requireClient } from '../client.js';
-import { printRecord, shortDate } from '../format.js';
+import { printRecord, shortDate, isJsonMode } from '../format.js';
 
 export function tokensCommand(): Command {
-  const cmd = new Command('tokens').description('Verify and revoke grant tokens');
+  const cmd = new Command('tokens').description('Exchange, verify, refresh, and revoke grant tokens');
+
+  cmd
+    .command('exchange')
+    .description('Exchange an authorization code for a grant token')
+    .requiredOption('--code <code>', 'Authorization code from consent approval')
+    .requiredOption('--agent-id <agentId>', 'Agent ID that was authorized')
+    .option('--code-verifier <verifier>', 'PKCE code verifier (if challenge was sent)')
+    .action(async (opts: { code: string; agentId: string; codeVerifier?: string }) => {
+      const client = await requireClient();
+      const res = await client.tokens.exchange({
+        code: opts.code,
+        agentId: opts.agentId,
+        ...(opts.codeVerifier !== undefined ? { codeVerifier: opts.codeVerifier } : {}),
+      });
+
+      if (isJsonMode()) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+
+      console.log(chalk.green('✓') + ' Token exchanged successfully.');
+      printRecord({
+        grantToken: res.grantToken.slice(0, 40) + '...',
+        grantId: res.grantId,
+        scopes: res.scopes.join(', '),
+        refreshToken: res.refreshToken,
+        expiresAt: shortDate(res.expiresAt),
+      });
+    });
 
   cmd
     .command('verify <token>')
@@ -12,6 +41,11 @@ export function tokensCommand(): Command {
     .action(async (token: string) => {
       const client = await requireClient();
       const res = await client.tokens.verify(token);
+
+      if (isJsonMode()) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
 
       if (!res.valid) {
         console.error(chalk.red('✗') + ' Token is invalid or has been revoked.');
@@ -29,11 +63,42 @@ export function tokensCommand(): Command {
     });
 
   cmd
+    .command('refresh')
+    .description('Refresh a grant token (rotates refresh token)')
+    .requiredOption('--refresh-token <token>', 'Current refresh token')
+    .requiredOption('--agent-id <agentId>', 'Agent ID for the grant')
+    .action(async (opts: { refreshToken: string; agentId: string }) => {
+      const client = await requireClient();
+      const res = await client.tokens.refresh({
+        refreshToken: opts.refreshToken,
+        agentId: opts.agentId,
+      });
+
+      if (isJsonMode()) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+
+      console.log(chalk.green('✓') + ' Token refreshed successfully.');
+      printRecord({
+        grantToken: res.grantToken.slice(0, 40) + '...',
+        grantId: res.grantId,
+        scopes: res.scopes.join(', '),
+        refreshToken: res.refreshToken,
+        expiresAt: shortDate(res.expiresAt),
+      });
+    });
+
+  cmd
     .command('revoke <jti>')
     .description('Revoke a grant token by JTI')
     .action(async (jti: string) => {
       const client = await requireClient();
       await client.tokens.revoke(jti);
+      if (isJsonMode()) {
+        console.log(JSON.stringify({ revoked: jti }));
+        return;
+      }
       console.log(chalk.green('✓') + ` Token ${jti} revoked.`);
     });
 

--- a/packages/cli/src/commands/usage.ts
+++ b/packages/cli/src/commands/usage.ts
@@ -1,0 +1,51 @@
+import { Command } from 'commander';
+import { requireClient } from '../client.js';
+import { printRecord, printTable, isJsonMode } from '../format.js';
+
+export function usageCommand(): Command {
+  const cmd = new Command('usage').description('View API usage metrics');
+
+  cmd
+    .command('current')
+    .description('Get current period usage')
+    .action(async () => {
+      const client = await requireClient();
+      const res = await client.usage.current();
+      if (isJsonMode()) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      printRecord({
+        developerId: res.developerId,
+        period: res.period,
+        tokenExchanges: String(res.tokenExchanges),
+        authorizations: String(res.authorizations),
+        verifications: String(res.verifications),
+        totalRequests: String(res.totalRequests),
+      });
+    });
+
+  cmd
+    .command('history')
+    .description('Get historical usage')
+    .option('--days <n>', 'Number of days to look back (default: 30)', parseInt)
+    .action(async (opts: { days?: number }) => {
+      const client = await requireClient();
+      const res = await client.usage.history({
+        ...(opts.days !== undefined ? { days: opts.days } : {}),
+      });
+      printTable(
+        res.entries.map((e) => ({
+          DATE: e.date,
+          EXCHANGES: String(e.tokenExchanges),
+          AUTHORIZATIONS: String(e.authorizations),
+          VERIFICATIONS: String(e.verifications),
+          TOTAL: String(e.totalRequests),
+        })),
+        ['DATE', 'EXCHANGES', 'AUTHORIZATIONS', 'VERIFICATIONS', 'TOTAL'],
+        res.entries.map((e) => ({ ...e })),
+      );
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/webhooks.ts
+++ b/packages/cli/src/commands/webhooks.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { requireClient } from '../client.js';
-import { printTable, shortDate } from '../format.js';
+import { printTable, shortDate, isJsonMode } from '../format.js';
 import type { WebhookEventType } from '@grantex/sdk';
 
 const VALID_EVENTS: WebhookEventType[] = ['grant.created', 'grant.revoked', 'token.issued'];
@@ -23,6 +23,7 @@ export function webhooksCommand(): Command {
           CREATED: shortDate(w.createdAt),
         })),
         ['ID', 'URL', 'EVENTS', 'CREATED'],
+        webhooks.map((w) => ({ ...w })),
       );
     });
 
@@ -48,6 +49,10 @@ export function webhooksCommand(): Command {
 
       const client = await requireClient();
       const wh = await client.webhooks.create({ url: opts.url, events });
+      if (isJsonMode()) {
+        console.log(JSON.stringify(wh, null, 2));
+        return;
+      }
       console.log(chalk.green('✓') + ` Webhook registered: ${wh.id}`);
       console.log(`Secret: ${chalk.bold(wh.secret)}  (shown once — store it securely)`);
     });
@@ -58,6 +63,10 @@ export function webhooksCommand(): Command {
     .action(async (webhookId: string) => {
       const client = await requireClient();
       await client.webhooks.delete(webhookId);
+      if (isJsonMode()) {
+        console.log(JSON.stringify({ deleted: webhookId }));
+        return;
+      }
       console.log(chalk.green('✓') + ` Webhook ${webhookId} deleted.`);
     });
 

--- a/packages/cli/src/format.ts
+++ b/packages/cli/src/format.ts
@@ -1,15 +1,40 @@
 /**
- * Minimal table formatter for CLI output.
- * Prints a header row + divider + data rows, padded to column widths.
+ * Output formatting for CLI.
+ * Supports --json global flag for machine-readable output (AI agent friendly).
  */
-export function printTable(rows: Record<string, string>[], columns: string[]): void {
-  if (rows.length === 0) {
+
+/** Whether --json was passed globally. Set by index.ts before commands run. */
+let jsonMode = false;
+
+export function setJsonMode(enabled: boolean): void {
+  jsonMode = enabled;
+}
+
+export function isJsonMode(): boolean {
+  return jsonMode;
+}
+
+/**
+ * Print data as JSON array (if --json) or ASCII table.
+ * `rawRows` contains unformatted data for JSON output; `displayRows`/`columns` are for tables.
+ */
+export function printTable(
+  displayRows: Record<string, string>[],
+  columns: string[],
+  rawRows?: Record<string, unknown>[],
+): void {
+  if (jsonMode) {
+    console.log(JSON.stringify(rawRows ?? displayRows, null, 2));
+    return;
+  }
+
+  if (displayRows.length === 0) {
     console.log('(no results)');
     return;
   }
 
   const widths = columns.map((col) =>
-    Math.max(col.length, ...rows.map((r) => (r[col] ?? '').length)),
+    Math.max(col.length, ...displayRows.map((r) => (r[col] ?? '').length)),
   );
 
   const pad = (s: string, w: number) => s.padEnd(w);
@@ -17,7 +42,7 @@ export function printTable(rows: Record<string, string>[], columns: string[]): v
 
   console.log(columns.map((c, i) => pad(c.toUpperCase(), widths[i] ?? c.length)).join('  '));
   console.log(divider);
-  for (const row of rows) {
+  for (const row of displayRows) {
     console.log(columns.map((c, i) => pad(row[c] ?? '', widths[i] ?? 0)).join('  '));
   }
 }
@@ -33,10 +58,32 @@ export function shortDate(iso: string): string {
   });
 }
 
-/** Print a labelled key-value block (for single-record views). */
-export function printRecord(record: Record<string, string>): void {
+/** Print a single record as JSON object (if --json) or key-value block. */
+export function printRecord(record: Record<string, string>, raw?: Record<string, unknown>): void {
+  if (jsonMode) {
+    console.log(JSON.stringify(raw ?? record, null, 2));
+    return;
+  }
+
   const keyWidth = Math.max(...Object.keys(record).map((k) => k.length));
   for (const [k, v] of Object.entries(record)) {
     console.log(`${k.padEnd(keyWidth)}  ${v}`);
   }
+}
+
+/** Build table string without printing (for file writing in compliance). */
+export function tableToString(rows: Record<string, string>[], columns: string[]): string {
+  if (rows.length === 0) return '(no results)';
+
+  const widths = columns.map((col) =>
+    Math.max(col.length, ...rows.map((r) => (r[col] ?? '').length)),
+  );
+  const pad = (s: string, w: number) => s.padEnd(w);
+  const lines: string[] = [];
+  lines.push(columns.map((c, i) => pad(c.toUpperCase(), widths[i] ?? c.length)).join('  '));
+  lines.push(widths.map((w) => '-'.repeat(w)).join('  '));
+  for (const row of rows) {
+    lines.push(columns.map((c, i) => pad(row[c] ?? '', widths[i] ?? 0)).join('  '));
+  }
+  return lines.join('\n');
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ import { configCommand } from './commands/config.js';
 import { domainsCommand } from './commands/domains.js';
 import { eventsCommand } from './commands/events.js';
 import { grantsCommand } from './commands/grants.js';
+import { meCommand } from './commands/me.js';
 import { policiesCommand } from './commands/policies.js';
 import { principalSessionsCommand } from './commands/principal-sessions.js';
 import { scimCommand } from './commands/scim.js';
@@ -34,6 +35,7 @@ program
   });
 
 program.addCommand(configCommand());
+program.addCommand(meCommand());
 program.addCommand(agentsCommand());
 program.addCommand(authorizeCommand());
 program.addCommand(grantsCommand());

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,39 +1,58 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
+import { setJsonMode } from './format.js';
 import { agentsCommand } from './commands/agents.js';
 import { anomaliesCommand } from './commands/anomalies.js';
 import { auditCommand } from './commands/audit.js';
+import { authorizeCommand } from './commands/authorize.js';
+import { billingCommand } from './commands/billing.js';
+import { budgetsCommand } from './commands/budgets.js';
 import { complianceCommand } from './commands/compliance.js';
 import { configCommand } from './commands/config.js';
+import { domainsCommand } from './commands/domains.js';
+import { eventsCommand } from './commands/events.js';
 import { grantsCommand } from './commands/grants.js';
-import { tokensCommand } from './commands/tokens.js';
-import { webhooksCommand } from './commands/webhooks.js';
 import { policiesCommand } from './commands/policies.js';
-import { billingCommand } from './commands/billing.js';
+import { principalSessionsCommand } from './commands/principal-sessions.js';
 import { scimCommand } from './commands/scim.js';
 import { ssoCommand } from './commands/sso.js';
+import { tokensCommand } from './commands/tokens.js';
+import { usageCommand } from './commands/usage.js';
+import { webhooksCommand } from './commands/webhooks.js';
 
 const program = new Command();
 
 program
   .name('grantex')
-  .description('CLI tool for local Grantex development')
-  .version('0.1.0');
+  .description('CLI for the Grantex delegated authorization protocol')
+  .version('0.1.6')
+  .option('--json', 'Output results as JSON (machine-readable)')
+  .hook('preAction', () => {
+    if (program.opts().json) {
+      setJsonMode(true);
+    }
+  });
 
 program.addCommand(configCommand());
 program.addCommand(agentsCommand());
+program.addCommand(authorizeCommand());
 program.addCommand(grantsCommand());
 program.addCommand(tokensCommand());
 program.addCommand(auditCommand());
 program.addCommand(webhooksCommand());
+program.addCommand(policiesCommand());
+program.addCommand(budgetsCommand());
+program.addCommand(usageCommand());
+program.addCommand(domainsCommand());
+program.addCommand(eventsCommand());
+program.addCommand(principalSessionsCommand());
 program.addCommand(complianceCommand());
 program.addCommand(anomaliesCommand());
-program.addCommand(policiesCommand());
 program.addCommand(billingCommand());
 program.addCommand(scimCommand());
 program.addCommand(ssoCommand());
 
 program.parseAsync(process.argv).catch((err: unknown) => {
-  console.error((err instanceof Error ? err.message : String(err)));
+  console.error(err instanceof Error ? err.message : String(err));
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- Adds the **authorize** and **tokens exchange** commands — the core authorization flow was completely missing from the CLI
- Adds **--json** global flag for machine-readable output, making the CLI usable from AI coding assistants (Claude Code, Cursor, Codex, VS Code)
- Adds 7 new command files and 13 new subcommands covering the full API surface
- Updates CLI docs with all commands, JSON usage, and a full workflow example

## Changes

### Critical (core flow was broken)
- `grantex authorize` — start authorization requests
- `grantex tokens exchange` — exchange code for grant token
- `grantex tokens refresh` — refresh grant tokens
- `grantex grants delegate` — create delegated sub-grants
- `grantex grants get` — inspect a single grant
- `grantex agents update` — was documented but not implemented

### New commands
- `grantex budgets` — allocate, debit, balance, transactions
- `grantex usage` — current and historical usage metrics
- `grantex domains` — add, list, verify, delete custom domains
- `grantex events stream` — real-time SSE event tailing
- `grantex principal-sessions create` — create end-user sessions

### AI agent compatibility
- `--json` global flag outputs JSON instead of ASCII tables
- chalk respects `NO_COLOR=1` env var for non-TTY environments
- Fixed version mismatch (0.1.0 hardcoded → 0.1.6 from package.json)

## Test plan
- [x] `npm run typecheck` passes clean
- [x] `npm test` — all 40 tests pass
- [x] `npm run build` — builds without errors
- [ ] Manual: run full workflow (authorize → exchange → verify → revoke) via CLI
- [ ] Manual: verify `--json` output parses correctly with `jq`