### PR TITLE
fix(security): resolve 7 CodeQL alerts in auth-service

### DIFF
--- a/apps/auth-service/src/lib/sd-jwt.ts
+++ b/apps/auth-service/src/lib/sd-jwt.ts
@@ -290,7 +290,15 @@ export async function verifySDJWT(sdJwt: string): Promise<SDJWTVerifyResult> {
       return { valid: false, ...vcIdFields, error: 'Disclosure hash not found in _sd array — possible tampering' };
     }
 
-    disclosedClaims[disclosure.claimName] = disclosure.claimValue;
+    if (disclosure.claimName === '__proto__' || disclosure.claimName === 'constructor' || disclosure.claimName === 'prototype') {
+      return { valid: false, ...vcIdFields, error: `Forbidden claim name: ${disclosure.claimName}` };
+    }
+    Object.defineProperty(disclosedClaims, disclosure.claimName, {
+      value: disclosure.claimValue,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
   }
 
   // If a key-binding JWT is present, verify it

--- a/apps/auth-service/src/routes/credentials.ts
+++ b/apps/auth-service/src/routes/credentials.ts
@@ -93,7 +93,7 @@ export async function credentialsRoutes(app: FastifyInstance): Promise<void> {
   // POST /v1/credentials/verify — verify a VC-JWT (public, skipAuth)
   app.post<{ Body: { credential: string } }>(
     '/v1/credentials/verify',
-    { config: { skipAuth: true } },
+    { config: { skipAuth: true, rateLimit: { max: 30, timeWindow: '1 minute' } } },
     async (request, reply) => {
       const { credential } = request.body;
       if (!credential) {
@@ -132,7 +132,7 @@ export async function credentialsRoutes(app: FastifyInstance): Promise<void> {
   // POST /v1/credentials/present — verify an SD-JWT presentation (public, skipAuth)
   app.post<{ Body: { sdJwt: string; nonce?: string; audience?: string } }>(
     '/v1/credentials/present',
-    { config: { skipAuth: true } },
+    { config: { skipAuth: true, rateLimit: { max: 30, timeWindow: '1 minute' } } },
     async (request, reply) => {
       const { sdJwt } = request.body;
       if (!sdJwt) {

--- a/apps/auth-service/tests/credentials.test.ts
+++ b/apps/auth-service/tests/credentials.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { buildTestApp, seedAuth, authHeader, sqlMock, TEST_DEVELOPER, TEST_AGENT } from './helpers.js';
 import type { FastifyInstance } from 'fastify';
-import { initKeys, getKeyPair } from '../src/lib/crypto.js';
+import { getKeyPair } from '../src/lib/crypto.js';
 import { SignJWT, decodeJwt } from 'jose';
 import { gzipSync } from 'node:zlib';
 

--- a/apps/auth-service/tests/sd-jwt.test.ts
+++ b/apps/auth-service/tests/sd-jwt.test.ts
@@ -101,12 +101,12 @@ describe('issueSDJWT', () => {
   });
 
   it('includes delegation depth in selective fields by default', async () => {
-    const { sdJwt, disclosures } = await issueSDJWT({
+    const result = await issueSDJWT({
       ...defaultParams,
       delegationDepth: 2,
     });
 
-    const decoded = disclosures.map(decodeDisclosure);
+    const decoded = result.disclosures.map(decodeDisclosure);
     const depthDisclosure = decoded.find((d) => d.claimName === 'delegationDepth');
     expect(depthDisclosure).toBeDefined();
     expect(depthDisclosure!.claimValue).toBe(2);
@@ -275,7 +275,6 @@ describe('verifySDJWT', () => {
     // Tamper with a disclosure — modify the base64url content
     const parts = sdJwt.split('~');
     const issuerJwt = parts[0]!;
-    const disclosures = parts.slice(1).filter((p) => p.length > 0);
 
     // Create a fake disclosure that does not match any _sd hash
     const fakeDisclosure = Buffer.from(

--- a/apps/auth-service/tests/security.test.ts
+++ b/apps/auth-service/tests/security.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { buildTestApp, seedAuth, authHeader, sqlMock, mockRedis, TEST_DEVELOPER, TEST_AGENT } from './helpers.js';
 import type { FastifyInstance } from 'fastify';
-import { initKeys, getKeyPair, signGrantToken } from '../src/lib/crypto.js';
+import { getKeyPair, signGrantToken } from '../src/lib/crypto.js';
 import { SignJWT, generateKeyPair } from 'jose';
 import { gzipSync } from 'node:zlib';
 


### PR DESCRIPTION
## Summary
- **Rate limiting** (#72, #73): Added per-route rate limits to public `/v1/credentials/verify` and `/v1/credentials/present` routes (30 req/min)
- **Prototype pollution** (#74): Replaced bracket assignment `disclosedClaims[claimName]` with `Object.defineProperty` and reject `__proto__`/`constructor`/`prototype` claim names in SD-JWT verification
- **Unused imports** (#75, #76): Removed unused `initKeys` from credentials.test.ts and security.test.ts
- **Unused variables** (#77, #78): Removed unused `sdJwt` and `disclosures` destructuring in sd-jwt.test.ts

## Test plan
- [x] auth-service typecheck passes
- [ ] CI passes
- [ ] CodeQL re-scan shows 0 open alerts