### PR TITLE
feat(anthropic): Anthropic SDK integration for scope-enforced tool use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - 'packages/sdk-ts/**'
       - 'packages/sdk-py/**'
       - 'packages/mpp/**'
+      - 'packages/anthropic/**'
       - '.github/workflows/ci.yml'
 
 jobs:
@@ -118,6 +119,38 @@ jobs:
 
       - name: Test
         working-directory: packages/mpp
+        run: npm test
+
+  anthropic:
+    name: Anthropic SDK Integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install SDK (peer dependency)
+        working-directory: packages/sdk-ts
+        run: npm ci
+
+      - name: Build SDK
+        working-directory: packages/sdk-ts
+        run: npm run build
+
+      - name: Install Anthropic dependencies
+        working-directory: packages/anthropic
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: packages/anthropic
+        run: npm run typecheck
+
+      - name: Test
+        working-directory: packages/anthropic
         run: npm test
 
   portal:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ go get github.com/mishrasanjeev/grantex-go  # Go
 npm install -g @grantex/cli     # CLI
 ```
 
-> **30+ packages** across TypeScript, Python, and Go. Integrations for **LangChain, OpenAI Agents SDK, Google ADK, CrewAI, Vercel AI, AutoGen, MCP, Express.js, FastAPI**, and **Terraform**. 679+ tests. Fully self-hostable. Apache 2.0.
+> **30+ packages** across TypeScript, Python, and Go. Integrations for **Anthropic SDK, LangChain, OpenAI Agents SDK, Google ADK, CrewAI, Vercel AI, AutoGen, MCP, Express.js, FastAPI**, and **Terraform**. 679+ tests. Fully self-hostable. Apache 2.0.
 
 ---
 
@@ -1174,6 +1174,7 @@ Service providers implement scope definitions for their APIs. Agents declare whi
 | **CrewAI** | `grantex-crewai` | `pip install grantex-crewai` | ✅ Shipped |
 | **OpenAI Agents SDK** | `grantex-openai-agents` | `pip install grantex-openai-agents` | ✅ Shipped |
 | **Google ADK** | `grantex-adk` | `pip install grantex-adk` | ✅ Shipped |
+| **Anthropic SDK** | `@grantex/anthropic` | `npm install @grantex/anthropic` | ✅ Shipped |
 | **Vercel AI SDK** | `@grantex/vercel-ai` | `npm install @grantex/vercel-ai` | ✅ Shipped |
 | **TypeScript SDK** | `@grantex/sdk` | `npm install @grantex/sdk` | ✅ Shipped |
 | **Python SDK** | `grantex` | `pip install grantex` | ✅ Shipped |
@@ -1351,6 +1352,7 @@ Walk through all 7 steps of the protocol: register an agent, authorize, exchange
 | [`quickstart-py`](examples/quickstart-py) | Same flow in Python | `python main.py` |
 | [`nextjs-starter`](examples/nextjs-starter) | **Interactive Next.js app** — full consent UI flow in the browser | `npm run dev` |
 | [`langchain-agent`](examples/langchain-agent) | LangChain agent with scope-enforced tools | `npm start` |
+| [`anthropic-tool-use`](examples/anthropic-tool-use) | Anthropic SDK tool use with scope enforcement | `npm start` |
 | [`vercel-ai-chatbot`](examples/vercel-ai-chatbot) | Vercel AI SDK chatbot with Grantex tools | `npm start` |
 | [`crewai-agent`](examples/crewai-agent) | CrewAI agent with Grantex authorization | `python main.py` |
 | [`openai-agents`](examples/openai-agents) | OpenAI Agents SDK integration | `python main.py` |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -95,7 +95,8 @@
               "examples/vercel-ai-chatbot",
               "examples/crewai-agent",
               "examples/openai-agents",
-              "examples/google-adk"
+              "examples/google-adk",
+              "examples/anthropic-tool-use"
             ]
           }
         ]
@@ -272,7 +273,8 @@
               "integrations/autogen",
               "integrations/crewai",
               "integrations/openai-agents",
-              "integrations/google-adk"
+              "integrations/google-adk",
+              "integrations/anthropic"
             ]
           },
           {

--- a/docs/examples/anthropic-tool-use.mdx
+++ b/docs/examples/anthropic-tool-use.mdx
@@ -1,0 +1,84 @@
+---
+title: "Anthropic SDK Tool Use"
+sidebarTitle: "Anthropic"
+description: "Scope-enforced tool use with audit logging using the Anthropic SDK."
+---
+
+## What it does
+
+This example demonstrates the `@grantex/anthropic` integration by building scope-enforced tools for Claude:
+
+1. **Register an agent** and obtain a grant token via the sandbox flow
+2. **Create scoped tools** using `createGrantexTool` with JSON Schema (`calendar:read`, `email:send`)
+3. **Use `GrantexToolRegistry`** to manage tools and dispatch `tool_use` blocks
+4. **Invoke tools** via `client.messages.create()` (if `ANTHROPIC_API_KEY` is set) or directly
+5. **Demonstrate `GrantexScopeError`** -- attempting to execute a tool with `storage:delete` (a scope not in the grant) throws a `GrantexScopeError` with `requiredScope` and `grantedScopes` properties
+6. **Inspect scopes offline** using `getGrantScopes()` to decode the JWT without a network call
+7. **Inspect the audit trail** to see the logged actions
+
+## Prerequisites
+
+- **Node.js 18+**
+- **Docker** (Docker Desktop or Docker Engine with Compose)
+
+## Run
+
+Start the local Grantex stack from the repository root:
+
+```bash
+docker compose up --build
+```
+
+In a separate terminal, run the example:
+
+```bash
+cd examples/anthropic-tool-use
+npm install
+npm start
+```
+
+To use Claude for real tool use instead of direct invocation, set `ANTHROPIC_API_KEY`:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-... npm start
+```
+
+## Expected output
+
+Without `ANTHROPIC_API_KEY` (direct invocation):
+
+```text
+Agent registered: ag_01HXYZ...
+Grant token received, grantId: grnt_01HXYZ...
+Tools created: read_calendar, send_email (registry has 2 tools)
+
+--- Invoking tools directly (no ANTHROPIC_API_KEY set) ---
+Calendar result: {"date":"today","events":[{"title":"Team standup","time":"9:00 AM"},{"title":"Design review","time":"2:00 PM"}]}
+Email result: {"sent":true,"to":"alice@example.com","subject":"Today's events","bodyLength":49}
+
+--- Testing scope enforcement ---
+GrantexScopeError caught:
+  Required scope:  storage:delete
+  Granted scopes:  calendar:read, email:send
+
+--- Inspecting grant scopes ---
+Scopes in token: calendar:read, email:send
+
+--- Audit trail ---
+  [success] tool:read_calendar — 2026-03-30T12:00:00.000Z
+  [success] tool:send_email — 2026-03-30T12:00:01.000Z
+
+Done! Anthropic SDK integration demo complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |
+| `ANTHROPIC_API_KEY` | _(none)_ | Optional. Set to use Claude for real tool use |
+
+## Source code
+
+The full source is in [`examples/anthropic-tool-use/src/index.ts`](https://github.com/mishrasanjeev/grantex/tree/main/examples/anthropic-tool-use).

--- a/docs/integrations/anthropic.mdx
+++ b/docs/integrations/anthropic.mdx
@@ -1,0 +1,185 @@
+---
+title: "Anthropic SDK"
+sidebarTitle: "Anthropic"
+description: "Scope-enforced tool use, registry, and audit logging for Claude models."
+---
+
+## Install
+
+```bash
+npm install @grantex/anthropic @grantex/sdk @anthropic-ai/sdk
+```
+
+## Scope-Enforced Tools
+
+Create Anthropic tool definitions with built-in Grantex scope enforcement:
+
+```typescript
+import Anthropic from '@anthropic-ai/sdk';
+import { createGrantexTool } from '@grantex/anthropic';
+
+const client = new Anthropic();
+
+const readFileTool = createGrantexTool({
+  name: 'read_file',
+  description: 'Read a file from disk',
+  inputSchema: {
+    type: 'object',
+    properties: { path: { type: 'string', description: 'File path' } },
+    required: ['path'],
+  },
+  grantToken,                 // JWT from Grantex token exchange
+  requiredScope: 'file:read', // must be in token's scp claim
+  execute: async ({ path }) => {
+    return await fs.readFile(path as string, 'utf-8');
+  },
+});
+
+// Pass definition to Claude
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  tools: [readFileTool.definition],
+  messages: [{ role: 'user', content: 'Read config.json' }],
+});
+
+// Handle tool_use blocks
+for (const block of response.content) {
+  if (block.type === 'tool_use') {
+    const result = await readFileTool.execute(block.input as { path: string });
+  }
+}
+```
+
+The scope check is **offline** — the grant token's `scp` claim is decoded from the JWT without any network call. If the required scope is missing, `execute()` throws a `GrantexScopeError` before your function runs.
+
+## Tool Registry
+
+Use `GrantexToolRegistry` to manage multiple tools and dispatch `tool_use` blocks by name:
+
+```typescript
+import { createGrantexTool, GrantexToolRegistry } from '@grantex/anthropic';
+
+const registry = new GrantexToolRegistry();
+registry.register(readFileTool);
+registry.register(writeFileTool);
+
+// Pass all definitions to Claude
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  tools: registry.definitions,
+  messages,
+});
+
+// Dispatch tool_use blocks
+for (const block of response.content) {
+  if (block.type === 'tool_use') {
+    const result = await registry.execute(block);
+  }
+}
+```
+
+## Inspect Grant Scopes
+
+Decode the scopes from a grant token offline:
+
+```typescript
+import { getGrantScopes } from '@grantex/anthropic';
+
+const scopes = getGrantScopes(grantToken);
+// ['file:read', 'file:write']
+```
+
+## Audit Logging
+
+### Wrap a tool
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+import { withAuditLogging } from '@grantex/anthropic';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+const audited = withAuditLogging(readFileTool, grantex, {
+  agentId: 'ag_01ABC...',
+  agentDid: 'did:key:z6Mk...',
+  grantId: 'grnt_01XYZ...',
+  principalId: 'user_01',
+});
+// audited.execute() logs success/failure automatically
+```
+
+### Handle a tool_use block directly
+
+```typescript
+import { handleToolCall } from '@grantex/anthropic';
+
+for (const block of response.content) {
+  if (block.type === 'tool_use') {
+    const result = await handleToolCall(readFileTool, block, grantex, {
+      agentId: 'ag_01ABC...',
+      agentDid: 'did:key:z6Mk...',
+      grantId: 'grnt_01XYZ...',
+      principalId: 'user_01',
+    });
+  }
+}
+```
+
+## API Reference
+
+### `createGrantexTool(options)`
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `name` | `string` | Tool name (matches `^[a-zA-Z0-9_-]+$`) |
+| `description` | `string` | Description shown to the model |
+| `inputSchema` | `JsonSchema` | JSON Schema for tool input |
+| `grantToken` | `string` | Grantex JWT from token exchange |
+| `requiredScope` | `string` | Scope required to invoke this tool |
+| `execute` | `(args: T) => Promise<unknown>` | Tool implementation |
+
+Returns `{ definition, execute }`.
+
+### `GrantexToolRegistry`
+
+| Method | Description |
+|--------|-------------|
+| `register(tool)` | Register a tool (chainable) |
+| `definitions` | All registered Anthropic tool definitions |
+| `execute(block)` | Execute a tool from a `tool_use` block |
+
+### `withAuditLogging(tool, client, options)`
+
+Returns a wrapped `GrantexTool` that automatically logs success/failure to the audit trail on every `execute()` call.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `agentId` | `string` | Agent ID for audit attribution |
+| `agentDid` | `string` | Agent DID (e.g. `did:key:z6Mk...`) |
+| `grantId` | `string` | Grant ID for the session |
+| `principalId` | `string` | Principal ID that granted authorization |
+
+### `handleToolCall(tool, block, client, options)`
+
+Same options as `withAuditLogging`. Executes the tool with `block.input` and logs the result.
+
+### `getGrantScopes(grantToken)`
+
+Returns `string[]` — the scopes from the token's `scp` claim.
+
+### `GrantexScopeError`
+
+Thrown when a grant token is missing a required scope.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `requiredScope` | `string` | The scope that was required |
+| `grantedScopes` | `string[]` | The scopes the token actually has |
+
+## Requirements
+
+- Node.js 18+
+- `@grantex/sdk` >= 0.1.0
+- `@anthropic-ai/sdk` >= 0.30.0

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -46,6 +46,9 @@ description: "Grantex integrates with every major AI agent framework."
   <Card title="Google ADK" icon="brain" href="/integrations/google-adk">
     Plain function tools for Google Agent Development Kit.
   </Card>
+  <Card title="Anthropic SDK" icon="message-bot" href="/integrations/anthropic">
+    Scope-enforced tool use and audit logging for Claude models.
+  </Card>
   <Card title="x402 Payment Protocol" icon="credit-card" href="/integrations/x402">
     Agent spend authorization for x402 payment flows — GDTs for USDC on Base L2.
   </Card>
@@ -85,6 +88,7 @@ description: "Grantex integrates with every major AI agent framework."
 | CrewAI | `grantex-crewai` | `pip install grantex-crewai` | Python |
 | OpenAI Agents SDK | `grantex-openai-agents` | `pip install grantex-openai-agents` | Python |
 | Google ADK | `grantex-adk` | `pip install grantex-adk` | Python |
+| Anthropic SDK | `@grantex/anthropic` | `npm install @grantex/anthropic` | TypeScript |
 | Go SDK | `grantex-go` | `go get github.com/mishrasanjeev/grantex-go` | Go |
 | A2A Bridge (TS) | `@grantex/a2a` | `npm install @grantex/a2a` | TypeScript |
 | A2A Bridge (Py) | `grantex-a2a` | `pip install grantex-a2a` | Python |

--- a/examples/anthropic-tool-use/README.md
+++ b/examples/anthropic-tool-use/README.md
@@ -1,0 +1,69 @@
+# Grantex + Anthropic SDK — Scoped Tool Use with Audit Logging
+
+Demo of Anthropic SDK tool use with Grantex scope enforcement and audit logging.
+
+## What it does
+
+1. Registers an agent with `calendar:read` and `email:send` scopes
+2. Gets a grant token via the sandbox flow (no consent UI)
+3. Creates two tools with JSON Schema and Grantex scope checks
+4. Uses `GrantexToolRegistry` to manage tools and dispatch `tool_use` blocks
+5. Wraps tools with `handleToolCall` for automatic audit trail entries
+6. Invokes tools via `client.messages.create()` (with Claude) or directly (without)
+7. Demonstrates `GrantexScopeError` thrown when a scope is missing
+
+## Prerequisites
+
+- Node.js 18+
+- Docker (for the local Grantex stack)
+
+**Optional**: Set `ANTHROPIC_API_KEY` to use Claude for real tool use. Without it, the example invokes tools directly to demonstrate scope enforcement and audit logging.
+
+## Run
+
+```bash
+# Start the local Grantex stack (from repo root)
+docker compose up -d
+
+# Run the example
+cd examples/anthropic-tool-use
+npm install
+npm start
+
+# Or with Claude:
+ANTHROPIC_API_KEY=sk-ant-... npm start
+```
+
+## Expected output
+
+```
+Agent registered: ag_01...
+Grant token received, grantId: grnt_01...
+Tools created: read_calendar, send_email (registry has 2 tools)
+
+--- Invoking tools directly (no ANTHROPIC_API_KEY set) ---
+Calendar result: {"date":"today","events":[...]}
+Email result: {"sent":true,"to":"alice@example.com",...}
+
+--- Testing scope enforcement ---
+GrantexScopeError caught:
+  Required scope:  storage:delete
+  Granted scopes:  calendar:read, email:send
+
+--- Inspecting grant scopes ---
+Scopes in token: calendar:read, email:send
+
+--- Audit trail ---
+  [success] tool:read_calendar — 2026-03-30T...
+  [success] tool:send_email — 2026-03-30T...
+
+Done! Anthropic SDK integration demo complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `GRANTEX_URL` | `http://localhost:3001` | Auth service base URL |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key (sandbox mode) |
+| `ANTHROPIC_API_KEY` | — | Anthropic key (optional, enables Claude tool use) |

--- a/examples/anthropic-tool-use/package.json
+++ b/examples/anthropic-tool-use/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "grantex-anthropic-tool-use",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "npx tsx src/index.ts"
+  },
+  "dependencies": {
+    "@grantex/sdk": "^0.2.0",
+    "@grantex/anthropic": "^0.1.0",
+    "@anthropic-ai/sdk": "^0.39.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/examples/anthropic-tool-use/src/index.ts
+++ b/examples/anthropic-tool-use/src/index.ts
@@ -1,0 +1,241 @@
+/**
+ * Grantex + Anthropic SDK — Scoped Tool Use with Audit Logging
+ *
+ * Shows Anthropic SDK tool use with Grantex scope enforcement:
+ *   1. Register agent & get a grant token (sandbox flow)
+ *   2. Create scoped tools via createGrantexTool with JSON Schema
+ *   3. Use GrantexToolRegistry to manage tools
+ *   4. Invoke tools using client.messages.create()
+ *   5. Demonstrate GrantexScopeError when scope is missing
+ *   6. Inspect grant scopes offline with getGrantScopes
+ *
+ * Prerequisites:
+ *   docker compose up          # from repo root
+ *   cd examples/anthropic-tool-use
+ *   npm install
+ *   ANTHROPIC_API_KEY=sk-ant-... npm start
+ *
+ * Without ANTHROPIC_API_KEY, the example skips the Claude call
+ * and demonstrates tool creation, scope checks, and audit logging directly.
+ */
+
+import { Grantex } from '@grantex/sdk';
+import {
+  createGrantexTool,
+  getGrantScopes,
+  handleToolCall,
+  GrantexToolRegistry,
+  GrantexScopeError,
+} from '@grantex/anthropic';
+
+const BASE_URL = process.env['GRANTEX_URL'] ?? 'http://localhost:3001';
+const API_KEY = process.env['GRANTEX_API_KEY'] ?? 'sandbox-api-key-local';
+
+async function getGrantToken(
+  grantex: Grantex,
+  agentId: string,
+): Promise<{ grantToken: string; grantId: string }> {
+  const authRequest = await grantex.authorize({
+    agentId,
+    userId: 'test-user-001',
+    scopes: ['calendar:read', 'email:send'],
+  });
+
+  const code = (authRequest as unknown as Record<string, unknown>)['code'] as string;
+  if (!code) throw new Error('No code returned — use the sandbox API key.');
+
+  return grantex.tokens.exchange({ code, agentId });
+}
+
+async function main(): Promise<void> {
+  const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
+
+  // ── 1. Register agent & get grant token ────────────────────────────
+  const agent = await grantex.agents.register({
+    name: 'anthropic-demo-agent',
+    description: 'Demo Anthropic SDK agent with Grantex authorization',
+    scopes: ['calendar:read', 'email:send'],
+  });
+  console.log('Agent registered:', agent.id);
+
+  const { grantToken, grantId } = await getGrantToken(grantex, agent.id);
+  console.log('Grant token received, grantId:', grantId);
+
+  // ── 2. Create scoped tools with JSON Schema ──────────────────────
+  const calendarTool = createGrantexTool({
+    name: 'read_calendar',
+    description: "Read the user's upcoming calendar events",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        date: { type: 'string', description: 'Date to query, e.g. "today"' },
+      },
+      required: ['date'],
+    },
+    grantToken,
+    requiredScope: 'calendar:read',
+    execute: async (args) => {
+      // Simulated calendar API
+      return {
+        date: args['date'],
+        events: [
+          { title: 'Team standup', time: '9:00 AM' },
+          { title: 'Design review', time: '2:00 PM' },
+        ],
+      };
+    },
+  });
+
+  const emailTool = createGrantexTool({
+    name: 'send_email',
+    description: 'Send an email on behalf of the user',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        to: { type: 'string', description: 'Recipient email address' },
+        subject: { type: 'string', description: 'Email subject' },
+        body: { type: 'string', description: 'Email body text' },
+      },
+      required: ['to', 'subject', 'body'],
+    },
+    grantToken,
+    requiredScope: 'email:send',
+    execute: async (args) => {
+      // Simulated email API
+      return {
+        sent: true,
+        to: args['to'],
+        subject: args['subject'],
+        bodyLength: (args['body'] as string).length,
+      };
+    },
+  });
+
+  // ── 3. Register tools ──────────────────────────────────────────────
+  const registry = new GrantexToolRegistry();
+  registry.register(calendarTool).register(emailTool);
+
+  console.log(
+    `Tools created: read_calendar, send_email (registry has ${registry.definitions.length} tools)`,
+  );
+
+  // ── 4. Invoke tools ────────────────────────────────────────────────
+  const auditOpts = {
+    agentId: agent.id,
+    agentDid: `did:key:${agent.id}`,
+    grantId,
+    principalId: 'test-user-001',
+  };
+
+  if (process.env['ANTHROPIC_API_KEY']) {
+    // With an Anthropic key, use Claude to pick tools
+    const Anthropic = (await import('@anthropic-ai/sdk')).default;
+    const client = new Anthropic();
+
+    console.log('\n--- Running with Claude (client.messages.create) ---');
+    const response = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 1024,
+      tools: registry.definitions,
+      messages: [
+        {
+          role: 'user',
+          content:
+            "Check my calendar for today and send alice@example.com an email summarizing today's events.",
+        },
+      ],
+    });
+
+    for (const block of response.content) {
+      if (block.type === 'tool_use') {
+        const tool = block.name === 'read_calendar' ? calendarTool : emailTool;
+        const result = await handleToolCall(tool, block, grantex, auditOpts);
+        console.log(`Tool ${block.name} result:`, JSON.stringify(result));
+      } else if (block.type === 'text') {
+        console.log('Claude:', block.text);
+      }
+    }
+  } else {
+    // Without an Anthropic key, invoke tools directly
+    console.log('\n--- Invoking tools directly (no ANTHROPIC_API_KEY set) ---');
+
+    const calendarBlock = {
+      type: 'tool_use' as const,
+      id: 'toolu_01',
+      name: 'read_calendar',
+      input: { date: 'today' },
+    };
+    const calendarResult = await handleToolCall(
+      calendarTool,
+      calendarBlock,
+      grantex,
+      auditOpts,
+    );
+    console.log('Calendar result:', JSON.stringify(calendarResult));
+
+    const emailBlock = {
+      type: 'tool_use' as const,
+      id: 'toolu_02',
+      name: 'send_email',
+      input: {
+        to: 'alice@example.com',
+        subject: "Today's events",
+        body: 'Team standup at 9 AM, Design review at 2 PM',
+      },
+    };
+    const emailResult = await handleToolCall(
+      emailTool,
+      emailBlock,
+      grantex,
+      auditOpts,
+    );
+    console.log('Email result:', JSON.stringify(emailResult));
+  }
+
+  // ── 5. Demonstrate GrantexScopeError ───────────────────────────────
+  console.log('\n--- Testing scope enforcement ---');
+  const restrictedTool = createGrantexTool({
+    name: 'delete_files',
+    description: 'Delete files from storage',
+    inputSchema: {
+      type: 'object',
+      properties: { path: { type: 'string' } },
+      required: ['path'],
+    },
+    grantToken,
+    requiredScope: 'storage:delete', // not in our grant!
+    execute: async () => ({ deleted: true }),
+  });
+
+  try {
+    await restrictedTool.execute({ path: '/tmp/secret.txt' });
+    console.log('ERROR: should have thrown');
+  } catch (err) {
+    if (err instanceof GrantexScopeError) {
+      console.log('GrantexScopeError caught:');
+      console.log('  Required scope: ', err.requiredScope);
+      console.log('  Granted scopes: ', err.grantedScopes.join(', '));
+    } else {
+      throw err;
+    }
+  }
+
+  // ── 6. Inspect scopes offline ──────────────────────────────────────
+  console.log('\n--- Inspecting grant scopes ---');
+  const scopes = getGrantScopes(grantToken);
+  console.log('Scopes in token:', scopes.join(', '));
+
+  // ── 7. Inspect audit trail ─────────────────────────────────────────
+  console.log('\n--- Audit trail ---');
+  const auditLog = await grantex.audit.list({ agentId: agent.id, grantId });
+  for (const entry of auditLog.entries) {
+    console.log(`  [${entry.status}] ${entry.action} — ${entry.timestamp}`);
+  }
+
+  console.log('\nDone! Anthropic SDK integration demo complete.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/anthropic-tool-use/src/index.ts
+++ b/examples/anthropic-tool-use/src/index.ts
@@ -56,9 +56,11 @@ async function main(): Promise<void> {
     description: 'Demo Anthropic SDK agent with Grantex authorization',
     scopes: ['calendar:read', 'email:send'],
   });
-  console.log('Agent registered:', agent.id);
+  // API returns agentId, SDK types say id — handle both
+  const agentId = agent.id ?? (agent as unknown as Record<string, string>)['agentId'];
+  console.log('Agent registered:', agentId);
 
-  const { grantToken, grantId } = await getGrantToken(grantex, agent.id);
+  const { grantToken, grantId } = await getGrantToken(grantex, agentId);
   console.log('Grant token received, grantId:', grantId);
 
   // ── 2. Create scoped tools with JSON Schema ──────────────────────
@@ -121,8 +123,8 @@ async function main(): Promise<void> {
 
   // ── 4. Invoke tools ────────────────────────────────────────────────
   const auditOpts = {
-    agentId: agent.id,
-    agentDid: `did:key:${agent.id}`,
+    agentId: agentId,
+    agentDid: `did:key:${agentId}`,
     grantId,
     principalId: 'test-user-001',
   };
@@ -227,7 +229,7 @@ async function main(): Promise<void> {
 
   // ── 7. Inspect audit trail ─────────────────────────────────────────
   console.log('\n--- Audit trail ---');
-  const auditLog = await grantex.audit.list({ agentId: agent.id, grantId });
+  const auditLog = await grantex.audit.list({ agentId: agentId, grantId });
   for (const entry of auditLog.entries) {
     console.log(`  [${entry.status}] ${entry.action} — ${entry.timestamp}`);
   }

--- a/examples/anthropic-tool-use/tsconfig.json
+++ b/examples/anthropic-tool-use/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/anthropic/README.md
+++ b/packages/anthropic/README.md
@@ -1,0 +1,62 @@
+# @grantex/anthropic
+
+Anthropic SDK integration for the [Grantex](https://grantex.dev) delegated authorization protocol.
+
+Enforce scopes, log audit trails, and inspect grant tokens when using Claude models with tool use.
+
+## Install
+
+```bash
+npm install @grantex/anthropic @grantex/sdk @anthropic-ai/sdk
+```
+
+## Quick Start
+
+```typescript
+import Anthropic from '@anthropic-ai/sdk';
+import { createGrantexTool } from '@grantex/anthropic';
+
+const client = new Anthropic();
+
+const readFileTool = createGrantexTool({
+  name: 'read_file',
+  description: 'Read a file from disk',
+  inputSchema: {
+    type: 'object',
+    properties: { path: { type: 'string' } },
+    required: ['path'],
+  },
+  grantToken: process.env.GRANT_TOKEN!,
+  requiredScope: 'file:read',
+  execute: async ({ path }) => fs.readFile(path as string, 'utf-8'),
+});
+
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  tools: [readFileTool.definition],
+  messages: [{ role: 'user', content: 'Read config.json' }],
+});
+
+for (const block of response.content) {
+  if (block.type === 'tool_use') {
+    const result = await readFileTool.execute(block.input as { path: string });
+  }
+}
+```
+
+## Features
+
+- **`createGrantexTool()`** — Wrap any Anthropic tool definition with offline scope enforcement
+- **`GrantexToolRegistry`** — Manage multiple tools and dispatch `tool_use` blocks by name
+- **`withAuditLogging()`** — Wrap tools to automatically log success/failure to the Grantex audit trail
+- **`handleToolCall()`** — Execute a tool from a `tool_use` block with audit logging in one step
+- **`getGrantScopes()`** — Decode scopes from a grant token offline
+
+## Documentation
+
+Full docs at [grantex.dev/integrations/anthropic](https://grantex.dev/integrations/anthropic).
+
+## License
+
+Apache-2.0

--- a/packages/anthropic/package-lock.json
+++ b/packages/anthropic/package-lock.json
@@ -1,0 +1,2326 @@
+{
+  "name": "@grantex/anthropic",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@grantex/anthropic",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@anthropic-ai/sdk": "^0.39.0",
+        "@grantex/sdk": "file:../sdk-ts",
+        "@types/node": "^20.11.0",
+        "typescript": "^5.3.3",
+        "vitest": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.30.0",
+        "@grantex/sdk": ">=0.1.0"
+      }
+    },
+    "../sdk-ts": {
+      "name": "@grantex/sdk",
+      "version": "0.2.6",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jose": "^5.2.4"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "@vitest/coverage-v8": "^1.6.1",
+        "typescript": "^5.3.3",
+        "vitest": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
+      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grantex/sdk": {
+      "resolved": "../sdk-ts",
+      "link": true
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@grantex/anthropic",
+  "version": "0.1.0",
+  "description": "Anthropic SDK integration for the Grantex delegated authorization protocol",
+  "homepage": "https://grantex.dev/for/anthropic",
+  "bugs": {
+    "url": "https://github.com/mishrasanjeev/grantex/issues"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@grantex/sdk": ">=0.1.0",
+    "@anthropic-ai/sdk": ">=0.30.0"
+  },
+  "devDependencies": {
+    "@grantex/sdk": "file:../sdk-ts",
+    "@anthropic-ai/sdk": "^0.39.0",
+    "@types/node": "^20.11.0",
+    "typescript": "^5.3.3",
+    "vitest": "^1.3.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "keywords": [
+    "grantex",
+    "anthropic",
+    "claude",
+    "ai-agents",
+    "authorization",
+    "oauth",
+    "jwt",
+    "agent-tools",
+    "scope-enforcement",
+    "delegated-auth",
+    "tool-use"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mishrasanjeev/grantex"
+  }
+}

--- a/packages/anthropic/src/_jwt.ts
+++ b/packages/anthropic/src/_jwt.ts
@@ -1,0 +1,14 @@
+/**
+ * Minimal offline JWT payload decoder — no signature verification.
+ * Used only to read the `scp` claim from a Grantex grant token without
+ * making a network round-trip.
+ */
+export function decodeJwtPayload(token: string): Record<string, unknown> {
+  const parts = token.split('.');
+  if (parts.length < 2 || !parts[1]) {
+    throw new Error('Grantex: invalid JWT format');
+  }
+  // Convert base64url → base64, then decode
+  const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+  return JSON.parse(Buffer.from(b64, 'base64').toString('utf8')) as Record<string, unknown>;
+}

--- a/packages/anthropic/src/audit.ts
+++ b/packages/anthropic/src/audit.ts
@@ -1,0 +1,119 @@
+import type { Grantex } from '@grantex/sdk';
+import type { GrantexTool, AnthropicToolUseBlock, AuditLoggingOptions } from './types.js';
+
+/**
+ * Wrap a {@link GrantexTool} with Grantex audit logging.
+ *
+ * Logs a `'success'` entry on completion and a `'failure'` entry when
+ * `execute()` throws. The original error is re-thrown after logging.
+ *
+ * @example
+ * ```ts
+ * import { createGrantexTool, withAuditLogging } from '@grantex/anthropic';
+ *
+ * const auditedTool = withAuditLogging(readFileTool, grantexClient, {
+ *   agentId: 'ag_01',
+ *   agentDid: 'did:key:z6Mk...',
+ *   grantId: tokenResponse.grantId,
+ *   principalId: 'user_01',
+ * });
+ * ```
+ */
+export function withAuditLogging<T extends Record<string, unknown>>(
+  tool: GrantexTool<T>,
+  client: Grantex,
+  options: AuditLoggingOptions,
+): GrantexTool<T> {
+  const { agentId, agentDid, grantId, principalId } = options;
+  const toolName = tool.definition.name;
+
+  return {
+    definition: tool.definition,
+    async execute(args: T): Promise<unknown> {
+      try {
+        const result = await tool.execute(args);
+        await client.audit.log({
+          agentId,
+          agentDid,
+          grantId,
+          principalId,
+          action: `tool:${toolName}`,
+          metadata: { args },
+          status: 'success' as const,
+        });
+        return result;
+      } catch (err) {
+        await client.audit.log({
+          agentId,
+          agentDid,
+          grantId,
+          principalId,
+          action: `tool:${toolName}`,
+          metadata: {
+            args,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          status: 'failure' as const,
+        });
+        throw err;
+      }
+    },
+  };
+}
+
+/**
+ * Handle an Anthropic `tool_use` block with automatic audit logging.
+ *
+ * Convenience function that executes the tool and logs the result in one step.
+ * Useful when iterating over response content blocks.
+ *
+ * @example
+ * ```ts
+ * for (const block of response.content) {
+ *   if (block.type === 'tool_use') {
+ *     const result = await handleToolCall(readFileTool, block, grantexClient, {
+ *       agentId: 'ag_01',
+ *       agentDid: 'did:key:z6Mk...',
+ *       grantId: tokenResponse.grantId,
+ *       principalId: 'user_01',
+ *     });
+ *   }
+ * }
+ * ```
+ */
+export async function handleToolCall<T extends Record<string, unknown>>(
+  tool: GrantexTool<T>,
+  block: AnthropicToolUseBlock,
+  client: Grantex,
+  options: AuditLoggingOptions,
+): Promise<unknown> {
+  const { agentId, agentDid, grantId, principalId } = options;
+
+  try {
+    const result = await tool.execute(block.input as T);
+    await client.audit.log({
+      agentId,
+      agentDid,
+      grantId,
+      principalId,
+      action: `tool:${block.name}`,
+      metadata: { args: block.input },
+      status: 'success' as const,
+    });
+    return result;
+  } catch (err) {
+    await client.audit.log({
+      agentId,
+      agentDid,
+      grantId,
+      principalId,
+      action: `tool:${block.name}`,
+      metadata: {
+        args: block.input,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      status: 'failure' as const,
+    });
+    throw err;
+  }
+}

--- a/packages/anthropic/src/index.ts
+++ b/packages/anthropic/src/index.ts
@@ -1,0 +1,13 @@
+export { createGrantexTool, getGrantScopes } from './tool.js';
+export { GrantexToolRegistry } from './registry.js';
+export { withAuditLogging, handleToolCall } from './audit.js';
+export {
+  GrantexScopeError,
+  type JsonSchema,
+  type AnthropicInputSchema,
+  type AnthropicToolDefinition,
+  type AnthropicToolUseBlock,
+  type CreateGrantexToolOptions,
+  type GrantexTool,
+  type AuditLoggingOptions,
+} from './types.js';

--- a/packages/anthropic/src/registry.ts
+++ b/packages/anthropic/src/registry.ts
@@ -1,0 +1,58 @@
+import type { GrantexTool, AnthropicToolDefinition, AnthropicToolUseBlock } from './types.js';
+
+/**
+ * Registry that collects multiple {@link GrantexTool}s and provides a
+ * single executor for dispatching `tool_use` blocks by name.
+ *
+ * @example
+ * ```ts
+ * import Anthropic from '@anthropic-ai/sdk';
+ * import { createGrantexTool, GrantexToolRegistry } from '@grantex/anthropic';
+ *
+ * const registry = new GrantexToolRegistry();
+ * registry.register(readFileTool).register(writeFileTool);
+ *
+ * const response = await client.messages.create({
+ *   model: 'claude-opus-4-6',
+ *   max_tokens: 1024,
+ *   tools: registry.definitions,
+ *   messages,
+ * });
+ *
+ * for (const block of response.content) {
+ *   if (block.type === 'tool_use') {
+ *     const result = await registry.execute(block);
+ *   }
+ * }
+ * ```
+ */
+export class GrantexToolRegistry {
+  readonly #tools = new Map<string, GrantexTool<Record<string, unknown>>>();
+
+  /**
+   * Register a Grantex tool.
+   * Returns `this` for chaining.
+   */
+  register<T extends Record<string, unknown>>(tool: GrantexTool<T>): this {
+    this.#tools.set(tool.definition.name, tool as GrantexTool<Record<string, unknown>>);
+    return this;
+  }
+
+  /** Anthropic tool definitions for all registered tools. */
+  get definitions(): AnthropicToolDefinition[] {
+    return Array.from(this.#tools.values()).map((t) => t.definition);
+  }
+
+  /**
+   * Execute a registered tool from an Anthropic `tool_use` block.
+   * @throws {Error} if no tool with that name is registered.
+   * @throws {GrantexScopeError} if the grant token lacks the required scope.
+   */
+  async execute(block: AnthropicToolUseBlock): Promise<unknown> {
+    const tool = this.#tools.get(block.name);
+    if (!tool) {
+      throw new Error(`Grantex: no tool registered with name '${block.name}'.`);
+    }
+    return tool.execute(block.input as Record<string, unknown>);
+  }
+}

--- a/packages/anthropic/src/tool.ts
+++ b/packages/anthropic/src/tool.ts
@@ -1,0 +1,81 @@
+import { decodeJwtPayload } from './_jwt.js';
+import {
+  GrantexScopeError,
+  type CreateGrantexToolOptions,
+  type GrantexTool,
+  type AnthropicToolDefinition,
+} from './types.js';
+
+/**
+ * Create a Grantex-authorized tool in Anthropic SDK format.
+ *
+ * The scope check is performed offline by reading the `scp` claim from the
+ * grant token JWT — no network call is made. If the agent does not hold
+ * `requiredScope`, `execute()` throws {@link GrantexScopeError} before
+ * calling the implementation.
+ *
+ * @example
+ * ```ts
+ * import Anthropic from '@anthropic-ai/sdk';
+ * import { createGrantexTool } from '@grantex/anthropic';
+ *
+ * const readFileTool = createGrantexTool({
+ *   name: 'read_file',
+ *   description: 'Read a file from disk',
+ *   inputSchema: {
+ *     type: 'object',
+ *     properties: { path: { type: 'string' } },
+ *     required: ['path'],
+ *   },
+ *   grantToken: process.env.GRANT_TOKEN!,
+ *   requiredScope: 'file:read',
+ *   execute: async ({ path }) => fs.readFile(path as string, 'utf-8'),
+ * });
+ *
+ * const response = await client.messages.create({
+ *   model: 'claude-opus-4-6',
+ *   max_tokens: 1024,
+ *   tools: [readFileTool.definition],
+ *   messages: [{ role: 'user', content: 'Read config.json' }],
+ * });
+ * ```
+ *
+ * @throws {Error} if the grant token is not a valid JWT.
+ */
+export function createGrantexTool<T extends Record<string, unknown>>(
+  options: CreateGrantexToolOptions<T>,
+): GrantexTool<T> {
+  const { name, description, inputSchema, grantToken, requiredScope, execute } = options;
+
+  const definition: AnthropicToolDefinition = {
+    name,
+    description,
+    input_schema: inputSchema,
+  };
+
+  return {
+    definition,
+    async execute(args: T): Promise<unknown> {
+      const payload = decodeJwtPayload(grantToken);
+      const scopes = Array.isArray(payload['scp'])
+        ? (payload['scp'] as string[])
+        : [];
+
+      if (!scopes.includes(requiredScope)) {
+        throw new GrantexScopeError(requiredScope, scopes);
+      }
+
+      return execute(args);
+    },
+  };
+}
+
+/**
+ * Return the scopes embedded in a Grantex grant token.
+ *
+ * Purely offline — no network call, no signature check.
+ */
+export function getGrantScopes(grantToken: string): string[] {
+  const payload = decodeJwtPayload(grantToken);
+  return Array.isArray(payload['scp']) ? (payload['scp'] as string[]) : [];
+}

--- a/packages/anthropic/src/types.ts
+++ b/packages/anthropic/src/types.ts
@@ -1,0 +1,100 @@
+/** JSON Schema for nested properties (type is a free string: 'string', 'number', etc.). */
+export interface JsonSchema {
+  type: string;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  description?: string;
+  items?: JsonSchema;
+  enum?: unknown[];
+  [key: string]: unknown;
+}
+
+/**
+ * Top-level input schema for an Anthropic tool.
+ * Anthropic requires `type: 'object'` at the top level.
+ */
+export interface AnthropicInputSchema {
+  type: 'object';
+  properties?: Record<string, JsonSchema> | null;
+  required?: string[];
+  [key: string]: unknown;
+}
+
+/** Anthropic tool definition as passed to `client.messages.create({ tools })`. */
+export interface AnthropicToolDefinition {
+  name: string;
+  description?: string;
+  input_schema: AnthropicInputSchema;
+}
+
+/**
+ * Anthropic tool_use content block from a response.
+ * `input` is typed as `unknown` to match the SDK's `ToolUseBlock.input`.
+ */
+export interface AnthropicToolUseBlock {
+  type: 'tool_use';
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+/** Options for {@link createGrantexTool}. */
+export interface CreateGrantexToolOptions<T extends Record<string, unknown>> {
+  /** Tool name shown to the model. Must match `^[a-zA-Z0-9_-]+$`. */
+  name: string;
+  /** Human-readable description shown to the model. */
+  description: string;
+  /** JSON Schema describing the tool's input parameters (`type` must be `'object'`). */
+  inputSchema: AnthropicInputSchema;
+  /** Grantex grant token obtained from the token exchange. */
+  grantToken: string;
+  /** Scope the agent must hold to invoke this tool (e.g. `'file:read'`). */
+  requiredScope: string;
+  /** The tool implementation. Receives typed args, returns any JSON-serialisable value. */
+  execute: (args: T) => Promise<unknown>;
+}
+
+/**
+ * A Grantex-authorized tool in Anthropic SDK format.
+ *
+ * - `definition` — pass this to the `tools` array of `client.messages.create()`
+ * - `execute(args)` — call when handling a `tool_use` block; enforces scope offline
+ */
+export interface GrantexTool<T extends Record<string, unknown>> {
+  /** Anthropic tool definition for passing to the model. */
+  readonly definition: AnthropicToolDefinition;
+  /**
+   * Execute the tool with the given arguments.
+   * Verifies the required scope offline before calling the implementation.
+   * @throws {GrantexScopeError} if the agent does not hold the required scope.
+   */
+  execute(args: T): Promise<unknown>;
+}
+
+/** Options for {@link withAuditLogging}. */
+export interface AuditLoggingOptions {
+  /** Agent ID to record in audit entries. */
+  agentId: string;
+  /** Agent DID (e.g. `'did:key:z6Mk...'`). */
+  agentDid: string;
+  /** Grant ID associated with the tool invocation. */
+  grantId: string;
+  /** Principal ID that granted authorization. */
+  principalId: string;
+}
+
+/** Thrown when a grant token is missing a required scope. */
+export class GrantexScopeError extends Error {
+  readonly requiredScope: string;
+  readonly grantedScopes: string[];
+
+  constructor(requiredScope: string, grantedScopes: string[]) {
+    super(
+      `Grantex: agent is not authorized for scope '${requiredScope}'. ` +
+        `Granted scopes: [${grantedScopes.join(', ')}]`,
+    );
+    this.name = 'GrantexScopeError';
+    this.requiredScope = requiredScope;
+    this.grantedScopes = grantedScopes;
+  }
+}

--- a/packages/anthropic/tests/audit.test.ts
+++ b/packages/anthropic/tests/audit.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from 'vitest';
+import { withAuditLogging, handleToolCall } from '../src/audit.js';
+import type { GrantexTool, AnthropicToolUseBlock } from '../src/types.js';
+import type { Grantex } from '@grantex/sdk';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+const AUDIT_OPTS = {
+  agentId: 'agent_1',
+  agentDid: 'did:key:z6Mk_agent1',
+  grantId: 'grnt_1',
+  principalId: 'user_1',
+};
+
+function makeClient(): Grantex {
+  return {
+    audit: {
+      log: vi.fn().mockResolvedValue({ entryId: 'entry_01' }),
+    },
+  } as unknown as Grantex;
+}
+
+function makeTool(
+  name: string,
+  impl: (args: Record<string, unknown>) => Promise<unknown>,
+): GrantexTool<Record<string, unknown>> {
+  return {
+    definition: {
+      name,
+      description: `test tool: ${name}`,
+      input_schema: { type: 'object' as const },
+    },
+    execute: vi.fn().mockImplementation(impl),
+  };
+}
+
+function makeBlock(name: string, input: Record<string, unknown> = {}): AnthropicToolUseBlock {
+  return { type: 'tool_use', id: 'toolu_01', name, input };
+}
+
+// ─── withAuditLogging ─────────────────────────────────────────────────────────
+
+describe('withAuditLogging', () => {
+  it('logs a success entry when execute resolves', async () => {
+    const client = makeClient();
+    const tool = makeTool('fetch_data', async () => ({ rows: 3 }));
+    const audited = withAuditLogging(tool, client, AUDIT_OPTS);
+
+    const result = await audited.execute({ q: 'test' });
+
+    expect(result).toEqual({ rows: 3 });
+    expect(client.audit.log).toHaveBeenCalledOnce();
+    expect(client.audit.log).toHaveBeenCalledWith({
+      agentId: 'agent_1',
+      agentDid: 'did:key:z6Mk_agent1',
+      grantId: 'grnt_1',
+      principalId: 'user_1',
+      action: 'tool:fetch_data',
+      metadata: { args: { q: 'test' } },
+      status: 'success',
+    });
+  });
+
+  it('logs a failure entry and re-throws when execute rejects', async () => {
+    const client = makeClient();
+    const tool = makeTool('fetch_data', async () => {
+      throw new Error('database offline');
+    });
+    const audited = withAuditLogging(tool, client, AUDIT_OPTS);
+
+    await expect(audited.execute({})).rejects.toThrow('database offline');
+    expect(client.audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'tool:fetch_data',
+        status: 'failure',
+        metadata: expect.objectContaining({ error: 'database offline' }),
+      }),
+    );
+  });
+
+  it('preserves the original definition unchanged', () => {
+    const client = makeClient();
+    const tool = makeTool('my_tool', async () => null);
+    const audited = withAuditLogging(tool, client, AUDIT_OPTS);
+
+    expect(audited.definition).toBe(tool.definition);
+  });
+
+  it('passes args through to the underlying tool', async () => {
+    const client = makeClient();
+    const tool = makeTool('my_tool', async () => 'done');
+    const audited = withAuditLogging(tool, client, AUDIT_OPTS);
+    const args = { x: 1, y: 2 };
+
+    await audited.execute(args);
+
+    expect(tool.execute).toHaveBeenCalledWith(args);
+  });
+});
+
+// ─── handleToolCall ───────────────────────────────────────────────────────────
+
+describe('handleToolCall', () => {
+  it('executes the tool and logs success', async () => {
+    const client = makeClient();
+    const tool = makeTool('read_file', async () => 'file contents');
+    const block = makeBlock('read_file', { path: '/tmp/x' });
+
+    const result = await handleToolCall(tool, block, client, AUDIT_OPTS);
+
+    expect(result).toBe('file contents');
+    expect(client.audit.log).toHaveBeenCalledWith({
+      agentId: 'agent_1',
+      agentDid: 'did:key:z6Mk_agent1',
+      grantId: 'grnt_1',
+      principalId: 'user_1',
+      action: 'tool:read_file',
+      metadata: { args: { path: '/tmp/x' } },
+      status: 'success',
+    });
+  });
+
+  it('logs failure and re-throws when tool errors', async () => {
+    const client = makeClient();
+    const tool = makeTool('read_file', async () => {
+      throw new Error('permission denied');
+    });
+    const block = makeBlock('read_file', { path: '/etc/shadow' });
+
+    await expect(
+      handleToolCall(tool, block, client, AUDIT_OPTS),
+    ).rejects.toThrow('permission denied');
+
+    expect(client.audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'tool:read_file',
+        status: 'failure',
+        metadata: expect.objectContaining({ error: 'permission denied' }),
+      }),
+    );
+  });
+
+  it('uses block.name for the audit action', async () => {
+    const client = makeClient();
+    const tool = makeTool('write_file', async () => 'ok');
+    const block = makeBlock('write_file', { content: 'hello' });
+
+    await handleToolCall(tool, block, client, AUDIT_OPTS);
+
+    expect(client.audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'tool:write_file' }),
+    );
+  });
+});

--- a/packages/anthropic/tests/docs-snippets.check.ts
+++ b/packages/anthropic/tests/docs-snippets.check.ts
@@ -1,0 +1,194 @@
+/**
+ * Docs snippet validation — verifies that code examples from anthropic.mdx
+ * actually compile. This is a compile-only check (tsc --noEmit), not a runtime test.
+ *
+ * Each function represents a code snippet from the docs page.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import { Grantex } from '@grantex/sdk';
+import {
+  createGrantexTool,
+  getGrantScopes,
+  withAuditLogging,
+  handleToolCall,
+  GrantexToolRegistry,
+  GrantexScopeError,
+} from '../src/index.js';
+
+// ─── Docs: "Scope-Enforced Tools" section ────────────────────────────────────
+
+async function docsSnippet_scopeEnforcedTools() {
+  const client = new Anthropic();
+  const grantToken = 'placeholder';
+
+  const readFileTool = createGrantexTool({
+    name: 'read_file',
+    description: 'Read a file from disk',
+    inputSchema: {
+      type: 'object',
+      properties: { path: { type: 'string', description: 'File path' } },
+      required: ['path'],
+    },
+    grantToken,
+    requiredScope: 'file:read',
+    execute: async ({ path }) => {
+      return `contents of ${path}`;
+    },
+  });
+
+  // Pass definition to Claude
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 1024,
+    tools: [readFileTool.definition],
+    messages: [{ role: 'user', content: 'Read config.json' }],
+  });
+
+  // Handle tool_use blocks
+  for (const block of response.content) {
+    if (block.type === 'tool_use') {
+      const result = await readFileTool.execute(block.input as { path: string });
+    }
+  }
+}
+
+// ─── Docs: "Tool Registry" section ───────────────────────────────────────────
+
+async function docsSnippet_toolRegistry() {
+  const client = new Anthropic();
+  const grantToken = 'placeholder';
+  const messages: Anthropic.MessageParam[] = [];
+
+  const readFileTool = createGrantexTool({
+    name: 'read_file',
+    description: 'Read a file',
+    inputSchema: { type: 'object', properties: { path: { type: 'string' } } },
+    grantToken,
+    requiredScope: 'file:read',
+    execute: async (args) => String(args['path']),
+  });
+
+  const writeFileTool = createGrantexTool({
+    name: 'write_file',
+    description: 'Write a file',
+    inputSchema: { type: 'object', properties: { path: { type: 'string' }, content: { type: 'string' } } },
+    grantToken,
+    requiredScope: 'file:write',
+    execute: async (args) => ({ written: true }),
+  });
+
+  const registry = new GrantexToolRegistry();
+  registry.register(readFileTool);
+  registry.register(writeFileTool);
+
+  // Pass all definitions to Claude
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 1024,
+    tools: registry.definitions,
+    messages,
+  });
+
+  // Dispatch tool_use blocks
+  for (const block of response.content) {
+    if (block.type === 'tool_use') {
+      const result = await registry.execute(block);
+    }
+  }
+}
+
+// ─── Docs: "Inspect Grant Scopes" section ────────────────────────────────────
+
+function docsSnippet_inspectScopes() {
+  const grantToken = 'placeholder';
+  const scopes = getGrantScopes(grantToken);
+  // scopes is string[]
+  const _check: string[] = scopes;
+}
+
+// ─── Docs: "Audit Logging — Wrap a tool" section ────────────────────────────
+
+async function docsSnippet_auditWrap() {
+  const grantToken = 'placeholder';
+  const grantex = new Grantex({ apiKey: 'test' });
+
+  const readFileTool = createGrantexTool({
+    name: 'read_file',
+    description: 'Read a file',
+    inputSchema: { type: 'object', properties: { path: { type: 'string' } } },
+    grantToken,
+    requiredScope: 'file:read',
+    execute: async (args) => String(args['path']),
+  });
+
+  const audited = withAuditLogging(readFileTool, grantex, {
+    agentId: 'ag_01ABC',
+    agentDid: 'did:key:z6Mk...',
+    grantId: 'grnt_01XYZ',
+    principalId: 'user_01',
+  });
+
+  // audited.execute() logs success/failure automatically
+  const _result = await audited.execute({ path: '/test' });
+}
+
+// ─── Docs: "Handle a tool_use block directly" section ────────────────────────
+
+async function docsSnippet_handleToolCall() {
+  const client = new Anthropic();
+  const grantex = new Grantex({ apiKey: 'test' });
+  const grantToken = 'placeholder';
+
+  const readFileTool = createGrantexTool({
+    name: 'read_file',
+    description: 'Read a file',
+    inputSchema: { type: 'object', properties: { path: { type: 'string' } } },
+    grantToken,
+    requiredScope: 'file:read',
+    execute: async (args) => String(args['path']),
+  });
+
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 1024,
+    tools: [readFileTool.definition],
+    messages: [{ role: 'user', content: 'test' }],
+  });
+
+  for (const block of response.content) {
+    if (block.type === 'tool_use') {
+      const result = await handleToolCall(readFileTool, block, grantex, {
+        agentId: 'ag_01ABC',
+        agentDid: 'did:key:z6Mk...',
+        grantId: 'grnt_01XYZ',
+        principalId: 'user_01',
+      });
+    }
+  }
+}
+
+// ─── Docs: GrantexScopeError catch pattern ───────────────────────────────────
+
+async function docsSnippet_errorHandling() {
+  const grantToken = 'placeholder';
+
+  const tool = createGrantexTool({
+    name: 'admin_tool',
+    description: 'Admin action',
+    inputSchema: { type: 'object' },
+    grantToken,
+    requiredScope: 'admin:all',
+    execute: async () => 'ok',
+  });
+
+  try {
+    await tool.execute({});
+  } catch (err) {
+    if (err instanceof GrantexScopeError) {
+      // Both properties must be accessible
+      const _required: string = err.requiredScope;
+      const _granted: string[] = err.grantedScopes;
+    }
+  }
+}

--- a/packages/anthropic/tests/integration.test.ts
+++ b/packages/anthropic/tests/integration.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Integration tests — exercises the full developer workflow:
+ *   1. Create tools with realistic JWTs
+ *   2. Register tools in a registry
+ *   3. Execute via registry dispatch (simulating tool_use blocks)
+ *   4. Audit logging with mock client
+ *   5. handleToolCall convenience flow
+ *   6. GrantexScopeError instanceof checks
+ *   7. getGrantScopes on realistic tokens
+ *
+ * Uses realistic Grantex JWT claim structures (not minimal fakes).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createGrantexTool,
+  getGrantScopes,
+  handleToolCall,
+  withAuditLogging,
+  GrantexToolRegistry,
+  GrantexScopeError,
+} from '../src/index.js';
+import type { Grantex } from '@grantex/sdk';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+/** Build a realistic Grantex JWT with full claim structure. */
+function makeRealisticToken(overrides: Record<string, unknown> = {}): string {
+  const header = { alg: 'RS256', kid: 'grantex-2026-03' };
+  const payload = {
+    iss: 'https://grantex.dev',
+    sub: 'user_abc123',
+    agt: 'did:grantex:ag_tool_demo',
+    dev: 'dev_xyz789',
+    scp: ['file:read', 'file:write', 'calendar:read'],
+    jti: 'tok_integration_01',
+    grnt: 'grnt_integration_01',
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    ...overrides,
+  };
+
+  const b64Header = Buffer.from(JSON.stringify(header))
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  const b64Payload = Buffer.from(JSON.stringify(payload))
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+  // Realistic-length fake signature (RS256 signatures are ~342 base64url chars)
+  const fakeSig = 'a'.repeat(342);
+  return `${b64Header}.${b64Payload}.${fakeSig}`;
+}
+
+function makeClient(): { client: Grantex; logCalls: unknown[] } {
+  const logCalls: unknown[] = [];
+  const client = {
+    audit: {
+      log: vi.fn().mockImplementation(async (params: unknown) => {
+        logCalls.push(params);
+        return { entryId: `entry_${logCalls.length}` };
+      }),
+    },
+  } as unknown as Grantex;
+  return { client, logCalls };
+}
+
+// ─── Full developer workflow ─────────────────────────────────────────────────
+
+describe('Integration: full developer workflow', () => {
+  const GRANT_TOKEN = makeRealisticToken();
+  const AUDIT_OPTS = {
+    agentId: 'ag_tool_demo',
+    agentDid: 'did:grantex:ag_tool_demo',
+    grantId: 'grnt_integration_01',
+    principalId: 'user_abc123',
+  };
+
+  it('end-to-end: create → register → execute → audit', async () => {
+    // Step 1: Create tools
+    const readFile = createGrantexTool({
+      name: 'read_file',
+      description: 'Read a file from disk',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'File path to read' },
+        },
+        required: ['path'],
+      },
+      grantToken: GRANT_TOKEN,
+      requiredScope: 'file:read',
+      execute: async (args) => ({ content: `Contents of ${args['path']}`, bytes: 1024 }),
+    });
+
+    const writeFile = createGrantexTool({
+      name: 'write_file',
+      description: 'Write content to a file',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          path: { type: 'string' },
+          content: { type: 'string' },
+        },
+        required: ['path', 'content'],
+      },
+      grantToken: GRANT_TOKEN,
+      requiredScope: 'file:write',
+      execute: async (args) => ({ written: true, path: args['path'] }),
+    });
+
+    // Step 2: Register in registry
+    const registry = new GrantexToolRegistry();
+    registry.register(readFile).register(writeFile);
+
+    // Verify definitions are Anthropic-compatible
+    expect(registry.definitions).toHaveLength(2);
+    for (const def of registry.definitions) {
+      expect(def).toHaveProperty('name');
+      expect(def).toHaveProperty('input_schema');
+      expect(def.input_schema.type).toBe('object');
+    }
+
+    // Step 3: Simulate Anthropic response — dispatch tool_use blocks
+    const readResult = await registry.execute({
+      type: 'tool_use',
+      id: 'toolu_01abc',
+      name: 'read_file',
+      input: { path: '/config.json' },
+    });
+    expect(readResult).toEqual({ content: 'Contents of /config.json', bytes: 1024 });
+
+    const writeResult = await registry.execute({
+      type: 'tool_use',
+      id: 'toolu_02def',
+      name: 'write_file',
+      input: { path: '/output.txt', content: 'hello' },
+    });
+    expect(writeResult).toEqual({ written: true, path: '/output.txt' });
+
+    // Step 4: Audit logging with handleToolCall
+    const { client, logCalls } = makeClient();
+    const auditedResult = await handleToolCall(
+      readFile,
+      { type: 'tool_use', id: 'toolu_03ghi', name: 'read_file', input: { path: '/secret.txt' } },
+      client,
+      AUDIT_OPTS,
+    );
+
+    expect(auditedResult).toEqual({ content: 'Contents of /secret.txt', bytes: 1024 });
+    expect(logCalls).toHaveLength(1);
+    expect(logCalls[0]).toMatchObject({
+      agentId: 'ag_tool_demo',
+      agentDid: 'did:grantex:ag_tool_demo',
+      grantId: 'grnt_integration_01',
+      principalId: 'user_abc123',
+      action: 'tool:read_file',
+      status: 'success',
+    });
+  });
+
+  it('scope enforcement blocks unauthorized tools', async () => {
+    const deleteTool = createGrantexTool({
+      name: 'delete_file',
+      description: 'Delete a file',
+      inputSchema: { type: 'object', properties: { path: { type: 'string' } } },
+      grantToken: GRANT_TOKEN,
+      requiredScope: 'file:delete', // NOT in the token's scp
+      execute: async () => ({ deleted: true }),
+    });
+
+    // Execute should throw GrantexScopeError
+    try {
+      await deleteTool.execute({ path: '/important.txt' });
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      // instanceof MUST work (critical for developer error handling)
+      expect(err).toBeInstanceOf(GrantexScopeError);
+      expect(err).toBeInstanceOf(Error);
+
+      const scopeErr = err as GrantexScopeError;
+      expect(scopeErr.requiredScope).toBe('file:delete');
+      expect(scopeErr.grantedScopes).toEqual(['file:read', 'file:write', 'calendar:read']);
+      expect(scopeErr.name).toBe('GrantexScopeError');
+      expect(scopeErr.message).toContain('file:delete');
+      expect(scopeErr.message).toContain('file:read');
+    }
+  });
+
+  it('withAuditLogging logs failure and preserves error', async () => {
+    const failingTool = createGrantexTool({
+      name: 'crash_tool',
+      description: 'Always fails',
+      inputSchema: { type: 'object' },
+      grantToken: GRANT_TOKEN,
+      requiredScope: 'file:read',
+      execute: async () => {
+        throw new Error('disk full');
+      },
+    });
+
+    const { client, logCalls } = makeClient();
+    const audited = withAuditLogging(failingTool, client, AUDIT_OPTS);
+
+    await expect(audited.execute({})).rejects.toThrow('disk full');
+
+    // Failure should be logged with error details
+    expect(logCalls).toHaveLength(1);
+    expect(logCalls[0]).toMatchObject({
+      action: 'tool:crash_tool',
+      status: 'failure',
+      metadata: { error: 'disk full' },
+    });
+  });
+
+  it('getGrantScopes reads realistic token correctly', () => {
+    const scopes = getGrantScopes(GRANT_TOKEN);
+    expect(scopes).toEqual(['file:read', 'file:write', 'calendar:read']);
+  });
+
+  it('handles delegation tokens with extra claims', () => {
+    const delegationToken = makeRealisticToken({
+      scp: ['read'],
+      parentAgt: 'did:grantex:ag_parent',
+      parentGrnt: 'grnt_parent',
+      delegationDepth: 1,
+    });
+
+    const scopes = getGrantScopes(delegationToken);
+    expect(scopes).toEqual(['read']);
+  });
+
+  it('handles token with budget claim', () => {
+    const budgetToken = makeRealisticToken({
+      scp: ['spend:usd'],
+      bdg: 50.0,
+    });
+
+    const scopes = getGrantScopes(budgetToken);
+    expect(scopes).toEqual(['spend:usd']);
+  });
+
+  it('handles token with empty scopes', () => {
+    const emptyToken = makeRealisticToken({ scp: [] });
+    expect(getGrantScopes(emptyToken)).toEqual([]);
+
+    const tool = createGrantexTool({
+      name: 'any_tool',
+      description: 'test',
+      inputSchema: { type: 'object' },
+      grantToken: emptyToken,
+      requiredScope: 'anything',
+      execute: vi.fn(),
+    });
+
+    expect(tool.execute({})).rejects.toThrow(GrantexScopeError);
+  });
+
+  it('registry rejects unknown tool names with clear error', async () => {
+    const registry = new GrantexToolRegistry();
+    const tool = createGrantexTool({
+      name: 'known_tool',
+      description: 'test',
+      inputSchema: { type: 'object' },
+      grantToken: GRANT_TOKEN,
+      requiredScope: 'file:read',
+      execute: async () => 'ok',
+    });
+    registry.register(tool);
+
+    await expect(
+      registry.execute({
+        type: 'tool_use',
+        id: 'toolu_bad',
+        name: 'hallucinated_tool',
+        input: {},
+      }),
+    ).rejects.toThrow("no tool registered with name 'hallucinated_tool'");
+  });
+});

--- a/packages/anthropic/tests/registry.test.ts
+++ b/packages/anthropic/tests/registry.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GrantexToolRegistry } from '../src/registry.js';
+import type { GrantexTool, AnthropicToolUseBlock } from '../src/types.js';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function makeTool(
+  name: string,
+  result: unknown = 'ok',
+): GrantexTool<Record<string, unknown>> {
+  return {
+    definition: {
+      name,
+      description: `Does ${name}`,
+      input_schema: { type: 'object' as const, properties: {} },
+    },
+    execute: vi.fn().mockResolvedValue(result),
+  };
+}
+
+function makeBlock(name: string, input: Record<string, unknown> = {}): AnthropicToolUseBlock {
+  return { type: 'tool_use', id: 'toolu_01', name, input };
+}
+
+// ─── GrantexToolRegistry ──────────────────────────────────────────────────────
+
+describe('GrantexToolRegistry', () => {
+  it('exposes definitions for all registered tools', () => {
+    const registry = new GrantexToolRegistry();
+    registry.register(makeTool('tool_a')).register(makeTool('tool_b'));
+
+    const names = registry.definitions.map((d) => d.name);
+    expect(names).toContain('tool_a');
+    expect(names).toContain('tool_b');
+    expect(registry.definitions).toHaveLength(2);
+  });
+
+  it('dispatches execute() to the correct tool', async () => {
+    const toolA = makeTool('tool_a', 'result_a');
+    const toolB = makeTool('tool_b', 'result_b');
+    const registry = new GrantexToolRegistry();
+    registry.register(toolA).register(toolB);
+
+    const result = await registry.execute(makeBlock('tool_b', { foo: 'bar' }));
+
+    expect(result).toBe('result_b');
+    expect(toolB.execute).toHaveBeenCalledWith({ foo: 'bar' });
+    expect(toolA.execute).not.toHaveBeenCalled();
+  });
+
+  it('throws when executing an unknown tool name', async () => {
+    const registry = new GrantexToolRegistry();
+    registry.register(makeTool('tool_a'));
+
+    await expect(registry.execute(makeBlock('nonexistent'))).rejects.toThrow('nonexistent');
+  });
+
+  it('returns this from register() for chaining', () => {
+    const registry = new GrantexToolRegistry();
+    const returned = registry.register(makeTool('tool_a'));
+    expect(returned).toBe(registry);
+  });
+
+  it('returns an empty definitions array when no tools are registered', () => {
+    const registry = new GrantexToolRegistry();
+    expect(registry.definitions).toEqual([]);
+  });
+
+  it('passes block.input as args to execute', async () => {
+    const tool = makeTool('my_tool');
+    const registry = new GrantexToolRegistry();
+    registry.register(tool);
+
+    await registry.execute(makeBlock('my_tool', { x: 1, y: 'hello' }));
+
+    expect(tool.execute).toHaveBeenCalledWith({ x: 1, y: 'hello' });
+  });
+});

--- a/packages/anthropic/tests/tool.test.ts
+++ b/packages/anthropic/tests/tool.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createGrantexTool, getGrantScopes } from '../src/tool.js';
+import { GrantexScopeError } from '../src/types.js';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function b64url(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj))
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function makeToken(scopes: string[]): string {
+  const header = b64url({ alg: 'RS256', typ: 'JWT' });
+  const payload = b64url({
+    iss: 'https://api.grantex.dev',
+    sub: 'user_01',
+    scp: scopes,
+    jti: 'tok_01',
+    grnt: 'grnt_01',
+    exp: 9999999999,
+  });
+  return `${header}.${payload}.fakesig`;
+}
+
+const TOKEN_WITH_SCOPES = makeToken(['file:read', 'file:write']);
+const TOKEN_EMPTY = makeToken([]);
+
+const INPUT_SCHEMA: import('../src/types.js').AnthropicInputSchema = {
+  type: 'object',
+  properties: { path: { type: 'string', description: 'File path' } },
+  required: ['path'],
+};
+
+// ─── createGrantexTool ────────────────────────────────────────────────────────
+
+describe('createGrantexTool', () => {
+  it('executes when agent holds the required scope', async () => {
+    const fn = vi.fn().mockResolvedValue('file contents');
+    const tool = createGrantexTool({
+      name: 'read_file',
+      description: 'Read a file from disk',
+      inputSchema: INPUT_SCHEMA,
+      grantToken: TOKEN_WITH_SCOPES,
+      requiredScope: 'file:read',
+      execute: fn,
+    });
+
+    const result = await tool.execute({ path: '/tmp/config.json' });
+
+    expect(result).toBe('file contents');
+    expect(fn).toHaveBeenCalledWith({ path: '/tmp/config.json' });
+  });
+
+  it('throws GrantexScopeError when agent lacks the required scope', async () => {
+    const fn = vi.fn();
+    const tool = createGrantexTool({
+      name: 'read_file',
+      description: 'Read a file from disk',
+      inputSchema: INPUT_SCHEMA,
+      grantToken: TOKEN_EMPTY,
+      requiredScope: 'file:read',
+      execute: fn,
+    });
+
+    await expect(tool.execute({ path: '/tmp/x' })).rejects.toThrow(GrantexScopeError);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('GrantexScopeError includes scope details', async () => {
+    const tool = createGrantexTool({
+      name: 'delete_file',
+      description: 'Delete a file',
+      inputSchema: INPUT_SCHEMA,
+      grantToken: makeToken(['file:read']),
+      requiredScope: 'file:delete',
+      execute: vi.fn(),
+    });
+
+    let caught: unknown;
+    try {
+      await tool.execute({});
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(GrantexScopeError);
+    expect((caught as GrantexScopeError).requiredScope).toBe('file:delete');
+    expect((caught as GrantexScopeError).grantedScopes).toEqual(['file:read']);
+  });
+
+  it('error message includes granted scopes for debugging', async () => {
+    const tool = createGrantexTool({
+      name: 'send_email',
+      description: 'Send an email',
+      inputSchema: INPUT_SCHEMA,
+      grantToken: makeToken(['profile:read']),
+      requiredScope: 'email:write',
+      execute: vi.fn(),
+    });
+
+    await expect(tool.execute({})).rejects.toThrow('profile:read');
+  });
+
+  it('exposes the correct Anthropic tool definition shape', () => {
+    const tool = createGrantexTool({
+      name: 'read_file',
+      description: 'Read a file from disk',
+      inputSchema: INPUT_SCHEMA,
+      grantToken: TOKEN_WITH_SCOPES,
+      requiredScope: 'file:read',
+      execute: vi.fn(),
+    });
+
+    expect(tool.definition).toEqual({
+      name: 'read_file',
+      description: 'Read a file from disk',
+      input_schema: INPUT_SCHEMA,
+    });
+  });
+
+  it('throws on a malformed grant token', async () => {
+    const tool = createGrantexTool({
+      name: 'read_file',
+      description: 'Read a file',
+      inputSchema: INPUT_SCHEMA,
+      grantToken: 'not-a-jwt',
+      requiredScope: 'file:read',
+      execute: vi.fn(),
+    });
+
+    await expect(tool.execute({})).rejects.toThrow();
+  });
+
+  it('handles token with no scp claim gracefully', async () => {
+    const header = b64url({ alg: 'RS256' });
+    const payload = b64url({ sub: 'user_01', jti: 'tok_01' });
+    const tokenNoScp = `${header}.${payload}.fakesig`;
+
+    const tool = createGrantexTool({
+      name: 'read_file',
+      description: 'Read a file',
+      inputSchema: { type: 'object', properties: {} },
+      grantToken: tokenNoScp,
+      requiredScope: 'file:read',
+      execute: vi.fn(),
+    });
+
+    await expect(tool.execute({})).rejects.toThrow(GrantexScopeError);
+  });
+});
+
+// ─── getGrantScopes ───────────────────────────────────────────────────────────
+
+describe('getGrantScopes', () => {
+  it('returns the scp array from the token', () => {
+    expect(getGrantScopes(TOKEN_WITH_SCOPES)).toEqual(['file:read', 'file:write']);
+  });
+
+  it('returns [] for a token with no scp', () => {
+    expect(getGrantScopes(TOKEN_EMPTY)).toEqual([]);
+  });
+
+  it('returns [] for a token with a non-array scp', () => {
+    const header = b64url({ alg: 'RS256' });
+    const payload = b64url({ scp: 'not-an-array' });
+    const token = `${header}.${payload}.fakesig`;
+
+    expect(getGrantScopes(token)).toEqual([]);
+  });
+});

--- a/packages/anthropic/tests/type-compat.check.ts
+++ b/packages/anthropic/tests/type-compat.check.ts
@@ -1,0 +1,120 @@
+/**
+ * Type compatibility test — verifies our types work with the real Anthropic SDK.
+ * This file is ONLY compiled (tsc --noEmit), never executed at runtime.
+ * If it compiles, our types are compatible with the Anthropic SDK.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import type { MessageCreateParamsNonStreaming } from '@anthropic-ai/sdk/resources/messages/messages';
+import {
+  createGrantexTool,
+  getGrantScopes,
+  handleToolCall,
+  GrantexToolRegistry,
+  GrantexScopeError,
+  type GrantexTool,
+  type AnthropicToolUseBlock,
+} from '../src/index.js';
+import type { Grantex } from '@grantex/sdk';
+
+// ─── Scenario 1: Pass tool.definition to client.messages.create ──────────────
+
+function testToolDefinitionCompat() {
+  const client = new Anthropic();
+
+  const tool = createGrantexTool({
+    name: 'read_file',
+    description: 'Read a file',
+    inputSchema: {
+      type: 'object',
+      properties: { path: { type: 'string' } },
+      required: ['path'],
+    },
+    grantToken: 'fake.jwt.token',
+    requiredScope: 'file:read',
+    execute: async (args) => String(args['path']),
+  });
+
+  // This MUST compile — our definition must be assignable to the SDK's Tool type
+  const _params: MessageCreateParamsNonStreaming = {
+    model: 'claude-sonnet-4-6',
+    max_tokens: 1024,
+    tools: [tool.definition],
+    messages: [{ role: 'user', content: 'Read config.json' }],
+  };
+}
+
+// ─── Scenario 2: Pass SDK ToolUseBlock to registry.execute ───────────────────
+
+async function testToolUseBlockCompat() {
+  const client = new Anthropic();
+  const registry = new GrantexToolRegistry();
+
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 1024,
+    tools: [],
+    messages: [{ role: 'user', content: 'test' }],
+  });
+
+  for (const block of response.content) {
+    if (block.type === 'tool_use') {
+      // This MUST compile — SDK's ToolUseBlock must be assignable to our AnthropicToolUseBlock
+      await registry.execute(block);
+    }
+  }
+}
+
+// ─── Scenario 3: Pass SDK ToolUseBlock to handleToolCall ─────────────────────
+
+async function testHandleToolCallCompat() {
+  const client = new Anthropic();
+  const grantex = {} as Grantex;
+
+  const tool = createGrantexTool({
+    name: 'read_file',
+    description: 'Read a file',
+    inputSchema: {
+      type: 'object',
+      properties: { path: { type: 'string' } },
+      required: ['path'],
+    },
+    grantToken: 'fake.jwt.token',
+    requiredScope: 'file:read',
+    execute: async (args) => String(args['path']),
+  });
+
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 1024,
+    tools: [tool.definition],
+    messages: [{ role: 'user', content: 'test' }],
+  });
+
+  for (const block of response.content) {
+    if (block.type === 'tool_use') {
+      // This MUST compile — SDK's ToolUseBlock to our handleToolCall
+      await handleToolCall(tool, block, grantex, {
+        agentId: 'ag_01',
+        agentDid: 'did:key:z6Mk',
+        grantId: 'grnt_01',
+        principalId: 'user_01',
+      });
+    }
+  }
+}
+
+// ─── Scenario 4: Registry definitions back to SDK ────────────────────────────
+
+async function testRegistryDefinitionsCompat() {
+  const client = new Anthropic();
+  const registry = new GrantexToolRegistry();
+
+  // Registry definitions MUST be assignable to the SDK's tools parameter
+  const _params: MessageCreateParamsNonStreaming = {
+    model: 'claude-sonnet-4-6',
+    max_tokens: 1024,
+    tools: registry.definitions,
+    messages: [{ role: 'user', content: 'test' }],
+  };
+}

--- a/packages/anthropic/tsconfig.build.json
+++ b/packages/anthropic/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/packages/anthropic/tsconfig.json
+++ b/packages/anthropic/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitOverride": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/anthropic/vitest.config.ts
+++ b/packages/anthropic/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+  },
+});

--- a/web/index.html
+++ b/web/index.html
@@ -76,7 +76,7 @@
         "name": "What AI agent frameworks does Grantex integrate with?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Grantex has official integrations for LangChain, CrewAI, AutoGen, Vercel AI SDK, OpenAI Agents SDK, Google ADK, and a Model Context Protocol (MCP) server for Claude Desktop and Cursor. SDKs are available for TypeScript, Python, and Go."
+          "text": "Grantex has official integrations for Anthropic SDK, LangChain, CrewAI, AutoGen, Vercel AI SDK, OpenAI Agents SDK, Google ADK, and a Model Context Protocol (MCP) server for Claude Desktop and Cursor. SDKs are available for TypeScript, Python, and Go."
         }
       },
       {
@@ -1796,6 +1796,10 @@
       <a href="/for/google-adk" class="integration-pill" style="text-decoration:none;">
         <span class="integration-icon" style="font-family:var(--mono);font-size:14px;font-weight:700;">G</span>
         Google ADK
+      </a>
+      <a href="/for/anthropic" class="integration-pill" style="text-decoration:none;">
+        <span class="integration-icon" style="font-family:var(--mono);font-size:14px;font-weight:700;">A</span>
+        Anthropic SDK
       </a>
       <a href="/for/vercel-ai" class="integration-pill" style="text-decoration:none;">
         <span class="integration-icon">&#x25B2;</span>


### PR DESCRIPTION
## Summary

- Adds `@grantex/anthropic` — first-class Anthropic SDK integration for delegated authorization with Claude models
- Scope-enforced tool use, tool registry, audit logging, and offline scope inspection
- Types are fully compatible with `@anthropic-ai/sdk` — `tool.definition` passes directly to `client.messages.create()`, SDK `ToolUseBlock` passes directly to `registry.execute()`
- 31 tests (unit + integration + type compatibility), all passing

Closes #217. Thanks to @kamesh231 for proposing this integration.

## What's included

**Package (`packages/anthropic/`):**
- `createGrantexTool()` — wrap Anthropic tool definitions with offline scope checks
- `GrantexToolRegistry` — manage multiple tools and dispatch `tool_use` blocks by name
- `withAuditLogging()` / `handleToolCall()` — automatic audit trail logging
- `getGrantScopes()` — decode scopes from a grant token offline
- `GrantexScopeError` — typed error with `requiredScope` and `grantedScopes`

**Docs & landing page:**
- Integration docs page (`docs/integrations/anthropic.mdx`)
- Example docs page (`docs/examples/anthropic-tool-use.mdx`)
- Navigation updated in `docs.json`
- Overview card and table row added
- Landing page integration pill + JSON-LD FAQ updated
- README integrations table + examples table updated

**CI:**
- Added `anthropic` job to `ci.yml` (typecheck + test)

## Test plan

- [x] 31 unit + integration tests passing
- [x] Type compatibility verified: `tool.definition` → `client.messages.create({ tools })` compiles
- [x] Type compatibility verified: SDK `ToolUseBlock` → `registry.execute(block)` compiles
- [x] Type compatibility verified: SDK `ToolUseBlock` → `handleToolCall(tool, block, ...)` compiles
- [x] All docs code snippets validated against real `@anthropic-ai/sdk` types
- [x] Example app (`examples/anthropic-tool-use/`) typechecks against both SDKs
- [x] `npm run build` produces correct ESM output with `.js` extension imports
- [x] Realistic JWT tests (full Grantex claim structure, delegation tokens, budget tokens)
- [ ] Publish to npm and verify `npm install @grantex/anthropic` works
- [ ] Run example against local Grantex stack (`docker compose up`)
- [ ] Run example with `ANTHROPIC_API_KEY` for live Claude tool use