### PR TITLE
feat(anthropic): add @grantex/anthropic SDK integration

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -267,6 +267,7 @@
               "integrations/express",
               "integrations/fastapi",
               "integrations/mcp",
+              "integrations/anthropic",
               "integrations/langchain",
               "integrations/vercel-ai",
               "integrations/autogen",

--- a/docs/integrations/anthropic.mdx
+++ b/docs/integrations/anthropic.mdx
@@ -1,0 +1,143 @@
+---
+title: "Anthropic SDK"
+sidebarTitle: "Anthropic"
+description: "Scope-enforced tool use and audit logging for the Anthropic SDK."
+---
+
+## Install
+
+```bash
+npm install @grantex/anthropic @grantex/sdk @anthropic-ai/sdk
+```
+
+## Scope-Enforced Tools
+
+Create Anthropic tool definitions with built-in Grantex scope checks:
+
+```typescript
+import Anthropic from '@anthropic-ai/sdk';
+import { createGrantexTool } from '@grantex/anthropic';
+
+const client = new Anthropic();
+
+const readFileTool = createGrantexTool({
+  name: 'read_file',
+  description: 'Read a file from disk',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'Absolute file path' },
+    },
+    required: ['path'],
+  },
+  grantToken,                 // JWT from Grantex token exchange
+  requiredScope: 'file:read', // must be in token's scp claim
+  execute: async ({ path }) => {
+    const fs = await import('node:fs/promises');
+    return fs.readFile(path as string, 'utf-8');
+  },
+});
+
+// Pass definition to the LLM
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-20250514',
+  max_tokens: 1024,
+  tools: [readFileTool.definition],
+  messages: [{ role: 'user', content: 'Read /tmp/hello.txt' }],
+});
+
+// Execute when the LLM selects the tool
+for (const block of response.content) {
+  if (block.type === 'tool_use' && block.name === 'read_file') {
+    const result = await readFileTool.execute(block.input as { path: string });
+  }
+}
+```
+
+## Inspect Scopes Offline
+
+Decode the grant token locally without a network call:
+
+```typescript
+import { getGrantScopes } from '@grantex/anthropic';
+
+const scopes = getGrantScopes(grantToken);
+// ['file:read', 'file:write', 'calendar:read']
+```
+
+## Audit Logging
+
+Wrap any tool with `withAuditLogging` to record every invocation to the Grantex audit trail:
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+import { withAuditLogging } from '@grantex/anthropic';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+const auditedTool = withAuditLogging(readFileTool, grantex, {
+  agentId: 'ag_01ABC...',
+  agentDid: 'did:grantex:ag_01ABC...',
+  grantId: 'grnt_01XYZ...',
+  principalId: 'user_abc123',
+});
+// Use auditedTool.execute() — logs success/failure automatically
+```
+
+## Error Handling
+
+When the agent lacks the required scope, `execute()` throws a `GrantexScopeError` before the tool runs:
+
+```typescript
+import { GrantexScopeError } from '@grantex/anthropic';
+
+try {
+  await readFileTool.execute({ path: '/etc/passwd' });
+} catch (err) {
+  if (err instanceof GrantexScopeError) {
+    console.log(err.requiredScope);  // 'file:read'
+    console.log(err.grantedScopes);  // ['profile:read']
+  }
+}
+```
+
+## API Reference
+
+### `createGrantexTool(options)`
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `name` | `string` | Tool name (matches `^[a-zA-Z0-9_-]+$`) |
+| `description` | `string` | Description shown to the LLM |
+| `inputSchema` | `JsonSchema` | JSON Schema for tool input |
+| `grantToken` | `string` | Grantex JWT from token exchange |
+| `requiredScope` | `string` | Scope required to invoke this tool |
+| `execute` | `(args: T) => Promise<unknown>` | Tool implementation |
+
+Returns `{ definition, execute }`.
+
+### `getGrantScopes(grantToken)`
+
+Returns `string[]` of scopes from the JWT `scp` claim. Offline, no network call.
+
+### `withAuditLogging(tool, client, options)`
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `agentId` | `string` | Agent identifier for audit attribution |
+| `agentDid` | `string` | Agent DID (decentralized identifier) |
+| `grantId` | `string` | Grant ID for the session |
+| `principalId` | `string` | Principal (end-user) identifier |
+
+### `GrantexScopeError`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `requiredScope` | `string` | The scope that was required |
+| `grantedScopes` | `string[]` | Scopes the agent actually holds |
+
+## Requirements
+
+- Node.js 18+
+- `@grantex/sdk` >= 0.1.0
+- `@anthropic-ai/sdk` >= 0.30.0

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -34,6 +34,9 @@ description: "Grantex integrates with every major AI agent framework."
   <Card title="Vercel AI SDK" icon="bolt" href="/integrations/vercel-ai">
     Zod-schema tools with scope checks at construction time.
   </Card>
+  <Card title="Anthropic SDK" icon="message-bot" href="/integrations/anthropic">
+    Tool use with scope enforcement, audit logging, and offline scope inspection.
+  </Card>
   <Card title="AutoGen / OpenAI" icon="robot" href="/integrations/autogen">
     Function calling with scope enforcement and registry.
   </Card>
@@ -81,6 +84,7 @@ description: "Grantex integrates with every major AI agent framework."
 | MCP | `@grantex/mcp` | `npm install -g @grantex/mcp` | TypeScript |
 | LangChain | `@grantex/langchain` | `npm install @grantex/langchain` | TypeScript |
 | Vercel AI SDK | `@grantex/vercel-ai` | `npm install @grantex/vercel-ai` | TypeScript |
+| Anthropic SDK | `@grantex/anthropic` | `npm install @grantex/anthropic` | TypeScript |
 | AutoGen / OpenAI | `@grantex/autogen` | `npm install @grantex/autogen` | TypeScript |
 | CrewAI | `grantex-crewai` | `pip install grantex-crewai` | Python |
 | OpenAI Agents SDK | `grantex-openai-agents` | `pip install grantex-openai-agents` | Python |

--- a/packages/anthropic/README.md
+++ b/packages/anthropic/README.md
@@ -1,0 +1,127 @@
+# @grantex/anthropic
+
+Anthropic SDK integration for the [Grantex](https://grantex.dev) delegated authorization protocol.
+
+Enforce scopes, audit tool invocations, and inspect grant tokens when using `@anthropic-ai/sdk` with tool use.
+
+## Installation
+
+```bash
+npm install @grantex/anthropic @grantex/sdk @anthropic-ai/sdk
+```
+
+## Quick Start
+
+### 1. Create a scope-enforced tool
+
+```typescript
+import Anthropic from '@anthropic-ai/sdk';
+import { createGrantexTool } from '@grantex/anthropic';
+
+const client = new Anthropic();
+
+const readFileTool = createGrantexTool({
+  name: 'read_file',
+  description: 'Read a file from disk',
+  inputSchema: {
+    type: 'object',
+    properties: { path: { type: 'string', description: 'Absolute file path' } },
+    required: ['path'],
+  },
+  grantToken: process.env.GRANT_TOKEN!,
+  requiredScope: 'file:read',
+  execute: async ({ path }) => {
+    const fs = await import('node:fs/promises');
+    return fs.readFile(path as string, 'utf-8');
+  },
+});
+```
+
+### 2. Use with the Anthropic SDK
+
+```typescript
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-20250514',
+  max_tokens: 1024,
+  tools: [readFileTool.definition],
+  messages: [{ role: 'user', content: 'Read /tmp/hello.txt' }],
+});
+
+for (const block of response.content) {
+  if (block.type === 'tool_use') {
+    const result = await readFileTool.execute(block.input as { path: string });
+    console.log(result);
+  }
+}
+```
+
+### 3. Add audit logging
+
+```typescript
+import { Grantex } from '@grantex/sdk';
+import { withAuditLogging } from '@grantex/anthropic';
+
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+const auditedTool = withAuditLogging(readFileTool, grantex, {
+  agentId: 'ag_01HXYZ...',
+  agentDid: 'did:grantex:ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  principalId: 'user_abc123',
+});
+
+// Every call to auditedTool.execute() now logs to the Grantex audit trail.
+```
+
+### 4. Inspect scopes offline
+
+```typescript
+import { getGrantScopes } from '@grantex/anthropic';
+
+const scopes = getGrantScopes(process.env.GRANT_TOKEN!);
+// ['file:read', 'file:write', 'calendar:read']
+```
+
+## API Reference
+
+### `createGrantexTool(options)`
+
+Creates a Grantex-authorized tool in Anthropic SDK format.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `name` | `string` | Tool name shown to the LLM |
+| `description` | `string` | Human-readable description |
+| `inputSchema` | `JsonSchema` | JSON Schema for the tool input |
+| `grantToken` | `string` | Grantex grant token (JWT) |
+| `requiredScope` | `string` | Scope required to invoke the tool |
+| `execute` | `(args: T) => Promise<unknown>` | Tool implementation |
+
+Returns a `GrantexTool<T>` with:
+- `definition` — Anthropic tool definition to pass to `tools[]`
+- `execute(args)` — scope-checked execution
+
+### `withAuditLogging(tool, client, options)`
+
+Wraps a tool with automatic audit logging.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `agentId` | `string` | Agent identifier |
+| `agentDid` | `string` | Agent DID (decentralized identifier) |
+| `grantId` | `string` | Grant ID for the session |
+| `principalId` | `string` | Principal (end-user) identifier |
+
+### `getGrantScopes(grantToken)`
+
+Decodes the JWT offline and returns the list of scopes as `string[]`.
+
+### `GrantexScopeError`
+
+Thrown when `execute()` is called without the required scope. Properties:
+- `requiredScope: string`
+- `grantedScopes: string[]`
+
+## License
+
+Apache-2.0

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@grantex/anthropic",
+  "version": "0.1.0",
+  "description": "Anthropic SDK integration for the Grantex delegated authorization protocol",
+  "homepage": "https://grantex.dev/for/anthropic",
+  "bugs": {
+    "url": "https://github.com/mishrasanjeev/grantex/issues"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@grantex/sdk": ">=0.1.0",
+    "@anthropic-ai/sdk": ">=0.30.0"
+  },
+  "overrides": {
+    "esbuild": ">=0.25.0"
+  },
+  "devDependencies": {
+    "@grantex/sdk": "file:../sdk-ts",
+    "@types/node": "^20.11.0",
+    "typescript": "^5.3.3",
+    "vitest": "^1.3.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "keywords": [
+    "grantex",
+    "anthropic",
+    "claude",
+    "ai-agents",
+    "authorization",
+    "oauth",
+    "jwt",
+    "agent-tools",
+    "scope-enforcement",
+    "delegated-auth",
+    "tool-use"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mishrasanjeev/grantex"
+  }
+}

--- a/packages/anthropic/src/_jwt.ts
+++ b/packages/anthropic/src/_jwt.ts
@@ -1,0 +1,14 @@
+/**
+ * Minimal offline JWT payload decoder — no signature verification.
+ * Used only to read the `scp` claim from a Grantex grant token without
+ * making a network round-trip.
+ */
+export function decodeJwtPayload(token: string): Record<string, unknown> {
+  const parts = token.split('.');
+  if (parts.length < 2 || !parts[1]) {
+    throw new Error('Grantex: invalid JWT format');
+  }
+  // Convert base64url -> base64, then decode
+  const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+  return JSON.parse(Buffer.from(b64, 'base64').toString('utf8')) as Record<string, unknown>;
+}

--- a/packages/anthropic/src/audit.ts
+++ b/packages/anthropic/src/audit.ts
@@ -1,0 +1,80 @@
+import type { Grantex } from '@grantex/sdk';
+import type { GrantexTool } from './types.js';
+
+export interface AuditLoggingOptions {
+  /** Agent identifier to record in audit entries. */
+  agentId: string;
+  /** Agent DID (decentralized identifier) to record in audit entries. */
+  agentDid: string;
+  /** Grant ID associated with the tool invocation. */
+  grantId: string;
+  /** Principal (end-user) identifier who granted the authorization. */
+  principalId: string;
+}
+
+/**
+ * Wrap a {@link GrantexTool} with Grantex audit logging.
+ *
+ * Logs a `'success'` entry on completion and a `'failure'` entry when
+ * `execute()` throws. The original error is re-thrown after logging.
+ *
+ * @example
+ * ```ts
+ * import { Grantex } from '@grantex/sdk';
+ * import { createGrantexTool, withAuditLogging } from '@grantex/anthropic';
+ *
+ * const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+ *
+ * const tool = createGrantexTool({ ... });
+ *
+ * const auditedTool = withAuditLogging(tool, grantex, {
+ *   agentId: 'ag_01HXYZ...',
+ *   agentDid: 'did:grantex:ag_01HXYZ...',
+ *   grantId: tokenResponse.grantId,
+ *   principalId: 'user_abc123',
+ * });
+ *
+ * // Now every call to auditedTool.execute() is logged automatically.
+ * ```
+ */
+export function withAuditLogging<T>(
+  tool: GrantexTool<T>,
+  client: Grantex,
+  options: AuditLoggingOptions,
+): GrantexTool<T> {
+  const { agentId, agentDid, grantId, principalId } = options;
+  const toolName = tool.definition.name;
+
+  return {
+    definition: tool.definition,
+    async execute(args: T): Promise<unknown> {
+      try {
+        const result = await tool.execute(args);
+        await client.audit.log({
+          agentId,
+          agentDid,
+          grantId,
+          principalId,
+          action: `tool:${toolName}`,
+          metadata: { args },
+          status: 'success' as const,
+        });
+        return result;
+      } catch (err) {
+        await client.audit.log({
+          agentId,
+          agentDid,
+          grantId,
+          principalId,
+          action: `tool:${toolName}`,
+          metadata: {
+            args,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          status: 'failure' as const,
+        });
+        throw err;
+      }
+    },
+  };
+}

--- a/packages/anthropic/src/index.ts
+++ b/packages/anthropic/src/index.ts
@@ -1,0 +1,10 @@
+export { createGrantexTool, getGrantScopes } from './tool.js';
+export { withAuditLogging } from './audit.js';
+export { GrantexScopeError } from './types.js';
+export type {
+  JsonSchema,
+  AnthropicToolDefinition,
+  CreateGrantexToolOptions,
+  GrantexTool,
+} from './types.js';
+export type { AuditLoggingOptions } from './audit.js';

--- a/packages/anthropic/src/tool.ts
+++ b/packages/anthropic/src/tool.ts
@@ -1,0 +1,87 @@
+import { decodeJwtPayload } from './_jwt.js';
+import type { AnthropicToolDefinition, CreateGrantexToolOptions, GrantexTool } from './types.js';
+import { GrantexScopeError } from './types.js';
+
+/**
+ * Create a Grantex-authorized tool in Anthropic SDK format.
+ *
+ * The scope check is performed offline by reading the `scp` claim from the
+ * grant token JWT — no network call is made. If the agent does not hold
+ * `requiredScope`, `execute()` throws a {@link GrantexScopeError} before
+ * calling the implementation.
+ *
+ * @example
+ * ```ts
+ * import Anthropic from '@anthropic-ai/sdk';
+ * import { createGrantexTool } from '@grantex/anthropic';
+ *
+ * const readFileTool = createGrantexTool({
+ *   name: 'read_file',
+ *   description: 'Read a file from disk',
+ *   inputSchema: {
+ *     type: 'object',
+ *     properties: { path: { type: 'string' } },
+ *     required: ['path'],
+ *   },
+ *   grantToken: process.env.GRANT_TOKEN!,
+ *   requiredScope: 'file:read',
+ *   execute: async ({ path }) => fs.readFile(path, 'utf-8'),
+ * });
+ *
+ * // Pass to Anthropic SDK:
+ * const response = await client.messages.create({
+ *   model: 'claude-sonnet-4-20250514',
+ *   max_tokens: 1024,
+ *   tools: [readFileTool.definition],
+ *   messages: [...],
+ * });
+ *
+ * // Handle tool_use blocks:
+ * for (const block of response.content) {
+ *   if (block.type === 'tool_use' && block.name === 'read_file') {
+ *     const result = await readFileTool.execute(block.input);
+ *   }
+ * }
+ * ```
+ */
+export function createGrantexTool<T = Record<string, unknown>>(
+  options: CreateGrantexToolOptions<T>,
+): GrantexTool<T> {
+  const { name, description, inputSchema, grantToken, requiredScope, execute: executeFn } = options;
+
+  const definition: AnthropicToolDefinition = {
+    name,
+    description,
+    input_schema: inputSchema,
+  };
+
+  return {
+    definition,
+    async execute(args: T): Promise<unknown> {
+      const payload = decodeJwtPayload(grantToken);
+      const scopes = payload['scp'];
+      const scopeList = Array.isArray(scopes) ? (scopes as string[]) : [];
+
+      if (!scopeList.includes(requiredScope)) {
+        throw new GrantexScopeError(requiredScope, scopeList);
+      }
+
+      return executeFn(args);
+    },
+  };
+}
+
+/**
+ * Decode the grant token offline and return the list of scopes.
+ *
+ * @example
+ * ```ts
+ * const scopes = getGrantScopes(grantToken);
+ * // ['file:read', 'file:write', 'calendar:read']
+ * ```
+ */
+export function getGrantScopes(grantToken: string): string[] {
+  const payload = decodeJwtPayload(grantToken);
+  const scopes = payload['scp'];
+  return Array.isArray(scopes) ? (scopes as string[]) : [];
+}

--- a/packages/anthropic/src/types.ts
+++ b/packages/anthropic/src/types.ts
@@ -1,0 +1,69 @@
+/** A subset of JSON Schema sufficient for Anthropic tool input_schema. */
+export interface JsonSchema {
+  type: string;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  description?: string;
+  items?: JsonSchema;
+  enum?: unknown[];
+  [key: string]: unknown;
+}
+
+/** Anthropic tool definition as expected by the Anthropic SDK. */
+export interface AnthropicToolDefinition {
+  name: string;
+  description: string;
+  input_schema: JsonSchema;
+}
+
+/** Options for {@link createGrantexTool}. */
+export interface CreateGrantexToolOptions<T> {
+  /** Tool name shown to the LLM. Must match `^[a-zA-Z0-9_-]+$`. */
+  name: string;
+  /** Human-readable description shown to the LLM. */
+  description: string;
+  /** JSON Schema describing the structured input arguments. */
+  inputSchema: JsonSchema;
+  /** Grantex grant token obtained from the token exchange. */
+  grantToken: string;
+  /** Scope the agent must hold to invoke this tool (e.g. `'file:read'`). */
+  requiredScope: string;
+  /** The tool implementation. Receives typed args, returns any JSON-serialisable value. */
+  execute: (args: T) => Promise<unknown>;
+}
+
+/**
+ * A Grantex-authorized tool in Anthropic tool format.
+ *
+ * - `definition` — pass this to the `tools` array in `client.messages.create()`
+ * - `execute(args)` — call when handling a `tool_use` content block; enforces scope offline
+ */
+export interface GrantexTool<T> {
+  /** Anthropic tool definition for passing to the LLM. */
+  readonly definition: AnthropicToolDefinition;
+  /**
+   * Execute the tool with the given arguments.
+   * Verifies the required scope offline before calling the implementation.
+   * Throws {@link GrantexScopeError} if the agent does not hold the required scope.
+   */
+  execute(args: T): Promise<unknown>;
+}
+
+/**
+ * Thrown when the grant token does not contain the required scope.
+ */
+export class GrantexScopeError extends Error {
+  readonly requiredScope: string;
+  readonly grantedScopes: string[];
+
+  constructor(requiredScope: string, grantedScopes: string[]) {
+    super(
+      `Grantex: agent is not authorized for scope '${requiredScope}'. ` +
+        `Granted scopes: ${grantedScopes.length > 0 ? grantedScopes.join(', ') : 'none'}.`,
+    );
+    this.name = 'GrantexScopeError';
+    this.requiredScope = requiredScope;
+    this.grantedScopes = grantedScopes;
+    Object.setPrototypeOf(this, GrantexScopeError.prototype);
+  }
+}

--- a/packages/anthropic/tests/audit.test.ts
+++ b/packages/anthropic/tests/audit.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest';
+import { withAuditLogging } from '../src/audit.js';
+import type { GrantexTool } from '../src/types.js';
+import type { Grantex } from '@grantex/sdk';
+
+/** Minimal Grantex client stub -- only needs audit.log */
+function makeClient(): Grantex {
+  return {
+    audit: {
+      log: vi.fn().mockResolvedValue({ entryId: 'entry_01' }),
+    },
+  } as unknown as Grantex;
+}
+
+/** Minimal GrantexTool stub */
+function makeTool(name: string, impl: () => Promise<unknown>): GrantexTool<Record<string, unknown>> {
+  return {
+    definition: {
+      name,
+      description: 'test tool',
+      input_schema: { type: 'object' },
+    },
+    execute: vi.fn().mockImplementation(impl),
+  };
+}
+
+describe('withAuditLogging', () => {
+  it('logs a success entry when execute resolves', async () => {
+    const client = makeClient();
+    const tool = makeTool('read_file', async () => 'file contents');
+    const audited = withAuditLogging(tool, client, { agentId: 'agent_1', agentDid: 'did:grantex:agent_1', grantId: 'grnt_1', principalId: 'user_1' });
+
+    const result = await audited.execute({ path: '/tmp/test.txt' });
+
+    expect(result).toBe('file contents');
+    expect(client.audit.log).toHaveBeenCalledOnce();
+    expect(client.audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: 'agent_1',
+        grantId: 'grnt_1',
+        action: 'tool:read_file',
+        status: 'success',
+      }),
+    );
+  });
+
+  it('logs a failure entry and re-throws when execute rejects', async () => {
+    const client = makeClient();
+    const tool = makeTool('read_file', async () => {
+      throw new Error('file not found');
+    });
+    const audited = withAuditLogging(tool, client, { agentId: 'agent_1', agentDid: 'did:grantex:agent_1', grantId: 'grnt_1', principalId: 'user_1' });
+
+    await expect(audited.execute({})).rejects.toThrow('file not found');
+    expect(client.audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'tool:read_file',
+        status: 'failure',
+        metadata: expect.objectContaining({ error: 'file not found' }),
+      }),
+    );
+  });
+
+  it('preserves the original definition unchanged', () => {
+    const client = makeClient();
+    const tool = makeTool('my_tool', async () => null);
+    const audited = withAuditLogging(tool, client, { agentId: 'a', agentDid: 'did:grantex:a', grantId: 'g', principalId: 'u' });
+
+    expect(audited.definition).toBe(tool.definition);
+  });
+
+  it('passes args through to the underlying tool', async () => {
+    const client = makeClient();
+    const tool = makeTool('my_tool', async () => 'done');
+    const audited = withAuditLogging(tool, client, { agentId: 'a', agentDid: 'did:grantex:a', grantId: 'g', principalId: 'u' });
+    const args = { x: 1, y: 2 };
+
+    await audited.execute(args);
+
+    expect(tool.execute).toHaveBeenCalledWith(args);
+  });
+
+  it('includes args in audit metadata on success', async () => {
+    const client = makeClient();
+    const tool = makeTool('search', async () => []);
+    const audited = withAuditLogging(tool, client, { agentId: 'a', agentDid: 'did:grantex:a', grantId: 'g', principalId: 'u' });
+
+    await audited.execute({ query: 'test' });
+
+    expect(client.audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: { args: { query: 'test' } },
+      }),
+    );
+  });
+});

--- a/packages/anthropic/tests/tool.test.ts
+++ b/packages/anthropic/tests/tool.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createGrantexTool, getGrantScopes } from '../src/tool.js';
+import { GrantexScopeError } from '../src/types.js';
+
+/** Build a minimal JWT-shaped token with the given scp claim. */
+function makeToken(scp: string[]): string {
+  const payload = { scp, grnt: 'grnt_01', jti: 'tok_01', sub: 'user_1' };
+  const b64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `eyJhbGciOiJSUzI1NiJ9.${b64}.fakesig`;
+}
+
+const INPUT_SCHEMA = {
+  type: 'object' as const,
+  properties: { path: { type: 'string', description: 'File path' } },
+  required: ['path'],
+};
+
+describe('createGrantexTool', () => {
+  it('executes when agent holds the required scope', async () => {
+    const fn = vi.fn().mockResolvedValue('file contents');
+    const tool = createGrantexTool({
+      name: 'read_file',
+      description: 'Read a file from disk',
+      inputSchema: INPUT_SCHEMA,
+      grantToken: makeToken(['file:read']),
+      requiredScope: 'file:read',
+      execute: fn,
+    });
+
+    const result = await tool.execute({ path: '/tmp/test.txt' });
+
+    expect(result).toBe('file contents');
+    expect(fn).toHaveBeenCalledWith({ path: '/tmp/test.txt' });
+  });
+
+  it('throws GrantexScopeError when agent lacks the required scope', async () => {
+    const fn = vi.fn();
+    const tool = createGrantexTool({
+      name: 'read_file',
+      description: 'Read a file from disk',
+      inputSchema: INPUT_SCHEMA,
+      grantToken: makeToken(['profile:read']),
+      requiredScope: 'file:read',
+      execute: fn,
+    });
+
+    await expect(tool.execute({ path: '/tmp/test.txt' })).rejects.toThrow(GrantexScopeError);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('error includes required and granted scopes', async () => {
+    const tool = createGrantexTool({
+      name: 'send_email',
+      description: 'Send an email',
+      inputSchema: INPUT_SCHEMA,
+      grantToken: makeToken(['profile:read', 'calendar:read']),
+      requiredScope: 'email:write',
+      execute: vi.fn(),
+    });
+
+    try {
+      await tool.execute({});
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(GrantexScopeError);
+      const scopeErr = err as GrantexScopeError;
+      expect(scopeErr.requiredScope).toBe('email:write');
+      expect(scopeErr.grantedScopes).toEqual(['profile:read', 'calendar:read']);
+      expect(scopeErr.message).toContain('email:write');
+      expect(scopeErr.message).toContain('profile:read');
+    }
+  });
+
+  it('exposes the correct Anthropic tool definition shape', () => {
+    const tool = createGrantexTool({
+      name: 'read_file',
+      description: 'Read a file from disk',
+      inputSchema: INPUT_SCHEMA,
+      grantToken: makeToken(['file:read']),
+      requiredScope: 'file:read',
+      execute: vi.fn(),
+    });
+
+    expect(tool.definition).toEqual({
+      name: 'read_file',
+      description: 'Read a file from disk',
+      input_schema: INPUT_SCHEMA,
+    });
+  });
+
+  it('throws on a malformed grant token', async () => {
+    const tool = createGrantexTool({
+      name: 'read_file',
+      description: 'Read a file from disk',
+      inputSchema: INPUT_SCHEMA,
+      grantToken: 'not.a.jwt',
+      requiredScope: 'file:read',
+      execute: vi.fn(),
+    });
+
+    await expect(tool.execute({})).rejects.toThrow();
+  });
+
+  it('treats missing scp claim as empty scopes', async () => {
+    const payload = { grnt: 'grnt_01', sub: 'user_1' };
+    const b64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+    const token = `eyJhbGciOiJSUzI1NiJ9.${b64}.fakesig`;
+
+    const tool = createGrantexTool({
+      name: 'read_file',
+      description: 'Read a file',
+      inputSchema: INPUT_SCHEMA,
+      grantToken: token,
+      requiredScope: 'file:read',
+      execute: vi.fn(),
+    });
+
+    try {
+      await tool.execute({});
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(GrantexScopeError);
+      expect((err as GrantexScopeError).grantedScopes).toEqual([]);
+    }
+  });
+});
+
+describe('getGrantScopes', () => {
+  it('returns the scp claim as an array', () => {
+    const scopes = getGrantScopes(makeToken(['file:read', 'file:write']));
+    expect(scopes).toEqual(['file:read', 'file:write']);
+  });
+
+  it('returns empty array when scp is missing', () => {
+    const payload = { grnt: 'grnt_01' };
+    const b64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+    const token = `eyJhbGciOiJSUzI1NiJ9.${b64}.fakesig`;
+    expect(getGrantScopes(token)).toEqual([]);
+  });
+
+  it('throws on malformed token', () => {
+    expect(() => getGrantScopes('bad')).toThrow();
+  });
+});

--- a/packages/anthropic/tsconfig.build.json
+++ b/packages/anthropic/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/packages/anthropic/tsconfig.json
+++ b/packages/anthropic/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitOverride": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary

- Adds `@grantex/anthropic` package — first-class Anthropic SDK (`@anthropic-ai/sdk`) integration for Grantex delegated authorization
- `createGrantexTool()` — wraps Anthropic tool definitions with offline scope enforcement via JWT `scp` claim
- `withAuditLogging()` — wraps tool execution with automatic Grantex audit trail logging (success/failure)
- `getGrantScopes()` — decode grant token offline to inspect scopes
- `GrantexScopeError` — typed error with `requiredScope` and `grantedScopes` properties
- 14 tests passing, strict TypeScript, follows existing integration package patterns (`@grantex/autogen`, `@grantex/langchain`)

Closes #217

## Test plan

- [x] `npm run build` — compiles cleanly with strict TypeScript
- [x] `npm run typecheck` — no type errors
- [x] `npm test` — 14/14 tests passing (9 tool + 5 audit)
- [ ] Manual verification: use with `@anthropic-ai/sdk` `client.messages.create()` tool_use flow