### PR TITLE
fix(mcp): add agentDid and principalId to audit log tool

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/mcp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "MCP server for Grantex delegated agent authorization",
   "homepage": "https://grantex.dev/for/mcp",
   "bugs": {
@@ -27,7 +27,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@grantex/sdk": "^0.1.6",
+    "@grantex/sdk": ">=0.2.0",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "zod": "^3.22.0"
   },

--- a/packages/mcp/src/tools/audit.ts
+++ b/packages/mcp/src/tools/audit.ts
@@ -8,15 +8,19 @@ export function registerAuditTools(server: McpServer, grantex: Grantex): void {
     'Log an audit entry for an agent action',
     {
       agentId: z.string().describe('Agent ID that performed the action'),
+      agentDid: z.string().describe('Agent DID (e.g. "did:key:z6Mk...")'),
       grantId: z.string().describe('Grant ID authorizing the action'),
+      principalId: z.string().describe('Principal ID (user) that granted authorization'),
       action: z.string().describe('Action name (e.g. "read_email", "send_message")'),
       metadata: z.record(z.unknown()).optional().describe('Additional context'),
       status: z.enum(['success', 'failure', 'blocked']).optional().describe('Outcome status'),
     },
-    async ({ agentId, grantId, action, metadata, status }) => {
+    async ({ agentId, agentDid, grantId, principalId, action, metadata, status }) => {
       const result = await grantex.audit.log({
         agentId,
+        agentDid,
         grantId,
+        principalId,
         action,
         ...(metadata !== undefined ? { metadata } : {}),
         ...(status !== undefined ? { status } : {}),


### PR DESCRIPTION
## Summary

- `grantex_audit_log` MCP tool was missing `agentDid` and `principalId` parameters, causing incomplete audit entries
- Adds both as required zod schema fields
- Bumps SDK constraint from `^0.1.6` to `>=0.2.0`
- Version bump to 0.1.5

## Test plan

- [x] Typecheck clean against SDK 0.2.6
- [x] 18/18 tests passing