### PR TITLE
feat(examples): multi-agent email flow with failure handling

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -96,7 +96,8 @@
               "examples/crewai-agent",
               "examples/openai-agents",
               "examples/google-adk",
-              "examples/anthropic-tool-use"
+              "examples/anthropic-tool-use",
+              "examples/multi-agent-email-flow"
             ]
           }
         ]

--- a/docs/examples/multi-agent-email-flow.mdx
+++ b/docs/examples/multi-agent-email-flow.mdx
@@ -1,0 +1,91 @@
+---
+title: "Multi-Agent Email Flow"
+sidebarTitle: "Email Flow"
+description: "Multi-agent delegation with failure handling, cascade revocation, and audit trail."
+---
+
+## What it does
+
+This example demonstrates a realistic two-agent email automation workflow with comprehensive failure handling:
+
+1. **Register two agents** — a planner (Agent A) and an executor (Agent B)
+2. **Agent A reads calendar events** after offline scope verification
+3. **Agent A delegates `email:send`** to Agent B (subset of its own scopes)
+4. **Agent B sends an email** using the delegated, scoped permission
+5. **Failure: unauthorized scope** — Agent B tries `calendar:read` (not delegated) and is rejected immediately
+6. **Failure: cascade revocation** — Agent A's grant is revoked, which automatically invalidates Agent B's delegated token
+7. **Recovery pattern** — Agent B detects the revoked token and reports that a new delegation is needed
+8. **Audit trail inspection** — shows a timeline of all success and failure events across both agents
+
+## Prerequisites
+
+- **Node.js 18+**
+- **Docker** (Docker Desktop or Docker Engine with Compose)
+
+## Run
+
+Start the local Grantex stack from the repository root:
+
+```bash
+docker compose up --build
+```
+
+In a separate terminal, run the example:
+
+```bash
+cd examples/multi-agent-email-flow
+npm install
+npm start
+```
+
+## Expected output
+
+```text
+=== Multi-Agent Email Flow ===
+
+Agent A (planner) registered: ag_01HXYZ...
+Agent B (executor) registered: ag_01HXYZ...
+
+Agent A grant token:
+  grantId: grnt_01HXYZ...
+  scopes:  calendar:read, email:send
+
+--- Agent A: Reading calendar ---
+Scope verified offline: calendar:read
+Calendar events found: 3
+
+--- Agent A: Delegating email:send to Agent B ---
+Delegated token issued:
+  scopes:  email:send
+  delegationDepth: 1
+
+--- Agent B: Sending email ---
+Email sent: msg_1234567890
+
+--- Failure: Agent B tries calendar:read (not delegated) ---
+Blocked! Agent B cannot read calendar.
+
+--- Failure: Revoking Agent A's grant (cascade to Agent B) ---
+After revocation:
+  Agent A token valid: false (revoked)
+  Agent B token valid: false (cascade revoked)
+
+--- Audit trail ---
+  [+] Agent A calendar:read — success
+  [+] Agent B email:send — success
+  [x] Agent B calendar:read — failure
+  [x] Agent B email:send — failure
+
+Done! Multi-agent email flow with failure handling complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |
+
+## Source code
+
+The full source is in [`examples/multi-agent-email-flow/src/index.ts`](https://github.com/mishrasanjeev/grantex/tree/main/examples/multi-agent-email-flow).

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,7 @@ All examples use the sandbox key by default.
 | [`nextjs-starter`](./nextjs-starter/) | Next.js interactive consent flow with callback handling | `@grantex/sdk` |
 | [`openai-agents`](./openai-agents/) | OpenAI Agents SDK with scope enforcement | `grantex`, `grantex-openai-agents` |
 | [`google-adk`](./google-adk/) | Google ADK with scoped function tools | `grantex`, `grantex-adk` |
+| [`multi-agent-email-flow`](./multi-agent-email-flow/) | Multi-agent delegation with failure handling and audit trail | `@grantex/sdk` |
 
 ## Running an example
 

--- a/examples/multi-agent-email-flow/README.md
+++ b/examples/multi-agent-email-flow/README.md
@@ -1,0 +1,80 @@
+# Multi-Agent Email Flow
+
+End-to-end multi-agent email automation with delegation, scope enforcement, failure handling, cascade revocation, and audit trail inspection.
+
+## What it does
+
+1. **Registers two agents** — Agent A (planner) with `calendar:read` + `email:send`, Agent B (executor) with `email:send`
+2. **Agent A obtains a grant token** via the sandbox flow
+3. **Agent A reads calendar events** with offline scope verification
+4. **Agent A delegates `email:send` only** to Agent B (not `calendar:read`)
+5. **Agent B sends an email** using the delegated scope
+6. **Failure: unauthorized scope** — Agent B tries `calendar:read` and is rejected
+7. **Failure: cascade revocation** — Agent A's grant is revoked, Agent B's delegated token becomes invalid
+8. **Recovery pattern** — Agent B detects revoked token, reports need for re-delegation
+9. **Audit trail** — inspects all logged actions showing the success/failure timeline
+
+## Prerequisites
+
+- Node.js 18+
+- Docker (for the local Grantex stack)
+
+## Run
+
+```bash
+# Start the local Grantex stack (from repo root)
+docker compose up -d
+
+# Run the example
+cd examples/multi-agent-email-flow
+npm install
+npm start
+```
+
+## Expected output
+
+```
+=== Multi-Agent Email Flow ===
+
+Agent A (planner) registered: ag_01...
+Agent B (executor) registered: ag_01...
+
+Agent A grant token:
+  grantId: grnt_01...
+  scopes:  calendar:read, email:send
+
+--- Agent A: Reading calendar ---
+Scope verified offline: calendar:read
+Calendar events found: 3
+
+--- Agent A: Delegating email:send to Agent B ---
+Delegated token issued:
+  scopes:  email:send
+  delegationDepth: 1
+
+--- Agent B: Sending email ---
+Email sent: msg_...
+
+--- Failure: Agent B tries calendar:read (not delegated) ---
+Blocked! Agent B cannot read calendar.
+
+--- Failure: Revoking Agent A's grant (cascade to Agent B) ---
+After revocation:
+  Agent A token valid: false (revoked)
+  Agent B token valid: false (cascade revoked)
+
+--- Audit trail ---
+  [+] Agent A calendar:read — success
+  [+] Agent B email:send — success
+  [x] Agent B calendar:read — failure
+  [x] Agent B email:send — failure
+
+Done! Multi-agent email flow with failure handling complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `GRANTEX_URL` | `http://localhost:3001` | Auth service base URL |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key (sandbox mode) |

--- a/examples/multi-agent-email-flow/package.json
+++ b/examples/multi-agent-email-flow/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "grantex-example-multi-agent-email-flow",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "npx tsx src/index.ts"
+  },
+  "dependencies": {
+    "@grantex/sdk": ">=0.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/examples/multi-agent-email-flow/src/index.ts
+++ b/examples/multi-agent-email-flow/src/index.ts
@@ -1,0 +1,267 @@
+/**
+ * Grantex Multi-Agent Email Flow — Failure & Recovery Patterns
+ *
+ * Demonstrates a realistic two-agent email automation workflow with
+ * comprehensive error handling and failure recovery:
+ *
+ *   1. Register a planner agent (Agent A) and an executor agent (Agent B)
+ *   2. Agent A obtains a grant with calendar:read + email:send scopes
+ *   3. Agent A reads calendar events (simulated) with scope verification
+ *   4. Agent A delegates only email:send to Agent B
+ *   5. Agent B sends email (simulated) using delegated scope
+ *   6. Failure: Agent B tries calendar:read (not delegated) — rejected
+ *   7. Failure: Parent grant revoked — Agent B's delegated token cascades
+ *   8. Full audit trail inspection showing success + failure timeline
+ *
+ * Prerequisites:
+ *   docker compose up          # from repo root
+ *   cd examples/multi-agent-email-flow
+ *   npm install && npm start
+ */
+
+import { Grantex, verifyGrantToken } from '@grantex/sdk';
+
+const BASE_URL = process.env['GRANTEX_URL'] ?? 'http://localhost:3001';
+const API_KEY = process.env['GRANTEX_API_KEY'] ?? 'sandbox-api-key-local';
+const JWKS_URI = `${BASE_URL}/.well-known/jwks.json`;
+
+// ── Simulated services ──────────────────────────────────────────────
+
+function readCalendar(date: string) {
+  return {
+    events: [
+      { title: 'Team standup', time: '9:00 AM', date },
+      { title: 'Design review', time: '2:00 PM', date },
+      { title: '1:1 with manager', time: '4:00 PM', date },
+    ],
+  };
+}
+
+function sendEmail(to: string, subject: string, body: string) {
+  return {
+    sent: true,
+    messageId: `msg_${Date.now()}`,
+    to,
+    subject,
+    preview: body.slice(0, 60) + '...',
+  };
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Handle agent.id vs agentId API response gotcha */
+function getAgentId(agent: Record<string, unknown>): string {
+  return (agent['id'] ?? agent['agentId']) as string;
+}
+
+// ── Main flow ───────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
+
+  // ── 1. Register agents ──────────────────────────────────────────
+  console.log('=== Multi-Agent Email Flow ===\n');
+
+  const plannerRaw = await grantex.agents.register({
+    name: 'email-planner',
+    description: 'Reads calendar and plans email communications',
+    scopes: ['calendar:read', 'email:send'],
+  });
+  const plannerId = getAgentId(plannerRaw as unknown as Record<string, unknown>);
+  const plannerDid = (plannerRaw as unknown as Record<string, unknown>)['did'] as string ?? `did:grantex:${plannerId}`;
+  console.log('Agent A (planner) registered:', plannerId);
+
+  const executorRaw = await grantex.agents.register({
+    name: 'email-executor',
+    description: 'Sends emails on behalf of the planner agent',
+    scopes: ['email:send'],
+  });
+  const executorId = getAgentId(executorRaw as unknown as Record<string, unknown>);
+  const executorDid = (executorRaw as unknown as Record<string, unknown>)['did'] as string ?? `did:grantex:${executorId}`;
+  console.log('Agent B (executor) registered:', executorId);
+
+  // ── 2. Authorize Agent A ────────────────────────────────────────
+  const authRequest = await grantex.authorize({
+    agentId: plannerId,
+    userId: 'user-alice',
+    scopes: ['calendar:read', 'email:send'],
+  });
+
+  const code = (authRequest as unknown as Record<string, unknown>)['code'] as string;
+  if (!code) {
+    console.error('No code returned — are you using the sandbox API key?');
+    process.exit(1);
+  }
+
+  const plannerToken = await grantex.tokens.exchange({
+    code,
+    agentId: plannerId,
+  });
+  console.log('\nAgent A grant token:');
+  console.log('  grantId:', plannerToken.grantId);
+  console.log('  scopes: ', plannerToken.scopes.join(', '));
+
+  // ── 3. Agent A reads calendar (scope-verified) ──────────────────
+  console.log('\n--- Agent A: Reading calendar ---');
+
+  const plannerVerified = await verifyGrantToken(plannerToken.grantToken, {
+    jwksUri: JWKS_URI,
+    requiredScopes: ['calendar:read'],
+  });
+  console.log('Scope verified offline: calendar:read');
+  console.log('  principalId:', plannerVerified.principalId);
+
+  const calendar = readCalendar('2026-03-30');
+  console.log('Calendar events found:', calendar.events.length);
+  for (const event of calendar.events) {
+    console.log(`  ${event.time} — ${event.title}`);
+  }
+
+  await grantex.audit.log({
+    agentId: plannerId,
+    agentDid: plannerDid,
+    grantId: plannerToken.grantId,
+    principalId: 'user-alice',
+    action: 'calendar:read',
+    status: 'success',
+    metadata: { eventsFound: calendar.events.length },
+  });
+
+  // ── 4. Agent A delegates email:send to Agent B ──────────────────
+  console.log('\n--- Agent A: Delegating email:send to Agent B ---');
+
+  const delegatedToken = await grantex.grants.delegate({
+    parentGrantToken: plannerToken.grantToken,
+    subAgentId: executorId,
+    scopes: ['email:send'],  // only email, NOT calendar
+  });
+  console.log('Delegated token issued:');
+  console.log('  grantId:', delegatedToken.grantId);
+  console.log('  scopes: ', delegatedToken.scopes.join(', '));
+
+  const delegatedVerified = await verifyGrantToken(delegatedToken.grantToken, {
+    jwksUri: JWKS_URI,
+  });
+  console.log('  delegationDepth:', delegatedVerified.delegationDepth);
+  if (delegatedVerified.parentAgentDid) {
+    console.log('  parentAgentDid:', delegatedVerified.parentAgentDid);
+  }
+
+  // ── 5. Agent B sends email (delegated scope) ───────────────────
+  console.log('\n--- Agent B: Sending email ---');
+
+  await verifyGrantToken(delegatedToken.grantToken, {
+    jwksUri: JWKS_URI,
+    requiredScopes: ['email:send'],
+  });
+  console.log('Scope verified offline: email:send');
+
+  const summary = calendar.events
+    .map((e) => `${e.title} at ${e.time}`)
+    .join(', ');
+
+  const emailResult = sendEmail(
+    'team@company.com',
+    'Daily schedule summary',
+    `Here is your schedule for today: ${summary}`,
+  );
+  console.log('Email sent:', emailResult.messageId);
+  console.log('  to:     ', emailResult.to);
+  console.log('  subject:', emailResult.subject);
+
+  await grantex.audit.log({
+    agentId: executorId,
+    agentDid: executorDid,
+    grantId: delegatedToken.grantId,
+    principalId: 'user-alice',
+    action: 'email:send',
+    status: 'success',
+    metadata: { to: emailResult.to, messageId: emailResult.messageId },
+  });
+
+  // ── 6. Failure: Agent B tries unauthorized scope ────────────────
+  console.log('\n--- Failure: Agent B tries calendar:read (not delegated) ---');
+
+  try {
+    await verifyGrantToken(delegatedToken.grantToken, {
+      jwksUri: JWKS_URI,
+      requiredScopes: ['calendar:read'],  // not in delegated scopes!
+    });
+    console.log('ERROR: should not reach here');
+  } catch (err) {
+    console.log('Blocked! Agent B cannot read calendar.');
+    console.log('  Error:', (err as Error).message);
+
+    await grantex.audit.log({
+      agentId: executorId,
+      agentDid: executorDid,
+      grantId: delegatedToken.grantId,
+      principalId: 'user-alice',
+      action: 'calendar:read',
+      status: 'failure',
+      metadata: { reason: 'scope_not_delegated' },
+    });
+  }
+
+  // ── 7. Failure: Revocation mid-flow (cascade) ──────────────────
+  console.log('\n--- Failure: Revoking Agent A\'s grant (cascade to Agent B) ---');
+
+  const beforeParent = await grantex.tokens.verify(plannerToken.grantToken);
+  const beforeChild = await grantex.tokens.verify(delegatedToken.grantToken);
+  console.log('Before revocation:');
+  console.log('  Agent A token valid:', beforeParent.valid);
+  console.log('  Agent B token valid:', beforeChild.valid);
+
+  await grantex.grants.revoke(plannerToken.grantId);
+  console.log('\nParent grant revoked.');
+
+  const afterParent = await grantex.tokens.verify(plannerToken.grantToken);
+  const afterChild = await grantex.tokens.verify(delegatedToken.grantToken);
+  console.log('After revocation:');
+  console.log('  Agent A token valid:', afterParent.valid, '(revoked)');
+  console.log('  Agent B token valid:', afterChild.valid, '(cascade revoked)');
+
+  // Agent B tries to send another email — fails
+  console.log('\nAgent B tries to send email after revocation...');
+  const postRevoke = await grantex.tokens.verify(delegatedToken.grantToken);
+  if (!postRevoke.valid) {
+    console.log('Blocked! Delegated token is no longer valid.');
+    console.log('Recovery: Agent B must request a new delegation from Agent A.');
+
+    await grantex.audit.log({
+      agentId: executorId,
+      agentDid: executorDid,
+      grantId: delegatedToken.grantId,
+      principalId: 'user-alice',
+      action: 'email:send',
+      status: 'failure',
+      metadata: { reason: 'grant_revoked_cascade' },
+    });
+  }
+
+  // ── 8. Audit trail inspection ──────────────────────────────────
+  console.log('\n--- Audit trail ---');
+
+  const plannerAudit = await grantex.audit.list({ agentId: plannerId });
+  const executorAudit = await grantex.audit.list({ agentId: executorId });
+
+  const allEntries = [...plannerAudit.entries, ...executorAudit.entries]
+    .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
+  for (const entry of allEntries) {
+    const agent = entry.agentId === plannerId ? 'Agent A' : 'Agent B';
+    const icon = entry.status === 'success' ? '+' : 'x';
+    console.log(`  [${icon}] ${agent} ${entry.action} — ${entry.status} — ${entry.timestamp}`);
+  }
+
+  console.log(`\nTotal audit entries: ${allEntries.length}`);
+  console.log('  Success:', allEntries.filter((e) => e.status === 'success').length);
+  console.log('  Failure:', allEntries.filter((e) => e.status === 'failure').length);
+
+  console.log('\nDone! Multi-agent email flow with failure handling complete.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/multi-agent-email-flow/tsconfig.json
+++ b/examples/multi-agent-email-flow/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- Adds `examples/multi-agent-email-flow/` — two-agent email automation with delegation, scope enforcement failure, cascade revocation, and recovery patterns
- Agent A (planner) reads calendar, delegates `email:send` to Agent B (executor)
- Demonstrates: unauthorized scope rejection, cascade revocation, recovery detection, full audit trail
- Includes docs page and navigation updates

Inspired by @bankyresearch's proposal in #225. Thanks for the great idea!

## Fixes applied vs #225

- `audit.log()` calls include all 4 required fields (`agentId`, `agentDid`, `grantId`, `principalId`)
- Handles `agent.id` vs `agentId` API response gotcha
- SDK constraint bumped from `^0.1.6` to `>=0.2.0`
- No `package-lock.json` committed

## Test plan

- [x] TypeScript compiles cleanly
- [x] E2E verified against production (`grantex-auth-dd4mtrt2gq-uc.a.run.app`)
- [x] All 8 steps pass: registration, delegation, scope check, email send, unauthorized rejection, cascade revocation, recovery, audit trail (4 entries: 2 success, 2 failure)