### PR TITLE
chore: bump SDK versions for enterprise SSO release

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "CLI tool for local Grantex development",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.2.3"
+version = "0.2.4"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev",
   "bugs": {


### PR DESCRIPTION
## Summary

- `@grantex/sdk` 0.2.5 → **0.2.6**
- `grantex` (PyPI) 0.2.3 → **0.2.4**
- `@grantex/cli` 0.1.7 → **0.1.8**

Enterprise SSO with OIDC + SAML 2.0 + LDAP — multi-IdP connections, domain routing, JIT provisioning, group mapping, SSO enforcement, session management.

## Test plan

- [x] All tests passing on PR #214
- [x] Production endpoints validated on Cloud Run