### PR TITLE
docs: update audit logging options for autogen, vercel-ai, langchain

### DIFF
--- a/docs/integrations/autogen.mdx
+++ b/docs/integrations/autogen.mdx
@@ -82,7 +82,9 @@ const client = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
 
 const audited = withAuditLogging(readCalendar, client, {
   agentId: 'ag_01ABC...',
+  agentDid: 'did:key:z6Mk...',
   grantId: 'grnt_01XYZ...',
+  principalId: 'user_01',
 });
 // Use audited.execute() — logs success/failure automatically
 ```
@@ -115,7 +117,9 @@ Returns `{ definition, execute }`.
 | Option | Type | Description |
 |--------|------|-------------|
 | `agentId` | `string` | Agent ID for audit attribution |
+| `agentDid` | `string` | Agent DID (e.g. `did:key:z6Mk...`) |
 | `grantId` | `string` | Grant ID for the session |
+| `principalId` | `string` | Principal ID that granted authorization |
 
 ## Requirements
 

--- a/docs/integrations/langchain.mdx
+++ b/docs/integrations/langchain.mdx
@@ -46,6 +46,8 @@ const client = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
 const auditHandler = new GrantexAuditHandler({
   client,
   agentId: 'ag_01ABC...',
+  agentDid: 'did:key:z6Mk...',
+  principalId: 'user_01',
   grantToken,
 });
 
@@ -81,6 +83,8 @@ LangChain callback handler that writes tool invocations to the Grantex audit tra
 |--------|------|-------------|
 | `client` | `Grantex` | Authenticated SDK client |
 | `agentId` | `string` | Agent ID for audit attribution |
+| `agentDid` | `string` | Agent DID (e.g. `did:key:z6Mk...`) |
+| `principalId` | `string` | Principal ID that granted authorization |
 | `grantToken` | `string` | JWT (grant ID extracted from `grnt` or `jti` claim) |
 
 ## Requirements

--- a/docs/integrations/vercel-ai.mdx
+++ b/docs/integrations/vercel-ai.mdx
@@ -64,7 +64,9 @@ const client = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
 
 const audited = withAuditLogging(readCalendar, client, {
   agentId: 'ag_01ABC...',
+  agentDid: 'did:key:z6Mk...',
   grantId: 'grnt_01XYZ...',
+  principalId: 'user_01',
 });
 // Use audited in place of readCalendar
 ```
@@ -93,7 +95,9 @@ Returns `string[]` of scopes from the token's `scp` claim (offline).
 | Option | Type | Description |
 |--------|------|-------------|
 | `agentId` | `string` | Agent ID for audit attribution |
+| `agentDid` | `string` | Agent DID (e.g. `did:key:z6Mk...`) |
 | `grantId` | `string` | Grant ID for the session |
+| `principalId` | `string` | Principal ID that granted authorization |
 | `toolName` | `string?` | Override tool name in audit entries |
 
 ### `GrantexScopeError`


### PR DESCRIPTION
## Summary

Docs pages for autogen, vercel-ai, and langchain still showed the old 2-field audit options (`agentId`, `grantId`). Updated code examples and API reference tables to include the new required `agentDid` and `principalId` fields.

## Test plan

- [x] Verified all three docs pages show correct 4-field options
- [x] Code examples match published package APIs