### PR TITLE
fix(deps): bump path-to-regexp to 8.4.0 in packages/mcp

### DIFF
--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grantex/mcp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grantex/mcp",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@grantex/sdk": "^0.1.6",
@@ -2167,9 +2167,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
## Summary
- Bumps `path-to-regexp` from 8.3.0 to 8.4.0 in `packages/mcp/package-lock.json`
- Transitive dependency via `@modelcontextprotocol/sdk` -> `express@5` -> `router`
- Fixes Dependabot alert #59 (high — ReDoS via sequential optional groups) and #60 (medium — ReDoS via multiple wildcards)

## Test plan
- [x] `npm ls path-to-regexp` confirms 8.4.0
- [x] `npm audit` shows 0 vulnerabilities