### PR TITLE
docs: update all surfaces with complete CLI coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1210,15 +1210,23 @@ read_calendar = create_grantex_tool(
 # Returns a plain function — pass directly to google.adk.Agent(tools=[...])
 ```
 
-**CLI**:
+**CLI** (83 commands, all support `--json` for AI agent / scripting use):
 
 ```bash
 grantex config set --url https://grantex-auth-dd4mtrt2gq-uc.a.run.app --key YOUR_API_KEY
-grantex agents list
-grantex grants list --status active
-grantex audit list --since 2026-01-01
-grantex anomalies detect
-grantex compliance summary
+grantex me                                            # check identity
+grantex agents register --name "Bot" --description "..." --scopes email:read
+grantex authorize --agent ag_... --principal user@example.com --scopes email:read
+grantex tokens exchange --code <code> --agent-id ag_...
+grantex tokens verify <jwt>
+grantex tokens refresh --refresh-token <token> --agent-id ag_...
+grantex grants delegate --grant-token <jwt> --agent-id ag_child... --scopes email:read
+grantex budgets allocate --grant-id grnt_... --amount 100
+grantex audit list --agent ag_...
+grantex grants revoke grnt_...
+
+# Machine-readable output for scripts and AI coding assistants
+grantex --json agents list | jq '.[0].agentId'
 ```
 
 ---

--- a/docs/integrations/cli.mdx
+++ b/docs/integrations/cli.mdx
@@ -211,6 +211,65 @@ grantex billing checkout pro --success-url https://myapp.com/success --cancel-ur
 grantex billing portal --return-url https://myapp.com/settings
 ```
 
+### Account
+
+```bash
+# Show your developer profile and settings
+grantex me
+grantex --json me
+```
+
+### Vault (Credential Storage)
+
+```bash
+grantex vault list
+grantex vault list --principal user@example.com --service google
+grantex vault get cred_01ABC...
+grantex vault store --principal-id user@example.com --service google --access-token ya29... \
+  --refresh-token 1//0e... --token-expires-at 2026-04-01T00:00:00Z
+grantex vault delete cred_01ABC...
+grantex vault exchange --grant-token <jwt> --service google
+```
+
+### WebAuthn / FIDO2
+
+```bash
+# Generate registration challenge
+grantex webauthn register-options --principal-id user@example.com
+
+# Verify registration (pass browser attestation response as JSON)
+grantex webauthn register-verify --challenge-id ch_01ABC... --response '{"id":"...","response":{...}}' \
+  --device-name "MacBook Pro"
+
+# List and delete credentials
+grantex webauthn list user@example.com
+grantex webauthn delete cred_01ABC...
+```
+
+### Verifiable Credentials
+
+```bash
+grantex credentials list
+grantex credentials list --grant-id grnt_01ABC... --status active
+grantex credentials get vc_01ABC...
+
+# Verify a VC-JWT
+grantex credentials verify --vc-jwt eyJ...
+
+# Verify an SD-JWT presentation
+grantex credentials present --sd-jwt eyJ... --nonce abc123
+```
+
+### Agent Passports (MPP)
+
+```bash
+grantex passports issue --agent-id ag_01ABC... --grant-id grnt_01XYZ... \
+  --categories "compute,storage" --max-amount 100 --currency USD
+grantex passports list --agent-id ag_01ABC...
+grantex passports get pp_01ABC...
+grantex passports revoke pp_01ABC...
+```
+
 ### SCIM
 
 ```bash
@@ -222,6 +281,10 @@ grantex scim tokens revoke tok_01ABC...
 # User provisioning
 grantex scim users list
 grantex scim users get usr_01ABC...
+grantex scim users create --user-name john@example.com --display-name "John Doe" --email john@example.com
+grantex scim users update usr_01ABC... --display-name "John D." --active true
+grantex scim users replace usr_01ABC... --user-name john@example.com --display-name "John Doe"
+grantex scim users delete usr_01ABC...
 ```
 
 ### SSO
@@ -232,6 +295,7 @@ grantex sso configure --issuer-url https://accounts.google.com --client-id CLIEN
   --client-secret CLIENT_SECRET --redirect-uri https://myapp.com/callback
 grantex sso delete
 grantex sso login-url my-org
+grantex sso callback --code AUTH_CODE --state STATE_PARAM
 ```
 
 ## Full Workflow Example

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -14,6 +14,11 @@ npm install @grantex/sdk
 ```bash pip
 pip install grantex
 ```
+
+```bash CLI
+npm install -g @grantex/cli
+grantex config set --url https://api.grantex.dev --key YOUR_API_KEY
+```
 </CodeGroup>
 
 ## 2. Register your agent
@@ -48,6 +53,13 @@ agent = client.agents.register(
 print(agent.did)
 # → did:grantex:ag_01HXYZ123abc...
 ```
+
+```bash CLI
+grantex agents register \
+  --name travel-booker \
+  --description "Books flights and hotels on behalf of users" \
+  --scopes calendar:read,payments:initiate:max_500,email:send
+```
 </CodeGroup>
 
 ## 3. Request authorization from a user
@@ -76,6 +88,14 @@ auth = client.authorize(
 
 # Redirect user to the consent page
 print(auth.consent_url)
+```
+
+```bash CLI
+grantex authorize \
+  --agent ag_01HXYZ... \
+  --principal user_abc123 \
+  --scopes calendar:read,payments:initiate:max_500
+# Sandbox mode returns the code directly
 ```
 </CodeGroup>
 
@@ -107,6 +127,11 @@ print(token.grant_token)  # RS256 JWT
 print(token.scopes)       # ('calendar:read', 'payments:initiate:max_500')
 print(token.grant_id)     # 'grnt_01HXYZ...'
 ```
+
+```bash CLI
+grantex tokens exchange --code <code> --agent-id ag_01HXYZ...
+# Returns grantToken (JWT), refreshToken, grantId, scopes
+```
 </CodeGroup>
 
 ## 5. Verify the token offline
@@ -134,6 +159,11 @@ grant = verify_grant_token(token.grant_token, VerifyGrantTokenOptions(
 print(grant.principal_id)  # 'user_abc123'
 print(grant.scopes)        # ('calendar:read', 'payments:initiate:max_500')
 ```
+
+```bash CLI
+grantex tokens verify <jwt>
+# Shows: valid, grantId, scopes, principal, agent, expiresAt
+```
 </CodeGroup>
 
 ## 6. Log every action
@@ -158,6 +188,17 @@ client.audit.log(
     metadata={"amount": 420, "currency": "USD", "merchant": "Air India"},
 )
 ```
+
+```bash CLI
+grantex audit log \
+  --agent-id ag_01HXYZ... \
+  --agent-did did:grantex:ag_01HXYZ... \
+  --grant-id grnt_01HXYZ... \
+  --principal-id user_abc123 \
+  --action payment.initiated \
+  --status success \
+  --metadata '{"amount":420,"currency":"USD","merchant":"Air India"}'
+```
 </CodeGroup>
 
 ## Next steps
@@ -174,5 +215,8 @@ client.audit.log(
   </Card>
   <Card title="Python SDK" icon="python" href="/sdks/python/overview">
     Full API reference for the Python SDK.
+  </Card>
+  <Card title="CLI" icon="terminal" href="/integrations/cli">
+    83 commands with --json support for scripting and AI agents.
   </Card>
 </CardGroup>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,9 +2,9 @@
 
 Command-line tool for the [Grantex](https://grantex.dev) delegated authorization protocol.
 
-Manage agents, grants, audit logs, webhooks, policies, anomalies, and compliance exports from your terminal.
+83 commands covering the full Grantex API — agents, grants, tokens, policies, budgets, audit, compliance, credentials, and more. All commands support `--json` for machine-readable output.
 
-> **[Homepage](https://grantex.dev)** | **[Docs](https://grantex.dev/docs)** | **[Sign Up Free](https://grantex.dev/dashboard/signup)** | **[GitHub](https://github.com/mishrasanjeev/grantex)**
+> **[Homepage](https://grantex.dev)** | **[Docs](https://docs.grantex.dev)** | **[CLI Docs](https://docs.grantex.dev/integrations/cli)** | **[GitHub](https://github.com/mishrasanjeev/grantex)**
 
 ## Install
 
@@ -14,97 +14,239 @@ npm install -g @grantex/cli
 
 ## Configure
 
-Point the CLI at your Grantex server and set your API key:
-
 ```bash
-# Interactive setup
 grantex config set --url https://grantex-auth-dd4mtrt2gq-uc.a.run.app --key YOUR_API_KEY
 
 # Or use environment variables
 export GRANTEX_URL=https://grantex-auth-dd4mtrt2gq-uc.a.run.app
 export GRANTEX_KEY=YOUR_API_KEY
+
+# Verify your setup
+grantex me
 ```
 
 Config is saved to `~/.grantex/config.json`. Environment variables override the config file.
 
+## JSON Output
+
+All commands support `--json` for machine-readable output — ideal for scripting, `jq`, and AI coding assistants (Claude Code, Cursor, Codex).
+
 ```bash
-# Verify your setup
-grantex config show
+grantex --json agents list | jq '.[0].agentId'
+grantex --json tokens verify <jwt> | jq '.valid'
 ```
 
+Set `NO_COLOR=1` to disable colored output.
+
 ## Commands
+
+### Core Flow
+
+```bash
+# 1. Register an agent
+grantex agents register --name "My Bot" --description "Reads email" --scopes email:read
+
+# 2. Start authorization
+grantex authorize --agent ag_... --principal user@example.com --scopes email:read
+
+# 3. Exchange code for token
+grantex tokens exchange --code <code> --agent-id ag_...
+
+# 4. Verify the token
+grantex tokens verify <jwt>
+
+# 5. Refresh when needed
+grantex tokens refresh --refresh-token <token> --agent-id ag_...
+
+# 6. Revoke when done
+grantex grants revoke grnt_...
+```
 
 ### Agents
 
 ```bash
 grantex agents list
-grantex agents register --name travel-booker --scopes calendar:read,payments:initiate
-grantex agents get ag_01ABC...
-grantex agents update ag_01ABC... --name new-name --scopes calendar:read,email:send
-grantex agents delete ag_01ABC...
+grantex agents register --name bot --description "..." --scopes email:read,calendar:write
+grantex agents get ag_...
+grantex agents update ag_... --name new-name --scopes email:read
+grantex agents delete ag_...
 ```
 
 ### Grants
 
 ```bash
-grantex grants list
-grantex grants list --agent ag_01ABC... --status active
-grantex grants revoke grnt_01XYZ...
+grantex grants list [--agent ag_... --status active]
+grantex grants get grnt_...
+grantex grants revoke grnt_...
+grantex grants delegate --grant-token <jwt> --agent-id ag_child... --scopes email:read
 ```
 
 ### Tokens
 
 ```bash
-grantex tokens verify <jwt-token>
+grantex tokens exchange --code <code> --agent-id ag_...
+grantex tokens verify <jwt>
+grantex tokens refresh --refresh-token <token> --agent-id ag_...
 grantex tokens revoke <jti>
 ```
 
-### Audit Log
+### Authorize
 
 ```bash
-grantex audit list
-grantex audit list --agent ag_01ABC... --action payment.initiated --since 2026-01-01
+grantex authorize --agent ag_... --principal user@example.com --scopes email:read
+grantex authorize --agent ag_... --principal user@example.com --scopes email:read \
+  --code-challenge <S256-challenge> --redirect-uri https://app.com/callback
+```
+
+### Audit
+
+```bash
+grantex audit list [--agent ag_... --grant grnt_... --action email.read --since 2026-01-01]
+grantex audit get alog_...
+grantex audit log --agent-id ag_... --agent-did did:grantex:ag_... --grant-id grnt_... \
+  --principal-id user@example.com --action email.read --status success
+```
+
+### Policies
+
+```bash
+grantex policies list
+grantex policies get pol_...
+grantex policies create --name "Allow Bot" --effect allow --agent-id ag_... --scopes email:read
+grantex policies update pol_... --priority 50
+grantex policies delete pol_...
+```
+
+### Budgets
+
+```bash
+grantex budgets allocate --grant-id grnt_... --amount 100 [--currency USD]
+grantex budgets debit --grant-id grnt_... --amount 25.50 --description "API call"
+grantex budgets balance grnt_...
+grantex budgets transactions grnt_...
+```
+
+### Usage
+
+```bash
+grantex usage current
+grantex usage history [--days 7]
 ```
 
 ### Webhooks
 
 ```bash
 grantex webhooks list
-grantex webhooks create --url https://example.com/hook --events grant.created,grant.revoked
-grantex webhooks delete wh_01XYZ...
+grantex webhooks create --url https://example.com/hook --events grant.created,token.issued
+grantex webhooks delete wh_...
 ```
 
-Supported events: `grant.created`, `grant.revoked`, `token.issued`
+### Events
+
+```bash
+grantex events stream [--types grant.created,token.issued]
+grantex --json events stream  # One JSON object per line
+```
+
+### Domains
+
+```bash
+grantex domains list
+grantex domains add --domain auth.mycompany.com
+grantex domains verify dom_...
+grantex domains delete dom_...
+```
+
+### Vault (Credential Storage)
+
+```bash
+grantex vault list [--principal user@example.com --service google]
+grantex vault get cred_...
+grantex vault store --principal-id user@example.com --service google --access-token ya29...
+grantex vault delete cred_...
+grantex vault exchange --grant-token <jwt> --service google
+```
+
+### WebAuthn / FIDO2
+
+```bash
+grantex webauthn register-options --principal-id user@example.com
+grantex webauthn register-verify --challenge-id ch_... --response '{"id":"..."}' --device-name "MacBook"
+grantex webauthn list user@example.com
+grantex webauthn delete cred_...
+```
+
+### Verifiable Credentials
+
+```bash
+grantex credentials list [--grant-id grnt_... --status active]
+grantex credentials get vc_...
+grantex credentials verify --vc-jwt eyJ...
+grantex credentials present --sd-jwt eyJ... --nonce abc123
+```
+
+### Agent Passports (MPP)
+
+```bash
+grantex passports issue --agent-id ag_... --grant-id grnt_... --categories "compute,storage" --max-amount 100
+grantex passports list [--agent-id ag_...]
+grantex passports get pp_...
+grantex passports revoke pp_...
+```
+
+### Principal Sessions
+
+```bash
+grantex principal-sessions create --principal-id user@example.com [--expires-in 1h]
+```
+
+### Account
+
+```bash
+grantex me
+```
 
 ### Compliance
 
 ```bash
-# Summary stats
-grantex compliance summary
-grantex compliance summary --since 2026-01-01 --until 2026-02-01
-
-# Export grants
+grantex compliance summary [--since 2026-01-01 --until 2026-02-01]
 grantex compliance export grants --format json --output grants.json
-
-# Export audit log
 grantex compliance export audit --format json --output audit.json
-
-# Evidence pack (SOC 2, GDPR, etc.)
 grantex compliance evidence-pack --framework soc2 --output evidence.json
 ```
 
-### Anomaly Detection
+### Anomalies
 
 ```bash
 grantex anomalies detect
-grantex anomalies list
-grantex anomalies list --unacknowledged
-grantex anomalies acknowledge anom_01XYZ...
+grantex anomalies list [--unacknowledged]
+grantex anomalies acknowledge anom_...
+```
+
+### Billing
+
+```bash
+grantex billing status
+grantex billing checkout pro --success-url https://app.com/ok --cancel-url https://app.com/cancel
+grantex billing portal --return-url https://app.com/settings
+```
+
+### SCIM
+
+```bash
+grantex scim tokens list | create --label "Okta" | revoke tok_...
+grantex scim users list | get usr_... | create --user-name john@co.com | update usr_... | delete usr_...
+```
+
+### SSO
+
+```bash
+grantex sso get | configure --issuer-url ... --client-id ... | delete
+grantex sso login-url my-org
+grantex sso callback --code CODE --state STATE
 ```
 
 ## Local Development
-
-For local development with `docker compose`:
 
 ```bash
 grantex config set --url http://localhost:3001 --key dev-api-key-local
@@ -113,23 +255,6 @@ grantex config set --url http://localhost:3001 --key dev-api-key-local
 ## Requirements
 
 - Node.js 18+
-
-## Links
-
-- [Grantex Protocol](https://github.com/mishrasanjeev/grantex)
-- [TypeScript SDK](https://www.npmjs.com/package/@grantex/sdk)
-- [Self-Hosting Guide](https://github.com/mishrasanjeev/grantex/blob/main/docs/self-hosting.md)
-- [Developer Portal](https://grantex.dev/dashboard)
-
-## Grantex Ecosystem
-
-This package is part of the [Grantex](https://grantex.dev) ecosystem. See also:
-
-- [`@grantex/sdk`](https://www.npmjs.com/package/@grantex/sdk) — Core TypeScript SDK
-- [`grantex`](https://pypi.org/project/grantex/) — Python SDK
-- [`@grantex/langchain`](https://www.npmjs.com/package/@grantex/langchain) — LangChain integration
-- [`@grantex/mcp`](https://www.npmjs.com/package/@grantex/mcp) — MCP server for Claude Desktop / Cursor / Windsurf
-- [`@grantex/vercel-ai`](https://www.npmjs.com/package/@grantex/vercel-ai) — Vercel AI SDK integration
 
 ## License
 

--- a/web/index.html
+++ b/web/index.html
@@ -958,12 +958,18 @@
         <code>pip install grantex</code>
         <span class="install-copy">Copy</span>
       </div>
+      <div class="install-cmd" onclick="copyInstall('npm install -g @grantex/cli', this)">
+        <span class="install-label">CLI</span>
+        <code>npm install -g @grantex/cli</code>
+        <span class="install-copy">Copy</span>
+      </div>
     </div>
 
     <div style="max-width:680px;">
       <div class="tabs">
         <button class="tab-btn active" onclick="switchTab('node', this)">Node.js</button>
         <button class="tab-btn" onclick="switchTab('python', this)">Python</button>
+        <button class="tab-btn" onclick="switchTab('cli', this)">CLI</button>
       </div>
 
       <!-- Node.js -->
@@ -1015,6 +1021,28 @@
 <span class="cm"># 3. Use the token — scopes, grantId, and JWT are all available</span>
 <span class="fn">print</span><span class="op">(</span><span class="id">token</span><span class="op">.</span><span class="id">scopes</span><span class="op">)</span>      <span class="cm"># ('calendar:read', 'email:send')</span>
 <span class="fn">print</span><span class="op">(</span><span class="id">token</span><span class="op">.</span><span class="id">grant_token</span><span class="op">)</span> <span class="cm"># RS256-signed JWT</span></pre>
+        </div>
+      </div>
+
+      <!-- CLI -->
+      <div class="tab-panel" id="tab-cli">
+        <div class="code-block">
+          <button class="copy-btn" onclick="copyCode('code-cli', this, 'cli_copy')">Copy</button>
+          <pre id="code-cli"><span class="cm"># npm install -g @grantex/cli</span>
+<span class="cm"># All commands support --json for AI agent / script use</span>
+
+<span class="cm"># 1. Request authorization (sandbox auto-approves)</span>
+<span class="id">grantex</span> <span class="id">authorize</span> <span class="op">--</span><span class="id">agent</span> <span class="str">ag_01J...</span> <span class="op">--</span><span class="id">principal</span> <span class="str">user@example.com</span> \
+  <span class="op">--</span><span class="id">scopes</span> <span class="str">calendar:read,email:send</span>
+
+<span class="cm"># 2. Exchange the code for a grant token</span>
+<span class="id">grantex</span> <span class="id">tokens</span> <span class="id">exchange</span> <span class="op">--</span><span class="id">code</span> <span class="str">&lt;code&gt;</span> <span class="op">--</span><span class="id">agent-id</span> <span class="str">ag_01J...</span>
+
+<span class="cm"># 3. Verify the token</span>
+<span class="id">grantex</span> <span class="id">tokens</span> <span class="id">verify</span> <span class="str">&lt;jwt&gt;</span>
+
+<span class="cm"># Machine-readable output</span>
+<span class="id">grantex</span> <span class="op">--</span><span class="id">json</span> <span class="id">grants</span> <span class="id">list</span> <span class="op">|</span> <span class="id">jq</span> <span class="str">'.[0].grantId'</span></pre>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Updates 5 documentation surfaces to reflect the full 83-command CLI
- Adds CLI as a first-class option alongside TypeScript and Python SDKs

## Changes

| Surface | What changed |
|---------|-------------|
| `docs/integrations/cli.mdx` | Added vault, webauthn, credentials, passports, me, SCIM user writes, SSO callback |
| `docs/quickstart.mdx` | Added CLI tab in every CodeGroup (install, register, authorize, exchange, verify, audit) + CLI card |
| `README.md` | Expanded CLI section with full workflow, --json examples, budget/delegation commands |
| `web/index.html` | Added CLI install button + CLI tab in quickstart code samples |
| `packages/cli/README.md` | Complete rewrite with all 83 commands, --json docs, core flow example |

## Test plan
- [ ] Verify Mintlify docs build (`docs/`)
- [ ] Verify landing page renders CLI tab correctly
- [ ] Verify README renders on GitHub