### PR TITLE
feat(examples): multi-agent email flow with failure handling

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -95,7 +95,8 @@
               "examples/vercel-ai-chatbot",
               "examples/crewai-agent",
               "examples/openai-agents",
-              "examples/google-adk"
+              "examples/google-adk",
+              "examples/multi-agent-email-flow"
             ]
           }
         ]

--- a/docs/examples/multi-agent-email-flow.mdx
+++ b/docs/examples/multi-agent-email-flow.mdx
@@ -1,0 +1,91 @@
+---
+title: "Multi-Agent Email Flow"
+sidebarTitle: "Email Flow"
+description: "Multi-agent delegation with failure handling, cascade revocation, and audit trail."
+---
+
+## What it does
+
+This example demonstrates a realistic two-agent email automation workflow with comprehensive failure handling:
+
+1. **Register two agents** — a planner (Agent A) and an executor (Agent B)
+2. **Agent A reads calendar events** after offline scope verification
+3. **Agent A delegates `email:send`** to Agent B (subset of its own scopes)
+4. **Agent B sends an email** using the delegated, scoped permission
+5. **Failure: unauthorized scope** — Agent B tries `calendar:read` (not delegated) and is rejected immediately
+6. **Failure: cascade revocation** — Agent A's grant is revoked, which automatically invalidates Agent B's delegated token
+7. **Recovery pattern** — Agent B detects the revoked token and reports that a new delegation is needed
+8. **Audit trail inspection** — shows a timeline of all success and failure events across both agents
+
+## Prerequisites
+
+- **Node.js 18+**
+- **Docker** (Docker Desktop or Docker Engine with Compose)
+
+## Run
+
+Start the local Grantex stack from the repository root:
+
+```bash
+docker compose up --build
+```
+
+In a separate terminal, run the example:
+
+```bash
+cd examples/multi-agent-email-flow
+npm install
+npm start
+```
+
+## Expected output
+
+```text
+=== Multi-Agent Email Flow ===
+
+Agent A (planner) registered: ag_01HXYZ...
+Agent B (executor) registered: ag_01HXYZ...
+
+Agent A grant token:
+  grantId: grnt_01HXYZ...
+  scopes:  calendar:read, email:send
+
+--- Agent A: Reading calendar ---
+Scope verified offline: calendar:read
+Calendar events found: 3
+
+--- Agent A: Delegating email:send to Agent B ---
+Delegated token issued:
+  scopes:  email:send
+  delegationDepth: 1
+
+--- Agent B: Sending email ---
+Email sent: msg_1234567890
+
+--- Failure: Agent B tries calendar:read (not delegated) ---
+Blocked! Agent B cannot read calendar.
+
+--- Failure: Revoking Agent A's grant (cascade to Agent B) ---
+After revocation:
+  Agent A token valid: false (revoked)
+  Agent B token valid: false (cascade revoked)
+
+--- Audit trail ---
+  [+] Agent A calendar:read — success
+  [+] Agent B email:send — success
+  [x] Agent B calendar:read — failure
+  [x] Agent B email:send — failure
+
+Done! Multi-agent email flow with failure handling complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |
+
+## Source code
+
+The full source is in [`examples/multi-agent-email-flow/src/index.ts`](https://github.com/mishrasanjeev/grantex/tree/main/examples/multi-agent-email-flow).

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,7 @@ All examples use the sandbox key by default.
 | [`nextjs-starter`](./nextjs-starter/) | Next.js interactive consent flow with callback handling | `@grantex/sdk` |
 | [`openai-agents`](./openai-agents/) | OpenAI Agents SDK with scope enforcement | `grantex`, `grantex-openai-agents` |
 | [`google-adk`](./google-adk/) | Google ADK with scoped function tools | `grantex`, `grantex-adk` |
+| [`multi-agent-email-flow`](./multi-agent-email-flow/) | Multi-agent delegation with failure handling and audit trail | `@grantex/sdk` |
 
 ## Running an example
 

--- a/examples/multi-agent-email-flow/README.md
+++ b/examples/multi-agent-email-flow/README.md
@@ -1,0 +1,106 @@
+# Multi-Agent Email Flow
+
+End-to-end multi-agent email automation with delegation, scope enforcement, failure handling, and audit trail inspection.
+
+## What it does
+
+1. **Registers two agents** — Agent A (planner) with `calendar:read` + `email:send`, Agent B (executor) with `email:send`
+2. **Agent A obtains a grant token** via the sandbox flow
+3. **Agent A reads calendar events** with offline scope verification
+4. **Agent A delegates `email:send` only** to Agent B (not `calendar:read`)
+5. **Agent B sends an email** using the delegated scope
+6. **Failure: unauthorized scope** — Agent B tries `calendar:read` and is rejected
+7. **Failure: cascade revocation** — Agent A's grant is revoked, Agent B's delegated token becomes invalid
+8. **Audit trail** — inspects all logged actions showing the success/failure timeline
+
+## Prerequisites
+
+- Node.js 18+
+- Docker (for the local Grantex stack)
+
+## Run
+
+Start the local Grantex stack from the repository root:
+
+```bash
+docker compose up -d
+```
+
+In a separate terminal, run the example:
+
+```bash
+cd examples/multi-agent-email-flow
+npm install
+npm start
+```
+
+## Expected output
+
+```text
+=== Multi-Agent Email Flow ===
+
+Agent A (planner) registered: ag_01...
+Agent B (executor) registered: ag_01...
+
+Agent A grant token:
+  grantId: grnt_01...
+  scopes:  calendar:read, email:send
+
+--- Agent A: Reading calendar ---
+Scope verified offline: calendar:read
+  principalId: user-alice
+Calendar events found: 3
+  9:00 AM — Team standup
+  2:00 PM — Design review
+  4:00 PM — 1:1 with manager
+
+--- Agent A: Delegating email:send to Agent B ---
+Delegated token issued:
+  grantId: grnt_01...
+  scopes:  email:send
+  delegationDepth: 1
+  parentAgentDid: did:grantex:ag_01...
+
+--- Agent B: Sending email ---
+Scope verified offline: email:send
+Email sent: msg_1234567890
+  to:      team@company.com
+  subject: Daily schedule summary
+
+--- Failure: Agent B tries calendar:read (not delegated) ---
+Blocked! Agent B cannot read calendar.
+  Error: Grant token does not include required scope "calendar:read"...
+
+--- Failure: Revoking Agent A's grant (cascade to Agent B) ---
+Before revocation:
+  Agent A token valid: true
+  Agent B token valid: true
+
+Parent grant revoked.
+After revocation:
+  Agent A token valid: false (revoked)
+  Agent B token valid: false (cascade revoked)
+
+Agent B tries to send email after revocation...
+Blocked! Delegated token is no longer valid.
+Recovery: Agent B must request a new delegation from Agent A.
+
+--- Audit trail ---
+  [+] Agent A calendar:read — success — 2026-03-30T...
+  [+] Agent B email:send — success — 2026-03-30T...
+  [x] Agent B calendar:read — failure — 2026-03-30T...
+  [x] Agent B email:send — failure — 2026-03-30T...
+
+Total audit entries: 4
+  Success: 2
+  Failure: 2
+
+Done! Multi-agent email flow with failure handling complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |

--- a/examples/multi-agent-email-flow/package-lock.json
+++ b/examples/multi-agent-email-flow/package-lock.json
@@ -1,0 +1,576 @@
+{
+  "name": "grantex-example-multi-agent-email-flow",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "grantex-example-multi-agent-email-flow",
+      "dependencies": {
+        "@grantex/sdk": "^0.1.6"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsx": "^4.7.0",
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@grantex/sdk": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@grantex/sdk/-/sdk-0.1.9.tgz",
+      "integrity": "sha512-9h155JD6KLrEM4rvPz4bLv550bRAy1St1YAU4Nv4qw/aHwQ/HkyWt/XxUrVz/vOcX3icAHV+olVUlu9dyuquyg==",
+      "dependencies": {
+        "jose": "^5.2.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    }
+  }
+}

--- a/examples/multi-agent-email-flow/package.json
+++ b/examples/multi-agent-email-flow/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "grantex-example-multi-agent-email-flow",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "npx tsx src/index.ts"
+  },
+  "dependencies": {
+    "@grantex/sdk": "^0.1.6"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/examples/multi-agent-email-flow/src/index.ts
+++ b/examples/multi-agent-email-flow/src/index.ts
@@ -1,0 +1,257 @@
+/**
+ * Grantex Multi-Agent Email Flow — Failure & Recovery Patterns
+ *
+ * Demonstrates a realistic two-agent email automation workflow with
+ * comprehensive error handling and failure recovery:
+ *
+ *   1. Register a planner agent (Agent A) and an executor agent (Agent B)
+ *   2. Agent A obtains a grant with calendar:read + email:send scopes
+ *   3. Agent A reads calendar events (simulated) with scope verification
+ *   4. Agent A delegates only email:send to Agent B
+ *   5. Agent B sends email (simulated) using delegated scope
+ *   6. Failure: Agent B tries calendar:read (not delegated) — rejected
+ *   7. Failure: Parent grant revoked — Agent B's delegated token cascades
+ *   8. Full audit trail inspection showing success + failure timeline
+ *
+ * Prerequisites:
+ *   docker compose up          # from repo root
+ *   cd examples/multi-agent-email-flow
+ *   npm install && npm start
+ */
+
+import { Grantex, verifyGrantToken } from '@grantex/sdk';
+
+const BASE_URL = process.env['GRANTEX_URL'] ?? 'http://localhost:3001';
+const API_KEY = process.env['GRANTEX_API_KEY'] ?? 'sandbox-api-key-local';
+const JWKS_URI = `${BASE_URL}/.well-known/jwks.json`;
+
+// ── Simulated services ──────────────────────────────────────────────
+
+function readCalendar(date: string) {
+  return {
+    events: [
+      { title: 'Team standup', time: '9:00 AM', date },
+      { title: 'Design review', time: '2:00 PM', date },
+      { title: '1:1 with manager', time: '4:00 PM', date },
+    ],
+  };
+}
+
+function sendEmail(to: string, subject: string, body: string) {
+  return {
+    sent: true,
+    messageId: `msg_${Date.now()}`,
+    to,
+    subject,
+    preview: body.slice(0, 60) + '...',
+  };
+}
+
+// ── Main flow ───────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
+
+  // ── 1. Register agents ──────────────────────────────────────────
+  console.log('=== Multi-Agent Email Flow ===\n');
+
+  const plannerAgent = await grantex.agents.register({
+    name: 'email-planner',
+    description: 'Reads calendar and plans email communications',
+    scopes: ['calendar:read', 'email:send'],
+  });
+  console.log('Agent A (planner) registered:', plannerAgent.id);
+
+  const executorAgent = await grantex.agents.register({
+    name: 'email-executor',
+    description: 'Sends emails on behalf of the planner agent',
+    scopes: ['email:send'],
+  });
+  console.log('Agent B (executor) registered:', executorAgent.id);
+
+  // ── 2. Authorize Agent A ────────────────────────────────────────
+  const authRequest = await grantex.authorize({
+    agentId: plannerAgent.id,
+    userId: 'user-alice',
+    scopes: ['calendar:read', 'email:send'],
+  });
+
+  const code = (authRequest as unknown as Record<string, unknown>)['code'] as string;
+  if (!code) {
+    console.error('No code returned — are you using the sandbox API key?');
+    process.exit(1);
+  }
+
+  const plannerToken = await grantex.tokens.exchange({
+    code,
+    agentId: plannerAgent.id,
+  });
+  console.log('\nAgent A grant token:');
+  console.log('  grantId:', plannerToken.grantId);
+  console.log('  scopes: ', plannerToken.scopes.join(', '));
+
+  // ── 3. Agent A reads calendar (scope-verified) ──────────────────
+  console.log('\n--- Agent A: Reading calendar ---');
+
+  const plannerVerified = await verifyGrantToken(plannerToken.grantToken, {
+    jwksUri: JWKS_URI,
+    requiredScopes: ['calendar:read'],
+  });
+  console.log('Scope verified offline: calendar:read');
+  console.log('  principalId:', plannerVerified.principalId);
+
+  const calendar = readCalendar('2026-03-30');
+  console.log('Calendar events found:', calendar.events.length);
+  for (const event of calendar.events) {
+    console.log(`  ${event.time} — ${event.title}`);
+  }
+
+  await grantex.audit.log({
+    agentId: plannerAgent.id,
+    grantId: plannerToken.grantId,
+    action: 'calendar:read',
+    status: 'success',
+    metadata: { eventsFound: calendar.events.length },
+  });
+
+  // ── 4. Agent A delegates email:send to Agent B ──────────────────
+  console.log('\n--- Agent A: Delegating email:send to Agent B ---');
+
+  const delegatedToken = await grantex.grants.delegate({
+    parentGrantToken: plannerToken.grantToken,
+    subAgentId: executorAgent.id,
+    scopes: ['email:send'],  // only email, NOT calendar
+  });
+  console.log('Delegated token issued:');
+  console.log('  grantId:', delegatedToken.grantId);
+  console.log('  scopes: ', delegatedToken.scopes.join(', '));
+
+  const delegatedVerified = await verifyGrantToken(delegatedToken.grantToken, {
+    jwksUri: JWKS_URI,
+  });
+  console.log('  delegationDepth:', delegatedVerified.delegationDepth);
+  if (delegatedVerified.parentAgentDid) {
+    console.log('  parentAgentDid:', delegatedVerified.parentAgentDid);
+  }
+
+  // ── 5. Agent B sends email (delegated scope) ───────────────────
+  console.log('\n--- Agent B: Sending email ---');
+
+  await verifyGrantToken(delegatedToken.grantToken, {
+    jwksUri: JWKS_URI,
+    requiredScopes: ['email:send'],
+  });
+  console.log('Scope verified offline: email:send');
+
+  const summary = calendar.events
+    .map((e) => `${e.title} at ${e.time}`)
+    .join(', ');
+
+  const emailResult = sendEmail(
+    'team@company.com',
+    'Daily schedule summary',
+    `Here is your schedule for today: ${summary}`,
+  );
+  console.log('Email sent:', emailResult.messageId);
+  console.log('  to:     ', emailResult.to);
+  console.log('  subject:', emailResult.subject);
+
+  await grantex.audit.log({
+    agentId: executorAgent.id,
+    grantId: delegatedToken.grantId,
+    action: 'email:send',
+    status: 'success',
+    metadata: { to: emailResult.to, messageId: emailResult.messageId },
+  });
+
+  // ── 6. Failure: Agent B tries unauthorized scope ────────────────
+  console.log('\n--- Failure: Agent B tries calendar:read (not delegated) ---');
+
+  try {
+    await verifyGrantToken(delegatedToken.grantToken, {
+      jwksUri: JWKS_URI,
+      requiredScopes: ['calendar:read'],  // not in delegated scopes!
+    });
+    console.log('ERROR: should not reach here');
+  } catch (err) {
+    console.log('Blocked! Agent B cannot read calendar.');
+    console.log('  Error:', (err as Error).message);
+
+    await grantex.audit.log({
+      agentId: executorAgent.id,
+      grantId: delegatedToken.grantId,
+      action: 'calendar:read',
+      status: 'failure',
+      metadata: { reason: 'scope_not_delegated' },
+    });
+  }
+
+  // ── 7. Failure: Revocation mid-flow (cascade) ──────────────────
+  console.log('\n--- Failure: Revoking Agent A\'s grant (cascade to Agent B) ---');
+
+  // Both tokens are valid before revocation
+  const beforeParent = await grantex.tokens.verify(plannerToken.grantToken);
+  const beforeChild = await grantex.tokens.verify(delegatedToken.grantToken);
+  console.log('Before revocation:');
+  console.log('  Agent A token valid:', beforeParent.valid);
+  console.log('  Agent B token valid:', beforeChild.valid);
+
+  // Revoke the parent grant
+  await grantex.grants.revoke(plannerToken.grantId);
+  console.log('\nParent grant revoked.');
+
+  // Both tokens should now be invalid
+  const afterParent = await grantex.tokens.verify(plannerToken.grantToken);
+  const afterChild = await grantex.tokens.verify(delegatedToken.grantToken);
+  console.log('After revocation:');
+  console.log('  Agent A token valid:', afterParent.valid, '(revoked)');
+  console.log('  Agent B token valid:', afterChild.valid, '(cascade revoked)');
+
+  // Agent B tries to send another email — fails
+  console.log('\nAgent B tries to send email after revocation...');
+  const postRevoke = await grantex.tokens.verify(delegatedToken.grantToken);
+  if (!postRevoke.valid) {
+    console.log('Blocked! Delegated token is no longer valid.');
+    console.log('Recovery: Agent B must request a new delegation from Agent A.');
+
+    await grantex.audit.log({
+      agentId: executorAgent.id,
+      grantId: delegatedToken.grantId,
+      action: 'email:send',
+      status: 'failure',
+      metadata: { reason: 'grant_revoked_cascade' },
+    });
+  }
+
+  // ── 8. Audit trail inspection ──────────────────────────────────
+  console.log('\n--- Audit trail ---');
+
+  const auditLog = await grantex.audit.list({
+    agentId: plannerAgent.id,
+  });
+
+  // Also get executor audit entries
+  const executorAudit = await grantex.audit.list({
+    agentId: executorAgent.id,
+  });
+
+  const allEntries = [...auditLog.entries, ...executorAudit.entries]
+    .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
+  for (const entry of allEntries) {
+    const agent = entry.agentId === plannerAgent.id ? 'Agent A' : 'Agent B';
+    const icon = entry.status === 'success' ? '+' : 'x';
+    console.log(`  [${icon}] ${agent} ${entry.action} — ${entry.status} — ${entry.timestamp}`);
+  }
+
+  console.log(`\nTotal audit entries: ${allEntries.length}`);
+  console.log('  Success:', allEntries.filter((e) => e.status === 'success').length);
+  console.log('  Failure:', allEntries.filter((e) => e.status === 'failure').length);
+
+  console.log('\nDone! Multi-agent email flow with failure handling complete.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/multi-agent-email-flow/tsconfig.json
+++ b/examples/multi-agent-email-flow/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- Adds `examples/multi-agent-email-flow/` — end-to-end two-agent email automation with comprehensive failure handling
- Agent A (planner) reads calendar, delegates `email:send` to Agent B (executor)
- Demonstrates scope enforcement failure (Agent B tries unauthorized `calendar:read`)
- Demonstrates cascade revocation (revoking Agent A invalidates Agent B's delegated token)
- Shows recovery pattern (Agent B detects revoked token, reports need for re-delegation)
- Full audit trail inspection with success/failure timeline
- Includes docs page (`docs/examples/multi-agent-email-flow.mdx`) and navigation updates

## Why

Existing examples cover happy paths only. No example shows error handling, scope rejection recovery, or revocation mid-workflow — the most common questions developers have when adopting Grantex.

## Test plan

- [x] `npx tsc --noEmit` — TypeScript compiles cleanly
- [ ] `docker compose up -d && npm start` — runs full flow against local Grantex stack
- [x] Follows existing example patterns (package.json, README, docs page structure)