### PR TITLE
feat(examples): audit dashboard with filtering, metrics, and hash chain verification

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -97,7 +97,8 @@
               "examples/openai-agents",
               "examples/google-adk",
               "examples/anthropic-tool-use",
-              "examples/multi-agent-email-flow"
+              "examples/multi-agent-email-flow",
+              "examples/audit-dashboard"
             ]
           }
         ]

--- a/docs/examples/audit-dashboard.mdx
+++ b/docs/examples/audit-dashboard.mdx
@@ -1,0 +1,82 @@
+---
+title: "Audit Dashboard"
+sidebarTitle: "Audit Dashboard"
+description: "Query, filter, and analyze the Grantex audit trail with metrics and hash chain verification."
+---
+
+## What it does
+
+This example demonstrates how to use the Grantex audit trail as a rich data source:
+
+1. **Set up two agents** with different scopes and generate grant tokens
+2. **Generate audit entries** — a mix of success, failure, and blocked statuses across agents
+3. **Display full audit timeline** — formatted table with status icons, agent names, and timestamps
+4. **Filter by agent** — show entries for each agent separately
+5. **Filter by action** — show only specific actions (e.g. `email:send`) with metadata
+6. **Compute metrics** — success rate, failure rate, entries per agent, top actions by frequency
+7. **Verify hash chain integrity** — walk the cryptographic chain to confirm tamper evidence
+
+## Prerequisites
+
+- **Node.js 18+**
+- **Docker** (Docker Desktop or Docker Engine with Compose)
+
+## Run
+
+Start the local Grantex stack from the repository root:
+
+```bash
+docker compose up --build
+```
+
+In a separate terminal, run the example:
+
+```bash
+cd examples/audit-dashboard
+npm install
+npm start
+```
+
+## Expected output
+
+```text
+=== Audit Dashboard Demo ===
+
+Agent A (data-reader) registered: ag_01HXYZ...
+Agent B (notifier) registered: ag_01HXYZ...
+Both agents authorized.
+
+--- Generating audit entries ---
+Generated 9 audit entries.
+
+--- Full Audit Timeline ---
+
+  #  Status    Agent          Action              Time
+   1 [+] success data-reader    data:read           12:00:01
+   2 [+] success data-reader    calendar:read       12:00:01
+   ...
+   8 [!] blocked notifier       email:send          12:00:02
+   9 [x] failure data-reader    calendar:write      12:00:02
+
+--- Metrics Summary ---
+  Total entries:  9
+  Success:        6 (67%)
+  Failure:        2 (22%)
+  Blocked:        1 (11%)
+
+--- Hash Chain Integrity Check ---
+  All hash chains verified: integrity PASSED
+
+Done! Audit dashboard demo complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |
+
+## Source code
+
+The full source is in [`examples/audit-dashboard/src/index.ts`](https://github.com/mishrasanjeev/grantex/tree/main/examples/audit-dashboard).

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,7 @@ All examples use the sandbox key by default.
 | [`nextjs-starter`](./nextjs-starter/) | Next.js interactive consent flow with callback handling | `@grantex/sdk` |
 | [`openai-agents`](./openai-agents/) | OpenAI Agents SDK with scope enforcement | `grantex`, `grantex-openai-agents` |
 | [`google-adk`](./google-adk/) | Google ADK with scoped function tools | `grantex`, `grantex-adk` |
+| [`audit-dashboard`](./audit-dashboard/) | Audit trail querying, filtering, metrics, and hash chain verification | `@grantex/sdk` |
 | [`multi-agent-email-flow`](./multi-agent-email-flow/) | Multi-agent delegation with failure handling and audit trail | `@grantex/sdk` |
 
 ## Running an example

--- a/examples/audit-dashboard/README.md
+++ b/examples/audit-dashboard/README.md
@@ -1,0 +1,95 @@
+# Audit Dashboard
+
+Demonstrates how to query, filter, and analyze the Grantex audit trail with metrics computation and hash chain integrity verification.
+
+## What it does
+
+1. **Sets up two agents** with different scopes and generates grant tokens
+2. **Generates 9 audit entries** — a mix of success, failure, and blocked statuses
+3. **Displays full audit timeline** — formatted table with status icons, agent names, and timestamps
+4. **Filters by agent** — shows entries for each agent separately
+5. **Filters by action** — shows only `email:send` entries with metadata
+6. **Computes metrics** — success rate, entries per agent, top actions by frequency
+7. **Verifies hash chain integrity** — walks the chain to confirm tamper evidence
+
+## Prerequisites
+
+- Node.js 18+
+- Docker (for the local Grantex stack)
+
+## Run
+
+```bash
+# Start the local Grantex stack (from repo root)
+docker compose up -d
+
+# Run the example
+cd examples/audit-dashboard
+npm install
+npm start
+```
+
+## Expected output
+
+```
+=== Audit Dashboard Demo ===
+
+Agent A (data-reader) registered: ag_01...
+Agent B (notifier) registered: ag_01...
+Both agents authorized.
+
+--- Generating audit entries ---
+Generated 9 audit entries (5 success, 2 failure, 1 blocked, 1 more success).
+
+--- Full Audit Timeline ---
+
+  #  Status    Agent          Action              Time
+  -  ------    -----          ------              ----
+   1 [+] success data-reader    data:read           12:00:01
+   2 [+] success data-reader    calendar:read       12:00:01
+   3 [+] success data-reader    data:read           12:00:01
+   4 [x] failure data-reader    data:write          12:00:01
+   5 [+] success notifier       email:send          12:00:01
+   6 [+] success notifier       notification:push   12:00:01
+   7 [+] success notifier       email:send          12:00:01
+   8 [!] blocked notifier       email:send          12:00:02
+   9 [x] failure data-reader    calendar:write      12:00:02
+
+--- Filter: Agent A (data-reader) only ---
+  Entries: 5
+
+--- Filter: Agent B (notifier) only ---
+  Entries: 4
+
+--- Filter: email:send actions only ---
+  Entries: 3
+
+--- Metrics Summary ---
+  Total entries:  9
+  Success:        6 (67%)
+  Failure:        2 (22%)
+  Blocked:        1 (11%)
+
+  Entries per agent:
+    data-reader: 5
+    notifier: 4
+
+  Top actions:
+    email:send: 3
+    data:read: 2
+    calendar:read: 1
+    ...
+
+--- Hash Chain Integrity Check ---
+  All hash chains verified: integrity PASSED
+  Chain length: 9 entries
+
+Done! Audit dashboard demo complete.
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
+| `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |

--- a/examples/audit-dashboard/package-lock.json
+++ b/examples/audit-dashboard/package-lock.json
@@ -1,0 +1,576 @@
+{
+  "name": "grantex-example-audit-dashboard",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "grantex-example-audit-dashboard",
+      "dependencies": {
+        "@grantex/sdk": ">=0.2.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsx": "^4.7.0",
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@grantex/sdk": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@grantex/sdk/-/sdk-0.2.6.tgz",
+      "integrity": "sha512-b4aJ8ye715WQXuQlGwhv34w6rvR1PkYbmMOjhEeyGQcCVnTIJ9jYiKLRHULc7mpi+YfLbCayiv4Rl+8652RmHg==",
+      "dependencies": {
+        "jose": "^5.2.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    }
+  }
+}

--- a/examples/audit-dashboard/package.json
+++ b/examples/audit-dashboard/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "grantex-example-audit-dashboard",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "npx tsx src/index.ts"
+  },
+  "dependencies": {
+    "@grantex/sdk": ">=0.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/examples/audit-dashboard/src/index.ts
+++ b/examples/audit-dashboard/src/index.ts
@@ -1,0 +1,230 @@
+/**
+ * Grantex Audit Dashboard — Querying, Filtering & Metrics
+ *
+ * Demonstrates how to use the Grantex audit trail as a rich data source:
+ *
+ *   1. Set up two agents with different scopes and generate audit entries
+ *   2. Generate a mix of success, failure, and blocked entries
+ *   3. Display the full audit timeline with formatted output
+ *   4. Filter audit entries by agent and by action
+ *   5. Compute metrics — success rate, entries per agent, top actions
+ *   6. Verify hash chain integrity for tamper evidence
+ *
+ * Prerequisites:
+ *   docker compose up          # from repo root
+ *   cd examples/audit-dashboard
+ *   npm install && npm start
+ */
+
+import { Grantex, verifyGrantToken } from '@grantex/sdk';
+
+const BASE_URL = process.env['GRANTEX_URL'] ?? 'http://localhost:3001';
+const API_KEY = process.env['GRANTEX_API_KEY'] ?? 'sandbox-api-key-local';
+const JWKS_URI = `${BASE_URL}/.well-known/jwks.json`;
+
+/** Handle agent.id vs agentId API response gotcha */
+function getAgentId(agent: Record<string, unknown>): string {
+  return (agent['id'] ?? agent['agentId']) as string;
+}
+
+function getAgentDid(agent: Record<string, unknown>, id: string): string {
+  return (agent['did'] as string) ?? `did:grantex:${id}`;
+}
+
+interface AuditEntry {
+  entryId: string;
+  agentId: string;
+  action: string;
+  status: string;
+  timestamp: string;
+  hash: string;
+  prevHash: string | null;
+  metadata: Record<string, unknown>;
+}
+
+async function main(): Promise<void> {
+  const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
+
+  // ── 1. Setup: Register agents and get tokens ──────────────────
+  console.log('=== Audit Dashboard Demo ===\n');
+
+  const agentARaw = await grantex.agents.register({
+    name: 'data-reader',
+    description: 'Agent that reads data from various sources',
+    scopes: ['data:read', 'calendar:read', 'email:send'],
+  });
+  const agentAId = getAgentId(agentARaw as unknown as Record<string, unknown>);
+  const agentADid = getAgentDid(agentARaw as unknown as Record<string, unknown>, agentAId);
+  console.log('Agent A (data-reader) registered:', agentAId);
+
+  const agentBRaw = await grantex.agents.register({
+    name: 'notifier',
+    description: 'Agent that sends notifications and emails',
+    scopes: ['email:send', 'notification:push'],
+  });
+  const agentBId = getAgentId(agentBRaw as unknown as Record<string, unknown>);
+  const agentBDid = getAgentDid(agentBRaw as unknown as Record<string, unknown>, agentBId);
+  console.log('Agent B (notifier) registered:', agentBId);
+
+  // Authorize Agent A
+  const authA = await grantex.authorize({
+    agentId: agentAId,
+    userId: 'user-alice',
+    scopes: ['data:read', 'calendar:read', 'email:send'],
+  });
+  const codeA = (authA as unknown as Record<string, unknown>)['code'] as string;
+  if (!codeA) { console.error('No code — sandbox key?'); process.exit(1); }
+  const tokenA = await grantex.tokens.exchange({ code: codeA, agentId: agentAId });
+
+  // Authorize Agent B
+  const authB = await grantex.authorize({
+    agentId: agentBId,
+    userId: 'user-alice',
+    scopes: ['email:send', 'notification:push'],
+  });
+  const codeB = (authB as unknown as Record<string, unknown>)['code'] as string;
+  if (!codeB) { console.error('No code — sandbox key?'); process.exit(1); }
+  const tokenB = await grantex.tokens.exchange({ code: codeB, agentId: agentBId });
+
+  console.log('Both agents authorized.\n');
+
+  // ── 2. Generate audit entries ─────────────────────────────────
+  console.log('--- Generating audit entries ---');
+
+  const auditBase = { principalId: 'user-alice' };
+
+  // Agent A — success entries
+  await grantex.audit.log({ ...auditBase, agentId: agentAId, agentDid: agentADid, grantId: tokenA.grantId, action: 'data:read', status: 'success', metadata: { source: 'database', rows: 150 } });
+  await grantex.audit.log({ ...auditBase, agentId: agentAId, agentDid: agentADid, grantId: tokenA.grantId, action: 'calendar:read', status: 'success', metadata: { eventsFound: 5 } });
+  await grantex.audit.log({ ...auditBase, agentId: agentAId, agentDid: agentADid, grantId: tokenA.grantId, action: 'data:read', status: 'success', metadata: { source: 'api', rows: 42 } });
+
+  // Agent A — failure entry
+  await grantex.audit.log({ ...auditBase, agentId: agentAId, agentDid: agentADid, grantId: tokenA.grantId, action: 'data:write', status: 'failure', metadata: { reason: 'scope_missing' } });
+
+  // Agent B — success entries
+  await grantex.audit.log({ ...auditBase, agentId: agentBId, agentDid: agentBDid, grantId: tokenB.grantId, action: 'email:send', status: 'success', metadata: { to: 'team@company.com' } });
+  await grantex.audit.log({ ...auditBase, agentId: agentBId, agentDid: agentBDid, grantId: tokenB.grantId, action: 'notification:push', status: 'success', metadata: { channel: 'slack' } });
+  await grantex.audit.log({ ...auditBase, agentId: agentBId, agentDid: agentBDid, grantId: tokenB.grantId, action: 'email:send', status: 'success', metadata: { to: 'manager@company.com' } });
+
+  // Agent B — blocked entry
+  await grantex.audit.log({ ...auditBase, agentId: agentBId, agentDid: agentBDid, grantId: tokenB.grantId, action: 'email:send', status: 'blocked', metadata: { reason: 'rate_limit_exceeded' } });
+
+  // Agent A — another failure
+  await grantex.audit.log({ ...auditBase, agentId: agentAId, agentDid: agentADid, grantId: tokenA.grantId, action: 'calendar:write', status: 'failure', metadata: { reason: 'scope_missing' } });
+
+  console.log('Generated 9 audit entries (5 success, 2 failure, 1 blocked, 1 more success).\n');
+
+  // ── 3. Full audit timeline ────────────────────────────────────
+  console.log('--- Full Audit Timeline ---');
+  console.log('');
+
+  const auditA = await grantex.audit.list({ agentId: agentAId });
+  const auditB = await grantex.audit.list({ agentId: agentBId });
+
+  const allEntries = [...auditA.entries, ...auditB.entries]
+    .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()) as AuditEntry[];
+
+  const statusIcon: Record<string, string> = { success: '+', failure: 'x', blocked: '!' };
+  const agentNames: Record<string, string> = { [agentAId]: 'data-reader', [agentBId]: 'notifier' };
+
+  console.log('  #  Status    Agent          Action              Time');
+  console.log('  -  ------    -----          ------              ----');
+  allEntries.forEach((entry, i) => {
+    const num = String(i + 1).padStart(2);
+    const icon = `[${statusIcon[entry.status] ?? '?'}]`;
+    const status = entry.status.padEnd(7);
+    const agent = (agentNames[entry.agentId] ?? 'unknown').padEnd(14);
+    const action = entry.action.padEnd(19);
+    const time = new Date(entry.timestamp).toISOString().slice(11, 19);
+    console.log(`  ${num} ${icon} ${status} ${agent} ${action} ${time}`);
+  });
+
+  // ── 4. Filter by agent ────────────────────────────────────────
+  console.log('\n--- Filter: Agent A (data-reader) only ---');
+  console.log(`  Entries: ${auditA.entries.length}`);
+  for (const entry of auditA.entries) {
+    console.log(`    [${statusIcon[entry.status] ?? '?'}] ${entry.action} — ${entry.status}`);
+  }
+
+  console.log('\n--- Filter: Agent B (notifier) only ---');
+  console.log(`  Entries: ${auditB.entries.length}`);
+  for (const entry of auditB.entries) {
+    console.log(`    [${statusIcon[entry.status] ?? '?'}] ${entry.action} — ${entry.status}`);
+  }
+
+  // ── 5. Filter by action ───────────────────────────────────────
+  console.log('\n--- Filter: email:send actions only ---');
+  const emailEntries = allEntries.filter((e) => e.action === 'email:send');
+  console.log(`  Entries: ${emailEntries.length}`);
+  for (const entry of emailEntries) {
+    const agent = agentNames[entry.agentId] ?? 'unknown';
+    console.log(`    [${statusIcon[entry.status] ?? '?'}] ${agent} — ${entry.status} — ${JSON.stringify(entry.metadata)}`);
+  }
+
+  // ── 6. Metrics summary ────────────────────────────────────────
+  console.log('\n--- Metrics Summary ---');
+
+  const total = allEntries.length;
+  const successCount = allEntries.filter((e) => e.status === 'success').length;
+  const failureCount = allEntries.filter((e) => e.status === 'failure').length;
+  const blockedCount = allEntries.filter((e) => e.status === 'blocked').length;
+
+  console.log(`  Total entries:  ${total}`);
+  console.log(`  Success:        ${successCount} (${((successCount / total) * 100).toFixed(0)}%)`);
+  console.log(`  Failure:        ${failureCount} (${((failureCount / total) * 100).toFixed(0)}%)`);
+  console.log(`  Blocked:        ${blockedCount} (${((blockedCount / total) * 100).toFixed(0)}%)`);
+
+  // Entries per agent
+  console.log('\n  Entries per agent:');
+  const agentCounts = new Map<string, number>();
+  for (const entry of allEntries) {
+    agentCounts.set(entry.agentId, (agentCounts.get(entry.agentId) ?? 0) + 1);
+  }
+  for (const [id, count] of agentCounts) {
+    console.log(`    ${agentNames[id] ?? id}: ${count}`);
+  }
+
+  // Most common actions
+  console.log('\n  Top actions:');
+  const actionCounts = new Map<string, number>();
+  for (const entry of allEntries) {
+    actionCounts.set(entry.action, (actionCounts.get(entry.action) ?? 0) + 1);
+  }
+  const sortedActions = [...actionCounts.entries()].sort((a, b) => b[1] - a[1]);
+  for (const [action, count] of sortedActions) {
+    console.log(`    ${action}: ${count}`);
+  }
+
+  // ── 7. Hash chain integrity check ─────────────────────────────
+  console.log('\n--- Hash Chain Integrity Check ---');
+
+  // Check each agent's audit chain separately (chains are per-developer)
+  let chainValid = true;
+  for (const [agentName, entries] of [['data-reader', auditA.entries], ['notifier', auditB.entries]] as const) {
+    const typed = entries as AuditEntry[];
+    for (let i = 1; i < typed.length; i++) {
+      const current = typed[i]!;
+      const previous = typed[i - 1]!;
+      if (current.prevHash !== previous.hash) {
+        console.log(`  BROKEN at entry ${i}: prevHash mismatch for ${agentName}`);
+        chainValid = false;
+      }
+    }
+  }
+
+  if (chainValid) {
+    console.log('  All hash chains verified: integrity PASSED');
+    console.log(`  Chain length: ${allEntries.length} entries`);
+    if (allEntries.length > 0) {
+      console.log(`  First hash: ${allEntries[0]!.hash.slice(0, 16)}...`);
+      console.log(`  Last hash:  ${allEntries[allEntries.length - 1]!.hash.slice(0, 16)}...`);
+    }
+  }
+
+  console.log('\nDone! Audit dashboard demo complete.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/audit-dashboard/tsconfig.json
+++ b/examples/audit-dashboard/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- Adds `examples/audit-dashboard/` — demonstrates audit trail querying, filtering, metrics computation, and hash chain integrity verification
- Generates 9 audit entries across 2 agents with success/failure/blocked statuses
- Shows filtering by agent and by action with formatted output
- Computes metrics: success rate, entries per agent, top actions by frequency
- Walks the cryptographic hash chain to verify tamper evidence
- Includes docs page and examples listing update

## Why

Audit entries are logged in many examples but never queried, filtered, or analyzed meaningfully. This example shows developers how to use the audit trail as a rich data source for monitoring and compliance.

## Test plan

- [x] `npx tsc --noEmit` — TypeScript compiles cleanly
- [ ] `docker compose up -d && npm start` — runs full flow
- [x] Follows existing example patterns (sandbox mode, `getAgentId` helper, ASCII separators)