### PR TITLE
test: comprehensive E2E suite + fix Python SDK bugs

### DIFF
--- a/packages/sdk-py/src/grantex/_types.py
+++ b/packages/sdk-py/src/grantex/_types.py
@@ -82,8 +82,8 @@ class Agent:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Agent:
         return cls(
-            id=data["id"],
-            did=data["did"],
+            id=data.get("id") or data.get("agentId", ""),
+            did=data.get("did", ""),
             name=data["name"],
             description=data.get("description", ""),
             scopes=tuple(data.get("scopes", [])),
@@ -152,19 +152,21 @@ class AuthorizationRequest:
     expires_at: str
     status: str
     created_at: str
+    code: str | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> AuthorizationRequest:
         return cls(
-            request_id=data["authRequestId"],
-            consent_url=data["consentUrl"],
-            agent_id=data["agentId"],
-            principal_id=data["principalId"],
+            request_id=data.get("authRequestId", ""),
+            consent_url=data.get("consentUrl", ""),
+            agent_id=data.get("agentId", ""),
+            principal_id=data.get("principalId", ""),
             scopes=tuple(data.get("scopes", [])),
-            expires_in=data["expiresIn"],
-            expires_at=data["expiresAt"],
-            status=data["status"],
-            created_at=data["createdAt"],
+            expires_in=data.get("expiresIn", ""),
+            expires_at=data.get("expiresAt", ""),
+            status=data.get("status", ""),
+            created_at=data.get("createdAt", ""),
+            code=data.get("code"),
         )
 
 
@@ -187,15 +189,15 @@ class Grant:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Grant:
         return cls(
-            id=data["id"],
-            agent_id=data["agentId"],
-            agent_did=data["agentDid"],
-            principal_id=data["principalId"],
-            developer_id=data["developerId"],
+            id=data.get("id") or data.get("grantId", ""),
+            agent_id=data.get("agentId", ""),
+            agent_did=data.get("agentDid", ""),
+            principal_id=data.get("principalId", ""),
+            developer_id=data.get("developerId", ""),
             scopes=tuple(data.get("scopes", [])),
-            status=data["status"],
-            issued_at=data["issuedAt"],
-            expires_at=data["expiresAt"],
+            status=data.get("status", ""),
+            issued_at=data.get("issuedAt", ""),
+            expires_at=data.get("expiresAt", ""),
             revoked_at=data.get("revokedAt"),
         )
 
@@ -234,9 +236,9 @@ class ListGrantsResponse:
     def from_dict(cls, data: dict[str, Any]) -> ListGrantsResponse:
         return cls(
             grants=tuple(Grant.from_dict(g) for g in data.get("grants", [])),
-            total=data["total"],
-            page=data["page"],
-            page_size=data["pageSize"],
+            total=data.get("total", 0),
+            page=data.get("page", 1),
+            page_size=data.get("pageSize", 50),
         )
 
 
@@ -362,7 +364,9 @@ class PrincipalSessionResponse:
 @dataclass
 class LogAuditParams:
     agent_id: str
+    agent_did: str
     grant_id: str
+    principal_id: str
     action: str
     metadata: dict[str, Any] | None = None
     status: str = "success"
@@ -370,7 +374,9 @@ class LogAuditParams:
     def to_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
             "agentId": self.agent_id,
+            "agentDid": self.agent_did,
             "grantId": self.grant_id,
+            "principalId": self.principal_id,
             "action": self.action,
             "status": self.status,
         }
@@ -453,9 +459,9 @@ class ListAuditResponse:
     def from_dict(cls, data: dict[str, Any]) -> ListAuditResponse:
         return cls(
             entries=tuple(AuditEntry.from_dict(e) for e in data.get("entries", [])),
-            total=data["total"],
-            page=data["page"],
-            page_size=data["pageSize"],
+            total=data.get("total", 0),
+            page=data.get("page", 1),
+            page_size=data.get("pageSize", 50),
         )
 
 

--- a/packages/sdk-py/src/grantex/resources/_audit.py
+++ b/packages/sdk-py/src/grantex/resources/_audit.py
@@ -15,14 +15,18 @@ class AuditClient:
         self,
         *,
         agent_id: str,
+        agent_did: str,
         grant_id: str,
+        principal_id: str,
         action: str,
         metadata: dict[str, Any] | None = None,
         status: str = "success",
     ) -> AuditEntry:
         params = LogAuditParams(
             agent_id=agent_id,
+            agent_did=agent_did,
             grant_id=grant_id,
+            principal_id=principal_id,
             action=action,
             metadata=metadata,
             status=status,

--- a/tests/e2e-extended.mjs
+++ b/tests/e2e-extended.mjs
@@ -1,0 +1,418 @@
+/**
+ * Extended E2E Test Suite — covers flows not in the negative test suite:
+ *
+ *   1. Token refresh lifecycle (exchange → refresh → verify new token)
+ *   2. Budget enforcement (allocate → debit → insufficient → 402)
+ *   3. Principal sessions (create → verify fields)
+ *   4. Webhook signature verification (valid, tampered, wrong secret)
+ *   5. Concurrent access (race conditions on exchange/revoke)
+ *   6. Payload edge cases (large metadata, many scopes, unicode)
+ *   7. Grant listing & filtering
+ *   8. Token introspection fields
+ *
+ * Run: node tests/e2e-extended.mjs
+ */
+
+import {
+  Grantex,
+  verifyGrantToken,
+  verifyWebhookSignature,
+  GrantexApiError,
+} from '@grantex/sdk';
+
+const BASE_URL = process.env['GRANTEX_URL'] ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+const API_KEY = process.env['GRANTEX_API_KEY'] ?? 'gx_test_playground_demo_2026';
+const JWKS_URI = `${BASE_URL}/.well-known/jwks.json`;
+
+const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
+
+let passed = 0;
+let failed = 0;
+
+function ok(cond, msg) {
+  if (cond) { passed++; console.log(`  ✓ ${msg}`); }
+  else { failed++; console.log(`  ✗ FAIL: ${msg}`); }
+}
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function setupAgent(name, scopes = ['calendar:read', 'email:send']) {
+  const agent = await grantex.agents.register({ name: `ext-${name}-${Date.now()}`, description: 'extended test', scopes });
+  const agentId = agent.id ?? agent['agentId'];
+  const auth = await grantex.authorize({ agentId, userId: 'ext-test-user', scopes });
+  const code = auth.code ?? auth['code'];
+  const token = await grantex.tokens.exchange({ code, agentId });
+  return { agentId, ...token };
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 1. TOKEN REFRESH LIFECYCLE
+// ════════════════════════════════════════════════════════════════════
+
+async function test_token_refresh() {
+  console.log('\n── 1. Token Refresh Lifecycle ──');
+
+  const { agentId, grantToken, refreshToken, grantId, scopes } = await setupAgent('refresh');
+
+  ok(!!refreshToken, 'Exchange returns refreshToken');
+  ok(!!grantId, 'Exchange returns grantId');
+
+  // Verify original token
+  const original = await grantex.tokens.verify(grantToken);
+  ok(original.valid === true, 'Original token is valid');
+
+  // Refresh
+  const refreshed = await grantex.tokens.refresh({ refreshToken, agentId });
+  ok(!!refreshed.grantToken, 'Refresh returns new grantToken');
+  ok(!!refreshed.refreshToken, 'Refresh returns new refreshToken');
+  ok(refreshed.grantId === grantId, 'Refresh preserves grantId');
+  ok(JSON.stringify(refreshed.scopes) === JSON.stringify(scopes), 'Refresh preserves scopes');
+
+  // New token is valid
+  const newVerify = await grantex.tokens.verify(refreshed.grantToken);
+  ok(newVerify.valid === true, 'Refreshed token is valid');
+
+  // Old refresh token should be invalidated (rotated)
+  try {
+    await grantex.tokens.refresh({ refreshToken, agentId }); // replay old refresh token
+    ok(false, 'Old refresh token replay should fail');
+  } catch (err) {
+    ok(err instanceof GrantexApiError, `Old refresh token rejected (${err.statusCode})`);
+  }
+
+  // Offline verify the refreshed token
+  const offlineVerified = await verifyGrantToken(refreshed.grantToken, { jwksUri: JWKS_URI });
+  ok(offlineVerified.grantId === grantId, 'Offline verify refreshed token — same grantId');
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 2. BUDGET ENFORCEMENT
+// ════════════════════════════════════════════════════════════════════
+
+async function test_budget_enforcement() {
+  console.log('\n── 2. Budget Enforcement ──');
+
+  const { agentId, grantToken, grantId } = await setupAgent('budget');
+
+  // Allocate budget
+  const allocation = await grantex.budgets.allocate({ grantId, initialBudget: 100.00, currency: 'USD' });
+  ok(Math.abs(allocation.initialBudget - 100) < 0.01, `Allocated budget: $${allocation.initialBudget}`);
+  ok(Math.abs(allocation.remainingBudget - 100) < 0.01, `Remaining: $${allocation.remainingBudget}`);
+
+  // Debit
+  const debit1 = await grantex.budgets.debit({ grantId, amount: 30, description: 'API call' });
+  ok(Math.abs(debit1.remaining - 70) < 0.01, `After $30 debit: $${debit1.remaining} remaining`);
+
+  // Check balance
+  const balance = await grantex.budgets.balance(grantId);
+  ok(Math.abs(balance.remainingBudget - 70) < 0.01, `Balance check: $${balance.remainingBudget}`);
+
+  // Debit more
+  await grantex.budgets.debit({ grantId, amount: 50, description: 'Big call' });
+
+  // Debit beyond remaining → should fail with 402
+  try {
+    await grantex.budgets.debit({ grantId, amount: 50, description: 'Exceeds budget' });
+    ok(false, 'Exceeding budget should throw');
+  } catch (err) {
+    ok(err instanceof GrantexApiError, `Insufficient budget → GrantexApiError`);
+    ok(err.statusCode === 402 || err.code === 'INSUFFICIENT_BUDGET', `Status: ${err.statusCode}, code: ${err.code}`);
+  }
+
+  // Transactions list
+  const txns = await grantex.budgets.transactions(grantId);
+  ok(txns.transactions.length >= 2, `${txns.transactions.length} transactions recorded`);
+
+  // Allocate on non-existent grant
+  try {
+    await grantex.budgets.allocate({ grantId: 'grnt_nonexistent', initialBudget: 100 });
+    ok(false, 'Budget on non-existent grant should throw');
+  } catch (err) {
+    ok(err instanceof GrantexApiError, `Non-existent grant budget → GrantexApiError (${err.statusCode})`);
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 3. PRINCIPAL SESSIONS
+// ════════════════════════════════════════════════════════════════════
+
+async function test_principal_sessions() {
+  console.log('\n── 3. Principal Sessions ──');
+
+  // Create session
+  const session = await grantex.principalSessions.create({ principalId: 'ext-test-user' });
+  ok(!!session.sessionToken, 'Session created with sessionToken');
+  ok(!!session.dashboardUrl, `Dashboard URL: ${session.dashboardUrl.slice(0, 50)}...`);
+  ok(!!session.expiresAt, `Expires at: ${session.expiresAt}`);
+
+  // Create with custom expiry
+  const shortSession = await grantex.principalSessions.create({ principalId: 'ext-test-user', expiresIn: '5m' });
+  ok(!!shortSession.sessionToken, 'Short session created');
+
+  // Create for principal that already has grants (from earlier tests)
+  const existingPrincipal = await grantex.principalSessions.create({ principalId: 'ext-test-user' });
+  ok(!!existingPrincipal.sessionToken, 'Existing principal session created');
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 4. WEBHOOK SIGNATURE VERIFICATION
+// ════════════════════════════════════════════════════════════════════
+
+async function test_webhook_verification() {
+  console.log('\n── 4. Webhook Signature Verification ──');
+
+  const secret = 'whsec_test_secret_for_verification';
+  const payload = JSON.stringify({ event: 'grant.revoked', grantId: 'grnt_01' });
+
+  // Compute valid signature
+  const { createHmac } = await import('node:crypto');
+  const validSig = 'sha256=' + createHmac('sha256', secret).update(payload).digest('hex');
+
+  // Valid signature
+  ok(verifyWebhookSignature(payload, validSig, secret) === true, 'Valid signature verified');
+
+  // Tampered payload
+  ok(verifyWebhookSignature(payload + 'tampered', validSig, secret) === false, 'Tampered payload rejected');
+
+  // Wrong secret
+  ok(verifyWebhookSignature(payload, validSig, 'wrong_secret') === false, 'Wrong secret rejected');
+
+  // Empty signature
+  ok(verifyWebhookSignature(payload, '', secret) === false, 'Empty signature rejected');
+
+  // Garbage signature
+  ok(verifyWebhookSignature(payload, 'sha256=0000000000', secret) === false, 'Garbage signature rejected');
+
+  // Buffer payload
+  ok(verifyWebhookSignature(Buffer.from(payload), validSig, secret) === true, 'Buffer payload verified');
+
+  // Different event payload
+  const payload2 = JSON.stringify({ event: 'token.exchanged', agentId: 'ag_01' });
+  const sig2 = 'sha256=' + createHmac('sha256', secret).update(payload2).digest('hex');
+  ok(verifyWebhookSignature(payload2, sig2, secret) === true, 'Different event payload verified');
+  ok(verifyWebhookSignature(payload2, validSig, secret) === false, 'Cross-event signature rejected');
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 5. CONCURRENT ACCESS
+// ════════════════════════════════════════════════════════════════════
+
+async function test_concurrent_access() {
+  console.log('\n── 5. Concurrent Access ──');
+
+  // Register 3 agents concurrently
+  const results = await Promise.allSettled([
+    grantex.agents.register({ name: `conc-a-${Date.now()}`, description: 'concurrent A', scopes: ['read'] }),
+    grantex.agents.register({ name: `conc-b-${Date.now()}`, description: 'concurrent B', scopes: ['read'] }),
+    grantex.agents.register({ name: `conc-c-${Date.now()}`, description: 'concurrent C', scopes: ['read'] }),
+  ]);
+  const fulfilled = results.filter(r => r.status === 'fulfilled');
+  ok(fulfilled.length === 3, `3 concurrent registrations: ${fulfilled.length}/3 succeeded`);
+
+  // Concurrent verify calls on same token
+  const { grantToken } = await setupAgent('conc-verify');
+  const verifyResults = await Promise.allSettled([
+    grantex.tokens.verify(grantToken),
+    grantex.tokens.verify(grantToken),
+    grantex.tokens.verify(grantToken),
+  ]);
+  const allValid = verifyResults
+    .filter(r => r.status === 'fulfilled')
+    .every(r => r.value.valid === true);
+  ok(allValid, 'Concurrent verify calls all return valid');
+
+  // Concurrent revoke of same grant — one succeeds, others get 404
+  const { grantId: revokeTarget } = await setupAgent('conc-revoke');
+  const revokeResults = await Promise.allSettled([
+    grantex.grants.revoke(revokeTarget),
+    grantex.grants.revoke(revokeTarget),
+  ]);
+  const revokeSucceeded = revokeResults.filter(r => r.status === 'fulfilled').length;
+  const revokeFailed = revokeResults.filter(r => r.status === 'rejected').length;
+  ok(revokeSucceeded >= 1, `Concurrent revoke: ${revokeSucceeded} succeeded, ${revokeFailed} got expected error`);
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 6. PAYLOAD EDGE CASES
+// ════════════════════════════════════════════════════════════════════
+
+async function test_payload_edge_cases() {
+  console.log('\n── 6. Payload Edge Cases ──');
+
+  const { agentId, grantToken, grantId } = await setupAgent('payload');
+  const agentDid = `did:grantex:${agentId}`;
+
+  // Large metadata in audit log
+  const largeMeta = {};
+  for (let i = 0; i < 50; i++) {
+    largeMeta[`key_${i}`] = `value_${i}_${'x'.repeat(100)}`;
+  }
+  try {
+    const entry = await grantex.audit.log({
+      agentId, agentDid, grantId, principalId: 'ext-test-user',
+      action: 'large_metadata_test',
+      status: 'success',
+      metadata: largeMeta,
+    });
+    ok(!!entry.entryId, `Large metadata (${JSON.stringify(largeMeta).length} bytes) accepted`);
+  } catch (err) {
+    ok(err instanceof GrantexApiError, `Large metadata → GrantexApiError (${err.statusCode})`);
+  }
+
+  // Unicode in agent name and metadata
+  const unicodeAgent = await grantex.agents.register({
+    name: `unicode-日本語-émojis-🤖-${Date.now()}`,
+    description: 'Ünïcödé тест agent 中文',
+    scopes: ['read'],
+  });
+  const unicodeId = unicodeAgent.id ?? unicodeAgent['agentId'];
+  ok(!!unicodeId, `Unicode agent created: ${unicodeId}`);
+
+  // Unicode in audit metadata
+  try {
+    await grantex.audit.log({
+      agentId, agentDid, grantId, principalId: 'ext-test-user',
+      action: 'unicode_test',
+      status: 'success',
+      metadata: { message: '日本語テスト 中文测试 émojis 🎉🚀' },
+    });
+    ok(true, 'Unicode metadata accepted');
+  } catch (err) {
+    ok(false, `Unicode metadata rejected: ${err.message}`);
+  }
+
+  // Many scopes
+  const manyScopes = Array.from({ length: 20 }, (_, i) => `scope:${i}`);
+  try {
+    const msAgent = await grantex.agents.register({
+      name: `many-scopes-${Date.now()}`,
+      description: 'test',
+      scopes: manyScopes,
+    });
+    ok(!!(msAgent.id ?? msAgent['agentId']), `Agent with ${manyScopes.length} scopes created`);
+  } catch (err) {
+    ok(err instanceof GrantexApiError, `Many scopes → GrantexApiError (${err.statusCode})`);
+  }
+
+  // Special characters in action name
+  try {
+    await grantex.audit.log({
+      agentId, agentDid, grantId, principalId: 'ext-test-user',
+      action: 'action/with:special.chars-and_underscores',
+      status: 'success',
+    });
+    ok(true, 'Special chars in action name accepted');
+  } catch (err) {
+    ok(false, `Special chars rejected: ${err.message}`);
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 7. GRANT LISTING & FILTERING
+// ════════════════════════════════════════════════════════════════════
+
+async function test_grant_listing() {
+  console.log('\n── 7. Grant Listing & Filtering ──');
+
+  const { agentId, grantId } = await setupAgent('listing');
+
+  // List grants for agent
+  const grants = await grantex.grants.list({ agentId });
+  ok(grants.grants.length >= 1, `Found ${grants.grants.length} grants for agent`);
+
+  // Get specific grant
+  const grant = await grantex.grants.get(grantId);
+  ok(grant.agentId === agentId || grant['agentId'] === agentId, 'Grant belongs to correct agent');
+  ok(grant.status === 'active', `Grant status: ${grant.status}`);
+
+  // List by principalId
+  const principalGrants = await grantex.grants.list({ principalId: 'ext-test-user' });
+  ok(principalGrants.grants.length >= 1, `Found ${principalGrants.grants.length} grants for principal`);
+
+  // List by status
+  const activeGrants = await grantex.grants.list({ agentId, status: 'active' });
+  ok(activeGrants.grants.every(g => g.status === 'active'), 'All listed grants are active');
+
+  // Revoke and list revoked
+  await grantex.grants.revoke(grantId);
+  const revokedGrants = await grantex.grants.list({ agentId, status: 'revoked' });
+  ok(revokedGrants.grants.some(g => g.grantId === grantId || g.id === grantId), 'Revoked grant appears in revoked list');
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 8. TOKEN INTROSPECTION FIELDS
+// ════════════════════════════════════════════════════════════════════
+
+async function test_token_introspection() {
+  console.log('\n── 8. Token Introspection Fields ──');
+
+  const { agentId, grantToken, grantId } = await setupAgent('introspect', ['calendar:read', 'email:send']);
+
+  // Online verify — check all returned fields
+  const verified = await grantex.tokens.verify(grantToken);
+  ok(verified.valid === true, 'Token is valid');
+  ok(!!verified.grantId, `grantId: ${verified.grantId}`);
+  ok(Array.isArray(verified.scopes), `scopes: [${verified.scopes}]`);
+  ok(verified.scopes.includes('calendar:read'), 'Has calendar:read scope');
+  ok(verified.scopes.includes('email:send'), 'Has email:send scope');
+  ok(!!verified.expiresAt, `expiresAt: ${verified.expiresAt}`);
+
+  // Offline verify — check claim fields
+  const offline = await verifyGrantToken(grantToken, { jwksUri: JWKS_URI });
+  ok(!!offline.tokenId, `tokenId (jti): ${offline.tokenId}`);
+  ok(!!offline.grantId, `grantId (grnt): ${offline.grantId}`);
+  ok(!!offline.principalId, `principalId (sub): ${offline.principalId}`);
+  ok(!!offline.agentDid, `agentDid (agt): ${offline.agentDid}`);
+  ok(!!offline.developerId, `developerId (dev): ${offline.developerId}`);
+  ok(typeof offline.issuedAt === 'number', `issuedAt: ${offline.issuedAt}`);
+  ok(typeof offline.expiresAt === 'number', `expiresAt: ${offline.expiresAt}`);
+  ok(offline.expiresAt > offline.issuedAt, 'expiresAt > issuedAt');
+}
+
+// ════════════════════════════════════════════════════════════════════
+// RUN ALL
+// ════════════════════════════════════════════════════════════════════
+
+console.log('Extended E2E Tests against production');
+console.log(`Target: ${BASE_URL}\n`);
+
+const sections = [
+  ['Token Refresh', test_token_refresh],
+  ['Budget Enforcement', test_budget_enforcement],
+  ['Principal Sessions', test_principal_sessions],
+  ['Webhook Verification', test_webhook_verification],
+  ['Concurrent Access', test_concurrent_access],
+  ['Payload Edge Cases', test_payload_edge_cases],
+  ['Grant Listing', test_grant_listing],
+  ['Token Introspection', test_token_introspection],
+];
+
+for (let i = 0; i < sections.length; i++) {
+  const [name, fn] = sections[i];
+  if (i > 0 && i % 2 === 0) {
+    console.log('\n  ⏳ Rate limit cooldown...');
+    await delay(15000);
+  }
+  try {
+    await fn();
+  } catch (err) {
+    if (err.message?.includes('Rate limit')) {
+      console.log(`  ⏳ Rate limited in ${name}, waiting 60s...`);
+      await delay(60000);
+      try { await fn(); } catch (retryErr) {
+        failed++;
+        console.log(`  ✗ CRASH in ${name} (retry): ${retryErr.message}`);
+      }
+    } else {
+      failed++;
+      console.log(`  ✗ CRASH in ${name}: ${err.message}`);
+      if (err.stack) console.log(`    ${err.stack.split('\n')[1]}`);
+    }
+  }
+  await delay(3000);
+}
+
+console.log(`\n${'='.repeat(60)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+console.log(`${'='.repeat(60)}`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/e2e-python.py
+++ b/tests/e2e-python.py
@@ -1,0 +1,420 @@
+"""
+Python SDK E2E Test Suite
+Tests grantex (core), grantex-crewai, grantex-openai-agents, grantex-adk against production.
+
+Run:
+  pip install grantex grantex-crewai grantex-openai-agents grantex-adk
+  python tests/e2e-python.py
+"""
+
+import os
+import sys
+import time
+import json
+import base64
+import traceback
+
+# Fix Windows console encoding
+sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+
+BASE_URL = os.environ.get("GRANTEX_URL", "https://grantex-auth-dd4mtrt2gq-uc.a.run.app")
+API_KEY = os.environ.get("GRANTEX_API_KEY", "gx_test_playground_demo_2026")
+
+passed = 0
+failed = 0
+skipped = 0
+
+
+def ok(cond, msg):
+    global passed, failed
+    if cond:
+        passed += 1
+        print(f"  [PASS] {msg}")
+    else:
+        failed += 1
+        print(f"  [FAIL] {msg}")
+
+
+def skip(msg):
+    global skipped
+    skipped += 1
+    print(f"  [SKIP] {msg}")
+
+
+def make_token(scopes):
+    """Create a fake JWT for offline scope testing."""
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(json.dumps({
+        "iss": "https://grantex.dev",
+        "sub": "user_01",
+        "scp": scopes,
+        "jti": "tok_01",
+        "grnt": "grnt_01",
+        "exp": 9999999999,
+    }).encode()).decode().rstrip("=")
+    return f"{header}.{payload}.fakesig"
+
+
+def getval(obj, *keys):
+    """Get a value from an object or dict, trying multiple key names."""
+    for key in keys:
+        val = getattr(obj, key, None)
+        if val is not None:
+            return val
+        if isinstance(obj, dict) and key in obj:
+            return obj[key]
+    return None
+
+
+def setup_agent(client, name, scopes=None):
+    """Register agent + get sandbox grant token."""
+    from grantex import AuthorizeParams, ExchangeTokenParams
+    if scopes is None:
+        scopes = ["calendar:read", "email:send"]
+    agent = client.agents.register(
+        name=f"py-{name}-{int(time.time())}",
+        description="python e2e test",
+        scopes=scopes,
+    )
+    agent_id = getval(agent, "id", "agent_id", "agentId")
+    auth = client.authorize(AuthorizeParams(agent_id=agent_id, user_id="py-test-user", scopes=scopes))
+    code = getval(auth, "code")
+    token = client.tokens.exchange(ExchangeTokenParams(code=code, agent_id=agent_id))
+    grant_token = getval(token, "grant_token", "grantToken")
+    grant_id = getval(token, "grant_id", "grantId")
+    refresh_token = getval(token, "refresh_token", "refreshToken")
+    scopes_out = getval(token, "scopes") or scopes
+    return agent_id, grant_token, grant_id, scopes_out, refresh_token
+
+
+# ================================================================
+# 1. CORE PYTHON SDK
+# ================================================================
+
+def test_core_sdk():
+    print("\n-- 1. Core Python SDK (grantex) --")
+    from grantex import Grantex, GrantexApiError, GrantexAuthError
+
+    client = Grantex(api_key=API_KEY, base_url=BASE_URL)
+
+    # Agent registration + token exchange
+    agent_id, grant_token, grant_id, scopes, refresh_token = setup_agent(client, "core")
+    ok(bool(agent_id), f"Agent registered: {agent_id}")
+    ok(bool(grant_token), "Grant token received")
+    ok("calendar:read" in scopes, "Scopes include calendar:read")
+
+    # Token verify (online)
+    result = client.tokens.verify(grant_token)
+    ok(getval(result, "valid") is True, "Token verified as valid")
+
+    # Token refresh
+    from grantex import RefreshTokenParams
+    if refresh_token:
+        refreshed = client.tokens.refresh(RefreshTokenParams(refresh_token=refresh_token, agent_id=agent_id))
+        new_token = getval(refreshed, "grant_token", "grantToken")
+        ok(bool(new_token), "Token refreshed successfully")
+        new_verify = client.tokens.verify(new_token)
+        ok(getval(new_verify, "valid") is True, "Refreshed token is valid")
+    else:
+        skip("No refresh token returned")
+
+    # Audit log
+    try:
+        entry = client.audit.log(
+            agent_id=agent_id,
+            agent_did=f"did:grantex:{agent_id}",
+            grant_id=grant_id,
+            principal_id="py-test-user",
+            action="test:python_sdk",
+            status="success",
+            metadata={"test": True},
+        )
+        entry_id = getval(entry, "entry_id", "entryId")
+        ok(bool(entry_id), f"Audit entry logged: {entry_id}")
+    except Exception as e:
+        ok(False, f"Audit log failed: {e}")
+
+    # Audit list
+    from grantex import ListAuditParams
+    audit_list = client.audit.list(ListAuditParams(agent_id=agent_id, grant_id=grant_id))
+    entries = getval(audit_list, "entries") or []
+    ok(len(entries) >= 1, f"Audit list has {len(entries)} entries")
+
+    # Invalid API key
+    bad_client = Grantex(api_key="invalid-key", base_url=BASE_URL)
+    try:
+        bad_client.agents.list()
+        ok(False, "Invalid API key should throw")
+    except GrantexAuthError:
+        ok(True, "Invalid API key -> GrantexAuthError")
+    except Exception as e:
+        ok("401" in str(e) or "Unauthorized" in str(e), f"Invalid API key -> {type(e).__name__}")
+
+    # Revoke and verify
+    client.grants.revoke(grant_id)
+    result2 = client.tokens.verify(grant_token)
+    ok(getval(result2, "valid") is False, "Token invalid after revocation")
+
+    # Non-existent agent
+    try:
+        client.agents.get("ag_nonexistent_py")
+        ok(False, "Non-existent agent should throw")
+    except GrantexApiError:
+        ok(True, "Non-existent agent -> GrantexApiError")
+    except Exception as e:
+        ok("404" in str(e), f"Non-existent agent -> {type(e).__name__}")
+
+    # Grant listing
+    from grantex import ListGrantsParams
+    grants = client.grants.list(ListGrantsParams(agent_id=agent_id, status="revoked"))
+    grant_list = getval(grants, "grants") or []
+    ok(len(grant_list) >= 1, f"Revoked grants listed: {len(grant_list)}")
+
+
+# ================================================================
+# 2. CREWAI INTEGRATION
+# ================================================================
+
+def test_crewai():
+    print("\n-- 2. CrewAI Integration (grantex-crewai) --")
+    try:
+        from grantex_crewai import create_grantex_tool  # noqa: F401
+        # Also verify the framework dep is available
+        import crewai  # noqa: F401
+    except (ImportError, ModuleNotFoundError):
+        skip("grantex-crewai or crewai not installed (requires heavy framework deps)")
+        return
+
+    token = make_token(["file:read", "file:write"])
+
+    tool = create_grantex_tool(
+        name="read_file",
+        description="Read a file",
+        grant_token=token,
+        required_scope="file:read",
+        func=lambda path: f"contents of {path}",
+    )
+    ok(tool.name == "read_file", "CrewAI tool created")
+
+    result = tool.run("test.txt")
+    ok("contents" in result, f"Tool executed: {result}")
+
+    bad_tool = create_grantex_tool(
+        name="admin_tool",
+        description="Admin",
+        grant_token=token,
+        required_scope="admin:all",
+        func=lambda: "bad",
+    )
+    try:
+        bad_tool.run("")
+        ok(False, "Missing scope should throw")
+    except Exception as e:
+        ok("admin:all" in str(e), f"Scope error: {e}")
+
+
+# ================================================================
+# 3. OPENAI AGENTS SDK INTEGRATION
+# ================================================================
+
+def test_openai_agents():
+    print("\n-- 3. OpenAI Agents SDK Integration (grantex-openai-agents) --")
+    try:
+        from grantex_openai_agents import create_grantex_tool  # noqa: F401
+        import agents  # noqa: F401
+    except (ImportError, ModuleNotFoundError):
+        skip("grantex-openai-agents or OpenAI Agents SDK not installed (requires heavy framework deps)")
+        return
+
+    token = make_token(["data:read"])
+
+    tool = create_grantex_tool(
+        name="query_data",
+        description="Query data",
+        grant_token=token,
+        required_scope="data:read",
+        func=lambda q: f"results for {q}",
+    )
+    ok(tool.name == "query_data", "OpenAI Agents tool created")
+
+
+# ================================================================
+# 4. GOOGLE ADK INTEGRATION
+# ================================================================
+
+def test_google_adk():
+    print("\n-- 4. Google ADK Integration (grantex-adk) --")
+    try:
+        from grantex_adk import create_grantex_tool
+    except ImportError:
+        skip("grantex-adk not installed")
+        return
+
+    token = make_token(["calendar:read"])
+
+    # Valid scope — ADK tools use **kwargs
+    tool = create_grantex_tool(
+        name="read_calendar",
+        description="Read calendar",
+        grant_token=token,
+        required_scope="calendar:read",
+        func=lambda date="today": f"events for {date}",
+    )
+    ok(callable(tool), "ADK tool created")
+
+    result = tool(date="2026-03-30")
+    ok("events" in result, f"ADK tool executed: {result}")
+
+    # Missing scope
+    try:
+        bad_tool = create_grantex_tool(
+            name="admin",
+            description="Admin",
+            grant_token=token,
+            required_scope="admin:all",
+            func=lambda: "bad",
+        )
+        # ADK checks scope at creation time
+        ok(False, "Missing scope should throw at creation")
+    except PermissionError as e:
+        ok("admin:all" in str(e), f"Scope error at creation: {e}")
+    except Exception as e:
+        ok("admin:all" in str(e), f"Scope error: {type(e).__name__}: {e}")
+
+
+# ================================================================
+# 5. PYTHON SDK NEGATIVE PATHS
+# ================================================================
+
+def test_python_negative():
+    print("\n-- 5. Python SDK Negative Paths --")
+    from grantex import Grantex, GrantexApiError
+
+    client = Grantex(api_key=API_KEY, base_url=BASE_URL)
+
+    # Token exchange with invalid code
+    from grantex import ExchangeTokenParams as ETP
+    try:
+        client.tokens.exchange(ETP(code="invalid-code", agent_id="ag_x"))
+        ok(False, "Invalid code should throw")
+    except GrantexApiError:
+        ok(True, "Invalid code -> GrantexApiError")
+    except Exception as e:
+        ok("400" in str(e), f"Invalid code -> {type(e).__name__}")
+
+    # Verify garbage token
+    result = client.tokens.verify("garbage.token.here")
+    ok(getval(result, "valid") is False, "Garbage token -> valid: False")
+
+    # Budget on non-existent grant
+    from grantex import AllocateBudgetParams
+    try:
+        client.budgets.allocate(AllocateBudgetParams(grant_id="grnt_nonexistent_py", initial_budget=100))
+        ok(False, "Budget on non-existent grant should throw")
+    except GrantexApiError:
+        ok(True, "Non-existent grant budget -> GrantexApiError")
+    except Exception as e:
+        ok("404" in str(e) or "400" in str(e), f"Non-existent budget -> {type(e).__name__}")
+
+    # Principal session — must use a principal that has grants
+    from grantex import CreatePrincipalSessionParams
+    # First create a grant for this principal so session creation works
+    try:
+        setup_agent(client, "for-session")
+    except Exception:
+        pass
+    try:
+        session = client.principal_sessions.create(CreatePrincipalSessionParams(principal_id="py-test-user"))
+        session_token = getval(session, "session_token", "sessionToken")
+        ok(bool(session_token), f"Principal session created")
+    except Exception as e:
+        ok(False, f"Principal session failed: {e}")
+
+    # Double revoke
+    agent_id, grant_token, grant_id, _, _ = setup_agent(client, "dbl-revoke")
+    client.grants.revoke(grant_id)
+    try:
+        client.grants.revoke(grant_id)
+        ok(True, "Double revoke handled")
+    except GrantexApiError:
+        ok(True, "Double revoke -> GrantexApiError")
+
+
+# ================================================================
+# 6. PYTHON SDK BUDGET FLOW
+# ================================================================
+
+def test_python_budgets():
+    print("\n-- 6. Python SDK Budget Flow --")
+    from grantex import Grantex, GrantexApiError
+
+    client = Grantex(api_key=API_KEY, base_url=BASE_URL)
+    agent_id, grant_token, grant_id, _, _ = setup_agent(client, "budget")
+
+    from grantex import AllocateBudgetParams as ABP, DebitBudgetParams as DBP
+
+    # Allocate
+    allocation = client.budgets.allocate(ABP(grant_id=grant_id, initial_budget=50.0, currency="USD"))
+    initial = getval(allocation, "initial_budget", "initialBudget")
+    ok(abs(float(initial) - 50.0) < 0.01, f"Budget allocated: ${initial}")
+
+    # Debit
+    debit = client.budgets.debit(DBP(grant_id=grant_id, amount=20.0, description="test debit"))
+    remaining = getval(debit, "remaining")
+    ok(abs(float(remaining) - 30.0) < 0.01, f"After debit: ${remaining} remaining")
+
+    # Balance check
+    balance = client.budgets.balance(grant_id)
+    bal = getval(balance, "remaining_budget", "remainingBudget")
+    ok(abs(float(bal) - 30.0) < 0.01, f"Balance: ${bal}")
+
+    # Exceed budget
+    try:
+        client.budgets.debit(DBP(grant_id=grant_id, amount=100.0, description="exceed"))
+        ok(False, "Exceeding budget should throw")
+    except GrantexApiError as e:
+        ok(True, f"Insufficient budget -> GrantexApiError ({getval(e, 'status_code', 'statusCode')})")
+    except Exception as e:
+        ok("402" in str(e) or "INSUFFICIENT" in str(e), f"Budget exceeded: {e}")
+
+
+# ================================================================
+# RUN ALL
+# ================================================================
+
+if __name__ == "__main__":
+    print("Python SDK E2E Tests against production")
+    print(f"Target: {BASE_URL}\n")
+
+    sections = [
+        ("Core Python SDK", test_core_sdk),
+        ("CrewAI", test_crewai),
+        ("OpenAI Agents", test_openai_agents),
+        ("Google ADK", test_google_adk),
+        ("Python Negative Paths", test_python_negative),
+        ("Python Budgets", test_python_budgets),
+    ]
+
+    for name, fn in sections:
+        try:
+            fn()
+        except Exception as e:
+            if "Rate limit" in str(e):
+                print(f"  [WAIT] Rate limited in {name}, waiting 60s...")
+                time.sleep(60)
+                try:
+                    fn()
+                except Exception as retry_err:
+                    failed += 1
+                    print(f"  [FAIL] CRASH in {name} (retry): {retry_err}")
+            else:
+                failed += 1
+                print(f"  [FAIL] CRASH in {name}: {e}")
+                traceback.print_exc()
+        time.sleep(5)
+
+    print(f"\n{'=' * 60}")
+    print(f"Results: {passed} passed, {failed} failed, {skipped} skipped")
+    print(f"{'=' * 60}")
+    sys.exit(1 if failed > 0 else 0)


### PR DESCRIPTION
## Summary

### New E2E tests (all passing against production)

| Suite | Tests | Key coverage |
|-------|-------|-------------|
| `e2e-extended.mjs` | 59 | Token refresh lifecycle, budget enforcement (allocate/debit/402), principal sessions, webhook HMAC (7 scenarios), concurrent access, payload edges (6KB metadata, unicode, 20 scopes), grant listing/filtering, token introspection |
| `e2e-python.py` | 24 | Core SDK full flow, Google ADK scope enforcement, budget flow, principal sessions, negative paths. CrewAI/OpenAI Agents skip when framework deps unavailable |

### Python SDK bugs discovered and fixed

| Bug | Impact |
|-----|--------|
| `Agent.from_dict` — `data["id"]` KeyError | Production returns `agentId` not `id` |
| `Grant.from_dict` — same `id` vs `grantId` issue | Grant listing crashes |
| `AuthorizationRequest.from_dict` — strict key lookups | Sandbox responses missing some fields |
| `ListAuditResponse`/`ListGrantsResponse` — `data["total"]` KeyError | API doesn't always return pagination metadata |
| `audit.log()` missing `agent_did`/`principal_id` | Same bug we fixed in TS integrations |

## Test plan

- [x] JS extended: 59/59 against production
- [x] Python: 24/24 against production (2 skipped — CrewAI/OpenAI need framework deps)
- [x] Combined with existing suites: 58 negative + 21 positive + 59 extended + 24 Python = **162 E2E tests**