### PR TITLE
docs: fix 404s for Gemma, MCP Auth, Trust Registry, DPDP integration pages

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -292,7 +292,9 @@
             "group": "Service Providers",
             "pages": [
               "integrations/adapters",
-              "integrations/gateway"
+              "integrations/gateway",
+              "integrations/mcp-auth",
+              "integrations/registry"
             ]
           },
           {
@@ -313,7 +315,14 @@
           {
             "group": "On-Device",
             "pages": [
-              "sdks/gemma"
+              "sdks/gemma",
+              "integrations/gemma"
+            ]
+          },
+          {
+            "group": "Compliance",
+            "pages": [
+              "integrations/dpdp"
             ]
           },
           {

--- a/docs/integrations/dpdp.mdx
+++ b/docs/integrations/dpdp.mdx
@@ -1,0 +1,37 @@
+---
+title: "DPDP & GDPR Compliance"
+sidebarTitle: "DPDP / GDPR"
+description: "India DPDP Act 2023 and EU GDPR compliance module for AI agent deployments — consent records, purpose limitation, grievances, and audit exports."
+---
+
+<Info>Full feature guide: [DPDP Compliance](/features/dpdp-compliance) | Regulatory reference: [DPDP Act 2023](/compliance/dpdp-act-2023)</Info>
+
+## Overview
+
+The Grantex DPDP module provides structured compliance tooling for AI agent deployments under the India Digital Personal Data Protection Act 2023 and the EU GDPR. It manages consent records, purpose limitation, right to withdrawal, grievance handling, and audit-ready exports.
+
+### Key Capabilities
+
+- **Consent records** — link consent to grants with purpose codes, processing expiry, and retention periods
+- **Consent notices** — versioned, content-hashed notices with grievance officer details
+- **Right to withdrawal** — withdraw consent with optional grant revocation and data deletion
+- **Grievance filing** — structured grievance workflow with reference numbers and SLA tracking
+- **Compliance exports** — DPDP audit, GDPR Article 15, and EU AI Act conformance reports
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/v1/dpdp/consent-records` | Create consent record |
+| `POST` | `/v1/dpdp/consent-records/:id/withdraw` | Withdraw consent |
+| `GET` | `/v1/dpdp/data-principals/:id/records` | Data principal access |
+| `POST` | `/v1/dpdp/consent-notices` | Create consent notice |
+| `POST` | `/v1/dpdp/grievances` | File grievance |
+| `GET` | `/v1/dpdp/grievances/:id` | Get grievance status |
+| `POST` | `/v1/dpdp/exports` | Generate compliance export |
+
+## Links
+
+- [Full Feature Guide](/features/dpdp-compliance)
+- [DPDP Act 2023 Reference](/compliance/dpdp-act-2023)
+- [EU AI Act Reference](/compliance/eu-ai-act)

--- a/docs/integrations/gemma.mdx
+++ b/docs/integrations/gemma.mdx
@@ -1,0 +1,76 @@
+---
+title: "Gemma 4 (On-Device)"
+sidebarTitle: "Gemma 4"
+description: "Offline authorization for Gemma 4 on-device AI agents — consent bundles, JWT verification, and tamper-evident audit logging without network calls."
+---
+
+<Info>Full SDK reference: [Gemma 4 SDK](/sdks/gemma)</Info>
+
+## Overview
+
+`@grantex/gemma` brings Grantex authorization to edge devices running Google Gemma models. Agents fetch a consent bundle while online, then verify permissions and log actions entirely offline.
+
+### Key Capabilities
+
+- **Consent bundles** — fetch signed grant tokens + JWKS keys, encrypt locally with AES-256-GCM
+- **Offline JWT verification** — verify scopes on-device using embedded JWKS snapshot, zero network calls
+- **Tamper-evident audit logging** — hash-chained, Ed25519-signed JSONL logs, sync to cloud when connectivity returns
+- **Framework adapters** — wraps Google ADK and LangChain tools with automatic auth enforcement
+
+## Install
+
+<CodeGroup>
+
+```bash TypeScript
+npm install @grantex/gemma
+```
+
+```bash Python
+pip install grantex-gemma
+```
+
+</CodeGroup>
+
+## Quick Start
+
+```typescript
+import {
+  createConsentBundle,
+  createOfflineVerifier,
+  createOfflineAuditLog,
+} from '@grantex/gemma';
+
+// 1. Fetch bundle while online
+const bundle = await createConsentBundle({
+  apiKey: process.env.GRANTEX_API_KEY!,
+  agentId: 'ag_01HXYZ...',
+  userId: 'user_abc123',
+  scopes: ['calendar:read', 'email:send'],
+});
+
+// 2. Verify offline — no network needed
+const verifier = createOfflineVerifier({
+  jwksSnapshot: bundle.jwksSnapshot,
+  requireScopes: ['calendar:read'],
+});
+const grant = await verifier.verify(bundle.grantToken);
+
+// 3. Log actions with tamper-evident audit trail
+const auditLog = createOfflineAuditLog({
+  signingKey: bundle.offlineAuditKey,
+  logPath: './audit.jsonl',
+});
+await auditLog.append({
+  action: 'calendar.read',
+  agentDID: grant.agentDID,
+  grantId: grant.grantId,
+  scopes: grant.scopes,
+  result: 'success',
+});
+```
+
+## Links
+
+- [Full SDK Reference](/sdks/gemma) — complete API docs for all functions
+- [npm: @grantex/gemma](https://npmjs.com/package/@grantex/gemma)
+- [Blog: Offline Authorization for Gemma 4 Agents](/blog/gemma-4-offline-agents-security)

--- a/docs/integrations/mcp-auth.mdx
+++ b/docs/integrations/mcp-auth.mdx
@@ -1,0 +1,45 @@
+---
+title: "MCP Auth Server"
+sidebarTitle: "MCP Auth"
+description: "Drop-in OAuth 2.1 + PKCE authorization server for any MCP server. Powered by Grantex."
+---
+
+<Info>Full feature guide: [MCP Auth Server](/features/mcp-auth-server)</Info>
+
+## Overview
+
+`@grantex/mcp-auth` is a production-ready OAuth 2.1 + PKCE authorization server that adds delegated auth to any MCP (Model Context Protocol) server. Works with Claude Desktop, Cursor, Windsurf, and any MCP-compatible client.
+
+## Install
+
+```bash
+npm install @grantex/mcp-auth
+```
+
+## Quick Start
+
+```typescript
+import { createMcpAuthServer } from '@grantex/mcp-auth';
+
+const auth = createMcpAuthServer({
+  grantexApiKey: process.env.GRANTEX_API_KEY!,
+  issuer: 'https://auth.myapp.com',
+  scopes: ['calendar:read', 'email:send'],
+});
+
+// Mount on Express
+app.use('/oauth', auth.routes());
+```
+
+### What You Get
+
+- **OAuth 2.1 + PKCE** — authorization code flow with S256 challenge
+- **Client registration** — dynamic or pre-registered MCP clients
+- **Token introspection** — validate tokens issued by this server
+- **Token revocation** — revoke access at any time
+- **Grantex-backed** — tokens are Grantex grant tokens with full audit trail
+
+## Links
+
+- [Full Feature Guide](/features/mcp-auth-server)
+- [npm: @grantex/mcp-auth](https://npmjs.com/package/@grantex/mcp-auth)

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -61,6 +61,15 @@ description: "Grantex integrates with every major AI agent framework."
   <Card title="A2A Bridge (Python)" icon="arrows-left-right" href="/integrations/a2a-py">
     Python client/server for Grantex-authenticated A2A task exchange.
   </Card>
+  <Card title="Gemma 4 (On-Device)" icon="microchip" href="/integrations/gemma">
+    Offline authorization for Gemma 4 on-device agents — consent bundles, JWT verification, and audit logging without network calls.
+  </Card>
+  <Card title="DPDP / GDPR Compliance" icon="shield-check" href="/integrations/dpdp">
+    India DPDP Act 2023 and EU GDPR compliance — consent records, purpose limitation, grievances, and audit exports.
+  </Card>
+  <Card title="Trust Registry" icon="building-columns" href="/integrations/registry">
+    Public directory of verified AI agent publishers with DID-based identity and compliance badges.
+  </Card>
   <Card title="Conformance Suite" icon="check" href="/integrations/conformance">
     Validate any Grantex server against the spec.
   </Card>

--- a/docs/integrations/registry.mdx
+++ b/docs/integrations/registry.mdx
@@ -1,0 +1,34 @@
+---
+title: "Trust Registry"
+sidebarTitle: "Trust Registry"
+description: "Public directory of verified AI agent publishers with DID-based identity and compliance badges."
+---
+
+<Info>Full feature guide: [Trust Registry](/features/trust-registry) | Setup guide: [Trust Registry Setup](/guides/trust-registry-setup)</Info>
+
+## Overview
+
+The Grantex Trust Registry is a public directory where organizations register their AI agents with verifiable identity. It enables consumers to look up agent publishers, verify their compliance status, and make trust decisions before granting access.
+
+### Key Capabilities
+
+- **Organization profiles** — register with DID-based identity, description, website, and compliance info
+- **DNS verification** — prove domain ownership via TXT records
+- **Compliance badges** — SOC 2, ISO 27001, GDPR, DPDP Act attestations
+- **Agent catalog** — list published agents with scopes, categories, and ratings
+- **Public search API** — query organizations by name, verification status, or badge
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/v1/trust-registry/orgs` | List registered organizations |
+| `GET` | `/v1/trust-registry/orgs/:did` | Get organization by DID |
+| `POST` | `/v1/trust-registry/register` | Register your organization |
+| `POST` | `/v1/trust-registry/orgs/:id/verify-dns` | Verify domain ownership |
+
+## Links
+
+- [Full Feature Guide](/features/trust-registry)
+- [Setup Guide](/guides/trust-registry-setup)
+- [Portal: Trust Registry](https://grantex.dev/dashboard/registry)


### PR DESCRIPTION
## Summary
- Adds 4 missing integration pages that were returning 404:
  - `/integrations/gemma` — Gemma 4 on-device offline auth
  - `/integrations/mcp-auth` — MCP Auth Server (OAuth 2.1 + PKCE)
  - `/integrations/registry` — Trust Registry (DID-based org directory)
  - `/integrations/dpdp` — DPDP Act 2023 & GDPR compliance module
- Updates `docs.json` sidebar nav to include all 4 pages
- Adds cards to integrations overview page

## Test plan
- [ ] Verify all 4 URLs resolve on docs.grantex.dev after deploy
- [ ] Confirm sidebar nav shows new entries under correct groups