### PR TITLE
fix(seo): add Anthropic SDK to sitemap.xml and llms.txt

### DIFF
--- a/web/llms.txt
+++ b/web/llms.txt
@@ -23,6 +23,7 @@ Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, hum
 
 ## Framework Integrations
 
+- Anthropic SDK: `npm install @grantex/anthropic @grantex/sdk`
 - LangChain: `npm install @grantex/langchain`
 - CrewAI: `pip install grantex-crewai`
 - OpenAI Agents SDK: `pip install grantex-openai-agents`

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -43,6 +43,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://grantex.dev/for/anthropic</loc>
+    <lastmod>2026-03-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://grantex.dev/for/google-adk</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
## Summary

- Add `/for/anthropic` to `sitemap.xml` (priority 0.9, matching other framework pages)
- Add Anthropic SDK install line to `llms.txt` for LLM discovery

## Test plan

- [x] Verify sitemap entry is well-formed XML
- [x] Verify llms.txt entry matches existing format