### PR TITLE
chore: bump Python SDK to 0.2.5

### DIFF
--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.2.4"
+version = "0.2.5"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Version bump for Python SDK bug fixes (Agent/Grant id handling, audit.log fields, pagination parsing).