### PR TITLE
fix(docs): remove duplicate nav tabs in header

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -14,15 +14,6 @@
   },
   "openapi": "openapi.yaml",
   "navigation": {
-    "global": {
-      "tabs": [
-        { "tab": "Documentation", "href": "/introduction" },
-        { "tab": "TypeScript SDK", "href": "/sdks/typescript/overview" },
-        { "tab": "Python SDK", "href": "/sdks/python/overview" },
-        { "tab": "Go SDK", "href": "/sdks/go/overview" },
-        { "tab": "Integrations", "href": "/integrations/overview" }
-      ]
-    },
     "tabs": [
       {
         "tab": "Documentation",


### PR DESCRIPTION
Removes the `global.tabs` block from docs.json which was causing TypeScript SDK, Python SDK, Go SDK, and Integrations to appear twice in the header navigation. The `tabs` array already generates header tabs automatically.