### PR TITLE
feat(examples): token expiry and refresh lifecycle

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -97,7 +97,9 @@
               "examples/openai-agents",
               "examples/google-adk",
               "examples/anthropic-tool-use",
-              "examples/multi-agent-email-flow"
+              "examples/multi-agent-email-flow",
+              "examples/token-expiry-refresh",
+              "examples/audit-dashboard"
             ]
           }
         ]

--- a/docs/examples/token-expiry-refresh.mdx
+++ b/docs/examples/token-expiry-refresh.mdx
@@ -1,0 +1,88 @@
+---
+title: "Token Expiry & Refresh"
+sidebarTitle: "Token Expiry"
+description: "Time-bound grants with expiry detection and refresh token rotation."
+---
+
+## What it does
+
+This example demonstrates the complete token expiry and refresh lifecycle:
+
+1. **Authorize with a short-lived token** (10 seconds) using the `expiresIn` parameter
+2. **Use the token** successfully before it expires (offline + online verification)
+3. **Wait for expiry** — observe the token becoming invalid
+4. **Detect expiry** — offline verification throws, online returns `valid: false`
+5. **Refresh the token** — get a new JWT with the same `grantId` and fresh expiry
+6. **Use the refreshed token** — verify it works with full scope access
+7. **Refresh token rotation** — demonstrate that old refresh tokens are single-use
+
+## Prerequisites
+
+- **Node.js 18+**
+- **Docker** (Docker Desktop or Docker Engine with Compose)
+
+## Run
+
+Start the local Grantex stack from the repository root:
+
+```bash
+docker compose up --build
+```
+
+In a separate terminal, run the example:
+
+```bash
+cd examples/token-expiry-refresh
+npm install
+npm start
+```
+
+## Expected output
+
+```text
+=== Token Expiry & Refresh Demo ===
+
+Agent registered: ag_01HXYZ...
+
+--- Authorizing with 10s TTL ---
+Grant token received:
+  expiresAt: 2026-03-30T12:00:10.000Z
+  refreshToken: ref_01HXYZ...
+
+--- Using token before expiry ---
+Offline verification: PASSED
+Online verification:  valid = true
+
+--- Waiting 12s for token to expire ---
+  Token should now be expired.
+
+--- Detecting expiry ---
+Offline verification: EXPIRED
+Online verification:  valid = false (expected: false)
+
+--- Refreshing token ---
+Token refreshed successfully!
+  grantId: grnt_01... (same as original)
+
+--- Using refreshed token ---
+Offline verification: PASSED
+Online verification:  valid = true
+
+--- Refresh token rotation (single-use enforcement) ---
+Blocked! Old refresh token rejected.
+  Reason: Refresh tokens are single-use and rotate on each refresh.
+
+Done! Token expiry and refresh lifecycle complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |
+| `TOKEN_TTL` | `10s` | Grant token time-to-live (e.g. `10s`, `1m`, `1h`) |
+
+## Source code
+
+The full source is in [`examples/token-expiry-refresh/src/index.ts`](https://github.com/mishrasanjeev/grantex/tree/main/examples/token-expiry-refresh).

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,8 @@ All examples use the sandbox key by default.
 | [`nextjs-starter`](./nextjs-starter/) | Next.js interactive consent flow with callback handling | `@grantex/sdk` |
 | [`openai-agents`](./openai-agents/) | OpenAI Agents SDK with scope enforcement | `grantex`, `grantex-openai-agents` |
 | [`google-adk`](./google-adk/) | Google ADK with scoped function tools | `grantex`, `grantex-adk` |
+| [`token-expiry-refresh`](./token-expiry-refresh/) | Time-bound grants with expiry detection and refresh token rotation | `@grantex/sdk` |
+| [`audit-dashboard`](./audit-dashboard/) | Audit trail querying, filtering, metrics, and hash chain verification | `@grantex/sdk` |
 | [`multi-agent-email-flow`](./multi-agent-email-flow/) | Multi-agent delegation with failure handling and audit trail | `@grantex/sdk` |
 
 ## Running an example

--- a/examples/token-expiry-refresh/README.md
+++ b/examples/token-expiry-refresh/README.md
@@ -1,0 +1,82 @@
+# Token Expiry & Refresh
+
+Demonstrates time-bound grant tokens with automatic expiry detection and refresh token rotation.
+
+## What it does
+
+1. **Registers an agent** and authorizes with a short-lived token (10 seconds)
+2. **Uses the token** successfully before expiry (offline + online verification)
+3. **Waits for expiry** with a visible countdown
+4. **Detects expiry** — offline verification throws, online verification returns `valid: false`
+5. **Refreshes the token** — gets a new JWT with the same `grantId`
+6. **Uses the refreshed token** — verifies it works with full scope access
+7. **Refresh token rotation** — old refresh token is rejected (single-use enforcement)
+
+## Prerequisites
+
+- Node.js 18+
+- Docker (for the local Grantex stack)
+
+## Run
+
+```bash
+# Start the local Grantex stack (from repo root)
+docker compose up -d
+
+# Run the example
+cd examples/token-expiry-refresh
+npm install
+npm start
+```
+
+## Expected output
+
+```
+=== Token Expiry & Refresh Demo ===
+
+Agent registered: ag_01...
+
+--- Authorizing with 10s TTL ---
+Grant token received:
+  grantId:      grnt_01...
+  scopes:       calendar:read, email:send
+  expiresAt:    2026-03-30T12:00:10.000Z
+  refreshToken: ref_01HXYZ...
+
+--- Using token before expiry ---
+Offline verification: PASSED
+Online verification:  valid = true
+
+--- Waiting 12s for token to expire ---
+  Token should now be expired.
+
+--- Detecting expiry ---
+Offline verification: EXPIRED
+  Error: "exp" claim timestamp check failed
+Online verification:  valid = false (expected: false)
+
+--- Refreshing token ---
+Token refreshed successfully!
+  grantId:       grnt_01... (same as original)
+  new expiresAt: 2026-03-30T12:00:22.000Z
+  scopes:        calendar:read, email:send
+
+--- Using refreshed token ---
+Offline verification: PASSED
+Online verification:  valid = true
+
+--- Refresh token rotation (single-use enforcement) ---
+Attempting to reuse the old refresh token...
+Blocked! Old refresh token rejected.
+  Reason: Refresh tokens are single-use and rotate on each refresh.
+
+Done! Token expiry and refresh lifecycle complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |
+| `TOKEN_TTL` | `10s` | Grant token time-to-live (e.g. `10s`, `1m`, `1h`) |

--- a/examples/token-expiry-refresh/package-lock.json
+++ b/examples/token-expiry-refresh/package-lock.json
@@ -1,0 +1,576 @@
+{
+  "name": "grantex-example-token-expiry-refresh",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "grantex-example-token-expiry-refresh",
+      "dependencies": {
+        "@grantex/sdk": ">=0.2.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsx": "^4.7.0",
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@grantex/sdk": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@grantex/sdk/-/sdk-0.2.6.tgz",
+      "integrity": "sha512-b4aJ8ye715WQXuQlGwhv34w6rvR1PkYbmMOjhEeyGQcCVnTIJ9jYiKLRHULc7mpi+YfLbCayiv4Rl+8652RmHg==",
+      "dependencies": {
+        "jose": "^5.2.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    }
+  }
+}

--- a/examples/token-expiry-refresh/package.json
+++ b/examples/token-expiry-refresh/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "grantex-example-token-expiry-refresh",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "npx tsx src/index.ts"
+  },
+  "dependencies": {
+    "@grantex/sdk": ">=0.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/examples/token-expiry-refresh/src/index.ts
+++ b/examples/token-expiry-refresh/src/index.ts
@@ -1,0 +1,163 @@
+/**
+ * Grantex Token Expiry & Refresh — Time-Bound Grants
+ *
+ * Demonstrates how to work with short-lived grant tokens and the
+ * refresh token rotation pattern:
+ *
+ *   1. Register an agent and authorize with a short-lived token (10s)
+ *   2. Use the token successfully before it expires
+ *   3. Wait for the token to expire, detect expiry (offline + online)
+ *   4. Refresh the expired token — get a new JWT with the same grantId
+ *   5. Use the refreshed token successfully
+ *   6. Demonstrate refresh token rotation (old refresh token is single-use)
+ *
+ * Prerequisites:
+ *   docker compose up          # from repo root
+ *   cd examples/token-expiry-refresh
+ *   npm install && npm start
+ */
+
+import { Grantex, verifyGrantToken } from '@grantex/sdk';
+
+const BASE_URL = process.env['GRANTEX_URL'] ?? 'http://localhost:3001';
+const API_KEY = process.env['GRANTEX_API_KEY'] ?? 'sandbox-api-key-local';
+const JWKS_URI = `${BASE_URL}/.well-known/jwks.json`;
+
+const TOKEN_TTL = process.env['TOKEN_TTL'] ?? '10s';
+
+/** Handle agent.id vs agentId API response gotcha */
+function getAgentId(agent: Record<string, unknown>): string {
+  return (agent['id'] ?? agent['agentId']) as string;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main(): Promise<void> {
+  const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
+
+  // ── 1. Register agent ──────────────────────────────────────────
+  console.log('=== Token Expiry & Refresh Demo ===\n');
+
+  const agentRaw = await grantex.agents.register({
+    name: 'time-sensitive-agent',
+    description: 'Agent with a short-lived grant token for expiry demo',
+    scopes: ['calendar:read', 'email:send'],
+  });
+  const agentId = getAgentId(agentRaw as unknown as Record<string, unknown>);
+  console.log('Agent registered:', agentId);
+
+  // ── 2. Authorize with short-lived token ────────────────────────
+  console.log(`\n--- Authorizing with ${TOKEN_TTL} TTL ---`);
+
+  const authRequest = await grantex.authorize({
+    agentId,
+    userId: 'user-alice',
+    scopes: ['calendar:read', 'email:send'],
+    expiresIn: TOKEN_TTL,
+  });
+
+  const code = (authRequest as unknown as Record<string, unknown>)['code'] as string;
+  if (!code) {
+    console.error('No code returned — are you using the sandbox API key?');
+    process.exit(1);
+  }
+
+  const tokenResponse = await grantex.tokens.exchange({ code, agentId });
+  console.log('Grant token received:');
+  console.log('  grantId:     ', tokenResponse.grantId);
+  console.log('  scopes:      ', tokenResponse.scopes.join(', '));
+  console.log('  expiresAt:   ', tokenResponse.expiresAt);
+  console.log('  refreshToken:', tokenResponse.refreshToken.slice(0, 12) + '...');
+
+  const savedRefreshToken = tokenResponse.refreshToken;
+
+  // ── 3. Use token before expiry ─────────────────────────────────
+  console.log('\n--- Using token before expiry ---');
+
+  const verified = await verifyGrantToken(tokenResponse.grantToken, {
+    jwksUri: JWKS_URI,
+    requiredScopes: ['calendar:read'],
+  });
+  console.log('Offline verification: PASSED');
+  console.log('  principalId:', verified.principalId);
+  console.log('  scopes:     ', verified.scopes.join(', '));
+
+  const onlineCheck = await grantex.tokens.verify(tokenResponse.grantToken);
+  console.log('Online verification:  valid =', onlineCheck.valid);
+
+  // ── 4. Wait for expiry ─────────────────────────────────────────
+  const ttlSeconds = parseInt(TOKEN_TTL.replace(/[^0-9]/g, ''), 10);
+  const waitMs = (ttlSeconds + 2) * 1000;  // wait TTL + 2s buffer
+
+  console.log(`\n--- Waiting ${ttlSeconds + 2}s for token to expire ---`);
+  for (let i = ttlSeconds + 2; i > 0; i--) {
+    process.stdout.write(`  ${i}s remaining...\r`);
+    await sleep(1000);
+  }
+  console.log('  Token should now be expired.       ');
+
+  // Detect expiry offline
+  console.log('\n--- Detecting expiry ---');
+  try {
+    await verifyGrantToken(tokenResponse.grantToken, { jwksUri: JWKS_URI });
+    console.log('ERROR: should not reach here');
+  } catch (err) {
+    console.log('Offline verification: EXPIRED');
+    console.log('  Error:', (err as Error).message);
+  }
+
+  // Detect expiry online
+  const expiredCheck = await grantex.tokens.verify(tokenResponse.grantToken);
+  console.log('Online verification:  valid =', expiredCheck.valid, '(expected: false)');
+
+  // ── 5. Refresh the token ───────────────────────────────────────
+  console.log('\n--- Refreshing token ---');
+
+  const refreshed = await grantex.tokens.refresh({
+    refreshToken: savedRefreshToken,
+    agentId,
+  });
+  console.log('Token refreshed successfully!');
+  console.log('  grantId:      ', refreshed.grantId, '(same as original)');
+  console.log('  new expiresAt:', refreshed.expiresAt);
+  console.log('  scopes:       ', refreshed.scopes.join(', '));
+
+  // ── 6. Use refreshed token ─────────────────────────────────────
+  console.log('\n--- Using refreshed token ---');
+
+  const refreshedVerified = await verifyGrantToken(refreshed.grantToken, {
+    jwksUri: JWKS_URI,
+    requiredScopes: ['calendar:read', 'email:send'],
+  });
+  console.log('Offline verification: PASSED');
+  console.log('  tokenId:', refreshedVerified.tokenId);
+  console.log('  scopes: ', refreshedVerified.scopes.join(', '));
+
+  const refreshedOnline = await grantex.tokens.verify(refreshed.grantToken);
+  console.log('Online verification:  valid =', refreshedOnline.valid);
+
+  // ── 7. Refresh token rotation (single-use) ────────────────────
+  console.log('\n--- Refresh token rotation (single-use enforcement) ---');
+  console.log('Attempting to reuse the old refresh token...');
+
+  try {
+    await grantex.tokens.refresh({
+      refreshToken: savedRefreshToken,  // already used!
+      agentId,
+    });
+    console.log('ERROR: should not reach here');
+  } catch (err) {
+    console.log('Blocked! Old refresh token rejected.');
+    console.log('  Error:', (err as Error).message);
+    console.log('  Reason: Refresh tokens are single-use and rotate on each refresh.');
+  }
+
+  console.log('\nDone! Token expiry and refresh lifecycle complete.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/token-expiry-refresh/tsconfig.json
+++ b/examples/token-expiry-refresh/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- Adds `examples/token-expiry-refresh/` — demonstrates time-bound grant tokens with short TTL, expiry detection, and refresh token rotation
- Shows offline expiry detection (`verifyGrantToken` throws on expired JWT) and online detection (`tokens.verify` returns `valid: false`)
- Demonstrates `tokens.refresh()` with same `grantId` preserved across refreshes
- Shows single-use refresh token enforcement (old token rejected after rotation)
- Includes docs page and examples listing update

## Why

No existing example covers token expiry or refresh patterns. Developers frequently ask how to handle expired tokens and when to refresh — this fills that gap.

## Test plan

- [x] `npx tsc --noEmit` — TypeScript compiles cleanly
- [ ] `docker compose up -d && npm start` — runs full flow with 10s TTL countdown
- [x] Follows existing example patterns (sandbox mode, `getAgentId` helper, ASCII separators)