### PR TITLE
chore: bump autogen 0.1.5, vercel-ai 0.1.5, langchain 0.1.6

### DIFF
--- a/packages/autogen/package.json
+++ b/packages/autogen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/autogen",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "AutoGen / OpenAI function-calling integration for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev/for/autogen",
   "bugs": {

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/langchain",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "LangChain integration for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev/for/langchain",
   "bugs": {

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/vercel-ai",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Vercel AI SDK integration for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev/for/vercel-ai",
   "bugs": {


### PR DESCRIPTION
## Summary

Version bumps for audit logging fix (#222). AuditLoggingOptions now requires `agentDid` and `principalId`.

| Package | Old | New |
|---------|-----|-----|
| `@grantex/autogen` | 0.1.4 | 0.1.5 |
| `@grantex/vercel-ai` | 0.1.4 | 0.1.5 |
| `@grantex/langchain` | 0.1.5 | 0.1.6 |