### PR TITLE
fix(landing): replace alternatives table with responsive card grid

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -876,46 +876,56 @@
       color: var(--accent);
     }
 
-    /* ── Alternatives table ─────────────────────────────────────────────────── */
-    .alt-table-wrap {
-      overflow-x: auto;
-      max-width: 900px;
+    /* ── Alternatives grid ────────────────────────────────────────────────── */
+    .alt-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 16px;
+      margin-bottom: 24px;
     }
-    .alt-table {
-      width: 100%;
-      border-collapse: collapse;
-      font-size: 14px;
+    .alt-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 24px;
     }
-    .alt-table th {
-      text-align: left;
-      font-size: 12px;
-      font-family: var(--mono);
-      letter-spacing: 0.5px;
-      color: var(--muted);
-      padding: 12px 14px;
-      border-bottom: 2px solid var(--border);
-      white-space: nowrap;
+    .alt-card.grantex-card {
+      border-color: var(--accent);
+      background: rgba(63, 185, 80, 0.04);
+      grid-column: 1 / -1;
     }
-    .alt-table td {
-      padding: 12px 14px;
-      border-bottom: 1px solid var(--border);
-      color: var(--muted);
+    .alt-card-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 8px;
     }
-    .alt-table tr:last-child td { border-bottom: none; }
-    .alt-table .tool-name {
+    .alt-card-name {
+      font-size: 16px;
       font-weight: 600;
       color: var(--text);
-      white-space: nowrap;
     }
-    .alt-table .grantex-row td {
-      background: rgba(63, 185, 80, 0.05);
-      color: var(--text);
-      font-weight: 500;
+    .alt-card.grantex-card .alt-card-name { color: var(--accent); }
+    .alt-card-desc {
+      font-size: 13px;
+      color: var(--muted);
+      margin-bottom: 14px;
     }
-    .alt-table .grantex-row .tool-name { color: var(--accent); }
-    .alt-table .check { color: var(--accent); }
-    .alt-table .cross { color: #484f58; }
-    .alt-table .partial { color: #d29922; }
+    .alt-caps {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .alt-cap {
+      font-family: var(--mono);
+      font-size: 11px;
+      padding: 3px 10px;
+      border-radius: 4px;
+      border: 1px solid var(--border);
+    }
+    .alt-cap.yes { color: var(--accent); border-color: rgba(63, 185, 80, 0.3); background: rgba(63, 185, 80, 0.08); }
+    .alt-cap.no { color: #484f58; border-color: var(--border); background: transparent; text-decoration: line-through; }
+    .alt-cap.partial { color: #d29922; border-color: rgba(210, 153, 34, 0.3); background: rgba(210, 153, 34, 0.08); }
 
     /* ── Responsive ────────────────────────────────────────────────────────── */
     @media (max-width: 640px) {
@@ -1147,76 +1157,73 @@
       agent identity layer that works alongside them.
     </p>
 
-    <div class="alt-table-wrap">
-      <table class="alt-table">
-        <thead>
-          <tr>
-            <th>Tool</th>
-            <th>What it solves</th>
-            <th>Secrets at rest</th>
-            <th>Agent identity</th>
-            <th>Scoped tokens</th>
-            <th>Per-agent revoke</th>
-            <th>Audit trail</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td class="tool-name">HashiCorp Vault</td>
-            <td>Secret storage & rotation</td>
-            <td class="check">&#10003;</td>
-            <td class="cross">&#10005;</td>
-            <td class="cross">&#10005;</td>
-            <td class="cross">&#10005;</td>
-            <td class="cross">&#10005;</td>
-          </tr>
-          <tr>
-            <td class="tool-name">AWS Secrets Manager</td>
-            <td>Encrypted secret storage</td>
-            <td class="check">&#10003;</td>
-            <td class="cross">&#10005;</td>
-            <td class="cross">&#10005;</td>
-            <td class="cross">&#10005;</td>
-            <td class="partial">partial</td>
-          </tr>
-          <tr>
-            <td class="tool-name">GitGuardian</td>
-            <td>Detects leaked secrets</td>
-            <td class="partial">detect</td>
-            <td class="cross">&#10005;</td>
-            <td class="cross">&#10005;</td>
-            <td class="cross">&#10005;</td>
-            <td class="cross">&#10005;</td>
-          </tr>
-          <tr>
-            <td class="tool-name">Snyk / Socket</td>
-            <td>Dependency vuln scanning</td>
-            <td class="cross">&#10005;</td>
-            <td class="cross">&#10005;</td>
-            <td class="cross">&#10005;</td>
-            <td class="cross">&#10005;</td>
-            <td class="cross">&#10005;</td>
-          </tr>
-          <tr>
-            <td class="tool-name">Doppler</td>
-            <td>Secrets injection at deploy</td>
-            <td class="check">&#10003;</td>
-            <td class="cross">&#10005;</td>
-            <td class="cross">&#10005;</td>
-            <td class="cross">&#10005;</td>
-            <td class="cross">&#10005;</td>
-          </tr>
-          <tr class="grantex-row">
-            <td class="tool-name">Grantex</td>
-            <td>Agent authorization protocol</td>
-            <td class="check">vault</td>
-            <td class="check">&#10003;</td>
-            <td class="check">&#10003;</td>
-            <td class="check">&#10003;</td>
-            <td class="check">&#10003;</td>
-          </tr>
-        </tbody>
-      </table>
+    <div class="alt-grid">
+      <div class="alt-card">
+        <div class="alt-card-name">HashiCorp Vault</div>
+        <div class="alt-card-desc">Secret storage &amp; rotation</div>
+        <div class="alt-caps">
+          <span class="alt-cap yes">Secrets at rest</span>
+          <span class="alt-cap no">Agent identity</span>
+          <span class="alt-cap no">Scoped tokens</span>
+          <span class="alt-cap no">Per-agent revoke</span>
+          <span class="alt-cap no">Audit trail</span>
+        </div>
+      </div>
+      <div class="alt-card">
+        <div class="alt-card-name">AWS Secrets Manager</div>
+        <div class="alt-card-desc">Encrypted secret storage</div>
+        <div class="alt-caps">
+          <span class="alt-cap yes">Secrets at rest</span>
+          <span class="alt-cap no">Agent identity</span>
+          <span class="alt-cap no">Scoped tokens</span>
+          <span class="alt-cap no">Per-agent revoke</span>
+          <span class="alt-cap partial">Audit trail</span>
+        </div>
+      </div>
+      <div class="alt-card">
+        <div class="alt-card-name">GitGuardian</div>
+        <div class="alt-card-desc">Detects leaked secrets</div>
+        <div class="alt-caps">
+          <span class="alt-cap partial">Secrets at rest</span>
+          <span class="alt-cap no">Agent identity</span>
+          <span class="alt-cap no">Scoped tokens</span>
+          <span class="alt-cap no">Per-agent revoke</span>
+          <span class="alt-cap no">Audit trail</span>
+        </div>
+      </div>
+      <div class="alt-card">
+        <div class="alt-card-name">Snyk / Socket</div>
+        <div class="alt-card-desc">Dependency vuln scanning</div>
+        <div class="alt-caps">
+          <span class="alt-cap no">Secrets at rest</span>
+          <span class="alt-cap no">Agent identity</span>
+          <span class="alt-cap no">Scoped tokens</span>
+          <span class="alt-cap no">Per-agent revoke</span>
+          <span class="alt-cap no">Audit trail</span>
+        </div>
+      </div>
+      <div class="alt-card">
+        <div class="alt-card-name">Doppler</div>
+        <div class="alt-card-desc">Secrets injection at deploy</div>
+        <div class="alt-caps">
+          <span class="alt-cap yes">Secrets at rest</span>
+          <span class="alt-cap no">Agent identity</span>
+          <span class="alt-cap no">Scoped tokens</span>
+          <span class="alt-cap no">Per-agent revoke</span>
+          <span class="alt-cap no">Audit trail</span>
+        </div>
+      </div>
+      <div class="alt-card grantex-card">
+        <div class="alt-card-name">Grantex</div>
+        <div class="alt-card-desc">Agent authorization protocol &mdash; works alongside your existing stack</div>
+        <div class="alt-caps">
+          <span class="alt-cap yes">Credential vault</span>
+          <span class="alt-cap yes">Agent identity</span>
+          <span class="alt-cap yes">Scoped tokens</span>
+          <span class="alt-cap yes">Per-agent revoke</span>
+          <span class="alt-cap yes">Audit trail</span>
+        </div>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- The 7-column comparison table in the "Your security tools have a blind spot" section caused horizontal scroll on most viewports
- Replaced with a responsive card grid layout — each tool gets a card with capability pills (green = yes, strikethrough = no, yellow = partial)
- Grantex card spans full width with accent border for visual emphasis
- No horizontal scroll at any breakpoint

## Test plan
- [ ] Verify no horizontal scroll on desktop and mobile
- [ ] Verify Grantex card spans full width with green border
- [ ] Verify capability pills show correct states (yes/no/partial)