### PR TITLE
chore(mcp-auth): bump version to 2.0.0

### DIFF
--- a/packages/mcp-auth/package-lock.json
+++ b/packages/mcp-auth/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@grantex/mcp-auth",
-  "version": "0.1.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grantex/mcp-auth",
-      "version": "0.1.2",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/rate-limit": "^10.2.1",
         "@grantex/sdk": "^0.1.8",
-        "fastify": "^5.2.1"
+        "fastify": "^5.2.1",
+        "jose": "^5.10.0"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/packages/mcp-auth/package.json
+++ b/packages/mcp-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/mcp-auth",
-  "version": "0.1.2",
+  "version": "2.0.0",
   "description": "OAuth 2.1 + PKCE authorization server for MCP servers, powered by Grantex",
   "homepage": "https://grantex.dev/for/mcp",
   "bugs": {


### PR DESCRIPTION
## Summary
- Bumps `@grantex/mcp-auth` from 0.1.2 to 2.0.0

## Test plan
- [ ] Verify package builds successfully
- [ ] Publish to npm after merge