### PR TITLE
feat(tests): comprehensive test coverage — portal, E2E, Python SDK

### DIFF
--- a/apps/auth-service/tests/dpdp.test.ts
+++ b/apps/auth-service/tests/dpdp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { buildTestApp, seedAuth, authHeader, sqlMock, TEST_DEVELOPER, TEST_GRANT } from './helpers.js';
+import { buildTestApp, seedAuth, authHeader, sqlMock, TEST_GRANT } from './helpers.js';
 import type { FastifyInstance } from 'fastify';
 
 let app: FastifyInstance;

--- a/apps/auth-service/tests/security-crypto.test.ts
+++ b/apps/auth-service/tests/security-crypto.test.ts
@@ -10,12 +10,10 @@ import {
   buildTestApp,
   seedAuth,
   authHeader,
-  sqlMock,
-  mockRedis,
 } from './helpers.js';
 import type { FastifyInstance } from 'fastify';
 import { getKeyPair, signGrantToken } from '../src/lib/crypto.js';
-import { exportJWK, generateKeyPair, SignJWT, importJWK } from 'jose';
+import { generateKeyPair, SignJWT } from 'jose';
 
 let app: FastifyInstance;
 

--- a/apps/auth-service/tests/security-escalation.test.ts
+++ b/apps/auth-service/tests/security-escalation.test.ts
@@ -11,7 +11,6 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import {
   buildTestApp,
   seedAuth,
-  seedSandboxAuth,
   authHeader,
   sqlMock,
   mockRedis,

--- a/apps/auth-service/tests/security-multi-tenancy.test.ts
+++ b/apps/auth-service/tests/security-multi-tenancy.test.ts
@@ -13,7 +13,6 @@ import {
   mockRedis,
   TEST_DEVELOPER,
   TEST_AGENT,
-  TEST_GRANT,
 } from './helpers.js';
 import type { FastifyInstance } from 'fastify';
 import { signGrantToken } from '../src/lib/crypto.js';
@@ -26,10 +25,6 @@ beforeAll(async () => {
 
 // A second developer to test cross-org isolation
 const TEST_DEVELOPER_B = { id: 'dev_other_org', name: 'Other Org', mode: 'live' };
-
-function seedAuthAsB() {
-  sqlMock.mockResolvedValueOnce([TEST_DEVELOPER_B]);
-}
 
 describe('Multi-tenancy isolation', () => {
   // ── Agents ──────────────────────────────────────────────────────────────

--- a/apps/portal/package-lock.json
+++ b/apps/portal/package-lock.json
@@ -16,15 +16,89 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
+        "@vitest/coverage-v8": "^4.1.2",
         "autoprefixer": "^10.4.20",
+        "jsdom": "^29.0.1",
         "postcss": "^8.4.49",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.3",
-        "vite": "^6.0.7"
+        "vite": "^6.0.7",
+        "vitest": "^4.1.2"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.4.tgz",
+      "integrity": "sha512-503MoTEmPSyEJ7zQ+5vlkwPtkyxDhbDwR9ajk/jpPGrCLiUFHzgEG4iViUPKdGlZPRT1mWSPSbDL2qkOoLU4vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
+      "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -260,6 +334,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -306,6 +390,169 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -750,6 +997,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1157,6 +1422,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
@@ -1493,6 +1765,104 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1537,6 +1907,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1594,6 +1982,214 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.2",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.2",
+        "vitest": "4.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
@@ -1642,6 +2238,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -1699,6 +2305,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1728,12 +2344,47 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1753,6 +2404,23 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1762,6 +2430,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -1783,6 +2459,26 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1834,6 +2530,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1900,6 +2616,92 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -1915,6 +2717,57 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2225,6 +3078,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2233,6 +3097,64 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -2265,6 +3187,37 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2324,6 +3277,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -2348,6 +3327,14 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -2397,6 +3384,30 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -2442,6 +3453,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -2467,6 +3491,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2476,6 +3507,53 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "2.6.1",
@@ -2508,6 +3586,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2525,6 +3620,62 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2537,6 +3688,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2644,6 +3805,170 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "typecheck": "tsc --noEmit",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "clsx": "^2.1.1",
@@ -17,14 +20,20 @@
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.0.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",
+    "@vitest/coverage-v8": "^4.1.2",
     "autoprefixer": "^10.4.20",
+    "jsdom": "^29.0.1",
     "postcss": "^8.4.49",
     "tailwindcss": "^4.0.0",
-    "@tailwindcss/vite": "^4.0.0",
     "typescript": "^5.7.3",
-    "vite": "^6.0.7"
+    "vite": "^6.0.7",
+    "vitest": "^4.1.2"
   }
 }

--- a/apps/portal/src/api/__tests__/admin.test.ts
+++ b/apps/portal/src/api/__tests__/admin.test.ts
@@ -74,7 +74,7 @@ describe('admin', () => {
     ok(stats);
     const result = await fetchStats();
     expect(result).toEqual(stats);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/admin/stats');
     expect(opts.method).toBe('GET');
     expect(opts.headers['Authorization']).toBe('Bearer admin-key');
@@ -119,7 +119,7 @@ describe('admin', () => {
     setAdminKey('my-admin-key');
     ok({ developers: [], total: 0, page: 1, pageSize: 50 });
     await fetchDevelopers();
-    const opts = mockFetch.mock.calls[0][1];
+    const opts = mockFetch.mock.calls[0]![1];
     expect(opts.headers['Authorization']).toBe('Bearer my-admin-key');
   });
 

--- a/apps/portal/src/api/__tests__/admin.test.ts
+++ b/apps/portal/src/api/__tests__/admin.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Mock sessionStorage
+const mockSessionStorage: Record<string, string> = {};
+vi.stubGlobal('sessionStorage', {
+  getItem: (key: string) => mockSessionStorage[key] ?? null,
+  setItem: (key: string, value: string) => { mockSessionStorage[key] = value; },
+  removeItem: (key: string) => { delete mockSessionStorage[key]; },
+});
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { setAdminKey, getAdminKey, clearAdminKey, fetchStats, fetchDevelopers } from '../admin';
+
+describe('admin', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    // Clear admin key state
+    clearAdminKey();
+    Object.keys(mockSessionStorage).forEach((k) => delete mockSessionStorage[k]);
+  });
+
+  // ── setAdminKey / getAdminKey / clearAdminKey ─────────────────────────
+
+  it('getAdminKey returns null when no key set', () => {
+    expect(getAdminKey()).toBeNull();
+  });
+
+  it('setAdminKey stores key and getAdminKey retrieves it', () => {
+    setAdminKey('admin-key-123');
+    expect(getAdminKey()).toBe('admin-key-123');
+  });
+
+  it('setAdminKey persists to sessionStorage', () => {
+    setAdminKey('admin-key-456');
+    expect(mockSessionStorage['gx_admin_key']).toBe('admin-key-456');
+  });
+
+  it('getAdminKey falls back to sessionStorage', () => {
+    mockSessionStorage['gx_admin_key'] = 'stored-key';
+    // clearAdminKey sets the in-memory key to null, so we need a fresh import state
+    // but the function should read from sessionStorage when in-memory is null
+    const result = getAdminKey();
+    expect(result).toBe('stored-key');
+  });
+
+  it('clearAdminKey removes key from memory and sessionStorage', () => {
+    setAdminKey('key');
+    clearAdminKey();
+    expect(getAdminKey()).toBeNull();
+    expect(mockSessionStorage['gx_admin_key']).toBeUndefined();
+  });
+
+  // ── fetchStats ────────────────────────────────────────────────────────
+
+  it('fetchStats sends GET /v1/admin/stats with admin key', async () => {
+    setAdminKey('admin-key');
+    const stats = { totalDevelopers: 100, last24h: 5, last7d: 20, last30d: 50, byMode: {}, totalAgents: 200, totalGrants: 500 };
+    ok(stats);
+    const result = await fetchStats();
+    expect(result).toEqual(stats);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/admin/stats');
+    expect(opts.method).toBe('GET');
+    expect(opts.headers['Authorization']).toBe('Bearer admin-key');
+  });
+
+  it('fetchStats throws when no admin key set', async () => {
+    await expect(fetchStats()).rejects.toThrow('Admin API key not set');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('fetchStats throws on server error', async () => {
+    setAdminKey('admin-key');
+    err(403, 'FORBIDDEN', 'Invalid admin key');
+    await expect(fetchStats()).rejects.toThrow('Invalid admin key');
+  });
+
+  // ── fetchDevelopers ───────────────────────────────────────────────────
+
+  it('fetchDevelopers sends GET with default page and pageSize', async () => {
+    setAdminKey('admin-key');
+    const resp = { developers: [{ id: 'd1', name: 'Alice' }], total: 1, page: 1, pageSize: 50 };
+    ok(resp);
+    const result = await fetchDevelopers();
+    expect(result).toEqual(resp);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/admin/developers?page=1&pageSize=50',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('fetchDevelopers sends GET with custom page and pageSize', async () => {
+    setAdminKey('admin-key');
+    ok({ developers: [], total: 0, page: 2, pageSize: 25 });
+    await fetchDevelopers(2, 25);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/admin/developers?page=2&pageSize=25',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('fetchDevelopers includes admin key in Authorization header', async () => {
+    setAdminKey('my-admin-key');
+    ok({ developers: [], total: 0, page: 1, pageSize: 50 });
+    await fetchDevelopers();
+    const opts = mockFetch.mock.calls[0][1];
+    expect(opts.headers['Authorization']).toBe('Bearer my-admin-key');
+  });
+
+  it('fetchDevelopers throws when no admin key set', async () => {
+    await expect(fetchDevelopers()).rejects.toThrow('Admin API key not set');
+  });
+
+  it('fetchDevelopers throws on server error', async () => {
+    setAdminKey('admin-key');
+    err(500, 'INTERNAL', 'Database error');
+    await expect(fetchDevelopers()).rejects.toThrow('Database error');
+  });
+});

--- a/apps/portal/src/api/__tests__/agents.test.ts
+++ b/apps/portal/src/api/__tests__/agents.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function noContent() {
+  mockFetch.mockResolvedValueOnce({ ok: true, status: 204, json: () => Promise.resolve(undefined) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { listAgents, getAgent, createAgent, updateAgent, deleteAgent } from '../agents';
+
+describe('agents', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── listAgents ─────────────────────────────────────────────────────────
+
+  it('listAgents sends GET /v1/agents and unwraps .agents', async () => {
+    const agents = [{ agentId: 'a1', name: 'Agent 1' }];
+    ok({ agents });
+    const result = await listAgents();
+    expect(result).toEqual(agents);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/agents', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('listAgents throws on error', async () => {
+    err(500, 'INTERNAL', 'Server error');
+    await expect(listAgents()).rejects.toThrow('Server error');
+  });
+
+  // ── getAgent ───────────────────────────────────────────────────────────
+
+  it('getAgent sends GET /v1/agents/:id', async () => {
+    const agent = { agentId: 'a1', name: 'Agent 1' };
+    ok(agent);
+    const result = await getAgent('a1');
+    expect(result).toEqual(agent);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/agents/a1', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('getAgent encodes id', async () => {
+    ok({ agentId: 'a/b' });
+    await getAgent('a/b');
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/agents/a%2Fb', expect.anything());
+  });
+
+  it('getAgent throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'Agent not found');
+    await expect(getAgent('missing')).rejects.toThrow('Agent not found');
+  });
+
+  // ── createAgent ────────────────────────────────────────────────────────
+
+  it('createAgent sends POST /v1/agents with body', async () => {
+    const data = { name: 'New Agent', scopes: ['read'] };
+    const created = { agentId: 'a2', ...data };
+    ok(created);
+    const result = await createAgent(data as any);
+    expect(result).toEqual(created);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/agents');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(data);
+  });
+
+  it('createAgent throws on 400', async () => {
+    err(400, 'VALIDATION', 'Name required');
+    await expect(createAgent({} as any)).rejects.toThrow('Name required');
+  });
+
+  // ── updateAgent ────────────────────────────────────────────────────────
+
+  it('updateAgent sends PATCH /v1/agents/:id with body', async () => {
+    const data = { name: 'Updated' };
+    ok({ agentId: 'a1', name: 'Updated' });
+    await updateAgent('a1', data);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/agents/a1');
+    expect(opts.method).toBe('PATCH');
+    expect(JSON.parse(opts.body)).toEqual(data);
+  });
+
+  it('updateAgent throws on error', async () => {
+    err(404, 'NOT_FOUND', 'Agent not found');
+    await expect(updateAgent('missing', { name: 'x' })).rejects.toThrow('Agent not found');
+  });
+
+  // ── deleteAgent ────────────────────────────────────────────────────────
+
+  it('deleteAgent sends DELETE /v1/agents/:id', async () => {
+    noContent();
+    await deleteAgent('a1');
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/agents/a1', expect.objectContaining({ method: 'DELETE' }));
+  });
+
+  it('deleteAgent throws on error', async () => {
+    err(404, 'NOT_FOUND', 'Agent not found');
+    await expect(deleteAgent('missing')).rejects.toThrow('Agent not found');
+  });
+});

--- a/apps/portal/src/api/__tests__/agents.test.ts
+++ b/apps/portal/src/api/__tests__/agents.test.ts
@@ -71,7 +71,7 @@ describe('agents', () => {
     ok(created);
     const result = await createAgent(data as any);
     expect(result).toEqual(created);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/agents');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(data);
@@ -88,7 +88,7 @@ describe('agents', () => {
     const data = { name: 'Updated' };
     ok({ agentId: 'a1', name: 'Updated' });
     await updateAgent('a1', data);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/agents/a1');
     expect(opts.method).toBe('PATCH');
     expect(JSON.parse(opts.body)).toEqual(data);

--- a/apps/portal/src/api/__tests__/anomalies.test.ts
+++ b/apps/portal/src/api/__tests__/anomalies.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function noContent() {
+  mockFetch.mockResolvedValueOnce({ ok: true, status: 204, json: () => Promise.resolve(undefined) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import {
+  listAnomalies,
+  detectAnomalies,
+  acknowledgeAnomaly,
+  listAlerts,
+  getAlert,
+  acknowledgeAlert,
+  resolveAlert,
+  getMetrics,
+  listRules,
+  createRule,
+  toggleRule,
+  deleteRule,
+  listChannels,
+  createChannel,
+  deleteChannel,
+} from '../anomalies';
+
+describe('anomalies', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── Legacy: listAnomalies ─────────────────────────────────────────────
+
+  it('listAnomalies sends GET /v1/anomalies and unwraps .anomalies', async () => {
+    ok({ anomalies: [{ id: 'an1' }], total: 1 });
+    const result = await listAnomalies();
+    expect(result).toEqual([{ id: 'an1' }]);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/anomalies', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('listAnomalies throws on error', async () => {
+    err(500, 'INTERNAL', 'Failed');
+    await expect(listAnomalies()).rejects.toThrow('Failed');
+  });
+
+  // ── Legacy: detectAnomalies ───────────────────────────────────────────
+
+  it('detectAnomalies sends POST /v1/anomalies/detect', async () => {
+    const resp = { detectedAt: '2026-04-01', total: 2, anomalies: [] };
+    ok(resp);
+    const result = await detectAnomalies();
+    expect(result).toEqual(resp);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/anomalies/detect');
+    expect(opts.method).toBe('POST');
+  });
+
+  // ── Legacy: acknowledgeAnomaly ────────────────────────────────────────
+
+  it('acknowledgeAnomaly sends PATCH /v1/anomalies/:id/acknowledge', async () => {
+    ok({ id: 'an1', acknowledged: true });
+    await acknowledgeAnomaly('an1');
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/anomalies/an1/acknowledge');
+    expect(opts.method).toBe('PATCH');
+  });
+
+  // ── Alerts: listAlerts ────────────────────────────────────────────────
+
+  it('listAlerts without params sends GET /v1/anomalies/alerts', async () => {
+    ok({ alerts: [{ alertId: 'al1' }], total: 1 });
+    const result = await listAlerts();
+    expect(result).toEqual([{ alertId: 'al1' }]);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/anomalies/alerts', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('listAlerts with status param', async () => {
+    ok({ alerts: [], total: 0 });
+    await listAlerts({ status: 'open' });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/anomalies/alerts?status=open');
+  });
+
+  it('listAlerts with severity param', async () => {
+    ok({ alerts: [], total: 0 });
+    await listAlerts({ severity: 'critical' });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/anomalies/alerts?severity=critical');
+  });
+
+  it('listAlerts with both params', async () => {
+    ok({ alerts: [], total: 0 });
+    await listAlerts({ status: 'open', severity: 'high' });
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toContain('status=open');
+    expect(url).toContain('severity=high');
+  });
+
+  it('listAlerts throws on error', async () => {
+    err(500, 'INTERNAL', 'Fail');
+    await expect(listAlerts()).rejects.toThrow('Fail');
+  });
+
+  // ── Alerts: getAlert ──────────────────────────────────────────────────
+
+  it('getAlert sends GET /v1/anomalies/alerts/:id', async () => {
+    ok({ alertId: 'al1' });
+    const result = await getAlert('al1');
+    expect(result).toEqual({ alertId: 'al1' });
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/anomalies/alerts/al1', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('getAlert throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'Alert not found');
+    await expect(getAlert('missing')).rejects.toThrow('Alert not found');
+  });
+
+  // ── Alerts: acknowledgeAlert ──────────────────────────────────────────
+
+  it('acknowledgeAlert sends POST with empty body when no note', async () => {
+    ok(undefined);
+    await acknowledgeAlert('al1');
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/anomalies/alerts/al1/acknowledge');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({});
+  });
+
+  it('acknowledgeAlert sends POST with note', async () => {
+    ok(undefined);
+    await acknowledgeAlert('al1', 'Investigating');
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toEqual({ note: 'Investigating' });
+  });
+
+  // ── Alerts: resolveAlert ──────────────────────────────────────────────
+
+  it('resolveAlert sends POST without note', async () => {
+    ok(undefined);
+    await resolveAlert('al1');
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/anomalies/alerts/al1/resolve');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({});
+  });
+
+  it('resolveAlert sends POST with note', async () => {
+    ok(undefined);
+    await resolveAlert('al1', 'Fixed');
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toEqual({ note: 'Fixed' });
+  });
+
+  // ── Metrics ───────────────────────────────────────────────────────────
+
+  it('getMetrics without params sends GET /v1/anomalies/metrics', async () => {
+    const metrics = { totalAlerts: 5, openAlerts: 2 };
+    ok(metrics);
+    const result = await getMetrics();
+    expect(result).toEqual(metrics);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/anomalies/metrics', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('getMetrics with agentId param', async () => {
+    ok({ totalAlerts: 0 });
+    await getMetrics('agent-1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/anomalies/metrics?agentId=agent-1');
+  });
+
+  it('getMetrics with both agentId and window', async () => {
+    ok({ totalAlerts: 0 });
+    await getMetrics('agent-1', '24h');
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toContain('agentId=agent-1');
+    expect(url).toContain('window=24h');
+  });
+
+  // ── Rules: listRules ──────────────────────────────────────────────────
+
+  it('listRules sends GET /v1/anomalies/rules and unwraps .rules', async () => {
+    ok({ rules: [{ ruleId: 'r1', name: 'Rule 1' }] });
+    const result = await listRules();
+    expect(result).toEqual([{ ruleId: 'r1', name: 'Rule 1' }]);
+  });
+
+  it('listRules throws on error', async () => {
+    err(500, 'INTERNAL', 'Fail');
+    await expect(listRules()).rejects.toThrow('Fail');
+  });
+
+  // ── Rules: createRule ─────────────────────────────────────────────────
+
+  it('createRule sends POST /v1/anomalies/rules with body', async () => {
+    const data = {
+      ruleId: 'r2',
+      name: 'New Rule',
+      description: 'Desc',
+      severity: 'high',
+      condition: { threshold: 10 },
+    };
+    ok({ ...data, builtin: false, enabled: true });
+    await createRule(data);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/anomalies/rules');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(data);
+  });
+
+  // ── Rules: toggleRule ─────────────────────────────────────────────────
+
+  it('toggleRule sends PATCH /v1/anomalies/rules/:id with enabled', async () => {
+    ok({ ruleId: 'r1', enabled: false });
+    await toggleRule('r1', false);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/anomalies/rules/r1');
+    expect(opts.method).toBe('PATCH');
+    expect(JSON.parse(opts.body)).toEqual({ enabled: false });
+  });
+
+  // ── Rules: deleteRule ─────────────────────────────────────────────────
+
+  it('deleteRule sends DELETE /v1/anomalies/rules/:id', async () => {
+    noContent();
+    await deleteRule('r1');
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/anomalies/rules/r1', expect.objectContaining({ method: 'DELETE' }));
+  });
+
+  // ── Channels: listChannels ────────────────────────────────────────────
+
+  it('listChannels sends GET /v1/anomalies/channels and unwraps', async () => {
+    ok({ channels: [{ id: 'ch1', type: 'slack' }] });
+    const result = await listChannels();
+    expect(result).toEqual([{ id: 'ch1', type: 'slack' }]);
+  });
+
+  // ── Channels: createChannel ───────────────────────────────────────────
+
+  it('createChannel sends POST /v1/anomalies/channels', async () => {
+    const data = { type: 'slack', name: 'alerts', config: { url: 'https://hooks.slack.com/x' }, severities: ['critical'] };
+    ok({ id: 'ch2', ...data, enabled: true });
+    await createChannel(data);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/anomalies/channels');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(data);
+  });
+
+  // ── Channels: deleteChannel ───────────────────────────────────────────
+
+  it('deleteChannel sends DELETE /v1/anomalies/channels/:id', async () => {
+    noContent();
+    await deleteChannel('ch1');
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/anomalies/channels/ch1', expect.objectContaining({ method: 'DELETE' }));
+  });
+
+  it('deleteChannel throws on error', async () => {
+    err(404, 'NOT_FOUND', 'Channel not found');
+    await expect(deleteChannel('missing')).rejects.toThrow('Channel not found');
+  });
+});

--- a/apps/portal/src/api/__tests__/anomalies.test.ts
+++ b/apps/portal/src/api/__tests__/anomalies.test.ts
@@ -64,7 +64,7 @@ describe('anomalies', () => {
     ok(resp);
     const result = await detectAnomalies();
     expect(result).toEqual(resp);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/anomalies/detect');
     expect(opts.method).toBe('POST');
   });
@@ -74,7 +74,7 @@ describe('anomalies', () => {
   it('acknowledgeAnomaly sends PATCH /v1/anomalies/:id/acknowledge', async () => {
     ok({ id: 'an1', acknowledged: true });
     await acknowledgeAnomaly('an1');
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/anomalies/an1/acknowledge');
     expect(opts.method).toBe('PATCH');
   });
@@ -91,19 +91,19 @@ describe('anomalies', () => {
   it('listAlerts with status param', async () => {
     ok({ alerts: [], total: 0 });
     await listAlerts({ status: 'open' });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/anomalies/alerts?status=open');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/anomalies/alerts?status=open');
   });
 
   it('listAlerts with severity param', async () => {
     ok({ alerts: [], total: 0 });
     await listAlerts({ severity: 'critical' });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/anomalies/alerts?severity=critical');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/anomalies/alerts?severity=critical');
   });
 
   it('listAlerts with both params', async () => {
     ok({ alerts: [], total: 0 });
     await listAlerts({ status: 'open', severity: 'high' });
-    const url = mockFetch.mock.calls[0][0];
+    const url = mockFetch.mock.calls[0]![0];
     expect(url).toContain('status=open');
     expect(url).toContain('severity=high');
   });
@@ -132,7 +132,7 @@ describe('anomalies', () => {
   it('acknowledgeAlert sends POST with empty body when no note', async () => {
     ok(undefined);
     await acknowledgeAlert('al1');
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/anomalies/alerts/al1/acknowledge');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual({});
@@ -141,7 +141,7 @@ describe('anomalies', () => {
   it('acknowledgeAlert sends POST with note', async () => {
     ok(undefined);
     await acknowledgeAlert('al1', 'Investigating');
-    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const body = JSON.parse(mockFetch.mock.calls[0]![1].body);
     expect(body).toEqual({ note: 'Investigating' });
   });
 
@@ -150,7 +150,7 @@ describe('anomalies', () => {
   it('resolveAlert sends POST without note', async () => {
     ok(undefined);
     await resolveAlert('al1');
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/anomalies/alerts/al1/resolve');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual({});
@@ -159,7 +159,7 @@ describe('anomalies', () => {
   it('resolveAlert sends POST with note', async () => {
     ok(undefined);
     await resolveAlert('al1', 'Fixed');
-    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toEqual({ note: 'Fixed' });
+    expect(JSON.parse(mockFetch.mock.calls[0]![1].body)).toEqual({ note: 'Fixed' });
   });
 
   // ── Metrics ───────────────────────────────────────────────────────────
@@ -175,13 +175,13 @@ describe('anomalies', () => {
   it('getMetrics with agentId param', async () => {
     ok({ totalAlerts: 0 });
     await getMetrics('agent-1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/anomalies/metrics?agentId=agent-1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/anomalies/metrics?agentId=agent-1');
   });
 
   it('getMetrics with both agentId and window', async () => {
     ok({ totalAlerts: 0 });
     await getMetrics('agent-1', '24h');
-    const url = mockFetch.mock.calls[0][0];
+    const url = mockFetch.mock.calls[0]![0];
     expect(url).toContain('agentId=agent-1');
     expect(url).toContain('window=24h');
   });
@@ -211,7 +211,7 @@ describe('anomalies', () => {
     };
     ok({ ...data, builtin: false, enabled: true });
     await createRule(data);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/anomalies/rules');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(data);
@@ -222,7 +222,7 @@ describe('anomalies', () => {
   it('toggleRule sends PATCH /v1/anomalies/rules/:id with enabled', async () => {
     ok({ ruleId: 'r1', enabled: false });
     await toggleRule('r1', false);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/anomalies/rules/r1');
     expect(opts.method).toBe('PATCH');
     expect(JSON.parse(opts.body)).toEqual({ enabled: false });
@@ -250,7 +250,7 @@ describe('anomalies', () => {
     const data = { type: 'slack', name: 'alerts', config: { url: 'https://hooks.slack.com/x' }, severities: ['critical'] };
     ok({ id: 'ch2', ...data, enabled: true });
     await createChannel(data);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/anomalies/channels');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(data);

--- a/apps/portal/src/api/__tests__/audit.test.ts
+++ b/apps/portal/src/api/__tests__/audit.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { listAuditEntries, getAuditEntry } from '../audit';
+
+describe('audit', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── listAuditEntries ──────────────────────────────────────────────────
+
+  it('listAuditEntries without params sends GET /v1/audit/entries', async () => {
+    ok({ entries: [{ id: 'e1', action: 'token.exchange' }] });
+    const result = await listAuditEntries();
+    expect(result).toEqual([{ id: 'e1', action: 'token.exchange' }]);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/audit/entries', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('listAuditEntries with agentId param', async () => {
+    ok({ entries: [] });
+    await listAuditEntries({ agentId: 'agent-1' });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/audit/entries?agentId=agent-1');
+  });
+
+  it('listAuditEntries with grantId param', async () => {
+    ok({ entries: [] });
+    await listAuditEntries({ grantId: 'g1' });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/audit/entries?grantId=g1');
+  });
+
+  it('listAuditEntries with principalId param', async () => {
+    ok({ entries: [] });
+    await listAuditEntries({ principalId: 'p1' });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/audit/entries?principalId=p1');
+  });
+
+  it('listAuditEntries with action param', async () => {
+    ok({ entries: [] });
+    await listAuditEntries({ action: 'token.verify' });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/audit/entries?action=token.verify');
+  });
+
+  it('listAuditEntries with multiple params', async () => {
+    ok({ entries: [] });
+    await listAuditEntries({ agentId: 'a1', action: 'grant.revoke' });
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toContain('agentId=a1');
+    expect(url).toContain('action=grant.revoke');
+  });
+
+  it('listAuditEntries throws on error', async () => {
+    err(500, 'INTERNAL', 'DB error');
+    await expect(listAuditEntries()).rejects.toThrow('DB error');
+  });
+
+  // ── getAuditEntry ─────────────────────────────────────────────────────
+
+  it('getAuditEntry sends GET /v1/audit/:id', async () => {
+    ok({ id: 'e1', action: 'token.exchange' });
+    const result = await getAuditEntry('e1');
+    expect(result).toEqual({ id: 'e1', action: 'token.exchange' });
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/audit/e1', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('getAuditEntry encodes id', async () => {
+    ok({ id: 'e/1' });
+    await getAuditEntry('e/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/audit/e%2F1');
+  });
+
+  it('getAuditEntry throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'Entry not found');
+    await expect(getAuditEntry('missing')).rejects.toThrow('Entry not found');
+  });
+});

--- a/apps/portal/src/api/__tests__/audit.test.ts
+++ b/apps/portal/src/api/__tests__/audit.test.ts
@@ -36,31 +36,31 @@ describe('audit', () => {
   it('listAuditEntries with agentId param', async () => {
     ok({ entries: [] });
     await listAuditEntries({ agentId: 'agent-1' });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/audit/entries?agentId=agent-1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/audit/entries?agentId=agent-1');
   });
 
   it('listAuditEntries with grantId param', async () => {
     ok({ entries: [] });
     await listAuditEntries({ grantId: 'g1' });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/audit/entries?grantId=g1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/audit/entries?grantId=g1');
   });
 
   it('listAuditEntries with principalId param', async () => {
     ok({ entries: [] });
     await listAuditEntries({ principalId: 'p1' });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/audit/entries?principalId=p1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/audit/entries?principalId=p1');
   });
 
   it('listAuditEntries with action param', async () => {
     ok({ entries: [] });
     await listAuditEntries({ action: 'token.verify' });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/audit/entries?action=token.verify');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/audit/entries?action=token.verify');
   });
 
   it('listAuditEntries with multiple params', async () => {
     ok({ entries: [] });
     await listAuditEntries({ agentId: 'a1', action: 'grant.revoke' });
-    const url = mockFetch.mock.calls[0][0];
+    const url = mockFetch.mock.calls[0]![0];
     expect(url).toContain('agentId=a1');
     expect(url).toContain('action=grant.revoke');
   });
@@ -82,7 +82,7 @@ describe('audit', () => {
   it('getAuditEntry encodes id', async () => {
     ok({ id: 'e/1' });
     await getAuditEntry('e/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/audit/e%2F1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/audit/e%2F1');
   });
 
   it('getAuditEntry throws on 404', async () => {

--- a/apps/portal/src/api/__tests__/auth.test.ts
+++ b/apps/portal/src/api/__tests__/auth.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { getMe, signup, sendVerificationEmail, rotateKey } from '../auth';
+
+describe('auth', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── getMe ──────────────────────────────────────────────────────────────
+
+  it('getMe sends GET /v1/me and returns developer', async () => {
+    const dev = { id: 'dev-1', name: 'Alice', email: 'alice@test.com' };
+    ok(dev);
+    const result = await getMe();
+    expect(result).toEqual(dev);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/me', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('getMe throws on 401', async () => {
+    err(401, 'UNAUTHORIZED', 'Invalid key');
+    await expect(getMe()).rejects.toThrow('Invalid key');
+  });
+
+  // ── signup ─────────────────────────────────────────────────────────────
+
+  it('signup sends POST /v1/signup with data', async () => {
+    const req = { name: 'Bob', email: 'bob@test.com' };
+    const resp = { developerId: 'dev-2', apiKey: 'key-123' };
+    ok(resp);
+    const result = await signup(req);
+    expect(result).toEqual(resp);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/signup');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(req);
+  });
+
+  it('signup throws on 409 conflict', async () => {
+    err(409, 'CONFLICT', 'Email already registered');
+    await expect(signup({ name: 'Bob', email: 'bob@test.com' } as any)).rejects.toThrow('Email already registered');
+  });
+
+  // ── sendVerificationEmail ──────────────────────────────────────────────
+
+  it('sendVerificationEmail sends POST /v1/signup/verify', async () => {
+    ok({ message: 'Verification email sent', expiresAt: '2026-04-04T00:00:00Z' });
+    const result = await sendVerificationEmail('test@test.com');
+    expect(result.message).toBe('Verification email sent');
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/signup/verify');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ email: 'test@test.com' });
+  });
+
+  it('sendVerificationEmail throws on error', async () => {
+    err(400, 'BAD_REQUEST', 'Invalid email');
+    await expect(sendVerificationEmail('bad')).rejects.toThrow('Invalid email');
+  });
+
+  // ── rotateKey ──────────────────────────────────────────────────────────
+
+  it('rotateKey sends POST /v1/keys/rotate', async () => {
+    const resp = { apiKey: 'new-key-456' };
+    ok(resp);
+    const result = await rotateKey();
+    expect(result).toEqual(resp);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/keys/rotate');
+    expect(opts.method).toBe('POST');
+  });
+
+  it('rotateKey throws on 403', async () => {
+    err(403, 'FORBIDDEN', 'Not allowed');
+    await expect(rotateKey()).rejects.toThrow('Not allowed');
+  });
+});

--- a/apps/portal/src/api/__tests__/auth.test.ts
+++ b/apps/portal/src/api/__tests__/auth.test.ts
@@ -47,7 +47,7 @@ describe('auth', () => {
     ok(resp);
     const result = await signup(req);
     expect(result).toEqual(resp);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/signup');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(req);
@@ -64,7 +64,7 @@ describe('auth', () => {
     ok({ message: 'Verification email sent', expiresAt: '2026-04-04T00:00:00Z' });
     const result = await sendVerificationEmail('test@test.com');
     expect(result.message).toBe('Verification email sent');
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/signup/verify');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual({ email: 'test@test.com' });
@@ -82,7 +82,7 @@ describe('auth', () => {
     ok(resp);
     const result = await rotateKey();
     expect(result).toEqual(resp);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/keys/rotate');
     expect(opts.method).toBe('POST');
   });

--- a/apps/portal/src/api/__tests__/billing.test.ts
+++ b/apps/portal/src/api/__tests__/billing.test.ts
@@ -51,7 +51,7 @@ describe('billing', () => {
     ok({ checkoutUrl: 'https://stripe.com/checkout/123' });
     const result = await createCheckout('pro');
     expect(result).toEqual({ checkoutUrl: 'https://stripe.com/checkout/123' });
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/billing/checkout');
     expect(opts.method).toBe('POST');
     const body = JSON.parse(opts.body);
@@ -71,7 +71,7 @@ describe('billing', () => {
     ok({ portalUrl: 'https://billing.stripe.com/portal/123' });
     const result = await getPortalUrl();
     expect(result).toEqual({ portalUrl: 'https://billing.stripe.com/portal/123' });
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/billing/portal');
     expect(opts.method).toBe('POST');
     const body = JSON.parse(opts.body);

--- a/apps/portal/src/api/__tests__/billing.test.ts
+++ b/apps/portal/src/api/__tests__/billing.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { getSubscription, createCheckout, getPortalUrl } from '../billing';
+
+// Mock window.location.origin for billing URLs
+Object.defineProperty(window, 'location', {
+  value: { origin: 'http://localhost:5173' },
+  writable: true,
+});
+
+describe('billing', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── getSubscription ───────────────────────────────────────────────────
+
+  it('getSubscription sends GET /v1/billing/subscription', async () => {
+    const sub = { plan: 'pro', status: 'active' };
+    ok(sub);
+    const result = await getSubscription();
+    expect(result).toEqual(sub);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/billing/subscription', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('getSubscription throws on error', async () => {
+    err(401, 'UNAUTHORIZED', 'Not authenticated');
+    await expect(getSubscription()).rejects.toThrow('Not authenticated');
+  });
+
+  // ── createCheckout ────────────────────────────────────────────────────
+
+  it('createCheckout sends POST /v1/billing/checkout with plan and URLs', async () => {
+    ok({ checkoutUrl: 'https://stripe.com/checkout/123' });
+    const result = await createCheckout('pro');
+    expect(result).toEqual({ checkoutUrl: 'https://stripe.com/checkout/123' });
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/billing/checkout');
+    expect(opts.method).toBe('POST');
+    const body = JSON.parse(opts.body);
+    expect(body.plan).toBe('pro');
+    expect(body.successUrl).toBe('http://localhost:5173/dashboard/billing?success=true');
+    expect(body.cancelUrl).toBe('http://localhost:5173/dashboard/billing');
+  });
+
+  it('createCheckout throws on error', async () => {
+    err(400, 'BAD_REQUEST', 'Invalid plan');
+    await expect(createCheckout('invalid')).rejects.toThrow('Invalid plan');
+  });
+
+  // ── getPortalUrl ──────────────────────────────────────────────────────
+
+  it('getPortalUrl sends POST /v1/billing/portal with returnUrl', async () => {
+    ok({ portalUrl: 'https://billing.stripe.com/portal/123' });
+    const result = await getPortalUrl();
+    expect(result).toEqual({ portalUrl: 'https://billing.stripe.com/portal/123' });
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/billing/portal');
+    expect(opts.method).toBe('POST');
+    const body = JSON.parse(opts.body);
+    expect(body.returnUrl).toBe('http://localhost:5173/dashboard/billing');
+  });
+
+  it('getPortalUrl throws on error', async () => {
+    err(403, 'FORBIDDEN', 'No subscription');
+    await expect(getPortalUrl()).rejects.toThrow('No subscription');
+  });
+});

--- a/apps/portal/src/api/__tests__/budgets.test.ts
+++ b/apps/portal/src/api/__tests__/budgets.test.ts
@@ -51,7 +51,7 @@ describe('budgets', () => {
   it('getBudget encodes grantId', async () => {
     ok({ id: 'b1' });
     await getBudget('g/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/budget/balance/g%2F1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/budget/balance/g%2F1');
   });
 
   it('getBudget throws on 404', async () => {
@@ -84,7 +84,7 @@ describe('budgets', () => {
   it('listTransactions encodes grantId', async () => {
     ok({ transactions: [], total: 0 });
     await listTransactions('g/1', 1, 20);
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/budget/transactions/g%2F1?page=1&pageSize=20');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/budget/transactions/g%2F1?page=1&pageSize=20');
   });
 
   it('listTransactions throws on error', async () => {

--- a/apps/portal/src/api/__tests__/budgets.test.ts
+++ b/apps/portal/src/api/__tests__/budgets.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { listBudgets, getBudget, listTransactions } from '../budgets';
+
+describe('budgets', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── listBudgets ───────────────────────────────────────────────────────
+
+  it('listBudgets sends GET /v1/budget/allocations and unwraps .allocations', async () => {
+    ok({ allocations: [{ id: 'b1', grantId: 'g1', remainingBudget: 100 }] });
+    const result = await listBudgets();
+    expect(result).toEqual([{ id: 'b1', grantId: 'g1', remainingBudget: 100 }]);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/budget/allocations', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('listBudgets throws on error', async () => {
+    err(500, 'INTERNAL', 'DB error');
+    await expect(listBudgets()).rejects.toThrow('DB error');
+  });
+
+  // ── getBudget ─────────────────────────────────────────────────────────
+
+  it('getBudget sends GET /v1/budget/balance/:grantId', async () => {
+    const budget = { id: 'b1', grantId: 'g1', remainingBudget: 50 };
+    ok(budget);
+    const result = await getBudget('g1');
+    expect(result).toEqual(budget);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/budget/balance/g1', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('getBudget encodes grantId', async () => {
+    ok({ id: 'b1' });
+    await getBudget('g/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/budget/balance/g%2F1');
+  });
+
+  it('getBudget throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'Budget not found');
+    await expect(getBudget('missing')).rejects.toThrow('Budget not found');
+  });
+
+  // ── listTransactions ──────────────────────────────────────────────────
+
+  it('listTransactions sends GET with default page and pageSize', async () => {
+    const data = { transactions: [{ id: 't1' }], total: 1 };
+    ok(data);
+    const result = await listTransactions('g1');
+    expect(result).toEqual(data);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/budget/transactions/g1?page=1&pageSize=20',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('listTransactions sends GET with custom page and pageSize', async () => {
+    ok({ transactions: [], total: 0 });
+    await listTransactions('g1', 3, 50);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/budget/transactions/g1?page=3&pageSize=50',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('listTransactions encodes grantId', async () => {
+    ok({ transactions: [], total: 0 });
+    await listTransactions('g/1', 1, 20);
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/budget/transactions/g%2F1?page=1&pageSize=20');
+  });
+
+  it('listTransactions throws on error', async () => {
+    err(500, 'INTERNAL', 'Failed');
+    await expect(listTransactions('g1')).rejects.toThrow('Failed');
+  });
+});

--- a/apps/portal/src/api/__tests__/bundles.test.ts
+++ b/apps/portal/src/api/__tests__/bundles.test.ts
@@ -36,19 +36,19 @@ describe('bundles', () => {
   it('listBundles with status param', async () => {
     ok({ bundles: [] });
     await listBundles({ status: 'revoked' });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/consent-bundles?status=revoked');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/consent-bundles?status=revoked');
   });
 
   it('listBundles with agentId param', async () => {
     ok({ bundles: [] });
     await listBundles({ agentId: 'agent-1' });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/consent-bundles?agentId=agent-1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/consent-bundles?agentId=agent-1');
   });
 
   it('listBundles with both params', async () => {
     ok({ bundles: [] });
     await listBundles({ status: 'active', agentId: 'a1' });
-    const url = mockFetch.mock.calls[0][0];
+    const url = mockFetch.mock.calls[0]![0];
     expect(url).toContain('status=active');
     expect(url).toContain('agentId=a1');
   });
@@ -70,7 +70,7 @@ describe('bundles', () => {
   it('getBundle encodes id', async () => {
     ok({ id: 'cb/1' });
     await getBundle('cb/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/consent-bundles/cb%2F1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/consent-bundles/cb%2F1');
   });
 
   it('getBundle throws on 404', async () => {
@@ -86,7 +86,7 @@ describe('bundles', () => {
     ok(resp);
     const result = await createBundle(params);
     expect(result).toEqual(resp);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/consent-bundles');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(params);
@@ -102,7 +102,7 @@ describe('bundles', () => {
   it('revokeBundle sends POST /v1/consent-bundles/:id/revoke', async () => {
     ok(undefined);
     await revokeBundle('cb1');
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/consent-bundles/cb1/revoke');
     expect(opts.method).toBe('POST');
   });
@@ -127,7 +127,7 @@ describe('bundles', () => {
   it('getBundleAuditEntries encodes id', async () => {
     ok({ entries: [] });
     await getBundleAuditEntries('cb/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/consent-bundles/cb%2F1/audit');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/consent-bundles/cb%2F1/audit');
   });
 
   it('getBundleAuditEntries throws on error', async () => {

--- a/apps/portal/src/api/__tests__/bundles.test.ts
+++ b/apps/portal/src/api/__tests__/bundles.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { listBundles, getBundle, createBundle, revokeBundle, getBundleAuditEntries, getRevocationStatus } from '../bundles';
+
+describe('bundles', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── listBundles ───────────────────────────────────────────────────────
+
+  it('listBundles without params sends GET /v1/consent-bundles', async () => {
+    ok({ bundles: [{ id: 'cb1', status: 'active' }] });
+    const result = await listBundles();
+    expect(result).toEqual([{ id: 'cb1', status: 'active' }]);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/consent-bundles', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('listBundles with status param', async () => {
+    ok({ bundles: [] });
+    await listBundles({ status: 'revoked' });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/consent-bundles?status=revoked');
+  });
+
+  it('listBundles with agentId param', async () => {
+    ok({ bundles: [] });
+    await listBundles({ agentId: 'agent-1' });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/consent-bundles?agentId=agent-1');
+  });
+
+  it('listBundles with both params', async () => {
+    ok({ bundles: [] });
+    await listBundles({ status: 'active', agentId: 'a1' });
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toContain('status=active');
+    expect(url).toContain('agentId=a1');
+  });
+
+  it('listBundles throws on error', async () => {
+    err(500, 'INTERNAL', 'Failed');
+    await expect(listBundles()).rejects.toThrow('Failed');
+  });
+
+  // ── getBundle ─────────────────────────────────────────────────────────
+
+  it('getBundle sends GET /v1/consent-bundles/:id', async () => {
+    ok({ id: 'cb1', status: 'active' });
+    const result = await getBundle('cb1');
+    expect(result).toEqual({ id: 'cb1', status: 'active' });
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/consent-bundles/cb1', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('getBundle encodes id', async () => {
+    ok({ id: 'cb/1' });
+    await getBundle('cb/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/consent-bundles/cb%2F1');
+  });
+
+  it('getBundle throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'Bundle not found');
+    await expect(getBundle('missing')).rejects.toThrow('Bundle not found');
+  });
+
+  // ── createBundle ──────────────────────────────────────────────────────
+
+  it('createBundle sends POST /v1/consent-bundles with params', async () => {
+    const params = { agentId: 'a1', userId: 'u1', scopes: ['read', 'write'] };
+    const resp = { bundle: { id: 'cb2' }, grantToken: 'tok', jwks: {}, auditKey: 'ak' };
+    ok(resp);
+    const result = await createBundle(params);
+    expect(result).toEqual(resp);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/consent-bundles');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(params);
+  });
+
+  it('createBundle throws on 400', async () => {
+    err(400, 'VALIDATION', 'Missing agentId');
+    await expect(createBundle({} as any)).rejects.toThrow('Missing agentId');
+  });
+
+  // ── revokeBundle ──────────────────────────────────────────────────────
+
+  it('revokeBundle sends POST /v1/consent-bundles/:id/revoke', async () => {
+    ok(undefined);
+    await revokeBundle('cb1');
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/consent-bundles/cb1/revoke');
+    expect(opts.method).toBe('POST');
+  });
+
+  it('revokeBundle throws on error', async () => {
+    err(404, 'NOT_FOUND', 'Bundle not found');
+    await expect(revokeBundle('missing')).rejects.toThrow('Bundle not found');
+  });
+
+  // ── getBundleAuditEntries ─────────────────────────────────────────────
+
+  it('getBundleAuditEntries sends GET /v1/consent-bundles/:id/audit and unwraps .entries', async () => {
+    ok({ entries: [{ id: 'ae1', action: 'access' }] });
+    const result = await getBundleAuditEntries('cb1');
+    expect(result).toEqual([{ id: 'ae1', action: 'access' }]);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/consent-bundles/cb1/audit',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('getBundleAuditEntries encodes id', async () => {
+    ok({ entries: [] });
+    await getBundleAuditEntries('cb/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/consent-bundles/cb%2F1/audit');
+  });
+
+  it('getBundleAuditEntries throws on error', async () => {
+    err(404, 'NOT_FOUND', 'Not found');
+    await expect(getBundleAuditEntries('x')).rejects.toThrow('Not found');
+  });
+
+  // ── getRevocationStatus ───────────────────────────────────────────────
+
+  it('getRevocationStatus sends GET /v1/consent-bundles/:id/revocation', async () => {
+    const status = { bundleId: 'cb1', revoked: false, revokedAt: null, propagated: false };
+    ok(status);
+    const result = await getRevocationStatus('cb1');
+    expect(result).toEqual(status);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/consent-bundles/cb1/revocation',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('getRevocationStatus throws on error', async () => {
+    err(404, 'NOT_FOUND', 'Not found');
+    await expect(getRevocationStatus('x')).rejects.toThrow('Not found');
+  });
+});

--- a/apps/portal/src/api/__tests__/client.test.ts
+++ b/apps/portal/src/api/__tests__/client.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function noContent() {
+  mockFetch.mockResolvedValueOnce({ ok: true, status: 204, json: () => Promise.resolve(undefined) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { api, ApiError, setApiKey, getApiKey } from '../client';
+
+describe('client', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    setApiKey(null);
+  });
+
+  // ── setApiKey / getApiKey ──────────────────────────────────────────────
+
+  it('getApiKey returns null by default', () => {
+    expect(getApiKey()).toBeNull();
+  });
+
+  it('setApiKey stores key and getApiKey retrieves it', () => {
+    setApiKey('test-key-123');
+    expect(getApiKey()).toBe('test-key-123');
+  });
+
+  it('setApiKey(null) clears the key', () => {
+    setApiKey('key');
+    setApiKey(null);
+    expect(getApiKey()).toBeNull();
+  });
+
+  // ── api.get ────────────────────────────────────────────────────────────
+
+  it('api.get sends GET request with correct URL', async () => {
+    ok({ foo: 'bar' });
+    const result = await api.get('/v1/test');
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/test', {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+      body: undefined,
+    });
+    expect(result).toEqual({ foo: 'bar' });
+  });
+
+  it('api.get includes Authorization header when api key is set', async () => {
+    setApiKey('my-key');
+    ok({ data: 1 });
+    await api.get('/v1/secure');
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/secure', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer my-key',
+      },
+      body: undefined,
+    });
+  });
+
+  // ── api.post ───────────────────────────────────────────────────────────
+
+  it('api.post sends POST with JSON body', async () => {
+    ok({ id: '1' });
+    const result = await api.post('/v1/items', { name: 'test' });
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'test' }),
+    });
+    expect(result).toEqual({ id: '1' });
+  });
+
+  it('api.post sends POST without body when body is undefined', async () => {
+    ok({ ok: true });
+    await api.post('/v1/action');
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/action', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: undefined,
+    });
+  });
+
+  // ── api.patch ──────────────────────────────────────────────────────────
+
+  it('api.patch sends PATCH with body', async () => {
+    ok({ updated: true });
+    await api.patch('/v1/items/1', { name: 'updated' });
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/items/1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'updated' }),
+    });
+  });
+
+  // ── api.put ────────────────────────────────────────────────────────────
+
+  it('api.put sends PUT with body', async () => {
+    ok({ replaced: true });
+    await api.put('/v1/items/1', { name: 'replaced' });
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/items/1', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'replaced' }),
+    });
+  });
+
+  // ── api.del ────────────────────────────────────────────────────────────
+
+  it('api.del sends DELETE request and returns undefined for 204', async () => {
+    noContent();
+    const result = await api.del('/v1/items/1');
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/items/1', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: undefined,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  // ── Error handling ─────────────────────────────────────────────────────
+
+  it('throws ApiError on non-ok response', async () => {
+    err(401, 'UNAUTHORIZED', 'Invalid API key');
+    await expect(api.get('/v1/me')).rejects.toThrow(ApiError);
+    try {
+      err(401, 'UNAUTHORIZED', 'Invalid API key');
+      await api.get('/v1/me');
+    } catch (e) {
+      const error = e as ApiError;
+      expect(error.status).toBe(401);
+      expect(error.code).toBe('UNAUTHORIZED');
+      expect(error.message).toBe('Invalid API key');
+      expect(error.name).toBe('ApiError');
+    }
+  });
+
+  it('uses UNKNOWN code when error json has no code', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () => Promise.resolve({ message: 'something broke' }),
+    });
+    try {
+      await api.get('/v1/fail');
+    } catch (e) {
+      const error = e as ApiError;
+      expect(error.code).toBe('UNKNOWN');
+      expect(error.message).toBe('something broke');
+    }
+  });
+
+  it('falls back to statusText when json parsing fails', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      json: () => Promise.reject(new Error('not json')),
+    });
+    try {
+      await api.get('/v1/fail');
+    } catch (e) {
+      const error = e as ApiError;
+      expect(error.code).toBe('UNKNOWN');
+      expect(error.message).toBe('Bad Gateway');
+    }
+  });
+});

--- a/apps/portal/src/api/__tests__/compliance.test.ts
+++ b/apps/portal/src/api/__tests__/compliance.test.ts
@@ -85,7 +85,7 @@ describe('compliance', () => {
   it('exportEvidencePack encodes framework with special chars', async () => {
     ok({});
     await exportEvidencePack('iso 27001');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/compliance/evidence-pack?framework=iso%2027001');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/compliance/evidence-pack?framework=iso%2027001');
   });
 
   it('exportEvidencePack throws on error', async () => {

--- a/apps/portal/src/api/__tests__/compliance.test.ts
+++ b/apps/portal/src/api/__tests__/compliance.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { getComplianceSummary, exportGrants, exportAudit, exportEvidencePack } from '../compliance';
+
+describe('compliance', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── getComplianceSummary ──────────────────────────────────────────────
+
+  it('getComplianceSummary sends GET /v1/compliance/summary', async () => {
+    const summary = { soc2: 'compliant', gdpr: 'partial' };
+    ok(summary);
+    const result = await getComplianceSummary();
+    expect(result).toEqual(summary);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/compliance/summary', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('getComplianceSummary throws on error', async () => {
+    err(500, 'INTERNAL', 'Failed');
+    await expect(getComplianceSummary()).rejects.toThrow('Failed');
+  });
+
+  // ── exportGrants ──────────────────────────────────────────────────────
+
+  it('exportGrants sends GET /v1/compliance/export/grants', async () => {
+    const data = { generatedAt: '2026-04-01', total: 5, grants: [] };
+    ok(data);
+    const result = await exportGrants();
+    expect(result).toEqual(data);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/compliance/export/grants', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('exportGrants throws on error', async () => {
+    err(403, 'FORBIDDEN', 'Not allowed');
+    await expect(exportGrants()).rejects.toThrow('Not allowed');
+  });
+
+  // ── exportAudit ───────────────────────────────────────────────────────
+
+  it('exportAudit sends GET /v1/compliance/export/audit', async () => {
+    const data = { generatedAt: '2026-04-01', total: 10, entries: [] };
+    ok(data);
+    const result = await exportAudit();
+    expect(result).toEqual(data);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/compliance/export/audit', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('exportAudit throws on error', async () => {
+    err(500, 'INTERNAL', 'Export failed');
+    await expect(exportAudit()).rejects.toThrow('Export failed');
+  });
+
+  // ── exportEvidencePack ────────────────────────────────────────────────
+
+  it('exportEvidencePack sends GET with framework query param', async () => {
+    const data = { framework: 'soc2', evidence: {} };
+    ok(data);
+    const result = await exportEvidencePack('soc2');
+    expect(result).toEqual(data);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/compliance/evidence-pack?framework=soc2',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('exportEvidencePack encodes framework with special chars', async () => {
+    ok({});
+    await exportEvidencePack('iso 27001');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/compliance/evidence-pack?framework=iso%2027001');
+  });
+
+  it('exportEvidencePack throws on error', async () => {
+    err(400, 'BAD_REQUEST', 'Unknown framework');
+    await expect(exportEvidencePack('invalid')).rejects.toThrow('Unknown framework');
+  });
+});

--- a/apps/portal/src/api/__tests__/credentials.test.ts
+++ b/apps/portal/src/api/__tests__/credentials.test.ts
@@ -36,19 +36,19 @@ describe('credentials', () => {
   it('listCredentials with grantId param', async () => {
     ok({ credentials: [] });
     await listCredentials({ grantId: 'g1' });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/credentials?grantId=g1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/credentials?grantId=g1');
   });
 
   it('listCredentials with status param', async () => {
     ok({ credentials: [] });
     await listCredentials({ status: 'active' });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/credentials?status=active');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/credentials?status=active');
   });
 
   it('listCredentials with both params', async () => {
     ok({ credentials: [] });
     await listCredentials({ grantId: 'g1', status: 'revoked' });
-    const url = mockFetch.mock.calls[0][0];
+    const url = mockFetch.mock.calls[0]![0];
     expect(url).toContain('grantId=g1');
     expect(url).toContain('status=revoked');
   });
@@ -71,7 +71,7 @@ describe('credentials', () => {
   it('getCredential encodes id', async () => {
     ok({ id: 'vc/1' });
     await getCredential('vc/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/credentials/vc%2F1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/credentials/vc%2F1');
   });
 
   it('getCredential throws on 404', async () => {

--- a/apps/portal/src/api/__tests__/credentials.test.ts
+++ b/apps/portal/src/api/__tests__/credentials.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { listCredentials, getCredential } from '../credentials';
+
+describe('credentials', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── listCredentials ───────────────────────────────────────────────────
+
+  it('listCredentials without params sends GET /v1/credentials', async () => {
+    ok({ credentials: [{ id: 'vc1', type: ['VerifiableCredential'] }] });
+    const result = await listCredentials();
+    expect(result).toEqual([{ id: 'vc1', type: ['VerifiableCredential'] }]);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/credentials', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('listCredentials with grantId param', async () => {
+    ok({ credentials: [] });
+    await listCredentials({ grantId: 'g1' });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/credentials?grantId=g1');
+  });
+
+  it('listCredentials with status param', async () => {
+    ok({ credentials: [] });
+    await listCredentials({ status: 'active' });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/credentials?status=active');
+  });
+
+  it('listCredentials with both params', async () => {
+    ok({ credentials: [] });
+    await listCredentials({ grantId: 'g1', status: 'revoked' });
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toContain('grantId=g1');
+    expect(url).toContain('status=revoked');
+  });
+
+  it('listCredentials throws on error', async () => {
+    err(500, 'INTERNAL', 'Failed');
+    await expect(listCredentials()).rejects.toThrow('Failed');
+  });
+
+  // ── getCredential ─────────────────────────────────────────────────────
+
+  it('getCredential sends GET /v1/credentials/:id', async () => {
+    const cred = { id: 'vc1', type: ['VerifiableCredential'], issuer: 'did:web:grantex.dev' };
+    ok(cred);
+    const result = await getCredential('vc1');
+    expect(result).toEqual(cred);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/credentials/vc1', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('getCredential encodes id', async () => {
+    ok({ id: 'vc/1' });
+    await getCredential('vc/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/credentials/vc%2F1');
+  });
+
+  it('getCredential throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'Credential not found');
+    await expect(getCredential('missing')).rejects.toThrow('Credential not found');
+  });
+});

--- a/apps/portal/src/api/__tests__/domains.test.ts
+++ b/apps/portal/src/api/__tests__/domains.test.ts
@@ -48,7 +48,7 @@ describe('domains', () => {
     ok(domain);
     const result = await createDomain('new.dev');
     expect(result).toEqual(domain);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/domains');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual({ domain: 'new.dev' });
@@ -65,7 +65,7 @@ describe('domains', () => {
     ok({ verified: true });
     const result = await verifyDomain('d1');
     expect(result).toEqual({ verified: true });
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/domains/d1/verify');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual({});
@@ -74,7 +74,7 @@ describe('domains', () => {
   it('verifyDomain encodes id', async () => {
     ok({ verified: false });
     await verifyDomain('d/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/domains/d%2F1/verify');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/domains/d%2F1/verify');
   });
 
   it('verifyDomain throws on error', async () => {

--- a/apps/portal/src/api/__tests__/domains.test.ts
+++ b/apps/portal/src/api/__tests__/domains.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function noContent() {
+  mockFetch.mockResolvedValueOnce({ ok: true, status: 204, json: () => Promise.resolve(undefined) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { listDomains, createDomain, verifyDomain, deleteDomain } from '../domains';
+
+describe('domains', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── listDomains ───────────────────────────────────────────────────────
+
+  it('listDomains sends GET /v1/domains and unwraps .domains', async () => {
+    ok({ domains: [{ id: 'd1', domain: 'example.com', verified: true }] });
+    const result = await listDomains();
+    expect(result).toEqual([{ id: 'd1', domain: 'example.com', verified: true }]);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/domains', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('listDomains throws on error', async () => {
+    err(500, 'INTERNAL', 'DB error');
+    await expect(listDomains()).rejects.toThrow('DB error');
+  });
+
+  // ── createDomain ──────────────────────────────────────────────────────
+
+  it('createDomain sends POST /v1/domains with domain in body', async () => {
+    const domain = { id: 'd2', domain: 'new.dev', verified: false, verificationToken: 'tok-123' };
+    ok(domain);
+    const result = await createDomain('new.dev');
+    expect(result).toEqual(domain);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/domains');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ domain: 'new.dev' });
+  });
+
+  it('createDomain throws on 409', async () => {
+    err(409, 'CONFLICT', 'Domain already registered');
+    await expect(createDomain('taken.com')).rejects.toThrow('Domain already registered');
+  });
+
+  // ── verifyDomain ──────────────────────────────────────────────────────
+
+  it('verifyDomain sends POST /v1/domains/:id/verify', async () => {
+    ok({ verified: true });
+    const result = await verifyDomain('d1');
+    expect(result).toEqual({ verified: true });
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/domains/d1/verify');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({});
+  });
+
+  it('verifyDomain encodes id', async () => {
+    ok({ verified: false });
+    await verifyDomain('d/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/domains/d%2F1/verify');
+  });
+
+  it('verifyDomain throws on error', async () => {
+    err(400, 'VERIFICATION_FAILED', 'DNS record not found');
+    await expect(verifyDomain('d1')).rejects.toThrow('DNS record not found');
+  });
+
+  // ── deleteDomain ──────────────────────────────────────────────────────
+
+  it('deleteDomain sends DELETE /v1/domains/:id', async () => {
+    noContent();
+    await deleteDomain('d1');
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/domains/d1', expect.objectContaining({ method: 'DELETE' }));
+  });
+
+  it('deleteDomain throws on error', async () => {
+    err(404, 'NOT_FOUND', 'Domain not found');
+    await expect(deleteDomain('missing')).rejects.toThrow('Domain not found');
+  });
+});

--- a/apps/portal/src/api/__tests__/dpdp.test.ts
+++ b/apps/portal/src/api/__tests__/dpdp.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import {
+  createConsentRecord,
+  withdrawConsent,
+  getDataPrincipalRecords,
+  createConsentNotice,
+  fileGrievance,
+  getGrievance,
+  createExport,
+  getExport,
+} from '../dpdp';
+
+describe('dpdp', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── createConsentRecord ───────────────────────────────────────────────
+
+  it('createConsentRecord sends POST /v1/dpdp/consent-records', async () => {
+    const data = {
+      grantId: 'g1',
+      dataPrincipalId: 'dp1',
+      purposes: [{ code: 'P01', description: 'Analytics' }],
+      consentNoticeId: 'cn1',
+      processingExpiresAt: '2027-01-01T00:00:00Z',
+    };
+    const resp = { recordId: 'cr1', grantId: 'g1', dataPrincipalId: 'dp1', status: 'active' };
+    ok(resp);
+    const result = await createConsentRecord(data);
+    expect(result).toEqual(resp);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/dpdp/consent-records');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(data);
+  });
+
+  it('createConsentRecord throws on 400', async () => {
+    err(400, 'VALIDATION', 'Missing grantId');
+    await expect(createConsentRecord({} as any)).rejects.toThrow('Missing grantId');
+  });
+
+  // ── withdrawConsent ───────────────────────────────────────────────────
+
+  it('withdrawConsent sends POST /v1/dpdp/consent-records/:id/withdraw', async () => {
+    const data = { reason: 'No longer needed', revokeGrant: true };
+    const resp = { recordId: 'cr1', status: 'withdrawn', withdrawnAt: '2026-04-01', grantRevoked: true, dataDeleted: false };
+    ok(resp);
+    const result = await withdrawConsent('cr1', data);
+    expect(result).toEqual(resp);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/dpdp/consent-records/cr1/withdraw');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(data);
+  });
+
+  it('withdrawConsent encodes recordId', async () => {
+    ok({ recordId: 'cr/1', status: 'withdrawn' });
+    await withdrawConsent('cr/1', { reason: 'test' });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/dpdp/consent-records/cr%2F1/withdraw');
+  });
+
+  it('withdrawConsent throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'Record not found');
+    await expect(withdrawConsent('missing', { reason: 'x' })).rejects.toThrow('Record not found');
+  });
+
+  // ── getDataPrincipalRecords ───────────────────────────────────────────
+
+  it('getDataPrincipalRecords sends GET /v1/dpdp/data-principals/:id/records', async () => {
+    const resp = { dataPrincipalId: 'dp1', records: [{ recordId: 'cr1' }], totalRecords: 1 };
+    ok(resp);
+    const result = await getDataPrincipalRecords('dp1');
+    expect(result).toEqual(resp);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/dpdp/data-principals/dp1/records',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('getDataPrincipalRecords encodes principalId', async () => {
+    ok({ dataPrincipalId: 'dp/1', records: [], totalRecords: 0 });
+    await getDataPrincipalRecords('dp/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/dpdp/data-principals/dp%2F1/records');
+  });
+
+  it('getDataPrincipalRecords throws on error', async () => {
+    err(404, 'NOT_FOUND', 'Principal not found');
+    await expect(getDataPrincipalRecords('missing')).rejects.toThrow('Principal not found');
+  });
+
+  // ── createConsentNotice ───────────────────────────────────────────────
+
+  it('createConsentNotice sends POST /v1/dpdp/consent-notices', async () => {
+    const data = {
+      noticeId: 'n1',
+      version: '1.0',
+      title: 'Consent Notice',
+      content: 'We collect data...',
+      purposes: [{ code: 'P01', description: 'Analytics' }],
+    };
+    const resp = { id: 'cn1', noticeId: 'n1', version: '1.0', language: 'en' };
+    ok(resp);
+    const result = await createConsentNotice(data);
+    expect(result).toEqual(resp);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/dpdp/consent-notices');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(data);
+  });
+
+  it('createConsentNotice throws on 400', async () => {
+    err(400, 'VALIDATION', 'Title required');
+    await expect(createConsentNotice({} as any)).rejects.toThrow('Title required');
+  });
+
+  // ── fileGrievance ─────────────────────────────────────────────────────
+
+  it('fileGrievance sends POST /v1/dpdp/grievances', async () => {
+    const data = { dataPrincipalId: 'dp1', type: 'data-breach', description: 'Data exposed' };
+    const resp = { grievanceId: 'gr1', referenceNumber: 'GR-001', type: 'data-breach', status: 'submitted' };
+    ok(resp);
+    const result = await fileGrievance(data);
+    expect(result).toEqual(resp);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/dpdp/grievances');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(data);
+  });
+
+  it('fileGrievance throws on error', async () => {
+    err(400, 'VALIDATION', 'Description required');
+    await expect(fileGrievance({} as any)).rejects.toThrow('Description required');
+  });
+
+  // ── getGrievance ──────────────────────────────────────────────────────
+
+  it('getGrievance sends GET /v1/dpdp/grievances/:id', async () => {
+    const grievance = { grievanceId: 'gr1', status: 'submitted', referenceNumber: 'GR-001' };
+    ok(grievance);
+    const result = await getGrievance('gr1');
+    expect(result).toEqual(grievance);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/dpdp/grievances/gr1',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('getGrievance encodes id', async () => {
+    ok({ grievanceId: 'gr/1' });
+    await getGrievance('gr/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/dpdp/grievances/gr%2F1');
+  });
+
+  it('getGrievance throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'Grievance not found');
+    await expect(getGrievance('missing')).rejects.toThrow('Grievance not found');
+  });
+
+  // ── createExport ──────────────────────────────────────────────────────
+
+  it('createExport sends POST /v1/dpdp/exports', async () => {
+    const data = { type: 'dpdp-audit' as const, dateFrom: '2026-01-01', dateTo: '2026-04-01' };
+    const resp = { exportId: 'ex1', type: 'dpdp-audit', format: 'json', recordCount: 10 };
+    ok(resp);
+    const result = await createExport(data);
+    expect(result).toEqual(resp);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/dpdp/exports');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(data);
+  });
+
+  it('createExport throws on error', async () => {
+    err(400, 'VALIDATION', 'Invalid date range');
+    await expect(createExport({} as any)).rejects.toThrow('Invalid date range');
+  });
+
+  // ── getExport ─────────────────────────────────────────────────────────
+
+  it('getExport sends GET /v1/dpdp/exports/:id', async () => {
+    const exp = { exportId: 'ex1', type: 'dpdp-audit', format: 'json' };
+    ok(exp);
+    const result = await getExport('ex1');
+    expect(result).toEqual(exp);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/dpdp/exports/ex1',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('getExport encodes id', async () => {
+    ok({ exportId: 'ex/1' });
+    await getExport('ex/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/dpdp/exports/ex%2F1');
+  });
+
+  it('getExport throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'Export not found');
+    await expect(getExport('missing')).rejects.toThrow('Export not found');
+  });
+});

--- a/apps/portal/src/api/__tests__/dpdp.test.ts
+++ b/apps/portal/src/api/__tests__/dpdp.test.ts
@@ -47,7 +47,7 @@ describe('dpdp', () => {
     ok(resp);
     const result = await createConsentRecord(data);
     expect(result).toEqual(resp);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/dpdp/consent-records');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(data);
@@ -66,7 +66,7 @@ describe('dpdp', () => {
     ok(resp);
     const result = await withdrawConsent('cr1', data);
     expect(result).toEqual(resp);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/dpdp/consent-records/cr1/withdraw');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(data);
@@ -75,7 +75,7 @@ describe('dpdp', () => {
   it('withdrawConsent encodes recordId', async () => {
     ok({ recordId: 'cr/1', status: 'withdrawn' });
     await withdrawConsent('cr/1', { reason: 'test' });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/dpdp/consent-records/cr%2F1/withdraw');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/dpdp/consent-records/cr%2F1/withdraw');
   });
 
   it('withdrawConsent throws on 404', async () => {
@@ -99,7 +99,7 @@ describe('dpdp', () => {
   it('getDataPrincipalRecords encodes principalId', async () => {
     ok({ dataPrincipalId: 'dp/1', records: [], totalRecords: 0 });
     await getDataPrincipalRecords('dp/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/dpdp/data-principals/dp%2F1/records');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/dpdp/data-principals/dp%2F1/records');
   });
 
   it('getDataPrincipalRecords throws on error', async () => {
@@ -121,7 +121,7 @@ describe('dpdp', () => {
     ok(resp);
     const result = await createConsentNotice(data);
     expect(result).toEqual(resp);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/dpdp/consent-notices');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(data);
@@ -140,7 +140,7 @@ describe('dpdp', () => {
     ok(resp);
     const result = await fileGrievance(data);
     expect(result).toEqual(resp);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/dpdp/grievances');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(data);
@@ -167,7 +167,7 @@ describe('dpdp', () => {
   it('getGrievance encodes id', async () => {
     ok({ grievanceId: 'gr/1' });
     await getGrievance('gr/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/dpdp/grievances/gr%2F1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/dpdp/grievances/gr%2F1');
   });
 
   it('getGrievance throws on 404', async () => {
@@ -183,7 +183,7 @@ describe('dpdp', () => {
     ok(resp);
     const result = await createExport(data);
     expect(result).toEqual(resp);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/dpdp/exports');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(data);
@@ -210,7 +210,7 @@ describe('dpdp', () => {
   it('getExport encodes id', async () => {
     ok({ exportId: 'ex/1' });
     await getExport('ex/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/dpdp/exports/ex%2F1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/dpdp/exports/ex%2F1');
   });
 
   it('getExport throws on 404', async () => {

--- a/apps/portal/src/api/__tests__/events.test.ts
+++ b/apps/portal/src/api/__tests__/events.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { listRecentEvents } from '../events';
+
+describe('events', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── listRecentEvents ──────────────────────────────────────────────────
+
+  it('listRecentEvents sends GET /v1/events/stream and returns events', async () => {
+    const events = [{ id: 'ev1', type: 'grant.created' }, { id: 'ev2', type: 'token.exchange' }];
+    ok({ events });
+    const result = await listRecentEvents();
+    expect(result).toEqual(events);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/events/stream', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('listRecentEvents returns empty array when events is null', async () => {
+    ok({ events: null });
+    const result = await listRecentEvents();
+    expect(result).toEqual([]);
+  });
+
+  it('listRecentEvents returns empty array when events is undefined', async () => {
+    ok({});
+    const result = await listRecentEvents();
+    expect(result).toEqual([]);
+  });
+
+  it('listRecentEvents throws on error', async () => {
+    err(401, 'UNAUTHORIZED', 'Not authenticated');
+    await expect(listRecentEvents()).rejects.toThrow('Not authenticated');
+  });
+});

--- a/apps/portal/src/api/__tests__/grants.test.ts
+++ b/apps/portal/src/api/__tests__/grants.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function noContent() {
+  mockFetch.mockResolvedValueOnce({ ok: true, status: 204, json: () => Promise.resolve(undefined) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { listGrants, getGrant, revokeGrant } from '../grants';
+
+describe('grants', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── listGrants ─────────────────────────────────────────────────────────
+
+  it('listGrants without params sends GET /v1/grants', async () => {
+    ok({ grants: [{ grantId: 'g1' }] });
+    const result = await listGrants();
+    expect(result).toEqual([{ grantId: 'g1' }]);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/grants', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('listGrants with agentId adds query param', async () => {
+    ok({ grants: [] });
+    await listGrants({ agentId: 'agent-1' });
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toBe('http://localhost:3000/v1/grants?agentId=agent-1');
+  });
+
+  it('listGrants with status adds query param', async () => {
+    ok({ grants: [] });
+    await listGrants({ status: 'active' });
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toBe('http://localhost:3000/v1/grants?status=active');
+  });
+
+  it('listGrants with both params adds both', async () => {
+    ok({ grants: [] });
+    await listGrants({ agentId: 'a1', status: 'revoked' });
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toContain('agentId=a1');
+    expect(url).toContain('status=revoked');
+  });
+
+  it('listGrants throws on error', async () => {
+    err(500, 'INTERNAL', 'Database error');
+    await expect(listGrants()).rejects.toThrow('Database error');
+  });
+
+  // ── getGrant ───────────────────────────────────────────────────────────
+
+  it('getGrant sends GET /v1/grants/:id', async () => {
+    ok({ grantId: 'g1', scopes: ['read'] });
+    const result = await getGrant('g1');
+    expect(result).toEqual({ grantId: 'g1', scopes: ['read'] });
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/grants/g1', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('getGrant encodes id', async () => {
+    ok({ grantId: 'g/1' });
+    await getGrant('g/1');
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/grants/g%2F1', expect.anything());
+  });
+
+  it('getGrant throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'Grant not found');
+    await expect(getGrant('missing')).rejects.toThrow('Grant not found');
+  });
+
+  // ── revokeGrant ────────────────────────────────────────────────────────
+
+  it('revokeGrant sends DELETE /v1/grants/:id', async () => {
+    noContent();
+    await revokeGrant('g1');
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/grants/g1', expect.objectContaining({ method: 'DELETE' }));
+  });
+
+  it('revokeGrant throws on error', async () => {
+    err(404, 'NOT_FOUND', 'Grant not found');
+    await expect(revokeGrant('bad')).rejects.toThrow('Grant not found');
+  });
+});

--- a/apps/portal/src/api/__tests__/grants.test.ts
+++ b/apps/portal/src/api/__tests__/grants.test.ts
@@ -39,21 +39,21 @@ describe('grants', () => {
   it('listGrants with agentId adds query param', async () => {
     ok({ grants: [] });
     await listGrants({ agentId: 'agent-1' });
-    const url = mockFetch.mock.calls[0][0];
+    const url = mockFetch.mock.calls[0]![0];
     expect(url).toBe('http://localhost:3000/v1/grants?agentId=agent-1');
   });
 
   it('listGrants with status adds query param', async () => {
     ok({ grants: [] });
     await listGrants({ status: 'active' });
-    const url = mockFetch.mock.calls[0][0];
+    const url = mockFetch.mock.calls[0]![0];
     expect(url).toBe('http://localhost:3000/v1/grants?status=active');
   });
 
   it('listGrants with both params adds both', async () => {
     ok({ grants: [] });
     await listGrants({ agentId: 'a1', status: 'revoked' });
-    const url = mockFetch.mock.calls[0][0];
+    const url = mockFetch.mock.calls[0]![0];
     expect(url).toContain('agentId=a1');
     expect(url).toContain('status=revoked');
   });

--- a/apps/portal/src/api/__tests__/mcp.test.ts
+++ b/apps/portal/src/api/__tests__/mcp.test.ts
@@ -36,25 +36,25 @@ describe('mcp', () => {
   it('listMcpServers with category param', async () => {
     ok({ servers: [] });
     await listMcpServers({ category: 'data' });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/mcp/servers?category=data');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/mcp/servers?category=data');
   });
 
   it('listMcpServers with certified param (true)', async () => {
     ok({ servers: [] });
     await listMcpServers({ certified: true });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/mcp/servers?certified=true');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/mcp/servers?certified=true');
   });
 
   it('listMcpServers with certified param (false)', async () => {
     ok({ servers: [] });
     await listMcpServers({ certified: false });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/mcp/servers?certified=false');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/mcp/servers?certified=false');
   });
 
   it('listMcpServers with both params', async () => {
     ok({ servers: [] });
     await listMcpServers({ category: 'auth', certified: true });
-    const url = mockFetch.mock.calls[0][0];
+    const url = mockFetch.mock.calls[0]![0];
     expect(url).toContain('category=auth');
     expect(url).toContain('certified=true');
   });
@@ -76,7 +76,7 @@ describe('mcp', () => {
   it('getMcpServer encodes id', async () => {
     ok({ id: 's/1' });
     await getMcpServer('s/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/mcp/servers/s%2F1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/mcp/servers/s%2F1');
   });
 
   it('getMcpServer throws on 404', async () => {
@@ -91,7 +91,7 @@ describe('mcp', () => {
     ok({ id: 's2', ...params });
     const result = await createMcpServer(params);
     expect(result).toEqual({ id: 's2', ...params });
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/mcp/servers');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(params);
@@ -109,7 +109,7 @@ describe('mcp', () => {
     ok(cert);
     const result = await applyForCertification('s1', 'gold');
     expect(result).toEqual(cert);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/mcp/servers/s1/certify');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual({ level: 'gold' });
@@ -118,7 +118,7 @@ describe('mcp', () => {
   it('applyForCertification encodes serverId', async () => {
     ok({ id: 'cert-1' });
     await applyForCertification('s/1', 'silver');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/mcp/servers/s%2F1/certify');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/mcp/servers/s%2F1/certify');
   });
 
   it('applyForCertification throws on error', async () => {

--- a/apps/portal/src/api/__tests__/mcp.test.ts
+++ b/apps/portal/src/api/__tests__/mcp.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { listMcpServers, getMcpServer, createMcpServer, applyForCertification, getCertification } from '../mcp';
+
+describe('mcp', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── listMcpServers ────────────────────────────────────────────────────
+
+  it('listMcpServers without params sends GET /v1/mcp/servers', async () => {
+    ok({ servers: [{ id: 's1', name: 'Server 1' }] });
+    const result = await listMcpServers();
+    expect(result).toEqual([{ id: 's1', name: 'Server 1' }]);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/mcp/servers', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('listMcpServers with category param', async () => {
+    ok({ servers: [] });
+    await listMcpServers({ category: 'data' });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/mcp/servers?category=data');
+  });
+
+  it('listMcpServers with certified param (true)', async () => {
+    ok({ servers: [] });
+    await listMcpServers({ certified: true });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/mcp/servers?certified=true');
+  });
+
+  it('listMcpServers with certified param (false)', async () => {
+    ok({ servers: [] });
+    await listMcpServers({ certified: false });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/mcp/servers?certified=false');
+  });
+
+  it('listMcpServers with both params', async () => {
+    ok({ servers: [] });
+    await listMcpServers({ category: 'auth', certified: true });
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toContain('category=auth');
+    expect(url).toContain('certified=true');
+  });
+
+  it('listMcpServers throws on error', async () => {
+    err(500, 'INTERNAL', 'Failed');
+    await expect(listMcpServers()).rejects.toThrow('Failed');
+  });
+
+  // ── getMcpServer ──────────────────────────────────────────────────────
+
+  it('getMcpServer sends GET /v1/mcp/servers/:id', async () => {
+    ok({ id: 's1', name: 'Server 1' });
+    const result = await getMcpServer('s1');
+    expect(result).toEqual({ id: 's1', name: 'Server 1' });
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/mcp/servers/s1', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('getMcpServer encodes id', async () => {
+    ok({ id: 's/1' });
+    await getMcpServer('s/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/mcp/servers/s%2F1');
+  });
+
+  it('getMcpServer throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'Server not found');
+    await expect(getMcpServer('missing')).rejects.toThrow('Server not found');
+  });
+
+  // ── createMcpServer ───────────────────────────────────────────────────
+
+  it('createMcpServer sends POST /v1/mcp/servers with params', async () => {
+    const params = { name: 'New Server', category: 'data', scopes: ['read'] };
+    ok({ id: 's2', ...params });
+    const result = await createMcpServer(params);
+    expect(result).toEqual({ id: 's2', ...params });
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/mcp/servers');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(params);
+  });
+
+  it('createMcpServer throws on 400', async () => {
+    err(400, 'VALIDATION', 'Name required');
+    await expect(createMcpServer({} as any)).rejects.toThrow('Name required');
+  });
+
+  // ── applyForCertification ─────────────────────────────────────────────
+
+  it('applyForCertification sends POST /v1/mcp/servers/:id/certify with level', async () => {
+    const cert = { id: 'cert-1', serverId: 's1', requestedLevel: 'gold', status: 'pending' };
+    ok(cert);
+    const result = await applyForCertification('s1', 'gold');
+    expect(result).toEqual(cert);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/mcp/servers/s1/certify');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ level: 'gold' });
+  });
+
+  it('applyForCertification encodes serverId', async () => {
+    ok({ id: 'cert-1' });
+    await applyForCertification('s/1', 'silver');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/mcp/servers/s%2F1/certify');
+  });
+
+  it('applyForCertification throws on error', async () => {
+    err(409, 'CONFLICT', 'Already certified');
+    await expect(applyForCertification('s1', 'gold')).rejects.toThrow('Already certified');
+  });
+
+  // ── getCertification ──────────────────────────────────────────────────
+
+  it('getCertification sends GET /v1/mcp/certifications/:id', async () => {
+    const cert = { id: 'cert-1', status: 'approved' };
+    ok(cert);
+    const result = await getCertification('cert-1');
+    expect(result).toEqual(cert);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/mcp/certifications/cert-1',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('getCertification throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'Certification not found');
+    await expect(getCertification('missing')).rejects.toThrow('Certification not found');
+  });
+});

--- a/apps/portal/src/api/__tests__/policies.test.ts
+++ b/apps/portal/src/api/__tests__/policies.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function noContent() {
+  mockFetch.mockResolvedValueOnce({ ok: true, status: 204, json: () => Promise.resolve(undefined) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { listPolicies, getPolicy, createPolicy, updatePolicy, deletePolicy } from '../policies';
+
+describe('policies', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── listPolicies ──────────────────────────────────────────────────────
+
+  it('listPolicies sends GET /v1/policies and unwraps .policies', async () => {
+    ok({ policies: [{ id: 'p1', name: 'Policy 1' }], total: 1 });
+    const result = await listPolicies();
+    expect(result).toEqual([{ id: 'p1', name: 'Policy 1' }]);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/policies', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('listPolicies throws on error', async () => {
+    err(500, 'INTERNAL', 'Failed');
+    await expect(listPolicies()).rejects.toThrow('Failed');
+  });
+
+  // ── getPolicy ─────────────────────────────────────────────────────────
+
+  it('getPolicy sends GET /v1/policies/:id', async () => {
+    ok({ id: 'p1', name: 'Policy 1' });
+    const result = await getPolicy('p1');
+    expect(result).toEqual({ id: 'p1', name: 'Policy 1' });
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/policies/p1', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('getPolicy encodes id', async () => {
+    ok({ id: 'p/1' });
+    await getPolicy('p/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/policies/p%2F1');
+  });
+
+  it('getPolicy throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'Policy not found');
+    await expect(getPolicy('missing')).rejects.toThrow('Policy not found');
+  });
+
+  // ── createPolicy ──────────────────────────────────────────────────────
+
+  it('createPolicy sends POST /v1/policies with body', async () => {
+    const data = { name: 'New', rules: [] };
+    ok({ id: 'p2', ...data });
+    const result = await createPolicy(data as any);
+    expect(result).toEqual({ id: 'p2', ...data });
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/policies');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(data);
+  });
+
+  it('createPolicy throws on 400', async () => {
+    err(400, 'VALIDATION', 'Name required');
+    await expect(createPolicy({} as any)).rejects.toThrow('Name required');
+  });
+
+  // ── updatePolicy ──────────────────────────────────────────────────────
+
+  it('updatePolicy sends PATCH /v1/policies/:id with body', async () => {
+    ok({ id: 'p1', name: 'Updated' });
+    await updatePolicy('p1', { name: 'Updated' } as any);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/policies/p1');
+    expect(opts.method).toBe('PATCH');
+    expect(JSON.parse(opts.body)).toEqual({ name: 'Updated' });
+  });
+
+  it('updatePolicy throws on error', async () => {
+    err(404, 'NOT_FOUND', 'Not found');
+    await expect(updatePolicy('x', {})).rejects.toThrow('Not found');
+  });
+
+  // ── deletePolicy ──────────────────────────────────────────────────────
+
+  it('deletePolicy sends DELETE /v1/policies/:id', async () => {
+    noContent();
+    await deletePolicy('p1');
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/policies/p1', expect.objectContaining({ method: 'DELETE' }));
+  });
+
+  it('deletePolicy throws on error', async () => {
+    err(404, 'NOT_FOUND', 'Policy not found');
+    await expect(deletePolicy('missing')).rejects.toThrow('Policy not found');
+  });
+});

--- a/apps/portal/src/api/__tests__/policies.test.ts
+++ b/apps/portal/src/api/__tests__/policies.test.ts
@@ -53,7 +53,7 @@ describe('policies', () => {
   it('getPolicy encodes id', async () => {
     ok({ id: 'p/1' });
     await getPolicy('p/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/policies/p%2F1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/policies/p%2F1');
   });
 
   it('getPolicy throws on 404', async () => {
@@ -68,7 +68,7 @@ describe('policies', () => {
     ok({ id: 'p2', ...data });
     const result = await createPolicy(data as any);
     expect(result).toEqual({ id: 'p2', ...data });
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/policies');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(data);
@@ -84,7 +84,7 @@ describe('policies', () => {
   it('updatePolicy sends PATCH /v1/policies/:id with body', async () => {
     ok({ id: 'p1', name: 'Updated' });
     await updatePolicy('p1', { name: 'Updated' } as any);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/policies/p1');
     expect(opts.method).toBe('PATCH');
     expect(JSON.parse(opts.body)).toEqual({ name: 'Updated' });

--- a/apps/portal/src/api/__tests__/registry.test.ts
+++ b/apps/portal/src/api/__tests__/registry.test.ts
@@ -37,25 +37,25 @@ describe('registry', () => {
   it('searchRegistryOrgs with q param', async () => {
     ok({ data: [], meta: { total: 0 } });
     await searchRegistryOrgs({ q: 'test' });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/registry/orgs?q=test');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/registry/orgs?q=test');
   });
 
   it('searchRegistryOrgs with verified param', async () => {
     ok({ data: [], meta: { total: 0 } });
     await searchRegistryOrgs({ verified: true });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/registry/orgs?verified=true');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/registry/orgs?verified=true');
   });
 
   it('searchRegistryOrgs with badge param', async () => {
     ok({ data: [], meta: { total: 0 } });
     await searchRegistryOrgs({ badge: 'gold' });
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/registry/orgs?badge=gold');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/registry/orgs?badge=gold');
   });
 
   it('searchRegistryOrgs with all params', async () => {
     ok({ data: [], meta: { total: 0 } });
     await searchRegistryOrgs({ q: 'acme', verified: true, badge: 'silver' });
-    const url = mockFetch.mock.calls[0][0];
+    const url = mockFetch.mock.calls[0]![0];
     expect(url).toContain('q=acme');
     expect(url).toContain('verified=true');
     expect(url).toContain('badge=silver');
@@ -103,7 +103,7 @@ describe('registry', () => {
     ok({ ...params, verificationLevel: 'none', badges: [], agents: [] });
     const result = await registerOrg(params);
     expect(result.did).toBe('did:web:neworg.com');
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/registry/orgs');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(params);
@@ -120,7 +120,7 @@ describe('registry', () => {
     ok({ verified: true });
     const result = await verifyOrgDns('org-1');
     expect(result).toEqual({ verified: true });
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/registry/orgs/org-1/verify-dns');
     expect(opts.method).toBe('POST');
   });
@@ -128,7 +128,7 @@ describe('registry', () => {
   it('verifyOrgDns encodes orgId', async () => {
     ok({ verified: false });
     await verifyOrgDns('org/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/registry/orgs/org%2F1/verify-dns');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/registry/orgs/org%2F1/verify-dns');
   });
 
   it('verifyOrgDns throws on error', async () => {

--- a/apps/portal/src/api/__tests__/registry.test.ts
+++ b/apps/portal/src/api/__tests__/registry.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { searchRegistryOrgs, getRegistryOrg, registerOrg, verifyOrgDns } from '../registry';
+
+describe('registry', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── searchRegistryOrgs ────────────────────────────────────────────────
+
+  it('searchRegistryOrgs without params sends GET /v1/registry/orgs', async () => {
+    const resp = { data: [{ did: 'did:web:example.com', name: 'Example' }], meta: { total: 1 } };
+    ok(resp);
+    const result = await searchRegistryOrgs();
+    expect(result).toEqual(resp);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/registry/orgs', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('searchRegistryOrgs with q param', async () => {
+    ok({ data: [], meta: { total: 0 } });
+    await searchRegistryOrgs({ q: 'test' });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/registry/orgs?q=test');
+  });
+
+  it('searchRegistryOrgs with verified param', async () => {
+    ok({ data: [], meta: { total: 0 } });
+    await searchRegistryOrgs({ verified: true });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/registry/orgs?verified=true');
+  });
+
+  it('searchRegistryOrgs with badge param', async () => {
+    ok({ data: [], meta: { total: 0 } });
+    await searchRegistryOrgs({ badge: 'gold' });
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/registry/orgs?badge=gold');
+  });
+
+  it('searchRegistryOrgs with all params', async () => {
+    ok({ data: [], meta: { total: 0 } });
+    await searchRegistryOrgs({ q: 'acme', verified: true, badge: 'silver' });
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toContain('q=acme');
+    expect(url).toContain('verified=true');
+    expect(url).toContain('badge=silver');
+  });
+
+  it('searchRegistryOrgs returns full {data, meta} structure', async () => {
+    const resp = { data: [], meta: { total: 0 } };
+    ok(resp);
+    const result = await searchRegistryOrgs();
+    expect(result.data).toEqual([]);
+    expect(result.meta).toEqual({ total: 0 });
+  });
+
+  it('searchRegistryOrgs throws on error', async () => {
+    err(500, 'INTERNAL', 'Search failed');
+    await expect(searchRegistryOrgs()).rejects.toThrow('Search failed');
+  });
+
+  // ── getRegistryOrg ────────────────────────────────────────────────────
+
+  it('getRegistryOrg sends GET /v1/registry/orgs/:did', async () => {
+    const org = { did: 'did:web:example.com', name: 'Example', agents: [] };
+    ok(org);
+    const result = await getRegistryOrg('did:web:example.com');
+    expect(result).toEqual(org);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/registry/orgs/did%3Aweb%3Aexample.com',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('getRegistryOrg throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'Org not found');
+    await expect(getRegistryOrg('did:web:missing')).rejects.toThrow('Org not found');
+  });
+
+  // ── registerOrg ───────────────────────────────────────────────────────
+
+  it('registerOrg sends POST /v1/registry/orgs with params', async () => {
+    const params = {
+      did: 'did:web:neworg.com',
+      name: 'New Org',
+      contact: { security: 'sec@neworg.com' },
+    };
+    ok({ ...params, verificationLevel: 'none', badges: [], agents: [] });
+    const result = await registerOrg(params);
+    expect(result.did).toBe('did:web:neworg.com');
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/registry/orgs');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(params);
+  });
+
+  it('registerOrg throws on 409', async () => {
+    err(409, 'CONFLICT', 'Org already registered');
+    await expect(registerOrg({ did: 'x', name: 'x', contact: { security: 'x' } })).rejects.toThrow('Org already registered');
+  });
+
+  // ── verifyOrgDns ──────────────────────────────────────────────────────
+
+  it('verifyOrgDns sends POST /v1/registry/orgs/:id/verify-dns', async () => {
+    ok({ verified: true });
+    const result = await verifyOrgDns('org-1');
+    expect(result).toEqual({ verified: true });
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/registry/orgs/org-1/verify-dns');
+    expect(opts.method).toBe('POST');
+  });
+
+  it('verifyOrgDns encodes orgId', async () => {
+    ok({ verified: false });
+    await verifyOrgDns('org/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/registry/orgs/org%2F1/verify-dns');
+  });
+
+  it('verifyOrgDns throws on error', async () => {
+    err(400, 'VERIFICATION_FAILED', 'DNS not configured');
+    await expect(verifyOrgDns('org-1')).rejects.toThrow('DNS not configured');
+  });
+});

--- a/apps/portal/src/api/__tests__/scim.test.ts
+++ b/apps/portal/src/api/__tests__/scim.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function noContent() {
+  mockFetch.mockResolvedValueOnce({ ok: true, status: 204, json: () => Promise.resolve(undefined) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { listScimTokens, createScimToken, deleteScimToken } from '../scim';
+
+describe('scim', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── listScimTokens ────────────────────────────────────────────────────
+
+  it('listScimTokens sends GET /v1/scim/tokens and unwraps .tokens', async () => {
+    ok({ tokens: [{ id: 't1', label: 'CI Token', createdAt: '2026-04-01', lastUsedAt: null }] });
+    const result = await listScimTokens();
+    expect(result).toEqual([{ id: 't1', label: 'CI Token', createdAt: '2026-04-01', lastUsedAt: null }]);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/scim/tokens', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('listScimTokens throws on error', async () => {
+    err(401, 'UNAUTHORIZED', 'Not authenticated');
+    await expect(listScimTokens()).rejects.toThrow('Not authenticated');
+  });
+
+  // ── createScimToken ───────────────────────────────────────────────────
+
+  it('createScimToken sends POST /v1/scim/tokens with label', async () => {
+    const resp = { id: 't2', label: 'Deploy', token: 'scim_tok_xxx', createdAt: '2026-04-01', lastUsedAt: null };
+    ok(resp);
+    const result = await createScimToken({ label: 'Deploy' });
+    expect(result).toEqual(resp);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/scim/tokens');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ label: 'Deploy' });
+  });
+
+  it('createScimToken throws on 400', async () => {
+    err(400, 'VALIDATION', 'Label required');
+    await expect(createScimToken({ label: '' })).rejects.toThrow('Label required');
+  });
+
+  // ── deleteScimToken ───────────────────────────────────────────────────
+
+  it('deleteScimToken sends DELETE /v1/scim/tokens/:id', async () => {
+    noContent();
+    await deleteScimToken('t1');
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/scim/tokens/t1', expect.objectContaining({ method: 'DELETE' }));
+  });
+
+  it('deleteScimToken encodes id', async () => {
+    noContent();
+    await deleteScimToken('t/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/scim/tokens/t%2F1');
+  });
+
+  it('deleteScimToken throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'Token not found');
+    await expect(deleteScimToken('missing')).rejects.toThrow('Token not found');
+  });
+});

--- a/apps/portal/src/api/__tests__/scim.test.ts
+++ b/apps/portal/src/api/__tests__/scim.test.ts
@@ -48,7 +48,7 @@ describe('scim', () => {
     ok(resp);
     const result = await createScimToken({ label: 'Deploy' });
     expect(result).toEqual(resp);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/scim/tokens');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual({ label: 'Deploy' });
@@ -70,7 +70,7 @@ describe('scim', () => {
   it('deleteScimToken encodes id', async () => {
     noContent();
     await deleteScimToken('t/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/scim/tokens/t%2F1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/scim/tokens/t%2F1');
   });
 
   it('deleteScimToken throws on 404', async () => {

--- a/apps/portal/src/api/__tests__/sso.test.ts
+++ b/apps/portal/src/api/__tests__/sso.test.ts
@@ -61,7 +61,7 @@ describe('sso', () => {
     };
     ok({ issuerUrl: data.issuerUrl, clientId: data.clientId, redirectUri: data.redirectUri });
     await saveSsoConfig(data);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/sso/config');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(data);
@@ -107,7 +107,7 @@ describe('sso', () => {
     ok({ id: 'conn-1', ...data, status: 'active' });
     const result = await createSsoConnection(data);
     expect(result.id).toBe('conn-1');
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/sso/connections');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(data);
@@ -138,7 +138,7 @@ describe('sso', () => {
     ok(testResult);
     const result = await testSsoConnection('conn-1');
     expect(result).toEqual(testResult);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/sso/connections/conn-1/test');
     expect(opts.method).toBe('POST');
   });

--- a/apps/portal/src/api/__tests__/sso.test.ts
+++ b/apps/portal/src/api/__tests__/sso.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function noContent() {
+  mockFetch.mockResolvedValueOnce({ ok: true, status: 204, json: () => Promise.resolve(undefined) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import {
+  getSsoConfig,
+  saveSsoConfig,
+  deleteSsoConfig,
+  listSsoConnections,
+  createSsoConnection,
+  deleteSsoConnection,
+  testSsoConnection,
+} from '../sso';
+
+describe('sso', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── getSsoConfig ──────────────────────────────────────────────────────
+
+  it('getSsoConfig sends GET /v1/sso/config', async () => {
+    const config = { issuerUrl: 'https://idp.example.com', clientId: 'client-1', redirectUri: 'https://app.com/cb' };
+    ok(config);
+    const result = await getSsoConfig();
+    expect(result).toEqual(config);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/sso/config', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('getSsoConfig throws on 404', async () => {
+    err(404, 'NOT_FOUND', 'No SSO configured');
+    await expect(getSsoConfig()).rejects.toThrow('No SSO configured');
+  });
+
+  // ── saveSsoConfig ─────────────────────────────────────────────────────
+
+  it('saveSsoConfig sends POST /v1/sso/config with data', async () => {
+    const data = {
+      issuerUrl: 'https://idp.example.com',
+      clientId: 'c1',
+      clientSecret: 'secret',
+      redirectUri: 'https://app.com/cb',
+    };
+    ok({ issuerUrl: data.issuerUrl, clientId: data.clientId, redirectUri: data.redirectUri });
+    await saveSsoConfig(data);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/sso/config');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(data);
+  });
+
+  it('saveSsoConfig throws on 400', async () => {
+    err(400, 'VALIDATION', 'Invalid issuer URL');
+    await expect(saveSsoConfig({ issuerUrl: '', clientId: '', clientSecret: '', redirectUri: '' })).rejects.toThrow('Invalid issuer URL');
+  });
+
+  // ── deleteSsoConfig ───────────────────────────────────────────────────
+
+  it('deleteSsoConfig sends DELETE /v1/sso/config', async () => {
+    noContent();
+    await deleteSsoConfig();
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/sso/config', expect.objectContaining({ method: 'DELETE' }));
+  });
+
+  it('deleteSsoConfig throws on error', async () => {
+    err(404, 'NOT_FOUND', 'No SSO configured');
+    await expect(deleteSsoConfig()).rejects.toThrow('No SSO configured');
+  });
+
+  // ── listSsoConnections ────────────────────────────────────────────────
+
+  it('listSsoConnections sends GET /v1/sso/connections and returns {connections}', async () => {
+    const resp = { connections: [{ id: 'c1', name: 'Okta', protocol: 'oidc' }] };
+    ok(resp);
+    const result = await listSsoConnections();
+    expect(result).toEqual(resp);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/sso/connections', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('listSsoConnections throws on error', async () => {
+    err(500, 'INTERNAL', 'Failed');
+    await expect(listSsoConnections()).rejects.toThrow('Failed');
+  });
+
+  // ── createSsoConnection ───────────────────────────────────────────────
+
+  it('createSsoConnection sends POST /v1/sso/connections with data', async () => {
+    const data = { name: 'Azure AD', protocol: 'oidc' as const, issuerUrl: 'https://login.microsoft.com/x', clientId: 'c1' };
+    ok({ id: 'conn-1', ...data, status: 'active' });
+    const result = await createSsoConnection(data);
+    expect(result.id).toBe('conn-1');
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/sso/connections');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(data);
+  });
+
+  it('createSsoConnection throws on 400', async () => {
+    err(400, 'VALIDATION', 'Name required');
+    await expect(createSsoConnection({ name: '', protocol: 'oidc' })).rejects.toThrow('Name required');
+  });
+
+  // ── deleteSsoConnection ───────────────────────────────────────────────
+
+  it('deleteSsoConnection sends DELETE /v1/sso/connections/:id', async () => {
+    noContent();
+    await deleteSsoConnection('conn-1');
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/sso/connections/conn-1', expect.objectContaining({ method: 'DELETE' }));
+  });
+
+  it('deleteSsoConnection throws on error', async () => {
+    err(404, 'NOT_FOUND', 'Connection not found');
+    await expect(deleteSsoConnection('missing')).rejects.toThrow('Connection not found');
+  });
+
+  // ── testSsoConnection ─────────────────────────────────────────────────
+
+  it('testSsoConnection sends POST /v1/sso/connections/:id/test', async () => {
+    const testResult = { success: true, protocol: 'oidc', issuer: 'https://idp.example.com' };
+    ok(testResult);
+    const result = await testSsoConnection('conn-1');
+    expect(result).toEqual(testResult);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/sso/connections/conn-1/test');
+    expect(opts.method).toBe('POST');
+  });
+
+  it('testSsoConnection returns failure result', async () => {
+    ok({ success: false, protocol: 'saml', error: 'IdP unreachable' });
+    const result = await testSsoConnection('conn-1');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('IdP unreachable');
+  });
+
+  it('testSsoConnection throws on server error', async () => {
+    err(500, 'INTERNAL', 'Test failed');
+    await expect(testSsoConnection('conn-1')).rejects.toThrow('Test failed');
+  });
+});

--- a/apps/portal/src/api/__tests__/usage.test.ts
+++ b/apps/portal/src/api/__tests__/usage.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { getUsage, getUsageHistory } from '../usage';
+
+describe('usage', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── getUsage ──────────────────────────────────────────────────────────
+
+  it('getUsage sends GET /v1/usage', async () => {
+    const data = { developerId: 'dev-1', period: '2026-04', tokenExchanges: 100, totalRequests: 500 };
+    ok(data);
+    const result = await getUsage();
+    expect(result).toEqual(data);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/usage', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('getUsage throws on error', async () => {
+    err(401, 'UNAUTHORIZED', 'Invalid key');
+    await expect(getUsage()).rejects.toThrow('Invalid key');
+  });
+
+  // ── getUsageHistory ───────────────────────────────────────────────────
+
+  it('getUsageHistory sends GET /v1/usage/history with days param', async () => {
+    const data = { entries: [{ date: '2026-04-01', requests: 50 }] };
+    ok(data);
+    const result = await getUsageHistory(30);
+    expect(result).toEqual(data);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/usage/history?days=30',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('getUsageHistory with different days value', async () => {
+    ok({ entries: [] });
+    await getUsageHistory(7);
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/usage/history?days=7');
+  });
+
+  it('getUsageHistory throws on error', async () => {
+    err(500, 'INTERNAL', 'Failed');
+    await expect(getUsageHistory(30)).rejects.toThrow('Failed');
+  });
+});

--- a/apps/portal/src/api/__tests__/usage.test.ts
+++ b/apps/portal/src/api/__tests__/usage.test.ts
@@ -55,7 +55,7 @@ describe('usage', () => {
   it('getUsageHistory with different days value', async () => {
     ok({ entries: [] });
     await getUsageHistory(7);
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/usage/history?days=7');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/usage/history?days=7');
   });
 
   it('getUsageHistory throws on error', async () => {

--- a/apps/portal/src/api/__tests__/webauthn.test.ts
+++ b/apps/portal/src/api/__tests__/webauthn.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function noContent() {
+  mockFetch.mockResolvedValueOnce({ ok: true, status: 204, json: () => Promise.resolve(undefined) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { listWebAuthnCredentials, deleteWebAuthnCredential } from '../webauthn';
+
+describe('webauthn', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── listWebAuthnCredentials ───────────────────────────────────────────
+
+  it('listWebAuthnCredentials sends GET /v1/webauthn/credentials with principalId', async () => {
+    ok({ credentials: [{ id: 'wc1', principalId: 'p1', credentialId: 'cred-1' }] });
+    const result = await listWebAuthnCredentials('p1');
+    expect(result).toEqual([{ id: 'wc1', principalId: 'p1', credentialId: 'cred-1' }]);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/webauthn/credentials?principalId=p1',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('listWebAuthnCredentials encodes principalId', async () => {
+    ok({ credentials: [] });
+    await listWebAuthnCredentials('p/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/webauthn/credentials?principalId=p%2F1');
+  });
+
+  it('listWebAuthnCredentials throws on error', async () => {
+    err(401, 'UNAUTHORIZED', 'Not authenticated');
+    await expect(listWebAuthnCredentials('p1')).rejects.toThrow('Not authenticated');
+  });
+
+  // ── deleteWebAuthnCredential ──────────────────────────────────────────
+
+  it('deleteWebAuthnCredential sends DELETE /v1/webauthn/credentials/:id', async () => {
+    noContent();
+    await deleteWebAuthnCredential('wc1');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/webauthn/credentials/wc1',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('deleteWebAuthnCredential encodes id', async () => {
+    noContent();
+    await deleteWebAuthnCredential('wc/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/webauthn/credentials/wc%2F1');
+  });
+
+  it('deleteWebAuthnCredential throws on error', async () => {
+    err(404, 'NOT_FOUND', 'Credential not found');
+    await expect(deleteWebAuthnCredential('missing')).rejects.toThrow('Credential not found');
+  });
+});

--- a/apps/portal/src/api/__tests__/webauthn.test.ts
+++ b/apps/portal/src/api/__tests__/webauthn.test.ts
@@ -42,7 +42,7 @@ describe('webauthn', () => {
   it('listWebAuthnCredentials encodes principalId', async () => {
     ok({ credentials: [] });
     await listWebAuthnCredentials('p/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/webauthn/credentials?principalId=p%2F1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/webauthn/credentials?principalId=p%2F1');
   });
 
   it('listWebAuthnCredentials throws on error', async () => {
@@ -64,7 +64,7 @@ describe('webauthn', () => {
   it('deleteWebAuthnCredential encodes id', async () => {
     noContent();
     await deleteWebAuthnCredential('wc/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/webauthn/credentials/wc%2F1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/webauthn/credentials/wc%2F1');
   });
 
   it('deleteWebAuthnCredential throws on error', async () => {

--- a/apps/portal/src/api/__tests__/webhooks.test.ts
+++ b/apps/portal/src/api/__tests__/webhooks.test.ts
@@ -49,7 +49,7 @@ describe('webhooks', () => {
     ok(resp);
     const result = await createWebhook(data);
     expect(result).toEqual(resp);
-    const [url, opts] = mockFetch.mock.calls[0];
+    const [url, opts] = mockFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:3000/v1/webhooks');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual(data);
@@ -71,7 +71,7 @@ describe('webhooks', () => {
   it('deleteWebhook encodes id', async () => {
     noContent();
     await deleteWebhook('wh/1');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/webhooks/wh%2F1');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/webhooks/wh%2F1');
   });
 
   it('deleteWebhook throws on error', async () => {
@@ -95,7 +95,7 @@ describe('webhooks', () => {
   it('listDeliveries with page and pageSize', async () => {
     ok({ deliveries: [], total: 0, page: 2, pageSize: 10 });
     await listDeliveries('wh1', { page: 2, pageSize: 10 });
-    const url = mockFetch.mock.calls[0][0];
+    const url = mockFetch.mock.calls[0]![0];
     expect(url).toContain('page=2');
     expect(url).toContain('pageSize=10');
   });
@@ -103,13 +103,13 @@ describe('webhooks', () => {
   it('listDeliveries with status filter', async () => {
     ok({ deliveries: [], total: 0, page: 1, pageSize: 20 });
     await listDeliveries('wh1', { status: 'failed' });
-    expect(mockFetch.mock.calls[0][0]).toContain('status=failed');
+    expect(mockFetch.mock.calls[0]![0]).toContain('status=failed');
   });
 
   it('listDeliveries encodes webhookId', async () => {
     ok({ deliveries: [], total: 0, page: 1, pageSize: 20 });
     await listDeliveries('wh/1');
-    expect(mockFetch.mock.calls[0][0]).toContain('/v1/webhooks/wh%2F1/deliveries');
+    expect(mockFetch.mock.calls[0]![0]).toContain('/v1/webhooks/wh%2F1/deliveries');
   });
 
   it('listDeliveries throws on error', async () => {

--- a/apps/portal/src/api/__tests__/webhooks.test.ts
+++ b/apps/portal/src/api/__tests__/webhooks.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/constants', () => ({ API_BASE_URL: 'http://localhost:3000' }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function ok(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({ ok: true, status, json: () => Promise.resolve(data) });
+}
+function noContent() {
+  mockFetch.mockResolvedValueOnce({ ok: true, status: 204, json: () => Promise.resolve(undefined) });
+}
+function err(status: number, code: string, msg: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: msg,
+    json: () => Promise.resolve({ code, message: msg }),
+  });
+}
+
+import { listWebhooks, createWebhook, deleteWebhook, listDeliveries } from '../webhooks';
+
+describe('webhooks', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // ── listWebhooks ──────────────────────────────────────────────────────
+
+  it('listWebhooks sends GET /v1/webhooks and unwraps .webhooks', async () => {
+    ok({ webhooks: [{ id: 'wh1', url: 'https://example.com/hook', events: ['grant.created'] }] });
+    const result = await listWebhooks();
+    expect(result).toEqual([{ id: 'wh1', url: 'https://example.com/hook', events: ['grant.created'] }]);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/webhooks', expect.objectContaining({ method: 'GET' }));
+  });
+
+  it('listWebhooks throws on error', async () => {
+    err(500, 'INTERNAL', 'Failed');
+    await expect(listWebhooks()).rejects.toThrow('Failed');
+  });
+
+  // ── createWebhook ─────────────────────────────────────────────────────
+
+  it('createWebhook sends POST /v1/webhooks with url and events', async () => {
+    const data = { url: 'https://example.com/hook', events: ['grant.created', 'grant.revoked'] };
+    const resp = { id: 'wh2', ...data, secret: 'whsec_123', createdAt: '2026-04-01' };
+    ok(resp);
+    const result = await createWebhook(data);
+    expect(result).toEqual(resp);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/webhooks');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(data);
+  });
+
+  it('createWebhook throws on 400', async () => {
+    err(400, 'VALIDATION', 'URL required');
+    await expect(createWebhook({ url: '', events: [] })).rejects.toThrow('URL required');
+  });
+
+  // ── deleteWebhook ─────────────────────────────────────────────────────
+
+  it('deleteWebhook sends DELETE /v1/webhooks/:id', async () => {
+    noContent();
+    await deleteWebhook('wh1');
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/webhooks/wh1', expect.objectContaining({ method: 'DELETE' }));
+  });
+
+  it('deleteWebhook encodes id', async () => {
+    noContent();
+    await deleteWebhook('wh/1');
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/webhooks/wh%2F1');
+  });
+
+  it('deleteWebhook throws on error', async () => {
+    err(404, 'NOT_FOUND', 'Webhook not found');
+    await expect(deleteWebhook('missing')).rejects.toThrow('Webhook not found');
+  });
+
+  // ── listDeliveries ────────────────────────────────────────────────────
+
+  it('listDeliveries sends GET /v1/webhooks/:id/deliveries without opts', async () => {
+    const data = { deliveries: [], total: 0, page: 1, pageSize: 20 };
+    ok(data);
+    const result = await listDeliveries('wh1');
+    expect(result).toEqual(data);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/webhooks/wh1/deliveries',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('listDeliveries with page and pageSize', async () => {
+    ok({ deliveries: [], total: 0, page: 2, pageSize: 10 });
+    await listDeliveries('wh1', { page: 2, pageSize: 10 });
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toContain('page=2');
+    expect(url).toContain('pageSize=10');
+  });
+
+  it('listDeliveries with status filter', async () => {
+    ok({ deliveries: [], total: 0, page: 1, pageSize: 20 });
+    await listDeliveries('wh1', { status: 'failed' });
+    expect(mockFetch.mock.calls[0][0]).toContain('status=failed');
+  });
+
+  it('listDeliveries encodes webhookId', async () => {
+    ok({ deliveries: [], total: 0, page: 1, pageSize: 20 });
+    await listDeliveries('wh/1');
+    expect(mockFetch.mock.calls[0][0]).toContain('/v1/webhooks/wh%2F1/deliveries');
+  });
+
+  it('listDeliveries throws on error', async () => {
+    err(404, 'NOT_FOUND', 'Webhook not found');
+    await expect(listDeliveries('missing')).rejects.toThrow('Webhook not found');
+  });
+});

--- a/apps/portal/src/components/__tests__/Badge.test.tsx
+++ b/apps/portal/src/components/__tests__/Badge.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Badge } from '../ui/Badge';
+
+describe('Badge', () => {
+  it('renders text content', () => {
+    render(<Badge>active</Badge>);
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  it('applies default variant styles', () => {
+    render(<Badge>default</Badge>);
+    expect(screen.getByText('default')).toHaveClass('bg-gx-border/50');
+    expect(screen.getByText('default')).toHaveClass('text-gx-muted');
+  });
+
+  it('applies success variant styles', () => {
+    render(<Badge variant="success">live</Badge>);
+    const el = screen.getByText('live');
+    expect(el).toHaveClass('bg-gx-accent/15');
+    expect(el).toHaveClass('text-gx-accent');
+  });
+
+  it('applies warning variant styles', () => {
+    render(<Badge variant="warning">sandbox</Badge>);
+    const el = screen.getByText('sandbox');
+    expect(el).toHaveClass('bg-gx-warning/15');
+    expect(el).toHaveClass('text-gx-warning');
+  });
+
+  it('applies danger variant styles', () => {
+    render(<Badge variant="danger">revoked</Badge>);
+    const el = screen.getByText('revoked');
+    expect(el).toHaveClass('bg-gx-danger/15');
+    expect(el).toHaveClass('text-gx-danger');
+  });
+
+  it('renders as an inline-flex span', () => {
+    render(<Badge>tag</Badge>);
+    const el = screen.getByText('tag');
+    expect(el.tagName).toBe('SPAN');
+    expect(el).toHaveClass('inline-flex');
+  });
+
+  it('uses monospace font', () => {
+    render(<Badge>mono</Badge>);
+    expect(screen.getByText('mono')).toHaveClass('font-mono');
+  });
+
+  it('uses extra-small text size', () => {
+    render(<Badge>small</Badge>);
+    expect(screen.getByText('small')).toHaveClass('text-xs');
+  });
+});

--- a/apps/portal/src/components/__tests__/Button.test.tsx
+++ b/apps/portal/src/components/__tests__/Button.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button } from '../ui/Button';
+
+describe('Button', () => {
+  it('renders children text', () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
+  });
+
+  it('calls onClick handler when clicked', async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(<Button onClick={onClick}>Click</Button>);
+    await user.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClick when disabled', async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(<Button onClick={onClick} disabled>Click</Button>);
+    await user.click(screen.getByRole('button'));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('applies primary variant classes by default', () => {
+    render(<Button>Primary</Button>);
+    expect(screen.getByRole('button')).toHaveClass('bg-gx-accent');
+  });
+
+  it('applies secondary variant classes', () => {
+    render(<Button variant="secondary">Secondary</Button>);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveClass('bg-transparent');
+    expect(btn).toHaveClass('border');
+  });
+
+  it('applies danger variant classes', () => {
+    render(<Button variant="danger">Danger</Button>);
+    expect(screen.getByRole('button')).toHaveClass('bg-gx-danger');
+  });
+
+  it('applies ghost variant classes', () => {
+    render(<Button variant="ghost">Ghost</Button>);
+    expect(screen.getByRole('button')).toHaveClass('bg-transparent');
+  });
+
+  it('applies md size by default', () => {
+    render(<Button>Medium</Button>);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveClass('px-4');
+    expect(btn).toHaveClass('py-2');
+    expect(btn).toHaveClass('text-sm');
+  });
+
+  it('applies sm size classes', () => {
+    render(<Button size="sm">Small</Button>);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveClass('px-3');
+    expect(btn).toHaveClass('text-xs');
+  });
+
+  it('forwards className prop', () => {
+    render(<Button className="my-custom-class">Custom</Button>);
+    expect(screen.getByRole('button')).toHaveClass('my-custom-class');
+  });
+
+  it('is disabled when disabled prop is set', () => {
+    render(<Button disabled>Disabled</Button>);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('forwards native button attributes like type and aria-label', () => {
+    render(<Button type="submit" aria-label="Submit form">Submit</Button>);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('type', 'submit');
+    expect(btn).toHaveAttribute('aria-label', 'Submit form');
+  });
+
+  it('renders as an inline-flex element', () => {
+    render(<Button>Flex</Button>);
+    expect(screen.getByRole('button')).toHaveClass('inline-flex');
+  });
+});

--- a/apps/portal/src/components/__tests__/Card.test.tsx
+++ b/apps/portal/src/components/__tests__/Card.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Card } from '../ui/Card';
+
+describe('Card', () => {
+  it('renders children', () => {
+    render(<Card>Hello World</Card>);
+    expect(screen.getByText('Hello World')).toBeInTheDocument();
+  });
+
+  it('renders complex children', () => {
+    render(
+      <Card>
+        <h2>Title</h2>
+        <p>Description</p>
+      </Card>,
+    );
+    expect(screen.getByText('Title')).toBeInTheDocument();
+    expect(screen.getByText('Description')).toBeInTheDocument();
+  });
+
+  it('applies default styling classes', () => {
+    const { container } = render(<Card>Styled</Card>);
+    const card = container.firstChild as HTMLElement;
+    expect(card).toHaveClass('bg-gx-surface');
+    expect(card).toHaveClass('border');
+    expect(card).toHaveClass('rounded-lg');
+    expect(card).toHaveClass('p-6');
+  });
+
+  it('forwards additional className', () => {
+    const { container } = render(<Card className="extra-class">Custom</Card>);
+    const card = container.firstChild as HTMLElement;
+    expect(card).toHaveClass('extra-class');
+  });
+
+  it('merges className with default classes', () => {
+    const { container } = render(<Card className="mt-4">Merged</Card>);
+    const card = container.firstChild as HTMLElement;
+    expect(card).toHaveClass('bg-gx-surface');
+    expect(card).toHaveClass('mt-4');
+  });
+});

--- a/apps/portal/src/components/__tests__/ConfirmDialog.test.tsx
+++ b/apps/portal/src/components/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ConfirmDialog } from '../ui/ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  const defaultProps = {
+    open: true,
+    onClose: vi.fn(),
+    onConfirm: vi.fn(),
+    title: 'Delete item?',
+    message: 'This action cannot be undone.',
+  };
+
+  it('renders title and message when open', () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(screen.getByText('Delete item?')).toBeInTheDocument();
+    expect(screen.getByText('This action cannot be undone.')).toBeInTheDocument();
+  });
+
+  it('renders nothing when closed', () => {
+    const { container } = render(<ConfirmDialog {...defaultProps} open={false} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders default confirm label as Confirm', () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+  });
+
+  it('renders custom confirm label', () => {
+    render(<ConfirmDialog {...defaultProps} confirmLabel="Delete" />);
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('renders Cancel button', () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('calls onConfirm when confirm button is clicked', async () => {
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    render(<ConfirmDialog {...defaultProps} onConfirm={onConfirm} />);
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when cancel button is clicked', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<ConfirmDialog {...defaultProps} onClose={onClose} />);
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables both buttons when loading', () => {
+    render(<ConfirmDialog {...defaultProps} loading />);
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+  });
+
+  it('buttons are enabled when not loading', () => {
+    render(<ConfirmDialog {...defaultProps} loading={false} />);
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeEnabled();
+  });
+
+  it('calls onClose on Escape key', () => {
+    const onClose = vi.fn();
+    render(<ConfirmDialog {...defaultProps} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('uses danger variant by default for confirm button', () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    const confirmBtn = screen.getByRole('button', { name: 'Confirm' });
+    expect(confirmBtn).toHaveClass('bg-gx-danger');
+  });
+
+  it('uses primary variant when specified', () => {
+    render(<ConfirmDialog {...defaultProps} variant="primary" />);
+    const confirmBtn = screen.getByRole('button', { name: 'Confirm' });
+    expect(confirmBtn).toHaveClass('bg-gx-accent');
+  });
+});

--- a/apps/portal/src/components/__tests__/CopyButton.test.tsx
+++ b/apps/portal/src/components/__tests__/CopyButton.test.tsx
@@ -1,44 +1,25 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CopyButton } from '../ui/CopyButton';
 
 describe('CopyButton', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('renders with Copy text initially', () => {
     render(<CopyButton text="some-value" />);
     expect(screen.getByText('Copy')).toBeInTheDocument();
   });
 
-  it('shows Copied! feedback when clicked (proves clipboard writeText was called)', async () => {
+  it('shows Copied! feedback when clicked', async () => {
     const user = userEvent.setup();
     render(<CopyButton text="gx_live_abc" />);
     await user.click(screen.getByText('Copy'));
-    // If clipboard.writeText was not called or failed, Copied! would not appear
     await waitFor(() => {
       expect(screen.getByText('Copied!')).toBeInTheDocument();
     });
-  });
-
-  it('reverts back to Copy after 2 seconds', async () => {
-    vi.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: (ms) => vi.advanceTimersByTime(ms) });
-    render(<CopyButton text="token" />);
-    await user.click(screen.getByText('Copy'));
-    await vi.runAllTicksAsync();
-    expect(screen.getByText('Copied!')).toBeInTheDocument();
-
-    act(() => {
-      vi.advanceTimersByTime(2100);
-    });
-
-    expect(screen.getByText('Copy')).toBeInTheDocument();
-    vi.useRealTimers();
-  });
-
-  it('applies custom className', () => {
-    render(<CopyButton text="val" className="ml-2" />);
-    const btn = screen.getByText('Copy');
-    expect(btn).toHaveClass('ml-2');
   });
 
   it('changes styling to accent when copied', async () => {
@@ -50,6 +31,28 @@ describe('CopyButton', () => {
       expect(el).toHaveClass('border-gx-accent');
       expect(el).toHaveClass('text-gx-accent');
     });
+  });
+
+  it('reverts back to Copy after 2 seconds', async () => {
+    vi.useFakeTimers();
+    render(<CopyButton text="token" />);
+    // Use fireEvent to avoid userEvent + fake timers conflict
+    fireEvent.click(screen.getByText('Copy'));
+    // Flush microtasks from clipboard promise
+    await vi.advanceTimersByTimeAsync(0);
+    expect(screen.getByText('Copied!')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    expect(screen.getByText('Copy')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    render(<CopyButton text="val" className="ml-2" />);
+    const btn = screen.getByText('Copy');
+    expect(btn).toHaveClass('ml-2');
   });
 
   it('has muted styling before copying', () => {

--- a/apps/portal/src/components/__tests__/CopyButton.test.tsx
+++ b/apps/portal/src/components/__tests__/CopyButton.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CopyButton } from '../ui/CopyButton';
+
+describe('CopyButton', () => {
+  it('renders with Copy text initially', () => {
+    render(<CopyButton text="some-value" />);
+    expect(screen.getByText('Copy')).toBeInTheDocument();
+  });
+
+  it('shows Copied! feedback when clicked (proves clipboard writeText was called)', async () => {
+    const user = userEvent.setup();
+    render(<CopyButton text="gx_live_abc" />);
+    await user.click(screen.getByText('Copy'));
+    // If clipboard.writeText was not called or failed, Copied! would not appear
+    await waitFor(() => {
+      expect(screen.getByText('Copied!')).toBeInTheDocument();
+    });
+  });
+
+  it('reverts back to Copy after 2 seconds', async () => {
+    vi.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: (ms) => vi.advanceTimersByTime(ms) });
+    render(<CopyButton text="token" />);
+    await user.click(screen.getByText('Copy'));
+    await vi.runAllTicksAsync();
+    expect(screen.getByText('Copied!')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    expect(screen.getByText('Copy')).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  it('applies custom className', () => {
+    render(<CopyButton text="val" className="ml-2" />);
+    const btn = screen.getByText('Copy');
+    expect(btn).toHaveClass('ml-2');
+  });
+
+  it('changes styling to accent when copied', async () => {
+    const user = userEvent.setup();
+    render(<CopyButton text="val" />);
+    await user.click(screen.getByText('Copy'));
+    await waitFor(() => {
+      const el = screen.getByText('Copied!');
+      expect(el).toHaveClass('border-gx-accent');
+      expect(el).toHaveClass('text-gx-accent');
+    });
+  });
+
+  it('has muted styling before copying', () => {
+    render(<CopyButton text="val" />);
+    const el = screen.getByText('Copy');
+    expect(el).toHaveClass('border-gx-border');
+    expect(el).toHaveClass('text-gx-muted');
+  });
+
+  it('uses monospace font', () => {
+    render(<CopyButton text="val" />);
+    expect(screen.getByText('Copy')).toHaveClass('font-mono');
+  });
+
+  it('renders as a button element', () => {
+    render(<CopyButton text="val" />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('uses extra-small text size', () => {
+    render(<CopyButton text="val" />);
+    expect(screen.getByText('Copy')).toHaveClass('text-xs');
+  });
+});

--- a/apps/portal/src/components/__tests__/DateRangeFilter.test.tsx
+++ b/apps/portal/src/components/__tests__/DateRangeFilter.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DateRangeFilter, filterByDays } from '../ui/DateRangeFilter';
+
+describe('DateRangeFilter', () => {
+  it('renders all preset buttons', () => {
+    render(<DateRangeFilter activeDays={7} onChange={vi.fn()} />);
+    expect(screen.getByText('24h')).toBeInTheDocument();
+    expect(screen.getByText('7d')).toBeInTheDocument();
+    expect(screen.getByText('30d')).toBeInTheDocument();
+    expect(screen.getByText('90d')).toBeInTheDocument();
+    expect(screen.getByText('All')).toBeInTheDocument();
+  });
+
+  it('highlights the active preset', () => {
+    render(<DateRangeFilter activeDays={7} onChange={vi.fn()} />);
+    expect(screen.getByText('7d').className).toContain('text-gx-accent');
+  });
+
+  it('calls onChange with correct days on click', () => {
+    const onChange = vi.fn();
+    render(<DateRangeFilter activeDays={7} onChange={onChange} />);
+    fireEvent.click(screen.getByText('30d'));
+    expect(onChange).toHaveBeenCalledWith(30);
+  });
+
+  it('calls onChange with 0 for All', () => {
+    const onChange = vi.fn();
+    render(<DateRangeFilter activeDays={7} onChange={onChange} />);
+    fireEvent.click(screen.getByText('All'));
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+});
+
+describe('filterByDays', () => {
+  const items = [
+    { ts: new Date(Date.now() - 1000).toISOString() },        // just now
+    { ts: new Date(Date.now() - 2 * 86400000).toISOString() }, // 2 days ago
+    { ts: new Date(Date.now() - 10 * 86400000).toISOString() }, // 10 days ago
+  ];
+
+  it('returns all items when days=0', () => {
+    expect(filterByDays(items, 0, i => i.ts)).toHaveLength(3);
+  });
+
+  it('filters items within 1 day', () => {
+    expect(filterByDays(items, 1, i => i.ts)).toHaveLength(1);
+  });
+
+  it('filters items within 7 days', () => {
+    expect(filterByDays(items, 7, i => i.ts)).toHaveLength(2);
+  });
+
+  it('filters items within 30 days', () => {
+    expect(filterByDays(items, 30, i => i.ts)).toHaveLength(3);
+  });
+});

--- a/apps/portal/src/components/__tests__/EmptyState.test.tsx
+++ b/apps/portal/src/components/__tests__/EmptyState.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EmptyState } from '../ui/EmptyState';
+
+describe('EmptyState', () => {
+  it('renders title', () => {
+    render(<EmptyState title="No agents" />);
+    expect(screen.getByText('No agents')).toBeInTheDocument();
+  });
+
+  it('renders description when provided', () => {
+    render(<EmptyState title="No agents" description="Create your first agent to get started." />);
+    expect(screen.getByText('Create your first agent to get started.')).toBeInTheDocument();
+  });
+
+  it('does not render description when omitted', () => {
+    render(<EmptyState title="No agents" />);
+    // Only the title text and the SVG icon should be present
+    expect(screen.queryByText('Create your first agent')).not.toBeInTheDocument();
+  });
+
+  it('renders action element when provided', () => {
+    render(
+      <EmptyState
+        title="No agents"
+        action={<button>Create Agent</button>}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Create Agent' })).toBeInTheDocument();
+  });
+
+  it('does not render action when omitted', () => {
+    render(<EmptyState title="No agents" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('action button is clickable', async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <EmptyState
+        title="Empty"
+        action={<button onClick={onClick}>Add</button>}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an icon SVG', () => {
+    const { container } = render(<EmptyState title="Empty" />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('centers content', () => {
+    const { container } = render(<EmptyState title="Centered" />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass('flex');
+    expect(wrapper).toHaveClass('items-center');
+    expect(wrapper).toHaveClass('justify-center');
+    expect(wrapper).toHaveClass('text-center');
+  });
+});

--- a/apps/portal/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/apps/portal/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ErrorBoundary } from '../ErrorBoundary';
+
+// Component that throws an error
+function ThrowError({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('Test error message');
+  }
+  return <div>Content renders fine</div>;
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    // Suppress console.error from React's error boundary logging
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('renders children when no error occurs', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Content renders fine')).toBeInTheDocument();
+  });
+
+  it('renders error UI when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('displays the error message', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Test error message')).toBeInTheDocument();
+  });
+
+  it('renders a Try Again button', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument();
+  });
+
+  it('renders a Go to Dashboard button', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole('button', { name: 'Go to Dashboard' })).toBeInTheDocument();
+  });
+
+  it('resets error state when Try Again is clicked', async () => {
+    const user = userEvent.setup();
+
+    // We need a stateful wrapper to control the throw
+    let shouldThrow = true;
+    function Wrapper() {
+      if (shouldThrow) throw new Error('Boom');
+      return <div>Recovered</div>;
+    }
+
+    const { rerender } = render(
+      <ErrorBoundary>
+        <Wrapper />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+
+    // Stop throwing and click Try Again
+    shouldThrow = false;
+    await user.click(screen.getByRole('button', { name: 'Try Again' }));
+
+    expect(screen.getByText('Recovered')).toBeInTheDocument();
+  });
+
+  it('shows fallback message when error has no message', () => {
+    function ThrowEmpty() {
+      throw new Error();
+    }
+    render(
+      <ErrorBoundary>
+        <ThrowEmpty />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('An unexpected error occurred.')).toBeInTheDocument();
+  });
+
+  it('logs the error and component stack to console.error', () => {
+    const consoleSpy = vi.spyOn(console, 'error');
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    // React and our ErrorBoundary both log errors
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/portal/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/apps/portal/src/components/__tests__/ErrorBoundary.test.tsx
@@ -72,7 +72,7 @@ describe('ErrorBoundary', () => {
       return <div>Recovered</div>;
     }
 
-    const { rerender } = render(
+    const { rerender: _rerender } = render(
       <ErrorBoundary>
         <Wrapper />
       </ErrorBoundary>,
@@ -88,7 +88,7 @@ describe('ErrorBoundary', () => {
   });
 
   it('shows fallback message when error has no message', () => {
-    function ThrowEmpty() {
+    function ThrowEmpty(): JSX.Element {
       throw new Error();
     }
     render(

--- a/apps/portal/src/components/__tests__/Input.test.tsx
+++ b/apps/portal/src/components/__tests__/Input.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Input } from '../ui/Input';
+
+describe('Input', () => {
+  it('renders an input element', () => {
+    render(<Input placeholder="Enter text" />);
+    expect(screen.getByPlaceholderText('Enter text')).toBeInTheDocument();
+  });
+
+  it('renders a label when label prop is provided', () => {
+    render(<Input label="Username" id="username" />);
+    expect(screen.getByLabelText('Username')).toBeInTheDocument();
+  });
+
+  it('renders hint text alongside the label', () => {
+    render(<Input label="API Key" hint="starts with gx_" id="apikey" />);
+    expect(screen.getByText('(starts with gx_)')).toBeInTheDocument();
+  });
+
+  it('forwards id to the input element', () => {
+    render(<Input label="Email" id="email-input" />);
+    const input = screen.getByLabelText('Email');
+    expect(input).toHaveAttribute('id', 'email-input');
+  });
+
+  it('forwards placeholder prop', () => {
+    render(<Input placeholder="Type here..." />);
+    expect(screen.getByPlaceholderText('Type here...')).toBeInTheDocument();
+  });
+
+  it('handles value and onChange', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Input value="" onChange={onChange} placeholder="type" />);
+    await user.type(screen.getByPlaceholderText('type'), 'a');
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('forwards className prop', () => {
+    render(<Input className="extra" placeholder="cls" />);
+    expect(screen.getByPlaceholderText('cls')).toHaveClass('extra');
+  });
+
+  it('renders error message when error prop is provided', () => {
+    render(<Input error="This field is required" placeholder="err" />);
+    expect(screen.getByText('This field is required')).toBeInTheDocument();
+  });
+
+  it('applies error border style when error prop is set', () => {
+    render(<Input error="Bad value" placeholder="err" />);
+    expect(screen.getByPlaceholderText('err')).toHaveClass('border-gx-danger');
+  });
+
+  it('applies normal border style when no error', () => {
+    render(<Input placeholder="normal" />);
+    expect(screen.getByPlaceholderText('normal')).toHaveClass('border-gx-border');
+  });
+
+  it('does not render label when label prop is omitted', () => {
+    const { container } = render(<Input placeholder="no-label" />);
+    expect(container.querySelector('label')).toBeNull();
+  });
+
+  it('does not render error message when error prop is omitted', () => {
+    render(<Input placeholder="no-error" />);
+    const errorP = document.querySelector('p.text-gx-danger');
+    expect(errorP).toBeNull();
+  });
+
+  it('forwards native input attributes like type and disabled', () => {
+    render(<Input type="password" disabled placeholder="pwd" />);
+    const input = screen.getByPlaceholderText('pwd');
+    expect(input).toHaveAttribute('type', 'password');
+    expect(input).toBeDisabled();
+  });
+});

--- a/apps/portal/src/components/__tests__/Modal.test.tsx
+++ b/apps/portal/src/components/__tests__/Modal.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Modal } from '../ui/Modal';
+
+describe('Modal', () => {
+  it('renders nothing when open is false', () => {
+    const { container } = render(
+      <Modal open={false} onClose={vi.fn()} title="Test">
+        <p>Content</p>
+      </Modal>,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders title and children when open is true', () => {
+    render(
+      <Modal open={true} onClose={vi.fn()} title="My Modal">
+        <p>Modal body</p>
+      </Modal>,
+    );
+    expect(screen.getByText('My Modal')).toBeInTheDocument();
+    expect(screen.getByText('Modal body')).toBeInTheDocument();
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Modal open={true} onClose={onClose} title="Close Me">
+        <p>Body</p>
+      </Modal>,
+    );
+    // The close button contains the x character
+    const closeBtn = screen.getByText('×');
+    await user.click(closeBtn);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when Escape key is pressed', () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open={true} onClose={onClose} title="Escape">
+        <p>Body</p>
+      </Modal>,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when overlay is clicked', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Modal open={true} onClose={onClose} title="Overlay">
+        <p>Body</p>
+      </Modal>,
+    );
+    // The overlay is the outermost fixed div
+    const overlay = screen.getByText('Overlay').closest('.fixed');
+    if (overlay) {
+      await user.click(overlay);
+      expect(onClose).toHaveBeenCalled();
+    }
+  });
+
+  it('does not call onClose when modal content is clicked', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Modal open={true} onClose={onClose} title="No Close">
+        <p>Click me</p>
+      </Modal>,
+    );
+    await user.click(screen.getByText('Click me'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not listen for Escape when closed', () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open={false} onClose={onClose} title="Closed">
+        <p>Body</p>
+      </Modal>,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('renders with overlay backdrop', () => {
+    render(
+      <Modal open={true} onClose={vi.fn()} title="Backdrop">
+        <p>Body</p>
+      </Modal>,
+    );
+    const overlay = screen.getByText('Backdrop').closest('.fixed');
+    expect(overlay).toHaveClass('bg-black/60');
+  });
+});

--- a/apps/portal/src/components/__tests__/ScopePills.test.tsx
+++ b/apps/portal/src/components/__tests__/ScopePills.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ScopePills } from '../ui/ScopePills';
+
+describe('ScopePills', () => {
+  it('renders all scopes as pill elements', () => {
+    render(<ScopePills scopes={['read', 'write', 'admin']} />);
+    expect(screen.getByText('read')).toBeInTheDocument();
+    expect(screen.getByText('write')).toBeInTheDocument();
+    expect(screen.getByText('admin')).toBeInTheDocument();
+  });
+
+  it('renders an empty container when scopes is empty', () => {
+    const { container } = render(<ScopePills scopes={[]} />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.children).toHaveLength(0);
+  });
+
+  it('renders single scope', () => {
+    render(<ScopePills scopes={['read:agents']} />);
+    expect(screen.getByText('read:agents')).toBeInTheDocument();
+  });
+
+  it('uses monospace font for pills', () => {
+    render(<ScopePills scopes={['read']} />);
+    expect(screen.getByText('read')).toHaveClass('font-mono');
+  });
+
+  it('uses extra-small text size', () => {
+    render(<ScopePills scopes={['write']} />);
+    expect(screen.getByText('write')).toHaveClass('text-xs');
+  });
+
+  it('renders pills as span elements', () => {
+    render(<ScopePills scopes={['scope1']} />);
+    expect(screen.getByText('scope1').tagName).toBe('SPAN');
+  });
+
+  it('applies flex-wrap for wrapping pills', () => {
+    const { container } = render(<ScopePills scopes={['a', 'b']} />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass('flex');
+    expect(wrapper).toHaveClass('flex-wrap');
+  });
+
+  it('forwards className to the wrapper', () => {
+    const { container } = render(<ScopePills scopes={['read']} className="mt-2" />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass('mt-2');
+  });
+
+  it('renders each scope with accent2 styling', () => {
+    render(<ScopePills scopes={['manage']} />);
+    expect(screen.getByText('manage')).toHaveClass('bg-gx-accent2/10');
+    expect(screen.getByText('manage')).toHaveClass('text-gx-accent2');
+  });
+});

--- a/apps/portal/src/components/__tests__/Select.test.tsx
+++ b/apps/portal/src/components/__tests__/Select.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Select } from '../ui/Select';
+
+const options = [
+  { value: 'a', label: 'Option A' },
+  { value: 'b', label: 'Option B' },
+  { value: 'c', label: 'Option C' },
+];
+
+describe('Select', () => {
+  it('renders all options', () => {
+    render(<Select options={options} />);
+    expect(screen.getByText('Option A')).toBeInTheDocument();
+    expect(screen.getByText('Option B')).toBeInTheDocument();
+    expect(screen.getByText('Option C')).toBeInTheDocument();
+  });
+
+  it('renders label when provided', () => {
+    render(<Select label="Choose one" options={options} id="sel" />);
+    expect(screen.getByText('Choose one')).toBeInTheDocument();
+    expect(screen.getByLabelText('Choose one')).toBeInTheDocument();
+  });
+
+  it('forwards id to select element', () => {
+    render(<Select options={options} id="my-select" />);
+    expect(document.getElementById('my-select')).toBeInTheDocument();
+  });
+
+  it('renders without label', () => {
+    render(<Select options={options} />);
+    expect(screen.queryByRole('label')).not.toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/components/__tests__/Shell.test.tsx
+++ b/apps/portal/src/components/__tests__/Shell.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { Shell } from '../layout/Shell';
+import { ToastProvider } from '../../store/toast';
+
+// Mock the auth store for TopBar
+vi.mock('../../store/auth', () => ({
+  useAuth: () => ({
+    developer: { name: 'TestDev', mode: 'live' as const, developerId: 'dev-1', email: null, plan: 'pro', fidoRequired: false, fidoRpName: null, createdAt: '' },
+    logout: vi.fn(),
+  }),
+}));
+
+function renderShell(initialPath = '/dashboard') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <ToastProvider>
+        <Routes>
+          <Route element={<Shell />}>
+            <Route path="/dashboard" element={<div>Dashboard Content</div>} />
+          </Route>
+        </Routes>
+      </ToastProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('Shell', () => {
+  it('renders the sidebar with navigation links', () => {
+    renderShell();
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+    expect(screen.getByText('Agents')).toBeInTheDocument();
+    expect(screen.getByText('Grants')).toBeInTheDocument();
+  });
+
+  it('renders the top bar', () => {
+    renderShell();
+    expect(screen.getByText('Log out')).toBeInTheDocument();
+  });
+
+  it('renders the outlet content', () => {
+    renderShell();
+    expect(screen.getByText('Dashboard Content')).toBeInTheDocument();
+  });
+
+  it('renders the grantex logo in sidebar', () => {
+    renderShell();
+    expect(screen.getByText('grant')).toBeInTheDocument();
+  });
+
+  it('renders the developer name in top bar', () => {
+    renderShell();
+    expect(screen.getByText('TestDev')).toBeInTheDocument();
+  });
+
+  it('renders the mode badge', () => {
+    renderShell();
+    expect(screen.getByText('live')).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/components/__tests__/Sidebar.test.tsx
+++ b/apps/portal/src/components/__tests__/Sidebar.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { Sidebar } from '../layout/Sidebar';
+
+function renderSidebar(open = true) {
+  const onClose = vi.fn();
+  const result = render(
+    <MemoryRouter initialEntries={['/dashboard']}>
+      <Sidebar open={open} onClose={onClose} />
+    </MemoryRouter>,
+  );
+  return { ...result, onClose };
+}
+
+describe('Sidebar', () => {
+  it('renders the grantex logo', () => {
+    renderSidebar();
+    expect(screen.getByText('grant')).toBeInTheDocument();
+  });
+
+  it('renders all navigation links', () => {
+    renderSidebar();
+    const expectedLinks = [
+      'Overview', 'Agents', 'Grants', 'Bundles', 'Audit Log', 'Webhooks',
+      'Policies', 'Anomalies', 'Compliance', 'Consent Records', 'Grievances',
+      'Exports', 'Budgets', 'Usage', 'Domains', 'WebAuthn', 'Credentials',
+      'Events', 'MCP Servers', 'Trust Registry', 'Billing', 'Settings',
+      'SSO', 'SCIM', 'Admin',
+    ];
+    for (const label of expectedLinks) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it('renders at least 25 nav links', () => {
+    renderSidebar();
+    const links = screen.getAllByRole('link');
+    // At least 25 NavLinks + the logo link
+    expect(links.length).toBeGreaterThanOrEqual(25);
+  });
+
+  it('applies translate-x-0 class when open', () => {
+    const { container } = renderSidebar(true);
+    const aside = container.querySelector('aside');
+    expect(aside).toHaveClass('translate-x-0');
+  });
+
+  it('applies -translate-x-full class when closed', () => {
+    const { container } = renderSidebar(false);
+    const aside = container.querySelector('aside');
+    expect(aside).toHaveClass('-translate-x-full');
+  });
+
+  it('renders overlay div when open', () => {
+    const { container } = renderSidebar(true);
+    // The overlay is the first child div with fixed+inset-0 classes (not inside the aside)
+    const divs = container.querySelectorAll('div');
+    const overlay = Array.from(divs).find(
+      (d) => d.classList.contains('fixed') && d.classList.contains('inset-0') && d.classList.contains('lg:hidden'),
+    );
+    expect(overlay).toBeTruthy();
+  });
+
+  it('does not render overlay when closed', () => {
+    const { container } = renderSidebar(false);
+    const divs = container.querySelectorAll('div');
+    const overlay = Array.from(divs).find(
+      (d) => d.classList.contains('fixed') && d.classList.contains('inset-0') && d.classList.contains('lg:hidden'),
+    );
+    expect(overlay).toBeUndefined();
+  });
+
+  it('calls onClose when overlay is clicked', async () => {
+    const { container, onClose } = renderSidebar(true);
+    const user = userEvent.setup();
+    const divs = container.querySelectorAll('div');
+    const overlay = Array.from(divs).find(
+      (d) => d.classList.contains('fixed') && d.classList.contains('inset-0') && d.classList.contains('lg:hidden'),
+    );
+    if (overlay) {
+      await user.click(overlay);
+      expect(onClose).toHaveBeenCalled();
+    }
+  });
+
+  it('calls onClose when close button is clicked', async () => {
+    const { container, onClose } = renderSidebar(true);
+    const user = userEvent.setup();
+    // The close button is inside the aside header
+    const aside = container.querySelector('aside');
+    const closeBtn = aside?.querySelector('button');
+    if (closeBtn) {
+      await user.click(closeBtn);
+      expect(onClose).toHaveBeenCalled();
+    }
+  });
+
+  it('highlights active Overview link when at /dashboard', () => {
+    renderSidebar();
+    const overviewLink = screen.getByText('Overview').closest('a');
+    expect(overviewLink).toHaveClass('bg-gx-accent/10');
+    expect(overviewLink).toHaveClass('text-gx-accent');
+  });
+
+  it('links point to correct paths', () => {
+    renderSidebar();
+    const agentsLink = screen.getByText('Agents').closest('a');
+    expect(agentsLink).toHaveAttribute('href', '/dashboard/agents');
+    const grantsLink = screen.getByText('Grants').closest('a');
+    expect(grantsLink).toHaveAttribute('href', '/dashboard/grants');
+    const settingsLink = screen.getByText('Settings').closest('a');
+    expect(settingsLink).toHaveAttribute('href', '/dashboard/settings');
+  });
+});

--- a/apps/portal/src/components/__tests__/Skeleton.test.tsx
+++ b/apps/portal/src/components/__tests__/Skeleton.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Skeleton, SkeletonCard, SkeletonTable, PageSkeleton } from '../ui/Skeleton';
+
+describe('Skeleton', () => {
+  it('renders with animate-pulse class', () => {
+    const { container } = render(<Skeleton />);
+    expect(container.firstChild).toHaveClass('animate-pulse');
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<Skeleton className="h-4 w-32" />);
+    expect(container.firstChild).toHaveClass('h-4');
+  });
+});
+
+describe('SkeletonCard', () => {
+  it('renders', () => {
+    const { container } = render(<SkeletonCard />);
+    expect(container.firstChild).toBeInTheDocument();
+  });
+});
+
+describe('SkeletonTable', () => {
+  it('renders default 5 rows', () => {
+    const { container } = render(<SkeletonTable />);
+    const rows = container.querySelectorAll('.border-b.border-gx-border\\/50');
+    expect(rows.length).toBe(5);
+  });
+
+  it('renders custom row count', () => {
+    const { container } = render(<SkeletonTable rows={3} />);
+    const rows = container.querySelectorAll('.border-b.border-gx-border\\/50');
+    expect(rows.length).toBe(3);
+  });
+});
+
+describe('PageSkeleton', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<PageSkeleton />);
+    expect(container.firstChild).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/components/__tests__/Spinner.test.tsx
+++ b/apps/portal/src/components/__tests__/Spinner.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Spinner } from '../ui/Spinner';
+
+describe('Spinner', () => {
+  it('renders an SVG element', () => {
+    const { container } = render(<Spinner />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('has animate-spin class for animation', () => {
+    const { container } = render(<Spinner />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('animate-spin');
+  });
+
+  it('applies default size classes', () => {
+    const { container } = render(<Spinner />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('h-5');
+    expect(svg).toHaveClass('w-5');
+  });
+
+  it('applies default color class', () => {
+    const { container } = render(<Spinner />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('text-gx-accent');
+  });
+
+  it('accepts additional className', () => {
+    const { container } = render(<Spinner className="h-8 w-8" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('animate-spin');
+    // custom classes should be applied
+    expect(svg).toHaveClass('h-8');
+    expect(svg).toHaveClass('w-8');
+  });
+
+  it('contains a circle and a path element', () => {
+    const { container } = render(<Spinner />);
+    expect(container.querySelector('circle')).toBeInTheDocument();
+    expect(container.querySelector('path')).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/components/__tests__/Table.test.tsx
+++ b/apps/portal/src/components/__tests__/Table.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Table } from '../ui/Table';
+
+interface TestRow {
+  id: string;
+  name: string;
+  email: string;
+}
+
+const sampleData: TestRow[] = [
+  { id: '1', name: 'Alice', email: 'alice@example.com' },
+  { id: '2', name: 'Bob', email: 'bob@example.com' },
+  { id: '3', name: 'Charlie', email: 'charlie@example.com' },
+];
+
+const columns = [
+  { key: 'name', header: 'Name', render: (row: TestRow) => row.name },
+  { key: 'email', header: 'Email', render: (row: TestRow) => row.email },
+];
+
+describe('Table', () => {
+  it('renders column headers', () => {
+    render(<Table columns={columns} data={sampleData} rowKey={(r) => r.id} />);
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Email')).toBeInTheDocument();
+  });
+
+  it('renders all data rows', () => {
+    render(<Table columns={columns} data={sampleData} rowKey={(r) => r.id} />);
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('Charlie')).toBeInTheDocument();
+  });
+
+  it('renders cell values using column render functions', () => {
+    render(<Table columns={columns} data={sampleData} rowKey={(r) => r.id} />);
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    expect(screen.getByText('bob@example.com')).toBeInTheDocument();
+  });
+
+  it('calls onRowClick when a row is clicked', async () => {
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Table columns={columns} data={sampleData} rowKey={(r) => r.id} onRowClick={onRowClick} />,
+    );
+    await user.click(screen.getByText('Alice'));
+    expect(onRowClick).toHaveBeenCalledWith(sampleData[0]);
+  });
+
+  it('applies cursor-pointer class when onRowClick is provided', () => {
+    const onRowClick = vi.fn();
+    render(
+      <Table columns={columns} data={sampleData} rowKey={(r) => r.id} onRowClick={onRowClick} />,
+    );
+    const row = screen.getByText('Alice').closest('tr');
+    expect(row).toHaveClass('cursor-pointer');
+  });
+
+  it('does not apply cursor-pointer class when onRowClick is absent', () => {
+    render(<Table columns={columns} data={sampleData} rowKey={(r) => r.id} />);
+    const row = screen.getByText('Alice').closest('tr');
+    expect(row).not.toHaveClass('cursor-pointer');
+  });
+
+  it('renders an empty table when data is empty', () => {
+    render(<Table columns={columns} data={[]} rowKey={(r: TestRow) => r.id} />);
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    // No data rows
+    const rows = screen.queryAllByRole('row');
+    // Only header row
+    expect(rows).toHaveLength(1);
+  });
+
+  it('uses custom render functions for complex cell content', () => {
+    const customColumns = [
+      {
+        key: 'name',
+        header: 'Name',
+        render: (row: TestRow) => <strong data-testid="strong-name">{row.name}</strong>,
+      },
+    ];
+    render(<Table columns={customColumns} data={[sampleData[0]!]} rowKey={(r) => r.id} />);
+    expect(screen.getByTestId('strong-name')).toHaveTextContent('Alice');
+  });
+
+  it('applies column className to header and cells', () => {
+    const colsWithClass = [
+      { key: 'name', header: 'Name', render: (row: TestRow) => row.name, className: 'w-1/2' },
+    ];
+    render(<Table columns={colsWithClass} data={[sampleData[0]!]} rowKey={(r) => r.id} />);
+    const th = screen.getByText('Name');
+    expect(th).toHaveClass('w-1/2');
+  });
+});

--- a/apps/portal/src/components/__tests__/Toast.test.tsx
+++ b/apps/portal/src/components/__tests__/Toast.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { ToastContainer } from '../ui/Toast';
+import { ToastProvider, useToast } from '../../store/toast';
+
+function ToastTrigger({ message, type }: { message: string; type?: 'success' | 'error' | 'info' }) {
+  const { show } = useToast();
+  return <button onClick={() => show(message, type)}>Show Toast</button>;
+}
+
+function renderWithToast(type?: 'success' | 'error' | 'info') {
+  return render(
+    <ToastProvider>
+      <ToastTrigger message="Test message" type={type} />
+      <ToastContainer />
+    </ToastProvider>,
+  );
+}
+
+describe('ToastContainer', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('renders nothing when there are no toasts', () => {
+    renderWithToast();
+    expect(screen.queryByText('Test message')).not.toBeInTheDocument();
+  });
+
+  it('renders a toast when triggered', () => {
+    renderWithToast();
+    act(() => { fireEvent.click(screen.getByText('Show Toast')); });
+    expect(screen.getByText('Test message')).toBeInTheDocument();
+  });
+
+  it('auto-dismisses toast after 4 seconds', () => {
+    renderWithToast();
+    act(() => { fireEvent.click(screen.getByText('Show Toast')); });
+    expect(screen.getByText('Test message')).toBeInTheDocument();
+    act(() => { vi.advanceTimersByTime(4100); });
+    expect(screen.queryByText('Test message')).not.toBeInTheDocument();
+  });
+
+  it('renders success toast with correct styling', () => {
+    renderWithToast('success');
+    act(() => { fireEvent.click(screen.getByText('Show Toast')); });
+    const el = screen.getByText('Test message').closest('[class*="border-gx"]');
+    expect(el?.className).toContain('border-gx-accent/50');
+  });
+
+  it('renders error toast with correct styling', () => {
+    renderWithToast('error');
+    act(() => { fireEvent.click(screen.getByText('Show Toast')); });
+    const el = screen.getByText('Test message').closest('[class*="border-gx"]');
+    expect(el?.className).toContain('border-gx-danger/50');
+  });
+
+  it('renders info toast with correct styling', () => {
+    renderWithToast('info');
+    act(() => { fireEvent.click(screen.getByText('Show Toast')); });
+    const el = screen.getByText('Test message').closest('[class*="border-gx"]');
+    expect(el?.className).toContain('border-gx-accent2/50');
+  });
+
+  it('dismisses toast when close button is clicked', () => {
+    renderWithToast();
+    act(() => { fireEvent.click(screen.getByText('Show Toast')); });
+    expect(screen.getByText('Test message')).toBeInTheDocument();
+    act(() => { fireEvent.click(screen.getByText('×')); });
+    expect(screen.queryByText('Test message')).not.toBeInTheDocument();
+  });
+
+  it('can show multiple toasts', () => {
+    function MultiTrigger() {
+      const { show } = useToast();
+      return (
+        <>
+          <button onClick={() => show('First')}>Add First</button>
+          <button onClick={() => show('Second')}>Add Second</button>
+        </>
+      );
+    }
+    render(
+      <ToastProvider>
+        <MultiTrigger />
+        <ToastContainer />
+      </ToastProvider>,
+    );
+    act(() => { fireEvent.click(screen.getByText('Add First')); });
+    act(() => { fireEvent.click(screen.getByText('Add Second')); });
+    expect(screen.getByText('First')).toBeInTheDocument();
+    expect(screen.getByText('Second')).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/components/__tests__/TopBar.test.tsx
+++ b/apps/portal/src/components/__tests__/TopBar.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TopBar } from '../layout/TopBar';
+
+const mockLogout = vi.fn();
+
+vi.mock('../../store/auth', () => ({
+  useAuth: () => ({
+    developer: {
+      name: 'Acme Corp',
+      mode: 'live' as const,
+      developerId: 'dev-123',
+      email: 'admin@acme.com',
+      plan: 'enterprise',
+      fidoRequired: false,
+      fidoRpName: null,
+      createdAt: '2026-01-01T00:00:00Z',
+    },
+    logout: mockLogout,
+  }),
+}));
+
+describe('TopBar', () => {
+  it('renders the developer name', () => {
+    render(<TopBar onMenuClick={vi.fn()} />);
+    expect(screen.getByText('Acme Corp')).toBeInTheDocument();
+  });
+
+  it('renders the mode badge', () => {
+    render(<TopBar onMenuClick={vi.fn()} />);
+    expect(screen.getByText('live')).toBeInTheDocument();
+  });
+
+  it('renders the logout button', () => {
+    render(<TopBar onMenuClick={vi.fn()} />);
+    expect(screen.getByText('Log out')).toBeInTheDocument();
+  });
+
+  it('calls logout when logout button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<TopBar onMenuClick={vi.fn()} />);
+    await user.click(screen.getByText('Log out'));
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onMenuClick when menu button is clicked', async () => {
+    const onMenuClick = vi.fn();
+    const user = userEvent.setup();
+    const { container } = render(<TopBar onMenuClick={onMenuClick} />);
+    // The menu button is the first button in the header (lg:hidden)
+    const menuBtn = container.querySelector('header button');
+    if (menuBtn) {
+      await user.click(menuBtn);
+      expect(onMenuClick).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('renders the badge with success variant for live mode', () => {
+    render(<TopBar onMenuClick={vi.fn()} />);
+    const badge = screen.getByText('live');
+    expect(badge).toHaveClass('bg-gx-accent/15');
+  });
+
+  it('renders as a header element', () => {
+    const { container } = render(<TopBar onMenuClick={vi.fn()} />);
+    expect(container.querySelector('header')).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/lib/__tests__/cn.test.ts
+++ b/apps/portal/src/lib/__tests__/cn.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { cn } from '../cn';
+
+describe('cn', () => {
+  it('merges class strings', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar');
+  });
+
+  it('handles conditional classes', () => {
+    expect(cn('base', false && 'hidden', 'visible')).toBe('base visible');
+  });
+
+  it('deduplicates tailwind classes', () => {
+    const result = cn('px-2 py-1', 'px-4');
+    expect(result).toContain('px-4');
+    expect(result).not.toContain('px-2');
+  });
+
+  it('handles undefined and null', () => {
+    expect(cn('base', undefined, null, 'end')).toBe('base end');
+  });
+
+  it('handles empty input', () => {
+    expect(cn()).toBe('');
+  });
+});

--- a/apps/portal/src/lib/__tests__/format.test.ts
+++ b/apps/portal/src/lib/__tests__/format.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { formatDate, formatDateTime, truncateId, timeAgo } from '../format';
+
+describe('formatDate', () => {
+  it('formats ISO date string', () => {
+    const result = formatDate('2024-06-15T12:00:00Z');
+    expect(result).toContain('Jun');
+    expect(result).toContain('15');
+    expect(result).toContain('2024');
+  });
+});
+
+describe('formatDateTime', () => {
+  it('includes time in output', () => {
+    const result = formatDateTime('2024-06-15T14:30:00Z');
+    expect(result).toContain('Jun');
+    expect(result).toContain('15');
+    expect(result).toContain('2024');
+  });
+});
+
+describe('truncateId', () => {
+  it('truncates long IDs', () => {
+    expect(truncateId('abcdefghijklmnop')).toBe('abcdefghijkl...');
+  });
+
+  it('does not truncate short IDs', () => {
+    expect(truncateId('short')).toBe('short');
+  });
+
+  it('uses custom length', () => {
+    expect(truncateId('abcdefghij', 5)).toBe('abcde...');
+  });
+
+  it('returns exact length strings unchanged', () => {
+    expect(truncateId('123456789012', 12)).toBe('123456789012');
+  });
+});
+
+describe('timeAgo', () => {
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('returns "just now" for recent times', () => {
+    expect(timeAgo(new Date().toISOString())).toBe('just now');
+  });
+
+  it('returns minutes ago', () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60000).toISOString();
+    expect(timeAgo(fiveMinAgo)).toBe('5m ago');
+  });
+
+  it('returns hours ago', () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 3600000).toISOString();
+    expect(timeAgo(twoHoursAgo)).toBe('2h ago');
+  });
+
+  it('returns days ago', () => {
+    const threeDaysAgo = new Date(Date.now() - 3 * 86400000).toISOString();
+    expect(timeAgo(threeDaysAgo)).toBe('3d ago');
+  });
+});

--- a/apps/portal/src/pages/__tests__/AdminPage.test.tsx
+++ b/apps/portal/src/pages/__tests__/AdminPage.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AdminPage } from '../admin/AdminPage';
+
+const mockFetchStats = vi.fn();
+const mockFetchDevelopers = vi.fn();
+const mockGetAdminKey = vi.fn();
+const mockSetAdminKey = vi.fn();
+const mockClearAdminKey = vi.fn();
+
+vi.mock('../../api/admin', () => ({
+  fetchStats: () => mockFetchStats(),
+  fetchDevelopers: (...a: unknown[]) => mockFetchDevelopers(...a),
+  getAdminKey: () => mockGetAdminKey(),
+  setAdminKey: (...a: unknown[]) => mockSetAdminKey(...a),
+  clearAdminKey: () => mockClearAdminKey(),
+}));
+
+const stats = {
+  totalDevelopers: 42, last24h: 5, last7d: 12, last30d: 30,
+  byMode: { live: 30, sandbox: 12 }, totalAgents: 100, totalGrants: 200,
+};
+
+const developers = {
+  developers: [
+    { id: 'd1', name: 'Dev One', email: 'dev1@test.com', mode: 'live', createdAt: '2026-01-01T00:00:00Z' },
+    { id: 'd2', name: 'Dev Two', email: null, mode: 'sandbox', createdAt: '2026-02-01T00:00:00Z' },
+  ],
+  total: 2, page: 1, pageSize: 50,
+};
+
+describe('AdminPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAdminKey.mockReturnValue(null);
+    mockFetchStats.mockResolvedValue(stats);
+    mockFetchDevelopers.mockResolvedValue(developers);
+  });
+
+  it('shows login form when not authenticated', () => {
+    render(<AdminPage />);
+    expect(screen.getByText('Admin Access')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('ADMIN_API_KEY')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Authenticate' })).toBeInTheDocument();
+  });
+
+  it('shows error for empty key submission', async () => {
+    const user = userEvent.setup();
+    render(<AdminPage />);
+    await user.click(screen.getByRole('button', { name: 'Authenticate' }));
+    expect(screen.getByText('Please enter an API key')).toBeInTheDocument();
+  });
+
+  it('authenticates and loads data', async () => {
+    const user = userEvent.setup();
+    render(<AdminPage />);
+    await user.type(screen.getByPlaceholderText('ADMIN_API_KEY'), 'admin_key_123');
+    await user.click(screen.getByRole('button', { name: 'Authenticate' }));
+    expect(mockSetAdminKey).toHaveBeenCalledWith('admin_key_123');
+    await waitFor(() => expect(screen.getByText('Admin Dashboard')).toBeInTheDocument());
+    expect(screen.getByText('42')).toBeInTheDocument(); // totalDevelopers
+  });
+
+  it('shows stat cards after authentication', async () => {
+    mockGetAdminKey.mockReturnValue('admin_key');
+    render(<AdminPage />);
+    await waitFor(() => expect(screen.getByText('Admin Dashboard')).toBeInTheDocument());
+    expect(screen.getByText('Total Developers')).toBeInTheDocument();
+    expect(screen.getByText('Last 24 Hours')).toBeInTheDocument();
+    expect(screen.getByText('Last 7 Days')).toBeInTheDocument();
+    expect(screen.getByText('Last 30 Days')).toBeInTheDocument();
+  });
+
+  it('shows developer table', async () => {
+    mockGetAdminKey.mockReturnValue('admin_key');
+    render(<AdminPage />);
+    await waitFor(() => expect(screen.getByText('Dev One')).toBeInTheDocument());
+    expect(screen.getByText('Dev Two')).toBeInTheDocument();
+  });
+
+  it('shows developer email or dash', async () => {
+    mockGetAdminKey.mockReturnValue('admin_key');
+    render(<AdminPage />);
+    await waitFor(() => expect(screen.getByText('dev1@test.com')).toBeInTheDocument());
+  });
+
+  it('has Sign out button', async () => {
+    mockGetAdminKey.mockReturnValue('admin_key');
+    render(<AdminPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Sign out' })).toBeInTheDocument());
+  });
+
+  it('signs out and shows login', async () => {
+    mockGetAdminKey.mockReturnValue('admin_key');
+    const user = userEvent.setup();
+    render(<AdminPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Sign out' })).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Sign out' }));
+    expect(mockClearAdminKey).toHaveBeenCalled();
+    expect(screen.getByText('Admin Access')).toBeInTheDocument();
+  });
+
+  it('handles unauthorized and returns to login', async () => {
+    mockGetAdminKey.mockReturnValue('bad_key');
+    mockFetchStats.mockRejectedValue(new Error('Unauthorized'));
+    render(<AdminPage />);
+    await waitFor(() => expect(screen.getByText('Admin Access')).toBeInTheDocument());
+    expect(screen.getByText('Invalid API key')).toBeInTheDocument();
+  });
+
+  it('shows mode badges', async () => {
+    mockGetAdminKey.mockReturnValue('admin_key');
+    render(<AdminPage />);
+    await waitFor(() => expect(screen.getByText('live')).toBeInTheDocument());
+    expect(screen.getByText('sandbox')).toBeInTheDocument();
+  });
+
+  it('shows agents and grants totals', async () => {
+    mockGetAdminKey.mockReturnValue('admin_key');
+    render(<AdminPage />);
+    await waitFor(() => expect(screen.getByText('Total Agents')).toBeInTheDocument());
+    expect(screen.getByText('100')).toBeInTheDocument();
+    expect(screen.getByText('Total Grants')).toBeInTheDocument();
+    expect(screen.getByText('200')).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/pages/__tests__/AgentDetail.test.tsx
+++ b/apps/portal/src/pages/__tests__/AgentDetail.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AgentDetail } from '../agents/AgentDetail';
+
+const mockGetAgent = vi.fn();
+const mockDeleteAgent = vi.fn();
+const mockUpdateAgent = vi.fn();
+const mockListGrants = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/agents', () => ({
+  getAgent: (...a: unknown[]) => mockGetAgent(...a),
+  deleteAgent: (...a: unknown[]) => mockDeleteAgent(...a),
+  updateAgent: (...a: unknown[]) => mockUpdateAgent(...a),
+}));
+vi.mock('../../api/grants', () => ({ listGrants: (...a: unknown[]) => mockListGrants(...a) }));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const agent = {
+  agentId: 'a1', did: 'did:web:a1', developerId: 'd1', name: 'Agent One',
+  description: 'A test agent', scopes: ['read', 'write'], status: 'active' as const,
+  createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-02T00:00:00Z',
+};
+
+const grants = [
+  { grantId: 'g1', agentId: 'a1', principalId: 'user@t.com', developerId: 'd1',
+    scopes: ['read'], status: 'active' as const, issuedAt: '2026-01-01T00:00:00Z',
+    expiresAt: '2026-12-31T00:00:00Z', delegationDepth: 0 },
+];
+
+function renderDetail() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard/agents/a1']}>
+      <Routes><Route path='/dashboard/agents/:id' element={<AgentDetail />} /></Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AgentDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAgent.mockResolvedValue(agent);
+    mockListGrants.mockResolvedValue(grants);
+  });
+
+  it('displays agent metadata', async () => {
+    renderDetail();
+    await waitFor(() => expect(screen.getByText('Agent One')).toBeInTheDocument());
+    expect(screen.getByText('a1')).toBeInTheDocument();
+    expect(screen.getByText('did:web:a1')).toBeInTheDocument();
+    expect(screen.getByText('A test agent')).toBeInTheDocument();
+  });
+
+  it('displays associated grants', async () => {
+    renderDetail();
+    await waitFor(() => expect(screen.getByText('Grants (1)')).toBeInTheDocument());
+  });
+
+  it('shows no grants message when empty', async () => {
+    mockListGrants.mockResolvedValue([]);
+    renderDetail();
+    await waitFor(() => expect(screen.getByText('No grants for this agent')).toBeInTheDocument());
+  });
+
+  it('has Suspend button for active agent', async () => {
+    renderDetail();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Suspend' })).toBeInTheDocument());
+  });
+
+  it('toggles status to suspended', async () => {
+    mockUpdateAgent.mockResolvedValueOnce({ ...agent, status: 'suspended' });
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Suspend' })).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Suspend' }));
+    await waitFor(() => expect(mockUpdateAgent).toHaveBeenCalledWith('a1', { status: 'suspended' }));
+  });
+
+  it('has Edit and Delete buttons', async () => {
+    renderDetail();
+    await waitFor(() => expect(screen.getByText('Agent One')).toBeInTheDocument());
+    expect(screen.getByRole('link', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('deletes agent on confirm', async () => {
+    mockDeleteAgent.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => expect(screen.getByText('Agent One')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => expect(screen.getByText('Delete Agent')).toBeInTheDocument());
+    await user.click(screen.getAllByRole('button', { name: 'Delete' }).pop()!);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Agent deleted', 'success'));
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard/agents');
+  });
+
+  it('redirects when agent not found', async () => {
+    mockGetAgent.mockRejectedValue(new Error('not found'));
+    renderDetail();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Agent not found', 'error'));
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard/agents');
+  });
+
+  it('displays scopes pills', async () => {
+    renderDetail();
+    await waitFor(() => expect(screen.getByText('Agent One')).toBeInTheDocument());
+    expect(screen.getAllByText('read').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('write').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/portal/src/pages/__tests__/AgentForm.test.tsx
+++ b/apps/portal/src/pages/__tests__/AgentForm.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AgentForm } from '../agents/AgentForm';
+
+const mockCreateAgent = vi.fn();
+const mockGetAgent = vi.fn();
+const mockUpdateAgent = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/agents', () => ({
+  createAgent: (...a: unknown[]) => mockCreateAgent(...a),
+  getAgent: (...a: unknown[]) => mockGetAgent(...a),
+  updateAgent: (...a: unknown[]) => mockUpdateAgent(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function renderCreate() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard/agents/new']}>
+      <Routes>
+        <Route path='/dashboard/agents/new' element={<AgentForm />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function renderEdit() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard/agents/a1/edit']}>
+      <Routes>
+        <Route path='/dashboard/agents/:id/edit' element={<AgentForm />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AgentForm', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('renders Create Agent mode', () => {
+    renderCreate();
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Create Agent');
+    expect(screen.getByRole('button', { name: 'Create Agent' })).toBeInTheDocument();
+  });
+
+  it('disables submit when name is empty', () => {
+    renderCreate();
+    expect(screen.getByRole('button', { name: 'Create Agent' })).toBeDisabled();
+  });
+
+  it('creates agent on submit', async () => {
+    mockCreateAgent.mockResolvedValueOnce({ agentId: 'new-id', name: 'Test' });
+    const user = userEvent.setup();
+    renderCreate();
+    await user.type(screen.getByLabelText('Name'), 'Test Agent');
+    await user.click(screen.getByRole('button', { name: 'Create Agent' }));
+    await waitFor(() => expect(mockCreateAgent).toHaveBeenCalledWith({
+      name: 'Test Agent', description: undefined, scopes: [],
+    }));
+    expect(mockShow).toHaveBeenCalledWith('Agent created', 'success');
+  });
+
+  it('shows error toast on create failure', async () => {
+    mockCreateAgent.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    renderCreate();
+    await user.type(screen.getByLabelText('Name'), 'Test');
+    await user.click(screen.getByRole('button', { name: 'Create Agent' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to create agent', 'error'));
+  });
+
+  it('loads agent data in edit mode', async () => {
+    mockGetAgent.mockResolvedValueOnce({
+      agentId: 'a1', name: 'Existing', description: 'Desc', scopes: ['read'],
+    });
+    renderEdit();
+    await waitFor(() => expect(screen.getByDisplayValue('Existing')).toBeInTheDocument());
+    expect(screen.getByDisplayValue('Desc')).toBeInTheDocument();
+    expect(screen.getByText('read')).toBeInTheDocument();
+    expect(screen.getByText('Edit Agent')).toBeInTheDocument();
+  });
+
+  it('updates agent in edit mode', async () => {
+    mockGetAgent.mockResolvedValueOnce({ agentId: 'a1', name: 'Old', description: '', scopes: [] });
+    mockUpdateAgent.mockResolvedValueOnce({ agentId: 'a1', name: 'New' });
+    const user = userEvent.setup();
+    renderEdit();
+    await waitFor(() => expect(screen.getByDisplayValue('Old')).toBeInTheDocument());
+    await user.clear(screen.getByLabelText('Name'));
+    await user.type(screen.getByLabelText('Name'), 'New');
+    await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+    await waitFor(() => expect(mockUpdateAgent).toHaveBeenCalled());
+    expect(mockShow).toHaveBeenCalledWith('Agent updated', 'success');
+  });
+
+  it('navigates back on agent not found in edit', async () => {
+    mockGetAgent.mockRejectedValueOnce(new Error('not found'));
+    renderEdit();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Agent not found', 'error'));
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard/agents');
+  });
+
+  it('adds scopes via Enter key', async () => {
+    const user = userEvent.setup();
+    renderCreate();
+    const scopeInput = screen.getByPlaceholderText('Type a scope and press Enter');
+    await user.type(scopeInput, 'read{Enter}');
+    expect(screen.getByText('read')).toBeInTheDocument();
+  });
+
+  it('has Cancel button', () => {
+    renderCreate();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/pages/__tests__/AgentList.test.tsx
+++ b/apps/portal/src/pages/__tests__/AgentList.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { AgentList } from '../agents/AgentList';
+
+const mockListAgents = vi.fn();
+const mockDeleteAgent = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/agents', () => ({
+  listAgents: () => mockListAgents(),
+  deleteAgent: (...a: unknown[]) => mockDeleteAgent(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const agents = [
+  { agentId: 'a1', did: 'did:web:a1', developerId: 'd1', name: 'Agent One', description: null, scopes: ['read', 'write'], status: 'active' as const, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+  { agentId: 'a2', did: 'did:web:a2', developerId: 'd1', name: 'Agent Two', description: 'Desc', scopes: ['read'], status: 'suspended' as const, createdAt: '2026-01-02T00:00:00Z', updatedAt: '2026-01-02T00:00:00Z' },
+];
+
+function r() { return render(<MemoryRouter><AgentList /></MemoryRouter>); }
+
+describe('AgentList', () => {
+  beforeEach(() => { vi.clearAllMocks(); mockListAgents.mockResolvedValue(agents); });
+
+  it('renders agent table after loading', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Agent One')).toBeInTheDocument());
+    expect(screen.getByText('Agent Two')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no agents', async () => {
+    mockListAgents.mockResolvedValue([]);
+    r();
+    await waitFor(() => expect(screen.getByText('No agents yet')).toBeInTheDocument());
+  });
+
+  it('has Create Agent link', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Agents')).toBeInTheDocument());
+    expect(screen.getAllByText('Create Agent').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockListAgents.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load agents', 'error'));
+  });
+
+  it('opens delete confirmation dialog', async () => {
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Agent One')).toBeInTheDocument());
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+    await waitFor(() => expect(screen.getByText('Delete Agent')).toBeInTheDocument());
+  });
+
+  it('deletes agent and shows success toast', async () => {
+    mockDeleteAgent.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Agent One')).toBeInTheDocument());
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+    await waitFor(() => expect(screen.getByText('Delete Agent')).toBeInTheDocument());
+    const modal = screen.getByText('Delete Agent').closest('div[class*="fixed"]')!;
+    const btns = within(modal as HTMLElement).getAllByRole('button', { name: 'Delete' });
+    await user.click(btns[btns.length - 1]!);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Agent deleted', 'success'));
+  });
+
+  it('shows error toast on delete failure', async () => {
+    mockDeleteAgent.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Agent One')).toBeInTheDocument());
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+    await waitFor(() => expect(screen.getByText('Delete Agent')).toBeInTheDocument());
+    const modal = screen.getByText('Delete Agent').closest('div[class*="fixed"]')!;
+    const btns = within(modal as HTMLElement).getAllByRole('button', { name: 'Delete' });
+    await user.click(btns[btns.length - 1]!);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to delete agent', 'error'));
+  });
+
+  it('displays status badges', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('active')).toBeInTheDocument());
+    expect(screen.getByText('suspended')).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/pages/__tests__/AlertDetail.test.tsx
+++ b/apps/portal/src/pages/__tests__/AlertDetail.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AlertDetail } from '../anomalies/AlertDetail';
+
+const mockGetAlert = vi.fn();
+const mockAcknowledgeAlert = vi.fn();
+const mockResolveAlert = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/anomalies', () => ({
+  getAlert: (...a: unknown[]) => mockGetAlert(...a),
+  acknowledgeAlert: (...a: unknown[]) => mockAcknowledgeAlert(...a),
+  resolveAlert: (...a: unknown[]) => mockResolveAlert(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+const alert = {
+  alertId: 'al1', ruleId: 'r1', ruleName: 'Velocity Check', severity: 'critical', status: 'open',
+  agentId: 'a1', description: 'High velocity detected',
+  detectedAt: '2026-01-01T00:00:00Z', acknowledgedAt: null, resolvedAt: null,
+  context: { grantId: 'g1', ip: '1.2.3.4' },
+};
+
+function r() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard/anomalies/al1']}>
+      <Routes><Route path="/dashboard/anomalies/:alertId" element={<AlertDetail />} /></Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AlertDetail', () => {
+  beforeEach(() => { vi.clearAllMocks(); mockGetAlert.mockResolvedValue(alert); });
+
+  it('displays alert metadata', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Velocity Check')).toBeInTheDocument());
+    expect(screen.getByText('critical')).toBeInTheDocument();
+    expect(screen.getByText('open')).toBeInTheDocument();
+    expect(screen.getByText('High velocity detected')).toBeInTheDocument();
+  });
+
+  it('displays timeline with Detected event', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Detected')).toBeInTheDocument());
+    expect(screen.getByText('Awaiting acknowledgement')).toBeInTheDocument();
+  });
+
+  it('displays context JSON', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Context')).toBeInTheDocument());
+  });
+
+  it('has Acknowledge button for open alert', async () => {
+    r();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Acknowledge' })).toBeInTheDocument());
+  });
+
+  it('has Resolve button for open alert', async () => {
+    r();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Resolve' })).toBeInTheDocument());
+  });
+
+  it('acknowledges alert on button click', async () => {
+    mockAcknowledgeAlert.mockResolvedValueOnce(undefined);
+    mockGetAlert.mockResolvedValue({ ...alert, status: 'acknowledged', acknowledgedAt: new Date().toISOString() });
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Acknowledge' })).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Acknowledge' }));
+    await waitFor(() => expect(mockAcknowledgeAlert).toHaveBeenCalledWith('al1', undefined));
+  });
+
+  it('shows not found when alert is null', async () => {
+    mockGetAlert.mockRejectedValue(new Error('not found'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load alert', 'error'));
+    expect(screen.getByText('Alert not found.')).toBeInTheDocument();
+  });
+
+  it('hides action buttons for resolved alert', async () => {
+    mockGetAlert.mockResolvedValue({
+      ...alert, status: 'resolved', resolvedAt: new Date().toISOString(),
+    });
+    r();
+    await waitFor(() => expect(screen.getByText('Resolved')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Acknowledge' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Resolution Note')).not.toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/pages/__tests__/AnomalyList.test.tsx
+++ b/apps/portal/src/pages/__tests__/AnomalyList.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { AnomalyList } from '../anomalies/AnomalyList';
+
+const mockListAlerts = vi.fn();
+const mockGetMetrics = vi.fn();
+const mockAcknowledgeAlert = vi.fn();
+const mockResolveAlert = vi.fn();
+const mockRevokeGrant = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/anomalies', () => ({
+  listAlerts: (...a: unknown[]) => mockListAlerts(...a),
+  getMetrics: () => mockGetMetrics(),
+  acknowledgeAlert: (...a: unknown[]) => mockAcknowledgeAlert(...a),
+  resolveAlert: (...a: unknown[]) => mockResolveAlert(...a),
+}));
+vi.mock('../../api/grants', () => ({ revokeGrant: (...a: unknown[]) => mockRevokeGrant(...a) }));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const alerts = [
+  { alertId: 'al1', ruleId: 'r1', ruleName: 'rate_spike', severity: 'critical' as const, status: 'open' as const, agentId: 'a1', detectedAt: new Date().toISOString(), description: 'High rate detected', context: { grantId: 'g1' }, acknowledgedAt: null, resolvedAt: null },
+  { alertId: 'al2', ruleId: 'r2', ruleName: 'off_hours', severity: 'low' as const, status: 'resolved' as const, agentId: null, detectedAt: new Date().toISOString(), description: 'Off hours activity', context: {}, acknowledgedAt: null, resolvedAt: new Date().toISOString() },
+];
+
+const metrics = {
+  totalAlerts: 5, openAlerts: 2,
+  bySeverity: { critical: 1, high: 0, medium: 0, low: 1 },
+  byRule: {}, recentActivity: [{ date: '2026-03-01', count: 2 }],
+};
+
+function r() { return render(<MemoryRouter><AnomalyList /></MemoryRouter>); }
+
+describe('AnomalyList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListAlerts.mockResolvedValue(alerts);
+    mockGetMetrics.mockResolvedValue(metrics);
+  });
+
+  it('renders alert cards', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('High rate detected')).toBeInTheDocument());
+    expect(screen.getByText('Off hours activity')).toBeInTheDocument();
+  });
+
+  it('displays severity badges', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('critical')).toBeInTheDocument());
+    expect(screen.getByText('low')).toBeInTheDocument();
+  });
+
+  it('displays status badges', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('open')).toBeInTheDocument());
+    expect(screen.getByText('resolved')).toBeInTheDocument();
+  });
+
+  it('renders metrics cards', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Open Alerts by Severity')).toBeInTheDocument());
+    expect(screen.getAllByText('Critical').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Total open')).toBeInTheDocument();
+  });
+
+  it('has status and severity filter dropdowns', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Anomaly Detection')).toBeInTheDocument());
+    expect(screen.getByDisplayValue('All statuses')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('All severities')).toBeInTheDocument();
+  });
+
+  it('shows Acknowledge button for open alerts', async () => {
+    r();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Acknowledge' })).toBeInTheDocument());
+  });
+
+  it('acknowledges alert on click', async () => {
+    mockAcknowledgeAlert.mockResolvedValueOnce(undefined);
+    mockListAlerts.mockResolvedValue(alerts);
+    mockGetMetrics.mockResolvedValue(metrics);
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Acknowledge' })).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Acknowledge' }));
+    await waitFor(() => expect(mockAcknowledgeAlert).toHaveBeenCalledWith('al1'));
+  });
+
+  it('shows Resolve button for non-resolved alerts', async () => {
+    r();
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'Resolve' }).length).toBeGreaterThanOrEqual(1));
+  });
+
+  it('shows empty state when no alerts', async () => {
+    mockListAlerts.mockResolvedValue([]);
+    r();
+    await waitFor(() => expect(screen.getByText('No alerts found')).toBeInTheDocument());
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockListAlerts.mockRejectedValue(new Error('fail'));
+    mockGetMetrics.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load anomaly data', 'error'));
+  });
+
+  it('has Refresh button', async () => {
+    r();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument());
+  });
+
+  it('shows alert count', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText(/2 alerts/)).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/AuditDetail.test.tsx
+++ b/apps/portal/src/pages/__tests__/AuditDetail.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AuditDetail } from '../audit/AuditDetail';
+
+const mockGetAuditEntry = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/audit', () => ({
+  getAuditEntry: (...a: unknown[]) => mockGetAuditEntry(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const entry = {
+  entryId: 'e1',
+  agentId: 'agent-1',
+  agentDid: 'did:web:a1',
+  grantId: 'grant-1',
+  principalId: 'user@test.com',
+  developerId: 'd1',
+  action: 'token.exchange',
+  metadata: { ip: '1.2.3.4' },
+  hash: 'abc123hash',
+  prevHash: 'prev-hash-value',
+  timestamp: '2026-01-01T00:00:00Z',
+  status: 'success' as const,
+};
+
+function r() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard/audit/e1']}>
+      <Routes><Route path="/dashboard/audit/:id" element={<AuditDetail />} /></Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AuditDetail', () => {
+  beforeEach(() => { vi.clearAllMocks(); mockGetAuditEntry.mockResolvedValue(entry); });
+
+  it('displays entry details after loading', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('e1')).toBeInTheDocument());
+    expect(screen.getByText('token.exchange')).toBeInTheDocument();
+    expect(screen.getByText('success')).toBeInTheDocument();
+  });
+
+  it('displays references section with links', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('agent-1')).toBeInTheDocument());
+    expect(screen.getByText('did:web:a1')).toBeInTheDocument();
+    expect(screen.getByText('grant-1')).toBeInTheDocument();
+    expect(screen.getByText('user@test.com')).toBeInTheDocument();
+  });
+
+  it('displays hash chain info', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('abc123hash')).toBeInTheDocument());
+    expect(screen.getByText('prev-hash-value')).toBeInTheDocument();
+  });
+
+  it('shows genesis entry message when no prevHash', async () => {
+    mockGetAuditEntry.mockResolvedValue({ ...entry, prevHash: null });
+    r();
+    await waitFor(() => expect(screen.getByText(/Genesis entry/)).toBeInTheDocument());
+  });
+
+  it('displays metadata JSON', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText(/1\.2\.3\.4/)).toBeInTheDocument());
+  });
+
+  it('hides metadata section when empty', async () => {
+    mockGetAuditEntry.mockResolvedValue({ ...entry, metadata: {} });
+    r();
+    await waitFor(() => expect(screen.getByText('e1')).toBeInTheDocument());
+    expect(screen.queryByText('Metadata')).not.toBeInTheDocument();
+  });
+
+  it('redirects on entry not found', async () => {
+    mockGetAuditEntry.mockRejectedValue(new Error('not found'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Audit entry not found', 'error'));
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard/audit');
+  });
+
+  it('has back link to audit log', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Audit Entry')).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/AuditLog.test.tsx
+++ b/apps/portal/src/pages/__tests__/AuditLog.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { AuditLog } from '../audit/AuditLog';
+
+const mockListAuditEntries = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/audit', () => ({ listAuditEntries: () => mockListAuditEntries() }));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const entries = [
+  { entryId: 'e1', agentId: 'agent-1', agentDid: 'did:web:a1', grantId: 'grant-1', principalId: 'user1', developerId: 'd1', action: 'token.exchange', metadata: {}, hash: 'h1', prevHash: null, timestamp: new Date().toISOString(), status: 'success' as const },
+  { entryId: 'e2', agentId: 'agent-2', agentDid: 'did:web:a2', grantId: 'grant-2', principalId: 'user2', developerId: 'd1', action: 'grant.revoke', metadata: {}, hash: 'h2', prevHash: 'h1', timestamp: new Date().toISOString(), status: 'blocked' as const },
+];
+
+function r() { return render(<MemoryRouter><AuditLog /></MemoryRouter>); }
+
+describe('AuditLog', () => {
+  beforeEach(() => { vi.clearAllMocks(); mockListAuditEntries.mockResolvedValue(entries); });
+
+  it('renders audit table', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Audit Log')).toBeInTheDocument());
+    expect(screen.getByText('token.exchange')).toBeInTheDocument();
+    expect(screen.getByText('grant.revoke')).toBeInTheDocument();
+  });
+
+  it('has search input', async () => {
+    r();
+    await waitFor(() => expect(screen.getByPlaceholderText(/Search by action/)).toBeInTheDocument());
+  });
+
+  it('filters entries by search', async () => {
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('token.exchange')).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText(/Search by action/), 'grant.revoke');
+    await waitFor(() => expect(screen.queryByText('token.exchange')).not.toBeInTheDocument());
+    expect(screen.getByText('grant.revoke')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no entries', async () => {
+    mockListAuditEntries.mockResolvedValue([]);
+    r();
+    await waitFor(() => expect(screen.getByText('No audit entries')).toBeInTheDocument());
+  });
+
+  it('shows empty state for no search matches', async () => {
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Audit Log')).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText(/Search by action/), 'nonexistent');
+    await waitFor(() => expect(screen.getByText('No audit entries')).toBeInTheDocument());
+    expect(screen.getByText(/No entries match your search/)).toBeInTheDocument();
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockListAuditEntries.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load audit entries', 'error'));
+  });
+
+  it('has date range filter buttons', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Audit Log')).toBeInTheDocument());
+    expect(screen.getByText('24h')).toBeInTheDocument();
+    expect(screen.getByText('7d')).toBeInTheDocument();
+    expect(screen.getByText('30d')).toBeInTheDocument();
+    expect(screen.getByText('All')).toBeInTheDocument();
+  });
+
+  it('displays status badges', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('success')).toBeInTheDocument());
+    expect(screen.getByText('blocked')).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/pages/__tests__/BillingPage.test.tsx
+++ b/apps/portal/src/pages/__tests__/BillingPage.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { BillingPage } from '../billing/BillingPage';
+
+const mockGetSubscription = vi.fn();
+const mockCreateCheckout = vi.fn();
+const mockGetPortalUrl = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/billing', () => ({
+  getSubscription: () => mockGetSubscription(),
+  createCheckout: (...a: unknown[]) => mockCreateCheckout(...a),
+  getPortalUrl: () => mockGetPortalUrl(),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+const subscription = {
+  plan: 'pro',
+  status: 'active',
+  currentPeriodEnd: '2026-05-01T00:00:00Z',
+};
+
+function r(entries = ['/billing']) {
+  return render(
+    <MemoryRouter initialEntries={entries}>
+      <BillingPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('BillingPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSubscription.mockResolvedValue(subscription);
+  });
+
+  it('renders billing page with current plan', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Billing')).toBeInTheDocument());
+    expect(screen.getByText('pro')).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  it('displays plan cards', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Free')).toBeInTheDocument());
+    expect(screen.getByText('Pro')).toBeInTheDocument();
+    expect(screen.getByText('Enterprise')).toBeInTheDocument();
+  });
+
+  it('shows plan prices', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('$0')).toBeInTheDocument());
+    expect(screen.getByText('$49/mo')).toBeInTheDocument();
+    expect(screen.getByText('$249/mo')).toBeInTheDocument();
+  });
+
+  it('shows Current badge on active plan', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Current')).toBeInTheDocument());
+  });
+
+  it('shows Manage Subscription button for paid plans', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Manage Subscription')).toBeInTheDocument());
+  });
+
+  it('hides Manage Subscription for free plan', async () => {
+    mockGetSubscription.mockResolvedValue({ plan: 'free', status: 'active', currentPeriodEnd: null });
+    r();
+    await waitFor(() => expect(screen.getByText('Billing')).toBeInTheDocument());
+    expect(screen.queryByText('Manage Subscription')).not.toBeInTheDocument();
+  });
+
+  it('shows Upgrade button for non-current plans', async () => {
+    mockGetSubscription.mockResolvedValue({ plan: 'free', status: 'active', currentPeriodEnd: null });
+    r();
+    await waitFor(() => expect(screen.getAllByText('Upgrade').length).toBeGreaterThanOrEqual(1));
+  });
+
+  it('calls createCheckout on Upgrade click', async () => {
+    mockGetSubscription.mockResolvedValue({ plan: 'free', status: 'active', currentPeriodEnd: null });
+    mockCreateCheckout.mockResolvedValueOnce({ checkoutUrl: 'https://checkout.example.com' });
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getAllByText('Upgrade').length).toBeGreaterThanOrEqual(1));
+    await user.click(screen.getAllByText('Upgrade')[0]!);
+    await waitFor(() => expect(mockCreateCheckout).toHaveBeenCalled());
+  });
+
+  it('shows error toast on checkout failure', async () => {
+    mockGetSubscription.mockResolvedValue({ plan: 'free', status: 'active', currentPeriodEnd: null });
+    mockCreateCheckout.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getAllByText('Upgrade').length).toBeGreaterThanOrEqual(1));
+    await user.click(screen.getAllByText('Upgrade')[0]!);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to start checkout', 'error'));
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockGetSubscription.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load subscription', 'error'));
+  });
+
+  it('displays plan features', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('500 agents')).toBeInTheDocument());
+    expect(screen.getByText('Unlimited agents')).toBeInTheDocument();
+  });
+
+  it('shows success toast on checkout return', async () => {
+    r(['/billing?success=true']);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Subscription activated!', 'success'));
+  });
+});

--- a/apps/portal/src/pages/__tests__/BudgetDetail.test.tsx
+++ b/apps/portal/src/pages/__tests__/BudgetDetail.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { BudgetDetail } from '../budgets/BudgetDetail';
+
+const mockGetBudget = vi.fn();
+const mockListTransactions = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/budgets', () => ({
+  getBudget: (...a: unknown[]) => mockGetBudget(...a),
+  listTransactions: (...a: unknown[]) => mockListTransactions(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+const allocation = {
+  id: 'b1', grantId: 'g1', developerId: 'd1',
+  initialBudget: '100.00', remainingBudget: '60.00', currency: 'USD',
+  createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z',
+};
+
+const transactions = [
+  { id: 'tx1', grantId: 'g1', amount: '20.00', description: 'API call', createdAt: '2026-01-02T00:00:00Z' },
+  { id: 'tx2', grantId: 'g1', amount: '20.00', description: 'Compute', createdAt: '2026-01-03T00:00:00Z' },
+];
+
+function r() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard/budgets/g1']}>
+      <Routes><Route path="/dashboard/budgets/:grantId" element={<BudgetDetail />} /></Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('BudgetDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetBudget.mockResolvedValue(allocation);
+    mockListTransactions.mockResolvedValue({ transactions, total: 2 });
+  });
+
+  it('displays spending bar', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Spending')).toBeInTheDocument());
+    expect(screen.getByText('40%')).toBeInTheDocument();
+  });
+
+  it('displays remaining amount', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText(/60\.00/)).toBeInTheDocument());
+  });
+
+  it('renders transaction history', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Transactions')).toBeInTheDocument());
+    expect(screen.getByText('API call')).toBeInTheDocument();
+    expect(screen.getByText('Compute')).toBeInTheDocument();
+  });
+
+  it('shows no transactions message when empty', async () => {
+    mockListTransactions.mockResolvedValue({ transactions: [], total: 0 });
+    r();
+    await waitFor(() => expect(screen.getByText('No transactions yet.')).toBeInTheDocument());
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockGetBudget.mockRejectedValue(new Error('fail'));
+    mockListTransactions.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load budget details', 'error'));
+  });
+
+  it('shows allocation not found when budget is null', async () => {
+    mockGetBudget.mockResolvedValue(null);
+    mockListTransactions.mockResolvedValue({ transactions: [], total: 0 });
+    r();
+    await waitFor(() => expect(screen.getByText('Budget allocation not found.')).toBeInTheDocument());
+  });
+
+  it('has back link to budgets', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText(/Budget/)).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/BudgetList.test.tsx
+++ b/apps/portal/src/pages/__tests__/BudgetList.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { BudgetList } from '../budgets/BudgetList';
+
+const mockListBudgets = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/budgets', () => ({ listBudgets: () => mockListBudgets() }));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const allocations = [
+  { id: 'b1', grantId: 'g1', developerId: 'd1', initialBudget: '100.00', remainingBudget: '75.00', currency: 'USD', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+  { id: 'b2', grantId: 'g2', developerId: 'd1', initialBudget: '50.00', remainingBudget: '0.00', currency: 'USD', createdAt: '2026-01-02T00:00:00Z', updatedAt: '2026-01-02T00:00:00Z' },
+];
+
+function r() { return render(<MemoryRouter><BudgetList /></MemoryRouter>); }
+
+describe('BudgetList', () => {
+  beforeEach(() => { vi.clearAllMocks(); mockListBudgets.mockResolvedValue(allocations); });
+
+  it('renders budget table with allocations', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Budgets')).toBeInTheDocument());
+  });
+
+  it('shows summary cards', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Total Allocated')).toBeInTheDocument());
+    expect(screen.getByText('Total Spent')).toBeInTheDocument();
+    expect(screen.getByText('Total Remaining')).toBeInTheDocument();
+  });
+
+  it('calculates total allocated correctly', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText(String.fromCharCode(36) + '150.00')).toBeInTheDocument());
+  });
+
+  it('shows empty state when no allocations', async () => {
+    mockListBudgets.mockResolvedValue([]);
+    r();
+    await waitFor(() => expect(screen.getByText('No budget allocations')).toBeInTheDocument());
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockListBudgets.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load budgets', 'error'));
+  });
+
+  it('displays usage status badges', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Healthy')).toBeInTheDocument());
+    expect(screen.getByText('Exhausted')).toBeInTheDocument();
+  });
+
+  it('displays usage percentage', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('25%')).toBeInTheDocument()); // b1: 25% used
+    expect(screen.getByText('100%')).toBeInTheDocument(); // b2: 100% used
+  });
+});

--- a/apps/portal/src/pages/__tests__/BundleDetail.test.tsx
+++ b/apps/portal/src/pages/__tests__/BundleDetail.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { BundleDetail } from '../bundles/BundleDetail';
+
+const mockGetBundle = vi.fn();
+const mockRevokeBundle = vi.fn();
+const mockGetBundleAuditEntries = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/bundles', () => ({
+  getBundle: (...a: unknown[]) => mockGetBundle(...a),
+  revokeBundle: (...a: unknown[]) => mockRevokeBundle(...a),
+  getBundleAuditEntries: (...a: unknown[]) => mockGetBundleAuditEntries(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const bundle = {
+  id: 'bnd-1', agentId: 'agent-1', userId: 'user-1', grantId: 'g-1',
+  scopes: ['read', 'write'], status: 'active', devicePlatform: 'iOS',
+  deviceId: 'dev-001', offlineTTL: '24h',
+  offlineExpiresAt: '2026-05-01T00:00:00Z', lastSyncAt: null,
+  auditEntryCount: 2, createdAt: '2026-01-01T00:00:00Z', revokedAt: null,
+};
+
+const entries = [
+  { id: 'ae-1', seq: 1, timestamp: '2026-04-01T00:00:00Z', action: 'token.verify', scopes: ['read'], result: 'allow', metadata: { ip: '1.2.3.4' } },
+  { id: 'ae-2', seq: 2, timestamp: '2026-04-01T01:00:00Z', action: 'data.access', scopes: ['write'], result: 'deny', metadata: {} },
+];
+
+function r() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard/bundles/bnd-1']}>
+      <Routes><Route path="/dashboard/bundles/:bundleId" element={<BundleDetail />} /></Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('BundleDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetBundle.mockResolvedValue(bundle);
+    mockGetBundleAuditEntries.mockResolvedValue(entries);
+  });
+
+  it('renders bundle details', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Details')).toBeInTheDocument());
+    expect(screen.getByText('agent-1')).toBeInTheDocument();
+    expect(screen.getByText('user-1')).toBeInTheDocument();
+    expect(screen.getByText('g-1')).toBeInTheDocument();
+  });
+
+  it('shows bundle status badge', async () => {
+    r();
+    await waitFor(() => expect(screen.getAllByText('active').length).toBeGreaterThanOrEqual(1));
+  });
+
+  it('shows metadata section with scopes and platform', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Metadata')).toBeInTheDocument());
+    expect(screen.getByText('iOS')).toBeInTheDocument();
+    expect(screen.getByText('24h')).toBeInTheDocument();
+  });
+
+  it('displays offline audit log', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Offline Audit Log (2)')).toBeInTheDocument());
+    expect(screen.getByText('token.verify')).toBeInTheDocument();
+    expect(screen.getByText('data.access')).toBeInTheDocument();
+  });
+
+  it('shows audit result badges', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('allow')).toBeInTheDocument());
+    expect(screen.getByText('deny')).toBeInTheDocument();
+  });
+
+  it('shows Scope Usage chart', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Scope Usage')).toBeInTheDocument());
+  });
+
+  it('shows empty audit state when no entries', async () => {
+    mockGetBundleAuditEntries.mockResolvedValue([]);
+    r();
+    await waitFor(() => expect(screen.getByText('No offline audit entries recorded yet.')).toBeInTheDocument());
+  });
+
+  it('shows Revoke Bundle button for active bundles', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Revoke Bundle')).toBeInTheDocument());
+  });
+
+  it('hides Revoke button for revoked bundles', async () => {
+    mockGetBundle.mockResolvedValue({ ...bundle, status: 'revoked' });
+    r();
+    await waitFor(() => expect(screen.getByText('Details')).toBeInTheDocument());
+    expect(screen.queryByText('Revoke Bundle')).not.toBeInTheDocument();
+  });
+
+  it('revokes bundle on confirm', async () => {
+    mockRevokeBundle.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Revoke Bundle')).toBeInTheDocument());
+    await user.click(screen.getByText('Revoke Bundle'));
+    await waitFor(() => {
+      const dialog = screen.getByText('Are you sure you want to revoke this bundle?').closest('div[class*="fixed"]')!;
+      expect(dialog).toBeInTheDocument();
+    });
+    const dialog = screen.getByText('Are you sure you want to revoke this bundle?').closest('div[class*="fixed"]')!;
+    const btns = within(dialog as HTMLElement).getAllByRole('button', { name: 'Revoke' });
+    await user.click(btns[btns.length - 1]!);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Bundle revoked', 'success'));
+  });
+
+  it('shows error toast on load failure and navigates back', async () => {
+    mockGetBundle.mockRejectedValue(new Error('not found'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Bundle not found', 'error'));
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard/bundles');
+  });
+
+  it('has Refresh Bundle button', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Refresh Bundle')).toBeInTheDocument());
+  });
+
+  it('has Download JWKS button', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Download JWKS')).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/BundleForm.test.tsx
+++ b/apps/portal/src/pages/__tests__/BundleForm.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { BundleForm } from '../bundles/BundleForm';
+
+const mockCreateBundle = vi.fn();
+const mockListAgents = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/bundles', () => ({
+  createBundle: (...a: unknown[]) => mockCreateBundle(...a),
+}));
+vi.mock('../../api/agents', () => ({
+  listAgents: () => mockListAgents(),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const agents = [
+  { agentId: 'agent-1', name: 'Test Agent', createdAt: '2026-01-01T00:00:00Z' },
+];
+
+function r() { return render(<MemoryRouter><BundleForm /></MemoryRouter>); }
+
+describe('BundleForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListAgents.mockResolvedValue(agents);
+  });
+
+  it('renders step 1 heading', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('New Offline Consent Bundle')).toBeInTheDocument());
+    expect(screen.getByText('Agent & User')).toBeInTheDocument();
+  });
+
+  it('shows step indicators', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Scopes & TTL')).toBeInTheDocument());
+    expect(screen.getByText('Review & Issue')).toBeInTheDocument();
+  });
+
+  it('disables Next when userId is empty', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('New Offline Consent Bundle')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+  });
+
+  it('advances to step 2 when step 1 is filled', async () => {
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('New Offline Consent Bundle')).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText('e.g., user@example.com or user-id'), 'user-123');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByText('Scopes')).toBeInTheDocument());
+  });
+
+  it('shows platform selection buttons', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Android')).toBeInTheDocument());
+    expect(screen.getByText('iOS')).toBeInTheDocument();
+    expect(screen.getByText('Raspberry Pi')).toBeInTheDocument();
+  });
+
+  it('shows error toast on agent load failure', async () => {
+    mockListAgents.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load agents', 'error'));
+  });
+
+  it('shows success result after bundle creation', async () => {
+    mockCreateBundle.mockResolvedValueOnce({
+      bundle: { id: 'bnd-new' },
+      grantToken: 'jwt-token-xyz',
+      jwks: { keys: [] },
+      auditKey: 'audit-key-secret',
+    });
+    const user = userEvent.setup();
+    r();
+    // Step 1
+    await waitFor(() => expect(screen.getByText('New Offline Consent Bundle')).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText('e.g., user@example.com or user-id'), 'user-123');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    // Step 2 - add scope
+    await waitFor(() => expect(screen.getByText('Scopes')).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText('Type a scope and press Enter'), 'read{enter}');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    // Step 3 - review and submit
+    await waitFor(() => expect(screen.getByText('Review Bundle')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Issue Bundle' }));
+    await waitFor(() => expect(screen.getByText('Bundle Issued')).toBeInTheDocument());
+    expect(screen.getByText('audit-key-secret')).toBeInTheDocument();
+    expect(mockShow).toHaveBeenCalledWith('Bundle issued successfully', 'success');
+  });
+
+  it('shows error toast on bundle creation failure', async () => {
+    mockCreateBundle.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    r();
+    // Step 1
+    await waitFor(() => expect(screen.getByText('New Offline Consent Bundle')).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText('e.g., user@example.com or user-id'), 'user-123');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    // Step 2
+    await waitFor(() => expect(screen.getByText('Scopes')).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText('Type a scope and press Enter'), 'read{enter}');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    // Step 3
+    await waitFor(() => expect(screen.getByText('Review Bundle')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Issue Bundle' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to issue bundle', 'error'));
+  });
+});

--- a/apps/portal/src/pages/__tests__/BundleList.test.tsx
+++ b/apps/portal/src/pages/__tests__/BundleList.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { BundleList } from '../bundles/BundleList';
+
+const mockListBundles = vi.fn();
+const mockRevokeBundle = vi.fn();
+const mockListAgents = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/bundles', () => ({
+  listBundles: (...a: unknown[]) => mockListBundles(...a),
+  revokeBundle: (...a: unknown[]) => mockRevokeBundle(...a),
+}));
+vi.mock('../../api/agents', () => ({
+  listAgents: () => mockListAgents(),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const bundles = [
+  {
+    id: 'bnd-1', agentId: 'agent-1', userId: 'user-1', grantId: 'g-1',
+    scopes: ['read'], status: 'active', devicePlatform: 'Android', deviceId: null,
+    offlineTTL: '24h', offlineExpiresAt: '2026-05-01T00:00:00Z',
+    lastSyncAt: '2026-04-01T00:00:00Z', auditEntryCount: 5, createdAt: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'bnd-2', agentId: 'agent-2', userId: 'user-2', grantId: 'g-2',
+    scopes: ['write'], status: 'revoked', devicePlatform: null, deviceId: null,
+    offlineTTL: '48h', offlineExpiresAt: '2026-05-02T00:00:00Z',
+    lastSyncAt: null, auditEntryCount: 0, createdAt: '2026-01-02T00:00:00Z',
+  },
+];
+
+function r() { return render(<MemoryRouter><BundleList /></MemoryRouter>); }
+
+describe('BundleList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListBundles.mockResolvedValue(bundles);
+    mockListAgents.mockResolvedValue([]);
+  });
+
+  it('renders heading', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Offline Consent Bundles')).toBeInTheDocument());
+  });
+
+  it('shows bundle rows', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('active')).toBeInTheDocument());
+    expect(screen.getByText('revoked')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no bundles', async () => {
+    mockListBundles.mockResolvedValue([]);
+    r();
+    await waitFor(() => expect(screen.getByText('No bundles found')).toBeInTheDocument());
+  });
+
+  it('has New Bundle button', async () => {
+    r();
+    await waitFor(() => expect(screen.getAllByText('+ New Bundle').length).toBeGreaterThanOrEqual(1));
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockListBundles.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load bundles', 'error'));
+  });
+
+  it('shows Revoke button only for active bundles', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('active')).toBeInTheDocument());
+    const revokeButtons = screen.getAllByText('Revoke');
+    expect(revokeButtons.length).toBe(1);
+  });
+
+  it('opens revoke confirmation dialog', async () => {
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('active')).toBeInTheDocument());
+    await user.click(screen.getByText('Revoke'));
+    await waitFor(() => expect(screen.getByText('Revoke Bundle')).toBeInTheDocument());
+  });
+
+  it('revokes bundle on confirm', async () => {
+    mockRevokeBundle.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('active')).toBeInTheDocument());
+    await user.click(screen.getByText('Revoke'));
+    await waitFor(() => expect(screen.getByText('Revoke Bundle')).toBeInTheDocument());
+    const dialog = screen.getByText('Revoke Bundle').closest('div[class*="fixed"]')!;
+    const btns = within(dialog as HTMLElement).getAllByRole('button', { name: 'Revoke' });
+    await user.click(btns[btns.length - 1]!);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Bundle revoked', 'success'));
+  });
+
+  it('displays platform badge for bundles with platform', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Android')).toBeInTheDocument());
+  });
+
+  it('shows last sync info', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Never')).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/ComplianceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/ComplianceDashboard.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { ComplianceDashboard } from '../compliance/ComplianceDashboard';
+
+const mockGetSummary = vi.fn();
+const mockExportGrants = vi.fn();
+const mockExportAudit = vi.fn();
+const mockExportEvidence = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/compliance', () => ({
+  getComplianceSummary: () => mockGetSummary(),
+  exportGrants: () => mockExportGrants(),
+  exportAudit: () => mockExportAudit(),
+  exportEvidencePack: (...a: unknown[]) => mockExportEvidence(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+// Mock URL.createObjectURL
+globalThis.URL.createObjectURL = vi.fn(() => 'blob:mock');
+globalThis.URL.revokeObjectURL = vi.fn();
+
+const summary = {
+  generatedAt: '2026-01-01T00:00:00Z', plan: 'pro',
+  agents: { total: 5, active: 4, suspended: 1, revoked: 0 },
+  grants: { total: 10, active: 7, revoked: 2, expired: 1 },
+  auditEntries: { total: 100, success: 90, failure: 5, blocked: 5 },
+  policies: { total: 3 },
+};
+
+function r() { return render(<MemoryRouter><ComplianceDashboard /></MemoryRouter>); }
+
+describe('ComplianceDashboard', () => {
+  beforeEach(() => { vi.clearAllMocks(); mockGetSummary.mockResolvedValue(summary); });
+
+  it('renders compliance scores', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('DPDP 2023')).toBeInTheDocument());
+    expect(screen.getByText('EU AI Act')).toBeInTheDocument();
+    expect(screen.getByText('OWASP Agentic Top 10')).toBeInTheDocument();
+  });
+
+  it('displays plan badge', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('pro plan')).toBeInTheDocument());
+  });
+
+  it('shows summary stats', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('5')).toBeInTheDocument()); // agents.total
+    expect(screen.getByText('10')).toBeInTheDocument(); // grants.total
+    expect(screen.getByText('100')).toBeInTheDocument(); // audit total
+    expect(screen.getByText('3')).toBeInTheDocument(); // policies total
+  });
+
+  it('shows no action items when compliant', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('No open action items')).toBeInTheDocument());
+  });
+
+  it('shows action items when policies missing', async () => {
+    mockGetSummary.mockResolvedValue({ ...summary, policies: { total: 0 } });
+    r();
+    await waitFor(() => expect(screen.getByText(/Create authorization policies/)).toBeInTheDocument());
+  });
+
+  it('has export buttons', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Grants Export')).toBeInTheDocument());
+    expect(screen.getByText('Audit Log Export')).toBeInTheDocument();
+    expect(screen.getByText('SOC 2 Evidence Pack')).toBeInTheDocument();
+    expect(screen.getByText('GDPR Evidence Pack')).toBeInTheDocument();
+  });
+
+  it('downloads grants export', async () => {
+    mockExportGrants.mockResolvedValueOnce({ generatedAt: '2026-01-01', total: 1, grants: [] });
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Grants Export')).toBeInTheDocument());
+    const downloadBtns = screen.getAllByRole('button', { name: 'Download' });
+    await user.click(downloadBtns[0]!);
+    await waitFor(() => expect(mockExportGrants).toHaveBeenCalled());
+    expect(mockShow).toHaveBeenCalledWith('Export downloaded', 'success');
+  });
+
+  it('shows error toast on export failure', async () => {
+    mockExportGrants.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Grants Export')).toBeInTheDocument());
+    const downloadBtns = screen.getAllByRole('button', { name: 'Download' });
+    await user.click(downloadBtns[0]!);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Export failed', 'error'));
+  });
+
+  it('shows error toast on summary load failure', async () => {
+    mockGetSummary.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load compliance data', 'error'));
+  });
+
+  it('has DPDP section links', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('DPDP Consent Records')).toBeInTheDocument());
+    expect(screen.getByText('Grievances')).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/pages/__tests__/ConsentRecordDetail.test.tsx
+++ b/apps/portal/src/pages/__tests__/ConsentRecordDetail.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ConsentRecordDetail } from '../dpdp/ConsentRecordDetail';
+
+const mockWithdrawConsent = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/dpdp', () => ({
+  withdrawConsent: (...a: unknown[]) => mockWithdrawConsent(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+function r() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard/dpdp/records/crec-1']}>
+      <Routes><Route path="/dashboard/dpdp/records/:recordId" element={<ConsentRecordDetail />} /></Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ConsentRecordDetail', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('renders the page with back link', async () => {
+    r();
+    // Since ConsentRecordDetail doesn't have a direct API fetch and shows a fallback message
+    // when record is null (navigated directly without state), we test that fallback
+    await waitFor(() => expect(screen.getByText('Go to Consent Records')).toBeInTheDocument());
+  });
+
+  it('shows fallback message when record is not available', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText(/Record details are available when navigating from the consent records list/)).toBeInTheDocument());
+  });
+
+  it('shows guidance to search by principal ID', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText(/Search by Data Principal ID/)).toBeInTheDocument());
+  });
+
+  it('has back navigation link', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Consent Records')).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/ConsentRecordList.test.tsx
+++ b/apps/portal/src/pages/__tests__/ConsentRecordList.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { ConsentRecordList } from '../dpdp/ConsentRecordList';
+
+const mockGetDataPrincipalRecords = vi.fn();
+const mockWithdrawConsent = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/dpdp', () => ({
+  getDataPrincipalRecords: (...a: unknown[]) => mockGetDataPrincipalRecords(...a),
+  withdrawConsent: (...a: unknown[]) => mockWithdrawConsent(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const records = [
+  {
+    recordId: 'crec-1', dataPrincipalId: 'user-1', grantId: 'g-1',
+    dataFiduciaryName: 'Acme', status: 'active',
+    purposes: [{ code: 'analytics' }], scopes: ['read'],
+    consentGivenAt: '2026-01-01T00:00:00Z', processingExpiresAt: '2027-01-01T00:00:00Z',
+    retentionUntil: '2028-01-01T00:00:00Z', accessCount: 15,
+    lastAccessedAt: null, withdrawnAt: null, withdrawnReason: null,
+    consentProof: {},
+  },
+  {
+    recordId: 'crec-2', dataPrincipalId: 'user-1', grantId: 'g-2',
+    dataFiduciaryName: 'Beta', status: 'withdrawn',
+    purposes: [{ code: 'marketing' }], scopes: ['write'],
+    consentGivenAt: '2026-02-01T00:00:00Z', processingExpiresAt: '2027-02-01T00:00:00Z',
+    retentionUntil: '2028-02-01T00:00:00Z', accessCount: 3,
+    lastAccessedAt: null, withdrawnAt: '2026-03-01T00:00:00Z', withdrawnReason: 'User request',
+    consentProof: {},
+  },
+];
+
+function r() { return render(<MemoryRouter><ConsentRecordList /></MemoryRouter>); }
+
+describe('ConsentRecordList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDataPrincipalRecords.mockResolvedValue({ records });
+  });
+
+  it('renders heading', () => {
+    r();
+    expect(screen.getByText('Consent Records')).toBeInTheDocument();
+  });
+
+  it('shows search prompt before search', () => {
+    r();
+    expect(screen.getByText('Search for consent records')).toBeInTheDocument();
+  });
+
+  it('shows results after search', async () => {
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('e.g. user_123'), 'user-1');
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(screen.getByText('active')).toBeInTheDocument());
+    expect(screen.getByText('withdrawn')).toBeInTheDocument();
+  });
+
+  it('shows record count after search', async () => {
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('e.g. user_123'), 'user-1');
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(screen.getByText(/2 records/)).toBeInTheDocument());
+  });
+
+  it('shows purposes in table', async () => {
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('e.g. user_123'), 'user-1');
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(screen.getByText('analytics')).toBeInTheDocument());
+    expect(screen.getByText('marketing')).toBeInTheDocument();
+  });
+
+  it('shows Withdraw button only for active records', async () => {
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('e.g. user_123'), 'user-1');
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(screen.getByText('active')).toBeInTheDocument());
+    const withdrawButtons = screen.getAllByText('Withdraw');
+    expect(withdrawButtons.length).toBe(1);
+  });
+
+  it('shows empty state when no records found', async () => {
+    mockGetDataPrincipalRecords.mockResolvedValue({ records: [] });
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('e.g. user_123'), 'user-1');
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(screen.getByText('No consent records')).toBeInTheDocument());
+  });
+
+  it('shows error toast on search failure', async () => {
+    mockGetDataPrincipalRecords.mockRejectedValue(new Error('fail'));
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('e.g. user_123'), 'user-1');
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load consent records', 'error'));
+  });
+
+  it('opens withdraw confirmation dialog', async () => {
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('e.g. user_123'), 'user-1');
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(screen.getByText('Withdraw')).toBeInTheDocument());
+    await user.click(screen.getByText('Withdraw'));
+    await waitFor(() => expect(screen.getByText('Withdraw Consent')).toBeInTheDocument());
+  });
+
+  it('disables Search button when input is empty', () => {
+    r();
+    expect(screen.getByRole('button', { name: 'Search' })).toBeDisabled();
+  });
+});

--- a/apps/portal/src/pages/__tests__/CredentialList.test.tsx
+++ b/apps/portal/src/pages/__tests__/CredentialList.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CredentialList } from '../credentials/CredentialList';
+
+describe('CredentialList', () => {
+  it('renders page title', () => {
+    render(<CredentialList />);
+    expect(screen.getByText('Credentials')).toBeInTheDocument();
+  });
+
+  it('shows empty state', () => {
+    render(<CredentialList />);
+    expect(screen.getByText('No credentials')).toBeInTheDocument();
+    expect(screen.getByText(/Create API credentials/)).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/pages/__tests__/Dashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/Dashboard.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Dashboard } from '../Dashboard';
+
+const mockListAgents = vi.fn();
+const mockListGrants = vi.fn();
+const mockListAuditEntries = vi.fn();
+const mockListAnomalies = vi.fn();
+
+vi.mock('../../api/agents', () => ({ listAgents: () => mockListAgents() }));
+vi.mock('../../api/grants', () => ({ listGrants: (...a: unknown[]) => mockListGrants(...a) }));
+vi.mock('../../api/audit', () => ({ listAuditEntries: () => mockListAuditEntries() }));
+vi.mock('../../api/anomalies', () => ({ listAnomalies: () => mockListAnomalies() }));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: vi.fn() }) }));
+
+function renderDashboard() {
+  return render(<MemoryRouter><Dashboard /></MemoryRouter>);
+}
+
+const entry = {
+  entryId: 'e1', agentId: 'agent-001', agentDid: 'did:web:t', grantId: 'grant-001',
+  principalId: 'user@test.com', developerId: 'dev1', action: 'token.exchange',
+  metadata: {}, hash: 'abc', prevHash: null, timestamp: new Date().toISOString(), status: 'success' as const,
+};
+
+describe('Dashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListAgents.mockResolvedValue([{ agentId: 'a1' }, { agentId: 'a2' }]);
+    mockListGrants.mockResolvedValue([{ grantId: 'g1' }]);
+    mockListAuditEntries.mockResolvedValue([entry]);
+    mockListAnomalies.mockResolvedValue([{ id: 'an1' }]);
+  });
+
+  it('renders stat cards after loading', async () => {
+    renderDashboard();
+    await waitFor(() => expect(screen.getByText('Overview')).toBeInTheDocument());
+    expect(screen.getByText('Agents')).toBeInTheDocument();
+    expect(screen.getByText('Active Grants')).toBeInTheDocument();
+    expect(screen.getByText('Audit Entries')).toBeInTheDocument();
+    expect(screen.getByText('Anomalies')).toBeInTheDocument();
+  });
+
+  it('shows correct agent count', async () => {
+    renderDashboard();
+    await waitFor(() => expect(screen.getByText('2')).toBeInTheDocument());
+  });
+
+  it('renders recent activity table', async () => {
+    renderDashboard();
+    await waitFor(() => expect(screen.getByText('Recent Activity')).toBeInTheDocument());
+    expect(screen.getByText('token.exchange')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no audit entries', async () => {
+    mockListAuditEntries.mockResolvedValue([]);
+    renderDashboard();
+    await waitFor(() => expect(screen.getByText('No recent activity')).toBeInTheDocument());
+  });
+
+  it('stat cards link to their pages', async () => {
+    renderDashboard();
+    await waitFor(() => expect(screen.getByText('Agents')).toBeInTheDocument());
+    expect(screen.getByText('Agents').closest('a')).toHaveAttribute('href', '/dashboard/agents');
+  });
+
+  it('handles all API failures gracefully', async () => {
+    mockListAgents.mockRejectedValue(new Error('fail'));
+    mockListGrants.mockRejectedValue(new Error('fail'));
+    mockListAuditEntries.mockRejectedValue(new Error('fail'));
+    mockListAnomalies.mockRejectedValue(new Error('fail'));
+    renderDashboard();
+    await waitFor(() => expect(screen.getByText('Overview')).toBeInTheDocument());
+    expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/apps/portal/src/pages/__tests__/DomainList.test.tsx
+++ b/apps/portal/src/pages/__tests__/DomainList.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { DomainList } from '../domains/DomainList';
+
+const mockApiGet = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/client', () => ({
+  api: { get: (...a: unknown[]) => mockApiGet(...a) },
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+const domains = [
+  { id: 'd1', domain: 'example.com', verified: true, verificationToken: 'tok1', createdAt: '2026-01-01T00:00:00Z' },
+  { id: 'd2', domain: 'pending.com', verified: false, verificationToken: 'tok2', createdAt: '2026-01-02T00:00:00Z' },
+];
+
+function r() { return render(<DomainList />); }
+
+describe('DomainList', () => {
+  beforeEach(() => { vi.clearAllMocks(); mockApiGet.mockResolvedValue({ domains }); });
+
+  it('renders domain table', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('example.com')).toBeInTheDocument());
+    expect(screen.getByText('pending.com')).toBeInTheDocument();
+  });
+
+  it('shows Verified badge for verified domains', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Verified')).toBeInTheDocument());
+  });
+
+  it('shows Pending badge for unverified domains', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Pending')).toBeInTheDocument());
+  });
+
+  it('shows empty state when no domains', async () => {
+    mockApiGet.mockResolvedValue({ domains: [] });
+    r();
+    await waitFor(() => expect(screen.getByText('No custom domains')).toBeInTheDocument());
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockApiGet.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load domains', 'error'));
+  });
+
+  it('displays page title', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Custom Domains')).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/EventList.test.tsx
+++ b/apps/portal/src/pages/__tests__/EventList.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EventList } from '../events/EventList';
+
+const mockListRecentEvents = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/events', () => ({
+  listRecentEvents: () => mockListRecentEvents(),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+const events = [
+  { id: 'ev1', type: 'grant.created', developerId: 'd1', payload: { grantId: 'g1' }, createdAt: new Date().toISOString() },
+  { id: 'ev2', type: 'token.issued', developerId: 'd1', payload: { tokenId: 't1' }, createdAt: new Date().toISOString() },
+  { id: 'ev3', type: 'grant.revoked', developerId: 'd1', payload: { grantId: 'g2' }, createdAt: new Date().toISOString() },
+];
+
+function r() { return render(<EventList />); }
+
+describe('EventList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockListRecentEvents.mockResolvedValue(events);
+  });
+
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('renders events table', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('grant.created')).toBeInTheDocument());
+    expect(screen.getByText('token.issued')).toBeInTheDocument();
+    expect(screen.getByText('grant.revoked')).toBeInTheDocument();
+  });
+
+  it('shows Live indicator when not paused', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Live')).toBeInTheDocument());
+  });
+
+  it('toggles pause/resume', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    r();
+    await waitFor(() => expect(screen.getByText('Pause')).toBeInTheDocument());
+    await user.click(screen.getByText('Pause'));
+    expect(screen.getByText('Resume')).toBeInTheDocument();
+    expect(screen.queryByText('Live')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when no events', async () => {
+    mockListRecentEvents.mockResolvedValue([]);
+    r();
+    await waitFor(() => expect(screen.getByText('No events yet')).toBeInTheDocument());
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockListRecentEvents.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load events', 'error'));
+  });
+
+  it('displays event payload', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Events')).toBeInTheDocument());
+    // Payload is JSON-stringified and truncated
+    expect(screen.getAllByText(/grantId/).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/portal/src/pages/__tests__/ExportPage.test.tsx
+++ b/apps/portal/src/pages/__tests__/ExportPage.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { ExportPage } from '../dpdp/ExportPage';
+
+const mockCreateExport = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/dpdp', () => ({
+  createExport: (...a: unknown[]) => mockCreateExport(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+function r() { return render(<MemoryRouter><ExportPage /></MemoryRouter>); }
+
+describe('ExportPage', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('renders heading', () => {
+    r();
+    expect(screen.getByText('Compliance Exports')).toBeInTheDocument();
+  });
+
+  it('shows Generate Export form', () => {
+    r();
+    expect(screen.getByText('Generate Export')).toBeInTheDocument();
+  });
+
+  it('shows export type options', () => {
+    r();
+    expect(screen.getByText('DPDP Audit')).toBeInTheDocument();
+    expect(screen.getByText('GDPR Article 15')).toBeInTheDocument();
+    expect(screen.getByText('EU AI Act Conformance')).toBeInTheDocument();
+  });
+
+  it('shows date range inputs', () => {
+    r();
+    expect(screen.getByText('Date From')).toBeInTheDocument();
+    expect(screen.getByText('Date To')).toBeInTheDocument();
+  });
+
+  it('shows format selector', () => {
+    r();
+    expect(screen.getByText('Format')).toBeInTheDocument();
+  });
+
+  it('shows checkboxes for includes', () => {
+    r();
+    expect(screen.getByText('Include Consent Records')).toBeInTheDocument();
+    expect(screen.getByText('Include Action Log')).toBeInTheDocument();
+  });
+
+  it('has Generate Export button', () => {
+    r();
+    expect(screen.getByRole('button', { name: 'Generate Export' })).toBeInTheDocument();
+  });
+
+  it('generates export successfully', async () => {
+    mockCreateExport.mockResolvedValueOnce({
+      exportId: 'exp-1', type: 'dpdp-audit', format: 'json',
+      recordCount: 42, createdAt: '2026-04-01T00:00:00Z',
+      data: { records: [] },
+    });
+    const user = userEvent.setup();
+    r();
+    await user.click(screen.getByRole('button', { name: 'Generate Export' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Export generated: 42 records', 'success'));
+  });
+
+  it('shows error toast on export failure', async () => {
+    mockCreateExport.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    r();
+    await user.click(screen.getByRole('button', { name: 'Generate Export' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Export failed', 'error'));
+  });
+
+  it('shows recent exports section', () => {
+    r();
+    expect(screen.getByText('Recent Exports')).toBeInTheDocument();
+    expect(screen.getByText('No exports generated yet in this session')).toBeInTheDocument();
+  });
+
+  it('adds completed export to recent list', async () => {
+    mockCreateExport.mockResolvedValueOnce({
+      exportId: 'exp-1', type: 'dpdp-audit', format: 'json',
+      recordCount: 10, createdAt: '2026-04-01T00:00:00Z',
+      data: { records: [] },
+    });
+    const user = userEvent.setup();
+    r();
+    await user.click(screen.getByRole('button', { name: 'Generate Export' }));
+    await waitFor(() => expect(screen.getByText('10 records')).toBeInTheDocument());
+    expect(screen.getByText('complete')).toBeInTheDocument();
+    expect(screen.getByText('Download')).toBeInTheDocument();
+  });
+
+  it('has optional Data Principal ID filter', () => {
+    r();
+    expect(screen.getByPlaceholderText('Filter by principal')).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/pages/__tests__/GrantDetail.test.tsx
+++ b/apps/portal/src/pages/__tests__/GrantDetail.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { GrantDetail } from '../grants/GrantDetail';
+
+const mockGetGrant = vi.fn();
+const mockRevokeGrant = vi.fn();
+const mockListAuditEntries = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/grants', () => ({
+  getGrant: (...a: unknown[]) => mockGetGrant(...a),
+  revokeGrant: (...a: unknown[]) => mockRevokeGrant(...a),
+}));
+vi.mock('../../api/audit', () => ({ listAuditEntries: (...a: unknown[]) => mockListAuditEntries(...a) }));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const grant = {
+  grantId: 'g1', agentId: 'a1', principalId: 'user@t.com', developerId: 'd1',
+  scopes: ['read', 'write'], status: 'active' as const,
+  issuedAt: '2026-01-01T00:00:00Z', expiresAt: '2026-12-31T00:00:00Z',
+  delegationDepth: 1, parentGrantId: 'g0',
+};
+
+const auditEntries = [{
+  entryId: 'e1', agentId: 'a1', agentDid: 'did:web:a1', grantId: 'g1',
+  principalId: 'user@t.com', developerId: 'd1', action: 'token.exchange',
+  metadata: {}, hash: 'abc', prevHash: null, timestamp: '2026-01-01T00:00:00Z', status: 'success' as const,
+}];
+
+function r() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard/grants/g1']}>
+      <Routes><Route path='/dashboard/grants/:id' element={<GrantDetail />} /></Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('GrantDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGrant.mockResolvedValue(grant);
+    mockListAuditEntries.mockResolvedValue(auditEntries);
+  });
+
+  it('displays grant metadata', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('g1')).toBeInTheDocument());
+    expect(screen.getByText('user@t.com')).toBeInTheDocument();
+  });
+
+  it('shows delegation info', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('1')).toBeInTheDocument()); // delegationDepth
+    expect(screen.getByText('g0')).toBeInTheDocument(); // parentGrantId
+  });
+
+  it('links agent to agent detail', async () => {
+    r();
+    await waitFor(() => {
+      const links = screen.getAllByText('a1');
+      const link = links.find(l => l.closest('a'));
+      expect(link.closest('a')).toHaveAttribute('href', '/dashboard/agents/a1');
+    });
+  });
+
+  it('renders audit trail', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Audit Trail (1)')).toBeInTheDocument());
+    expect(screen.getByText('token.exchange')).toBeInTheDocument();
+  });
+
+  it('shows no audit entries message when empty', async () => {
+    mockListAuditEntries.mockResolvedValue([]);
+    r();
+    await waitFor(() => expect(screen.getByText('No audit entries for this grant')).toBeInTheDocument());
+  });
+
+  it('has Revoke button for active grant', async () => {
+    r();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Revoke' })).toBeInTheDocument());
+  });
+
+  it('revokes grant on confirm', async () => {
+    mockRevokeGrant.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Revoke' })).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Revoke' }));
+    await waitFor(() => expect(screen.getByText('Revoke Grant')).toBeInTheDocument());
+    await user.click(screen.getAllByRole('button', { name: 'Revoke' }).pop()!);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Grant revoked', 'success'));
+  });
+
+  it('hides Revoke for already revoked grants', async () => {
+    mockGetGrant.mockResolvedValue({ ...grant, status: 'revoked' });
+    r();
+    await waitFor(() => expect(screen.getByText('g1')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Revoke' })).not.toBeInTheDocument();
+  });
+
+  it('redirects when grant not found', async () => {
+    mockGetGrant.mockRejectedValue(new Error('not found'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Grant not found', 'error'));
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard/grants');
+  });
+});

--- a/apps/portal/src/pages/__tests__/GrantDetail.test.tsx
+++ b/apps/portal/src/pages/__tests__/GrantDetail.test.tsx
@@ -66,7 +66,7 @@ describe('GrantDetail', () => {
     await waitFor(() => {
       const links = screen.getAllByText('a1');
       const link = links.find(l => l.closest('a'));
-      expect(link.closest('a')).toHaveAttribute('href', '/dashboard/agents/a1');
+      expect(link!.closest('a')).toHaveAttribute('href', '/dashboard/agents/a1');
     });
   });
 

--- a/apps/portal/src/pages/__tests__/GrantList.test.tsx
+++ b/apps/portal/src/pages/__tests__/GrantList.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { GrantList } from '../grants/GrantList';
+
+const mockListGrants = vi.fn();
+const mockRevokeGrant = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/grants', () => ({
+  listGrants: () => mockListGrants(),
+  revokeGrant: (...a: unknown[]) => mockRevokeGrant(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const grants = [
+  { grantId: 'g1', agentId: 'a1', principalId: 'user1', developerId: 'd1', scopes: ['read'], status: 'active' as const, issuedAt: '2026-01-01T00:00:00Z', expiresAt: '2026-12-31T00:00:00Z', delegationDepth: 0 },
+  { grantId: 'g2', agentId: 'a2', principalId: 'user2', developerId: 'd1', scopes: ['write'], status: 'revoked' as const, issuedAt: '2026-01-02T00:00:00Z', expiresAt: '2026-12-31T00:00:00Z', delegationDepth: 0 },
+  { grantId: 'g3', agentId: 'a1', principalId: 'user1', developerId: 'd1', scopes: ['admin'], status: 'expired' as const, issuedAt: '2025-01-01T00:00:00Z', expiresAt: '2025-12-31T00:00:00Z', delegationDepth: 0 },
+];
+
+function r() { return render(<MemoryRouter><GrantList /></MemoryRouter>); }
+
+describe('GrantList', () => {
+  beforeEach(() => { vi.clearAllMocks(); mockListGrants.mockResolvedValue(grants); });
+
+  it('renders analytics stat cards', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Total')).toBeInTheDocument());
+    expect(screen.getAllByText('Active').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Revoked').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Expired').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows correct stat values', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('3')).toBeInTheDocument()); // total
+  });
+
+  it('renders grant table', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Grants')).toBeInTheDocument());
+  });
+
+  it('filters by status', async () => {
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Grants')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Active' }));
+    // Only active grants shown - g2 (revoked) and g3 (expired) should be filtered
+    await waitFor(() => expect(screen.queryByText('revoked')).not.toBeInTheDocument());
+  });
+
+  it('shows empty state when no grants match filter', async () => {
+    mockListGrants.mockResolvedValue([]);
+    r();
+    await waitFor(() => expect(screen.getByText('No grants found')).toBeInTheDocument());
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockListGrants.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load grants', 'error'));
+  });
+
+  it('opens revoke confirmation for active grant', async () => {
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Grants')).toBeInTheDocument());
+    const revokeButtons = screen.getAllByRole('button', { name: 'Revoke' });
+    await user.click(revokeButtons[0]!);
+    await waitFor(() => expect(screen.getByText('Revoke Grant')).toBeInTheDocument());
+  });
+
+  it('shows top scopes section', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Top Scopes')).toBeInTheDocument());
+  });
+
+  it('has principal filter input', async () => {
+    r();
+    await waitFor(() => expect(screen.getByPlaceholderText('Filter by principal ID...')).toBeInTheDocument());
+  });
+
+  it('has select all active button', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Select all active')).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/GrievanceList.test.tsx
+++ b/apps/portal/src/pages/__tests__/GrievanceList.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { GrievanceList } from '../dpdp/GrievanceList';
+
+const mockFileGrievance = vi.fn();
+const mockGetGrievance = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/dpdp', () => ({
+  fileGrievance: (...a: unknown[]) => mockFileGrievance(...a),
+  getGrievance: (...a: unknown[]) => mockGetGrievance(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+function r() { return render(<MemoryRouter><GrievanceList /></MemoryRouter>); }
+
+describe('GrievanceList', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('renders heading', () => {
+    r();
+    expect(screen.getByText('Grievances')).toBeInTheDocument();
+  });
+
+  it('shows empty state initially', () => {
+    r();
+    expect(screen.getByText('No grievances')).toBeInTheDocument();
+  });
+
+  it('has File Grievance button', () => {
+    r();
+    expect(screen.getByText('File Grievance')).toBeInTheDocument();
+  });
+
+  it('opens file form on button click', async () => {
+    const user = userEvent.setup();
+    r();
+    await user.click(screen.getByText('File Grievance'));
+    await waitFor(() => expect(screen.getByText('File New Grievance')).toBeInTheDocument());
+  });
+
+  it('shows grievance form fields', async () => {
+    const user = userEvent.setup();
+    r();
+    await user.click(screen.getByText('File Grievance'));
+    await waitFor(() => expect(screen.getByText('Data Principal ID *')).toBeInTheDocument());
+    expect(screen.getByText('Type *')).toBeInTheDocument();
+    expect(screen.getByText('Description *')).toBeInTheDocument();
+  });
+
+  it('files grievance successfully', async () => {
+    mockFileGrievance.mockResolvedValueOnce({
+      grievanceId: 'grv-1', type: 'data-erasure',
+      referenceNumber: 'REF-001', expectedResolutionBy: '2026-05-01T00:00:00Z',
+      createdAt: '2026-04-01T00:00:00Z',
+    });
+    const user = userEvent.setup();
+    r();
+    await user.click(screen.getByText('File Grievance'));
+    await waitFor(() => expect(screen.getByText('File New Grievance')).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText('e.g. user_123'), 'user-1');
+    await user.type(screen.getByPlaceholderText('Describe the grievance...'), 'Request data erasure');
+    await user.click(screen.getAllByText('File Grievance').find(el => el.tagName === 'BUTTON' && el.getAttribute('type') === 'submit')!);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Grievance filed: REF-001', 'success'));
+  });
+
+  it('shows error toast on file failure', async () => {
+    mockFileGrievance.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    r();
+    await user.click(screen.getByText('File Grievance'));
+    await waitFor(() => expect(screen.getByText('File New Grievance')).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText('e.g. user_123'), 'user-1');
+    await user.type(screen.getByPlaceholderText('Describe the grievance...'), 'Test');
+    await user.click(screen.getAllByText('File Grievance').find(el => el.tagName === 'BUTTON' && el.getAttribute('type') === 'submit')!);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to file grievance', 'error'));
+  });
+
+  it('has lookup field', () => {
+    r();
+    expect(screen.getByPlaceholderText('e.g. grv_01ABCDEF...')).toBeInTheDocument();
+  });
+
+  it('looks up grievance by ID', async () => {
+    mockGetGrievance.mockResolvedValueOnce({
+      grievanceId: 'grv-1', dataPrincipalId: 'user-1', recordId: null,
+      type: 'data-erasure', description: 'Test', evidence: {},
+      status: 'submitted', referenceNumber: 'REF-001',
+      expectedResolutionBy: '2026-05-01T00:00:00Z',
+      resolvedAt: null, resolution: null, createdAt: '2026-04-01T00:00:00Z',
+    });
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('e.g. grv_01ABCDEF...'), 'grv-1');
+    await user.click(screen.getByRole('button', { name: 'Lookup' }));
+    await waitFor(() => expect(screen.getByText('REF-001')).toBeInTheDocument());
+  });
+
+  it('shows error on lookup failure', async () => {
+    mockGetGrievance.mockRejectedValueOnce(new Error('not found'));
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('e.g. grv_01ABCDEF...'), 'grv-999');
+    await user.click(screen.getByRole('button', { name: 'Lookup' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Grievance not found', 'error'));
+  });
+
+  it('disables Lookup button when input is empty', () => {
+    r();
+    expect(screen.getByRole('button', { name: 'Lookup' })).toBeDisabled();
+  });
+
+  it('shows grievance type dropdown', async () => {
+    const user = userEvent.setup();
+    r();
+    await user.click(screen.getByText('File Grievance'));
+    await waitFor(() => expect(screen.getByText('Type *')).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/Login.test.tsx
+++ b/apps/portal/src/pages/__tests__/Login.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { Login } from '../Login';
+
+const mockLogin = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('../../store/auth', () => ({
+  useAuth: () => ({ login: mockLogin }),
+}));
+
+vi.mock('../../store/toast', () => ({
+  useToast: () => ({ show: mockShow }),
+}));
+
+function renderLogin() {
+  return render(<MemoryRouter><Login /></MemoryRouter>);
+}
+
+describe('Login', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('renders the login form with API key input', () => {
+    renderLogin();
+    expect(screen.getByLabelText('API Key')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+    expect(screen.getByText(/Sign in to your developer dashboard/)).toBeInTheDocument();
+  });
+
+  it('has a link to the signup page', () => {
+    renderLogin();
+    expect(screen.getByText('Create one')).toHaveAttribute('href', '/dashboard/signup');
+  });
+
+  it('disables the submit button when input is empty', () => {
+    renderLogin();
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeDisabled();
+  });
+
+  it('enables the submit button when API key is entered', async () => {
+    const user = userEvent.setup();
+    renderLogin();
+    await user.type(screen.getByLabelText('API Key'), 'gx_live_abc123');
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeEnabled();
+  });
+
+  it('calls login and navigates to dashboard on success', async () => {
+    mockLogin.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    renderLogin();
+    await user.type(screen.getByLabelText('API Key'), 'gx_live_abc123');
+    await user.click(screen.getByRole('button', { name: 'Sign in' }));
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith('gx_live_abc123');
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+    });
+  });
+
+  it('trims whitespace from the API key', async () => {
+    mockLogin.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    renderLogin();
+    await user.type(screen.getByLabelText('API Key'), '  gx_live_abc  ');
+    await user.click(screen.getByRole('button', { name: 'Sign in' }));
+    await waitFor(() => expect(mockLogin).toHaveBeenCalledWith('gx_live_abc'));
+  });
+
+  it('shows error toast on login failure', async () => {
+    mockLogin.mockRejectedValueOnce(new Error('bad'));
+    const user = userEvent.setup();
+    renderLogin();
+    await user.type(screen.getByLabelText('API Key'), 'gx_live_bad');
+    await user.click(screen.getByRole('button', { name: 'Sign in' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Invalid API key', 'error'));
+  });
+
+  it('does not navigate on login failure', async () => {
+    mockLogin.mockRejectedValueOnce(new Error('bad'));
+    const user = userEvent.setup();
+    renderLogin();
+    await user.type(screen.getByLabelText('API Key'), 'gx_live_bad');
+    await user.click(screen.getByRole('button', { name: 'Sign in' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalled());
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('does not submit if only whitespace is entered', async () => {
+    const user = userEvent.setup();
+    renderLogin();
+    await user.type(screen.getByLabelText('API Key'), '   ');
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeDisabled();
+  });
+});

--- a/apps/portal/src/pages/__tests__/McpServerDetail.test.tsx
+++ b/apps/portal/src/pages/__tests__/McpServerDetail.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { McpServerDetail } from '../mcp/McpServerDetail';
+
+const mockGetMcpServer = vi.fn();
+const mockApplyForCertification = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/mcp', () => ({
+  getMcpServer: (...a: unknown[]) => mockGetMcpServer(...a),
+  applyForCertification: (...a: unknown[]) => mockApplyForCertification(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+const server = {
+  id: 'mcp-1', name: 'Data Server', description: 'A data MCP server',
+  category: 'data', status: 'active', certified: false, certificationLevel: null,
+  certifiedAt: null, authEndpoint: 'https://auth.example.com/mcp',
+  serverUrl: 'https://mcp.example.com', scopes: ['read', 'write'],
+  weeklyActiveAgents: 142, stars: 87, npmPackage: null,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+function r() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard/mcp/mcp-1']}>
+      <Routes><Route path="/dashboard/mcp/:serverId" element={<McpServerDetail />} /></Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('McpServerDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMcpServer.mockResolvedValue(server);
+  });
+
+  it('renders server name', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Data Server')).toBeInTheDocument());
+  });
+
+  it('displays server details', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Server Details')).toBeInTheDocument());
+    expect(screen.getByText('mcp-1')).toBeInTheDocument();
+    expect(screen.getByText('data')).toBeInTheDocument();
+  });
+
+  it('shows auth endpoint', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('https://auth.example.com/mcp')).toBeInTheDocument());
+  });
+
+  it('shows server URL', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('https://mcp.example.com')).toBeInTheDocument());
+  });
+
+  it('displays scopes', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Scopes')).toBeInTheDocument());
+  });
+
+  it('shows description', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('A data MCP server')).toBeInTheDocument());
+  });
+
+  it('shows stats row', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Weekly Agents')).toBeInTheDocument());
+    expect(screen.getByText('Stars')).toBeInTheDocument();
+    expect(screen.getByText('142')).toBeInTheDocument();
+    expect(screen.getByText('87')).toBeInTheDocument();
+  });
+
+  it('shows certification section', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Certification')).toBeInTheDocument());
+    expect(screen.getByText('Current Level')).toBeInTheDocument();
+    expect(screen.getByText('none')).toBeInTheDocument();
+  });
+
+  it('shows Apply buttons for uncertified server', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Apply for Bronze')).toBeInTheDocument());
+    expect(screen.getByText('Apply for Silver')).toBeInTheDocument();
+    expect(screen.getByText('Apply for Gold')).toBeInTheDocument();
+  });
+
+  it('applies for certification on click', async () => {
+    mockApplyForCertification.mockResolvedValueOnce(undefined);
+    mockGetMcpServer.mockResolvedValueOnce(server).mockResolvedValueOnce({ ...server, certificationLevel: 'bronze' });
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Apply for Bronze')).toBeInTheDocument());
+    await user.click(screen.getByText('Apply for Bronze'));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Applied for bronze certification', 'success'));
+  });
+
+  it('shows error toast on certification failure', async () => {
+    mockApplyForCertification.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Apply for Bronze')).toBeInTheDocument());
+    await user.click(screen.getByText('Apply for Bronze'));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to apply for certification', 'error'));
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockGetMcpServer.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load MCP server', 'error'));
+  });
+
+  it('shows Active Clients table', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Active Clients')).toBeInTheDocument());
+    expect(screen.getByText('data-pipeline-agent')).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/pages/__tests__/McpServerForm.test.tsx
+++ b/apps/portal/src/pages/__tests__/McpServerForm.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { McpServerForm } from '../mcp/McpServerForm';
+
+const mockCreateMcpServer = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/mcp', () => ({
+  createMcpServer: (...a: unknown[]) => mockCreateMcpServer(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function r() { return render(<MemoryRouter><McpServerForm /></MemoryRouter>); }
+
+describe('McpServerForm', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('renders step 1 heading', () => {
+    r();
+    expect(screen.getByText('Register MCP Server')).toBeInTheDocument();
+    expect(screen.getByText('Server Details')).toBeInTheDocument();
+  });
+
+  it('shows Name input', () => {
+    r();
+    expect(screen.getByPlaceholderText('My MCP Server')).toBeInTheDocument();
+  });
+
+  it('disables Next when name is empty', () => {
+    r();
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+  });
+
+  it('advances through steps', async () => {
+    const user = userEvent.setup();
+    r();
+    // Step 1 - enter name
+    await user.type(screen.getByPlaceholderText('My MCP Server'), 'Test Server');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    // Step 2 - Scope Definition
+    await waitFor(() => expect(screen.getByText('Scope Definition')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    // Step 3 - Deployment Mode
+    await waitFor(() => expect(screen.getByText('Deployment Mode')).toBeInTheDocument());
+    expect(screen.getByText('Managed')).toBeInTheDocument();
+    expect(screen.getByText('Self-hosted')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    // Step 4 - Review
+    await waitFor(() => expect(screen.getByText('Review & Create')).toBeInTheDocument());
+    expect(screen.getByText('Test Server')).toBeInTheDocument();
+  });
+
+  it('shows Back button on steps > 1', async () => {
+    const user = userEvent.setup();
+    r();
+    // Step 1 has no Back
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText('My MCP Server'), 'Test');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument());
+  });
+
+  it('has Cancel button', () => {
+    r();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('shows Docker Compose for self-hosted mode', async () => {
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('My MCP Server'), 'Test');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByText('Scope Definition')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByText('Deployment Mode')).toBeInTheDocument());
+    await user.click(screen.getByText('Self-hosted'));
+    await waitFor(() => expect(screen.getByText(/Docker Compose/)).toBeInTheDocument());
+  });
+
+  it('submits and navigates on success', async () => {
+    mockCreateMcpServer.mockResolvedValueOnce({ id: 'mcp-new' });
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('My MCP Server'), 'My Server');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByText('Scope Definition')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByText('Deployment Mode')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByText('Review & Create')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Register Server' }));
+    await waitFor(() => expect(mockCreateMcpServer).toHaveBeenCalled());
+    expect(mockShow).toHaveBeenCalledWith('MCP server registered', 'success');
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard/mcp/mcp-new');
+  });
+
+  it('shows error toast on submission failure', async () => {
+    mockCreateMcpServer.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('My MCP Server'), 'My Server');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByText('Scope Definition')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByText('Deployment Mode')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByText('Review & Create')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Register Server' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to register MCP server', 'error'));
+  });
+
+  it('shows category dropdown', () => {
+    r();
+    expect(screen.getByText('Productivity')).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/pages/__tests__/McpServerList.test.tsx
+++ b/apps/portal/src/pages/__tests__/McpServerList.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { McpServerList } from '../mcp/McpServerList';
+
+const mockListMcpServers = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/mcp', () => ({
+  listMcpServers: (...a: unknown[]) => mockListMcpServers(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const servers = [
+  {
+    id: 'mcp-1', name: 'Data Server', description: 'Data access', category: 'data',
+    status: 'active', certified: true, certificationLevel: 'gold',
+    weeklyActiveAgents: 142, stars: 87, scopes: ['read'],
+    createdAt: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'mcp-2', name: 'Compute Server', description: null, category: 'compute',
+    status: 'pending', certified: false, certificationLevel: null,
+    weeklyActiveAgents: 5, stars: 2, scopes: [],
+    createdAt: '2026-02-01T00:00:00Z',
+  },
+];
+
+function r() { return render(<MemoryRouter><McpServerList /></MemoryRouter>); }
+
+describe('McpServerList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListMcpServers.mockResolvedValue(servers);
+  });
+
+  it('renders heading', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('MCP Servers')).toBeInTheDocument());
+  });
+
+  it('shows server names', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Data Server')).toBeInTheDocument());
+    expect(screen.getByText('Compute Server')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no servers', async () => {
+    mockListMcpServers.mockResolvedValue([]);
+    r();
+    await waitFor(() => expect(screen.getByText('No MCP servers found')).toBeInTheDocument());
+  });
+
+  it('has Register Server button', async () => {
+    r();
+    await waitFor(() => expect(screen.getAllByText('+ Register Server').length).toBeGreaterThanOrEqual(1));
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockListMcpServers.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load MCP servers', 'error'));
+  });
+
+  it('displays certification badges', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('gold')).toBeInTheDocument());
+    expect(screen.getByText('none')).toBeInTheDocument();
+  });
+
+  it('displays category badges', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('data')).toBeInTheDocument());
+    expect(screen.getByText('compute')).toBeInTheDocument();
+  });
+
+  it('displays status badges', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('active')).toBeInTheDocument());
+    expect(screen.getByText('pending')).toBeInTheDocument();
+  });
+
+  it('displays weekly agents count', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('142')).toBeInTheDocument());
+  });
+
+  it('has category filter dropdown', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('All Categories')).toBeInTheDocument());
+  });
+
+  it('has certified only checkbox', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Certified only')).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/NotFound.test.tsx
+++ b/apps/portal/src/pages/__tests__/NotFound.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { NotFound } from '../NotFound';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+describe('NotFound', () => {
+  it('renders 404 message', () => {
+    render(<MemoryRouter><NotFound /></MemoryRouter>);
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByText('Page not found')).toBeInTheDocument();
+  });
+
+  it('has Back to Dashboard button', () => {
+    render(<MemoryRouter><NotFound /></MemoryRouter>);
+    expect(screen.getByRole('button', { name: 'Back to Dashboard' })).toBeInTheDocument();
+  });
+
+  it('navigates to dashboard on click', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><NotFound /></MemoryRouter>);
+    await user.click(screen.getByRole('button', { name: 'Back to Dashboard' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+  });
+});

--- a/apps/portal/src/pages/__tests__/PolicyForm.test.tsx
+++ b/apps/portal/src/pages/__tests__/PolicyForm.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { PolicyForm } from '../policies/PolicyForm';
+
+const mockCreatePolicy = vi.fn();
+const mockGetPolicy = vi.fn();
+const mockUpdatePolicy = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/policies', () => ({
+  createPolicy: (...a: unknown[]) => mockCreatePolicy(...a),
+  getPolicy: (...a: unknown[]) => mockGetPolicy(...a),
+  updatePolicy: (...a: unknown[]) => mockUpdatePolicy(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function renderCreate() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard/policies/new']}>
+      <Routes><Route path="/dashboard/policies/new" element={<PolicyForm />} /></Routes>
+    </MemoryRouter>,
+  );
+}
+
+function renderEdit() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard/policies/p1/edit']}>
+      <Routes><Route path="/dashboard/policies/:id/edit" element={<PolicyForm />} /></Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('PolicyForm', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('renders Create Policy mode', () => {
+    renderCreate();
+    expect(screen.getByText('Create Policy')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create Policy' })).toBeInTheDocument();
+  });
+
+  it('disables submit when name is empty', () => {
+    renderCreate();
+    expect(screen.getByRole('button', { name: 'Create Policy' })).toBeDisabled();
+  });
+
+  it('creates policy on submit', async () => {
+    mockCreatePolicy.mockResolvedValueOnce({ id: 'p-new' });
+    const user = userEvent.setup();
+    renderCreate();
+    await user.type(screen.getByLabelText('Name'), 'Test Policy');
+    await user.click(screen.getByRole('button', { name: 'Create Policy' }));
+    await waitFor(() => expect(mockCreatePolicy).toHaveBeenCalled());
+    expect(mockShow).toHaveBeenCalledWith('Policy created', 'success');
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard/policies');
+  });
+
+  it('shows error toast on create failure', async () => {
+    mockCreatePolicy.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    renderCreate();
+    await user.type(screen.getByLabelText('Name'), 'Test');
+    await user.click(screen.getByRole('button', { name: 'Create Policy' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to create policy', 'error'));
+  });
+
+  it('loads policy data in edit mode', async () => {
+    mockGetPolicy.mockResolvedValueOnce({
+      id: 'p1', name: 'Existing', effect: 'deny', priority: 5,
+      agentId: 'a1', principalId: null, scopes: ['read'],
+      timeOfDayStart: '09:00', timeOfDayEnd: '17:00',
+    });
+    renderEdit();
+    await waitFor(() => expect(screen.getByDisplayValue('Existing')).toBeInTheDocument());
+    expect(screen.getByText('Edit Policy')).toBeInTheDocument();
+    expect(screen.getByText('read')).toBeInTheDocument();
+  });
+
+  it('updates policy in edit mode', async () => {
+    mockGetPolicy.mockResolvedValueOnce({
+      id: 'p1', name: 'Old', effect: 'allow', priority: 0,
+      agentId: '', principalId: '', scopes: [], timeOfDayStart: '', timeOfDayEnd: '',
+    });
+    mockUpdatePolicy.mockResolvedValueOnce({ id: 'p1' });
+    const user = userEvent.setup();
+    renderEdit();
+    await waitFor(() => expect(screen.getByDisplayValue('Old')).toBeInTheDocument());
+    await user.clear(screen.getByLabelText('Name'));
+    await user.type(screen.getByLabelText('Name'), 'Updated');
+    await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+    await waitFor(() => expect(mockUpdatePolicy).toHaveBeenCalled());
+    expect(mockShow).toHaveBeenCalledWith('Policy updated', 'success');
+  });
+
+  it('navigates back on policy not found in edit', async () => {
+    mockGetPolicy.mockRejectedValueOnce(new Error('not found'));
+    renderEdit();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Policy not found', 'error'));
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard/policies');
+  });
+
+  it('has Cancel button', () => {
+    renderCreate();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('has effect selector', () => {
+    renderCreate();
+    expect(screen.getByLabelText('Effect')).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/pages/__tests__/PolicyList.test.tsx
+++ b/apps/portal/src/pages/__tests__/PolicyList.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { PolicyList } from '../policies/PolicyList';
+
+const mockListPolicies = vi.fn();
+const mockDeletePolicy = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/policies', () => ({
+  listPolicies: () => mockListPolicies(),
+  deletePolicy: (...a: unknown[]) => mockDeletePolicy(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const policies = [
+  { id: 'p1', name: 'Allow Read', effect: 'allow' as const, priority: 1, agentId: 'a1', principalId: null, scopes: ['read'], timeOfDayStart: null, timeOfDayEnd: null, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+  { id: 'p2', name: 'Deny Write', effect: 'deny' as const, priority: 2, agentId: null, principalId: null, scopes: null, timeOfDayStart: '09:00', timeOfDayEnd: '17:00', createdAt: '2026-01-02T00:00:00Z', updatedAt: '2026-01-02T00:00:00Z' },
+];
+
+function r() { return render(<MemoryRouter><PolicyList /></MemoryRouter>); }
+
+describe('PolicyList', () => {
+  beforeEach(() => { vi.clearAllMocks(); mockListPolicies.mockResolvedValue(policies); });
+
+  it('renders policy table', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Allow Read')).toBeInTheDocument());
+    expect(screen.getByText('Deny Write')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no policies', async () => {
+    mockListPolicies.mockResolvedValue([]);
+    r();
+    await waitFor(() => expect(screen.getByText('No policies')).toBeInTheDocument());
+  });
+
+  it('has Create Policy link', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Policies')).toBeInTheDocument());
+    expect(screen.getAllByText('Create Policy').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockListPolicies.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load policies', 'error'));
+  });
+
+  it('has Edit and Delete buttons', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Allow Read')).toBeInTheDocument());
+    expect(screen.getAllByRole('button', { name: 'Edit' }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByRole('button', { name: 'Delete' }).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('navigates to edit on Edit click', async () => {
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Allow Read')).toBeInTheDocument());
+    await user.click(screen.getAllByRole('button', { name: 'Edit' })[0]!);
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard/policies/p1/edit');
+  });
+
+  it('deletes policy on confirm', async () => {
+    mockDeletePolicy.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Allow Read')).toBeInTheDocument());
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+    await waitFor(() => expect(screen.getByText('Delete Policy')).toBeInTheDocument());
+    const modal = screen.getByText('Delete Policy').closest('div[class*="fixed"]')!;
+    const btns = within(modal as HTMLElement).getAllByRole('button', { name: 'Delete' });
+    await user.click(btns[btns.length - 1]!);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Policy deleted', 'success'));
+  });
+
+  it('displays effect badges', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('allow')).toBeInTheDocument());
+    expect(screen.getByText('deny')).toBeInTheDocument();
+  });
+
+  it('displays time window', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Allow Read')).toBeInTheDocument());
+    expect(screen.getByText(/09:00/)).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/pages/__tests__/RegisterOrgForm.test.tsx
+++ b/apps/portal/src/pages/__tests__/RegisterOrgForm.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { RegisterOrgForm } from '../registry/RegisterOrgForm';
+
+const mockRegisterOrg = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../api/registry', () => ({
+  registerOrg: (...a: unknown[]) => mockRegisterOrg(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function r() { return render(<MemoryRouter><RegisterOrgForm /></MemoryRouter>); }
+
+describe('RegisterOrgForm', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('renders heading', () => {
+    r();
+    expect(screen.getByText('Register Your Organization')).toBeInTheDocument();
+  });
+
+  it('shows step 1 form fields', () => {
+    r();
+    expect(screen.getByText('Organization Details')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('did:web:your-domain.com')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Acme Corp')).toBeInTheDocument();
+  });
+
+  it('disables Next when DID and name are empty', () => {
+    r();
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+  });
+
+  it('advances to step 2', async () => {
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('did:web:your-domain.com'), 'did:web:test.com');
+    await user.type(screen.getByPlaceholderText('Acme Corp'), 'Test Org');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByText('Contact Information')).toBeInTheDocument());
+  });
+
+  it('advances to step 3', async () => {
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('did:web:your-domain.com'), 'did:web:test.com');
+    await user.type(screen.getByPlaceholderText('Acme Corp'), 'Test Org');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByText('Contact Information')).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText('security@your-domain.com'), 'sec@test.com');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByText('Verification Method')).toBeInTheDocument());
+  });
+
+  it('shows verification methods in step 3', async () => {
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('did:web:your-domain.com'), 'did:web:test.com');
+    await user.type(screen.getByPlaceholderText('Acme Corp'), 'Test Org');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByText('Contact Information')).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText('security@your-domain.com'), 'sec@test.com');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByText('DNS TXT Record')).toBeInTheDocument());
+    expect(screen.getByText('Recommended')).toBeInTheDocument();
+    expect(screen.getByText('.well-known Endpoint')).toBeInTheDocument();
+    expect(screen.getByText('SOC 2 Attestation')).toBeInTheDocument();
+    expect(screen.getByText('Manual Review')).toBeInTheDocument();
+  });
+
+  it('submits and navigates on success', async () => {
+    mockRegisterOrg.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    r();
+    // Step 1
+    await user.type(screen.getByPlaceholderText('did:web:your-domain.com'), 'did:web:test.com');
+    await user.type(screen.getByPlaceholderText('Acme Corp'), 'Test Org');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    // Step 2
+    await waitFor(() => expect(screen.getByText('Contact Information')).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText('security@your-domain.com'), 'sec@test.com');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    // Step 3
+    await waitFor(() => expect(screen.getByText('Verification Method')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    // Step 4 - Review
+    await waitFor(() => expect(screen.getByText('Review & Submit')).toBeInTheDocument());
+    expect(screen.getByText('did:web:test.com')).toBeInTheDocument();
+    expect(screen.getByText('Test Org')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Register Organization' }));
+    await waitFor(() => expect(mockRegisterOrg).toHaveBeenCalled());
+    expect(mockShow).toHaveBeenCalledWith('Organization registered successfully', 'success');
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard/registry');
+  });
+
+  it('shows error toast on submission failure', async () => {
+    mockRegisterOrg.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    r();
+    // Step 1
+    await user.type(screen.getByPlaceholderText('did:web:your-domain.com'), 'did:web:test.com');
+    await user.type(screen.getByPlaceholderText('Acme Corp'), 'Test Org');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    // Step 2
+    await waitFor(() => expect(screen.getByText('Contact Information')).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText('security@your-domain.com'), 'sec@test.com');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    // Step 3
+    await waitFor(() => expect(screen.getByText('Verification Method')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    // Step 4
+    await waitFor(() => expect(screen.getByText('Review & Submit')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Register Organization' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to register organization', 'error'));
+  });
+
+  it('has Back to Registry link', () => {
+    r();
+    expect(screen.getByText('Back to Registry')).toBeInTheDocument();
+  });
+
+  it('shows Back button on step 2+', async () => {
+    const user = userEvent.setup();
+    r();
+    await user.type(screen.getByPlaceholderText('did:web:your-domain.com'), 'did:web:test.com');
+    await user.type(screen.getByPlaceholderText('Acme Corp'), 'Test Org');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/RegistryOrgDetail.test.tsx
+++ b/apps/portal/src/pages/__tests__/RegistryOrgDetail.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { RegistryOrgDetail } from '../registry/RegistryOrgDetail';
+
+const mockGetRegistryOrg = vi.fn();
+const mockVerifyOrgDns = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/registry', () => ({
+  getRegistryOrg: (...a: unknown[]) => mockGetRegistryOrg(...a),
+  verifyOrgDns: (...a: unknown[]) => mockVerifyOrgDns(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+const org = {
+  did: 'did:web:acme.com', name: 'Acme Corp', description: 'An org description',
+  verificationLevel: 'unverified', badges: ['soc2'], logoUrl: null,
+  website: 'https://acme.com', verifiedAt: null, verificationMethod: null,
+  compliance: { soc2: true, dpdp: false, gdpr: true },
+  contact: { security: 'sec@acme.com', dpo: 'dpo@acme.com' },
+  agents: [
+    {
+      agentDid: 'did:web:acme.com:agent-1', name: 'Agent One',
+      category: 'data', scopes: ['read', 'write'], weeklyActiveGrants: 50, rating: 4.2,
+    },
+  ],
+  publicKeys: [{ id: 'key-1', type: 'Ed25519', publicKeyMultibase: 'z...' }],
+  stats: { totalAgents: 1, weeklyActiveGrants: 50, averageRating: 4.2 },
+};
+
+function r() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard/registry/did%3Aweb%3Aacme.com']}>
+      <Routes><Route path="/dashboard/registry/:did" element={<RegistryOrgDetail />} /></Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('RegistryOrgDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRegistryOrg.mockResolvedValue(org);
+  });
+
+  it('renders org name', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Acme Corp')).toBeInTheDocument());
+  });
+
+  it('displays DID', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('did:web:acme.com')).toBeInTheDocument());
+  });
+
+  it('shows description', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('An org description')).toBeInTheDocument());
+  });
+
+  it('shows compliance section', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Compliance')).toBeInTheDocument());
+    expect(screen.getByText('SOC 2 Type II')).toBeInTheDocument();
+    expect(screen.getByText('DPDP Compliant')).toBeInTheDocument();
+    expect(screen.getByText('GDPR Compliant')).toBeInTheDocument();
+  });
+
+  it('shows contact info', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Contact')).toBeInTheDocument());
+    expect(screen.getByText('sec@acme.com')).toBeInTheDocument();
+    expect(screen.getByText('dpo@acme.com')).toBeInTheDocument();
+  });
+
+  it('shows agents table', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Agents (1)')).toBeInTheDocument());
+    expect(screen.getByText('Agent One')).toBeInTheDocument();
+  });
+
+  it('shows public keys', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Public Keys')).toBeInTheDocument());
+  });
+
+  it('shows Verify DID button for unverified orgs', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Verify DID')).toBeInTheDocument());
+  });
+
+  it('hides Verify button for verified orgs', async () => {
+    mockGetRegistryOrg.mockResolvedValue({ ...org, verificationLevel: 'verified' });
+    r();
+    await waitFor(() => expect(screen.getByText('Acme Corp')).toBeInTheDocument());
+    expect(screen.queryByText('Verify DID')).not.toBeInTheDocument();
+  });
+
+  it('verifies DID on click', async () => {
+    mockVerifyOrgDns.mockResolvedValueOnce({ verified: true });
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Verify DID')).toBeInTheDocument());
+    await user.click(screen.getByText('Verify DID'));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('DID verified successfully', 'success'));
+  });
+
+  it('shows error on DNS verification failure', async () => {
+    mockVerifyOrgDns.mockResolvedValueOnce({ verified: false });
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Verify DID')).toBeInTheDocument());
+    await user.click(screen.getByText('Verify DID'));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('DNS verification failed. Check your TXT record.', 'error'));
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockGetRegistryOrg.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load organization', 'error'));
+  });
+
+  it('shows not found message when org is null', async () => {
+    mockGetRegistryOrg.mockRejectedValue(new Error('not found'));
+    r();
+    await waitFor(() => expect(screen.getByText('Organization not found.')).toBeInTheDocument());
+  });
+
+  it('shows badges', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('soc2')).toBeInTheDocument());
+  });
+
+  it('shows website link', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('acme.com')).toBeInTheDocument());
+  });
+
+  it('has Back to Registry link', async () => {
+    r();
+    await waitFor(() => expect(screen.getAllByText('Back to Registry').length).toBeGreaterThanOrEqual(1));
+  });
+});

--- a/apps/portal/src/pages/__tests__/RegistrySearch.test.tsx
+++ b/apps/portal/src/pages/__tests__/RegistrySearch.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { RegistrySearch } from '../registry/RegistrySearch';
 

--- a/apps/portal/src/pages/__tests__/RegistrySearch.test.tsx
+++ b/apps/portal/src/pages/__tests__/RegistrySearch.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { RegistrySearch } from '../registry/RegistrySearch';
+
+const mockSearchRegistryOrgs = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/registry', () => ({
+  searchRegistryOrgs: (...a: unknown[]) => mockSearchRegistryOrgs(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+const orgs = [
+  {
+    did: 'did:web:acme.com', name: 'Acme Corp', description: 'Acme description',
+    verificationLevel: 'verified', badges: ['soc2', 'gdpr'], logoUrl: null,
+    website: 'https://acme.com',
+    stats: { totalAgents: 10, weeklyActiveGrants: 500, averageRating: 4.5 },
+  },
+  {
+    did: 'did:web:beta.io', name: 'Beta Inc', description: null,
+    verificationLevel: 'unverified', badges: [], logoUrl: 'https://example.com/logo.png',
+    website: null,
+    stats: { totalAgents: 3, weeklyActiveGrants: 50, averageRating: 3.8 },
+  },
+];
+
+function r() { return render(<MemoryRouter><RegistrySearch /></MemoryRouter>); }
+
+describe('RegistrySearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchRegistryOrgs.mockResolvedValue({ data: orgs, meta: { total: 2 } });
+  });
+
+  it('renders heading', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Trust Registry')).toBeInTheDocument());
+  });
+
+  it('shows organization cards', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Acme Corp')).toBeInTheDocument());
+    expect(screen.getByText('Beta Inc')).toBeInTheDocument();
+  });
+
+  it('shows verified badge for verified orgs', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Verified')).toBeInTheDocument());
+  });
+
+  it('shows compliance badges', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('soc2')).toBeInTheDocument());
+    expect(screen.getByText('gdpr')).toBeInTheDocument();
+  });
+
+  it('shows org stats', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('10 agents')).toBeInTheDocument());
+    expect(screen.getByText('500/wk')).toBeInTheDocument();
+    expect(screen.getByText('4.5')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no orgs', async () => {
+    mockSearchRegistryOrgs.mockResolvedValue({ data: [], meta: { total: 0 } });
+    r();
+    await waitFor(() => expect(screen.getByText('No organizations found')).toBeInTheDocument());
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockSearchRegistryOrgs.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load registry', 'error'));
+  });
+
+  it('has Register Your Organization button', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Register Your Organization')).toBeInTheDocument());
+  });
+
+  it('has search input', async () => {
+    r();
+    await waitFor(() => expect(screen.getByPlaceholderText('Search organizations by name or DID...')).toBeInTheDocument());
+  });
+
+  it('has Verified only checkbox', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Verified only')).toBeInTheDocument());
+  });
+
+  it('has badge filter dropdown', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('All Badges')).toBeInTheDocument());
+  });
+
+  it('shows total stats bar', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText(/2 orgs/)).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/RuleBuilder.test.tsx
+++ b/apps/portal/src/pages/__tests__/RuleBuilder.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { RuleBuilder } from '../anomalies/RuleBuilder';
+
+const mockListRules = vi.fn();
+const mockCreateRule = vi.fn();
+const mockToggleRule = vi.fn();
+const mockDeleteRule = vi.fn();
+const mockListChannels = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/anomalies', () => ({
+  listRules: () => mockListRules(),
+  createRule: (...a: unknown[]) => mockCreateRule(...a),
+  toggleRule: (...a: unknown[]) => mockToggleRule(...a),
+  deleteRule: (...a: unknown[]) => mockDeleteRule(...a),
+  listChannels: () => mockListChannels(),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+const rules = [
+  { ruleId: 'builtin-1', name: 'Built-in Rule', description: 'Default', severity: 'high', enabled: true, builtin: true, condition: {} },
+  { ruleId: 'custom-1', name: 'Custom Rule', description: 'User-defined', severity: 'medium', enabled: true, builtin: false, condition: {} },
+];
+
+function r() { return render(<MemoryRouter><RuleBuilder /></MemoryRouter>); }
+
+describe('RuleBuilder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListRules.mockResolvedValue(rules);
+    mockListChannels.mockResolvedValue([]);
+  });
+
+  it('renders rules list', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Built-in Rule')).toBeInTheDocument());
+    expect(screen.getByText('Custom Rule')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no rules', async () => {
+    mockListRules.mockResolvedValue([]);
+    r();
+    await waitFor(() => expect(screen.getByText('No rules configured')).toBeInTheDocument());
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockListRules.mockRejectedValue(new Error('fail'));
+    mockListChannels.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load rules', 'error'));
+  });
+
+  it('has Create Rule button', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('+ Create Rule')).toBeInTheDocument());
+  });
+
+  it('separates built-in and custom rules', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText(/Built-in Rules/)).toBeInTheDocument());
+    expect(screen.getByText(/Custom Rules/)).toBeInTheDocument();
+  });
+
+  it('shows delete button only for custom rules', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Custom Rule')).toBeInTheDocument());
+    const deleteButtons = screen.getAllByRole('button', { name: 'Delete' });
+    expect(deleteButtons.length).toBe(1);
+  });
+
+  it('toggles rule enabled state', async () => {
+    mockToggleRule.mockResolvedValueOnce({ ...rules[1], enabled: false });
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Custom Rule')).toBeInTheDocument());
+    const toggleButtons = screen.getAllByTitle(/rule/);
+    await user.click(toggleButtons[0]!);
+    await waitFor(() => expect(mockToggleRule).toHaveBeenCalled());
+  });
+
+  it('displays severity badges', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('high')).toBeInTheDocument());
+    expect(screen.getByText('medium')).toBeInTheDocument();
+  });
+
+  it('has header with Anomaly Rules title', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Anomaly Rules')).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/ScimTokensPage.test.tsx
+++ b/apps/portal/src/pages/__tests__/ScimTokensPage.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ScimTokensPage } from '../settings/ScimTokensPage';
+
+const mockListScimTokens = vi.fn();
+const mockCreateScimToken = vi.fn();
+const mockDeleteScimToken = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/scim', () => ({
+  listScimTokens: () => mockListScimTokens(),
+  createScimToken: (...a: unknown[]) => mockCreateScimToken(...a),
+  deleteScimToken: (...a: unknown[]) => mockDeleteScimToken(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+const tokens = [
+  { id: 'st1', label: 'Okta Prod', createdAt: '2026-01-01T00:00:00Z', lastUsedAt: '2026-03-01T00:00:00Z' },
+  { id: 'st2', label: 'Azure AD', createdAt: '2026-02-01T00:00:00Z', lastUsedAt: null },
+];
+
+describe('ScimTokensPage', () => {
+  beforeEach(() => { vi.clearAllMocks(); mockListScimTokens.mockResolvedValue(tokens); });
+
+  it('renders token table', async () => {
+    render(<ScimTokensPage />);
+    await waitFor(() => expect(screen.getByText('Okta Prod')).toBeInTheDocument());
+    expect(screen.getByText('Azure AD')).toBeInTheDocument();
+  });
+
+  it('shows Never for unused tokens', async () => {
+    render(<ScimTokensPage />);
+    await waitFor(() => expect(screen.getByText('Never')).toBeInTheDocument());
+  });
+
+  it('shows empty state when no tokens', async () => {
+    mockListScimTokens.mockResolvedValue([]);
+    render(<ScimTokensPage />);
+    await waitFor(() => expect(screen.getByText('No SCIM tokens')).toBeInTheDocument());
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockListScimTokens.mockRejectedValue(new Error('fail'));
+    render(<ScimTokensPage />);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load SCIM tokens', 'error'));
+  });
+
+  it('has Create Token button', async () => {
+    render(<ScimTokensPage />);
+    await waitFor(() => expect(screen.getByText('SCIM Provisioning Tokens')).toBeInTheDocument());
+    expect(screen.getAllByText('Create Token').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('creates token and shows secret', async () => {
+    mockCreateScimToken.mockResolvedValueOnce({ id: 'st3', label: 'New', token: 'scim_secret_abc', createdAt: '2026-03-01T00:00:00Z', lastUsedAt: null });
+    const user = userEvent.setup();
+    render(<ScimTokensPage />);
+    await waitFor(() => expect(screen.getByText('SCIM Provisioning Tokens')).toBeInTheDocument());
+    await user.click(screen.getAllByText('Create Token')[0]!);
+    await waitFor(() => expect(screen.getByText('Create SCIM Token')).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText('e.g., Okta Production'), 'New');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+    await waitFor(() => expect(screen.getByText('SCIM Token Created')).toBeInTheDocument());
+    expect(screen.getByText('scim_secret_abc')).toBeInTheDocument();
+  });
+
+  it('has Revoke buttons', async () => {
+    render(<ScimTokensPage />);
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'Revoke' }).length).toBeGreaterThanOrEqual(1));
+  });
+
+  it('revokes token on confirm', async () => {
+    mockDeleteScimToken.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    render(<ScimTokensPage />);
+    await waitFor(() => expect(screen.getByText('Okta Prod')).toBeInTheDocument());
+    await user.click(screen.getAllByRole('button', { name: 'Revoke' })[0]!);
+    await waitFor(() => expect(screen.getByText('Revoke SCIM Token')).toBeInTheDocument());
+    const modal = screen.getByText('Revoke SCIM Token').closest('div[class*="fixed"]')!;
+    const btns = within(modal as HTMLElement).getAllByRole('button', { name: 'Revoke' });
+    await user.click(btns[btns.length - 1]!);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('SCIM token revoked', 'success'));
+  });
+
+  it('has About SCIM section', async () => {
+    render(<ScimTokensPage />);
+    await waitFor(() => expect(screen.getByText('About SCIM Provisioning')).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/SettingsPage.test.tsx
+++ b/apps/portal/src/pages/__tests__/SettingsPage.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SettingsPage } from '../settings/SettingsPage';
+
+const mockLogin = vi.fn();
+const mockShow = vi.fn();
+const mockRotateKey = vi.fn();
+const mockSetApiKey = vi.fn();
+const mockApiPatch = vi.fn();
+
+const developer = {
+  developerId: 'dev-1', name: 'Test Dev', email: 'dev@test.com',
+  mode: 'live' as const, plan: 'pro', fidoRequired: false,
+  fidoRpName: null, createdAt: '2026-01-01T00:00:00Z',
+};
+
+vi.mock('../../store/auth', () => ({
+  useAuth: () => ({ developer, apiKey: 'gx_live_xxx', login: mockLogin }),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('../../api/auth', () => ({ rotateKey: () => mockRotateKey() }));
+vi.mock('../../api/client', () => ({
+  setApiKey: (...a: unknown[]) => mockSetApiKey(...a),
+  api: { patch: (...a: unknown[]) => mockApiPatch(...a) },
+}));
+
+describe('SettingsPage', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('displays developer profile', () => {
+    render(<SettingsPage />);
+    expect(screen.getByText('dev-1')).toBeInTheDocument();
+    expect(screen.getByText('Test Dev')).toBeInTheDocument();
+    expect(screen.getByText('dev@test.com')).toBeInTheDocument();
+    expect(screen.getByText('live')).toBeInTheDocument();
+    expect(screen.getByText('pro')).toBeInTheDocument();
+  });
+
+  it('shows masked API key', () => {
+    render(<SettingsPage />);
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText('API Key')).toBeInTheDocument();
+  });
+
+  it('rotates API key successfully', async () => {
+    mockRotateKey.mockResolvedValueOnce({ apiKey: 'gx_live_new456' });
+    mockLogin.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+    await user.click(screen.getByRole('button', { name: 'Rotate Key' }));
+    await waitFor(() => expect(mockRotateKey).toHaveBeenCalled());
+    expect(mockShow).toHaveBeenCalledWith('API key rotated successfully', 'success');
+    expect(screen.getByText('gx_live_new456')).toBeInTheDocument();
+  });
+
+  it('shows error toast on rotate failure', async () => {
+    mockRotateKey.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+    await user.click(screen.getByRole('button', { name: 'Rotate Key' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to rotate API key', 'error'));
+  });
+
+  it('has FIDO2 toggle checkbox', () => {
+    render(<SettingsPage />);
+    expect(screen.getByText('FIDO2 / WebAuthn')).toBeInTheDocument();
+    expect(screen.getByText('Require FIDO2 for consent flows')).toBeInTheDocument();
+  });
+
+  it('saves FIDO2 settings', async () => {
+    mockApiPatch.mockResolvedValueOnce({});
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+    await user.click(screen.getByText('Require FIDO2 for consent flows'));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(mockApiPatch).toHaveBeenCalledWith('/v1/me', { fidoRequired: true, fidoRpName: '' }));
+    expect(mockShow).toHaveBeenCalledWith('FIDO2 settings saved', 'success');
+  });
+
+  it('shows error toast on FIDO2 save failure', async () => {
+    mockApiPatch.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to save FIDO2 settings', 'error'));
+  });
+
+  it('has Relying Party Name input', () => {
+    render(<SettingsPage />);
+    expect(screen.getByPlaceholderText('My Organization')).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/pages/__tests__/Signup.test.tsx
+++ b/apps/portal/src/pages/__tests__/Signup.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { Signup } from '../Signup';
+
+const mockLogin = vi.fn();
+const mockShow = vi.fn();
+const mockNavigate = vi.fn();
+const mockSignup = vi.fn();
+const mockSendVerificationEmail = vi.fn();
+const mockSetApiKey = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+vi.mock('../../store/auth', () => ({ useAuth: () => ({ login: mockLogin }) }));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+vi.mock('../../api/auth', () => ({
+  signup: (...a: unknown[]) => mockSignup(...a),
+  sendVerificationEmail: (...a: unknown[]) => mockSendVerificationEmail(...a),
+}));
+vi.mock('../../api/client', () => ({ setApiKey: (...a: unknown[]) => mockSetApiKey(...a) }));
+
+function renderSignup() {
+  return render(<MemoryRouter><Signup /></MemoryRouter>);
+}
+
+describe('Signup', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('renders the signup form', () => {
+    renderSignup();
+    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Email/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create Account' })).toBeInTheDocument();
+  });
+
+  it('has a link to login', () => {
+    renderSignup();
+    expect(screen.getByText('Sign in')).toHaveAttribute('href', '/dashboard/login');
+  });
+
+  it('disables submit when name is empty', () => {
+    renderSignup();
+    expect(screen.getByRole('button', { name: 'Create Account' })).toBeDisabled();
+  });
+
+  it('enables submit when name is provided', async () => {
+    const user = userEvent.setup();
+    renderSignup();
+    await user.type(screen.getByLabelText('Name'), 'Acme');
+    expect(screen.getByRole('button', { name: 'Create Account' })).toBeEnabled();
+  });
+
+  it('calls signup with name only', async () => {
+    mockSignup.mockResolvedValueOnce({ apiKey: 'gx_new' });
+    const user = userEvent.setup();
+    renderSignup();
+    await user.type(screen.getByLabelText('Name'), 'Acme');
+    await user.click(screen.getByRole('button', { name: 'Create Account' }));
+    await waitFor(() => expect(mockSignup).toHaveBeenCalledWith({ name: 'Acme' }));
+  });
+
+  it('calls signup with name and email', async () => {
+    mockSignup.mockResolvedValueOnce({ apiKey: 'gx_new' });
+    mockSendVerificationEmail.mockResolvedValueOnce({});
+    const user = userEvent.setup();
+    renderSignup();
+    await user.type(screen.getByLabelText('Name'), 'Acme');
+    await user.type(screen.getByLabelText(/Email/), 'a@b.com');
+    await user.click(screen.getByRole('button', { name: 'Create Account' }));
+    await waitFor(() => expect(mockSignup).toHaveBeenCalledWith({ name: 'Acme', email: 'a@b.com' }));
+  });
+
+  it('shows API key after successful signup', async () => {
+    mockSignup.mockResolvedValueOnce({ apiKey: 'gx_live_key123' });
+    const user = userEvent.setup();
+    renderSignup();
+    await user.type(screen.getByLabelText('Name'), 'Acme');
+    await user.click(screen.getByRole('button', { name: 'Create Account' }));
+    await waitFor(() => expect(screen.getByText('gx_live_key123')).toBeInTheDocument());
+    expect(screen.getByText('Account created')).toBeInTheDocument();
+    expect(screen.getByText(/Save your API key/)).toBeInTheDocument();
+  });
+
+  it('shows success toast', async () => {
+    mockSignup.mockResolvedValueOnce({ apiKey: 'gx_new' });
+    const user = userEvent.setup();
+    renderSignup();
+    await user.type(screen.getByLabelText('Name'), 'Acme');
+    await user.click(screen.getByRole('button', { name: 'Create Account' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Account created!', 'success'));
+  });
+
+  it('shows error toast on failure', async () => {
+    mockSignup.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    renderSignup();
+    await user.type(screen.getByLabelText('Name'), 'Acme');
+    await user.click(screen.getByRole('button', { name: 'Create Account' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to create account', 'error'));
+  });
+
+  it('Continue to Dashboard calls login and navigates', async () => {
+    mockSignup.mockResolvedValueOnce({ apiKey: 'gx_key' });
+    mockLogin.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    renderSignup();
+    await user.type(screen.getByLabelText('Name'), 'Acme');
+    await user.click(screen.getByRole('button', { name: 'Create Account' }));
+    await waitFor(() => expect(screen.getByText('Continue to Dashboard')).toBeInTheDocument());
+    await user.click(screen.getByText('Continue to Dashboard'));
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith('gx_key');
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+    });
+  });
+
+  it('shows error toast if continue fails', async () => {
+    mockSignup.mockResolvedValueOnce({ apiKey: 'gx_key' });
+    mockLogin.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    renderSignup();
+    await user.type(screen.getByLabelText('Name'), 'Acme');
+    await user.click(screen.getByRole('button', { name: 'Create Account' }));
+    await waitFor(() => expect(screen.getByText('Continue to Dashboard')).toBeInTheDocument());
+    await user.click(screen.getByText('Continue to Dashboard'));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to authenticate', 'error'));
+  });
+
+  it('shows verification email notice', async () => {
+    mockSignup.mockResolvedValueOnce({ apiKey: 'gx_key' });
+    mockSendVerificationEmail.mockResolvedValueOnce({});
+    const user = userEvent.setup();
+    renderSignup();
+    await user.type(screen.getByLabelText('Name'), 'Acme');
+    await user.type(screen.getByLabelText(/Email/), 'a@b.com');
+    await user.click(screen.getByRole('button', { name: 'Create Account' }));
+    await waitFor(() => expect(screen.getByText(/verification email has been sent/)).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/SsoConfigPage.test.tsx
+++ b/apps/portal/src/pages/__tests__/SsoConfigPage.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SsoConfigPage } from '../settings/SsoConfigPage';
+
+const mockListConnections = vi.fn();
+const mockCreateConnection = vi.fn();
+const mockDeleteConnection = vi.fn();
+const mockTestConnection = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/sso', () => ({
+  listSsoConnections: () => mockListConnections(),
+  createSsoConnection: (...a: unknown[]) => mockCreateConnection(...a),
+  deleteSsoConnection: (...a: unknown[]) => mockDeleteConnection(...a),
+  testSsoConnection: (...a: unknown[]) => mockTestConnection(...a),
+}));
+vi.mock('../../api/client', () => ({
+  ApiError: class extends Error { status: number; constructor(m: string, s: number) { super(m); this.status = s; } },
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+const connections = [
+  { id: 'sso1', name: 'Corporate Okta', protocol: 'oidc', status: 'active', domains: ['corp.com'], enforce: true, jitProvisioning: false, createdAt: '2026-01-01T00:00:00Z' },
+];
+
+describe('SsoConfigPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListConnections.mockResolvedValue({ connections });
+  });
+
+  it('renders SSO connections table', async () => {
+    render(<SsoConfigPage />);
+    await waitFor(() => expect(screen.getByText('Corporate Okta')).toBeInTheDocument());
+  });
+
+  it('displays protocol badge', async () => {
+    render(<SsoConfigPage />);
+    await waitFor(() => expect(screen.getByText('OIDC')).toBeInTheDocument());
+  });
+
+  it('displays status badge', async () => {
+    render(<SsoConfigPage />);
+    await waitFor(() => expect(screen.getByText('active')).toBeInTheDocument());
+  });
+
+  it('shows empty state when no connections', async () => {
+    mockListConnections.mockResolvedValue({ connections: [] });
+    render(<SsoConfigPage />);
+    await waitFor(() => expect(screen.getByText(/No SSO connections configured/)).toBeInTheDocument());
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockListConnections.mockRejectedValue(new Error('fail'));
+    render(<SsoConfigPage />);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load SSO connections', 'error'));
+  });
+
+  it('has Create Connection button', async () => {
+    render(<SsoConfigPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Create Connection' })).toBeInTheDocument());
+  });
+
+  it('opens create modal', async () => {
+    const user = userEvent.setup();
+    render(<SsoConfigPage />);
+    await waitFor(() => expect(screen.getByText('SSO Connections')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Create Connection' }));
+    await waitFor(() => expect(screen.getByText('Create SSO Connection')).toBeInTheDocument());
+  });
+
+  it('has Test and Delete buttons per connection', async () => {
+    render(<SsoConfigPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Test' })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('tests connection successfully', async () => {
+    mockTestConnection.mockResolvedValueOnce({ success: true });
+    const user = userEvent.setup();
+    render(<SsoConfigPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Test' })).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Test' }));
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Connection test passed', 'success'));
+  });
+
+  it('has About SSO section', async () => {
+    render(<SsoConfigPage />);
+    await waitFor(() => expect(screen.getByText('About SSO')).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/UsageDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/UsageDashboard.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UsageDashboard } from '../usage/UsageDashboard';
+
+const mockGetUsage = vi.fn();
+const mockGetUsageHistory = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/usage', () => ({
+  getUsage: () => mockGetUsage(),
+  getUsageHistory: (...a: unknown[]) => mockGetUsageHistory(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+const usage = {
+  developerId: 'd1', period: 'current',
+  tokenExchanges: 1500, authorizations: 200, verifications: 3000, totalRequests: 4700,
+};
+
+const history = {
+  entries: [
+    { date: '2026-03-01', tokenExchanges: 100, authorizations: 20, verifications: 200, totalRequests: 320 },
+    { date: '2026-03-02', tokenExchanges: 150, authorizations: 25, verifications: 250, totalRequests: 425 },
+  ],
+};
+
+function r() { return render(<UsageDashboard />); }
+
+describe('UsageDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUsage.mockResolvedValue(usage);
+    mockGetUsageHistory.mockResolvedValue(history);
+  });
+
+  it('renders usage stat cards', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Token Exchanges')).toBeInTheDocument());
+    expect(screen.getAllByText('Authorizations').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Verifications').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Total Requests').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('displays correct values', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('1,500')).toBeInTheDocument());
+    expect(screen.getByText('4,700')).toBeInTheDocument();
+  });
+
+  it('renders daily history table', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Daily History')).toBeInTheDocument());
+    expect(screen.getByText('Exchanges')).toBeInTheDocument();
+  });
+
+  it('has period selector buttons', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('7d')).toBeInTheDocument());
+    expect(screen.getByText('30d')).toBeInTheDocument();
+    expect(screen.getByText('90d')).toBeInTheDocument();
+  });
+
+  it('switches period on click', async () => {
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('7d')).toBeInTheDocument());
+    await user.click(screen.getByText('7d'));
+    await waitFor(() => expect(mockGetUsageHistory).toHaveBeenCalledWith(7));
+  });
+
+  it('shows empty state for no history', async () => {
+    mockGetUsageHistory.mockResolvedValue({ entries: [] });
+    r();
+    await waitFor(() => expect(screen.getByText('No usage data for this period')).toBeInTheDocument());
+  });
+
+  it('handles usage API failure', async () => {
+    mockGetUsage.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load usage data', 'error'));
+  });
+
+  it('handles history API failure', async () => {
+    mockGetUsageHistory.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load usage history', 'error'));
+  });
+});

--- a/apps/portal/src/pages/__tests__/WebAuthnList.test.tsx
+++ b/apps/portal/src/pages/__tests__/WebAuthnList.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { WebAuthnList } from '../webauthn/WebAuthnList';
+
+describe('WebAuthnList', () => {
+  it('renders page title', () => {
+    render(<WebAuthnList />);
+    expect(screen.getByText('WebAuthn')).toBeInTheDocument();
+  });
+
+  it('shows empty state', () => {
+    render(<WebAuthnList />);
+    expect(screen.getByText('No WebAuthn credentials')).toBeInTheDocument();
+    expect(screen.getByText(/Register a passkey or security key/)).toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/pages/__tests__/WebhookDeliveries.test.tsx
+++ b/apps/portal/src/pages/__tests__/WebhookDeliveries.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { WebhookDeliveries } from '../webhooks/WebhookDeliveries';
 

--- a/apps/portal/src/pages/__tests__/WebhookDeliveries.test.tsx
+++ b/apps/portal/src/pages/__tests__/WebhookDeliveries.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { WebhookDeliveries } from '../webhooks/WebhookDeliveries';
+
+const mockListDeliveries = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/webhooks', () => ({
+  listDeliveries: (...a: unknown[]) => mockListDeliveries(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+const deliveries = [
+  { id: 'del1', eventType: 'grant.created', status: 'delivered', attempts: 1, maxAttempts: 3, lastError: null, createdAt: '2026-01-01T00:00:00Z' },
+  { id: 'del2', eventType: 'grant.revoked', status: 'failed', attempts: 3, maxAttempts: 3, lastError: 'Connection refused', createdAt: '2026-01-02T00:00:00Z' },
+  { id: 'del3', eventType: 'token.issued', status: 'pending', attempts: 1, maxAttempts: 3, lastError: null, createdAt: '2026-01-03T00:00:00Z' },
+];
+
+function r() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard/webhooks/wh1/deliveries']}>
+      <Routes><Route path="/dashboard/webhooks/:id/deliveries" element={<WebhookDeliveries />} /></Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('WebhookDeliveries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListDeliveries.mockResolvedValue({ deliveries, total: 3 });
+  });
+
+  it('renders deliveries table', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Deliveries')).toBeInTheDocument());
+  });
+
+  it('shows delivery status badges', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('delivered')).toBeInTheDocument());
+    expect(screen.getByText('failed')).toBeInTheDocument();
+    expect(screen.getByText('pending')).toBeInTheDocument();
+  });
+
+  it('shows event types', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('grant.created')).toBeInTheDocument());
+    expect(screen.getByText('grant.revoked')).toBeInTheDocument();
+    expect(screen.getByText('token.issued')).toBeInTheDocument();
+  });
+
+  it('shows error messages for failed deliveries', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Connection refused')).toBeInTheDocument());
+  });
+
+  it('shows attempt counts', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('1/3')).toBeInTheDocument());
+    expect(screen.getByText('3/3')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no deliveries', async () => {
+    mockListDeliveries.mockResolvedValue({ deliveries: [], total: 0 });
+    r();
+    await waitFor(() => expect(screen.getByText('No deliveries')).toBeInTheDocument());
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockListDeliveries.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load deliveries', 'error'));
+  });
+
+  it('has status filter buttons', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('All')).toBeInTheDocument());
+    expect(screen.getByText('delivered')).toBeInTheDocument();
+    expect(screen.getByText('pending')).toBeInTheDocument();
+    expect(screen.getByText('failed')).toBeInTheDocument();
+  });
+
+  it('has back link to webhooks', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Webhooks')).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/pages/__tests__/WebhookList.test.tsx
+++ b/apps/portal/src/pages/__tests__/WebhookList.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { WebhookList } from '../webhooks/WebhookList';
+
+const mockListWebhooks = vi.fn();
+const mockCreateWebhook = vi.fn();
+const mockDeleteWebhook = vi.fn();
+const mockShow = vi.fn();
+
+vi.mock('../../api/webhooks', () => ({
+  listWebhooks: () => mockListWebhooks(),
+  createWebhook: (...a: unknown[]) => mockCreateWebhook(...a),
+  deleteWebhook: (...a: unknown[]) => mockDeleteWebhook(...a),
+}));
+vi.mock('../../store/toast', () => ({ useToast: () => ({ show: mockShow }) }));
+
+const webhooks = [
+  { id: 'w1', url: 'https://example.com/hook', events: ['grant.created', 'grant.revoked'], createdAt: '2026-01-01T00:00:00Z' },
+];
+
+function r() { return render(<MemoryRouter><WebhookList /></MemoryRouter>); }
+
+describe('WebhookList', () => {
+  beforeEach(() => { vi.clearAllMocks(); mockListWebhooks.mockResolvedValue(webhooks); });
+
+  it('renders webhook table', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('https://example.com/hook')).toBeInTheDocument());
+  });
+
+  it('shows empty state when no webhooks', async () => {
+    mockListWebhooks.mockResolvedValue([]);
+    r();
+    await waitFor(() => expect(screen.getByText('No webhooks yet')).toBeInTheDocument());
+  });
+
+  it('has Add Endpoint button', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText('Webhooks')).toBeInTheDocument());
+    expect(screen.getAllByText('Add Endpoint').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('opens create modal on Add click', async () => {
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Webhooks')).toBeInTheDocument());
+    await user.click(screen.getAllByText('Add Endpoint')[0]!);
+    await waitFor(() => expect(screen.getByText('Add Webhook Endpoint')).toBeInTheDocument());
+    expect(screen.getByText('Endpoint URL')).toBeInTheDocument();
+    expect(screen.getByText('grant.created')).toBeInTheDocument();
+  });
+
+  it('creates webhook and shows secret', async () => {
+    mockCreateWebhook.mockResolvedValueOnce({ id: 'w2', url: 'https://new.com/hook', events: ['grant.created'], secret: 'sec_123', createdAt: '2026-01-01T00:00:00Z' });
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('Webhooks')).toBeInTheDocument());
+    await user.click(screen.getAllByText('Add Endpoint')[0]!);
+    await waitFor(() => expect(screen.getByText('Add Webhook Endpoint')).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText('https://example.com/webhook'), 'https://new.com/hook');
+    await user.click(screen.getByText('grant.created'));
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+    await waitFor(() => expect(screen.getByText('Webhook Created')).toBeInTheDocument());
+    expect(screen.getByText('sec_123')).toBeInTheDocument();
+  });
+
+  it('shows error toast on load failure', async () => {
+    mockListWebhooks.mockRejectedValue(new Error('fail'));
+    r();
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to load webhooks', 'error'));
+  });
+
+  it('deletes webhook on confirm', async () => {
+    mockDeleteWebhook.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    r();
+    await waitFor(() => expect(screen.getByText('https://example.com/hook')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => expect(screen.getByText('Delete Webhook')).toBeInTheDocument());
+    const modal = screen.getByText('Delete Webhook').closest('div[class*="fixed"]')!;
+    const btns = within(modal as HTMLElement).getAllByRole('button', { name: 'Delete' });
+    await user.click(btns[btns.length - 1]!);
+    await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Webhook deleted', 'success'));
+  });
+
+  it('displays events for each webhook', async () => {
+    r();
+    await waitFor(() => expect(screen.getByText(/grant.created, grant.revoked/)).toBeInTheDocument());
+  });
+});

--- a/apps/portal/src/store/__tests__/auth.test.tsx
+++ b/apps/portal/src/store/__tests__/auth.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AuthProvider, useAuth } from '../auth';
+
+// Mock the API modules
+const mockSetApiKey = vi.fn();
+const mockGetMe = vi.fn();
+
+vi.mock('../../api/client', () => ({
+  setApiKey: (...args: unknown[]) => mockSetApiKey(...args),
+}));
+
+vi.mock('../../api/auth', () => ({
+  getMe: () => mockGetMe(),
+}));
+
+const mockDeveloper = {
+  developerId: 'dev-123',
+  name: 'Test Developer',
+  email: 'test@example.com',
+  mode: 'live' as const,
+  plan: 'pro',
+  fidoRequired: false,
+  fidoRpName: null,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+// Test harness component that exposes auth state
+function AuthTestHarness() {
+  const { apiKey, developer, loading, login, logout } = useAuth();
+  return (
+    <div>
+      <div data-testid="api-key">{apiKey ?? 'null'}</div>
+      <div data-testid="developer-name">{developer?.name ?? 'null'}</div>
+      <div data-testid="loading">{loading ? 'true' : 'false'}</div>
+      <button onClick={() => login('gx_live_test123')}>Login</button>
+      <button onClick={logout}>Logout</button>
+    </div>
+  );
+}
+
+function renderAuthHarness() {
+  return render(
+    <AuthProvider>
+      <AuthTestHarness />
+    </AuthProvider>,
+  );
+}
+
+describe('Auth store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  it('starts with null apiKey and developer when no stored session', async () => {
+    mockGetMe.mockResolvedValue(mockDeveloper);
+    renderAuthHarness();
+    // Wait for any effects to settle
+    await waitFor(() => {
+      expect(screen.getByTestId('api-key')).toHaveTextContent('null');
+      expect(screen.getByTestId('developer-name')).toHaveTextContent('null');
+    });
+  });
+
+  it('starts with loading false when no stored session', () => {
+    renderAuthHarness();
+    expect(screen.getByTestId('loading')).toHaveTextContent('false');
+  });
+
+  it('sets apiKey, fetches developer, and stores session on login', async () => {
+    mockGetMe.mockResolvedValue(mockDeveloper);
+    const user = userEvent.setup();
+    renderAuthHarness();
+
+    await user.click(screen.getByText('Login'));
+
+    await waitFor(() => {
+      expect(mockSetApiKey).toHaveBeenCalledWith('gx_live_test123');
+      expect(mockGetMe).toHaveBeenCalled();
+      expect(screen.getByTestId('api-key')).toHaveTextContent('gx_live_test123');
+      expect(screen.getByTestId('developer-name')).toHaveTextContent('Test Developer');
+    });
+
+    expect(sessionStorage.getItem('grantex_api_key')).toBe('gx_live_test123');
+  });
+
+  it('clears everything on logout', async () => {
+    mockGetMe.mockResolvedValue(mockDeveloper);
+    const user = userEvent.setup();
+    renderAuthHarness();
+
+    // Login first
+    await user.click(screen.getByText('Login'));
+    await waitFor(() => {
+      expect(screen.getByTestId('developer-name')).toHaveTextContent('Test Developer');
+    });
+
+    // Now logout
+    await user.click(screen.getByText('Logout'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('api-key')).toHaveTextContent('null');
+      expect(screen.getByTestId('developer-name')).toHaveTextContent('null');
+    });
+
+    expect(sessionStorage.getItem('grantex_api_key')).toBeNull();
+    expect(mockSetApiKey).toHaveBeenCalledWith(null);
+  });
+
+  it('restores session on mount when API key is stored', async () => {
+    sessionStorage.setItem('grantex_api_key', 'gx_live_stored');
+    mockGetMe.mockResolvedValue(mockDeveloper);
+
+    renderAuthHarness();
+
+    // loading should start as true
+    expect(screen.getByTestId('loading')).toHaveTextContent('true');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading')).toHaveTextContent('false');
+      expect(screen.getByTestId('developer-name')).toHaveTextContent('Test Developer');
+    });
+
+    expect(mockSetApiKey).toHaveBeenCalledWith('gx_live_stored');
+    expect(mockGetMe).toHaveBeenCalled();
+  });
+
+  it('clears session when getMe fails during restore', async () => {
+    sessionStorage.setItem('grantex_api_key', 'gx_live_invalid');
+    mockGetMe.mockRejectedValue(new Error('Unauthorized'));
+
+    renderAuthHarness();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading')).toHaveTextContent('false');
+      expect(screen.getByTestId('api-key')).toHaveTextContent('null');
+      expect(screen.getByTestId('developer-name')).toHaveTextContent('null');
+    });
+
+    expect(sessionStorage.getItem('grantex_api_key')).toBeNull();
+  });
+
+  it('handles login failure by propagating error', async () => {
+    mockGetMe.mockRejectedValue(new Error('Invalid API key'));
+    const user = userEvent.setup();
+
+    // We need a component that catches the error
+    function ErrorCatcher() {
+      const { login } = useAuth();
+      const [error, setError] = vi.importActual<typeof import('react')>('react').then ? null : null;
+      return null;
+    }
+
+    // Just verify the mock rejects - the login function propagates errors
+    renderAuthHarness();
+    // The login call will reject, but the component doesn't catch it in this harness
+    // The key behavior is that getMe is called with the right key
+    await user.click(screen.getByText('Login'));
+    await waitFor(() => {
+      expect(mockSetApiKey).toHaveBeenCalledWith('gx_live_test123');
+      expect(mockGetMe).toHaveBeenCalled();
+    });
+  });
+
+  it('throws error when useAuth is used outside AuthProvider', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(<AuthTestHarness />)).toThrow('useAuth must be used within AuthProvider');
+  });
+});

--- a/apps/portal/src/store/__tests__/auth.test.tsx
+++ b/apps/portal/src/store/__tests__/auth.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AuthProvider, useAuth } from '../auth';
 
@@ -145,13 +145,6 @@ describe('Auth store', () => {
   it('handles login failure by propagating error', async () => {
     mockGetMe.mockRejectedValue(new Error('Invalid API key'));
     const user = userEvent.setup();
-
-    // We need a component that catches the error
-    function ErrorCatcher() {
-      const { login } = useAuth();
-      const [error, setError] = vi.importActual<typeof import('react')>('react').then ? null : null;
-      return null;
-    }
 
     // Just verify the mock rejects - the login function propagates errors
     renderAuthHarness();

--- a/apps/portal/src/store/__tests__/toast.test.tsx
+++ b/apps/portal/src/store/__tests__/toast.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ToastProvider, useToast } from '../toast';
+
+// Helper component that exposes the toast API for testing
+function ToastTestHarness() {
+  const { toasts, show, dismiss } = useToast();
+  return (
+    <div>
+      <button onClick={() => show('Info toast')}>Show Info</button>
+      <button onClick={() => show('Success!', 'success')}>Show Success</button>
+      <button onClick={() => show('Error!', 'error')}>Show Error</button>
+      <div data-testid="toast-count">{toasts.length}</div>
+      {toasts.map((t) => (
+        <div key={t.id} data-testid={`toast-${t.id}`}>
+          <span data-testid={`toast-msg-${t.id}`}>{t.message}</span>
+          <span data-testid={`toast-type-${t.id}`}>{t.type}</span>
+          <button onClick={() => dismiss(t.id)}>Dismiss {t.id}</button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function renderToastHarness() {
+  return render(
+    <ToastProvider>
+      <ToastTestHarness />
+    </ToastProvider>,
+  );
+}
+
+describe('Toast store', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts with no toasts', () => {
+    renderToastHarness();
+    expect(screen.getByTestId('toast-count')).toHaveTextContent('0');
+  });
+
+  it('adds a toast when show is called', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderToastHarness();
+    await user.click(screen.getByText('Show Info'));
+    expect(screen.getByTestId('toast-count')).toHaveTextContent('1');
+  });
+
+  it('toast defaults to info type', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderToastHarness();
+    await user.click(screen.getByText('Show Info'));
+    // Find the toast type element
+    const toasts = screen.getAllByTestId(/^toast-type-/);
+    expect(toasts[0]).toHaveTextContent('info');
+  });
+
+  it('supports success type', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderToastHarness();
+    await user.click(screen.getByText('Show Success'));
+    const toasts = screen.getAllByTestId(/^toast-type-/);
+    expect(toasts[0]).toHaveTextContent('success');
+  });
+
+  it('supports error type', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderToastHarness();
+    await user.click(screen.getByText('Show Error'));
+    const toasts = screen.getAllByTestId(/^toast-type-/);
+    expect(toasts[0]).toHaveTextContent('error');
+  });
+
+  it('dismisses a toast when dismiss is called', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderToastHarness();
+    await user.click(screen.getByText('Show Info'));
+    expect(screen.getByTestId('toast-count')).toHaveTextContent('1');
+
+    // Find and click the dismiss button
+    const dismissBtns = screen.getAllByText(/^Dismiss /);
+    await user.click(dismissBtns[0]!);
+
+    expect(screen.getByTestId('toast-count')).toHaveTextContent('0');
+  });
+
+  it('auto-dismisses toast after 4 seconds', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderToastHarness();
+    await user.click(screen.getByText('Show Info'));
+    expect(screen.getByTestId('toast-count')).toHaveTextContent('1');
+
+    act(() => {
+      vi.advanceTimersByTime(4100);
+    });
+
+    expect(screen.getByTestId('toast-count')).toHaveTextContent('0');
+  });
+
+  it('can show multiple toasts simultaneously', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderToastHarness();
+    await user.click(screen.getByText('Show Info'));
+    await user.click(screen.getByText('Show Success'));
+    await user.click(screen.getByText('Show Error'));
+    expect(screen.getByTestId('toast-count')).toHaveTextContent('3');
+  });
+
+  it('preserves other toasts when one is dismissed', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderToastHarness();
+    await user.click(screen.getByText('Show Info'));
+    await user.click(screen.getByText('Show Success'));
+    expect(screen.getByTestId('toast-count')).toHaveTextContent('2');
+
+    // Dismiss first toast
+    const dismissBtns = screen.getAllByText(/^Dismiss /);
+    await user.click(dismissBtns[0]!);
+
+    expect(screen.getByTestId('toast-count')).toHaveTextContent('1');
+  });
+
+  it('stores correct message in toast', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderToastHarness();
+    await user.click(screen.getByText('Show Info'));
+    const msgs = screen.getAllByTestId(/^toast-msg-/);
+    expect(msgs[0]).toHaveTextContent('Info toast');
+  });
+
+  it('throws error when useToast is used outside ToastProvider', () => {
+    // Suppress console.error for this test
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(<ToastTestHarness />)).toThrow('useToast must be used within ToastProvider');
+  });
+});

--- a/apps/portal/src/store/__tests__/toast.test.tsx
+++ b/apps/portal/src/store/__tests__/toast.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import { ToastProvider, useToast } from '../toast';
 
 // Helper component that exposes the toast API for testing
@@ -45,55 +44,47 @@ describe('Toast store', () => {
     expect(screen.getByTestId('toast-count')).toHaveTextContent('0');
   });
 
-  it('adds a toast when show is called', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  it('adds a toast when show is called', () => {
     renderToastHarness();
-    await user.click(screen.getByText('Show Info'));
+    fireEvent.click(screen.getByText('Show Info'));
     expect(screen.getByTestId('toast-count')).toHaveTextContent('1');
   });
 
-  it('toast defaults to info type', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  it('toast defaults to info type', () => {
     renderToastHarness();
-    await user.click(screen.getByText('Show Info'));
-    // Find the toast type element
+    fireEvent.click(screen.getByText('Show Info'));
     const toasts = screen.getAllByTestId(/^toast-type-/);
     expect(toasts[0]).toHaveTextContent('info');
   });
 
-  it('supports success type', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  it('supports success type', () => {
     renderToastHarness();
-    await user.click(screen.getByText('Show Success'));
+    fireEvent.click(screen.getByText('Show Success'));
     const toasts = screen.getAllByTestId(/^toast-type-/);
     expect(toasts[0]).toHaveTextContent('success');
   });
 
-  it('supports error type', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  it('supports error type', () => {
     renderToastHarness();
-    await user.click(screen.getByText('Show Error'));
+    fireEvent.click(screen.getByText('Show Error'));
     const toasts = screen.getAllByTestId(/^toast-type-/);
     expect(toasts[0]).toHaveTextContent('error');
   });
 
-  it('dismisses a toast when dismiss is called', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  it('dismisses a toast when dismiss is called', () => {
     renderToastHarness();
-    await user.click(screen.getByText('Show Info'));
+    fireEvent.click(screen.getByText('Show Info'));
     expect(screen.getByTestId('toast-count')).toHaveTextContent('1');
 
-    // Find and click the dismiss button
     const dismissBtns = screen.getAllByText(/^Dismiss /);
-    await user.click(dismissBtns[0]!);
+    fireEvent.click(dismissBtns[0]!);
 
     expect(screen.getByTestId('toast-count')).toHaveTextContent('0');
   });
 
-  it('auto-dismisses toast after 4 seconds', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  it('auto-dismisses toast after 4 seconds', () => {
     renderToastHarness();
-    await user.click(screen.getByText('Show Info'));
+    fireEvent.click(screen.getByText('Show Info'));
     expect(screen.getByTestId('toast-count')).toHaveTextContent('1');
 
     act(() => {
@@ -103,39 +94,34 @@ describe('Toast store', () => {
     expect(screen.getByTestId('toast-count')).toHaveTextContent('0');
   });
 
-  it('can show multiple toasts simultaneously', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  it('can show multiple toasts simultaneously', () => {
     renderToastHarness();
-    await user.click(screen.getByText('Show Info'));
-    await user.click(screen.getByText('Show Success'));
-    await user.click(screen.getByText('Show Error'));
+    fireEvent.click(screen.getByText('Show Info'));
+    fireEvent.click(screen.getByText('Show Success'));
+    fireEvent.click(screen.getByText('Show Error'));
     expect(screen.getByTestId('toast-count')).toHaveTextContent('3');
   });
 
-  it('preserves other toasts when one is dismissed', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  it('preserves other toasts when one is dismissed', () => {
     renderToastHarness();
-    await user.click(screen.getByText('Show Info'));
-    await user.click(screen.getByText('Show Success'));
+    fireEvent.click(screen.getByText('Show Info'));
+    fireEvent.click(screen.getByText('Show Success'));
     expect(screen.getByTestId('toast-count')).toHaveTextContent('2');
 
-    // Dismiss first toast
     const dismissBtns = screen.getAllByText(/^Dismiss /);
-    await user.click(dismissBtns[0]!);
+    fireEvent.click(dismissBtns[0]!);
 
     expect(screen.getByTestId('toast-count')).toHaveTextContent('1');
   });
 
-  it('stores correct message in toast', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  it('stores correct message in toast', () => {
     renderToastHarness();
-    await user.click(screen.getByText('Show Info'));
+    fireEvent.click(screen.getByText('Show Info'));
     const msgs = screen.getAllByTestId(/^toast-msg-/);
     expect(msgs[0]).toHaveTextContent('Info toast');
   });
 
   it('throws error when useToast is used outside ToastProvider', () => {
-    // Suppress console.error for this test
     vi.spyOn(console, 'error').mockImplementation(() => {});
     expect(() => render(<ToastTestHarness />)).toThrow('useToast must be used within ToastProvider');
   });

--- a/apps/portal/src/test-setup.ts
+++ b/apps/portal/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/apps/portal/vitest.config.ts
+++ b/apps/portal/vitest.config.ts
@@ -1,20 +1,18 @@
-import { defineConfig, mergeConfig } from 'vitest/config';
-import viteConfig from './vite.config';
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
 
-export default mergeConfig(
-  viteConfig,
-  defineConfig({
-    test: {
-      globals: true,
-      environment: 'jsdom',
-      setupFiles: ['./src/test-setup.ts'],
-      include: ['src/**/*.test.{ts,tsx}'],
-      css: false,
-      coverage: {
-        provider: 'v8',
-        include: ['src/components/**', 'src/store/**'],
-        exclude: ['src/**/__tests__/**'],
-      },
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/test-setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+    css: false,
+    coverage: {
+      provider: 'v8',
+      include: ['src/components/**', 'src/store/**'],
+      exclude: ['src/**/__tests__/**'],
     },
-  }),
-);
+  },
+});

--- a/apps/portal/vitest.config.ts
+++ b/apps/portal/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config';
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: ['./src/test-setup.ts'],
+      include: ['src/**/*.test.{ts,tsx}'],
+      css: false,
+      coverage: {
+        provider: 'v8',
+        include: ['src/components/**', 'src/store/**'],
+        exclude: ['src/**/__tests__/**'],
+      },
+    },
+  }),
+);

--- a/packages/dpdp/src/purpose/purpose-enforcer.ts
+++ b/packages/dpdp/src/purpose/purpose-enforcer.ts
@@ -8,7 +8,7 @@
 
 import type { DPDPConsentRecord } from '../types.js';
 import type { PurposeRegistry } from './purpose-registry.js';
-import { PurposeViolationError, ConsentRequiredError, DpdpError } from '../errors.js';
+import { PurposeViolationError, DpdpError } from '../errors.js';
 
 /**
  * Enforce that a grant's scopes satisfy a named purpose.

--- a/packages/dpdp/tests/consent-record.test.ts
+++ b/packages/dpdp/tests/consent-record.test.ts
@@ -50,14 +50,6 @@ function mockFetchSuccess(data: unknown) {
   });
 }
 
-function mockFetchError(status: number, message: string) {
-  return vi.fn().mockResolvedValue({
-    ok: false,
-    status,
-    json: () => Promise.resolve({ message }),
-  });
-}
-
 function makeOptions(overrides?: Partial<CreateConsentRecordOptions>): CreateConsentRecordOptions {
   return {
     grantId: 'grant_abc',
@@ -206,7 +198,7 @@ describe('consent-record', () => {
 
     vi.stubGlobal('fetch', mockFetchSuccess(serverResponse));
 
-    const record = await createConsentRecord(
+    await createConsentRecord(
       makeOptions({ consentNoticeContent: noticeContent }),
     );
 

--- a/packages/dpdp/tests/exports.test.ts
+++ b/packages/dpdp/tests/exports.test.ts
@@ -5,9 +5,8 @@ import {
   requestEuAiActExport,
   getExportStatus,
   EU_AI_ACT_ARTICLES,
-  ExportError,
 } from '../src/index.js';
-import type { ComplianceExportRequest, ComplianceExportResult } from '../src/index.js';
+import type { ComplianceExportRequest } from '../src/index.js';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/dpdp/tests/security.test.ts
+++ b/packages/dpdp/tests/security.test.ts
@@ -4,7 +4,6 @@ import {
   computeNoticeHash,
   ConsentRegistry,
   withdrawConsent,
-  WithdrawalError,
 } from '../src/index.js';
 import type { DPDPConsentRecord } from '../src/index.js';
 

--- a/packages/dpdp/tests/withdrawal.test.ts
+++ b/packages/dpdp/tests/withdrawal.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   withdrawConsent,
   ConsentRegistry,
-  WithdrawalError,
   checkPurposeCompliance,
 } from '../src/index.js';
 import type { DPDPConsentRecord } from '../src/index.js';

--- a/packages/gemma/tests/offline-audit-log.test.ts
+++ b/packages/gemma/tests/offline-audit-log.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { generateKeyPairSync } from 'node:crypto';

--- a/packages/gemma/tests/offline-verifier.test.ts
+++ b/packages/gemma/tests/offline-verifier.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import * as jose from 'jose';
 import { createOfflineVerifier } from '../src/verifier/offline-verifier.js';
 import type { JWKSSnapshot } from '../src/verifier/jwks-cache.js';

--- a/packages/gemma/tests/security.test.ts
+++ b/packages/gemma/tests/security.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { generateKeyPairSync } from 'node:crypto';
 import { createOfflineVerifier } from '../src/verifier/offline-verifier.js';
 import { createOfflineAuditLog, verifyEntrySignature } from '../src/audit/offline-audit-log.js';
-import { verifyChain, GENESIS_HASH, computeEntryHash } from '../src/audit/hash-chain.js';
+import { verifyChain, computeEntryHash } from '../src/audit/hash-chain.js';
 import { storeBundle, loadBundle } from '../src/consent/bundle-storage.js';
 import type { JWKSSnapshot } from '../src/verifier/jwks-cache.js';
 import type { ConsentBundle } from '../src/consent/consent-bundle.js';

--- a/packages/sdk-py/tests/test_domains.py
+++ b/packages/sdk-py/tests/test_domains.py
@@ -1,19 +1,25 @@
-"""Tests for DomainsClient."""
+"""Tests for DomainsClient — create, list, verify, delete."""
 from __future__ import annotations
+
+import json
 
 import pytest
 import respx
 import httpx
 
 from grantex import Grantex
+from grantex._errors import GrantexApiError
+from grantex.resources._domains import CreateDomainParams
 
+
+BASE_URL = "https://api.grantex.dev"
 
 MOCK_DOMAIN_CREATE = {
     "id": "dom_01",
     "domain": "example.com",
     "verified": False,
-    "verificationToken": "gx-verify-abc123",
-    "instructions": "Add a TXT record with value gx-verify-abc123 to _grantex.example.com",
+    "verificationToken": "grantex-verify-abc123",
+    "instructions": "Add a DNS TXT record: _grantex.example.com = grantex-verify-abc123",
 }
 
 MOCK_DOMAIN_ENTRY = {
@@ -24,7 +30,16 @@ MOCK_DOMAIN_ENTRY = {
     "createdAt": "2024-06-01T10:00:00Z",
 }
 
-MOCK_VERIFY_RESPONSE = {"verified": True, "message": "Domain verified successfully"}
+MOCK_DOMAIN_ENTRY_UNVERIFIED = {
+    "id": "dom_02",
+    "domain": "staging.example.com",
+    "verified": False,
+    "verifiedAt": None,
+    "createdAt": "2024-06-02T10:00:00Z",
+}
+
+MOCK_VERIFY_SUCCESS = {"verified": True, "message": "Domain verified successfully"}
+MOCK_VERIFY_FAILURE = {"verified": False, "message": "DNS verification failed. Ensure TXT record is set."}
 
 
 @pytest.fixture
@@ -32,32 +47,77 @@ def client() -> Grantex:
     return Grantex(api_key="test-key")
 
 
+# ── Create Domain ─────────────────────────────────────────────────────────
+
 @respx.mock
 def test_create_domain(client: Grantex) -> None:
-    import json
-
-    route = respx.post("https://api.grantex.dev/v1/domains").mock(
+    route = respx.post(f"{BASE_URL}/v1/domains").mock(
         return_value=httpx.Response(200, json=MOCK_DOMAIN_CREATE)
     )
-    from grantex.resources._domains import CreateDomainParams
-
     result = client.domains.create(CreateDomainParams(domain="example.com"))
+
     assert result.id == "dom_01"
     assert result.domain == "example.com"
     assert result.verified is False
-    assert result.verification_token == "gx-verify-abc123"
+    assert result.verification_token == "grantex-verify-abc123"
     assert "TXT record" in result.instructions
+    assert "example.com" in result.instructions
 
     body = json.loads(route.calls[0].request.content)
     assert body["domain"] == "example.com"
 
 
 @respx.mock
+def test_create_domain_sends_correct_body(client: Grantex) -> None:
+    route = respx.post(f"{BASE_URL}/v1/domains").mock(
+        return_value=httpx.Response(200, json=MOCK_DOMAIN_CREATE)
+    )
+    client.domains.create(CreateDomainParams(domain="api.mysite.io"))
+
+    body = json.loads(route.calls[0].request.content)
+    assert body == {"domain": "api.mysite.io"}
+
+
+@respx.mock
+def test_create_domain_plan_limit_error(client: Grantex) -> None:
+    respx.post(f"{BASE_URL}/v1/domains").mock(
+        return_value=httpx.Response(
+            402,
+            json={
+                "message": "Custom domains require Enterprise plan",
+                "code": "PLAN_LIMIT_EXCEEDED",
+            },
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.domains.create(CreateDomainParams(domain="premium.example.com"))
+    assert exc_info.value.status_code == 402
+    assert exc_info.value.code == "PLAN_LIMIT_EXCEEDED"
+
+
+@respx.mock
+def test_create_domain_conflict_error(client: Grantex) -> None:
+    respx.post(f"{BASE_URL}/v1/domains").mock(
+        return_value=httpx.Response(
+            409,
+            json={"message": "Domain already registered", "code": "CONFLICT"},
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.domains.create(CreateDomainParams(domain="duplicate.example.com"))
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.code == "CONFLICT"
+
+
+# ── List Domains ──────────────────────────────────────────────────────────
+
+@respx.mock
 def test_list_domains(client: Grantex) -> None:
-    respx.get("https://api.grantex.dev/v1/domains").mock(
+    respx.get(f"{BASE_URL}/v1/domains").mock(
         return_value=httpx.Response(200, json={"domains": [MOCK_DOMAIN_ENTRY]})
     )
     result = client.domains.list()
+
     assert len(result.domains) == 1
     assert result.domains[0].id == "dom_01"
     assert result.domains[0].domain == "example.com"
@@ -67,39 +127,122 @@ def test_list_domains(client: Grantex) -> None:
 
 
 @respx.mock
+def test_list_domains_multiple(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/domains").mock(
+        return_value=httpx.Response(
+            200, json={"domains": [MOCK_DOMAIN_ENTRY, MOCK_DOMAIN_ENTRY_UNVERIFIED]}
+        )
+    )
+    result = client.domains.list()
+
+    assert len(result.domains) == 2
+    assert result.domains[0].verified is True
+    assert result.domains[1].verified is False
+    assert result.domains[1].verified_at is None
+    assert result.domains[1].domain == "staging.example.com"
+
+
+@respx.mock
 def test_list_domains_empty(client: Grantex) -> None:
-    respx.get("https://api.grantex.dev/v1/domains").mock(
+    respx.get(f"{BASE_URL}/v1/domains").mock(
         return_value=httpx.Response(200, json={"domains": []})
     )
     result = client.domains.list()
     assert len(result.domains) == 0
 
 
+# ── Verify Domain ────────────────────────────────────────────────────────
+
 @respx.mock
 def test_verify_domain_success(client: Grantex) -> None:
-    respx.post("https://api.grantex.dev/v1/domains/dom_01/verify").mock(
-        return_value=httpx.Response(200, json=MOCK_VERIFY_RESPONSE)
+    respx.post(f"{BASE_URL}/v1/domains/dom_01/verify").mock(
+        return_value=httpx.Response(200, json=MOCK_VERIFY_SUCCESS)
     )
     result = client.domains.verify("dom_01")
+
     assert result.verified is True
     assert result.message == "Domain verified successfully"
 
 
 @respx.mock
-def test_verify_domain_not_verified(client: Grantex) -> None:
-    respx.post("https://api.grantex.dev/v1/domains/dom_01/verify").mock(
+def test_verify_domain_failure(client: Grantex) -> None:
+    respx.post(f"{BASE_URL}/v1/domains/dom_01/verify").mock(
         return_value=httpx.Response(
-            200, json={"verified": False, "message": "TXT record not found"}
+            400,
+            json={
+                "message": "DNS verification failed. Ensure TXT record is set.",
+                "code": "VERIFICATION_FAILED",
+            },
         )
     )
-    result = client.domains.verify("dom_01")
-    assert result.verified is False
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.domains.verify("dom_01")
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.code == "VERIFICATION_FAILED"
 
 
 @respx.mock
+def test_verify_domain_already_verified(client: Grantex) -> None:
+    respx.post(f"{BASE_URL}/v1/domains/dom_01/verify").mock(
+        return_value=httpx.Response(
+            200, json={"verified": True, "message": "Domain already verified"}
+        )
+    )
+    result = client.domains.verify("dom_01")
+    assert result.verified is True
+    assert result.message == "Domain already verified"
+
+
+@respx.mock
+def test_verify_domain_not_found(client: Grantex) -> None:
+    respx.post(f"{BASE_URL}/v1/domains/dom_nonexistent/verify").mock(
+        return_value=httpx.Response(
+            404, json={"message": "Domain not found", "code": "NOT_FOUND"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.domains.verify("dom_nonexistent")
+    assert exc_info.value.status_code == 404
+
+
+@respx.mock
+def test_verify_domain_sends_post_to_correct_url(client: Grantex) -> None:
+    route = respx.post(f"{BASE_URL}/v1/domains/dom_xyz/verify").mock(
+        return_value=httpx.Response(200, json=MOCK_VERIFY_SUCCESS)
+    )
+    client.domains.verify("dom_xyz")
+    assert route.called
+    assert str(route.calls[0].request.url) == f"{BASE_URL}/v1/domains/dom_xyz/verify"
+
+
+# ── Delete Domain ────────────────────────────────────────────────────────
+
+@respx.mock
 def test_delete_domain(client: Grantex) -> None:
-    route = respx.delete("https://api.grantex.dev/v1/domains/dom_01").mock(
+    route = respx.delete(f"{BASE_URL}/v1/domains/dom_01").mock(
         return_value=httpx.Response(204)
     )
-    client.domains.delete("dom_01")
+    result = client.domains.delete("dom_01")
+    assert result is None
     assert route.called
+
+
+@respx.mock
+def test_delete_domain_not_found(client: Grantex) -> None:
+    respx.delete(f"{BASE_URL}/v1/domains/dom_nonexistent").mock(
+        return_value=httpx.Response(
+            404, json={"message": "Domain not found", "code": "NOT_FOUND"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.domains.delete("dom_nonexistent")
+    assert exc_info.value.status_code == 404
+
+
+@respx.mock
+def test_delete_domain_sends_correct_method(client: Grantex) -> None:
+    route = respx.delete(f"{BASE_URL}/v1/domains/dom_abc").mock(
+        return_value=httpx.Response(204)
+    )
+    client.domains.delete("dom_abc")
+    assert route.calls[0].request.method == "DELETE"

--- a/packages/sdk-py/tests/test_domains.py
+++ b/packages/sdk-py/tests/test_domains.py
@@ -1,0 +1,105 @@
+"""Tests for DomainsClient."""
+from __future__ import annotations
+
+import pytest
+import respx
+import httpx
+
+from grantex import Grantex
+
+
+MOCK_DOMAIN_CREATE = {
+    "id": "dom_01",
+    "domain": "example.com",
+    "verified": False,
+    "verificationToken": "gx-verify-abc123",
+    "instructions": "Add a TXT record with value gx-verify-abc123 to _grantex.example.com",
+}
+
+MOCK_DOMAIN_ENTRY = {
+    "id": "dom_01",
+    "domain": "example.com",
+    "verified": True,
+    "verifiedAt": "2024-06-01T12:00:00Z",
+    "createdAt": "2024-06-01T10:00:00Z",
+}
+
+MOCK_VERIFY_RESPONSE = {"verified": True, "message": "Domain verified successfully"}
+
+
+@pytest.fixture
+def client() -> Grantex:
+    return Grantex(api_key="test-key")
+
+
+@respx.mock
+def test_create_domain(client: Grantex) -> None:
+    import json
+
+    route = respx.post("https://api.grantex.dev/v1/domains").mock(
+        return_value=httpx.Response(200, json=MOCK_DOMAIN_CREATE)
+    )
+    from grantex.resources._domains import CreateDomainParams
+
+    result = client.domains.create(CreateDomainParams(domain="example.com"))
+    assert result.id == "dom_01"
+    assert result.domain == "example.com"
+    assert result.verified is False
+    assert result.verification_token == "gx-verify-abc123"
+    assert "TXT record" in result.instructions
+
+    body = json.loads(route.calls[0].request.content)
+    assert body["domain"] == "example.com"
+
+
+@respx.mock
+def test_list_domains(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/domains").mock(
+        return_value=httpx.Response(200, json={"domains": [MOCK_DOMAIN_ENTRY]})
+    )
+    result = client.domains.list()
+    assert len(result.domains) == 1
+    assert result.domains[0].id == "dom_01"
+    assert result.domains[0].domain == "example.com"
+    assert result.domains[0].verified is True
+    assert result.domains[0].verified_at == "2024-06-01T12:00:00Z"
+    assert result.domains[0].created_at == "2024-06-01T10:00:00Z"
+
+
+@respx.mock
+def test_list_domains_empty(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/domains").mock(
+        return_value=httpx.Response(200, json={"domains": []})
+    )
+    result = client.domains.list()
+    assert len(result.domains) == 0
+
+
+@respx.mock
+def test_verify_domain_success(client: Grantex) -> None:
+    respx.post("https://api.grantex.dev/v1/domains/dom_01/verify").mock(
+        return_value=httpx.Response(200, json=MOCK_VERIFY_RESPONSE)
+    )
+    result = client.domains.verify("dom_01")
+    assert result.verified is True
+    assert result.message == "Domain verified successfully"
+
+
+@respx.mock
+def test_verify_domain_not_verified(client: Grantex) -> None:
+    respx.post("https://api.grantex.dev/v1/domains/dom_01/verify").mock(
+        return_value=httpx.Response(
+            200, json={"verified": False, "message": "TXT record not found"}
+        )
+    )
+    result = client.domains.verify("dom_01")
+    assert result.verified is False
+
+
+@respx.mock
+def test_delete_domain(client: Grantex) -> None:
+    route = respx.delete("https://api.grantex.dev/v1/domains/dom_01").mock(
+        return_value=httpx.Response(204)
+    )
+    client.domains.delete("dom_01")
+    assert route.called

--- a/packages/sdk-py/tests/test_error_handling.py
+++ b/packages/sdk-py/tests/test_error_handling.py
@@ -1,4 +1,8 @@
-"""Tests for error handling across SDK clients."""
+"""Tests for error handling across SDK clients.
+
+Covers 400, 401, 403, 404, 429, 500, 502 errors across multiple client methods,
+error body parsing, request ID propagation, rate limit headers, and network errors.
+"""
 from __future__ import annotations
 
 import pytest
@@ -13,16 +17,21 @@ from grantex._errors import (
 )
 
 
+BASE_URL = "https://api.grantex.dev"
+
+
 @pytest.fixture
 def client() -> Grantex:
     return Grantex(api_key="test-key")
 
 
-# ── 400 Bad Request ─────────────────────────────────────────────────────────
+# ═══════════════════════════════════════════════════════════════════════════
+# 400 Bad Request
+# ═══════════════════════════════════════════════════════════════════════════
 
 @respx.mock
-def test_400_raises_api_error(client: Grantex) -> None:
-    respx.get("https://api.grantex.dev/v1/agents").mock(
+def test_400_raises_api_error_on_agents_list(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/agents").mock(
         return_value=httpx.Response(
             400, json={"code": "INVALID_REQUEST", "message": "Missing required field"}
         )
@@ -34,11 +43,70 @@ def test_400_raises_api_error(client: Grantex) -> None:
     assert "Missing required field" in str(exc_info.value)
 
 
-# ── 401 Unauthorized ────────────────────────────────────────────────────────
+@respx.mock
+def test_400_on_token_exchange(client: Grantex) -> None:
+    from grantex import ExchangeTokenParams
+
+    respx.post(f"{BASE_URL}/v1/token").mock(
+        return_value=httpx.Response(
+            400, json={"code": "INVALID_CODE", "message": "Authorization code expired or invalid"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.tokens.exchange(ExchangeTokenParams(code="bad_code", agent_id="ag_01"))
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.code == "INVALID_CODE"
+
+
+@respx.mock
+def test_400_on_webhook_creation(client: Grantex) -> None:
+    from grantex import CreateWebhookParams
+
+    respx.post(f"{BASE_URL}/v1/webhooks").mock(
+        return_value=httpx.Response(
+            400, json={"code": "BAD_REQUEST", "message": "url and events are required"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.webhooks.create(CreateWebhookParams(url="", events=[]))
+    assert exc_info.value.status_code == 400
+
+
+@respx.mock
+def test_400_on_policy_creation(client: Grantex) -> None:
+    from grantex import CreatePolicyParams
+
+    respx.post(f"{BASE_URL}/v1/policies").mock(
+        return_value=httpx.Response(
+            400, json={"code": "BAD_REQUEST", "message": "name and effect (allow|deny) are required"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.policies.create(CreatePolicyParams(name="", effect="allow"))
+    assert exc_info.value.status_code == 400
+
+
+@respx.mock
+def test_400_on_budget_allocate(client: Grantex) -> None:
+    from grantex import AllocateBudgetParams
+
+    respx.post(f"{BASE_URL}/v1/budget/allocate").mock(
+        return_value=httpx.Response(
+            400, json={"code": "BAD_REQUEST", "message": "grantId and positive initialBudget are required"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.budgets.allocate(AllocateBudgetParams(grant_id="", initial_budget=0))
+    assert exc_info.value.status_code == 400
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 401 Unauthorized
+# ═══════════════════════════════════════════════════════════════════════════
 
 @respx.mock
 def test_401_raises_auth_error(client: Grantex) -> None:
-    respx.get("https://api.grantex.dev/v1/agents").mock(
+    respx.get(f"{BASE_URL}/v1/agents").mock(
         return_value=httpx.Response(
             401, json={"code": "UNAUTHORIZED", "message": "Invalid API key"}
         )
@@ -46,14 +114,50 @@ def test_401_raises_auth_error(client: Grantex) -> None:
     with pytest.raises(GrantexAuthError) as exc_info:
         client.agents.list()
     assert exc_info.value.status_code == 401
-    assert isinstance(exc_info.value, GrantexApiError)  # subclass
+    assert isinstance(exc_info.value, GrantexApiError)  # subclass check
 
 
-# ── 403 Forbidden ───────────────────────────────────────────────────────────
+@respx.mock
+def test_401_on_grants_list(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/grants").mock(
+        return_value=httpx.Response(
+            401, json={"code": "UNAUTHORIZED", "message": "API key expired"}
+        )
+    )
+    with pytest.raises(GrantexAuthError) as exc_info:
+        client.grants.list()
+    assert exc_info.value.status_code == 401
+
+
+@respx.mock
+def test_401_on_compliance_summary(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/compliance/summary").mock(
+        return_value=httpx.Response(
+            401, json={"code": "UNAUTHORIZED", "message": "Authentication required"}
+        )
+    )
+    with pytest.raises(GrantexAuthError):
+        client.compliance.summary()
+
+
+@respx.mock
+def test_401_on_usage(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/usage").mock(
+        return_value=httpx.Response(
+            401, json={"code": "UNAUTHORIZED", "message": "Invalid API key"}
+        )
+    )
+    with pytest.raises(GrantexAuthError):
+        client.usage.current()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 403 Forbidden
+# ═══════════════════════════════════════════════════════════════════════════
 
 @respx.mock
 def test_403_raises_auth_error(client: Grantex) -> None:
-    respx.get("https://api.grantex.dev/v1/agents").mock(
+    respx.get(f"{BASE_URL}/v1/agents").mock(
         return_value=httpx.Response(
             403, json={"code": "FORBIDDEN", "message": "Insufficient permissions"}
         )
@@ -63,11 +167,24 @@ def test_403_raises_auth_error(client: Grantex) -> None:
     assert exc_info.value.status_code == 403
 
 
-# ── 404 Not Found ───────────────────────────────────────────────────────────
+@respx.mock
+def test_403_on_vault(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/vault/credentials").mock(
+        return_value=httpx.Response(
+            403, json={"code": "FORBIDDEN", "message": "Access denied"}
+        )
+    )
+    with pytest.raises(GrantexAuthError):
+        client.vault.list()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 404 Not Found
+# ═══════════════════════════════════════════════════════════════════════════
 
 @respx.mock
-def test_404_raises_api_error(client: Grantex) -> None:
-    respx.get("https://api.grantex.dev/v1/agents/nonexistent").mock(
+def test_404_raises_api_error_on_agent_get(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/agents/nonexistent").mock(
         return_value=httpx.Response(
             404, json={"code": "NOT_FOUND", "message": "Agent not found"}
         )
@@ -78,11 +195,109 @@ def test_404_raises_api_error(client: Grantex) -> None:
     assert exc_info.value.code == "NOT_FOUND"
 
 
-# ── 429 Too Many Requests ──────────────────────────────────────────────────
+@respx.mock
+def test_404_on_grant_get(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/grants/nonexistent").mock(
+        return_value=httpx.Response(
+            404, json={"code": "NOT_FOUND", "message": "Grant not found"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.grants.get("nonexistent")
+    assert exc_info.value.status_code == 404
+
+
+@respx.mock
+def test_404_on_vault_get(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/vault/credentials/vault_nonexistent").mock(
+        return_value=httpx.Response(
+            404, json={"code": "NOT_FOUND", "message": "Credential not found"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.vault.get("vault_nonexistent")
+    assert exc_info.value.status_code == 404
+
+
+@respx.mock
+def test_404_on_webhook_delete(client: Grantex) -> None:
+    respx.delete(f"{BASE_URL}/v1/webhooks/wh_nonexistent").mock(
+        return_value=httpx.Response(
+            404, json={"code": "NOT_FOUND", "message": "Webhook not found"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.webhooks.delete("wh_nonexistent")
+    assert exc_info.value.status_code == 404
+
+
+@respx.mock
+def test_404_on_domain_delete(client: Grantex) -> None:
+    from grantex.resources._domains import CreateDomainParams
+
+    respx.delete(f"{BASE_URL}/v1/domains/dom_nonexistent").mock(
+        return_value=httpx.Response(
+            404, json={"code": "NOT_FOUND", "message": "Domain not found"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.domains.delete("dom_nonexistent")
+    assert exc_info.value.status_code == 404
+
+
+@respx.mock
+def test_404_on_budget_balance(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/budget/balance/grnt_nonexistent").mock(
+        return_value=httpx.Response(
+            404, json={"code": "NOT_FOUND", "message": "No budget allocation found for this grant"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.budgets.balance("grnt_nonexistent")
+    assert exc_info.value.status_code == 404
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 402 Payment Required (Plan Limits)
+# ═══════════════════════════════════════════════════════════════════════════
+
+@respx.mock
+def test_402_on_budget_debit_insufficient(client: Grantex) -> None:
+    from grantex import DebitBudgetParams
+
+    respx.post(f"{BASE_URL}/v1/budget/debit").mock(
+        return_value=httpx.Response(
+            402, json={"code": "INSUFFICIENT_BUDGET", "message": "Insufficient budget"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.budgets.debit(DebitBudgetParams(grant_id="grnt_01", amount=9999))
+    assert exc_info.value.status_code == 402
+    assert exc_info.value.code == "INSUFFICIENT_BUDGET"
+
+
+@respx.mock
+def test_402_on_domain_create_plan_limit(client: Grantex) -> None:
+    from grantex.resources._domains import CreateDomainParams
+
+    respx.post(f"{BASE_URL}/v1/domains").mock(
+        return_value=httpx.Response(
+            402, json={"code": "PLAN_LIMIT_EXCEEDED", "message": "Custom domains require Enterprise plan"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.domains.create(CreateDomainParams(domain="paid.example.com"))
+    assert exc_info.value.status_code == 402
+    assert exc_info.value.code == "PLAN_LIMIT_EXCEEDED"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 429 Too Many Requests
+# ═══════════════════════════════════════════════════════════════════════════
 
 @respx.mock
 def test_429_includes_rate_limit_info(client: Grantex) -> None:
-    respx.get("https://api.grantex.dev/v1/agents").mock(
+    respx.get(f"{BASE_URL}/v1/agents").mock(
         return_value=httpx.Response(
             429,
             json={"code": "RATE_LIMITED", "message": "Too many requests"},
@@ -101,13 +316,57 @@ def test_429_includes_rate_limit_info(client: Grantex) -> None:
     assert exc_info.value.rate_limit.limit == 100
     assert exc_info.value.rate_limit.remaining == 0
     assert exc_info.value.rate_limit.retry_after == 60
+    assert exc_info.value.rate_limit.reset == 1700000000
 
 
-# ── 500 Internal Server Error ──────────────────────────────────────────────
+@respx.mock
+def test_429_on_token_verify(client: Grantex) -> None:
+    respx.post(f"{BASE_URL}/v1/tokens/verify").mock(
+        return_value=httpx.Response(
+            429,
+            json={"code": "RATE_LIMITED", "message": "Rate limit exceeded"},
+            headers={
+                "x-ratelimit-limit": "50",
+                "x-ratelimit-remaining": "0",
+                "x-ratelimit-reset": "1700000099",
+                "retry-after": "30",
+            },
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.tokens.verify("some.jwt.token")
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.rate_limit is not None
+    assert exc_info.value.rate_limit.limit == 50
+    assert exc_info.value.rate_limit.retry_after == 30
+
+
+@respx.mock
+def test_429_without_retry_after(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/agents").mock(
+        return_value=httpx.Response(
+            429,
+            json={"code": "RATE_LIMITED", "message": "Slow down"},
+            headers={
+                "x-ratelimit-limit": "100",
+                "x-ratelimit-remaining": "0",
+                "x-ratelimit-reset": "1700000000",
+            },
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.list()
+    assert exc_info.value.rate_limit is not None
+    assert exc_info.value.rate_limit.retry_after is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 500 Internal Server Error
+# ═══════════════════════════════════════════════════════════════════════════
 
 @respx.mock
 def test_500_raises_api_error(client: Grantex) -> None:
-    respx.get("https://api.grantex.dev/v1/agents").mock(
+    respx.get(f"{BASE_URL}/v1/agents").mock(
         return_value=httpx.Response(
             500, json={"code": "INTERNAL_ERROR", "message": "Internal server error"}
         )
@@ -117,11 +376,36 @@ def test_500_raises_api_error(client: Grantex) -> None:
     assert exc_info.value.status_code == 500
 
 
-# ── Malformed JSON response ────────────────────────────────────────────────
+@respx.mock
+def test_500_on_audit_list(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/audit/entries").mock(
+        return_value=httpx.Response(
+            500, json={"code": "INTERNAL_ERROR", "message": "Database error"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.audit.list()
+    assert exc_info.value.status_code == 500
+
+
+@respx.mock
+def test_500_on_domains_list(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/domains").mock(
+        return_value=httpx.Response(
+            500, json={"code": "INTERNAL_ERROR", "message": "Unexpected failure"}
+        )
+    )
+    with pytest.raises(GrantexApiError):
+        client.domains.list()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Malformed & Edge Case Responses
+# ═══════════════════════════════════════════════════════════════════════════
 
 @respx.mock
 def test_malformed_json_error_response(client: Grantex) -> None:
-    respx.get("https://api.grantex.dev/v1/agents").mock(
+    respx.get(f"{BASE_URL}/v1/agents").mock(
         return_value=httpx.Response(502, text="Bad Gateway")
     )
     with pytest.raises(GrantexApiError) as exc_info:
@@ -129,35 +413,29 @@ def test_malformed_json_error_response(client: Grantex) -> None:
     assert exc_info.value.status_code == 502
 
 
-# ── Network timeout ─────────────────────────────────────────────────────────
+@respx.mock
+def test_503_service_unavailable(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/agents").mock(
+        return_value=httpx.Response(503, text="Service Unavailable")
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.list()
+    assert exc_info.value.status_code == 503
+
 
 @respx.mock
-def test_network_timeout_raises_network_error(client: Grantex) -> None:
-    respx.get("https://api.grantex.dev/v1/agents").mock(
-        side_effect=httpx.ReadTimeout("Connection timed out")
+def test_error_with_empty_body(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/agents").mock(
+        return_value=httpx.Response(500, text="")
     )
-    with pytest.raises(GrantexNetworkError) as exc_info:
+    with pytest.raises(GrantexApiError) as exc_info:
         client.agents.list()
-    assert "timed out" in str(exc_info.value).lower()
-    assert exc_info.value.cause is not None
+    assert exc_info.value.status_code == 500
 
-
-# ── Connection error ────────────────────────────────────────────────────────
-
-@respx.mock
-def test_connection_error_raises_network_error(client: Grantex) -> None:
-    respx.get("https://api.grantex.dev/v1/agents").mock(
-        side_effect=httpx.ConnectError("Connection refused")
-    )
-    with pytest.raises(GrantexNetworkError):
-        client.agents.list()
-
-
-# ── Error body without code ─────────────────────────────────────────────────
 
 @respx.mock
 def test_error_without_code_field(client: Grantex) -> None:
-    respx.get("https://api.grantex.dev/v1/agents").mock(
+    respx.get(f"{BASE_URL}/v1/agents").mock(
         return_value=httpx.Response(
             400, json={"message": "Something went wrong"}
         )
@@ -168,11 +446,9 @@ def test_error_without_code_field(client: Grantex) -> None:
     assert "Something went wrong" in str(exc_info.value)
 
 
-# ── Error body with 'error' key instead of 'message' ───────────────────────
-
 @respx.mock
 def test_error_with_error_key_instead_of_message(client: Grantex) -> None:
-    respx.get("https://api.grantex.dev/v1/agents").mock(
+    respx.get(f"{BASE_URL}/v1/agents").mock(
         return_value=httpx.Response(
             400, json={"error": "Bad input"}
         )
@@ -182,11 +458,27 @@ def test_error_with_error_key_instead_of_message(client: Grantex) -> None:
     assert "Bad input" in str(exc_info.value)
 
 
-# ── Request ID propagation ──────────────────────────────────────────────────
+@respx.mock
+def test_error_with_numeric_code(client: Grantex) -> None:
+    """Numeric error codes should not crash the parser."""
+    respx.get(f"{BASE_URL}/v1/agents").mock(
+        return_value=httpx.Response(
+            400, json={"code": 12345, "message": "Numeric code"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.list()
+    # Non-string codes should be returned as None (per _extract_error_code)
+    assert exc_info.value.code is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Request ID Propagation
+# ═══════════════════════════════════════════════════════════════════════════
 
 @respx.mock
 def test_request_id_in_error(client: Grantex) -> None:
-    respx.get("https://api.grantex.dev/v1/agents").mock(
+    respx.get(f"{BASE_URL}/v1/agents").mock(
         return_value=httpx.Response(
             500,
             json={"code": "INTERNAL_ERROR", "message": "fail"},
@@ -196,3 +488,108 @@ def test_request_id_in_error(client: Grantex) -> None:
     with pytest.raises(GrantexApiError) as exc_info:
         client.agents.list()
     assert exc_info.value.request_id == "req_12345"
+
+
+@respx.mock
+def test_request_id_absent_is_none(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/agents").mock(
+        return_value=httpx.Response(
+            500, json={"code": "INTERNAL_ERROR", "message": "fail"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.list()
+    assert exc_info.value.request_id is None
+
+
+@respx.mock
+def test_request_id_on_404(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/agents/ag_missing").mock(
+        return_value=httpx.Response(
+            404,
+            json={"code": "NOT_FOUND", "message": "Not found"},
+            headers={"x-request-id": "req_67890"},
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.get("ag_missing")
+    assert exc_info.value.request_id == "req_67890"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Network Errors
+# ═══════════════════════════════════════════════════════════════════════════
+
+@respx.mock
+def test_network_timeout_raises_network_error(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/agents").mock(
+        side_effect=httpx.ReadTimeout("Connection timed out")
+    )
+    with pytest.raises(GrantexNetworkError) as exc_info:
+        client.agents.list()
+    assert "timed out" in str(exc_info.value).lower()
+    assert exc_info.value.cause is not None
+
+
+@respx.mock
+def test_connection_error_raises_network_error(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/agents").mock(
+        side_effect=httpx.ConnectError("Connection refused")
+    )
+    with pytest.raises(GrantexNetworkError):
+        client.agents.list()
+
+
+@respx.mock
+def test_connect_timeout_raises_network_error(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/agents").mock(
+        side_effect=httpx.ConnectTimeout("Connect timed out")
+    )
+    with pytest.raises(GrantexNetworkError) as exc_info:
+        client.agents.list()
+    assert exc_info.value.cause is not None
+
+
+@respx.mock
+def test_write_timeout_raises_network_error(client: Grantex) -> None:
+    respx.post(f"{BASE_URL}/v1/audit/log").mock(
+        side_effect=httpx.WriteTimeout("Write timed out")
+    )
+    from grantex import LogAuditParams
+
+    with pytest.raises(GrantexNetworkError):
+        client.audit.log(
+            LogAuditParams(
+                agent_id="ag_01",
+                agent_did="did:grantex:ag_01",
+                grant_id="grnt_01",
+                principal_id="user_01",
+                action="test",
+            )
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Error body preservation
+# ═══════════════════════════════════════════════════════════════════════════
+
+@respx.mock
+def test_error_body_preserved(client: Grantex) -> None:
+    error_body = {"code": "CUSTOM", "message": "Custom error", "details": {"field": "name"}}
+    respx.get(f"{BASE_URL}/v1/agents").mock(
+        return_value=httpx.Response(400, json=error_body)
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.list()
+    assert exc_info.value.body == error_body
+    assert exc_info.value.body["details"]["field"] == "name"
+
+
+@respx.mock
+def test_error_body_text_when_not_json(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/agents").mock(
+        return_value=httpx.Response(500, text="Plain text error")
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.list()
+    assert exc_info.value.body == "Plain text error"

--- a/packages/sdk-py/tests/test_error_handling.py
+++ b/packages/sdk-py/tests/test_error_handling.py
@@ -1,0 +1,198 @@
+"""Tests for error handling across SDK clients."""
+from __future__ import annotations
+
+import pytest
+import respx
+import httpx
+
+from grantex import Grantex
+from grantex._errors import (
+    GrantexApiError,
+    GrantexAuthError,
+    GrantexNetworkError,
+)
+
+
+@pytest.fixture
+def client() -> Grantex:
+    return Grantex(api_key="test-key")
+
+
+# ── 400 Bad Request ─────────────────────────────────────────────────────────
+
+@respx.mock
+def test_400_raises_api_error(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(
+            400, json={"code": "INVALID_REQUEST", "message": "Missing required field"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.list()
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.code == "INVALID_REQUEST"
+    assert "Missing required field" in str(exc_info.value)
+
+
+# ── 401 Unauthorized ────────────────────────────────────────────────────────
+
+@respx.mock
+def test_401_raises_auth_error(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(
+            401, json={"code": "UNAUTHORIZED", "message": "Invalid API key"}
+        )
+    )
+    with pytest.raises(GrantexAuthError) as exc_info:
+        client.agents.list()
+    assert exc_info.value.status_code == 401
+    assert isinstance(exc_info.value, GrantexApiError)  # subclass
+
+
+# ── 403 Forbidden ───────────────────────────────────────────────────────────
+
+@respx.mock
+def test_403_raises_auth_error(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(
+            403, json={"code": "FORBIDDEN", "message": "Insufficient permissions"}
+        )
+    )
+    with pytest.raises(GrantexAuthError) as exc_info:
+        client.agents.list()
+    assert exc_info.value.status_code == 403
+
+
+# ── 404 Not Found ───────────────────────────────────────────────────────────
+
+@respx.mock
+def test_404_raises_api_error(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/agents/nonexistent").mock(
+        return_value=httpx.Response(
+            404, json={"code": "NOT_FOUND", "message": "Agent not found"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.get("nonexistent")
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.code == "NOT_FOUND"
+
+
+# ── 429 Too Many Requests ──────────────────────────────────────────────────
+
+@respx.mock
+def test_429_includes_rate_limit_info(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(
+            429,
+            json={"code": "RATE_LIMITED", "message": "Too many requests"},
+            headers={
+                "x-ratelimit-limit": "100",
+                "x-ratelimit-remaining": "0",
+                "x-ratelimit-reset": "1700000000",
+                "retry-after": "60",
+            },
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.list()
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.rate_limit is not None
+    assert exc_info.value.rate_limit.limit == 100
+    assert exc_info.value.rate_limit.remaining == 0
+    assert exc_info.value.rate_limit.retry_after == 60
+
+
+# ── 500 Internal Server Error ──────────────────────────────────────────────
+
+@respx.mock
+def test_500_raises_api_error(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(
+            500, json={"code": "INTERNAL_ERROR", "message": "Internal server error"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.list()
+    assert exc_info.value.status_code == 500
+
+
+# ── Malformed JSON response ────────────────────────────────────────────────
+
+@respx.mock
+def test_malformed_json_error_response(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(502, text="Bad Gateway")
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.list()
+    assert exc_info.value.status_code == 502
+
+
+# ── Network timeout ─────────────────────────────────────────────────────────
+
+@respx.mock
+def test_network_timeout_raises_network_error(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        side_effect=httpx.ReadTimeout("Connection timed out")
+    )
+    with pytest.raises(GrantexNetworkError) as exc_info:
+        client.agents.list()
+    assert "timed out" in str(exc_info.value).lower()
+    assert exc_info.value.cause is not None
+
+
+# ── Connection error ────────────────────────────────────────────────────────
+
+@respx.mock
+def test_connection_error_raises_network_error(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        side_effect=httpx.ConnectError("Connection refused")
+    )
+    with pytest.raises(GrantexNetworkError):
+        client.agents.list()
+
+
+# ── Error body without code ─────────────────────────────────────────────────
+
+@respx.mock
+def test_error_without_code_field(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(
+            400, json={"message": "Something went wrong"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.list()
+    assert exc_info.value.code is None
+    assert "Something went wrong" in str(exc_info.value)
+
+
+# ── Error body with 'error' key instead of 'message' ───────────────────────
+
+@respx.mock
+def test_error_with_error_key_instead_of_message(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(
+            400, json={"error": "Bad input"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.list()
+    assert "Bad input" in str(exc_info.value)
+
+
+# ── Request ID propagation ──────────────────────────────────────────────────
+
+@respx.mock
+def test_request_id_in_error(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(
+            500,
+            json={"code": "INTERNAL_ERROR", "message": "fail"},
+            headers={"x-request-id": "req_12345"},
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.agents.list()
+    assert exc_info.value.request_id == "req_12345"

--- a/packages/sdk-py/tests/test_error_handling.py
+++ b/packages/sdk-py/tests/test_error_handling.py
@@ -68,7 +68,7 @@ def test_400_on_webhook_creation(client: Grantex) -> None:
         )
     )
     with pytest.raises(GrantexApiError) as exc_info:
-        client.webhooks.create(CreateWebhookParams(url="", events=[]))
+        client.webhooks.create(url="", events=[])
     assert exc_info.value.status_code == 400
 
 
@@ -137,7 +137,7 @@ def test_401_on_compliance_summary(client: Grantex) -> None:
         )
     )
     with pytest.raises(GrantexAuthError):
-        client.compliance.summary()
+        client.compliance.get_summary()
 
 
 @respx.mock
@@ -559,13 +559,11 @@ def test_write_timeout_raises_network_error(client: Grantex) -> None:
 
     with pytest.raises(GrantexNetworkError):
         client.audit.log(
-            LogAuditParams(
-                agent_id="ag_01",
-                agent_did="did:grantex:ag_01",
-                grant_id="grnt_01",
-                principal_id="user_01",
-                action="test",
-            )
+            agent_id="ag_01",
+            agent_did="did:grantex:ag_01",
+            grant_id="grnt_01",
+            principal_id="user_01",
+            action="test",
         )
 
 

--- a/packages/sdk-py/tests/test_http_edge_cases.py
+++ b/packages/sdk-py/tests/test_http_edge_cases.py
@@ -1,0 +1,177 @@
+"""Tests for HttpClient edge cases."""
+from __future__ import annotations
+
+import pytest
+import respx
+import httpx
+
+from grantex._http import HttpClient, _parse_rate_limit_headers, _extract_error_code, _extract_error_message
+
+
+# ── 204 No Content ─────────────────────────────────────────────────────────
+
+@respx.mock
+def test_204_returns_none() -> None:
+    respx.delete("https://api.grantex.dev/v1/agents/a1").mock(
+        return_value=httpx.Response(204)
+    )
+    client = HttpClient("https://api.grantex.dev", "test-key")
+    result = client.delete("/v1/agents/a1")
+    assert result is None
+    client.close()
+
+
+# ── Rate limit header parsing ──────────────────────────────────────────────
+
+def test_parse_rate_limit_headers_complete() -> None:
+    headers = httpx.Headers({
+        "x-ratelimit-limit": "100",
+        "x-ratelimit-remaining": "42",
+        "x-ratelimit-reset": "1700000000",
+        "retry-after": "30",
+    })
+    rl = _parse_rate_limit_headers(headers)
+    assert rl is not None
+    assert rl.limit == 100
+    assert rl.remaining == 42
+    assert rl.reset == 1700000000
+    assert rl.retry_after == 30
+
+
+def test_parse_rate_limit_headers_without_retry_after() -> None:
+    headers = httpx.Headers({
+        "x-ratelimit-limit": "100",
+        "x-ratelimit-remaining": "99",
+        "x-ratelimit-reset": "1700000000",
+    })
+    rl = _parse_rate_limit_headers(headers)
+    assert rl is not None
+    assert rl.retry_after is None
+
+
+def test_parse_rate_limit_headers_missing_returns_none() -> None:
+    headers = httpx.Headers({"content-type": "application/json"})
+    rl = _parse_rate_limit_headers(headers)
+    assert rl is None
+
+
+def test_parse_rate_limit_partial_headers_returns_none() -> None:
+    headers = httpx.Headers({"x-ratelimit-limit": "100"})
+    rl = _parse_rate_limit_headers(headers)
+    assert rl is None
+
+
+# ── Error extraction helpers ───────────────────────────────────────────────
+
+def test_extract_error_code_from_dict() -> None:
+    assert _extract_error_code({"code": "INVALID"}) == "INVALID"
+
+
+def test_extract_error_code_missing() -> None:
+    assert _extract_error_code({"message": "fail"}) is None
+
+
+def test_extract_error_code_non_dict() -> None:
+    assert _extract_error_code("just a string") is None
+    assert _extract_error_code(None) is None
+
+
+def test_extract_error_message_from_message_key() -> None:
+    assert _extract_error_message({"message": "Bad request"}, 400) == "Bad request"
+
+
+def test_extract_error_message_from_error_key() -> None:
+    assert _extract_error_message({"error": "Something broke"}, 500) == "Something broke"
+
+
+def test_extract_error_message_fallback() -> None:
+    assert _extract_error_message({}, 502) == "HTTP 502"
+    assert _extract_error_message(None, 503) == "HTTP 503"
+
+
+# ── Custom base_url ────────────────────────────────────────────────────────
+
+@respx.mock
+def test_custom_base_url() -> None:
+    respx.get("https://custom.example.com/v1/agents").mock(
+        return_value=httpx.Response(200, json={"agents": []})
+    )
+    client = HttpClient("https://custom.example.com", "test-key")
+    result = client.get("/v1/agents")
+    assert result == {"agents": []}
+    client.close()
+
+
+@respx.mock
+def test_base_url_trailing_slash_stripped() -> None:
+    respx.get("https://custom.example.com/v1/agents").mock(
+        return_value=httpx.Response(200, json={"agents": []})
+    )
+    client = HttpClient("https://custom.example.com/", "test-key")
+    result = client.get("/v1/agents")
+    assert result == {"agents": []}
+    client.close()
+
+
+# ── Context manager ────────────────────────────────────────────────────────
+
+@respx.mock
+def test_context_manager() -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(200, json={"agents": []})
+    )
+    with HttpClient("https://api.grantex.dev", "test-key") as client:
+        result = client.get("/v1/agents")
+    assert result == {"agents": []}
+
+
+# ── Rate limit stored after request ────────────────────────────────────────
+
+@respx.mock
+def test_rate_limit_stored_after_successful_request() -> None:
+    respx.get("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(
+            200,
+            json={"agents": []},
+            headers={
+                "x-ratelimit-limit": "100",
+                "x-ratelimit-remaining": "99",
+                "x-ratelimit-reset": "1700000000",
+            },
+        )
+    )
+    client = HttpClient("https://api.grantex.dev", "test-key")
+    client.get("/v1/agents")
+    assert client.last_rate_limit is not None
+    assert client.last_rate_limit.remaining == 99
+    client.close()
+
+
+# ── POST with JSON body ───────────────────────────────────────────────────
+
+@respx.mock
+def test_post_sends_json_body() -> None:
+    import json
+
+    route = respx.post("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(200, json={"id": "ag_01"})
+    )
+    client = HttpClient("https://api.grantex.dev", "test-key")
+    client.post("/v1/agents", {"name": "test", "scopes": ["read"]})
+    body = json.loads(route.calls[0].request.content)
+    assert body["name"] == "test"
+    assert body["scopes"] == ["read"]
+    client.close()
+
+
+# ── Authorization header sent ──────────────────────────────────────────────
+
+@respx.mock
+def test_authorization_header_sent() -> None:
+    route = respx.get("https://api.grantex.dev/v1/agents").mock(
+        return_value=httpx.Response(200, json={"agents": []})
+    )
+    client = HttpClient("https://api.grantex.dev", "my-api-key")
+    client.get("/v1/agents")
+    assert route.calls[0].request.headers["authorization"] == "Bearer my-api-key"
+    client.close()

--- a/packages/sdk-py/tests/test_pkce.py
+++ b/packages/sdk-py/tests/test_pkce.py
@@ -1,12 +1,16 @@
-"""Tests for PKCE utilities."""
+"""Tests for PKCE utilities — verifier/challenge generation and validation."""
 from __future__ import annotations
 
 import base64
 import hashlib
 import re
 
+import pytest
+
 from grantex._pkce import generate_pkce, PkceChallenge
 
+
+# ── Basic Generation ──────────────────────────────────────────────────────
 
 def test_generate_pkce_returns_challenge() -> None:
     result = generate_pkce()
@@ -15,6 +19,15 @@ def test_generate_pkce_returns_challenge() -> None:
     assert result.code_challenge
     assert result.code_challenge_method == "S256"
 
+
+def test_generate_pkce_returns_non_empty_strings() -> None:
+    result = generate_pkce()
+    assert len(result.code_verifier) > 0
+    assert len(result.code_challenge) > 0
+    assert len(result.code_challenge_method) > 0
+
+
+# ── Verifier Validation ──────────────────────────────────────────────────
 
 def test_verifier_is_url_safe_base64() -> None:
     result = generate_pkce()
@@ -27,6 +40,26 @@ def test_verifier_length_43_to_128() -> None:
     assert 43 <= len(result.code_verifier) <= 128
 
 
+def test_verifier_length_consistent_across_calls() -> None:
+    """All verifiers should be the same length since we use 32 random bytes."""
+    lengths = {len(generate_pkce().code_verifier) for _ in range(20)}
+    assert len(lengths) == 1, f"Expected uniform verifier length, got {lengths}"
+
+
+def test_verifier_contains_only_ascii() -> None:
+    result = generate_pkce()
+    assert result.code_verifier.isascii()
+
+
+def test_verifier_no_padding_chars() -> None:
+    """URL-safe base64 should not contain padding '=' characters."""
+    for _ in range(10):
+        result = generate_pkce()
+        assert "=" not in result.code_verifier
+
+
+# ── Challenge Validation ─────────────────────────────────────────────────
+
 def test_challenge_is_s256_of_verifier() -> None:
     result = generate_pkce()
     # Recompute the challenge from the verifier
@@ -35,22 +68,104 @@ def test_challenge_is_s256_of_verifier() -> None:
     assert result.code_challenge == expected
 
 
-def test_multiple_calls_produce_different_values() -> None:
-    a = generate_pkce()
-    b = generate_pkce()
-    assert a.code_verifier != b.code_verifier
-    assert a.code_challenge != b.code_challenge
-
-
-def test_pkce_challenge_is_frozen() -> None:
-    result = generate_pkce()
-    import pytest
-
-    with pytest.raises(AttributeError):
-        result.code_verifier = "mutated"  # type: ignore[misc]
-
-
 def test_challenge_is_url_safe_base64() -> None:
     result = generate_pkce()
     # Should only contain URL-safe characters
     assert re.match(r"^[A-Za-z0-9_-]+$", result.code_challenge)
+
+
+def test_challenge_no_padding_chars() -> None:
+    for _ in range(10):
+        result = generate_pkce()
+        assert "=" not in result.code_challenge
+
+
+def test_challenge_has_expected_length() -> None:
+    """SHA-256 digest = 32 bytes, base64url without padding = 43 chars."""
+    result = generate_pkce()
+    assert len(result.code_challenge) == 43
+
+
+def test_challenge_method_is_always_s256() -> None:
+    for _ in range(10):
+        result = generate_pkce()
+        assert result.code_challenge_method == "S256"
+
+
+# ── Uniqueness ────────────────────────────────────────────────────────────
+
+def test_multiple_calls_produce_different_verifiers() -> None:
+    a = generate_pkce()
+    b = generate_pkce()
+    assert a.code_verifier != b.code_verifier
+
+
+def test_multiple_calls_produce_different_challenges() -> None:
+    a = generate_pkce()
+    b = generate_pkce()
+    assert a.code_challenge != b.code_challenge
+
+
+def test_100_unique_verifiers() -> None:
+    verifiers = {generate_pkce().code_verifier for _ in range(100)}
+    assert len(verifiers) == 100, "Expected 100 unique verifiers"
+
+
+def test_100_unique_challenges() -> None:
+    challenges = {generate_pkce().code_challenge for _ in range(100)}
+    assert len(challenges) == 100, "Expected 100 unique challenges"
+
+
+# ── Immutability ─────────────────────────────────────────────────────────
+
+def test_pkce_challenge_is_frozen() -> None:
+    result = generate_pkce()
+    with pytest.raises(AttributeError):
+        result.code_verifier = "mutated"  # type: ignore[misc]
+
+
+def test_pkce_challenge_challenge_is_frozen() -> None:
+    result = generate_pkce()
+    with pytest.raises(AttributeError):
+        result.code_challenge = "mutated"  # type: ignore[misc]
+
+
+def test_pkce_challenge_method_is_frozen() -> None:
+    result = generate_pkce()
+    with pytest.raises(AttributeError):
+        result.code_challenge_method = "S384"  # type: ignore[misc]
+
+
+# ── Cross-verification ───────────────────────────────────────────────────
+
+def test_verifier_challenge_pair_validates_cross_check() -> None:
+    """Simulate what a server would do: verify the challenge matches."""
+    pkce = generate_pkce()
+
+    # Server receives code_verifier and code_challenge
+    server_digest = hashlib.sha256(pkce.code_verifier.encode("ascii")).digest()
+    server_challenge = base64.urlsafe_b64encode(server_digest).rstrip(b"=").decode("ascii")
+
+    assert server_challenge == pkce.code_challenge
+
+
+def test_wrong_verifier_does_not_match_challenge() -> None:
+    """A different verifier should produce a different challenge."""
+    pkce = generate_pkce()
+
+    wrong_digest = hashlib.sha256(b"wrong-verifier").digest()
+    wrong_challenge = base64.urlsafe_b64encode(wrong_digest).rstrip(b"=").decode("ascii")
+
+    assert wrong_challenge != pkce.code_challenge
+
+
+def test_deterministic_challenge_for_same_verifier() -> None:
+    """Same verifier should always produce the same challenge."""
+    pkce = generate_pkce()
+    verifier = pkce.code_verifier
+
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge_1 = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    challenge_2 = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+    assert challenge_1 == challenge_2 == pkce.code_challenge

--- a/packages/sdk-py/tests/test_pkce.py
+++ b/packages/sdk-py/tests/test_pkce.py
@@ -1,0 +1,56 @@
+"""Tests for PKCE utilities."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+
+from grantex._pkce import generate_pkce, PkceChallenge
+
+
+def test_generate_pkce_returns_challenge() -> None:
+    result = generate_pkce()
+    assert isinstance(result, PkceChallenge)
+    assert result.code_verifier
+    assert result.code_challenge
+    assert result.code_challenge_method == "S256"
+
+
+def test_verifier_is_url_safe_base64() -> None:
+    result = generate_pkce()
+    # Should only contain URL-safe characters (no +, /, =)
+    assert re.match(r"^[A-Za-z0-9_-]+$", result.code_verifier)
+
+
+def test_verifier_length_43_to_128() -> None:
+    result = generate_pkce()
+    assert 43 <= len(result.code_verifier) <= 128
+
+
+def test_challenge_is_s256_of_verifier() -> None:
+    result = generate_pkce()
+    # Recompute the challenge from the verifier
+    digest = hashlib.sha256(result.code_verifier.encode("ascii")).digest()
+    expected = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    assert result.code_challenge == expected
+
+
+def test_multiple_calls_produce_different_values() -> None:
+    a = generate_pkce()
+    b = generate_pkce()
+    assert a.code_verifier != b.code_verifier
+    assert a.code_challenge != b.code_challenge
+
+
+def test_pkce_challenge_is_frozen() -> None:
+    result = generate_pkce()
+    import pytest
+
+    with pytest.raises(AttributeError):
+        result.code_verifier = "mutated"  # type: ignore[misc]
+
+
+def test_challenge_is_url_safe_base64() -> None:
+    result = generate_pkce()
+    # Should only contain URL-safe characters
+    assert re.match(r"^[A-Za-z0-9_-]+$", result.code_challenge)

--- a/packages/sdk-py/tests/test_usage.py
+++ b/packages/sdk-py/tests/test_usage.py
@@ -1,0 +1,84 @@
+"""Tests for UsageClient."""
+from __future__ import annotations
+
+import pytest
+import respx
+import httpx
+
+from grantex import Grantex
+
+MOCK_USAGE = {
+    "developerId": "dev_01",
+    "period": "2024-06",
+    "tokenExchanges": 1500,
+    "authorizations": 300,
+    "verifications": 800,
+    "totalRequests": 2600,
+}
+
+MOCK_HISTORY = {
+    "developerId": "dev_01",
+    "days": 7,
+    "entries": [
+        {
+            "date": "2024-06-01",
+            "tokenExchanges": 200,
+            "authorizations": 50,
+            "verifications": 100,
+            "totalRequests": 350,
+        },
+        {
+            "date": "2024-06-02",
+            "tokenExchanges": 220,
+            "authorizations": 55,
+            "verifications": 110,
+            "totalRequests": 385,
+        },
+    ],
+}
+
+
+@pytest.fixture
+def client() -> Grantex:
+    return Grantex(api_key="test-key")
+
+
+@respx.mock
+def test_current_usage(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/usage").mock(
+        return_value=httpx.Response(200, json=MOCK_USAGE)
+    )
+    result = client.usage.current()
+    assert result.developer_id == "dev_01"
+    assert result.period == "2024-06"
+    assert result.token_exchanges == 1500
+    assert result.authorizations == 300
+    assert result.verifications == 800
+    assert result.total_requests == 2600
+
+
+@respx.mock
+def test_usage_history_default_days(client: Grantex) -> None:
+    route = respx.get("https://api.grantex.dev/v1/usage/history?days=30").mock(
+        return_value=httpx.Response(200, json=MOCK_HISTORY)
+    )
+    result = client.usage.history()
+    assert route.called
+    assert result.developer_id == "dev_01"
+    assert len(result.entries) == 2
+
+
+@respx.mock
+def test_usage_history_custom_days(client: Grantex) -> None:
+    route = respx.get("https://api.grantex.dev/v1/usage/history?days=7").mock(
+        return_value=httpx.Response(200, json=MOCK_HISTORY)
+    )
+    result = client.usage.history(days=7)
+    assert route.called
+    assert result.days == 7
+    entry = result.entries[0]
+    assert entry.date == "2024-06-01"
+    assert entry.token_exchanges == 200
+    assert entry.authorizations == 50
+    assert entry.verifications == 100
+    assert entry.total_requests == 350

--- a/packages/sdk-py/tests/test_usage.py
+++ b/packages/sdk-py/tests/test_usage.py
@@ -1,19 +1,34 @@
-"""Tests for UsageClient."""
+"""Tests for UsageClient — current usage and history."""
 from __future__ import annotations
+
+import json
 
 import pytest
 import respx
 import httpx
 
 from grantex import Grantex
+from grantex._errors import GrantexApiError
+
+
+BASE_URL = "https://api.grantex.dev"
 
 MOCK_USAGE = {
     "developerId": "dev_01",
-    "period": "2024-06",
+    "period": "2024-06-15",
     "tokenExchanges": 1500,
     "authorizations": 300,
     "verifications": 800,
     "totalRequests": 2600,
+}
+
+MOCK_USAGE_ZERO = {
+    "developerId": "dev_new",
+    "period": "2024-06-15",
+    "tokenExchanges": 0,
+    "authorizations": 0,
+    "verifications": 0,
+    "totalRequests": 0,
 }
 
 MOCK_HISTORY = {
@@ -21,20 +36,33 @@ MOCK_HISTORY = {
     "days": 7,
     "entries": [
         {
-            "date": "2024-06-01",
+            "date": "2024-06-15",
             "tokenExchanges": 200,
             "authorizations": 50,
             "verifications": 100,
             "totalRequests": 350,
         },
         {
-            "date": "2024-06-02",
+            "date": "2024-06-14",
             "tokenExchanges": 220,
             "authorizations": 55,
             "verifications": 110,
             "totalRequests": 385,
         },
+        {
+            "date": "2024-06-13",
+            "tokenExchanges": 180,
+            "authorizations": 40,
+            "verifications": 90,
+            "totalRequests": 310,
+        },
     ],
+}
+
+MOCK_HISTORY_EMPTY = {
+    "developerId": "dev_new",
+    "days": 7,
+    "entries": [],
 }
 
 
@@ -43,14 +71,17 @@ def client() -> Grantex:
     return Grantex(api_key="test-key")
 
 
+# ── Current Usage ─────────────────────────────────────────────────────────
+
 @respx.mock
 def test_current_usage(client: Grantex) -> None:
-    respx.get("https://api.grantex.dev/v1/usage").mock(
+    respx.get(f"{BASE_URL}/v1/usage").mock(
         return_value=httpx.Response(200, json=MOCK_USAGE)
     )
     result = client.usage.current()
+
     assert result.developer_id == "dev_01"
-    assert result.period == "2024-06"
+    assert result.period == "2024-06-15"
     assert result.token_exchanges == 1500
     assert result.authorizations == 300
     assert result.verifications == 800
@@ -58,27 +89,147 @@ def test_current_usage(client: Grantex) -> None:
 
 
 @respx.mock
+def test_current_usage_total_equals_sum(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/usage").mock(
+        return_value=httpx.Response(200, json=MOCK_USAGE)
+    )
+    result = client.usage.current()
+    assert result.total_requests == (
+        result.token_exchanges + result.authorizations + result.verifications
+    )
+
+
+@respx.mock
+def test_current_usage_zero_values(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/usage").mock(
+        return_value=httpx.Response(200, json=MOCK_USAGE_ZERO)
+    )
+    result = client.usage.current()
+
+    assert result.developer_id == "dev_new"
+    assert result.token_exchanges == 0
+    assert result.authorizations == 0
+    assert result.verifications == 0
+    assert result.total_requests == 0
+
+
+@respx.mock
+def test_current_usage_sends_get(client: Grantex) -> None:
+    route = respx.get(f"{BASE_URL}/v1/usage").mock(
+        return_value=httpx.Response(200, json=MOCK_USAGE)
+    )
+    client.usage.current()
+    assert route.called
+    assert route.calls[0].request.method == "GET"
+
+
+@respx.mock
+def test_current_usage_unauthorized(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/usage").mock(
+        return_value=httpx.Response(
+            401, json={"message": "Invalid API key", "code": "UNAUTHORIZED"}
+        )
+    )
+    from grantex._errors import GrantexAuthError
+
+    with pytest.raises(GrantexAuthError) as exc_info:
+        client.usage.current()
+    assert exc_info.value.status_code == 401
+
+
+# ── Usage History ─────────────────────────────────────────────────────────
+
+@respx.mock
 def test_usage_history_default_days(client: Grantex) -> None:
-    route = respx.get("https://api.grantex.dev/v1/usage/history?days=30").mock(
+    route = respx.get(f"{BASE_URL}/v1/usage/history?days=30").mock(
         return_value=httpx.Response(200, json=MOCK_HISTORY)
     )
     result = client.usage.history()
+
     assert route.called
     assert result.developer_id == "dev_01"
-    assert len(result.entries) == 2
+    assert result.days == 7  # from mock response
+    assert len(result.entries) == 3
 
 
 @respx.mock
 def test_usage_history_custom_days(client: Grantex) -> None:
-    route = respx.get("https://api.grantex.dev/v1/usage/history?days=7").mock(
+    route = respx.get(f"{BASE_URL}/v1/usage/history?days=7").mock(
         return_value=httpx.Response(200, json=MOCK_HISTORY)
     )
     result = client.usage.history(days=7)
+
     assert route.called
     assert result.days == 7
+
+
+@respx.mock
+def test_usage_history_90_days(client: Grantex) -> None:
+    route = respx.get(f"{BASE_URL}/v1/usage/history?days=90").mock(
+        return_value=httpx.Response(200, json={**MOCK_HISTORY, "days": 90})
+    )
+    result = client.usage.history(days=90)
+    assert route.called
+    assert result.days == 90
+
+
+@respx.mock
+def test_usage_history_entry_fields(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/usage/history?days=7").mock(
+        return_value=httpx.Response(200, json=MOCK_HISTORY)
+    )
+    result = client.usage.history(days=7)
     entry = result.entries[0]
-    assert entry.date == "2024-06-01"
+
+    assert entry.date == "2024-06-15"
     assert entry.token_exchanges == 200
     assert entry.authorizations == 50
     assert entry.verifications == 100
     assert entry.total_requests == 350
+
+
+@respx.mock
+def test_usage_history_multiple_entries(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/usage/history?days=7").mock(
+        return_value=httpx.Response(200, json=MOCK_HISTORY)
+    )
+    result = client.usage.history(days=7)
+
+    assert len(result.entries) == 3
+    dates = [e.date for e in result.entries]
+    assert dates == ["2024-06-15", "2024-06-14", "2024-06-13"]
+
+
+@respx.mock
+def test_usage_history_empty(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/usage/history?days=7").mock(
+        return_value=httpx.Response(200, json=MOCK_HISTORY_EMPTY)
+    )
+    result = client.usage.history(days=7)
+
+    assert result.developer_id == "dev_new"
+    assert len(result.entries) == 0
+
+
+@respx.mock
+def test_usage_history_url_format(client: Grantex) -> None:
+    route = respx.get(f"{BASE_URL}/v1/usage/history?days=14").mock(
+        return_value=httpx.Response(200, json=MOCK_HISTORY)
+    )
+    client.usage.history(days=14)
+
+    assert route.called
+    request_url = str(route.calls[0].request.url)
+    assert "days=14" in request_url
+
+
+@respx.mock
+def test_usage_history_server_error(client: Grantex) -> None:
+    respx.get(f"{BASE_URL}/v1/usage/history?days=30").mock(
+        return_value=httpx.Response(
+            500, json={"message": "Internal server error", "code": "INTERNAL_ERROR"}
+        )
+    )
+    with pytest.raises(GrantexApiError) as exc_info:
+        client.usage.history()
+    assert exc_info.value.status_code == 500

--- a/tests/e2e/budget.test.ts
+++ b/tests/e2e/budget.test.ts
@@ -1,0 +1,237 @@
+/**
+ * E2E Tests: Budget Management
+ *
+ * Tests budget allocation, debit, balance check, transactions listing,
+ * insufficient funds (402), bad request validation, and pagination.
+ * Run: npx vitest run tests/e2e/budget.test.ts
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Grantex } from '@grantex/sdk';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+
+let grantex: Grantex;
+let apiKey: string;
+let grantId: string;
+let grantToken: string;
+let secondGrantId: string;
+
+async function authorizeAndExchange(agentId: string, scopes: string[]) {
+  const auth = await grantex.authorize({ agentId, userId: `budget-user-${Date.now()}`, scopes });
+  const code = ('code' in auth && typeof (auth as any).code === 'string')
+    ? (auth as any).code
+    : await fetch(`${BASE_URL}/v1/authorize/${auth.authRequestId}/approve`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` }, body: '{}',
+      }).then(r => r.json()).then((d: any) => d.code);
+  return grantex.tokens.exchange({ code, agentId });
+}
+
+beforeAll(async () => {
+  const account = await Grantex.signup({ name: `e2e-budget-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
+  apiKey = account.apiKey;
+  grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
+
+  const agent = await grantex.agents.register({ name: `budget-agent-${Date.now()}`, scopes: ['files:read', 'calendar:read'] });
+
+  // Create two grants for multi-grant testing
+  const token1 = await authorizeAndExchange(agent.agentId, ['files:read']);
+  grantId = token1.grantId;
+  grantToken = token1.grantToken;
+
+  const token2 = await authorizeAndExchange(agent.agentId, ['calendar:read']);
+  secondGrantId = token2.grantId;
+});
+
+describe('E2E: Budget Allocation', () => {
+  it('allocates a budget to a grant', async () => {
+    const result = await grantex.budgets.allocate({
+      grantId,
+      initialBudget: 1000,
+      currency: 'USD',
+    });
+    expect(result).toBeDefined();
+    expect(result.grantId).toBe(grantId);
+    expect(result.initialBudget).toBe(1000);
+    expect(result.remainingBudget).toBe(1000);
+    expect(result.id).toBeDefined();
+    expect(typeof result.id).toBe('string');
+  });
+
+  it('rejects duplicate budget allocation for the same grant', async () => {
+    await expect(
+      grantex.budgets.allocate({ grantId, initialBudget: 500 }),
+    ).rejects.toThrow();
+  });
+
+  it('allocates a budget to a second grant independently', async () => {
+    const result = await grantex.budgets.allocate({
+      grantId: secondGrantId,
+      initialBudget: 2000,
+      currency: 'EUR',
+    });
+    expect(result.grantId).toBe(secondGrantId);
+    expect(result.initialBudget).toBe(2000);
+    expect(result.remainingBudget).toBe(2000);
+  });
+
+  it('rejects allocation with zero budget', async () => {
+    const agent = await grantex.agents.register({ name: `budget-zero-${Date.now()}`, scopes: ['files:read'] });
+    const token = await authorizeAndExchange(agent.agentId, ['files:read']);
+    await expect(
+      grantex.budgets.allocate({ grantId: token.grantId, initialBudget: 0 }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects allocation with negative budget', async () => {
+    const agent = await grantex.agents.register({ name: `budget-neg-${Date.now()}`, scopes: ['files:read'] });
+    const token = await authorizeAndExchange(agent.agentId, ['files:read']);
+    await expect(
+      grantex.budgets.allocate({ grantId: token.grantId, initialBudget: -100 }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects allocation for non-existent grant', async () => {
+    await expect(
+      grantex.budgets.allocate({ grantId: 'grnt_nonexistent_000', initialBudget: 100 }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('E2E: Budget Debit', () => {
+  it('debits from the budget', async () => {
+    const result = await grantex.budgets.debit({
+      grantId,
+      amount: 250,
+      description: 'test debit',
+    });
+    expect(result.remaining).toBe(750);
+    expect(result.transactionId).toBeTruthy();
+    expect(typeof result.transactionId).toBe('string');
+    expect(result.grantId).toBe(grantId);
+  });
+
+  it('debits again and reflects cumulative spending', async () => {
+    const result = await grantex.budgets.debit({
+      grantId,
+      amount: 300,
+      description: 'second debit',
+    });
+    expect(result.remaining).toBe(450);
+    expect(result.transactionId).toBeTruthy();
+  });
+
+  it('debits with metadata', async () => {
+    const result = await grantex.budgets.debit({
+      grantId,
+      amount: 50,
+      description: 'debit with metadata',
+      metadata: { action: 'api-call', endpoint: '/v1/data' },
+    });
+    expect(result.remaining).toBe(400);
+  });
+
+  it('rejects debit with zero amount', async () => {
+    await expect(
+      grantex.budgets.debit({ grantId, amount: 0, description: 'zero debit' }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects debit with negative amount', async () => {
+    await expect(
+      grantex.budgets.debit({ grantId, amount: -50, description: 'negative debit' }),
+    ).rejects.toThrow();
+  });
+
+  it('returns 402 INSUFFICIENT_BUDGET when overdrawing', async () => {
+    try {
+      await grantex.budgets.debit({ grantId, amount: 9999, description: 'too much' });
+      expect.fail('Should have thrown');
+    } catch (err: any) {
+      const status = err.status ?? err.statusCode ?? err.response?.status;
+      expect(status).toBe(402);
+    }
+  });
+
+  it('debits from second grant independently', async () => {
+    const result = await grantex.budgets.debit({
+      grantId: secondGrantId,
+      amount: 100,
+      description: 'second grant debit',
+    });
+    expect(result.remaining).toBe(1900);
+    expect(result.grantId).toBe(secondGrantId);
+  });
+});
+
+describe('E2E: Budget Balance', () => {
+  it('checks budget balance reflects debits', async () => {
+    const balance = await grantex.budgets.balance(grantId);
+    expect(balance.remainingBudget).toBe(400);
+    expect(balance.initialBudget).toBe(1000);
+    expect(balance.grantId).toBe(grantId);
+  });
+
+  it('checks second grant balance independently', async () => {
+    const balance = await grantex.budgets.balance(secondGrantId);
+    expect(balance.remainingBudget).toBe(1900);
+    expect(balance.initialBudget).toBe(2000);
+  });
+
+  it('returns 404 for balance of non-existent grant', async () => {
+    await expect(
+      grantex.budgets.balance('grnt_nonexistent_000000'),
+    ).rejects.toThrow();
+  });
+});
+
+describe('E2E: Budget Transactions', () => {
+  it('lists budget transactions for the grant', async () => {
+    const txns = await grantex.budgets.transactions(grantId);
+    expect(txns.transactions).toBeDefined();
+    expect(Array.isArray(txns.transactions)).toBe(true);
+    expect(txns.transactions.length).toBeGreaterThanOrEqual(3);
+    expect(txns.total).toBeGreaterThanOrEqual(3);
+
+    // Verify transaction shape
+    const tx = txns.transactions[0];
+    expect(tx).toHaveProperty('amount');
+    expect(typeof tx.amount).toBe('number');
+  });
+
+  it('lists transactions for the second grant separately', async () => {
+    const txns = await grantex.budgets.transactions(secondGrantId);
+    expect(txns.transactions.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('returns empty transactions for grant with no debits', async () => {
+    const agent = await grantex.agents.register({ name: `budget-notx-${Date.now()}`, scopes: ['files:read'] });
+    const token = await authorizeAndExchange(agent.agentId, ['files:read']);
+    await grantex.budgets.allocate({ grantId: token.grantId, initialBudget: 100 });
+
+    const txns = await grantex.budgets.transactions(token.grantId);
+    expect(txns.transactions.length).toBe(0);
+    expect(txns.total).toBe(0);
+  });
+});
+
+describe('E2E: Budget Allocations List', () => {
+  it('lists all budget allocations for the developer', async () => {
+    const res = await fetch(`${BASE_URL}/v1/budget/allocations`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as { allocations: any[] };
+    expect(body.allocations).toBeDefined();
+    expect(Array.isArray(body.allocations)).toBe(true);
+    // Should have at least the two allocations we created + the no-tx one
+    expect(body.allocations.length).toBeGreaterThanOrEqual(3);
+
+    // Verify allocation shape
+    const alloc = body.allocations[0];
+    expect(alloc).toHaveProperty('id');
+    expect(alloc).toHaveProperty('grantId');
+    expect(alloc).toHaveProperty('initialBudget');
+    expect(alloc).toHaveProperty('remainingBudget');
+  });
+});

--- a/tests/e2e/compliance.test.ts
+++ b/tests/e2e/compliance.test.ts
@@ -1,0 +1,233 @@
+/**
+ * E2E Tests: Compliance Reporting
+ *
+ * Tests compliance summary, export grants, export audit,
+ * evidence pack, filtering by date range and status.
+ * Run: npx vitest run tests/e2e/compliance.test.ts
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Grantex } from '@grantex/sdk';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+
+let grantex: Grantex;
+let apiKey: string;
+let agentId: string;
+let grantId: string;
+
+async function authorizeAndExchange(agentId: string, scopes: string[]) {
+  const auth = await grantex.authorize({ agentId, userId: `compliance-user-${Date.now()}`, scopes });
+  const code = ('code' in auth && typeof (auth as any).code === 'string')
+    ? (auth as any).code
+    : await fetch(`${BASE_URL}/v1/authorize/${auth.authRequestId}/approve`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` }, body: '{}',
+      }).then(r => r.json()).then((d: any) => d.code);
+  return grantex.tokens.exchange({ code, agentId });
+}
+
+beforeAll(async () => {
+  const account = await Grantex.signup({ name: `e2e-compliance-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
+  apiKey = account.apiKey;
+  grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
+
+  // Register an agent and create a grant to have data for compliance reports
+  const agent = await grantex.agents.register({ name: `comp-agent-${Date.now()}`, scopes: ['files:read', 'email:send'] });
+  agentId = agent.agentId;
+
+  const token = await authorizeAndExchange(agentId, ['files:read']);
+  grantId = token.grantId;
+
+  // Log some audit entries
+  await grantex.audit.log({
+    agentId,
+    agentDid: agent.did,
+    grantId,
+    principalId: 'compliance-user',
+    action: 'compliance.test.action',
+    metadata: { test: true },
+  });
+});
+
+describe('E2E: Compliance Summary', () => {
+  it('gets compliance summary with all sections', async () => {
+    const summary = await grantex.compliance.summary();
+
+    expect(summary).toBeDefined();
+    expect(summary).toHaveProperty('generatedAt');
+    expect(typeof summary.generatedAt).toBe('string');
+
+    // Agents section
+    expect(summary).toHaveProperty('agents');
+    expect(summary.agents).toHaveProperty('total');
+    expect(summary.agents).toHaveProperty('active');
+    expect(summary.agents).toHaveProperty('suspended');
+    expect(summary.agents).toHaveProperty('revoked');
+    expect(typeof summary.agents.total).toBe('number');
+    expect(summary.agents.total).toBeGreaterThanOrEqual(1);
+
+    // Grants section
+    expect(summary).toHaveProperty('grants');
+    expect(summary.grants).toHaveProperty('total');
+    expect(summary.grants).toHaveProperty('active');
+    expect(summary.grants).toHaveProperty('revoked');
+    expect(summary.grants).toHaveProperty('expired');
+    expect(summary.grants.total).toBeGreaterThanOrEqual(1);
+
+    // Audit section
+    expect(summary).toHaveProperty('auditEntries');
+    expect(summary.auditEntries).toHaveProperty('total');
+    expect(summary.auditEntries).toHaveProperty('success');
+    expect(summary.auditEntries).toHaveProperty('failure');
+    expect(summary.auditEntries).toHaveProperty('blocked');
+
+    // Policies section
+    expect(summary).toHaveProperty('policies');
+    expect(summary.policies).toHaveProperty('total');
+
+    // Plan
+    expect(summary).toHaveProperty('plan');
+    expect(typeof summary.plan).toBe('string');
+  });
+
+  it('gets compliance summary with date filters', async () => {
+    const since = new Date(Date.now() - 86400000 * 7).toISOString();
+    const until = new Date().toISOString();
+
+    const res = await fetch(`${BASE_URL}/v1/compliance/summary?since=${since}&until=${until}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.ok).toBe(true);
+    const summary = (await res.json()) as any;
+    expect(summary.since).toBe(since);
+    expect(summary.until).toBe(until);
+    expect(summary.agents).toBeDefined();
+  });
+});
+
+describe('E2E: Compliance Export Grants', () => {
+  it('exports all grants', async () => {
+    const result = await grantex.compliance.exportGrants();
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty('generatedAt');
+    expect(result).toHaveProperty('total');
+    expect(result).toHaveProperty('grants');
+    expect(Array.isArray(result.grants)).toBe(true);
+    expect(result.total).toBeGreaterThanOrEqual(1);
+
+    // Verify grant shape in export
+    const grant = result.grants[0];
+    expect(grant).toHaveProperty('grantId');
+    expect(grant).toHaveProperty('agentId');
+    expect(grant).toHaveProperty('principalId');
+    expect(grant).toHaveProperty('scopes');
+    expect(grant).toHaveProperty('status');
+    expect(grant).toHaveProperty('issuedAt');
+    expect(grant).toHaveProperty('expiresAt');
+    expect(grant).toHaveProperty('delegationDepth');
+  });
+
+  it('exports grants with status filter', async () => {
+    const res = await fetch(`${BASE_URL}/v1/compliance/export/grants?status=active`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as any;
+    expect(body.grants).toBeDefined();
+    body.grants.forEach((g: any) => {
+      expect(g.status).toBe('active');
+    });
+  });
+
+  it('exports grants with date range', async () => {
+    const since = new Date(Date.now() - 86400000).toISOString();
+    const res = await fetch(`${BASE_URL}/v1/compliance/export/grants?since=${since}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as any;
+    expect(body.total).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('E2E: Compliance Export Audit', () => {
+  it('exports audit entries', async () => {
+    const result = await grantex.compliance.exportAudit();
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty('generatedAt');
+    expect(result).toHaveProperty('total');
+    expect(result).toHaveProperty('entries');
+    expect(Array.isArray(result.entries)).toBe(true);
+  });
+
+  it('exports audit entries with agentId filter', async () => {
+    const res = await fetch(`${BASE_URL}/v1/compliance/export/audit?agentId=${agentId}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as any;
+    expect(body.entries).toBeDefined();
+    body.entries.forEach((e: any) => {
+      expect(e.agentId).toBe(agentId);
+    });
+  });
+
+  it('exports audit entries with status filter', async () => {
+    const res = await fetch(`${BASE_URL}/v1/compliance/export/audit?status=success`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as any;
+    body.entries.forEach((e: any) => {
+      expect(e.status).toBe('success');
+    });
+  });
+
+  it('audit entries have hash chain fields', async () => {
+    const result = await grantex.compliance.exportAudit();
+    if (result.entries.length > 0) {
+      const entry = result.entries[0];
+      expect(entry).toHaveProperty('hash');
+      expect(typeof entry.hash).toBe('string');
+      // First entry might not have a prevHash
+      expect(entry).toHaveProperty('prevHash');
+    }
+  });
+});
+
+describe('E2E: Evidence Pack', () => {
+  it('generates a comprehensive evidence pack', async () => {
+    const res = await fetch(`${BASE_URL}/v1/compliance/evidence-pack`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as any;
+
+    expect(body).toHaveProperty('meta');
+    expect(body.meta).toHaveProperty('schemaVersion');
+    expect(body.meta).toHaveProperty('generatedAt');
+    expect(body.meta).toHaveProperty('framework');
+
+    expect(body).toHaveProperty('summary');
+    expect(body.summary).toHaveProperty('agents');
+    expect(body.summary).toHaveProperty('grants');
+    expect(body.summary).toHaveProperty('auditEntries');
+    expect(body.summary).toHaveProperty('policies');
+    expect(body.summary).toHaveProperty('plan');
+
+    expect(body).toHaveProperty('grants');
+    expect(Array.isArray(body.grants)).toBe(true);
+
+    expect(body).toHaveProperty('auditEntries');
+    expect(Array.isArray(body.auditEntries)).toBe(true);
+
+    expect(body).toHaveProperty('policies');
+    expect(Array.isArray(body.policies)).toBe(true);
+
+    expect(body).toHaveProperty('chainIntegrity');
+    expect(body.chainIntegrity).toHaveProperty('valid');
+    expect(body.chainIntegrity).toHaveProperty('checkedEntries');
+  });
+});

--- a/tests/e2e/credentials.test.ts
+++ b/tests/e2e/credentials.test.ts
@@ -1,0 +1,146 @@
+/**
+ * E2E Tests: Verifiable Credentials
+ *
+ * Tests VC listing, VC verification, DID document, JWKS, and status list endpoints.
+ * Run: npx vitest run tests/e2e/credentials.test.ts
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Grantex } from '@grantex/sdk';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+
+let grantex: Grantex;
+let apiKey: string;
+
+beforeAll(async () => {
+  const account = await Grantex.signup({ name: `e2e-creds-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
+  apiKey = account.apiKey;
+  grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
+});
+
+describe('E2E: Credential Listing', () => {
+  it('lists credentials (initially empty)', async () => {
+    const result = await grantex.credentials.list();
+    expect(result).toBeDefined();
+    expect(result.credentials).toBeDefined();
+    expect(Array.isArray(result.credentials)).toBe(true);
+    expect(result.credentials.length).toBe(0);
+  });
+
+  it('lists credentials with grantId filter', async () => {
+    const res = await fetch(`${BASE_URL}/v1/credentials?grantId=grnt_nonexistent`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as { credentials: any[] };
+    expect(body.credentials).toBeDefined();
+    expect(body.credentials.length).toBe(0);
+  });
+
+  it('lists credentials with status filter', async () => {
+    const res = await fetch(`${BASE_URL}/v1/credentials?status=active`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as { credentials: any[] };
+    expect(body.credentials).toBeDefined();
+    expect(Array.isArray(body.credentials)).toBe(true);
+  });
+
+  it('returns 404 for non-existent credential by ID', async () => {
+    const res = await fetch(`${BASE_URL}/v1/credentials/vc_nonexistent_000`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe('NOT_FOUND');
+  });
+});
+
+describe('E2E: VC Verification', () => {
+  it('rejects verification with missing credential', async () => {
+    const res = await fetch(`${BASE_URL}/v1/credentials/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe('BAD_REQUEST');
+  });
+
+  it('rejects verification with invalid JWT', async () => {
+    const res = await fetch(`${BASE_URL}/v1/credentials/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ credential: 'not-a-valid-jwt' }),
+    });
+    // Should return 200 with valid=false or a 400 error
+    const body = (await res.json()) as { valid?: boolean; code?: string };
+    if (res.ok) {
+      expect(body.valid).toBe(false);
+    } else {
+      expect(body.code).toBeDefined();
+    }
+  });
+});
+
+describe('E2E: SD-JWT Presentation', () => {
+  it('rejects presentation with missing sdJwt', async () => {
+    const res = await fetch(`${BASE_URL}/v1/credentials/present`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe('BAD_REQUEST');
+  });
+
+  it('rejects presentation with invalid SD-JWT', async () => {
+    const res = await fetch(`${BASE_URL}/v1/credentials/present`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sdJwt: 'invalid~sd~jwt' }),
+    });
+    const body = (await res.json()) as { valid?: boolean; code?: string };
+    if (res.ok) {
+      expect(body.valid).toBe(false);
+    } else {
+      expect(body.code).toBeDefined();
+    }
+  });
+});
+
+describe('E2E: DID & JWKS Public Endpoints', () => {
+  it('DID document is accessible and has required fields', async () => {
+    const res = await fetch(`${BASE_URL}/.well-known/did.json`);
+    expect(res.status).toBe(200);
+    const doc = (await res.json()) as Record<string, unknown>;
+    expect(doc).toHaveProperty('id');
+    expect(doc).toHaveProperty('verificationMethod');
+    expect(doc['@context']).toBeDefined();
+    expect(typeof doc.id).toBe('string');
+    expect(Array.isArray(doc.verificationMethod)).toBe(true);
+  });
+
+  it('JWKS endpoint returns valid key set', async () => {
+    const res = await fetch(`${BASE_URL}/.well-known/jwks.json`);
+    expect(res.status).toBe(200);
+    const jwks = (await res.json()) as { keys: any[] };
+    expect(jwks).toHaveProperty('keys');
+    expect(Array.isArray(jwks.keys)).toBe(true);
+    expect(jwks.keys.length).toBeGreaterThan(0);
+
+    // Each key should have required JWK fields
+    const key = jwks.keys[0];
+    expect(key).toHaveProperty('kty');
+    expect(key).toHaveProperty('kid');
+  });
+
+  it('StatusList endpoint returns 404 for non-existent list', async () => {
+    const res = await fetch(`${BASE_URL}/v1/credentials/status/nonexistent-list`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/e2e/cross-feature.test.ts
+++ b/tests/e2e/cross-feature.test.ts
@@ -1,8 +1,15 @@
 /**
- * E2E: Cross-Feature Integration Tests
+ * E2E Tests: Cross-Feature Integration
  *
- * Tests interactions between multiple features working together.
+ * Tests interactions between multiple features working together:
+ * - Policy + Authorization (deny policy blocks auth)
+ * - Revocation Cascade (revoke parent -> child revoked)
+ * - Audit Chain Integrity (hash chain verification)
+ * - Budget + Delegation
+ * - Compliance after revocation
+ * Run: npx vitest run tests/e2e/cross-feature.test.ts
  */
+
 import { describe, it, expect, beforeAll } from 'vitest';
 import { Grantex, verifyGrantToken } from '@grantex/sdk';
 
@@ -32,8 +39,8 @@ beforeAll(async () => {
   grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
 });
 
-describe('E2E: Policy + Authorization', () => {
-  it('deny policy prevents authorization for specific scope', async () => {
+describe('E2E: Policy + Authorization Integration', () => {
+  it('deny policy prevents authorization for specific scope and agent', async () => {
     const agent = await grantex.agents.register({
       name: `cross-policy-agent-${Date.now()}`,
       scopes: ['files:read', 'files:write'],
@@ -48,13 +55,51 @@ describe('E2E: Policy + Authorization', () => {
       agentId: agent.agentId,
     });
 
-    // Authorization for files:read should work
-    const { code } = await authorizeAndGetCode(agent.agentId, 'user@test.com', ['files:read']);
+    // Authorization for files:read should still work
+    const { code } = await authorizeAndGetCode(agent.agentId, 'user@policy.test', ['files:read']);
+    const token = await grantex.tokens.exchange({ code, agentId: agent.agentId });
+    expect(token.grantToken).toBeTruthy();
+    expect(token.scopes).toContain('files:read');
+
+    // Cleanup
+    await grantex.policies.delete(policy.id);
+  });
+
+  it('multiple policies with different priorities are evaluated correctly', async () => {
+    const agent = await grantex.agents.register({
+      name: `cross-multi-policy-${Date.now()}`,
+      scopes: ['calendar:read', 'calendar:write'],
+    });
+
+    // Low priority allow
+    const allowPolicy = await grantex.policies.create({
+      name: `allow-all-${Date.now()}`,
+      effect: 'allow',
+      priority: 1,
+      scopes: ['calendar:read', 'calendar:write'],
+    });
+
+    // High priority deny for calendar:write
+    const denyPolicy = await grantex.policies.create({
+      name: `deny-write-${Date.now()}`,
+      effect: 'deny',
+      priority: 100,
+      scopes: ['calendar:write'],
+      agentId: agent.agentId,
+    });
+
+    // Verify both policies exist
+    const policies = await grantex.policies.list();
+    expect(policies.total).toBeGreaterThanOrEqual(2);
+
+    // calendar:read should work
+    const { code } = await authorizeAndGetCode(agent.agentId, 'user@multi-policy.test', ['calendar:read']);
     const token = await grantex.tokens.exchange({ code, agentId: agent.agentId });
     expect(token.grantToken).toBeTruthy();
 
     // Cleanup
-    await grantex.policies.delete(policy.id);
+    await grantex.policies.delete(allowPolicy.id);
+    await grantex.policies.delete(denyPolicy.id);
   });
 });
 
@@ -78,6 +123,11 @@ describe('E2E: Revocation Cascade', () => {
       agentId: parentAgent.agentId,
     });
 
+    // Verify parent token is valid
+    const parentVerifyBefore = await grantex.tokens.verify(parentToken.grantToken);
+    expect(parentVerifyBefore.valid).toBe(true);
+    expect(parentVerifyBefore.grantId).toBe(parentToken.grantId);
+
     // Delegate to child
     const delegated = await grantex.grants.delegate({
       parentGrantToken: parentToken.grantToken,
@@ -85,58 +135,125 @@ describe('E2E: Revocation Cascade', () => {
       scopes: ['calendar:read'],
     });
     expect(delegated.grantToken).toBeTruthy();
+    expect(delegated.scopes).toEqual(['calendar:read']);
+
+    // Verify child token is valid
+    const childVerifyBefore = await grantex.tokens.verify(delegated.grantToken);
+    expect(childVerifyBefore.valid).toBe(true);
+
+    // Verify delegation claims in the child token
+    const childGrant = await verifyGrantToken(delegated.grantToken, { jwksUri: JWKS_URI });
+    expect(childGrant.parentGrantId).toBeDefined();
+    expect(childGrant.delegationDepth).toBeGreaterThanOrEqual(1);
 
     // Revoke parent grant
     await grantex.grants.revoke(parentToken.grantId);
 
     // Parent token should be invalid
-    const parentVerify = await grantex.tokens.verify(parentToken.grantToken);
-    expect(parentVerify.valid).toBe(false);
+    const parentVerifyAfter = await grantex.tokens.verify(parentToken.grantToken);
+    expect(parentVerifyAfter.valid).toBe(false);
 
-    // Child delegated token should also be invalid
+    // Child delegated token should also be invalid (cascade)
+    const childVerifyAfter = await grantex.tokens.verify(delegated.grantToken);
+    expect(childVerifyAfter.valid).toBe(false);
+  });
+
+  it('revoking child does not invalidate parent', async () => {
+    const parentAgent = await grantex.agents.register({
+      name: `cross-parent-indep-${Date.now()}`,
+      scopes: ['files:read'],
+    });
+    const childAgent = await grantex.agents.register({
+      name: `cross-child-indep-${Date.now()}`,
+      scopes: ['files:read'],
+    });
+
+    // Authorize parent
+    const { code } = await authorizeAndGetCode(
+      parentAgent.agentId, 'user@indep.test', ['files:read'],
+    );
+    const parentToken = await grantex.tokens.exchange({
+      code,
+      agentId: parentAgent.agentId,
+    });
+
+    // Delegate to child
+    const delegated = await grantex.grants.delegate({
+      parentGrantToken: parentToken.grantToken,
+      subAgentId: childAgent.agentId,
+      scopes: ['files:read'],
+    });
+
+    // Revoke child grant
+    await grantex.grants.revoke(delegated.grantId);
+
+    // Child should be invalid
     const childVerify = await grantex.tokens.verify(delegated.grantToken);
     expect(childVerify.valid).toBe(false);
+
+    // Parent should still be valid
+    const parentVerify = await grantex.tokens.verify(parentToken.grantToken);
+    expect(parentVerify.valid).toBe(true);
   });
 });
 
 describe('E2E: Audit Chain Integrity', () => {
-  it('audit entries maintain hash chain', async () => {
+  it('audit entries maintain hash chain across multiple actions', async () => {
     const agent = await grantex.agents.register({
       name: `cross-audit-${Date.now()}`,
       scopes: ['files:read'],
     });
 
-    // Create several audit entries
-    for (let i = 0; i < 3; i++) {
-      await grantex.audit.log({
+    // Create several audit entries sequentially
+    const entries = [];
+    for (let i = 0; i < 5; i++) {
+      const entry = await grantex.audit.log({
         agentId: agent.agentId,
         agentDid: agent.did,
-        grantId: `grnt_fake_${i}`,
+        grantId: `grnt_chain_test_${i}`,
         principalId: 'user@chain.test',
         action: `test.action.${i}`,
-        metadata: { step: i },
+        metadata: { step: i, timestamp: Date.now() },
         status: 'success',
       });
+      entries.push(entry);
     }
 
-    // Verify chain
-    const entries = await grantex.audit.list({ agentId: agent.agentId });
-    expect(entries.length).toBeGreaterThanOrEqual(3);
+    expect(entries.length).toBe(5);
 
-    // Each entry should have a hash, and entries after the first should have prevHash
-    for (let i = 0; i < entries.length; i++) {
-      expect(entries[i].hash).toBeTruthy();
-      if (i > 0) {
-        // prevHash of entry i should equal hash of entry i-1 (entries are newest-first)
-        // The exact ordering depends on the API; just verify hashes are present
-        expect(typeof entries[i].hash).toBe('string');
-      }
+    // Each entry should have a unique entryId
+    const entryIds = entries.map((e) => e.entryId);
+    const uniqueIds = new Set(entryIds);
+    expect(uniqueIds.size).toBe(5);
+
+    // List entries and verify hash chain
+    const auditResult = await grantex.audit.list();
+    expect(auditResult.entries.length).toBeGreaterThanOrEqual(5);
+
+    // Each entry should have a hash field
+    for (const entry of auditResult.entries) {
+      expect(entry.hash).toBeDefined();
+      expect(typeof entry.hash).toBe('string');
+      expect(entry.hash.length).toBeGreaterThan(0);
     }
+  });
+
+  it('compliance evidence pack confirms chain integrity', async () => {
+    const res = await fetch(`${BASE_URL}/v1/compliance/evidence-pack`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.ok).toBe(true);
+    const pack = (await res.json()) as any;
+
+    expect(pack.chainIntegrity).toBeDefined();
+    expect(pack.chainIntegrity.valid).toBe(true);
+    expect(pack.chainIntegrity.checkedEntries).toBeGreaterThan(0);
+    expect(pack.chainIntegrity.firstBrokenAt).toBeNull();
   });
 });
 
 describe('E2E: Budget + Delegation', () => {
-  it('allocates budget on parent and delegates', async () => {
+  it('allocates budget on parent and delegates without affecting budget', async () => {
     const parentAgent = await grantex.agents.register({
       name: `cross-budget-parent-${Date.now()}`,
       scopes: ['files:read'],
@@ -148,7 +265,7 @@ describe('E2E: Budget + Delegation', () => {
 
     // Authorize parent
     const { code } = await authorizeAndGetCode(
-      parentAgent.agentId, 'user@budget.test', ['files:read'],
+      parentAgent.agentId, 'user@budget-delegate.test', ['files:read'],
     );
     const parentToken = await grantex.tokens.exchange({
       code,
@@ -156,11 +273,12 @@ describe('E2E: Budget + Delegation', () => {
     });
 
     // Allocate budget to parent grant
-    await grantex.budgets.allocate({
+    const allocation = await grantex.budgets.allocate({
       grantId: parentToken.grantId,
       initialBudget: 500,
       currency: 'USD',
     });
+    expect(allocation.remainingBudget).toBe(500);
 
     // Delegate to child
     const delegated = await grantex.grants.delegate({
@@ -168,11 +286,50 @@ describe('E2E: Budget + Delegation', () => {
       subAgentId: childAgent.agentId,
       scopes: ['files:read'],
     });
-
     expect(delegated.grantToken).toBeTruthy();
 
-    // Check parent budget is still intact
+    // Parent budget should be unaffected by delegation
     const balance = await grantex.budgets.balance(parentToken.grantId);
     expect(balance.remainingBudget).toBe(500);
+
+    // Debit from parent budget
+    const debit = await grantex.budgets.debit({
+      grantId: parentToken.grantId,
+      amount: 100,
+      description: 'Post-delegation debit',
+    });
+    expect(debit.remaining).toBe(400);
+  });
+});
+
+describe('E2E: Compliance After Revocation', () => {
+  it('compliance summary reflects revoked grants', async () => {
+    const agent = await grantex.agents.register({
+      name: `cross-comp-${Date.now()}`,
+      scopes: ['files:read'],
+    });
+
+    // Create and then revoke a grant
+    const { code } = await authorizeAndGetCode(
+      agent.agentId, 'user@comp-revoke.test', ['files:read'],
+    );
+    const token = await grantex.tokens.exchange({ code, agentId: agent.agentId });
+    await grantex.grants.revoke(token.grantId);
+
+    // Compliance summary should show revoked grants
+    const summary = await grantex.compliance.summary();
+    expect(summary.grants.revoked).toBeGreaterThanOrEqual(1);
+  });
+
+  it('grant export includes revoked grants', async () => {
+    const result = await grantex.compliance.exportGrants();
+
+    const revokedGrants = result.grants.filter((g: any) => g.status === 'revoked');
+    expect(revokedGrants.length).toBeGreaterThanOrEqual(1);
+
+    // Revoked grants should have revokedAt timestamp
+    for (const g of revokedGrants) {
+      expect(g.revokedAt).not.toBeNull();
+    }
   });
 });

--- a/tests/e2e/cross-feature.test.ts
+++ b/tests/e2e/cross-feature.test.ts
@@ -1,0 +1,178 @@
+/**
+ * E2E: Cross-Feature Integration Tests
+ *
+ * Tests interactions between multiple features working together.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Grantex, verifyGrantToken } from '@grantex/sdk';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+const JWKS_URI = `${BASE_URL}/.well-known/jwks.json`;
+
+let grantex: Grantex;
+let apiKey: string;
+
+async function authorizeAndGetCode(agentId: string, userId: string, scopes: string[]) {
+  const auth = await grantex.authorize({ agentId, userId, scopes });
+  if ('code' in auth && typeof (auth as any).code === 'string') {
+    return { code: (auth as any).code, authRequestId: auth.authRequestId };
+  }
+  const approveRes = await fetch(`${BASE_URL}/v1/authorize/${auth.authRequestId}/approve`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+    body: '{}',
+  });
+  const approved = (await approveRes.json()) as { code: string };
+  return { code: approved.code, authRequestId: auth.authRequestId };
+}
+
+beforeAll(async () => {
+  const account = await Grantex.signup({ name: `e2e-cross-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
+  apiKey = account.apiKey;
+  grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
+});
+
+describe('E2E: Policy + Authorization', () => {
+  it('deny policy prevents authorization for specific scope', async () => {
+    const agent = await grantex.agents.register({
+      name: `cross-policy-agent-${Date.now()}`,
+      scopes: ['files:read', 'files:write'],
+    });
+
+    // Create a deny policy for files:write on this agent
+    const policy = await grantex.policies.create({
+      name: `deny-write-${Date.now()}`,
+      effect: 'deny',
+      priority: 100,
+      scopes: ['files:write'],
+      agentId: agent.agentId,
+    });
+
+    // Authorization for files:read should work
+    const { code } = await authorizeAndGetCode(agent.agentId, 'user@test.com', ['files:read']);
+    const token = await grantex.tokens.exchange({ code, agentId: agent.agentId });
+    expect(token.grantToken).toBeTruthy();
+
+    // Cleanup
+    await grantex.policies.delete(policy.id);
+  });
+});
+
+describe('E2E: Revocation Cascade', () => {
+  it('revoking parent grant invalidates child delegated grants', async () => {
+    const parentAgent = await grantex.agents.register({
+      name: `cross-parent-${Date.now()}`,
+      scopes: ['calendar:read', 'email:send'],
+    });
+    const childAgent = await grantex.agents.register({
+      name: `cross-child-${Date.now()}`,
+      scopes: ['calendar:read'],
+    });
+
+    // Authorize parent
+    const { code: parentCode } = await authorizeAndGetCode(
+      parentAgent.agentId, 'user@cascade.test', ['calendar:read', 'email:send'],
+    );
+    const parentToken = await grantex.tokens.exchange({
+      code: parentCode,
+      agentId: parentAgent.agentId,
+    });
+
+    // Delegate to child
+    const delegated = await grantex.grants.delegate({
+      parentGrantToken: parentToken.grantToken,
+      subAgentId: childAgent.agentId,
+      scopes: ['calendar:read'],
+    });
+    expect(delegated.grantToken).toBeTruthy();
+
+    // Revoke parent grant
+    await grantex.grants.revoke(parentToken.grantId);
+
+    // Parent token should be invalid
+    const parentVerify = await grantex.tokens.verify(parentToken.grantToken);
+    expect(parentVerify.valid).toBe(false);
+
+    // Child delegated token should also be invalid
+    const childVerify = await grantex.tokens.verify(delegated.grantToken);
+    expect(childVerify.valid).toBe(false);
+  });
+});
+
+describe('E2E: Audit Chain Integrity', () => {
+  it('audit entries maintain hash chain', async () => {
+    const agent = await grantex.agents.register({
+      name: `cross-audit-${Date.now()}`,
+      scopes: ['files:read'],
+    });
+
+    // Create several audit entries
+    for (let i = 0; i < 3; i++) {
+      await grantex.audit.log({
+        agentId: agent.agentId,
+        agentDid: agent.did,
+        grantId: `grnt_fake_${i}`,
+        principalId: 'user@chain.test',
+        action: `test.action.${i}`,
+        metadata: { step: i },
+        status: 'success',
+      });
+    }
+
+    // Verify chain
+    const entries = await grantex.audit.list({ agentId: agent.agentId });
+    expect(entries.length).toBeGreaterThanOrEqual(3);
+
+    // Each entry should have a hash, and entries after the first should have prevHash
+    for (let i = 0; i < entries.length; i++) {
+      expect(entries[i].hash).toBeTruthy();
+      if (i > 0) {
+        // prevHash of entry i should equal hash of entry i-1 (entries are newest-first)
+        // The exact ordering depends on the API; just verify hashes are present
+        expect(typeof entries[i].hash).toBe('string');
+      }
+    }
+  });
+});
+
+describe('E2E: Budget + Delegation', () => {
+  it('allocates budget on parent and delegates', async () => {
+    const parentAgent = await grantex.agents.register({
+      name: `cross-budget-parent-${Date.now()}`,
+      scopes: ['files:read'],
+    });
+    const childAgent = await grantex.agents.register({
+      name: `cross-budget-child-${Date.now()}`,
+      scopes: ['files:read'],
+    });
+
+    // Authorize parent
+    const { code } = await authorizeAndGetCode(
+      parentAgent.agentId, 'user@budget.test', ['files:read'],
+    );
+    const parentToken = await grantex.tokens.exchange({
+      code,
+      agentId: parentAgent.agentId,
+    });
+
+    // Allocate budget to parent grant
+    await grantex.budgets.allocate({
+      grantId: parentToken.grantId,
+      initialBudget: 500,
+      currency: 'USD',
+    });
+
+    // Delegate to child
+    const delegated = await grantex.grants.delegate({
+      parentGrantToken: parentToken.grantToken,
+      subAgentId: childAgent.agentId,
+      scopes: ['files:read'],
+    });
+
+    expect(delegated.grantToken).toBeTruthy();
+
+    // Check parent budget is still intact
+    const balance = await grantex.budgets.balance(parentToken.grantId);
+    expect(balance.remainingBudget).toBe(500);
+  });
+});

--- a/tests/e2e/domains.test.ts
+++ b/tests/e2e/domains.test.ts
@@ -1,0 +1,128 @@
+/**
+ * E2E Tests: Custom Domain Management
+ *
+ * Tests domain creation, listing, DNS verification, deletion,
+ * plan enforcement, and error handling.
+ * Run: npx vitest run tests/e2e/domains.test.ts
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Grantex } from '@grantex/sdk';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+
+let grantex: Grantex;
+let apiKey: string;
+
+beforeAll(async () => {
+  const account = await Grantex.signup({ name: `e2e-domains-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
+  apiKey = account.apiKey;
+  grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
+});
+
+describe('E2E: Domain CRUD', () => {
+  let domainId: string;
+  let domainName: string;
+  let verificationToken: string;
+
+  it('creates a custom domain', async () => {
+    domainName = `test-${Date.now()}.example.com`;
+    const domain = await grantex.domains.create({ domain: domainName });
+    domainId = domain.id;
+
+    expect(domain.id).toBeDefined();
+    expect(typeof domain.id).toBe('string');
+    expect(domain.domain).toBe(domainName);
+    expect(domain.verified).toBe(false);
+    expect(domain.verificationToken).toBeDefined();
+    expect(typeof domain.verificationToken).toBe('string');
+    expect(domain.verificationToken.length).toBeGreaterThan(0);
+    expect(domain.instructions).toBeDefined();
+    expect(domain.instructions).toContain('TXT');
+    expect(domain.instructions).toContain(domainName);
+
+    verificationToken = domain.verificationToken;
+  });
+
+  it('creates a second domain', async () => {
+    const secondDomain = `api-${Date.now()}.example.org`;
+    const domain = await grantex.domains.create({ domain: secondDomain });
+
+    expect(domain.id).toBeDefined();
+    expect(domain.id).not.toBe(domainId);
+    expect(domain.domain).toBe(secondDomain);
+    expect(domain.verified).toBe(false);
+    expect(domain.verificationToken).not.toBe(verificationToken);
+  });
+
+  it('lists all domains', async () => {
+    const result = await grantex.domains.list();
+    expect(result).toBeDefined();
+    expect(result.domains).toBeDefined();
+    expect(Array.isArray(result.domains)).toBe(true);
+    expect(result.domains.length).toBeGreaterThanOrEqual(2);
+
+    // Find our domain
+    const found = result.domains.find((d: any) => d.id === domainId);
+    expect(found).toBeDefined();
+    expect(found!.domain).toBe(domainName);
+    expect(found!.verified).toBe(false);
+    expect(found!.createdAt).toBeDefined();
+  });
+
+  it('verify domain fails for non-existent DNS record', async () => {
+    // DNS record doesn't exist, so verification should fail
+    try {
+      const result = await grantex.domains.verify(domainId);
+      // If it returns, verified should be false
+      expect(result.verified).toBe(false);
+    } catch (err: any) {
+      // Some implementations throw on verification failure
+      expect(err).toBeDefined();
+    }
+  });
+
+  it('returns 404 when verifying non-existent domain', async () => {
+    try {
+      await grantex.domains.verify('dom_nonexistent_000');
+      expect.fail('Should have thrown');
+    } catch (err: any) {
+      expect(err).toBeDefined();
+    }
+  });
+
+  it('deletes a domain', async () => {
+    await grantex.domains.delete(domainId);
+
+    // Verify it's gone
+    const result = await grantex.domains.list();
+    const found = result.domains.find((d: any) => d.id === domainId);
+    expect(found).toBeUndefined();
+  });
+
+  it('returns 404 when deleting an already-deleted domain', async () => {
+    await expect(grantex.domains.delete(domainId)).rejects.toThrow();
+  });
+
+  it('returns 404 when deleting a non-existent domain', async () => {
+    await expect(grantex.domains.delete('dom_nonexistent_000')).rejects.toThrow();
+  });
+});
+
+describe('E2E: Domain Validation', () => {
+  it('rejects creating a domain with empty string', async () => {
+    await expect(
+      grantex.domains.create({ domain: '' }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects duplicate domain registration', async () => {
+    const domainName = `dup-${Date.now()}.example.com`;
+    await grantex.domains.create({ domain: domainName });
+
+    // Second registration of the same domain should fail
+    await expect(
+      grantex.domains.create({ domain: domainName }),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/e2e/dpdp.test.ts
+++ b/tests/e2e/dpdp.test.ts
@@ -1,0 +1,351 @@
+/**
+ * E2E Tests: DPDP / Data Protection
+ *
+ * Tests consent notice creation, consent record creation and withdrawal,
+ * grievance filing, data principal access, and compliance exports.
+ * Run: npx vitest run tests/e2e/dpdp.test.ts
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Grantex } from '@grantex/sdk';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+
+let grantex: Grantex;
+let apiKey: string;
+let grantId: string;
+let agentId: string;
+const dataPrincipalId = `principal-${Date.now()}`;
+let noticeId: string;
+
+async function authorizeAndExchange(agentId: string, scopes: string[]) {
+  const auth = await grantex.authorize({ agentId, userId: `dpdp-user-${Date.now()}`, scopes });
+  const code = ('code' in auth && typeof (auth as any).code === 'string')
+    ? (auth as any).code
+    : await fetch(`${BASE_URL}/v1/authorize/${auth.authRequestId}/approve`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` }, body: '{}',
+      }).then(r => r.json()).then((d: any) => d.code);
+  return grantex.tokens.exchange({ code, agentId });
+}
+
+beforeAll(async () => {
+  const account = await Grantex.signup({ name: `e2e-dpdp-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
+  apiKey = account.apiKey;
+  grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
+
+  const agent = await grantex.agents.register({ name: `dpdp-agent-${Date.now()}`, scopes: ['files:read', 'email:send'] });
+  agentId = agent.agentId;
+  const token = await authorizeAndExchange(agentId, ['files:read']);
+  grantId = token.grantId;
+});
+
+describe('E2E: DPDP Consent Notices', () => {
+  it('creates a consent notice', async () => {
+    noticeId = `notice-${Date.now()}`;
+    const res = await fetch(`${BASE_URL}/v1/dpdp/consent-notices`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        noticeId,
+        version: '1.0',
+        title: 'Data Processing Notice',
+        content: 'We process your data for service improvement and analytics.',
+        purposes: [
+          { code: 'service', description: 'Service improvement' },
+          { code: 'analytics', description: 'Usage analytics' },
+        ],
+        language: 'en',
+        dataFiduciaryContact: 'privacy@example.com',
+        grievanceOfficer: { name: 'Jane Smith', email: 'grievance@example.com', phone: '+1234567890' },
+      }),
+    });
+    expect(res.status).toBe(201);
+    const notice = (await res.json()) as any;
+    expect(notice.noticeId).toBe(noticeId);
+    expect(notice.version).toBe('1.0');
+    expect(notice.language).toBe('en');
+    expect(notice.contentHash).toBeDefined();
+    expect(typeof notice.contentHash).toBe('string');
+    expect(notice.createdAt).toBeDefined();
+  });
+
+  it('rejects duplicate notice version', async () => {
+    const res = await fetch(`${BASE_URL}/v1/dpdp/consent-notices`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        noticeId,
+        version: '1.0',
+        title: 'Same notice',
+        content: 'Duplicate content',
+        purposes: [{ code: 'service', description: 'Service' }],
+      }),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it('creates a second version of the same notice', async () => {
+    const res = await fetch(`${BASE_URL}/v1/dpdp/consent-notices`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        noticeId,
+        version: '2.0',
+        title: 'Updated Data Processing Notice',
+        content: 'We process your data for service improvement, analytics, and compliance.',
+        purposes: [
+          { code: 'service', description: 'Service improvement' },
+          { code: 'analytics', description: 'Usage analytics' },
+          { code: 'compliance', description: 'Regulatory compliance' },
+        ],
+      }),
+    });
+    expect(res.status).toBe(201);
+    const notice = (await res.json()) as any;
+    expect(notice.version).toBe('2.0');
+  });
+
+  it('rejects notice without required fields', async () => {
+    const res = await fetch(`${BASE_URL}/v1/dpdp/consent-notices`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ noticeId: 'incomplete' }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('E2E: DPDP Consent Records', () => {
+  let recordId: string;
+
+  it('creates a consent record linked to a grant', async () => {
+    const res = await fetch(`${BASE_URL}/v1/dpdp/consent-records`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        grantId,
+        dataPrincipalId,
+        purposes: [
+          { code: 'service', description: 'Service improvement' },
+          { code: 'analytics', description: 'Usage analytics' },
+        ],
+        consentNoticeId: noticeId,
+        processingExpiresAt: new Date(Date.now() + 86400000 * 365).toISOString(),
+      }),
+    });
+    expect(res.status).toBe(201);
+    const record = (await res.json()) as any;
+    recordId = record.recordId;
+
+    expect(record.recordId).toBeDefined();
+    expect(typeof record.recordId).toBe('string');
+    expect(record.grantId).toBe(grantId);
+    expect(record.dataPrincipalId).toBe(dataPrincipalId);
+    expect(record.status).toBe('active');
+    expect(record.consentNoticeHash).toBeDefined();
+    expect(typeof record.consentNoticeHash).toBe('string');
+    expect(record.consentProof).toBeDefined();
+    expect(record.processingExpiresAt).toBeDefined();
+    expect(record.retentionUntil).toBeDefined();
+    expect(record.createdAt).toBeDefined();
+  });
+
+  it('rejects consent record without required fields', async () => {
+    const res = await fetch(`${BASE_URL}/v1/dpdp/consent-records`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ grantId }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects consent record with invalid grant', async () => {
+    const res = await fetch(`${BASE_URL}/v1/dpdp/consent-records`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        grantId: 'grnt_nonexistent_000',
+        dataPrincipalId,
+        purposes: [{ code: 'test', description: 'Test' }],
+        consentNoticeId: noticeId,
+        processingExpiresAt: new Date(Date.now() + 86400000).toISOString(),
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('provides data principal access to their records', async () => {
+    const res = await fetch(`${BASE_URL}/v1/dpdp/data-principals/${dataPrincipalId}/records`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as any;
+
+    expect(body.dataPrincipalId).toBe(dataPrincipalId);
+    expect(body.records).toBeDefined();
+    expect(Array.isArray(body.records)).toBe(true);
+    expect(body.records.length).toBeGreaterThanOrEqual(1);
+    expect(body.totalRecords).toBeGreaterThanOrEqual(1);
+
+    // Verify record shape
+    const record = body.records[0];
+    expect(record).toHaveProperty('recordId');
+    expect(record).toHaveProperty('grantId');
+    expect(record).toHaveProperty('purposes');
+    expect(record).toHaveProperty('scopes');
+    expect(record).toHaveProperty('status');
+    expect(record).toHaveProperty('accessCount');
+    expect(record.accessCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('withdraws consent', async () => {
+    const res = await fetch(`${BASE_URL}/v1/dpdp/consent-records/${recordId}/withdraw`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        reason: 'User no longer wishes data to be processed',
+        revokeGrant: false,
+        deleteProcessedData: true,
+      }),
+    });
+    expect(res.ok).toBe(true);
+    const result = (await res.json()) as any;
+
+    expect(result.recordId).toBe(recordId);
+    expect(result.status).toBe('withdrawn');
+    expect(result.withdrawnAt).toBeDefined();
+    expect(result.grantRevoked).toBe(false);
+    expect(result.dataDeleted).toBe(true);
+  });
+
+  it('rejects double withdrawal', async () => {
+    const res = await fetch(`${BASE_URL}/v1/dpdp/consent-records/${recordId}/withdraw`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ reason: 'Second attempt' }),
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as any;
+    expect(body.code).toBe('ALREADY_WITHDRAWN');
+  });
+
+  it('withdrawal with revokeGrant=true revokes the grant', async () => {
+    // Create a new grant and consent for this test
+    const token = await authorizeAndExchange(agentId, ['email:send']);
+
+    const consentRes = await fetch(`${BASE_URL}/v1/dpdp/consent-records`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        grantId: token.grantId,
+        dataPrincipalId: `revoke-principal-${Date.now()}`,
+        purposes: [{ code: 'service', description: 'Service' }],
+        consentNoticeId: noticeId,
+        processingExpiresAt: new Date(Date.now() + 86400000).toISOString(),
+      }),
+    });
+    expect(consentRes.status).toBe(201);
+    const consentRecord = (await consentRes.json()) as any;
+
+    // Withdraw with grant revocation
+    const withdrawRes = await fetch(`${BASE_URL}/v1/dpdp/consent-records/${consentRecord.recordId}/withdraw`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ reason: 'Revoke grant too', revokeGrant: true }),
+    });
+    expect(withdrawRes.ok).toBe(true);
+    const result = (await withdrawRes.json()) as any;
+    expect(result.grantRevoked).toBe(true);
+
+    // Verify the grant token is now invalid
+    const verify = await grantex.tokens.verify(token.grantToken);
+    expect(verify.valid).toBe(false);
+  });
+});
+
+describe('E2E: DPDP Grievances', () => {
+  let grievanceId: string;
+  let referenceNumber: string;
+
+  it('files a grievance', async () => {
+    const res = await fetch(`${BASE_URL}/v1/dpdp/grievances`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        dataPrincipalId,
+        type: 'data-breach',
+        description: 'Suspected unauthorized access to personal data',
+        evidence: { incidentDate: '2026-04-01', affectedSystems: ['email', 'files'] },
+      }),
+    });
+    expect(res.status).toBe(202);
+    const grievance = (await res.json()) as any;
+    grievanceId = grievance.grievanceId;
+    referenceNumber = grievance.referenceNumber;
+
+    expect(grievance.grievanceId).toBeDefined();
+    expect(typeof grievance.grievanceId).toBe('string');
+    expect(grievance.referenceNumber).toBeDefined();
+    expect(grievance.referenceNumber).toMatch(/^GRV-\d{4}-\d{5}$/);
+    expect(grievance.type).toBe('data-breach');
+    expect(grievance.status).toBe('submitted');
+    expect(grievance.expectedResolutionBy).toBeDefined();
+    expect(grievance.createdAt).toBeDefined();
+
+    // Expected resolution should be 7 days from now (within 1 day margin)
+    const resolution = new Date(grievance.expectedResolutionBy);
+    const sevenDaysFromNow = Date.now() + 7 * 86400000;
+    expect(resolution.getTime()).toBeGreaterThan(sevenDaysFromNow - 86400000);
+    expect(resolution.getTime()).toBeLessThan(sevenDaysFromNow + 86400000);
+  });
+
+  it('retrieves a grievance by ID', async () => {
+    const res = await fetch(`${BASE_URL}/v1/dpdp/grievances/${grievanceId}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.ok).toBe(true);
+    const grievance = (await res.json()) as any;
+
+    expect(grievance.grievanceId).toBe(grievanceId);
+    expect(grievance.dataPrincipalId).toBe(dataPrincipalId);
+    expect(grievance.type).toBe('data-breach');
+    expect(grievance.description).toContain('unauthorized access');
+    expect(grievance.status).toBe('submitted');
+    expect(grievance.referenceNumber).toBe(referenceNumber);
+    expect(grievance.evidence).toBeDefined();
+    expect(grievance.resolvedAt).toBeNull();
+    expect(grievance.resolution).toBeNull();
+  });
+
+  it('files a second grievance with different type', async () => {
+    const res = await fetch(`${BASE_URL}/v1/dpdp/grievances`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        dataPrincipalId,
+        type: 'consent-violation',
+        description: 'Data used beyond consented purposes',
+      }),
+    });
+    expect(res.status).toBe(202);
+    const grievance = (await res.json()) as any;
+    expect(grievance.type).toBe('consent-violation');
+    expect(grievance.referenceNumber).not.toBe(referenceNumber);
+  });
+
+  it('rejects grievance without required fields', async () => {
+    const res = await fetch(`${BASE_URL}/v1/dpdp/grievances`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ dataPrincipalId }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for non-existent grievance', async () => {
+    const res = await fetch(`${BASE_URL}/v1/dpdp/grievances/grv_nonexistent_000`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/e2e/events.test.ts
+++ b/tests/e2e/events.test.ts
@@ -1,0 +1,119 @@
+/**
+ * E2E Tests: Event Streaming
+ *
+ * Tests SSE event stream connection, content type headers,
+ * and connection limits.
+ * Run: npx vitest run tests/e2e/events.test.ts
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Grantex } from '@grantex/sdk';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+
+let grantex: Grantex;
+let apiKey: string;
+
+beforeAll(async () => {
+  const account = await Grantex.signup({ name: `e2e-events-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
+  apiKey = account.apiKey;
+  grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
+});
+
+describe('E2E: SSE Event Stream', () => {
+  it('SSE stream endpoint returns 200 with correct content type', async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+
+    try {
+      const res = await fetch(`${BASE_URL}/v1/events/stream`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal: controller.signal,
+      });
+
+      expect(res.status).toBe(200);
+      const contentType = res.headers.get('content-type');
+      expect(contentType).toContain('text/event-stream');
+
+      // The connection header should indicate keep-alive
+      const cacheControl = res.headers.get('cache-control');
+      expect(cacheControl).toContain('no-cache');
+    } catch (err: any) {
+      // AbortError is expected since we're closing the SSE connection
+      if (err.name !== 'AbortError') {
+        throw err;
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  });
+
+  it('SSE stream rejects unauthenticated requests', async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+
+    try {
+      const res = await fetch(`${BASE_URL}/v1/events/stream`, {
+        signal: controller.signal,
+      });
+
+      // Should return 401 or similar auth error
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(res.status).toBeLessThan(500);
+    } catch (err: any) {
+      if (err.name !== 'AbortError') {
+        throw err;
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  });
+
+  it('SSE stream accepts type filter parameter', async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+
+    try {
+      const res = await fetch(`${BASE_URL}/v1/events/stream?types=grant.created,token.issued`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal: controller.signal,
+      });
+
+      expect(res.status).toBe(200);
+    } catch (err: any) {
+      if (err.name !== 'AbortError') {
+        throw err;
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  });
+});
+
+describe('E2E: Event Stream Headers', () => {
+  it('SSE stream includes buffering headers', async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+
+    try {
+      const res = await fetch(`${BASE_URL}/v1/events/stream`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal: controller.signal,
+      });
+
+      expect(res.status).toBe(200);
+
+      // X-Accel-Buffering should be disabled for SSE
+      const accelBuffering = res.headers.get('x-accel-buffering');
+      if (accelBuffering !== null) {
+        expect(accelBuffering).toBe('no');
+      }
+    } catch (err: any) {
+      if (err.name !== 'AbortError') {
+        throw err;
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  });
+});

--- a/tests/e2e/policies.test.ts
+++ b/tests/e2e/policies.test.ts
@@ -1,0 +1,238 @@
+/**
+ * E2E Tests: Policy Management & Enforcement
+ *
+ * Tests policy CRUD, allow/deny effects, time-of-day policies,
+ * priority ordering, agent-scoped policies, and principal-scoped policies.
+ * Run: npx vitest run tests/e2e/policies.test.ts
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Grantex } from '@grantex/sdk';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+
+let grantex: Grantex;
+let apiKey: string;
+let agentId: string;
+let agentDid: string;
+
+beforeAll(async () => {
+  const account = await Grantex.signup({ name: `e2e-policy-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
+  apiKey = account.apiKey;
+  grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
+
+  const agent = await grantex.agents.register({
+    name: `policy-agent-${Date.now()}`,
+    scopes: ['files:read', 'email:send', 'calendar:read'],
+  });
+  agentId = agent.agentId;
+  agentDid = agent.did;
+});
+
+describe('E2E: Policy CRUD', () => {
+  let allowPolicyId: string;
+  let denyPolicyId: string;
+  let todPolicyId: string;
+  let principalPolicyId: string;
+
+  it('creates an allow policy', async () => {
+    const policy = await grantex.policies.create({
+      name: 'allow-files',
+      effect: 'allow',
+      priority: 10,
+      scopes: ['files:read'],
+    });
+    allowPolicyId = policy.id;
+    expect(policy.id).toBeDefined();
+    expect(typeof policy.id).toBe('string');
+    expect(policy.name).toBe('allow-files');
+    expect(policy.effect).toBe('allow');
+    expect(policy.priority).toBe(10);
+    expect(policy.scopes).toEqual(['files:read']);
+    expect(policy.agentId).toBeNull();
+    expect(policy.principalId).toBeNull();
+    expect(policy.timeOfDayStart).toBeNull();
+    expect(policy.timeOfDayEnd).toBeNull();
+    expect(policy.createdAt).toBeDefined();
+    expect(policy.updatedAt).toBeDefined();
+  });
+
+  it('creates a deny policy scoped to an agent', async () => {
+    const policy = await grantex.policies.create({
+      name: 'deny-email-for-agent',
+      effect: 'deny',
+      priority: 50,
+      scopes: ['email:send'],
+      agentId,
+    });
+    denyPolicyId = policy.id;
+    expect(policy.effect).toBe('deny');
+    expect(policy.priority).toBe(50);
+    expect(policy.agentId).toBe(agentId);
+    expect(policy.scopes).toEqual(['email:send']);
+  });
+
+  it('creates a time-of-day policy', async () => {
+    const policy = await grantex.policies.create({
+      name: 'business-hours-only',
+      effect: 'allow',
+      priority: 5,
+      timeOfDayStart: '09:00',
+      timeOfDayEnd: '17:00',
+      scopes: ['calendar:read'],
+    });
+    todPolicyId = policy.id;
+    expect(policy.timeOfDayStart).toBe('09:00');
+    expect(policy.timeOfDayEnd).toBe('17:00');
+    expect(policy.effect).toBe('allow');
+  });
+
+  it('creates a principal-scoped policy', async () => {
+    const policy = await grantex.policies.create({
+      name: 'allow-specific-principal',
+      effect: 'allow',
+      priority: 30,
+      principalId: 'principal-test-user@example.com',
+      scopes: ['files:read', 'calendar:read'],
+    });
+    principalPolicyId = policy.id;
+    expect(policy.principalId).toBe('principal-test-user@example.com');
+    expect(policy.scopes).toEqual(['files:read', 'calendar:read']);
+  });
+
+  it('lists policies with correct ordering by priority DESC', async () => {
+    const result = await grantex.policies.list();
+    expect(result).toBeDefined();
+    expect(Array.isArray(result.policies)).toBe(true);
+    expect(result.total).toBeGreaterThanOrEqual(4);
+
+    // Verify policies are ordered by priority DESC
+    const priorities = result.policies.map((p: any) => p.priority);
+    for (let i = 1; i < priorities.length; i++) {
+      expect(priorities[i]).toBeLessThanOrEqual(priorities[i - 1]);
+    }
+
+    // Deny policy (priority 50) should be before allow policy (priority 10)
+    const denyIdx = result.policies.findIndex((p: any) => p.id === denyPolicyId);
+    const allowIdx = result.policies.findIndex((p: any) => p.id === allowPolicyId);
+    expect(denyIdx).toBeLessThan(allowIdx);
+  });
+
+  it('gets a policy by ID', async () => {
+    const policy = await grantex.policies.get(allowPolicyId);
+    expect(policy.id).toBe(allowPolicyId);
+    expect(policy.name).toBe('allow-files');
+    expect(policy.effect).toBe('allow');
+    expect(policy.priority).toBe(10);
+  });
+
+  it('updates a policy name and priority', async () => {
+    const updated = await grantex.policies.update(allowPolicyId, {
+      name: 'allow-files-updated',
+      priority: 20,
+    });
+    expect(updated.name).toBe('allow-files-updated');
+    expect(updated.priority).toBe(20);
+    expect(updated.effect).toBe('allow');
+    expect(updated.updatedAt).toBeDefined();
+  });
+
+  it('updates a policy effect from allow to deny', async () => {
+    const updated = await grantex.policies.update(allowPolicyId, {
+      effect: 'deny',
+    });
+    expect(updated.effect).toBe('deny');
+    expect(updated.name).toBe('allow-files-updated');
+  });
+
+  it('returns 400 for invalid effect value', async () => {
+    try {
+      await grantex.policies.update(allowPolicyId, {
+        effect: 'maybe' as any,
+      });
+      expect.fail('Should have thrown');
+    } catch (err: any) {
+      expect(err).toBeDefined();
+    }
+  });
+
+  it('returns 404 for non-existent policy', async () => {
+    await expect(grantex.policies.get('pol_nonexistent_000')).rejects.toThrow();
+  });
+
+  it('deletes the time-of-day policy', async () => {
+    await grantex.policies.delete(todPolicyId);
+
+    // Verify it's gone
+    await expect(grantex.policies.get(todPolicyId)).rejects.toThrow();
+  });
+
+  it('deletes the principal-scoped policy', async () => {
+    await grantex.policies.delete(principalPolicyId);
+
+    const result = await grantex.policies.list();
+    const found = result.policies.find((p: any) => p.id === principalPolicyId);
+    expect(found).toBeUndefined();
+  });
+
+  it('returns 404 when deleting an already-deleted policy', async () => {
+    await expect(grantex.policies.delete(todPolicyId)).rejects.toThrow();
+  });
+
+  it('rejects creating a policy without name', async () => {
+    await expect(
+      grantex.policies.create({
+        name: '',
+        effect: 'allow',
+      } as any),
+    ).rejects.toThrow();
+  });
+});
+
+describe('E2E: Policy Enforcement', () => {
+  it('deny policy blocks authorization for specific scope and agent', async () => {
+    // Create a fresh deny policy
+    const policy = await grantex.policies.create({
+      name: `deny-email-enforcement-${Date.now()}`,
+      effect: 'deny',
+      priority: 100,
+      scopes: ['email:send'],
+      agentId,
+    });
+
+    // Attempt to authorize with the denied scope
+    try {
+      const auth = await grantex.authorize({ agentId, userId: 'user@policy-test.com', scopes: ['email:send'] });
+      // If sandbox auto-approves, the policy might block at token exchange or authorize
+      if ('code' in auth && typeof (auth as any).code === 'string') {
+        try {
+          await grantex.tokens.exchange({ code: (auth as any).code, agentId });
+        } catch (err: any) {
+          // Expected: policy blocks the exchange
+          expect(err.message || err.code).toBeTruthy();
+        }
+      }
+    } catch (err: any) {
+      // Expected: policy blocks the authorization
+      expect(err.message || err.code).toBeTruthy();
+    }
+
+    // Cleanup
+    await grantex.policies.delete(policy.id);
+  });
+
+  it('allow policy with non-matching scope does not block other scopes', async () => {
+    const policy = await grantex.policies.create({
+      name: `allow-calendar-only-${Date.now()}`,
+      effect: 'allow',
+      priority: 5,
+      scopes: ['calendar:read'],
+    });
+
+    // Should be able to authorize with files:read (no deny policy for it)
+    const auth = await grantex.authorize({ agentId, userId: 'user@scope-test.com', scopes: ['files:read'] });
+    expect(auth.authRequestId).toBeDefined();
+
+    await grantex.policies.delete(policy.id);
+  });
+});

--- a/tests/e2e/principal-sessions.test.ts
+++ b/tests/e2e/principal-sessions.test.ts
@@ -1,0 +1,94 @@
+/**
+ * E2E Tests: Principal Sessions
+ *
+ * Tests principal session creation, custom expiry, response shape,
+ * and multiple sessions for different principals.
+ * Run: npx vitest run tests/e2e/principal-sessions.test.ts
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Grantex } from '@grantex/sdk';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+
+let grantex: Grantex;
+
+beforeAll(async () => {
+  const account = await Grantex.signup({ name: `e2e-sessions-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
+  grantex = new Grantex({ apiKey: account.apiKey, baseUrl: BASE_URL });
+});
+
+describe('E2E: Principal Session Creation', () => {
+  it('creates a principal session with default expiry', async () => {
+    const principalId = `user-${Date.now()}@example.com`;
+    const session = await grantex.principalSessions.create({
+      principalId,
+    });
+
+    expect(session).toBeDefined();
+    expect(session.sessionToken).toBeDefined();
+    expect(typeof session.sessionToken).toBe('string');
+    expect(session.sessionToken.length).toBeGreaterThan(0);
+    expect(session.dashboardUrl).toBeDefined();
+    expect(typeof session.dashboardUrl).toBe('string');
+    expect(session.dashboardUrl).toContain('http');
+    expect(session.expiresAt).toBeDefined();
+    expect(typeof session.expiresAt).toBe('string');
+
+    // Verify the expiresAt is in the future
+    const expiresAt = new Date(session.expiresAt);
+    expect(expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('creates a session with custom 1-hour expiry', async () => {
+    const principalId = `user-1h-${Date.now()}@example.com`;
+    const session = await grantex.principalSessions.create({
+      principalId,
+      expiresIn: '1h',
+    });
+
+    expect(session.sessionToken).toBeDefined();
+    expect(session.dashboardUrl).toBeDefined();
+    expect(session.expiresAt).toBeDefined();
+
+    // Verify expiry is approximately 1 hour from now (within 5-minute margin)
+    const expiresAt = new Date(session.expiresAt);
+    const expectedMin = Date.now() + 55 * 60 * 1000; // 55 minutes
+    const expectedMax = Date.now() + 65 * 60 * 1000; // 65 minutes
+    expect(expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin);
+    expect(expiresAt.getTime()).toBeLessThanOrEqual(expectedMax);
+  });
+
+  it('creates sessions for different principals independently', async () => {
+    const session1 = await grantex.principalSessions.create({
+      principalId: `user-a-${Date.now()}@example.com`,
+    });
+    const session2 = await grantex.principalSessions.create({
+      principalId: `user-b-${Date.now()}@example.com`,
+    });
+
+    expect(session1.sessionToken).not.toBe(session2.sessionToken);
+    expect(session1.dashboardUrl).toBeDefined();
+    expect(session2.dashboardUrl).toBeDefined();
+  });
+
+  it('session token is a valid JWT-like string', async () => {
+    const session = await grantex.principalSessions.create({
+      principalId: `user-jwt-${Date.now()}@example.com`,
+    });
+
+    // JWT should have 3 parts separated by dots
+    const parts = session.sessionToken.split('.');
+    expect(parts.length).toBe(3);
+  });
+
+  it('dashboard URL contains the session context', async () => {
+    const session = await grantex.principalSessions.create({
+      principalId: `user-dash-${Date.now()}@example.com`,
+    });
+
+    // Dashboard URL should be a valid URL
+    const url = new URL(session.dashboardUrl);
+    expect(url.protocol).toMatch(/^https?:$/);
+  });
+});

--- a/tests/e2e/scim.test.ts
+++ b/tests/e2e/scim.test.ts
@@ -1,0 +1,181 @@
+/**
+ * E2E Tests: SCIM Token Management
+ *
+ * Tests SCIM token creation, listing, deletion, token secrecy,
+ * and SCIM v2 ServiceProviderConfig endpoint.
+ * Run: npx vitest run tests/e2e/scim.test.ts
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Grantex } from '@grantex/sdk';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+
+let grantex: Grantex;
+let apiKey: string;
+
+beforeAll(async () => {
+  const account = await Grantex.signup({ name: `e2e-scim-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
+  apiKey = account.apiKey;
+  grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
+});
+
+describe('E2E: SCIM Token Management', () => {
+  let tokenId: string;
+  let rawToken: string;
+  let secondTokenId: string;
+
+  it('creates a SCIM token', async () => {
+    const token = await grantex.scim.createToken({ label: 'e2e-test-token' });
+    tokenId = token.id;
+    rawToken = token.token;
+
+    expect(token.id).toBeDefined();
+    expect(typeof token.id).toBe('string');
+    expect(token.label).toBe('e2e-test-token');
+    expect(token.token).toBeDefined();
+    expect(typeof token.token).toBe('string');
+    expect(token.token.length).toBeGreaterThan(0);
+    expect(token.createdAt).toBeDefined();
+  });
+
+  it('creates a second SCIM token with different label', async () => {
+    const token = await grantex.scim.createToken({ label: 'e2e-second-token' });
+    secondTokenId = token.id;
+
+    expect(token.id).toBeDefined();
+    expect(token.id).not.toBe(tokenId);
+    expect(token.label).toBe('e2e-second-token');
+    expect(token.token).toBeDefined();
+    // Each token should be unique
+    expect(token.token).not.toBe(rawToken);
+  });
+
+  it('lists SCIM tokens', async () => {
+    const result = await grantex.scim.listTokens();
+
+    expect(result).toBeDefined();
+    expect(result.tokens).toBeDefined();
+    expect(Array.isArray(result.tokens)).toBe(true);
+    expect(result.tokens.length).toBeGreaterThanOrEqual(2);
+
+    // First token should be in the list
+    const found = result.tokens.find((t: any) => t.id === tokenId);
+    expect(found).toBeDefined();
+    expect(found!.label).toBe('e2e-test-token');
+    expect(found!.createdAt).toBeDefined();
+
+    // Raw token should NOT be in the list response
+    expect((found as any).token).toBeUndefined();
+  });
+
+  it('token IDs are present in list', async () => {
+    const result = await grantex.scim.listTokens();
+    const ids = result.tokens.map((t: any) => t.id);
+    expect(ids).toContain(tokenId);
+    expect(ids).toContain(secondTokenId);
+  });
+
+  it('revokes a SCIM token', async () => {
+    await grantex.scim.revokeToken(tokenId);
+
+    // Verify it's gone
+    const result = await grantex.scim.listTokens();
+    const found = result.tokens.find((t: any) => t.id === tokenId);
+    expect(found).toBeUndefined();
+
+    // Second token should still exist
+    const second = result.tokens.find((t: any) => t.id === secondTokenId);
+    expect(second).toBeDefined();
+  });
+
+  it('returns 404 when revoking an already-deleted token', async () => {
+    await expect(grantex.scim.revokeToken(tokenId)).rejects.toThrow();
+  });
+
+  it('returns 404 for non-existent token ID', async () => {
+    await expect(grantex.scim.revokeToken('scim_nonexistent_000')).rejects.toThrow();
+  });
+
+  it('revokes the second token', async () => {
+    await grantex.scim.revokeToken(secondTokenId);
+    const result = await grantex.scim.listTokens();
+    expect(result.tokens.length).toBe(0);
+  });
+});
+
+describe('E2E: SCIM Token Validation', () => {
+  it('rejects token creation without label', async () => {
+    await expect(
+      grantex.scim.createToken({ label: '' }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('E2E: SCIM ServiceProviderConfig', () => {
+  it('returns ServiceProviderConfig (public endpoint)', async () => {
+    const res = await fetch(`${BASE_URL}/scim/v2/ServiceProviderConfig`);
+    expect(res.ok).toBe(true);
+
+    const config = (await res.json()) as any;
+    expect(config.schemas).toBeDefined();
+    expect(Array.isArray(config.schemas)).toBe(true);
+    expect(config.schemas).toContain('urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig');
+
+    expect(config.patch).toBeDefined();
+    expect(config.patch.supported).toBe(true);
+
+    expect(config.bulk).toBeDefined();
+    expect(config.bulk.supported).toBe(false);
+
+    expect(config.authenticationSchemes).toBeDefined();
+    expect(Array.isArray(config.authenticationSchemes)).toBe(true);
+    expect(config.authenticationSchemes.length).toBeGreaterThan(0);
+    expect(config.authenticationSchemes[0].type).toBe('oauthbearertoken');
+  });
+});
+
+describe('E2E: SCIM Users (with SCIM token auth)', () => {
+  let scimToken: string;
+
+  beforeAll(async () => {
+    const result = await grantex.scim.createToken({ label: 'e2e-scim-users' });
+    scimToken = result.token;
+  });
+
+  it('lists users (initially empty)', async () => {
+    const res = await fetch(`${BASE_URL}/scim/v2/Users`, {
+      headers: { Authorization: `Bearer ${scimToken}` },
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as any;
+    expect(body.schemas).toContain('urn:ietf:params:scim:api:messages:2.0:ListResponse');
+    expect(body.totalResults).toBe(0);
+    expect(body.Resources).toBeDefined();
+    expect(Array.isArray(body.Resources)).toBe(true);
+  });
+
+  it('provisions a SCIM user', async () => {
+    const res = await fetch(`${BASE_URL}/scim/v2/Users`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${scimToken}` },
+      body: JSON.stringify({
+        userName: 'john.doe@example.com',
+        displayName: 'John Doe',
+        emails: [{ value: 'john.doe@example.com', primary: true }],
+      }),
+    });
+    expect(res.status).toBe(201);
+    const user = (await res.json()) as any;
+    expect(user.schemas).toContain('urn:ietf:params:scim:schemas:core:2.0:User');
+    expect(user.userName).toBe('john.doe@example.com');
+    expect(user.displayName).toBe('John Doe');
+    expect(user.active).toBe(true);
+    expect(user.id).toBeDefined();
+  });
+
+  it('rejects SCIM requests without bearer token', async () => {
+    const res = await fetch(`${BASE_URL}/scim/v2/Users`);
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/e2e/sso.test.ts
+++ b/tests/e2e/sso.test.ts
@@ -1,0 +1,244 @@
+/**
+ * E2E Tests: SSO Connection Management
+ *
+ * Tests SSO connection CRUD for OIDC, SAML, and LDAP protocols,
+ * connection updates, status changes, and validation.
+ * Run: npx vitest run tests/e2e/sso.test.ts
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Grantex } from '@grantex/sdk';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+
+let grantex: Grantex;
+let apiKey: string;
+
+beforeAll(async () => {
+  const account = await Grantex.signup({ name: `e2e-sso-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
+  apiKey = account.apiKey;
+  grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
+});
+
+describe('E2E: SSO OIDC Connection', () => {
+  let connectionId: string;
+
+  it('creates an OIDC connection', async () => {
+    const conn = await grantex.sso.createConnection({
+      name: 'test-oidc',
+      protocol: 'oidc',
+      issuerUrl: 'https://accounts.google.com',
+      clientId: 'test-client-id',
+      clientSecret: 'test-secret',
+      domains: ['example.com'],
+      jitProvisioning: true,
+      defaultScopes: ['openid', 'email', 'profile'],
+    });
+    connectionId = conn.id;
+
+    expect(conn.id).toBeDefined();
+    expect(typeof conn.id).toBe('string');
+    expect(conn.name).toBe('test-oidc');
+    expect(conn.protocol).toBe('oidc');
+    expect(conn.status).toBeDefined();
+    expect(conn.issuerUrl).toBe('https://accounts.google.com');
+    expect(conn.clientId).toBe('test-client-id');
+    expect(conn.domains).toEqual(['example.com']);
+    expect(conn.jitProvisioning).toBe(true);
+    expect(conn.defaultScopes).toEqual(['openid', 'email', 'profile']);
+    expect(conn.createdAt).toBeDefined();
+  });
+
+  it('gets a connection by ID', async () => {
+    const conn = await grantex.sso.getConnection(connectionId);
+
+    expect(conn.id).toBe(connectionId);
+    expect(conn.name).toBe('test-oidc');
+    expect(conn.protocol).toBe('oidc');
+    expect(conn.issuerUrl).toBe('https://accounts.google.com');
+  });
+
+  it('updates the connection name and status', async () => {
+    const updated = await grantex.sso.updateConnection(connectionId, {
+      name: 'updated-oidc',
+      status: 'active',
+    });
+
+    expect(updated.name).toBe('updated-oidc');
+    expect(updated.protocol).toBe('oidc');
+  });
+
+  it('updates connection domains', async () => {
+    const updated = await grantex.sso.updateConnection(connectionId, {
+      domains: ['example.com', 'example.org'],
+    });
+
+    expect(updated.domains).toEqual(['example.com', 'example.org']);
+  });
+
+  it('lists SSO connections', async () => {
+    const result = await grantex.sso.listConnections();
+
+    expect(result).toBeDefined();
+    expect(result.connections).toBeDefined();
+    expect(Array.isArray(result.connections)).toBe(true);
+    expect(result.connections.length).toBeGreaterThanOrEqual(1);
+
+    const found = result.connections.find((c: any) => c.id === connectionId);
+    expect(found).toBeDefined();
+    expect(found!.name).toBe('updated-oidc');
+  });
+
+  it('deletes the OIDC connection', async () => {
+    await grantex.sso.deleteConnection(connectionId);
+    const result = await grantex.sso.listConnections();
+    const found = result.connections.find((c: any) => c.id === connectionId);
+    expect(found).toBeUndefined();
+  });
+});
+
+describe('E2E: SSO SAML Connection', () => {
+  let connectionId: string;
+
+  it('creates a SAML connection', async () => {
+    const conn = await grantex.sso.createConnection({
+      name: 'test-saml',
+      protocol: 'saml',
+      idpEntityId: 'https://idp.example.com/metadata',
+      idpSsoUrl: 'https://idp.example.com/sso',
+      idpCertificate: 'MIIC...base64cert',
+      spEntityId: 'https://app.grantex.dev/saml',
+      spAcsUrl: 'https://app.grantex.dev/saml/acs',
+      domains: ['saml.example.com'],
+    });
+    connectionId = conn.id;
+
+    expect(conn.name).toBe('test-saml');
+    expect(conn.protocol).toBe('saml');
+    expect(conn.idpEntityId).toBe('https://idp.example.com/metadata');
+    expect(conn.idpSsoUrl).toBe('https://idp.example.com/sso');
+    expect(conn.domains).toEqual(['saml.example.com']);
+  });
+
+  it('gets the SAML connection', async () => {
+    const conn = await grantex.sso.getConnection(connectionId);
+    expect(conn.protocol).toBe('saml');
+    expect(conn.spEntityId).toBe('https://app.grantex.dev/saml');
+    expect(conn.spAcsUrl).toBe('https://app.grantex.dev/saml/acs');
+  });
+
+  it('deletes the SAML connection', async () => {
+    await grantex.sso.deleteConnection(connectionId);
+    await expect(grantex.sso.getConnection(connectionId)).rejects.toThrow();
+  });
+});
+
+describe('E2E: SSO LDAP Connection', () => {
+  let connectionId: string;
+
+  it('creates an LDAP connection', async () => {
+    const conn = await grantex.sso.createConnection({
+      name: 'test-ldap',
+      protocol: 'ldap',
+      ldapUrl: 'ldap://ldap.example.com:389',
+      ldapBindDn: 'cn=admin,dc=example,dc=com',
+      ldapBindPassword: 'admin-password',
+      ldapSearchBase: 'ou=users,dc=example,dc=com',
+      ldapSearchFilter: '(uid={{username}})',
+      ldapTlsEnabled: false,
+      domains: ['ldap.example.com'],
+    });
+    connectionId = conn.id;
+
+    expect(conn.name).toBe('test-ldap');
+    expect(conn.protocol).toBe('ldap');
+    expect(conn.ldapUrl).toBe('ldap://ldap.example.com:389');
+    expect(conn.ldapBindDn).toBe('cn=admin,dc=example,dc=com');
+    expect(conn.ldapSearchBase).toBe('ou=users,dc=example,dc=com');
+    expect(conn.ldapTlsEnabled).toBe(false);
+  });
+
+  it('deletes the LDAP connection', async () => {
+    await grantex.sso.deleteConnection(connectionId);
+  });
+});
+
+describe('E2E: SSO Validation', () => {
+  it('rejects connection without name', async () => {
+    await expect(
+      grantex.sso.createConnection({
+        name: '',
+        protocol: 'oidc',
+        issuerUrl: 'https://example.com',
+        clientId: 'id',
+        clientSecret: 'secret',
+      } as any),
+    ).rejects.toThrow();
+  });
+
+  it('rejects OIDC connection without required fields', async () => {
+    await expect(
+      grantex.sso.createConnection({
+        name: 'incomplete-oidc',
+        protocol: 'oidc',
+        issuerUrl: 'https://example.com',
+        // Missing clientId and clientSecret
+      } as any),
+    ).rejects.toThrow();
+  });
+
+  it('rejects SAML connection without required fields', async () => {
+    await expect(
+      grantex.sso.createConnection({
+        name: 'incomplete-saml',
+        protocol: 'saml',
+        idpEntityId: 'https://idp.example.com',
+        // Missing idpSsoUrl and idpCertificate
+      } as any),
+    ).rejects.toThrow();
+  });
+
+  it('rejects LDAP connection without required fields', async () => {
+    await expect(
+      grantex.sso.createConnection({
+        name: 'incomplete-ldap',
+        protocol: 'ldap',
+        ldapUrl: 'ldap://example.com',
+        // Missing ldapBindDn, ldapBindPassword, ldapSearchBase
+      } as any),
+    ).rejects.toThrow();
+  });
+
+  it('returns 404 for non-existent connection', async () => {
+    await expect(grantex.sso.getConnection('sso_nonexistent_000')).rejects.toThrow();
+  });
+
+  it('returns 404 when deleting non-existent connection', async () => {
+    await expect(grantex.sso.deleteConnection('sso_nonexistent_000')).rejects.toThrow();
+  });
+});
+
+describe('E2E: SSO Group Mappings', () => {
+  it('creates a connection with group mappings', async () => {
+    const conn = await grantex.sso.createConnection({
+      name: 'test-group-mappings',
+      protocol: 'oidc',
+      issuerUrl: 'https://accounts.google.com',
+      clientId: 'group-test-id',
+      clientSecret: 'group-test-secret',
+      groupAttribute: 'groups',
+      groupMappings: {
+        admin: ['files:write', 'admin:manage'],
+        viewer: ['files:read'],
+      },
+      defaultScopes: ['files:read'],
+    });
+
+    expect(conn.groupAttribute).toBe('groups');
+    expect(conn.groupMappings).toBeDefined();
+    expect(conn.defaultScopes).toEqual(['files:read']);
+
+    // Cleanup
+    await grantex.sso.deleteConnection(conn.id);
+  });
+});

--- a/tests/e2e/usage.test.ts
+++ b/tests/e2e/usage.test.ts
@@ -1,0 +1,145 @@
+/**
+ * E2E Tests: Usage Metering
+ *
+ * Tests current period usage, historical usage, field types,
+ * and edge cases for usage queries.
+ * Run: npx vitest run tests/e2e/usage.test.ts
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Grantex } from '@grantex/sdk';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+
+let grantex: Grantex;
+let apiKey: string;
+let agentId: string;
+
+async function authorizeAndExchange(agentId: string, scopes: string[]) {
+  const auth = await grantex.authorize({ agentId, userId: `usage-user-${Date.now()}`, scopes });
+  const code = ('code' in auth && typeof (auth as any).code === 'string')
+    ? (auth as any).code
+    : await fetch(`${BASE_URL}/v1/authorize/${auth.authRequestId}/approve`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` }, body: '{}',
+      }).then(r => r.json()).then((d: any) => d.code);
+  return grantex.tokens.exchange({ code, agentId });
+}
+
+beforeAll(async () => {
+  const account = await Grantex.signup({ name: `e2e-usage-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
+  apiKey = account.apiKey;
+  grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
+
+  // Create some activity to have non-zero usage
+  const agent = await grantex.agents.register({ name: `usage-agent-${Date.now()}`, scopes: ['files:read'] });
+  agentId = agent.agentId;
+
+  // Authorize + exchange to generate usage
+  const token = await authorizeAndExchange(agentId, ['files:read']);
+  // Verify to generate verification usage
+  await grantex.tokens.verify(token.grantToken);
+});
+
+describe('E2E: Current Usage', () => {
+  it('returns current period usage with all fields', async () => {
+    const usage = await grantex.usage.current();
+
+    expect(usage).toBeDefined();
+    expect(usage).toHaveProperty('developerId');
+    expect(typeof usage.developerId).toBe('string');
+    expect(usage.developerId.length).toBeGreaterThan(0);
+
+    expect(usage).toHaveProperty('period');
+    expect(typeof usage.period).toBe('string');
+    // Period should be a date string like YYYY-MM-DD
+    expect(usage.period).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+    expect(usage).toHaveProperty('tokenExchanges');
+    expect(typeof usage.tokenExchanges).toBe('number');
+    expect(usage.tokenExchanges).toBeGreaterThanOrEqual(0);
+
+    expect(usage).toHaveProperty('authorizations');
+    expect(typeof usage.authorizations).toBe('number');
+    expect(usage.authorizations).toBeGreaterThanOrEqual(0);
+
+    expect(usage).toHaveProperty('verifications');
+    expect(typeof usage.verifications).toBe('number');
+    expect(usage.verifications).toBeGreaterThanOrEqual(0);
+
+    expect(usage).toHaveProperty('totalRequests');
+    expect(typeof usage.totalRequests).toBe('number');
+    expect(usage.totalRequests).toBeGreaterThanOrEqual(0);
+
+    // totalRequests should equal the sum of the three categories
+    expect(usage.totalRequests).toBe(
+      usage.tokenExchanges + usage.authorizations + usage.verifications,
+    );
+  });
+
+  it('reflects activity from the test setup', async () => {
+    const usage = await grantex.usage.current();
+
+    // We did at least 1 authorization + 1 token exchange + 1 verification in setup
+    expect(usage.authorizations).toBeGreaterThanOrEqual(1);
+    expect(usage.tokenExchanges).toBeGreaterThanOrEqual(1);
+    expect(usage.verifications).toBeGreaterThanOrEqual(1);
+    expect(usage.totalRequests).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('E2E: Usage History', () => {
+  it('returns usage history with default days (30)', async () => {
+    const history = await grantex.usage.history({ days: 30 });
+
+    expect(history).toBeDefined();
+    expect(history).toHaveProperty('developerId');
+    expect(history).toHaveProperty('days');
+    expect(history.days).toBe(30);
+    expect(history).toHaveProperty('entries');
+    expect(Array.isArray(history.entries)).toBe(true);
+  });
+
+  it('returns usage history with 7 days', async () => {
+    const history = await grantex.usage.history({ days: 7 });
+
+    expect(history.days).toBe(7);
+    expect(history.entries).toBeDefined();
+  });
+
+  it('entries have correct shape', async () => {
+    const history = await grantex.usage.history({ days: 7 });
+
+    if (history.entries.length > 0) {
+      const entry = history.entries[0];
+      expect(entry).toHaveProperty('date');
+      expect(typeof entry.date).toBe('string');
+      expect(entry).toHaveProperty('tokenExchanges');
+      expect(typeof entry.tokenExchanges).toBe('number');
+      expect(entry).toHaveProperty('authorizations');
+      expect(typeof entry.authorizations).toBe('number');
+      expect(entry).toHaveProperty('verifications');
+      expect(typeof entry.verifications).toBe('number');
+      expect(entry).toHaveProperty('totalRequests');
+      expect(typeof entry.totalRequests).toBe('number');
+    }
+  });
+
+  it('history entries are ordered by date descending', async () => {
+    const history = await grantex.usage.history({ days: 30 });
+
+    if (history.entries.length > 1) {
+      for (let i = 1; i < history.entries.length; i++) {
+        const prev = new Date(history.entries[i - 1].date).getTime();
+        const curr = new Date(history.entries[i].date).getTime();
+        expect(prev).toBeGreaterThanOrEqual(curr);
+      }
+    }
+  });
+
+  it('returns max 90 days of history', async () => {
+    const history = await grantex.usage.history({ days: 180 });
+
+    // Server caps at 90 days
+    expect(history.days).toBeLessThanOrEqual(90);
+  });
+});

--- a/tests/e2e/vault.test.ts
+++ b/tests/e2e/vault.test.ts
@@ -1,0 +1,199 @@
+/**
+ * E2E Tests: Vault Credential Storage
+ *
+ * Tests store, list, get, delete vault credentials, filtering,
+ * upsert behavior, and error handling.
+ * Run: npx vitest run tests/e2e/vault.test.ts
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Grantex } from '@grantex/sdk';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+
+let grantex: Grantex;
+let apiKey: string;
+
+beforeAll(async () => {
+  const account = await Grantex.signup({ name: `e2e-vault-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
+  apiKey = account.apiKey;
+  grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
+});
+
+describe('E2E: Vault CRUD', () => {
+  let credId: string;
+  const principalId = `vault-principal-${Date.now()}`;
+
+  it('stores a credential in the vault', async () => {
+    const cred = await grantex.vault.store({
+      principalId,
+      service: 'github',
+      accessToken: 'ghp_test123456789',
+      refreshToken: 'ghr_refresh_token',
+      credentialType: 'oauth2',
+      metadata: { org: 'grantex-dev' },
+    });
+    credId = cred.id;
+
+    expect(cred.id).toBeDefined();
+    expect(typeof cred.id).toBe('string');
+    expect(cred.principalId).toBe(principalId);
+    expect(cred.service).toBe('github');
+    expect(cred.credentialType).toBe('oauth2');
+    expect(cred.createdAt).toBeDefined();
+  });
+
+  it('stores a second credential for a different service', async () => {
+    const cred = await grantex.vault.store({
+      principalId,
+      service: 'google',
+      accessToken: 'ya29.access_token_google',
+      credentialType: 'oauth2',
+      tokenExpiresAt: new Date(Date.now() + 3600000).toISOString(),
+    });
+
+    expect(cred.id).toBeDefined();
+    expect(cred.service).toBe('google');
+  });
+
+  it('stores a credential for a different principal', async () => {
+    const otherPrincipal = `vault-other-${Date.now()}`;
+    const cred = await grantex.vault.store({
+      principalId: otherPrincipal,
+      service: 'slack',
+      accessToken: 'xoxb-slack-token',
+      credentialType: 'api_key',
+    });
+
+    expect(cred.principalId).toBe(otherPrincipal);
+    expect(cred.service).toBe('slack');
+  });
+
+  it('lists all vault credentials', async () => {
+    const result = await grantex.vault.list();
+    expect(result).toBeDefined();
+    expect(result.credentials).toBeDefined();
+    expect(Array.isArray(result.credentials)).toBe(true);
+    expect(result.credentials.length).toBeGreaterThanOrEqual(3);
+
+    // Verify credential shape (metadata only, no raw tokens)
+    const cred = result.credentials[0];
+    expect(cred).toHaveProperty('id');
+    expect(cred).toHaveProperty('principalId');
+    expect(cred).toHaveProperty('service');
+    expect(cred).toHaveProperty('credentialType');
+    expect(cred).toHaveProperty('createdAt');
+    // Raw tokens should NOT be in the list response
+    expect((cred as any).accessToken).toBeUndefined();
+  });
+
+  it('lists credentials filtered by principalId', async () => {
+    const res = await fetch(`${BASE_URL}/v1/vault/credentials?principalId=${principalId}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as { credentials: any[] };
+    expect(body.credentials.length).toBe(2); // github + google
+    body.credentials.forEach((c: any) => {
+      expect(c.principalId).toBe(principalId);
+    });
+  });
+
+  it('lists credentials filtered by service', async () => {
+    const res = await fetch(`${BASE_URL}/v1/vault/credentials?service=github`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as { credentials: any[] };
+    expect(body.credentials.length).toBeGreaterThanOrEqual(1);
+    body.credentials.forEach((c: any) => {
+      expect(c.service).toBe('github');
+    });
+  });
+
+  it('gets a vault credential by ID', async () => {
+    const cred = await grantex.vault.get(credId);
+
+    expect(cred.id).toBe(credId);
+    expect(cred.principalId).toBe(principalId);
+    expect(cred.service).toBe('github');
+    expect(cred.credentialType).toBe('oauth2');
+    // Should not expose raw tokens
+    expect((cred as any).accessToken).toBeUndefined();
+    expect((cred as any).refreshToken).toBeUndefined();
+  });
+
+  it('returns 404 for non-existent credential ID', async () => {
+    await expect(grantex.vault.get('vault_nonexistent_000')).rejects.toThrow();
+  });
+
+  it('deletes a vault credential', async () => {
+    await grantex.vault.delete(credId);
+
+    // Verify it's gone
+    await expect(grantex.vault.get(credId)).rejects.toThrow();
+  });
+
+  it('returns 404 when deleting an already-deleted credential', async () => {
+    await expect(grantex.vault.delete(credId)).rejects.toThrow();
+  });
+});
+
+describe('E2E: Vault Upsert Behavior', () => {
+  it('upserts credential for same principal+service combination', async () => {
+    const principalId = `vault-upsert-${Date.now()}`;
+
+    // First store
+    const first = await grantex.vault.store({
+      principalId,
+      service: 'datadog',
+      accessToken: 'dd_original_token',
+    });
+    expect(first.id).toBeDefined();
+
+    // Second store with same principal+service should upsert
+    const second = await grantex.vault.store({
+      principalId,
+      service: 'datadog',
+      accessToken: 'dd_updated_token',
+    });
+    expect(second.id).toBeDefined();
+
+    // Should only have one credential for this principal+service
+    const res = await fetch(
+      `${BASE_URL}/v1/vault/credentials?principalId=${principalId}&service=datadog`,
+      { headers: { Authorization: `Bearer ${apiKey}` } },
+    );
+    const body = (await res.json()) as { credentials: any[] };
+    expect(body.credentials.length).toBe(1);
+  });
+});
+
+describe('E2E: Vault Validation', () => {
+  it('rejects store without principalId', async () => {
+    const res = await fetch(`${BASE_URL}/v1/vault/credentials`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ service: 'test', accessToken: 'tok' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects store without service', async () => {
+    const res = await fetch(`${BASE_URL}/v1/vault/credentials`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ principalId: 'user', accessToken: 'tok' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects store without accessToken', async () => {
+    const res = await fetch(`${BASE_URL}/v1/vault/credentials`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ principalId: 'user', service: 'test' }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/e2e/webhooks.test.ts
+++ b/tests/e2e/webhooks.test.ts
@@ -1,0 +1,179 @@
+/**
+ * E2E Tests: Webhook Management
+ *
+ * Tests webhook creation, listing, deletion, secret uniqueness,
+ * invalid event types, and duplicate webhook handling.
+ * Run: npx vitest run tests/e2e/webhooks.test.ts
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Grantex } from '@grantex/sdk';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+
+let grantex: Grantex;
+let apiKey: string;
+
+beforeAll(async () => {
+  const account = await Grantex.signup({ name: `e2e-webhook-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
+  apiKey = account.apiKey;
+  grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
+});
+
+describe('E2E: Webhook CRUD', () => {
+  let webhookId: string;
+  let webhookSecret: string;
+  let secondWebhookId: string;
+  let secondWebhookSecret: string;
+
+  it('creates a webhook with multiple events', async () => {
+    const webhook = await grantex.webhooks.create({
+      url: 'https://example.com/webhook/grantex',
+      events: ['grant.created', 'grant.revoked'],
+    });
+    webhookId = webhook.id;
+    webhookSecret = webhook.secret;
+
+    expect(webhook.id).toBeDefined();
+    expect(typeof webhook.id).toBe('string');
+    expect(webhook.url).toBe('https://example.com/webhook/grantex');
+    expect(webhook.events).toEqual(['grant.created', 'grant.revoked']);
+    expect(webhook.events).toHaveLength(2);
+    expect(webhook.secret).toBeDefined();
+    expect(typeof webhook.secret).toBe('string');
+    expect(webhook.secret.length).toBeGreaterThan(0);
+    expect(webhook.createdAt).toBeDefined();
+  });
+
+  it('creates a second webhook with a single event', async () => {
+    const webhook = await grantex.webhooks.create({
+      url: 'https://example.com/webhook/tokens',
+      events: ['token.issued'],
+    });
+    secondWebhookId = webhook.id;
+    secondWebhookSecret = webhook.secret;
+
+    expect(webhook.id).toBeDefined();
+    expect(webhook.id).not.toBe(webhookId);
+    expect(webhook.events).toEqual(['token.issued']);
+    expect(webhook.url).toBe('https://example.com/webhook/tokens');
+  });
+
+  it('each webhook gets a unique secret', async () => {
+    expect(webhookSecret).not.toBe(secondWebhookSecret);
+  });
+
+  it('lists all webhooks for the developer', async () => {
+    const result = await grantex.webhooks.list();
+    expect(result).toBeDefined();
+    expect(result.webhooks).toBeDefined();
+    expect(Array.isArray(result.webhooks)).toBe(true);
+    expect(result.webhooks.length).toBeGreaterThanOrEqual(2);
+
+    // First webhook should be in the list
+    const first = result.webhooks.find((w: any) => w.id === webhookId);
+    expect(first).toBeDefined();
+    expect(first!.url).toBe('https://example.com/webhook/grantex');
+    expect(first!.events).toEqual(['grant.created', 'grant.revoked']);
+
+    // Second webhook should also be present
+    const second = result.webhooks.find((w: any) => w.id === secondWebhookId);
+    expect(second).toBeDefined();
+    expect(second!.url).toBe('https://example.com/webhook/tokens');
+  });
+
+  it('deletes the first webhook', async () => {
+    await grantex.webhooks.delete(webhookId);
+
+    // Verify it's gone
+    const result = await grantex.webhooks.list();
+    const found = result.webhooks.find((w: any) => w.id === webhookId);
+    expect(found).toBeUndefined();
+
+    // Second webhook should still exist
+    const second = result.webhooks.find((w: any) => w.id === secondWebhookId);
+    expect(second).toBeDefined();
+  });
+
+  it('returns 404 when deleting an already-deleted webhook', async () => {
+    await expect(grantex.webhooks.delete(webhookId)).rejects.toThrow();
+  });
+
+  it('deletes the second webhook', async () => {
+    await grantex.webhooks.delete(secondWebhookId);
+    const result = await grantex.webhooks.list();
+    expect(result.webhooks.length).toBe(0);
+  });
+});
+
+describe('E2E: Webhook Validation', () => {
+  it('rejects invalid event types', async () => {
+    await expect(
+      grantex.webhooks.create({
+        url: 'https://example.com/bad',
+        events: ['invalid.event.type'],
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects empty events array', async () => {
+    await expect(
+      grantex.webhooks.create({
+        url: 'https://example.com/empty',
+        events: [],
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects mix of valid and invalid events', async () => {
+    await expect(
+      grantex.webhooks.create({
+        url: 'https://example.com/mixed',
+        events: ['grant.created', 'nonexistent.event'],
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('creates a webhook with all valid event types', async () => {
+    const webhook = await grantex.webhooks.create({
+      url: 'https://example.com/all-events',
+      events: ['grant.created', 'grant.revoked', 'token.issued'],
+    });
+    expect(webhook.events).toEqual(['grant.created', 'grant.revoked', 'token.issued']);
+    expect(webhook.events).toHaveLength(3);
+
+    // Cleanup
+    await grantex.webhooks.delete(webhook.id);
+  });
+});
+
+describe('E2E: Webhook Deliveries', () => {
+  it('returns deliveries endpoint for a valid webhook', async () => {
+    const webhook = await grantex.webhooks.create({
+      url: 'https://example.com/deliveries-test',
+      events: ['grant.created'],
+    });
+
+    // Query deliveries via raw fetch (may not be in SDK)
+    const res = await fetch(`${BASE_URL}/v1/webhooks/${webhook.id}/deliveries`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as { deliveries: any[]; total: number; page: number; pageSize: number };
+    expect(body.deliveries).toBeDefined();
+    expect(Array.isArray(body.deliveries)).toBe(true);
+    expect(typeof body.total).toBe('number');
+    expect(typeof body.page).toBe('number');
+    expect(typeof body.pageSize).toBe('number');
+
+    // Cleanup
+    await grantex.webhooks.delete(webhook.id);
+  });
+
+  it('returns 404 for deliveries of non-existent webhook', async () => {
+    const res = await fetch(`${BASE_URL}/v1/webhooks/wh_nonexistent_000/deliveries`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/e2e/**/*.test.ts'],
+    // Run E2E tests sequentially to avoid production rate limits
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
## Summary
- **111 new test files**, 13,500+ lines of test code across 3 areas
- Portal UI: 90 test files (was 0) — components, pages, API layer, stores, utilities
- E2E: 14 new test files against production — budget, policies, webhooks, credentials, domains, vault, compliance, usage, events, SCIM, SSO, DPDP, principal sessions, cross-feature
- Python SDK: 5 new test files — domains, usage, PKCE, error handling, HTTP edge cases
- Root vitest config for sequential E2E execution (avoids rate limiting)

## Production test results
| Suite | Passed | Total | Rate |
|-------|--------|-------|------|
| Python SDK | 200 | 200 | 100% |
| Portal UI | 820 | 846 | 96.9% |
| E2E (Production) | 154 | 178 | 86.5% |
| **Grand Total** | **1,174** | **1,224** | **95.9%** |

## Test plan
- [x] Python SDK: `cd packages/sdk-py && python -m pytest tests/ -v` — 200/200 pass
- [x] Portal UI: `cd apps/portal && npx vitest run` — 820/846 pass
- [x] E2E sequential: run files individually against production — 154/178 pass
- [ ] Fix 24 remaining assertion mismatches (SDK response shape, timing)