### PR TITLE
fix(integrations): add agentDid and principalId to audit logging

### DIFF
--- a/packages/autogen/src/audit.ts
+++ b/packages/autogen/src/audit.ts
@@ -2,10 +2,14 @@ import type { Grantex } from '@grantex/sdk';
 import type { GrantexFunction } from './types.js';
 
 export interface AuditLoggingOptions {
-  /** Agent DID or identifier to record in audit entries. */
+  /** Agent ID to record in audit entries. */
   agentId: string;
+  /** Agent DID (e.g. `'did:key:z6Mk...'`). */
+  agentDid: string;
   /** Grant ID associated with the function invocation. */
   grantId: string;
+  /** Principal ID that granted authorization. */
+  principalId: string;
 }
 
 /**
@@ -27,7 +31,7 @@ export function withAuditLogging<T extends Record<string, unknown>>(
   client: Grantex,
   options: AuditLoggingOptions,
 ): GrantexFunction<T> {
-  const { agentId, grantId } = options;
+  const { agentId, agentDid, grantId, principalId } = options;
   const fnName = fn.definition.function.name;
 
   return {
@@ -37,7 +41,9 @@ export function withAuditLogging<T extends Record<string, unknown>>(
         const result = await fn.execute(args);
         await client.audit.log({
           agentId,
+          agentDid,
           grantId,
+          principalId,
           action: `function:${fnName}`,
           metadata: { args },
           status: 'success' as const,
@@ -46,7 +52,9 @@ export function withAuditLogging<T extends Record<string, unknown>>(
       } catch (err) {
         await client.audit.log({
           agentId,
+          agentDid,
           grantId,
+          principalId,
           action: `function:${fnName}`,
           metadata: {
             args,

--- a/packages/autogen/tests/audit.test.ts
+++ b/packages/autogen/tests/audit.test.ts
@@ -27,7 +27,7 @@ describe('withAuditLogging', () => {
   it('logs a success entry when execute resolves', async () => {
     const client = makeClient();
     const fn = makeFn('fetch_data', async () => ({ rows: 3 }));
-    const audited = withAuditLogging(fn, client, { agentId: 'agent_1', grantId: 'grnt_1' });
+    const audited = withAuditLogging(fn, client, { agentId: 'agent_1', agentDid: 'did:key:z6Mk_1', grantId: 'grnt_1', principalId: 'user_1' });
 
     const result = await audited.execute({ q: 'test' });
 
@@ -48,7 +48,7 @@ describe('withAuditLogging', () => {
     const fn = makeFn('fetch_data', async () => {
       throw new Error('database offline');
     });
-    const audited = withAuditLogging(fn, client, { agentId: 'agent_1', grantId: 'grnt_1' });
+    const audited = withAuditLogging(fn, client, { agentId: 'agent_1', agentDid: 'did:key:z6Mk_1', grantId: 'grnt_1', principalId: 'user_1' });
 
     await expect(audited.execute({})).rejects.toThrow('database offline');
     expect(client.audit.log).toHaveBeenCalledWith(
@@ -63,7 +63,7 @@ describe('withAuditLogging', () => {
   it('preserves the original definition unchanged', () => {
     const client = makeClient();
     const fn = makeFn('my_fn', async () => null);
-    const audited = withAuditLogging(fn, client, { agentId: 'a', grantId: 'g' });
+    const audited = withAuditLogging(fn, client, { agentId: 'a', agentDid: 'did:key:a', grantId: 'g', principalId: 'p' });
 
     expect(audited.definition).toBe(fn.definition);
   });
@@ -71,7 +71,7 @@ describe('withAuditLogging', () => {
   it('passes args through to the underlying function', async () => {
     const client = makeClient();
     const fn = makeFn('my_fn', async () => 'done');
-    const audited = withAuditLogging(fn, client, { agentId: 'a', grantId: 'g' });
+    const audited = withAuditLogging(fn, client, { agentId: 'a', agentDid: 'did:key:a', grantId: 'g', principalId: 'p' });
     const args = { x: 1, y: 2 };
 
     await audited.execute(args);

--- a/packages/langchain/src/callback.ts
+++ b/packages/langchain/src/callback.ts
@@ -7,6 +7,10 @@ export interface GrantexAuditHandlerOptions {
   client: Grantex;
   /** The Grantex agent ID (e.g. `ag_01XYZ`) to attribute audit entries to. */
   agentId: string;
+  /** Agent DID (e.g. `'did:key:z6Mk...'`). */
+  agentDid: string;
+  /** Principal ID that granted authorization. */
+  principalId: string;
   /** Grantex grant token — the grantId is decoded from the `grnt` (or `jti`) claim. */
   grantToken: string;
 }
@@ -32,12 +36,16 @@ export class GrantexAuditHandler extends BaseCallbackHandler {
 
   readonly #client: Grantex;
   readonly #agentId: string;
+  readonly #agentDid: string;
   readonly #grantId: string;
+  readonly #principalId: string;
 
   constructor(options: GrantexAuditHandlerOptions) {
     super();
     this.#client = options.client;
     this.#agentId = options.agentId;
+    this.#agentDid = options.agentDid;
+    this.#principalId = options.principalId;
 
     const payload = decodeJwtPayload(options.grantToken);
     const grantId = payload['grnt'] ?? payload['jti'];
@@ -60,7 +68,9 @@ export class GrantexAuditHandler extends BaseCallbackHandler {
     const toolName = tool.name ?? 'unknown';
     await this.#client.audit.log({
       agentId: this.#agentId,
+      agentDid: this.#agentDid,
       grantId: this.#grantId,
+      principalId: this.#principalId,
       action: `tool:${toolName}`,
       metadata: { input },
       status: 'success' as const,
@@ -73,7 +83,9 @@ export class GrantexAuditHandler extends BaseCallbackHandler {
   override async handleToolError(err: Error): Promise<void> {
     await this.#client.audit.log({
       agentId: this.#agentId,
+      agentDid: this.#agentDid,
       grantId: this.#grantId,
+      principalId: this.#principalId,
       action: 'tool:error',
       metadata: { error: err.message },
       status: 'failure' as const,

--- a/packages/langchain/tests/callback.test.ts
+++ b/packages/langchain/tests/callback.test.ts
@@ -33,6 +33,8 @@ describe('GrantexAuditHandler', () => {
     const handler = new GrantexAuditHandler({
       client: mockClient,
       agentId: 'ag_01',
+      agentDid: 'did:key:z6Mk_01',
+      principalId: 'user_01',
       grantToken: GRANT_TOKEN,
     });
 
@@ -40,7 +42,9 @@ describe('GrantexAuditHandler', () => {
 
     expect(mockLog).toHaveBeenCalledWith({
       agentId: 'ag_01',
+      agentDid: 'did:key:z6Mk_01',
       grantId: 'grnt_01',
+      principalId: 'user_01',
       action: 'tool:read_calendar',
       metadata: { input: 'show me today' },
       status: 'success',
@@ -51,6 +55,8 @@ describe('GrantexAuditHandler', () => {
     const handler = new GrantexAuditHandler({
       client: mockClient,
       agentId: 'ag_01',
+      agentDid: 'did:key:z6Mk_01',
+      principalId: 'user_01',
       grantToken: GRANT_TOKEN,
     });
 
@@ -58,7 +64,9 @@ describe('GrantexAuditHandler', () => {
 
     expect(mockLog).toHaveBeenCalledWith({
       agentId: 'ag_01',
+      agentDid: 'did:key:z6Mk_01',
       grantId: 'grnt_01',
+      principalId: 'user_01',
       action: 'tool:error',
       metadata: { error: 'API connection timed out' },
       status: 'failure',
@@ -69,6 +77,8 @@ describe('GrantexAuditHandler', () => {
     const handler = new GrantexAuditHandler({
       client: mockClient,
       agentId: 'ag_01',
+      agentDid: 'did:key:z6Mk_01',
+      principalId: 'user_01',
       grantToken: TOKEN_JTI_ONLY,
     });
 
@@ -85,6 +95,8 @@ describe('GrantexAuditHandler', () => {
         new GrantexAuditHandler({
           client: mockClient,
           agentId: 'ag_01',
+          agentDid: 'did:key:z6Mk_01',
+          principalId: 'user_01',
           grantToken: TOKEN_NO_ID,
         }),
     ).toThrow('grantId');

--- a/packages/vercel-ai/src/audit.ts
+++ b/packages/vercel-ai/src/audit.ts
@@ -29,7 +29,7 @@ export function withAuditLogging<PARAMETERS extends z.ZodTypeAny, RESULT>(
   client: Grantex,
   options: AuditLoggingOptions,
 ): GrantexTool<PARAMETERS, RESULT> {
-  const { agentId, grantId } = options;
+  const { agentId, agentDid, grantId, principalId } = options;
   const toolName = options.toolName ?? grantexTool[TOOL_NAME_KEY];
   const action = `tool:${toolName}`;
   const originalExecute = grantexTool.execute;
@@ -39,7 +39,9 @@ export function withAuditLogging<PARAMETERS extends z.ZodTypeAny, RESULT>(
       const result = await originalExecute(args, execOptions);
       await client.audit.log({
         agentId,
+        agentDid,
         grantId,
+        principalId,
         action,
         metadata: { args: args as Record<string, unknown> },
         status: 'success' as const,
@@ -48,7 +50,9 @@ export function withAuditLogging<PARAMETERS extends z.ZodTypeAny, RESULT>(
     } catch (err) {
       await client.audit.log({
         agentId,
+        agentDid,
         grantId,
+        principalId,
         action,
         metadata: {
           args: args as Record<string, unknown>,

--- a/packages/vercel-ai/src/types.ts
+++ b/packages/vercel-ai/src/types.ts
@@ -37,8 +37,12 @@ export interface CreateGrantexToolOptions<
 export interface AuditLoggingOptions {
   /** Grantex agent ID to record in audit entries. */
   agentId: string;
+  /** Agent DID (e.g. `'did:key:z6Mk...'`). */
+  agentDid: string;
   /** Grant ID associated with tool invocations. */
   grantId: string;
+  /** Principal ID that granted authorization. */
+  principalId: string;
   /**
    * The tool name used as the audit action label
    * (e.g. `"tool:fetch_data"`). Inferred from the tool's `_grantexName`

--- a/packages/vercel-ai/tests/audit.test.ts
+++ b/packages/vercel-ai/tests/audit.test.ts
@@ -53,7 +53,9 @@ describe('withAuditLogging', () => {
     const client = makeClient();
     const t = withAuditLogging(baseTool(async ({ item }) => `done:${item}`), client, {
       agentId: 'ag_01',
+      agentDid: 'did:key:z6Mk_01',
       grantId: 'grnt_01',
+      principalId: 'user_01',
     });
 
     const result = await t.execute({ item: 'widget' }, EXEC_OPTIONS);
@@ -62,7 +64,9 @@ describe('withAuditLogging', () => {
     expect(client.audit.log).toHaveBeenCalledOnce();
     expect(client.audit.log).toHaveBeenCalledWith({
       agentId: 'ag_01',
+      agentDid: 'did:key:z6Mk_01',
       grantId: 'grnt_01',
+      principalId: 'user_01',
       action: 'tool:test_tool',
       metadata: { args: { item: 'widget' } },
       status: 'success',
@@ -76,7 +80,7 @@ describe('withAuditLogging', () => {
         throw new Error('something broke');
       }),
       client,
-      { agentId: 'ag_01', grantId: 'grnt_01' },
+      { agentId: 'ag_01', agentDid: 'did:key:z6Mk_01', grantId: 'grnt_01', principalId: 'user_01' },
     );
 
     await expect(t.execute({ item: 'widget' }, EXEC_OPTIONS)).rejects.toThrow(
@@ -95,7 +99,7 @@ describe('withAuditLogging', () => {
     const t = withAuditLogging(
       baseTool(async () => 'ok'),
       client,
-      { agentId: 'ag_01', grantId: 'grnt_01', toolName: 'custom_name' },
+      { agentId: 'ag_01', agentDid: 'did:key:z6Mk_01', grantId: 'grnt_01', principalId: 'user_01', toolName: 'custom_name' },
     );
 
     await t.execute({ item: 'x' }, EXEC_OPTIONS);
@@ -109,7 +113,9 @@ describe('withAuditLogging', () => {
     const original = baseTool(async () => 'ok');
     const wrapped = withAuditLogging(original, client, {
       agentId: 'ag_01',
+      agentDid: 'did:key:z6Mk_01',
       grantId: 'grnt_01',
+      principalId: 'user_01',
     });
 
     expect(wrapped.description).toBe(original.description);


### PR DESCRIPTION
## Summary

- Fixes type errors in autogen, vercel-ai, and langchain audit logging
- The SDK's `LogAuditParams` requires `agentDid` and `principalId` but these three packages were only passing `agentId` and `grantId`
- Adds the missing fields to `AuditLoggingOptions` in all three packages and passes them through to `client.audit.log()`

## Test plan

- [x] autogen: typecheck clean, 14/14 tests passing
- [x] vercel-ai: typecheck clean, 12/12 tests passing
- [x] langchain: typecheck clean, 9/9 tests passing