### PR TITLE
feat(sdk): scope enforcement — enforce(), ToolManifest, 54 manifests (v0.3.0)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/cli",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "CLI tool for local Grantex development",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/cli/src/commands/enforce.ts
+++ b/packages/cli/src/commands/enforce.ts
@@ -1,0 +1,69 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { requireClient } from '../client.js';
+import { isJsonMode } from '../format.js';
+
+export function enforceCommand(): Command {
+  const cmd = new Command('enforce').description('Test scope enforcement against a grant token');
+
+  cmd
+    .command('test')
+    .description('Dry-run scope enforcement for a tool call')
+    .requiredOption('--token <token>', 'Grantex grant token (JWT)')
+    .requiredOption('--connector <connector>', 'Connector name (e.g., salesforce)')
+    .requiredOption('--tool <tool>', 'Tool name (e.g., delete_contact)')
+    .option('--amount <amount>', 'Amount for capped scope check', parseFloat)
+    .action(async (opts: { token: string; connector: string; tool: string; amount?: number }) => {
+      const client = await requireClient();
+
+      // Load the manifest for the connector
+      try {
+        const mod = await import(`@grantex/sdk/manifests/${opts.connector}.js`);
+        const manifest = Object.values(mod)[0] as import('@grantex/sdk').ToolManifest;
+        client.loadManifest(manifest);
+      } catch {
+        if (isJsonMode()) {
+          console.log(JSON.stringify({
+            allowed: false,
+            reason: `No manifest found for connector '${opts.connector}'`,
+          }));
+          return;
+        }
+        console.log(chalk.red(`\n  ❌ No manifest found for connector '${opts.connector}'`));
+        console.log(chalk.dim('  Run `grantex manifest list` to see available connectors.'));
+        return;
+      }
+
+      const result = await client.enforce({
+        grantToken: opts.token,
+        connector: opts.connector,
+        tool: opts.tool,
+        ...(opts.amount !== undefined ? { amount: opts.amount } : {}),
+      });
+
+      if (isJsonMode()) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      console.log();
+      if (result.allowed) {
+        console.log(chalk.green('  ✅ ALLOWED'));
+      } else {
+        console.log(chalk.red('  ❌ DENIED'));
+      }
+      console.log();
+      console.log(`  ${chalk.dim('Token scopes:')}  [${result.scopes.join(', ')}]`);
+      console.log(`  ${chalk.dim('Tool permission:')} ${result.permission || '?'} (from manifest)`);
+      if (!result.allowed) {
+        console.log(`  ${chalk.dim('Reason:')}         ${result.reason}`);
+      }
+      if (result.grantId) {
+        console.log(`  ${chalk.dim('Grant ID:')}       ${result.grantId}`);
+        console.log(`  ${chalk.dim('Agent DID:')}      ${result.agentDid}`);
+      }
+      console.log();
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/manifest.ts
+++ b/packages/cli/src/commands/manifest.ts
@@ -1,0 +1,188 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { isJsonMode } from '../format.js';
+
+// Bundled manifest metadata (connector name → tool count + category)
+const BUNDLED_MANIFESTS: { connector: string; tools: number; category: string }[] = [
+  // Finance
+  { connector: 'banking_aa', tools: 5, category: 'finance' },
+  { connector: 'gstn', tools: 8, category: 'finance' },
+  { connector: 'netsuite', tools: 8, category: 'finance' },
+  { connector: 'oracle_fusion', tools: 10, category: 'finance' },
+  { connector: 'quickbooks', tools: 6, category: 'finance' },
+  { connector: 'sap', tools: 7, category: 'finance' },
+  { connector: 'stripe', tools: 8, category: 'finance' },
+  { connector: 'tally', tools: 6, category: 'finance' },
+  { connector: 'zoho_books', tools: 7, category: 'finance' },
+  { connector: 'pinelabs_plural', tools: 6, category: 'finance' },
+  { connector: 'income_tax_india', tools: 7, category: 'finance' },
+  // HR
+  { connector: 'darwinbox', tools: 10, category: 'hr' },
+  { connector: 'docusign', tools: 6, category: 'hr' },
+  { connector: 'epfo', tools: 6, category: 'hr' },
+  { connector: 'greenhouse', tools: 8, category: 'hr' },
+  { connector: 'keka', tools: 6, category: 'hr' },
+  { connector: 'linkedin_talent', tools: 6, category: 'hr' },
+  { connector: 'okta', tools: 8, category: 'hr' },
+  { connector: 'zoom', tools: 6, category: 'hr' },
+  // Marketing
+  { connector: 'salesforce', tools: 6, category: 'marketing' },
+  { connector: 'hubspot', tools: 13, category: 'marketing' },
+  { connector: 'mailchimp', tools: 10, category: 'marketing' },
+  { connector: 'google_ads', tools: 5, category: 'marketing' },
+  { connector: 'meta_ads', tools: 5, category: 'marketing' },
+  { connector: 'linkedin_ads', tools: 4, category: 'marketing' },
+  { connector: 'ga4', tools: 6, category: 'marketing' },
+  { connector: 'mixpanel', tools: 5, category: 'marketing' },
+  { connector: 'moengage', tools: 6, category: 'marketing' },
+  { connector: 'ahrefs', tools: 5, category: 'marketing' },
+  { connector: 'bombora', tools: 4, category: 'marketing' },
+  { connector: 'brandwatch', tools: 5, category: 'marketing' },
+  { connector: 'buffer', tools: 5, category: 'marketing' },
+  { connector: 'g2', tools: 4, category: 'marketing' },
+  { connector: 'trustradius', tools: 4, category: 'marketing' },
+  { connector: 'wordpress', tools: 7, category: 'marketing' },
+  // Ops
+  { connector: 'jira', tools: 11, category: 'ops' },
+  { connector: 'confluence', tools: 6, category: 'ops' },
+  { connector: 'servicenow', tools: 6, category: 'ops' },
+  { connector: 'zendesk', tools: 8, category: 'ops' },
+  { connector: 'pagerduty', tools: 6, category: 'ops' },
+  { connector: 'sanctions_api', tools: 5, category: 'ops' },
+  { connector: 'mca_portal', tools: 4, category: 'ops' },
+  // Comms
+  { connector: 'gmail', tools: 4, category: 'comms' },
+  { connector: 'slack', tools: 7, category: 'comms' },
+  { connector: 'github', tools: 9, category: 'comms' },
+  { connector: 'google_calendar', tools: 5, category: 'comms' },
+  { connector: 's3', tools: 6, category: 'comms' },
+  { connector: 'sendgrid', tools: 7, category: 'comms' },
+  { connector: 'twilio', tools: 5, category: 'comms' },
+  { connector: 'twitter', tools: 6, category: 'comms' },
+  { connector: 'whatsapp', tools: 5, category: 'comms' },
+  { connector: 'youtube', tools: 6, category: 'comms' },
+  { connector: 'langsmith', tools: 5, category: 'comms' },
+];
+
+export function manifestCommand(): Command {
+  const cmd = new Command('manifest').description('Manage tool manifests for scope enforcement');
+
+  /* ── list ─────────────────────────────────────────────────────────── */
+  cmd
+    .command('list')
+    .description('List available pre-built manifests')
+    .option('--category <category>', 'Filter by category (finance, hr, marketing, ops, comms)')
+    .action((opts: { category?: string }) => {
+      let manifests = BUNDLED_MANIFESTS;
+      if (opts.category) {
+        manifests = manifests.filter((m) => m.category === opts.category.toLowerCase());
+      }
+
+      if (isJsonMode()) {
+        console.log(JSON.stringify(manifests, null, 2));
+        return;
+      }
+
+      const totalTools = manifests.reduce((sum, m) => sum + m.tools, 0);
+      console.log(chalk.bold(`\nAvailable manifests (${manifests.length} connectors, ${totalTools} tools):\n`));
+
+      const categories = [...new Set(manifests.map((m) => m.category))];
+      for (const cat of categories) {
+        console.log(chalk.dim(`  ${cat.toUpperCase()}`));
+        for (const m of manifests.filter((x) => x.category === cat)) {
+          console.log(`    ${chalk.cyan(m.connector.padEnd(20))} ${String(m.tools).padStart(3)} tools`);
+        }
+        console.log();
+      }
+
+      console.log(chalk.dim(`  Usage: from grantex.manifests.${manifests[0].connector} import manifest`));
+    });
+
+  /* ── show ─────────────────────────────────────────────────────────── */
+  cmd
+    .command('show <connector>')
+    .description('Show tools and permissions for a manifest')
+    .action(async (connector: string) => {
+      try {
+        // Dynamically import the manifest from the SDK
+        const mod = await import(`@grantex/sdk/manifests/${connector}.js`);
+        const manifest = Object.values(mod)[0] as { connector: string; tools: Record<string, string>; toolCount: number };
+
+        if (isJsonMode()) {
+          console.log(JSON.stringify(manifest, null, 2));
+          return;
+        }
+
+        console.log(chalk.bold(`\n${manifest.connector} (${manifest.toolCount} tools):\n`));
+        for (const [tool, perm] of Object.entries(manifest.tools)) {
+          const color = perm === 'read' ? chalk.green : perm === 'write' ? chalk.yellow : perm === 'delete' ? chalk.red : chalk.magenta;
+          console.log(`  ${tool.padEnd(35)} → ${color(perm)}`);
+        }
+        console.log();
+      } catch {
+        console.error(chalk.red(`Manifest not found: ${connector}`));
+        console.error(chalk.dim('Run `grantex manifest list` to see available manifests.'));
+        process.exit(1);
+      }
+    });
+
+  /* ── validate ─────────────────────────────────────────────────────── */
+  cmd
+    .command('validate')
+    .description('Validate that tools have manifest coverage')
+    .requiredOption('--agent-tools <tools>', 'Comma-separated tool names to check')
+    .option('--connector <connector>', 'Connector to check against')
+    .action(async (opts: { agentTools: string; connector?: string }) => {
+      const toolNames = opts.agentTools.split(',').map((t) => t.trim());
+      const results: { tool: string; connector: string; permission: string; status: string }[] = [];
+
+      // Try to find each tool in loaded manifests
+      for (const toolName of toolNames) {
+        let found = false;
+        for (const meta of BUNDLED_MANIFESTS) {
+          if (opts.connector && meta.connector !== opts.connector) continue;
+          try {
+            const mod = await import(`@grantex/sdk/manifests/${meta.connector}.js`);
+            const manifest = Object.values(mod)[0] as { tools: Record<string, string> };
+            if (manifest.tools[toolName]) {
+              results.push({
+                tool: toolName,
+                connector: meta.connector,
+                permission: manifest.tools[toolName],
+                status: 'found',
+              });
+              found = true;
+              break;
+            }
+          } catch {
+            continue;
+          }
+        }
+        if (!found) {
+          results.push({ tool: toolName, connector: '?', permission: '?', status: 'missing' });
+        }
+      }
+
+      if (isJsonMode()) {
+        console.log(JSON.stringify(results, null, 2));
+        return;
+      }
+
+      const missing = results.filter((r) => r.status === 'missing');
+      for (const r of results) {
+        const icon = r.status === 'found' ? chalk.green('✓') : chalk.red('✗');
+        const perm = r.status === 'found'
+          ? chalk.dim(` → ${r.permission} (${r.connector})`)
+          : chalk.red(' — no manifest entry');
+        console.log(`  ${icon} ${r.tool}${perm}`);
+      }
+
+      if (missing.length > 0) {
+        console.log(chalk.yellow(`\n  ⚠ ${missing.length} tool(s) have no manifest entry (defaulting to read)`));
+      } else {
+        console.log(chalk.green(`\n  ✓ All ${results.length} tools have manifest entries`));
+      }
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,6 +29,8 @@ import { decodeCommand } from './commands/decode.js';
 import { auditCmdCommand } from './commands/audit-cmd.js';
 import { registryCommand } from './commands/registry-cmd.js';
 import { initCommand } from './commands/init.js';
+import { manifestCommand } from './commands/manifest.js';
+import { enforceCommand } from './commands/enforce.js';
 
 export function createProgram(): Command {
   const program = new Command();
@@ -36,7 +38,7 @@ export function createProgram(): Command {
   program
     .name('grantex')
     .description('CLI for the Grantex delegated authorization protocol')
-    .version('0.1.7')
+    .version('0.2.0')
     .option('--json', 'Output results as JSON (machine-readable)')
     .hook('preAction', () => {
       if (program.opts().json) {
@@ -72,6 +74,8 @@ export function createProgram(): Command {
   program.addCommand(auditCmdCommand());
   program.addCommand(registryCommand());
   program.addCommand(initCommand());
+  program.addCommand(manifestCommand());
+  program.addCommand(enforceCommand());
 
   return program;
 }

--- a/packages/cli/tests/enforce.test.ts
+++ b/packages/cli/tests/enforce.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/client.js', () => ({
+  requireClient: vi.fn(),
+}));
+
+import { requireClient } from '../src/client.js';
+import { enforceCommand } from '../src/commands/enforce.js';
+import { setJsonMode } from '../src/format.js';
+
+const enforceAllowedResult = {
+  allowed: true,
+  scopes: ['salesforce:read', 'salesforce:write'],
+  permission: 'read',
+  grantId: 'grnt_1',
+  agentDid: 'did:grantex:ag_1',
+  reason: '',
+  connector: 'salesforce',
+  tool: 'query',
+};
+
+const enforceDeniedResult = {
+  allowed: false,
+  scopes: ['salesforce:read'],
+  permission: 'delete',
+  reason: 'Scope salesforce:delete required but not granted',
+  grantId: 'grnt_1',
+  agentDid: 'did:grantex:ag_1',
+  connector: 'salesforce',
+  tool: 'delete_contact',
+};
+
+const mockClient = {
+  enforce: vi.fn(),
+  loadManifest: vi.fn(),
+};
+
+describe('enforceCommand()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (requireClient as ReturnType<typeof vi.fn>).mockResolvedValue(mockClient);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    setJsonMode(false);
+  });
+
+  it('registers the "enforce" command name', () => {
+    const cmd = enforceCommand();
+    expect(cmd.name()).toBe('enforce');
+  });
+
+  it('has test subcommand', () => {
+    const cmd = enforceCommand();
+    const names = cmd.commands.map((c) => c.name());
+    expect(names).toContain('test');
+  });
+
+  // ── test (allowed) ────────────────────────────────────────────────────
+
+  it('test calls enforce with token, connector, and tool', async () => {
+    mockClient.enforce.mockResolvedValue(enforceAllowedResult);
+    const cmd = enforceCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'test',
+      '--token',
+      'jwt_token_value',
+      '--connector',
+      'salesforce',
+      '--tool',
+      'query',
+    ]);
+    expect(mockClient.loadManifest).toHaveBeenCalledOnce();
+    expect(mockClient.enforce).toHaveBeenCalledWith({
+      grantToken: 'jwt_token_value',
+      connector: 'salesforce',
+      tool: 'query',
+    });
+    expect(console.log).toHaveBeenCalled();
+  });
+
+  it('test outputs ALLOWED for permitted tool call', async () => {
+    mockClient.enforce.mockResolvedValue(enforceAllowedResult);
+    const cmd = enforceCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'test',
+      '--token',
+      'jwt_token_value',
+      '--connector',
+      'salesforce',
+      '--tool',
+      'query',
+    ]);
+    const allArgs = (console.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c.join(' '))
+      .join('\n');
+    expect(allArgs).toContain('ALLOWED');
+  });
+
+  it('test outputs scopes and permission in text mode', async () => {
+    mockClient.enforce.mockResolvedValue(enforceAllowedResult);
+    const cmd = enforceCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'test',
+      '--token',
+      'jwt_token_value',
+      '--connector',
+      'salesforce',
+      '--tool',
+      'query',
+    ]);
+    const allArgs = (console.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c.join(' '))
+      .join('\n');
+    expect(allArgs).toContain('salesforce:read');
+    expect(allArgs).toContain('salesforce:write');
+    expect(allArgs).toContain('read');
+  });
+
+  it('test displays grantId and agentDid when present', async () => {
+    mockClient.enforce.mockResolvedValue(enforceAllowedResult);
+    const cmd = enforceCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'test',
+      '--token',
+      'jwt_token_value',
+      '--connector',
+      'salesforce',
+      '--tool',
+      'query',
+    ]);
+    const allArgs = (console.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c.join(' '))
+      .join('\n');
+    expect(allArgs).toContain('grnt_1');
+    expect(allArgs).toContain('did:grantex:ag_1');
+  });
+
+  // ── test (denied) ─────────────────────────────────────────────────────
+
+  it('test outputs DENIED for disallowed tool call', async () => {
+    mockClient.enforce.mockResolvedValue(enforceDeniedResult);
+    const cmd = enforceCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'test',
+      '--token',
+      'jwt_token_value',
+      '--connector',
+      'salesforce',
+      '--tool',
+      'delete_contact',
+    ]);
+    const allArgs = (console.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c.join(' '))
+      .join('\n');
+    expect(allArgs).toContain('DENIED');
+  });
+
+  it('test outputs denial reason for disallowed tool call', async () => {
+    mockClient.enforce.mockResolvedValue(enforceDeniedResult);
+    const cmd = enforceCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'test',
+      '--token',
+      'jwt_token_value',
+      '--connector',
+      'salesforce',
+      '--tool',
+      'delete_contact',
+    ]);
+    const allArgs = (console.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c.join(' '))
+      .join('\n');
+    expect(allArgs).toContain('Scope salesforce:delete required but not granted');
+  });
+
+  // ── test --amount ─────────────────────────────────────────────────────
+
+  it('test passes amount when --amount is set', async () => {
+    mockClient.enforce.mockResolvedValue(enforceAllowedResult);
+    const cmd = enforceCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'test',
+      '--token',
+      'jwt_token_value',
+      '--connector',
+      'salesforce',
+      '--tool',
+      'query',
+      '--amount',
+      '50.5',
+    ]);
+    expect(mockClient.enforce).toHaveBeenCalledWith({
+      grantToken: 'jwt_token_value',
+      connector: 'salesforce',
+      tool: 'query',
+      amount: 50.5,
+    });
+  });
+
+  // ── test --json ───────────────────────────────────────────────────────
+
+  it('test --json outputs JSON for allowed result', async () => {
+    mockClient.enforce.mockResolvedValue(enforceAllowedResult);
+    setJsonMode(true);
+    const cmd = enforceCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'test',
+      '--token',
+      'jwt_token_value',
+      '--connector',
+      'salesforce',
+      '--tool',
+      'query',
+    ]);
+    const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    const parsed = JSON.parse(output);
+    expect(parsed.allowed).toBe(true);
+    expect(parsed.scopes).toEqual(['salesforce:read', 'salesforce:write']);
+    expect(parsed.permission).toBe('read');
+    expect(parsed.grantId).toBe('grnt_1');
+  });
+
+  it('test --json outputs JSON for denied result', async () => {
+    mockClient.enforce.mockResolvedValue(enforceDeniedResult);
+    setJsonMode(true);
+    const cmd = enforceCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'test',
+      '--token',
+      'jwt_token_value',
+      '--connector',
+      'salesforce',
+      '--tool',
+      'delete_contact',
+    ]);
+    const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    const parsed = JSON.parse(output);
+    expect(parsed.allowed).toBe(false);
+    expect(parsed.reason).toContain('salesforce:delete');
+  });
+
+  // ── test with unknown connector ───────────────────────────────────────
+
+  it('test with unknown connector outputs error in text mode', async () => {
+    const cmd = enforceCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'test',
+      '--token',
+      'jwt_token_value',
+      '--connector',
+      'unknown_connector',
+      '--tool',
+      'query',
+    ]);
+    const allArgs = (console.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c.join(' '))
+      .join('\n');
+    expect(allArgs).toContain("No manifest found for connector 'unknown_connector'");
+    expect(allArgs).toContain('grantex manifest list');
+    // enforce should not have been called
+    expect(mockClient.enforce).not.toHaveBeenCalled();
+  });
+
+  it('test --json with unknown connector outputs JSON error', async () => {
+    setJsonMode(true);
+    const cmd = enforceCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'test',
+      '--token',
+      'jwt_token_value',
+      '--connector',
+      'unknown_connector',
+      '--tool',
+      'query',
+    ]);
+    const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    const parsed = JSON.parse(output);
+    expect(parsed.allowed).toBe(false);
+    expect(parsed.reason).toContain('unknown_connector');
+    expect(mockClient.enforce).not.toHaveBeenCalled();
+  });
+
+  it('test with unknown connector does not call loadManifest', async () => {
+    const cmd = enforceCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'test',
+      '--token',
+      'jwt_token_value',
+      '--connector',
+      'nonexistent',
+      '--tool',
+      'some_tool',
+    ]);
+    expect(mockClient.loadManifest).not.toHaveBeenCalled();
+    expect(mockClient.enforce).not.toHaveBeenCalled();
+  });
+
+  it('test --json with unknown connector returns correct JSON shape', async () => {
+    setJsonMode(true);
+    const cmd = enforceCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'test',
+      '--token',
+      'jwt_token_value',
+      '--connector',
+      'no_such_thing',
+      '--tool',
+      'query',
+    ]);
+    const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    const parsed = JSON.parse(output);
+    expect(parsed).toEqual({
+      allowed: false,
+      reason: "No manifest found for connector 'no_such_thing'",
+    });
+  });
+
+  // ── loadManifest called ───────────────────────────────────────────────
+
+  it('test loads the manifest before calling enforce', async () => {
+    mockClient.enforce.mockResolvedValue(enforceAllowedResult);
+    const cmd = enforceCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'test',
+      '--token',
+      'jwt_token_value',
+      '--connector',
+      'salesforce',
+      '--tool',
+      'list_opportunities',
+    ]);
+    // loadManifest should be called with the salesforce manifest object
+    expect(mockClient.loadManifest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connector: 'salesforce',
+      }),
+    );
+    // enforce should follow
+    expect(mockClient.enforce).toHaveBeenCalledWith({
+      grantToken: 'jwt_token_value',
+      connector: 'salesforce',
+      tool: 'list_opportunities',
+    });
+  });
+
+  it('test calls loadManifest before enforce in correct order', async () => {
+    mockClient.enforce.mockResolvedValue(enforceAllowedResult);
+    const callOrder: string[] = [];
+    mockClient.loadManifest.mockImplementation(() => {
+      callOrder.push('loadManifest');
+    });
+    mockClient.enforce.mockImplementation(async () => {
+      callOrder.push('enforce');
+      return enforceAllowedResult;
+    });
+
+    const cmd = enforceCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync([
+      'node',
+      'test',
+      'test',
+      '--token',
+      'jwt_token_value',
+      '--connector',
+      'salesforce',
+      '--tool',
+      'query',
+    ]);
+    expect(callOrder).toEqual(['loadManifest', 'enforce']);
+  });
+});

--- a/packages/cli/tests/index.test.ts
+++ b/packages/cli/tests/index.test.ts
@@ -40,7 +40,7 @@ describe('createProgram()', () => {
 
   it('has the correct version', () => {
     const program = createProgram();
-    expect(program.version()).toBe('0.1.7');
+    expect(program.version()).toBe('0.2.0');
   });
 
   it('has a --json global option', () => {
@@ -49,7 +49,7 @@ describe('createProgram()', () => {
     expect(jsonOpt).toBeDefined();
   });
 
-  it('registers all 28 expected commands', () => {
+  it('registers all 30 expected commands', () => {
     const program = createProgram();
     const names = program.commands.map((c) => c.name());
 
@@ -59,7 +59,7 @@ describe('createProgram()', () => {
       'events', 'principal-sessions', 'credentials', 'passports',
       'vault', 'webauthn', 'compliance', 'anomalies', 'billing',
       'scim', 'sso', 'verify', 'decode', 'audit-log', 'registry',
-      'init',
+      'init', 'manifest', 'enforce',
     ];
 
     for (const name of expected) {

--- a/packages/cli/tests/manifest.test.ts
+++ b/packages/cli/tests/manifest.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { manifestCommand } from '../src/commands/manifest.js';
+import { setJsonMode } from '../src/format.js';
+
+describe('manifestCommand()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    setJsonMode(false);
+  });
+
+  it('registers the "manifest" command name', () => {
+    const cmd = manifestCommand();
+    expect(cmd.name()).toBe('manifest');
+  });
+
+  it('has list, show, validate subcommands', () => {
+    const cmd = manifestCommand();
+    const names = cmd.commands.map((c) => c.name());
+    expect(names).toContain('list');
+    expect(names).toContain('show');
+    expect(names).toContain('validate');
+  });
+
+  // ── list ──────────────────────────────────────────────────────────────
+
+  it('list outputs all 53 connectors with tool counts', async () => {
+    const cmd = manifestCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync(['node', 'test', 'list']);
+    const allArgs = (console.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c.join(' '))
+      .join('\n');
+    // Check total count in the header
+    expect(allArgs).toContain('53 connectors');
+    // Spot-check a connector from each category
+    expect(allArgs).toContain('stripe');
+    expect(allArgs).toContain('darwinbox');
+    expect(allArgs).toContain('salesforce');
+    expect(allArgs).toContain('jira');
+    expect(allArgs).toContain('gmail');
+  });
+
+  it('list shows tool counts for connectors', async () => {
+    const cmd = manifestCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync(['node', 'test', 'list']);
+    const allArgs = (console.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c.join(' '))
+      .join('\n');
+    expect(allArgs).toContain('tools');
+  });
+
+  it('list shows category headers', async () => {
+    const cmd = manifestCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync(['node', 'test', 'list']);
+    const allArgs = (console.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c.join(' '))
+      .join('\n');
+    expect(allArgs).toContain('FINANCE');
+    expect(allArgs).toContain('HR');
+    expect(allArgs).toContain('MARKETING');
+    expect(allArgs).toContain('OPS');
+    expect(allArgs).toContain('COMMS');
+  });
+
+  it('list --category finance filters to finance only', async () => {
+    const cmd = manifestCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync(['node', 'test', 'list', '--category', 'finance']);
+    const allArgs = (console.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c.join(' '))
+      .join('\n');
+    // Should contain finance connectors
+    expect(allArgs).toContain('stripe');
+    expect(allArgs).toContain('quickbooks');
+    expect(allArgs).toContain('FINANCE');
+    // Should NOT contain non-finance connectors or category headers
+    expect(allArgs).not.toContain('HR');
+    expect(allArgs).not.toContain('MARKETING');
+    expect(allArgs).not.toContain('jira');
+    expect(allArgs).not.toContain('salesforce');
+    expect(allArgs).not.toContain('gmail');
+  });
+
+  it('list --category hr filters to hr only', async () => {
+    const cmd = manifestCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync(['node', 'test', 'list', '--category', 'hr']);
+    const allArgs = (console.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c.join(' '))
+      .join('\n');
+    expect(allArgs).toContain('darwinbox');
+    expect(allArgs).toContain('okta');
+    expect(allArgs).not.toContain('FINANCE');
+    expect(allArgs).not.toContain('stripe');
+  });
+
+  it('list --category marketing filters to marketing only', async () => {
+    const cmd = manifestCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync(['node', 'test', 'list', '--category', 'marketing']);
+    const allArgs = (console.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c.join(' '))
+      .join('\n');
+    expect(allArgs).toContain('hubspot');
+    expect(allArgs).toContain('mailchimp');
+    expect(allArgs).not.toContain('FINANCE');
+    expect(allArgs).not.toContain('jira');
+  });
+
+  it('list --json with unknown category outputs empty JSON array', async () => {
+    setJsonMode(true);
+    const cmd = manifestCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync(['node', 'test', 'list', '--category', 'nonexistent']);
+    const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    const parsed = JSON.parse(output);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBe(0);
+  });
+
+  it('list --json outputs JSON array', async () => {
+    setJsonMode(true);
+    const cmd = manifestCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync(['node', 'test', 'list']);
+    const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    const parsed = JSON.parse(output);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBe(53);
+    // Check structure
+    expect(parsed[0]).toHaveProperty('connector');
+    expect(parsed[0]).toHaveProperty('tools');
+    expect(parsed[0]).toHaveProperty('category');
+    expect(typeof parsed[0].connector).toBe('string');
+    expect(typeof parsed[0].tools).toBe('number');
+    expect(typeof parsed[0].category).toBe('string');
+  });
+
+  it('list --json with --category filters JSON output', async () => {
+    setJsonMode(true);
+    const cmd = manifestCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync(['node', 'test', 'list', '--category', 'finance']);
+    const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    const parsed = JSON.parse(output);
+    expect(Array.isArray(parsed)).toBe(true);
+    // Every entry should be finance category
+    for (const entry of parsed) {
+      expect(entry.category).toBe('finance');
+    }
+    // Should include known finance connectors
+    const connectors = parsed.map((e: { connector: string }) => e.connector);
+    expect(connectors).toContain('stripe');
+    expect(connectors).toContain('quickbooks');
+    expect(connectors).not.toContain('jira');
+    expect(connectors).not.toContain('gmail');
+  });
+
+  it('list --json contains expected connectors in each category', async () => {
+    setJsonMode(true);
+    const cmd = manifestCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync(['node', 'test', 'list']);
+    const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    const parsed = JSON.parse(output) as { connector: string; tools: number; category: string }[];
+
+    const byCategory = (cat: string) => parsed.filter((e) => e.category === cat);
+
+    expect(byCategory('finance').length).toBe(11);
+    expect(byCategory('hr').length).toBe(8);
+    expect(byCategory('marketing').length).toBe(16);
+    expect(byCategory('ops').length).toBe(7);
+    expect(byCategory('comms').length).toBe(11);
+  });
+
+  it('list text mode includes usage hint', async () => {
+    const cmd = manifestCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync(['node', 'test', 'list']);
+    const allArgs = (console.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c.join(' '))
+      .join('\n');
+    expect(allArgs).toContain('grantex.manifests.');
+  });
+
+  it('list text mode shows total tool count across all connectors', async () => {
+    const cmd = manifestCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync(['node', 'test', 'list']);
+    const allArgs = (console.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c.join(' '))
+      .join('\n');
+    // The header should contain the total tools count
+    expect(allArgs).toMatch(/\d+ tools/);
+  });
+});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,6 +1,22 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const sdkManifestsDir = path.resolve(__dirname, 'node_modules/@grantex/sdk/src/manifests');
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        // The enforce command does `import('@grantex/sdk/manifests/<connector>.js')`
+        // which requires subpath resolution not declared in the SDK package exports.
+        // Map it to the SDK source for tests, rewriting .js → .ts.
+        find: /^@grantex\/sdk\/manifests\/(.+)\.js$/,
+        replacement: `${sdkManifestsDir}/$1.ts`,
+      },
+    ],
+  },
   test: {
     environment: 'node',
     globals: false,

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.2.5"
+version = "0.3.0"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -125,6 +125,7 @@ from .resources._events import EventsClient, GrantexEvent as GrantexStreamEvent,
 from ._pkce import PkceChallenge, generate_pkce
 from ._verify import verify_grant_token
 from ._webhook import verify_webhook_signature
+from .manifest import ToolManifest, Permission, EnforceResult
 
 __version__ = "0.1.6"
 
@@ -260,6 +261,10 @@ __all__ = [
     "EventsClient",
     "GrantexStreamEvent",
     "StreamOptions",
+    # Scope Enforcement / Manifests
+    "ToolManifest",
+    "Permission",
+    "EnforceResult",
     # Version
     "__version__",
 ]

--- a/packages/sdk-py/src/grantex/_client.py
+++ b/packages/sdk-py/src/grantex/_client.py
@@ -194,14 +194,10 @@ class Grantex:
             if not result.allowed:
                 raise PermissionError(result.reason)
         """
-        base = {
-            "grant_id": "",
-            "agent_did": "",
-            "scopes": [],
-            "permission": "",
-            "connector": connector,
-            "tool": tool,
-        }
+        grant_id = ""
+        agent_did = ""
+        scopes: list[str] = []
+        permission = ""
 
         # 1. Verify the token offline via JWKS
         try:
@@ -211,64 +207,53 @@ class Grantex:
             )
         except Exception as e:
             return EnforceResult(
-                allowed=False,
-                reason=f"Token verification failed: {e}",
-                **base,
+                allowed=False, reason=f"Token verification failed: {e}",
+                grant_id=grant_id, agent_did=agent_did, scopes=scopes,
+                permission=permission, connector=connector, tool=tool,
             )
 
-        base["grant_id"] = getattr(grant, "grant_id", "")
-        base["agent_did"] = getattr(grant, "agent_did", "")
-        base["scopes"] = getattr(grant, "scopes", [])
+        grant_id = getattr(grant, "grant_id", "")
+        agent_did = getattr(grant, "agent_did", "")
+        scopes = list(getattr(grant, "scopes", []))
+
+        def _denied(reason: str) -> EnforceResult:
+            return EnforceResult(
+                allowed=False, reason=reason,
+                grant_id=grant_id, agent_did=agent_did, scopes=scopes,
+                permission=permission, connector=connector, tool=tool,
+            )
 
         # 2. Look up manifest for the connector
         manifest = self._manifests.get(connector)
         if not manifest:
-            return EnforceResult(
-                allowed=False,
-                reason=f"No manifest loaded for connector '{connector}'. Load a manifest first.",
-                **base,
-            )
+            return _denied(f"No manifest loaded for connector '{connector}'. Load a manifest first.")
 
         # 3. Look up tool permission from manifest
         required_permission = manifest.get_permission(tool)
         if not required_permission:
-            return EnforceResult(
-                allowed=False,
-                reason=f"Unknown tool '{tool}' on connector '{connector}'. Tool not found in manifest.",
-                **base,
-            )
-        base["permission"] = required_permission
+            return _denied(f"Unknown tool '{tool}' on connector '{connector}'. Tool not found in manifest.")
+        permission = required_permission
 
         # 4. Find the best matching scope for this connector
-        granted_permission = self._resolve_granted_permission(
-            base["scopes"], connector
-        )
+        granted_permission = self._resolve_granted_permission(scopes, connector)
         if not granted_permission:
-            return EnforceResult(
-                allowed=False,
-                reason=f"No scope grants access to connector '{connector}'.",
-                **base,
-            )
+            return _denied(f"No scope grants access to connector '{connector}'.")
 
         # 5. Check permission hierarchy
         if not Permission.covers(granted_permission, required_permission):
-            return EnforceResult(
-                allowed=False,
-                reason=f"{granted_permission} scope does not permit {required_permission} operations on {connector}.",
-                **base,
-            )
+            return _denied(f"{granted_permission} scope does not permit {required_permission} operations on {connector}.")
 
         # 6. Check capped amount if provided
         if amount is not None:
-            cap = self._extract_cap(base["scopes"], connector)
+            cap = self._extract_cap(scopes, connector)
             if cap is not None and amount > cap:
-                return EnforceResult(
-                    allowed=False,
-                    reason=f"Amount {amount} exceeds budget cap of {cap} on {connector}.",
-                    **base,
-                )
+                return _denied(f"Amount {amount} exceeds budget cap of {cap} on {connector}.")
 
-        return EnforceResult(allowed=True, reason="", **base)
+        return EnforceResult(
+            allowed=True, reason="",
+            grant_id=grant_id, agent_did=agent_did, scopes=scopes,
+            permission=permission, connector=connector, tool=tool,
+        )
 
     @staticmethod
     def _resolve_granted_permission(

--- a/packages/sdk-py/src/grantex/_client.py
+++ b/packages/sdk-py/src/grantex/_client.py
@@ -34,6 +34,9 @@ from .resources._usage import UsageClient
 from .resources._domains import DomainsClient
 from .resources._webauthn import WebAuthnClient
 from .resources._credentials import CredentialsClient
+from .manifest import ToolManifest, Permission, EnforceResult
+from ._verify import verify_grant_token
+from ._types import VerifyGrantTokenOptions
 
 _DEFAULT_BASE_URL = "https://api.grantex.dev"
 
@@ -104,6 +107,8 @@ class Grantex:
         self.domains = DomainsClient(self._http)
         self.webauthn = WebAuthnClient(self._http)
         self.credentials = CredentialsClient(self._http)
+        self._manifests: dict[str, ToolManifest] = {}
+        self._jwks_uri = f"{base_url.rstrip('/')}/.well-known/jwks.json"
 
     @staticmethod
     def signup(
@@ -154,6 +159,149 @@ class Grantex:
         """
         data = self._http.post("/v1/authorize", params.to_dict())
         return AuthorizationRequest.from_dict(data)
+
+    def load_manifest(self, manifest: ToolManifest) -> None:
+        """Load a tool manifest for scope enforcement."""
+        self._manifests[manifest.connector] = manifest
+
+    def load_manifests(self, manifests: list[ToolManifest]) -> None:
+        """Load multiple tool manifests at once."""
+        for m in manifests:
+            self._manifests[m.connector] = m
+
+    def enforce(
+        self,
+        grant_token: str,
+        connector: str,
+        tool: str,
+        amount: float | None = None,
+    ) -> EnforceResult:
+        """Enforce scope for a tool call.
+
+        1. Verifies the grant token JWT offline (JWKS cached, <1ms after first call)
+        2. Looks up the tool's required permission from loaded manifests
+        3. Checks if the granted scope level covers the required permission
+
+        Fails closed: unknown connectors/tools are denied by default.
+
+        Example::
+
+            result = grantex.enforce(
+                grant_token=token,
+                connector="salesforce",
+                tool="delete_contact",
+            )
+            if not result.allowed:
+                raise PermissionError(result.reason)
+        """
+        base = {
+            "grant_id": "",
+            "agent_did": "",
+            "scopes": [],
+            "permission": "",
+            "connector": connector,
+            "tool": tool,
+        }
+
+        # 1. Verify the token offline via JWKS
+        try:
+            grant = verify_grant_token(
+                grant_token,
+                VerifyGrantTokenOptions(jwks_uri=self._jwks_uri),
+            )
+        except Exception as e:
+            return EnforceResult(
+                allowed=False,
+                reason=f"Token verification failed: {e}",
+                **base,
+            )
+
+        base["grant_id"] = getattr(grant, "grant_id", "")
+        base["agent_did"] = getattr(grant, "agent_did", "")
+        base["scopes"] = getattr(grant, "scopes", [])
+
+        # 2. Look up manifest for the connector
+        manifest = self._manifests.get(connector)
+        if not manifest:
+            return EnforceResult(
+                allowed=False,
+                reason=f"No manifest loaded for connector '{connector}'. Load a manifest first.",
+                **base,
+            )
+
+        # 3. Look up tool permission from manifest
+        required_permission = manifest.get_permission(tool)
+        if not required_permission:
+            return EnforceResult(
+                allowed=False,
+                reason=f"Unknown tool '{tool}' on connector '{connector}'. Tool not found in manifest.",
+                **base,
+            )
+        base["permission"] = required_permission
+
+        # 4. Find the best matching scope for this connector
+        granted_permission = self._resolve_granted_permission(
+            base["scopes"], connector
+        )
+        if not granted_permission:
+            return EnforceResult(
+                allowed=False,
+                reason=f"No scope grants access to connector '{connector}'.",
+                **base,
+            )
+
+        # 5. Check permission hierarchy
+        if not Permission.covers(granted_permission, required_permission):
+            return EnforceResult(
+                allowed=False,
+                reason=f"{granted_permission} scope does not permit {required_permission} operations on {connector}.",
+                **base,
+            )
+
+        # 6. Check capped amount if provided
+        if amount is not None:
+            cap = self._extract_cap(base["scopes"], connector)
+            if cap is not None and amount > cap:
+                return EnforceResult(
+                    allowed=False,
+                    reason=f"Amount {amount} exceeds budget cap of {cap} on {connector}.",
+                    **base,
+                )
+
+        return EnforceResult(allowed=True, reason="", **base)
+
+    @staticmethod
+    def _resolve_granted_permission(
+        scopes: list[str], connector: str
+    ) -> str | None:
+        """Resolve the highest granted permission level for a connector."""
+        levels = {"read": 0, "write": 1, "delete": 2, "admin": 3}
+        best: str | None = None
+        best_level = -1
+
+        for scope in scopes:
+            parts = scope.split(":")
+            if len(parts) >= 3 and parts[0] in ("tool", "agenticorg") and parts[1] == connector:
+                level = levels.get(parts[2], -1)
+                if level > best_level:
+                    best_level = level
+                    best = parts[2]
+
+        return best
+
+    @staticmethod
+    def _extract_cap(scopes: list[str], connector: str) -> float | None:
+        """Extract budget cap from capped scopes."""
+        for scope in scopes:
+            parts = scope.split(":")
+            if parts[0] == "tool" and len(parts) > 1 and parts[1] == connector:
+                try:
+                    idx = parts.index("capped")
+                    if idx + 1 < len(parts):
+                        return float(parts[idx + 1])
+                except ValueError:
+                    continue
+        return None
 
     def close(self) -> None:
         self._http.close()

--- a/packages/sdk-py/src/grantex/manifest.py
+++ b/packages/sdk-py/src/grantex/manifest.py
@@ -158,7 +158,7 @@ class EnforceResult:
     agent_did: str = ""
     """Agent DID from the JWT."""
 
-    scopes: list = field(default_factory=list)
+    scopes: list[str] = field(default_factory=list)
     """All scopes from the grant token."""
 
     permission: str = ""

--- a/packages/sdk-py/src/grantex/manifest.py
+++ b/packages/sdk-py/src/grantex/manifest.py
@@ -1,0 +1,171 @@
+"""Tool Manifest & Permission — scope enforcement for AI agent tool calls.
+
+A ToolManifest declares the permission level (read/write/delete/admin)
+required for each tool on a connector. The ``enforce()`` method on the
+Grantex client uses loaded manifests to check whether a grant token's
+scopes allow a given tool call.
+
+Example::
+
+    from grantex import ToolManifest, Permission
+
+    manifest = ToolManifest(
+        connector="salesforce",
+        tools={
+            "query": Permission.READ,
+            "create_lead": Permission.WRITE,
+            "delete_contact": Permission.DELETE,
+        },
+    )
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+# ── Permission ──────────────────────────────────────────────────────────
+
+
+class Permission:
+    """Permission levels for tool operations.
+
+    Hierarchy: ``admin > delete > write > read``
+
+    A ``write`` scope covers ``read`` + ``write`` tools.
+    A ``delete`` scope covers ``read`` + ``write`` + ``delete`` tools.
+    An ``admin`` scope covers everything.
+    """
+
+    READ = "read"
+    WRITE = "write"
+    DELETE = "delete"
+    ADMIN = "admin"
+
+    _LEVELS: Dict[str, int] = {
+        "read": 0,
+        "write": 1,
+        "delete": 2,
+        "admin": 3,
+    }
+
+    @staticmethod
+    def covers(granted: str, required: str) -> bool:
+        """Check whether a granted permission level covers the required level."""
+        granted_level = Permission._LEVELS.get(granted, -1)
+        required_level = Permission._LEVELS.get(required, 99)
+        return granted_level >= required_level
+
+    @staticmethod
+    def is_valid(value: str) -> bool:
+        """Check whether a string is a valid permission level."""
+        return value in Permission._LEVELS
+
+
+# ── ToolManifest ────────────────────────────────────────────────────────
+
+
+class ToolManifest:
+    """Declares the required permission level for each tool on a connector.
+
+    Load manifests via ``grantex.load_manifest()`` and they will be used
+    automatically by ``grantex.enforce()``.
+    """
+
+    def __init__(
+        self,
+        connector: str,
+        tools: Dict[str, str],
+        version: str = "1.0.0",
+        description: str = "",
+    ) -> None:
+        if not connector:
+            raise ValueError("ToolManifest: connector name is required")
+        if not tools:
+            raise ValueError("ToolManifest: at least one tool is required")
+        for name, perm in tools.items():
+            if not Permission.is_valid(perm):
+                raise ValueError(
+                    f'ToolManifest: invalid permission "{perm}" for tool "{name}". '
+                    f"Must be one of: {', '.join(Permission._LEVELS.keys())}"
+                )
+
+        self.connector = connector
+        self.tools: Dict[str, str] = dict(tools)
+        self.version = version
+        self.description = description
+
+    def get_permission(self, tool_name: str) -> Optional[str]:
+        """Get the declared permission for a tool. Returns None if not found."""
+        return self.tools.get(tool_name)
+
+    def add_tool(self, tool_name: str, permission: str) -> None:
+        """Add or update a tool's permission in this manifest."""
+        if not Permission.is_valid(permission):
+            raise ValueError(f"Invalid permission: {permission}")
+        self.tools[tool_name] = permission
+
+    @property
+    def tool_count(self) -> int:
+        """Number of tools in this manifest."""
+        return len(self.tools)
+
+    @classmethod
+    def from_file(cls, path: str) -> "ToolManifest":
+        """Load a ToolManifest from a JSON file.
+
+        Expected shape::
+
+            { "connector": "salesforce", "tools": { "query": "read", ... } }
+        """
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ToolManifest":
+        """Create a ToolManifest from a dict (e.g., parsed JSON)."""
+        connector = data.get("connector")
+        tools = data.get("tools")
+        if not connector or not tools:
+            raise ValueError('ToolManifest: missing "connector" or "tools" field')
+        return cls(
+            connector=str(connector),
+            tools=dict(tools),
+            version=str(data.get("version", "1.0.0")),
+            description=str(data.get("description", "")),
+        )
+
+
+# ── EnforceResult ───────────────────────────────────────────────────────
+
+
+@dataclass
+class EnforceResult:
+    """Result of a ``grantex.enforce()`` call."""
+
+    allowed: bool
+    """Whether the tool call is permitted."""
+
+    reason: str
+    """Human-readable reason if denied."""
+
+    grant_id: str = ""
+    """Grant ID from the JWT."""
+
+    agent_did: str = ""
+    """Agent DID from the JWT."""
+
+    scopes: list = field(default_factory=list)
+    """All scopes from the grant token."""
+
+    permission: str = ""
+    """Resolved permission for the requested tool."""
+
+    connector: str = ""
+    """Connector name."""
+
+    tool: str = ""
+    """Tool name."""

--- a/packages/sdk-py/src/grantex/manifests/__init__.py
+++ b/packages/sdk-py/src/grantex/manifests/__init__.py
@@ -1,0 +1,125 @@
+"""Pre-built tool manifests for common enterprise connectors."""
+
+# Finance
+from grantex.manifests.banking_aa import manifest as banking_aa_manifest
+from grantex.manifests.gstn import manifest as gstn_manifest
+from grantex.manifests.netsuite import manifest as netsuite_manifest
+from grantex.manifests.oracle_fusion import manifest as oracle_fusion_manifest
+from grantex.manifests.quickbooks import manifest as quickbooks_manifest
+from grantex.manifests.sap import manifest as sap_manifest
+from grantex.manifests.stripe import manifest as stripe_manifest
+from grantex.manifests.tally import manifest as tally_manifest
+from grantex.manifests.zoho_books import manifest as zoho_books_manifest
+from grantex.manifests.pinelabs_plural import manifest as pinelabs_plural_manifest
+from grantex.manifests.income_tax_india import manifest as income_tax_india_manifest
+
+# HR
+from grantex.manifests.darwinbox import manifest as darwinbox_manifest
+from grantex.manifests.docusign import manifest as docusign_manifest
+from grantex.manifests.epfo import manifest as epfo_manifest
+from grantex.manifests.greenhouse import manifest as greenhouse_manifest
+from grantex.manifests.keka import manifest as keka_manifest
+from grantex.manifests.linkedin_talent import manifest as linkedin_talent_manifest
+from grantex.manifests.okta import manifest as okta_manifest
+from grantex.manifests.zoom import manifest as zoom_manifest
+
+# Marketing
+from grantex.manifests.salesforce import manifest as salesforce_manifest
+from grantex.manifests.hubspot import manifest as hubspot_manifest
+from grantex.manifests.mailchimp import manifest as mailchimp_manifest
+from grantex.manifests.google_ads import manifest as google_ads_manifest
+from grantex.manifests.meta_ads import manifest as meta_ads_manifest
+from grantex.manifests.linkedin_ads import manifest as linkedin_ads_manifest
+from grantex.manifests.ga4 import manifest as ga4_manifest
+from grantex.manifests.mixpanel import manifest as mixpanel_manifest
+from grantex.manifests.moengage import manifest as moengage_manifest
+from grantex.manifests.ahrefs import manifest as ahrefs_manifest
+from grantex.manifests.bombora import manifest as bombora_manifest
+from grantex.manifests.brandwatch import manifest as brandwatch_manifest
+from grantex.manifests.buffer import manifest as buffer_manifest
+from grantex.manifests.g2 import manifest as g2_manifest
+from grantex.manifests.trustradius import manifest as trustradius_manifest
+from grantex.manifests.wordpress import manifest as wordpress_manifest
+
+# Ops
+from grantex.manifests.jira import manifest as jira_manifest
+from grantex.manifests.confluence import manifest as confluence_manifest
+from grantex.manifests.servicenow import manifest as servicenow_manifest
+from grantex.manifests.zendesk import manifest as zendesk_manifest
+from grantex.manifests.pagerduty import manifest as pagerduty_manifest
+from grantex.manifests.sanctions_api import manifest as sanctions_api_manifest
+from grantex.manifests.mca_portal import manifest as mca_portal_manifest
+
+# Comms
+from grantex.manifests.gmail import manifest as gmail_manifest
+from grantex.manifests.slack import manifest as slack_manifest
+from grantex.manifests.github import manifest as github_manifest
+from grantex.manifests.google_calendar import manifest as google_calendar_manifest
+from grantex.manifests.s3 import manifest as s3_manifest
+from grantex.manifests.sendgrid import manifest as sendgrid_manifest
+from grantex.manifests.twilio import manifest as twilio_manifest
+from grantex.manifests.twitter import manifest as twitter_manifest
+from grantex.manifests.whatsapp import manifest as whatsapp_manifest
+from grantex.manifests.youtube import manifest as youtube_manifest
+from grantex.manifests.langsmith import manifest as langsmith_manifest
+
+__all__ = [
+    # Finance
+    "banking_aa_manifest",
+    "gstn_manifest",
+    "netsuite_manifest",
+    "oracle_fusion_manifest",
+    "quickbooks_manifest",
+    "sap_manifest",
+    "stripe_manifest",
+    "tally_manifest",
+    "zoho_books_manifest",
+    "pinelabs_plural_manifest",
+    "income_tax_india_manifest",
+    # HR
+    "darwinbox_manifest",
+    "docusign_manifest",
+    "epfo_manifest",
+    "greenhouse_manifest",
+    "keka_manifest",
+    "linkedin_talent_manifest",
+    "okta_manifest",
+    "zoom_manifest",
+    # Marketing
+    "salesforce_manifest",
+    "hubspot_manifest",
+    "mailchimp_manifest",
+    "google_ads_manifest",
+    "meta_ads_manifest",
+    "linkedin_ads_manifest",
+    "ga4_manifest",
+    "mixpanel_manifest",
+    "moengage_manifest",
+    "ahrefs_manifest",
+    "bombora_manifest",
+    "brandwatch_manifest",
+    "buffer_manifest",
+    "g2_manifest",
+    "trustradius_manifest",
+    "wordpress_manifest",
+    # Ops
+    "jira_manifest",
+    "confluence_manifest",
+    "servicenow_manifest",
+    "zendesk_manifest",
+    "pagerduty_manifest",
+    "sanctions_api_manifest",
+    "mca_portal_manifest",
+    # Comms
+    "gmail_manifest",
+    "slack_manifest",
+    "github_manifest",
+    "google_calendar_manifest",
+    "s3_manifest",
+    "sendgrid_manifest",
+    "twilio_manifest",
+    "twitter_manifest",
+    "whatsapp_manifest",
+    "youtube_manifest",
+    "langsmith_manifest",
+]

--- a/packages/sdk-py/src/grantex/manifests/ahrefs.py
+++ b/packages/sdk-py/src/grantex/manifests/ahrefs.py
@@ -1,0 +1,13 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="ahrefs",
+    description="Ahrefs SEO API",
+    tools={
+        "get_domain_rating": Permission.READ,
+        "get_backlinks": Permission.READ,
+        "get_organic_keywords": Permission.READ,
+        "get_content_gap": Permission.READ,
+        "get_site_audit": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/banking_aa.py
+++ b/packages/sdk-py/src/grantex/manifests/banking_aa.py
@@ -1,0 +1,13 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="banking_aa",
+    description="Banking Account Aggregator API",
+    tools={
+        "fetch_bank_statement": Permission.READ,
+        "check_account_balance": Permission.READ,
+        "get_transaction_list": Permission.READ,
+        "request_consent": Permission.WRITE,
+        "fetch_fi_data": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/bombora.py
+++ b/packages/sdk-py/src/grantex/manifests/bombora.py
@@ -1,0 +1,12 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="bombora",
+    description="Bombora Intent Data API",
+    tools={
+        "get_surge_scores": Permission.READ,
+        "get_topic_clusters": Permission.READ,
+        "get_weekly_report": Permission.READ,
+        "search_companies": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/brandwatch.py
+++ b/packages/sdk-py/src/grantex/manifests/brandwatch.py
@@ -1,0 +1,13 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="brandwatch",
+    description="Brandwatch Social Listening API",
+    tools={
+        "get_mentions": Permission.READ,
+        "get_mention_summary": Permission.READ,
+        "get_share_of_voice": Permission.READ,
+        "create_alert": Permission.WRITE,
+        "export_report": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/buffer.py
+++ b/packages/sdk-py/src/grantex/manifests/buffer.py
@@ -1,0 +1,13 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="buffer",
+    description="Buffer Social Media Management API",
+    tools={
+        "create_update": Permission.WRITE,
+        "get_update_analytics": Permission.READ,
+        "get_pending_updates": Permission.READ,
+        "list_profiles": Permission.READ,
+        "move_to_top": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/confluence.py
+++ b/packages/sdk-py/src/grantex/manifests/confluence.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="confluence",
+    description="Confluence Wiki REST API",
+    tools={
+        "create_page": Permission.WRITE,
+        "update_page": Permission.WRITE,
+        "search_content": Permission.READ,
+        "get_page": Permission.READ,
+        "get_page_tree": Permission.READ,
+        "list_spaces": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/darwinbox.py
+++ b/packages/sdk-py/src/grantex/manifests/darwinbox.py
@@ -1,0 +1,18 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="darwinbox",
+    description="Darwinbox HRMS API",
+    tools={
+        "get_employee": Permission.READ,
+        "create_employee": Permission.WRITE,
+        "run_payroll": Permission.ADMIN,
+        "get_attendance": Permission.READ,
+        "apply_leave": Permission.WRITE,
+        "get_org_chart": Permission.READ,
+        "update_performance": Permission.WRITE,
+        "terminate_employee": Permission.DELETE,
+        "transfer_employee": Permission.WRITE,
+        "get_payslip": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/docusign.py
+++ b/packages/sdk-py/src/grantex/manifests/docusign.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="docusign",
+    description="DocuSign eSignature API",
+    tools={
+        "send_envelope": Permission.WRITE,
+        "get_envelope_status": Permission.READ,
+        "void_envelope": Permission.DELETE,
+        "download_document": Permission.READ,
+        "list_templates": Permission.READ,
+        "create_envelope_from_template": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/epfo.py
+++ b/packages/sdk-py/src/grantex/manifests/epfo.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="epfo",
+    description="EPFO (Employees Provident Fund Organisation) API",
+    tools={
+        "file_ecr": Permission.WRITE,
+        "get_uan": Permission.READ,
+        "check_claim_status": Permission.READ,
+        "download_passbook": Permission.READ,
+        "generate_trrn": Permission.WRITE,
+        "verify_member": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/g2.py
+++ b/packages/sdk-py/src/grantex/manifests/g2.py
@@ -1,0 +1,12 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="g2",
+    description="G2 Buyer Intent API",
+    tools={
+        "get_intent_signals": Permission.READ,
+        "get_product_reviews": Permission.READ,
+        "get_comparison_data": Permission.READ,
+        "get_category_leaders": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/ga4.py
+++ b/packages/sdk-py/src/grantex/manifests/ga4.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="ga4",
+    description="Google Analytics 4 Data API",
+    tools={
+        "run_report": Permission.READ,
+        "run_realtime_report": Permission.READ,
+        "get_conversions": Permission.READ,
+        "get_user_acquisition": Permission.READ,
+        "get_page_analytics": Permission.READ,
+        "get_metadata": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/github.py
+++ b/packages/sdk-py/src/grantex/manifests/github.py
@@ -1,0 +1,17 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="github",
+    description="GitHub REST API",
+    tools={
+        "list_repos": Permission.READ,
+        "get_repo": Permission.READ,
+        "list_repository_issues": Permission.READ,
+        "create_issue": Permission.WRITE,
+        "create_pull_request": Permission.WRITE,
+        "get_repository_statistics": Permission.READ,
+        "search_code": Permission.READ,
+        "create_release": Permission.WRITE,
+        "trigger_github_action_workflow": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/gmail.py
+++ b/packages/sdk-py/src/grantex/manifests/gmail.py
@@ -1,0 +1,12 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="gmail",
+    description="Gmail API",
+    tools={
+        "send_email": Permission.WRITE,
+        "read_inbox": Permission.READ,
+        "search_emails": Permission.READ,
+        "get_thread": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/google_ads.py
+++ b/packages/sdk-py/src/grantex/manifests/google_ads.py
@@ -1,0 +1,13 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="google_ads",
+    description="Google Ads API",
+    tools={
+        "search_campaigns": Permission.READ,
+        "get_campaign_performance": Permission.READ,
+        "mutate_campaign_budget": Permission.WRITE,
+        "get_search_terms": Permission.READ,
+        "create_user_list": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/google_calendar.py
+++ b/packages/sdk-py/src/grantex/manifests/google_calendar.py
@@ -1,0 +1,13 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="google_calendar",
+    description="Google Calendar API",
+    tools={
+        "create_event": Permission.WRITE,
+        "list_events": Permission.READ,
+        "check_availability": Permission.READ,
+        "delete_event": Permission.DELETE,
+        "find_free_slot": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/greenhouse.py
+++ b/packages/sdk-py/src/grantex/manifests/greenhouse.py
@@ -1,0 +1,16 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="greenhouse",
+    description="Greenhouse Recruiting API",
+    tools={
+        "list_jobs": Permission.READ,
+        "get_candidate": Permission.READ,
+        "list_applications": Permission.READ,
+        "schedule_interview": Permission.WRITE,
+        "create_candidate": Permission.WRITE,
+        "advance_application": Permission.WRITE,
+        "reject_application": Permission.DELETE,
+        "get_scorecards": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/gstn.py
+++ b/packages/sdk-py/src/grantex/manifests/gstn.py
@@ -1,0 +1,16 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="gstn",
+    description="GST Network API",
+    tools={
+        "fetch_gstr2a": Permission.READ,
+        "push_gstr1_data": Permission.WRITE,
+        "file_gstr3b": Permission.WRITE,
+        "file_gstr9": Permission.WRITE,
+        "generate_eway_bill": Permission.WRITE,
+        "generate_einvoice_irn": Permission.WRITE,
+        "check_filing_status": Permission.READ,
+        "get_compliance_notice": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/hubspot.py
+++ b/packages/sdk-py/src/grantex/manifests/hubspot.py
@@ -1,0 +1,21 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="hubspot",
+    description="HubSpot CRM API",
+    tools={
+        "list_contacts": Permission.READ,
+        "search_contacts": Permission.READ,
+        "create_contact": Permission.WRITE,
+        "get_contact": Permission.READ,
+        "update_contact": Permission.WRITE,
+        "list_deals": Permission.READ,
+        "create_deal": Permission.WRITE,
+        "get_deal": Permission.READ,
+        "update_deal": Permission.WRITE,
+        "list_pipelines": Permission.READ,
+        "list_companies": Permission.READ,
+        "create_company": Permission.WRITE,
+        "get_campaign_analytics": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/income_tax_india.py
+++ b/packages/sdk-py/src/grantex/manifests/income_tax_india.py
@@ -1,0 +1,15 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="income_tax_india",
+    description="Income Tax India e-Filing API",
+    tools={
+        "file_26q_return": Permission.WRITE,
+        "file_24q_return": Permission.WRITE,
+        "check_tds_credit_in_26as": Permission.READ,
+        "download_form_16a": Permission.READ,
+        "file_itr": Permission.WRITE,
+        "get_compliance_notice": Permission.READ,
+        "pay_tax_challan": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/jira.py
+++ b/packages/sdk-py/src/grantex/manifests/jira.py
@@ -1,0 +1,19 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="jira",
+    description="Jira Software REST API",
+    tools={
+        "list_projects": Permission.READ,
+        "get_project": Permission.READ,
+        "search_issues": Permission.READ,
+        "get_issue": Permission.READ,
+        "create_issue": Permission.WRITE,
+        "update_issue": Permission.WRITE,
+        "transition_issue": Permission.WRITE,
+        "get_transitions": Permission.READ,
+        "add_comment": Permission.WRITE,
+        "get_sprint_data": Permission.READ,
+        "get_project_metrics": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/keka.py
+++ b/packages/sdk-py/src/grantex/manifests/keka.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="keka",
+    description="Keka HR API",
+    tools={
+        "get_employee": Permission.READ,
+        "list_employees": Permission.READ,
+        "run_payroll": Permission.ADMIN,
+        "get_leave_balance": Permission.READ,
+        "post_reimbursement": Permission.WRITE,
+        "get_attendance_summary": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/langsmith.py
+++ b/packages/sdk-py/src/grantex/manifests/langsmith.py
@@ -1,0 +1,13 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="langsmith",
+    description="LangSmith Observability API",
+    tools={
+        "list_runs": Permission.READ,
+        "get_run": Permission.READ,
+        "get_run_stats": Permission.READ,
+        "list_datasets": Permission.READ,
+        "create_feedback": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/linkedin_ads.py
+++ b/packages/sdk-py/src/grantex/manifests/linkedin_ads.py
@@ -1,0 +1,12 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="linkedin_ads",
+    description="LinkedIn Ads API",
+    tools={
+        "create_campaign": Permission.WRITE,
+        "get_analytics": Permission.READ,
+        "create_lead_gen_form": Permission.WRITE,
+        "get_targeting_criteria": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/linkedin_talent.py
+++ b/packages/sdk-py/src/grantex/manifests/linkedin_talent.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="linkedin_talent",
+    description="LinkedIn Talent Solutions API",
+    tools={
+        "post_job": Permission.WRITE,
+        "search_candidates": Permission.READ,
+        "send_inmail": Permission.WRITE,
+        "get_applicants": Permission.READ,
+        "get_analytics": Permission.READ,
+        "get_job_insights": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/mailchimp.py
+++ b/packages/sdk-py/src/grantex/manifests/mailchimp.py
@@ -1,0 +1,18 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="mailchimp",
+    description="Mailchimp Email Marketing API",
+    tools={
+        "list_campaigns": Permission.READ,
+        "create_campaign": Permission.WRITE,
+        "send_campaign": Permission.WRITE,
+        "get_campaign_report": Permission.READ,
+        "add_list_member": Permission.WRITE,
+        "search_members": Permission.READ,
+        "create_template": Permission.WRITE,
+        "create_ab_campaign": Permission.WRITE,
+        "get_ab_results": Permission.READ,
+        "send_winner": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/mca_portal.py
+++ b/packages/sdk-py/src/grantex/manifests/mca_portal.py
@@ -1,0 +1,12 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="mca_portal",
+    description="MCA (Ministry of Corporate Affairs) Portal API",
+    tools={
+        "file_annual_return": Permission.WRITE,
+        "complete_director_kyc": Permission.WRITE,
+        "fetch_company_master_data": Permission.READ,
+        "file_charge_satisfaction": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/meta_ads.py
+++ b/packages/sdk-py/src/grantex/manifests/meta_ads.py
@@ -1,0 +1,13 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="meta_ads",
+    description="Meta Ads (Facebook/Instagram) API",
+    tools={
+        "get_campaign_insights": Permission.READ,
+        "update_campaign_budget": Permission.WRITE,
+        "create_custom_audience": Permission.WRITE,
+        "update_adset_status": Permission.WRITE,
+        "get_ad_account_info": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/mixpanel.py
+++ b/packages/sdk-py/src/grantex/manifests/mixpanel.py
@@ -1,0 +1,13 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="mixpanel",
+    description="Mixpanel Analytics API",
+    tools={
+        "get_funnel": Permission.READ,
+        "get_retention": Permission.READ,
+        "query_jql": Permission.READ,
+        "get_segmentation": Permission.READ,
+        "export_events": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/moengage.py
+++ b/packages/sdk-py/src/grantex/manifests/moengage.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="moengage",
+    description="MoEngage Customer Engagement API",
+    tools={
+        "create_campaign": Permission.WRITE,
+        "get_campaign_stats": Permission.READ,
+        "create_segment": Permission.WRITE,
+        "send_push_notification": Permission.WRITE,
+        "get_user_profile": Permission.READ,
+        "track_event": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/netsuite.py
+++ b/packages/sdk-py/src/grantex/manifests/netsuite.py
@@ -1,0 +1,16 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="netsuite",
+    description="NetSuite ERP API",
+    tools={
+        "create_invoice": Permission.WRITE,
+        "get_invoice": Permission.READ,
+        "create_journal_entry": Permission.WRITE,
+        "get_account_balance": Permission.READ,
+        "create_vendor_bill": Permission.WRITE,
+        "create_purchase_order": Permission.WRITE,
+        "get_trial_balance": Permission.READ,
+        "search_records": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/okta.py
+++ b/packages/sdk-py/src/grantex/manifests/okta.py
@@ -1,0 +1,16 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="okta",
+    description="Okta Identity Management API",
+    tools={
+        "provision_user": Permission.WRITE,
+        "deactivate_user": Permission.DELETE,
+        "assign_group": Permission.WRITE,
+        "remove_group": Permission.DELETE,
+        "get_access_log": Permission.READ,
+        "reset_mfa": Permission.ADMIN,
+        "list_active_sessions": Permission.READ,
+        "suspend_user": Permission.DELETE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/oracle_fusion.py
+++ b/packages/sdk-py/src/grantex/manifests/oracle_fusion.py
@@ -1,0 +1,18 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="oracle_fusion",
+    description="Oracle Fusion Cloud ERP API",
+    tools={
+        "post_journal_entry": Permission.WRITE,
+        "get_gl_balance": Permission.READ,
+        "create_ap_invoice": Permission.WRITE,
+        "approve_payment": Permission.WRITE,
+        "get_budget": Permission.READ,
+        "create_po": Permission.WRITE,
+        "get_trial_balance": Permission.READ,
+        "run_period_close": Permission.ADMIN,
+        "get_cash_position": Permission.READ,
+        "run_reconciliation": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/pagerduty.py
+++ b/packages/sdk-py/src/grantex/manifests/pagerduty.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="pagerduty",
+    description="PagerDuty Incident Management API",
+    tools={
+        "create_incident": Permission.WRITE,
+        "acknowledge_incident": Permission.WRITE,
+        "resolve_incident": Permission.WRITE,
+        "get_on_call": Permission.READ,
+        "list_incidents": Permission.READ,
+        "create_postmortem": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/pinelabs_plural.py
+++ b/packages/sdk-py/src/grantex/manifests/pinelabs_plural.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="pinelabs_plural",
+    description="Pine Labs Plural Payments API",
+    tools={
+        "create_order": Permission.WRITE,
+        "check_order_status": Permission.READ,
+        "create_payment_link": Permission.WRITE,
+        "initiate_refund": Permission.WRITE,
+        "get_settlement_report": Permission.READ,
+        "get_payout_analytics": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/quickbooks.py
+++ b/packages/sdk-py/src/grantex/manifests/quickbooks.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="quickbooks",
+    description="QuickBooks Online API",
+    tools={
+        "create_invoice": Permission.WRITE,
+        "record_payment": Permission.WRITE,
+        "get_profit_loss": Permission.READ,
+        "get_balance_sheet": Permission.READ,
+        "query": Permission.READ,
+        "get_company_info": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/s3.py
+++ b/packages/sdk-py/src/grantex/manifests/s3.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="s3",
+    description="Amazon S3 API",
+    tools={
+        "upload_document": Permission.WRITE,
+        "download_document": Permission.READ,
+        "list_objects": Permission.READ,
+        "generate_signed_url": Permission.READ,
+        "delete_object": Permission.DELETE,
+        "copy_object": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/salesforce.py
+++ b/packages/sdk-py/src/grantex/manifests/salesforce.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="salesforce",
+    description="Salesforce CRM REST API",
+    tools={
+        "create_lead": Permission.WRITE,
+        "update_opportunity": Permission.WRITE,
+        "query": Permission.READ,
+        "create_task": Permission.WRITE,
+        "get_account": Permission.READ,
+        "list_opportunities": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/sanctions_api.py
+++ b/packages/sdk-py/src/grantex/manifests/sanctions_api.py
@@ -1,0 +1,13 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="sanctions_api",
+    description="Sanctions Screening API",
+    tools={
+        "screen_entity": Permission.READ,
+        "screen_transaction": Permission.READ,
+        "get_alert": Permission.READ,
+        "batch_screen": Permission.READ,
+        "generate_report": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/sap.py
+++ b/packages/sdk-py/src/grantex/manifests/sap.py
@@ -1,0 +1,15 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="sap",
+    description="SAP S/4HANA API",
+    tools={
+        "post_journal_entry": Permission.WRITE,
+        "get_gl_balance": Permission.READ,
+        "create_purchase_order": Permission.WRITE,
+        "post_goods_receipt": Permission.WRITE,
+        "run_payment_run": Permission.ADMIN,
+        "get_vendor_master": Permission.READ,
+        "get_cost_center": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/sendgrid.py
+++ b/packages/sdk-py/src/grantex/manifests/sendgrid.py
@@ -1,0 +1,15 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="sendgrid",
+    description="SendGrid Email API",
+    tools={
+        "send_email": Permission.WRITE,
+        "create_template": Permission.WRITE,
+        "get_stats": Permission.READ,
+        "get_bounces": Permission.READ,
+        "validate_email": Permission.READ,
+        "send_email_with_tracking": Permission.WRITE,
+        "get_email_activity": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/servicenow.py
+++ b/packages/sdk-py/src/grantex/manifests/servicenow.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="servicenow",
+    description="ServiceNow ITSM API",
+    tools={
+        "create_incident": Permission.WRITE,
+        "update_incident": Permission.WRITE,
+        "submit_change_request": Permission.WRITE,
+        "get_cmdb_ci": Permission.READ,
+        "check_sla_status": Permission.READ,
+        "get_kb_article": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/slack.py
+++ b/packages/sdk-py/src/grantex/manifests/slack.py
@@ -1,0 +1,15 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="slack",
+    description="Slack Web API",
+    tools={
+        "send_message": Permission.WRITE,
+        "create_channel": Permission.WRITE,
+        "upload_file": Permission.WRITE,
+        "search_messages": Permission.READ,
+        "list_channels": Permission.READ,
+        "set_reminder": Permission.WRITE,
+        "post_alert": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/stripe.py
+++ b/packages/sdk-py/src/grantex/manifests/stripe.py
@@ -1,0 +1,16 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="stripe",
+    description="Stripe Payments API",
+    tools={
+        "create_payment_intent": Permission.WRITE,
+        "list_charges": Permission.READ,
+        "create_payout": Permission.WRITE,
+        "get_balance": Permission.READ,
+        "list_invoices": Permission.READ,
+        "create_customer": Permission.WRITE,
+        "list_disputes": Permission.READ,
+        "create_refund": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/tally.py
+++ b/packages/sdk-py/src/grantex/manifests/tally.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="tally",
+    description="Tally ERP API",
+    tools={
+        "post_voucher": Permission.WRITE,
+        "get_ledger_balance": Permission.READ,
+        "generate_gst_report": Permission.READ,
+        "export_tally_xml_data": Permission.READ,
+        "get_trial_balance": Permission.READ,
+        "get_stock_summary": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/trustradius.py
+++ b/packages/sdk-py/src/grantex/manifests/trustradius.py
@@ -1,0 +1,12 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="trustradius",
+    description="TrustRadius Buyer Intent API",
+    tools={
+        "get_buyer_intent": Permission.READ,
+        "get_product_reviews": Permission.READ,
+        "get_comparison_traffic": Permission.READ,
+        "search_vendors": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/twilio.py
+++ b/packages/sdk-py/src/grantex/manifests/twilio.py
@@ -1,0 +1,13 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="twilio",
+    description="Twilio Communications API",
+    tools={
+        "send_sms": Permission.WRITE,
+        "make_call": Permission.WRITE,
+        "send_whatsapp": Permission.WRITE,
+        "get_recordings": Permission.READ,
+        "get_message_status": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/twitter.py
+++ b/packages/sdk-py/src/grantex/manifests/twitter.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="twitter",
+    description="Twitter/X API v2",
+    tools={
+        "create_tweet": Permission.WRITE,
+        "get_tweet": Permission.READ,
+        "search_recent": Permission.READ,
+        "get_user_tweets": Permission.READ,
+        "get_user_by_username": Permission.READ,
+        "get_tweet_metrics": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/whatsapp.py
+++ b/packages/sdk-py/src/grantex/manifests/whatsapp.py
@@ -1,0 +1,13 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="whatsapp",
+    description="WhatsApp Business API",
+    tools={
+        "send_template_message": Permission.WRITE,
+        "send_text_message": Permission.WRITE,
+        "send_media_message": Permission.WRITE,
+        "get_message_templates": Permission.READ,
+        "get_business_profile": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/wordpress.py
+++ b/packages/sdk-py/src/grantex/manifests/wordpress.py
@@ -1,0 +1,15 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="wordpress",
+    description="WordPress REST API",
+    tools={
+        "create_post": Permission.WRITE,
+        "update_post": Permission.WRITE,
+        "list_posts": Permission.READ,
+        "get_post": Permission.READ,
+        "upload_media": Permission.WRITE,
+        "list_categories": Permission.READ,
+        "create_page": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/youtube.py
+++ b/packages/sdk-py/src/grantex/manifests/youtube.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="youtube",
+    description="YouTube Data API v3",
+    tools={
+        "list_videos": Permission.READ,
+        "get_video_stats": Permission.READ,
+        "list_channel_videos": Permission.READ,
+        "get_channel_stats": Permission.READ,
+        "list_playlists": Permission.READ,
+        "get_video_analytics": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/zendesk.py
+++ b/packages/sdk-py/src/grantex/manifests/zendesk.py
@@ -1,0 +1,16 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="zendesk",
+    description="Zendesk Support API",
+    tools={
+        "create_ticket": Permission.WRITE,
+        "update_ticket": Permission.WRITE,
+        "get_ticket": Permission.READ,
+        "apply_macro": Permission.WRITE,
+        "get_csat_score": Permission.READ,
+        "escalate_ticket": Permission.WRITE,
+        "merge_tickets": Permission.WRITE,
+        "get_sla_status": Permission.READ,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/zoho_books.py
+++ b/packages/sdk-py/src/grantex/manifests/zoho_books.py
@@ -1,0 +1,15 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="zoho_books",
+    description="Zoho Books API",
+    tools={
+        "create_invoice": Permission.WRITE,
+        "list_invoices": Permission.READ,
+        "record_expense": Permission.WRITE,
+        "get_balance_sheet": Permission.READ,
+        "get_profit_loss": Permission.READ,
+        "list_chartofaccounts": Permission.READ,
+        "reconcile_transaction": Permission.WRITE,
+    },
+)

--- a/packages/sdk-py/src/grantex/manifests/zoom.py
+++ b/packages/sdk-py/src/grantex/manifests/zoom.py
@@ -1,0 +1,14 @@
+from grantex.manifest import ToolManifest, Permission
+
+manifest = ToolManifest(
+    connector="zoom",
+    description="Zoom Video Communications API",
+    tools={
+        "create_meeting": Permission.WRITE,
+        "get_recording": Permission.READ,
+        "cancel_meeting": Permission.DELETE,
+        "get_attendance_report": Permission.READ,
+        "add_panelist": Permission.WRITE,
+        "get_transcript": Permission.READ,
+    },
+)

--- a/packages/sdk-py/tests/test_enforce.py
+++ b/packages/sdk-py/tests/test_enforce.py
@@ -536,7 +536,7 @@ class TestEnforceResultFields:
         assert result.reason == ""
         assert result.grant_id == "grnt_custom"
         assert result.agent_did == "did:grantex:ag_custom"
-        assert result.scopes == ("tool:salesforce:write",)
+        assert result.scopes == ["tool:salesforce:write"]
         assert result.permission == "write"
         assert result.connector == "salesforce"
         assert result.tool == "create_lead"
@@ -555,7 +555,7 @@ class TestEnforceResultFields:
         assert result.allowed is False
         assert result.grant_id == "grnt_denied"
         assert result.agent_did == "did:grantex:ag_denied"
-        assert result.scopes == ("tool:salesforce:read",)
+        assert result.scopes == ["tool:salesforce:read"]
         assert result.connector == "salesforce"
         assert result.tool == "delete_contact"
         assert result.permission == "delete"

--- a/packages/sdk-py/tests/test_enforce.py
+++ b/packages/sdk-py/tests/test_enforce.py
@@ -1,0 +1,561 @@
+"""Tests for Grantex.enforce() scope enforcement."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from grantex import Grantex, ToolManifest, Permission, EnforceResult
+from grantex._errors import GrantexTokenError
+from grantex._types import VerifiedGrant
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_verified_grant(
+    scopes: tuple[str, ...] = ("tool:salesforce:write",),
+    grant_id: str = "grnt_01HXYZ",
+    agent_did: str = "did:grantex:ag_01HXYZ123abc",
+) -> VerifiedGrant:
+    """Create a VerifiedGrant with the given scopes."""
+    return VerifiedGrant(
+        token_id="tok_01HXYZ987xyz",
+        grant_id=grant_id,
+        principal_id="user_abc123",
+        agent_did=agent_did,
+        developer_id="org_test",
+        scopes=scopes,
+        issued_at=1709000000,
+        expires_at=9999999999,
+    )
+
+
+def _salesforce_manifest() -> ToolManifest:
+    return ToolManifest(
+        connector="salesforce",
+        tools={
+            "query": Permission.READ,
+            "create_lead": Permission.WRITE,
+            "delete_contact": Permission.DELETE,
+            "manage_org": Permission.ADMIN,
+        },
+    )
+
+
+def _github_manifest() -> ToolManifest:
+    return ToolManifest(
+        connector="github",
+        tools={
+            "list_repos": Permission.READ,
+            "create_issue": Permission.WRITE,
+            "delete_repo": Permission.DELETE,
+        },
+    )
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def client() -> Grantex:
+    c = Grantex(api_key="test-key")
+    c.load_manifest(_salesforce_manifest())
+    return c
+
+
+# ── Basic allow/deny ────────────────────────────────────────────────────────
+
+
+class TestEnforceBasic:
+    @patch("grantex._client.verify_grant_token")
+    def test_allowed_when_scope_matches(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:write",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "create_lead")
+
+        assert result.allowed is True
+        assert result.reason == ""
+        assert result.connector == "salesforce"
+        assert result.tool == "create_lead"
+        assert result.permission == "write"
+        assert result.grant_id == "grnt_01HXYZ"
+        assert result.agent_did == "did:grantex:ag_01HXYZ123abc"
+
+    @patch("grantex._client.verify_grant_token")
+    def test_denied_when_scope_insufficient(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:read",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "create_lead")
+
+        assert result.allowed is False
+        assert "does not permit" in result.reason
+        assert result.permission == "write"
+
+    @patch("grantex._client.verify_grant_token")
+    def test_denied_for_unknown_connector(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:write",)
+        )
+        result = client.enforce("fake.jwt.token", "unknown_connector", "some_tool")
+
+        assert result.allowed is False
+        assert "No manifest loaded" in result.reason
+        assert result.connector == "unknown_connector"
+
+    @patch("grantex._client.verify_grant_token")
+    def test_denied_for_unknown_tool(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:write",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "nonexistent_tool")
+
+        assert result.allowed is False
+        assert "Unknown tool" in result.reason
+        assert result.tool == "nonexistent_tool"
+
+
+# ── Permission hierarchy ────────────────────────────────────────────────────
+
+
+class TestEnforcePermissionHierarchy:
+    @patch("grantex._client.verify_grant_token")
+    def test_write_scope_allows_read_tool(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:write",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "query")
+
+        assert result.allowed is True
+        assert result.permission == "read"
+
+    @patch("grantex._client.verify_grant_token")
+    def test_read_scope_denies_write_tool(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:read",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "create_lead")
+
+        assert result.allowed is False
+        assert "does not permit" in result.reason
+
+    @patch("grantex._client.verify_grant_token")
+    def test_delete_scope_allows_write_tool(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:delete",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "create_lead")
+
+        assert result.allowed is True
+
+    @patch("grantex._client.verify_grant_token")
+    def test_delete_scope_allows_read_tool(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:delete",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "query")
+
+        assert result.allowed is True
+
+    @patch("grantex._client.verify_grant_token")
+    def test_admin_scope_allows_all_tools(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:admin",)
+        )
+        for tool in ("query", "create_lead", "delete_contact", "manage_org"):
+            result = client.enforce("fake.jwt.token", "salesforce", tool)
+            assert result.allowed is True, f"admin should allow {tool}"
+
+    @patch("grantex._client.verify_grant_token")
+    def test_read_scope_denies_delete_tool(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:read",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "delete_contact")
+
+        assert result.allowed is False
+
+    @patch("grantex._client.verify_grant_token")
+    def test_write_scope_denies_delete_tool(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:write",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "delete_contact")
+
+        assert result.allowed is False
+
+    @patch("grantex._client.verify_grant_token")
+    def test_write_scope_denies_admin_tool(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:write",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "manage_org")
+
+        assert result.allowed is False
+
+    @patch("grantex._client.verify_grant_token")
+    def test_delete_scope_denies_admin_tool(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:delete",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "manage_org")
+
+        assert result.allowed is False
+
+
+# ── Token verification failures ─────────────────────────────────────────────
+
+
+class TestEnforceTokenFailures:
+    @patch("grantex._client.verify_grant_token")
+    def test_denied_for_expired_token(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.side_effect = GrantexTokenError(  # type: ignore[attr-defined]
+            "Grant token verification failed: Signature has expired"
+        )
+        result = client.enforce("expired.jwt.token", "salesforce", "query")
+
+        assert result.allowed is False
+        assert "Token verification failed" in result.reason
+        assert result.grant_id == ""
+        assert result.agent_did == ""
+
+    @patch("grantex._client.verify_grant_token")
+    def test_denied_for_invalid_token(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.side_effect = GrantexTokenError(  # type: ignore[attr-defined]
+            "Grant token verification failed: invalid token"
+        )
+        result = client.enforce("garbage-token", "salesforce", "query")
+
+        assert result.allowed is False
+        assert "Token verification failed" in result.reason
+
+    @patch("grantex._client.verify_grant_token")
+    def test_denied_for_tampered_token(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.side_effect = GrantexTokenError(  # type: ignore[attr-defined]
+            "Grant token verification failed: Signature verification failed"
+        )
+        result = client.enforce("tampered.jwt.token", "salesforce", "query")
+
+        assert result.allowed is False
+        assert "Token verification failed" in result.reason
+
+    @patch("grantex._client.verify_grant_token")
+    def test_denied_for_jwks_fetch_failure(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.side_effect = GrantexTokenError(  # type: ignore[attr-defined]
+            "Failed to fetch JWKS"
+        )
+        result = client.enforce("some.jwt.token", "salesforce", "query")
+
+        assert result.allowed is False
+        assert "Token verification failed" in result.reason
+
+
+# ── No matching scope for connector ─────────────────────────────────────────
+
+
+class TestEnforceNoMatchingScope:
+    @patch("grantex._client.verify_grant_token")
+    def test_denied_when_scope_for_different_connector(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:github:admin",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "query")
+
+        assert result.allowed is False
+        assert "No scope grants access" in result.reason
+
+    @patch("grantex._client.verify_grant_token")
+    def test_denied_when_scopes_empty(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=()
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "query")
+
+        assert result.allowed is False
+
+    @patch("grantex._client.verify_grant_token")
+    def test_non_tool_scopes_ignored(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("calendar:read", "payments:initiate:max_500")
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "query")
+
+        assert result.allowed is False
+        assert "No scope grants access" in result.reason
+
+
+# ── Capped scope enforcement ────────────────────────────────────────────────
+
+
+class TestEnforceCappedScopes:
+    @patch("grantex._client.verify_grant_token")
+    def test_amount_within_cap_allowed(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:write:capped:500",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "create_lead", amount=200)
+
+        assert result.allowed is True
+
+    @patch("grantex._client.verify_grant_token")
+    def test_amount_exceeds_cap_denied(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:write:capped:500",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "create_lead", amount=750)
+
+        assert result.allowed is False
+        assert "exceeds budget cap" in result.reason
+        assert "500" in result.reason
+
+    @patch("grantex._client.verify_grant_token")
+    def test_amount_exactly_at_cap_allowed(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:write:capped:100",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "create_lead", amount=100)
+
+        assert result.allowed is True
+
+    @patch("grantex._client.verify_grant_token")
+    def test_no_amount_skips_cap_check(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:write:capped:100",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "create_lead")
+
+        assert result.allowed is True
+
+    @patch("grantex._client.verify_grant_token")
+    def test_no_cap_in_scope_ignores_amount(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:write",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "create_lead", amount=999999)
+
+        assert result.allowed is True
+
+
+# ── load_manifest / load_manifests ──────────────────────────────────────────
+
+
+class TestManifestLoading:
+    @patch("grantex._client.verify_grant_token")
+    def test_load_manifest_enables_enforcement(self, mock_verify: object) -> None:
+        client = Grantex(api_key="test-key")
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:write",)
+        )
+
+        # Before loading, enforcement denies (no manifest)
+        result = client.enforce("fake.jwt.token", "salesforce", "query")
+        assert result.allowed is False
+        assert "No manifest loaded" in result.reason
+
+        # After loading, enforcement works
+        client.load_manifest(_salesforce_manifest())
+        result = client.enforce("fake.jwt.token", "salesforce", "query")
+        assert result.allowed is True
+
+    @patch("grantex._client.verify_grant_token")
+    def test_load_manifests_loads_multiple(self, mock_verify: object) -> None:
+        client = Grantex(api_key="test-key")
+        client.load_manifests([_salesforce_manifest(), _github_manifest()])
+
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:read",)
+        )
+        sf_result = client.enforce("fake.jwt.token", "salesforce", "query")
+        assert sf_result.allowed is True
+
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:github:write",)
+        )
+        gh_result = client.enforce("fake.jwt.token", "github", "create_issue")
+        assert gh_result.allowed is True
+
+    @patch("grantex._client.verify_grant_token")
+    def test_load_manifest_overwrites_existing(self, mock_verify: object) -> None:
+        client = Grantex(api_key="test-key")
+        original = ToolManifest(
+            connector="salesforce",
+            tools={"query": Permission.READ},
+        )
+        client.load_manifest(original)
+
+        # Now overwrite with a different manifest for the same connector
+        updated = ToolManifest(
+            connector="salesforce",
+            tools={"export_data": Permission.ADMIN},
+        )
+        client.load_manifest(updated)
+
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:admin",)
+        )
+
+        # Old tool no longer recognized
+        result = client.enforce("fake.jwt.token", "salesforce", "query")
+        assert result.allowed is False
+        assert "Unknown tool" in result.reason
+
+        # New tool recognized
+        result = client.enforce("fake.jwt.token", "salesforce", "export_data")
+        assert result.allowed is True
+
+
+# ── Multiple scopes — best match ────────────────────────────────────────────
+
+
+class TestEnforceMultipleScopes:
+    @patch("grantex._client.verify_grant_token")
+    def test_highest_permission_wins(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:read", "tool:salesforce:delete")
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "delete_contact")
+
+        assert result.allowed is True
+
+    @patch("grantex._client.verify_grant_token")
+    def test_mixed_connector_scopes(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:github:admin", "tool:salesforce:read")
+        )
+        # Read-level salesforce scope should allow read tool
+        result = client.enforce("fake.jwt.token", "salesforce", "query")
+        assert result.allowed is True
+
+        # But not write tool
+        result = client.enforce("fake.jwt.token", "salesforce", "create_lead")
+        assert result.allowed is False
+
+
+# ── agenticorg prefix scopes ────────────────────────────────────────────────
+
+
+class TestEnforceAgenticorgScopes:
+    @patch("grantex._client.verify_grant_token")
+    def test_agenticorg_prefix_works(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("agenticorg:salesforce:write",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "create_lead")
+
+        assert result.allowed is True
+
+    @patch("grantex._client.verify_grant_token")
+    def test_agenticorg_prefix_hierarchy(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("agenticorg:salesforce:read",)
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "query")
+        assert result.allowed is True
+
+        result = client.enforce("fake.jwt.token", "salesforce", "create_lead")
+        assert result.allowed is False
+
+
+# ── EnforceResult field population ──────────────────────────────────────────
+
+
+class TestEnforceResultFields:
+    @patch("grantex._client.verify_grant_token")
+    def test_allowed_result_has_all_fields(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:write",),
+            grant_id="grnt_custom",
+            agent_did="did:grantex:ag_custom",
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "create_lead")
+
+        assert isinstance(result, EnforceResult)
+        assert result.allowed is True
+        assert result.reason == ""
+        assert result.grant_id == "grnt_custom"
+        assert result.agent_did == "did:grantex:ag_custom"
+        assert result.scopes == ("tool:salesforce:write",)
+        assert result.permission == "write"
+        assert result.connector == "salesforce"
+        assert result.tool == "create_lead"
+
+    @patch("grantex._client.verify_grant_token")
+    def test_denied_result_preserves_context(
+        self, mock_verify: object, client: Grantex
+    ) -> None:
+        mock_verify.return_value = _make_verified_grant(  # type: ignore[attr-defined]
+            scopes=("tool:salesforce:read",),
+            grant_id="grnt_denied",
+            agent_did="did:grantex:ag_denied",
+        )
+        result = client.enforce("fake.jwt.token", "salesforce", "delete_contact")
+
+        assert result.allowed is False
+        assert result.grant_id == "grnt_denied"
+        assert result.agent_did == "did:grantex:ag_denied"
+        assert result.scopes == ("tool:salesforce:read",)
+        assert result.connector == "salesforce"
+        assert result.tool == "delete_contact"
+        assert result.permission == "delete"

--- a/packages/sdk-py/tests/test_manifest.py
+++ b/packages/sdk-py/tests/test_manifest.py
@@ -1,0 +1,275 @@
+"""Tests for ToolManifest, Permission, and EnforceResult."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from grantex import ToolManifest, Permission, EnforceResult
+
+
+# ── ToolManifest construction ────────────────────────────────────────────────
+
+
+class TestToolManifestConstruction:
+    def test_valid_construction(self) -> None:
+        m = ToolManifest(
+            connector="salesforce",
+            tools={"query": Permission.READ, "create_lead": Permission.WRITE},
+            version="2.0.0",
+            description="Salesforce CRM",
+        )
+        assert m.connector == "salesforce"
+        assert m.tools == {"query": "read", "create_lead": "write"}
+        assert m.version == "2.0.0"
+        assert m.description == "Salesforce CRM"
+
+    def test_valid_construction_defaults(self) -> None:
+        m = ToolManifest(connector="slack", tools={"send_message": Permission.WRITE})
+        assert m.version == "1.0.0"
+        assert m.description == ""
+
+    def test_raises_on_empty_connector(self) -> None:
+        with pytest.raises(ValueError, match="connector name is required"):
+            ToolManifest(connector="", tools={"query": Permission.READ})
+
+    def test_raises_on_empty_tools(self) -> None:
+        with pytest.raises(ValueError, match="at least one tool is required"):
+            ToolManifest(connector="salesforce", tools={})
+
+    def test_raises_on_invalid_permission(self) -> None:
+        with pytest.raises(ValueError, match='invalid permission "execute"'):
+            ToolManifest(
+                connector="salesforce",
+                tools={"query": "execute"},
+            )
+
+
+# ── ToolManifest methods ─────────────────────────────────────────────────────
+
+
+class TestToolManifestMethods:
+    @pytest.fixture()
+    def manifest(self) -> ToolManifest:
+        return ToolManifest(
+            connector="salesforce",
+            tools={
+                "query": Permission.READ,
+                "create_lead": Permission.WRITE,
+                "delete_contact": Permission.DELETE,
+                "manage_org": Permission.ADMIN,
+            },
+        )
+
+    def test_get_permission_returns_correct_value(self, manifest: ToolManifest) -> None:
+        assert manifest.get_permission("query") == "read"
+        assert manifest.get_permission("create_lead") == "write"
+        assert manifest.get_permission("delete_contact") == "delete"
+        assert manifest.get_permission("manage_org") == "admin"
+
+    def test_get_permission_returns_none_for_unknown(self, manifest: ToolManifest) -> None:
+        assert manifest.get_permission("nonexistent_tool") is None
+
+    def test_add_tool_adds_new_tool(self, manifest: ToolManifest) -> None:
+        assert manifest.get_permission("export_report") is None
+        manifest.add_tool("export_report", Permission.READ)
+        assert manifest.get_permission("export_report") == "read"
+
+    def test_add_tool_overwrites_existing(self, manifest: ToolManifest) -> None:
+        assert manifest.get_permission("query") == "read"
+        manifest.add_tool("query", Permission.ADMIN)
+        assert manifest.get_permission("query") == "admin"
+
+    def test_add_tool_rejects_invalid_permission(self, manifest: ToolManifest) -> None:
+        with pytest.raises(ValueError, match="Invalid permission"):
+            manifest.add_tool("new_tool", "superadmin")
+
+    def test_tool_count(self, manifest: ToolManifest) -> None:
+        assert manifest.tool_count == 4
+
+    def test_tool_count_after_add(self, manifest: ToolManifest) -> None:
+        manifest.add_tool("export_report", Permission.READ)
+        assert manifest.tool_count == 5
+
+    def test_tool_count_unchanged_on_overwrite(self, manifest: ToolManifest) -> None:
+        manifest.add_tool("query", Permission.ADMIN)
+        assert manifest.tool_count == 4
+
+
+# ── ToolManifest.from_file ───────────────────────────────────────────────────
+
+
+class TestToolManifestFromFile:
+    def test_from_file_loads_json(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        p = Path(str(tmp_path)) / "salesforce.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "connector": "salesforce",
+                    "tools": {"query": "read", "create_lead": "write"},
+                    "version": "2.0.0",
+                    "description": "Salesforce CRM",
+                }
+            ),
+            encoding="utf-8",
+        )
+        m = ToolManifest.from_file(str(p))
+        assert m.connector == "salesforce"
+        assert m.tools == {"query": "read", "create_lead": "write"}
+        assert m.version == "2.0.0"
+        assert m.description == "Salesforce CRM"
+
+    def test_from_file_minimal_fields(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        p = Path(str(tmp_path)) / "slack.json"
+        p.write_text(
+            json.dumps({"connector": "slack", "tools": {"send": "write"}}),
+            encoding="utf-8",
+        )
+        m = ToolManifest.from_file(str(p))
+        assert m.connector == "slack"
+        assert m.version == "1.0.0"
+        assert m.description == ""
+
+    def test_from_file_nonexistent_raises(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            ToolManifest.from_file("/nonexistent/path/manifest.json")
+
+
+# ── ToolManifest.from_dict ───────────────────────────────────────────────────
+
+
+class TestToolManifestFromDict:
+    def test_from_dict_creates_manifest(self) -> None:
+        m = ToolManifest.from_dict(
+            {
+                "connector": "hubspot",
+                "tools": {"get_contact": "read", "update_deal": "write"},
+                "version": "1.2.0",
+                "description": "HubSpot CRM",
+            }
+        )
+        assert m.connector == "hubspot"
+        assert m.tool_count == 2
+        assert m.version == "1.2.0"
+        assert m.description == "HubSpot CRM"
+
+    def test_from_dict_raises_on_missing_connector(self) -> None:
+        with pytest.raises(ValueError, match='missing "connector" or "tools"'):
+            ToolManifest.from_dict({"tools": {"query": "read"}})
+
+    def test_from_dict_raises_on_missing_tools(self) -> None:
+        with pytest.raises(ValueError, match='missing "connector" or "tools"'):
+            ToolManifest.from_dict({"connector": "salesforce"})
+
+    def test_from_dict_raises_on_empty_dict(self) -> None:
+        with pytest.raises(ValueError, match='missing "connector" or "tools"'):
+            ToolManifest.from_dict({})
+
+    def test_from_dict_with_defaults(self) -> None:
+        m = ToolManifest.from_dict(
+            {"connector": "stripe", "tools": {"charge": "write"}}
+        )
+        assert m.version == "1.0.0"
+        assert m.description == ""
+
+
+# ── Permission ───────────────────────────────────────────────────────────────
+
+
+class TestPermission:
+    # ── covers ───────────────────────────────────────────────────────────
+
+    def test_admin_covers_all(self) -> None:
+        assert Permission.covers("admin", "read") is True
+        assert Permission.covers("admin", "write") is True
+        assert Permission.covers("admin", "delete") is True
+        assert Permission.covers("admin", "admin") is True
+
+    def test_delete_covers_read_write_delete(self) -> None:
+        assert Permission.covers("delete", "read") is True
+        assert Permission.covers("delete", "write") is True
+        assert Permission.covers("delete", "delete") is True
+        assert Permission.covers("delete", "admin") is False
+
+    def test_write_covers_read_write(self) -> None:
+        assert Permission.covers("write", "read") is True
+        assert Permission.covers("write", "write") is True
+        assert Permission.covers("write", "delete") is False
+        assert Permission.covers("write", "admin") is False
+
+    def test_read_covers_only_read(self) -> None:
+        assert Permission.covers("read", "read") is True
+        assert Permission.covers("read", "write") is False
+        assert Permission.covers("read", "delete") is False
+        assert Permission.covers("read", "admin") is False
+
+    def test_unknown_granted_covers_nothing(self) -> None:
+        assert Permission.covers("unknown", "read") is False
+
+    def test_unknown_required_never_covered(self) -> None:
+        assert Permission.covers("admin", "unknown") is False
+
+    # ── is_valid ─────────────────────────────────────────────────────────
+
+    def test_is_valid_returns_true_for_valid_values(self) -> None:
+        assert Permission.is_valid("read") is True
+        assert Permission.is_valid("write") is True
+        assert Permission.is_valid("delete") is True
+        assert Permission.is_valid("admin") is True
+
+    def test_is_valid_returns_false_for_invalid_values(self) -> None:
+        assert Permission.is_valid("execute") is False
+        assert Permission.is_valid("ADMIN") is False
+        assert Permission.is_valid("") is False
+        assert Permission.is_valid("superuser") is False
+
+
+# ── EnforceResult ────────────────────────────────────────────────────────────
+
+
+class TestEnforceResult:
+    def test_construction_with_all_fields(self) -> None:
+        r = EnforceResult(
+            allowed=True,
+            reason="",
+            grant_id="grnt_01",
+            agent_did="did:grantex:ag_01",
+            scopes=["tool:salesforce:write"],
+            permission="write",
+            connector="salesforce",
+            tool="create_lead",
+        )
+        assert r.allowed is True
+        assert r.reason == ""
+        assert r.grant_id == "grnt_01"
+        assert r.agent_did == "did:grantex:ag_01"
+        assert r.scopes == ["tool:salesforce:write"]
+        assert r.permission == "write"
+        assert r.connector == "salesforce"
+        assert r.tool == "create_lead"
+
+    def test_default_values(self) -> None:
+        r = EnforceResult(allowed=False, reason="denied")
+        assert r.grant_id == ""
+        assert r.agent_did == ""
+        assert r.scopes == []
+        assert r.permission == ""
+        assert r.connector == ""
+        assert r.tool == ""
+
+    def test_denied_result(self) -> None:
+        r = EnforceResult(
+            allowed=False,
+            reason="read scope does not permit write operations on salesforce.",
+            connector="salesforce",
+            tool="create_lead",
+            permission="write",
+        )
+        assert r.allowed is False
+        assert "read scope" in r.reason
+        assert r.connector == "salesforce"
+        assert r.tool == "create_lead"

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/sdk-ts/src/client.ts
+++ b/packages/sdk-ts/src/client.ts
@@ -19,6 +19,8 @@ import { DomainsClient } from './resources/domains.js';
 import { WebAuthnClient } from './resources/webauthn.js';
 import { CredentialsClient } from './resources/credentials.js';
 import { PassportsClient } from './resources/passports.js';
+import { ToolManifest, Permission, permissionCovers, type EnforceOptions, type EnforceResult } from './manifest.js';
+import { verifyGrantToken } from './verify.js';
 import type {
   AuthorizationRequest,
   AuthorizeParams,
@@ -29,12 +31,15 @@ import type {
   SignupResponse,
   UpdateDeveloperSettingsParams,
   UpdateDeveloperSettingsResponse,
+  VerifiedGrant,
 } from './types.js';
 
 const DEFAULT_BASE_URL = 'https://api.grantex.dev';
 
 export class Grantex {
   readonly #http: HttpClient;
+  readonly #manifests: Map<string, ToolManifest> = new Map();
+  #jwksUri: string;
 
   readonly agents: AgentsClient;
   readonly grants: GrantsClient;
@@ -97,6 +102,7 @@ export class Grantex {
     this.webauthn = new WebAuthnClient(this.#http);
     this.credentials = new CredentialsClient(this.#http);
     this.passports = new PassportsClient(this.#http);
+    this.#jwksUri = `${(options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '')}/.well-known/jwks.json`;
   }
 
   /**
@@ -153,5 +159,173 @@ export class Grantex {
    */
   updateSettings(params: UpdateDeveloperSettingsParams): Promise<UpdateDeveloperSettingsResponse> {
     return this.#http.patch<UpdateDeveloperSettingsResponse>('/v1/me', params);
+  }
+
+  /**
+   * Load a tool manifest for scope enforcement.
+   * Manifests define what permission level each tool requires.
+   */
+  loadManifest(manifest: ToolManifest): void {
+    this.#manifests.set(manifest.connector, manifest);
+  }
+
+  /**
+   * Load multiple tool manifests at once.
+   */
+  loadManifests(manifests: ToolManifest[]): void {
+    for (const m of manifests) {
+      this.#manifests.set(m.connector, m);
+    }
+  }
+
+  /**
+   * Enforce scope for a tool call.
+   *
+   * 1. Verifies the grant token JWT offline (JWKS cached, <1ms after first call)
+   * 2. Looks up the tool's required permission from loaded manifests
+   * 3. Checks if the granted scope level covers the required permission
+   *
+   * Fails closed: unknown connectors/tools are denied by default.
+   *
+   * @example
+   * ```ts
+   * const result = await grantex.enforce({
+   *   grantToken: token,
+   *   connector: 'salesforce',
+   *   tool: 'delete_contact',
+   * });
+   * if (!result.allowed) throw new Error(result.reason);
+   * ```
+   */
+  async enforce(options: EnforceOptions): Promise<EnforceResult> {
+    const { grantToken, connector, tool, amount } = options;
+    const base: Omit<EnforceResult, 'allowed' | 'reason'> = {
+      grantId: '',
+      agentDid: '',
+      scopes: [],
+      permission: '',
+      connector,
+      tool,
+    };
+
+    // 1. Verify the token offline via JWKS
+    let grant: VerifiedGrant;
+    try {
+      grant = await verifyGrantToken(grantToken, { jwksUri: this.#jwksUri });
+    } catch (err) {
+      return {
+        ...base,
+        allowed: false,
+        reason: `Token verification failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    base.grantId = grant.grantId;
+    base.agentDid = grant.agentDid;
+    base.scopes = grant.scopes;
+
+    // 2. Look up manifest for the connector
+    const manifest = this.#manifests.get(connector);
+    if (!manifest) {
+      return {
+        ...base,
+        allowed: false,
+        reason: `No manifest loaded for connector '${connector}'. Load a manifest first.`,
+      };
+    }
+
+    // 3. Look up tool permission from manifest
+    const requiredPermission = manifest.getPermission(tool);
+    if (!requiredPermission) {
+      return {
+        ...base,
+        allowed: false,
+        reason: `Unknown tool '${tool}' on connector '${connector}'. Tool not found in manifest.`,
+      };
+    }
+    base.permission = requiredPermission;
+
+    // 4. Find the best matching scope for this connector
+    const grantedPermission = this.#resolveGrantedPermission(grant.scopes, connector);
+    if (!grantedPermission) {
+      return {
+        ...base,
+        allowed: false,
+        reason: `No scope grants access to connector '${connector}'.`,
+      };
+    }
+
+    // 5. Check permission hierarchy
+    if (!permissionCovers(grantedPermission, requiredPermission)) {
+      return {
+        ...base,
+        allowed: false,
+        reason: `${grantedPermission} scope does not permit ${requiredPermission} operations on ${connector}.`,
+      };
+    }
+
+    // 6. Check capped amount if provided
+    if (amount !== undefined) {
+      const cap = this.#extractCap(grant.scopes, connector);
+      if (cap !== undefined && amount > cap) {
+        return {
+          ...base,
+          allowed: false,
+          reason: `Amount ${amount} exceeds budget cap of ${cap} on ${connector}.`,
+        };
+      }
+    }
+
+    return { ...base, allowed: true, reason: '' };
+  }
+
+  /**
+   * Resolve the highest granted permission level for a connector from scope strings.
+   * Scope format: `tool:{connector}:{permission}[:{resource}][:capped:{N}]`
+   */
+  #resolveGrantedPermission(scopes: string[], connector: string): string | undefined {
+    let best: string | undefined;
+    let bestLevel = -1;
+
+    const levels: Record<string, number> = { read: 0, write: 1, delete: 2, admin: 3 };
+
+    for (const scope of scopes) {
+      const parts = scope.split(':');
+      // Match: tool:{connector}:{permission}:...
+      if (parts[0] === 'tool' && parts[1] === connector && parts[2]) {
+        const level = levels[parts[2]] ?? -1;
+        if (level > bestLevel) {
+          bestLevel = level;
+          best = parts[2];
+        }
+      }
+      // Also match agenticorg:{connector}:{permission}
+      if (parts[0] === 'agenticorg' && parts[1] === connector && parts[2]) {
+        const level = levels[parts[2]] ?? -1;
+        if (level > bestLevel) {
+          bestLevel = level;
+          best = parts[2];
+        }
+      }
+    }
+
+    return best;
+  }
+
+  /**
+   * Extract the budget cap from capped scopes for a connector.
+   * Scope format: `tool:{connector}:{permission}:{resource}:capped:{N}`
+   */
+  #extractCap(scopes: string[], connector: string): number | undefined {
+    for (const scope of scopes) {
+      const parts = scope.split(':');
+      if (parts[0] === 'tool' && parts[1] === connector) {
+        const cappedIdx = parts.indexOf('capped');
+        if (cappedIdx !== -1 && parts[cappedIdx + 1]) {
+          return Number(parts[cappedIdx + 1]);
+        }
+      }
+    }
+    return undefined;
   }
 }

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -32,6 +32,9 @@ export {
   type ListPassportsParams,
 } from './resources/passports.js';
 
+// Scope enforcement
+export { ToolManifest, Permission, permissionCovers, type EnforceOptions, type EnforceResult, type ToolManifestOptions } from './manifest.js';
+
 // Types
 export type {
   RateLimit,

--- a/packages/sdk-ts/src/manifest.ts
+++ b/packages/sdk-ts/src/manifest.ts
@@ -1,0 +1,178 @@
+/**
+ * Tool Manifest & Permission — scope enforcement for AI agent tool calls.
+ *
+ * A ToolManifest declares the permission level (read/write/delete/admin)
+ * required for each tool on a connector. The `enforce()` method on the
+ * Grantex client uses loaded manifests to check whether a grant token's
+ * scopes allow a given tool call.
+ *
+ * @example
+ * ```ts
+ * import { ToolManifest, Permission } from '@grantex/sdk';
+ *
+ * const manifest = new ToolManifest({
+ *   connector: 'salesforce',
+ *   tools: {
+ *     query: Permission.READ,
+ *     create_lead: Permission.WRITE,
+ *     delete_contact: Permission.DELETE,
+ *   },
+ * });
+ * ```
+ */
+
+/* ------------------------------------------------------------------ */
+/*  Permission                                                         */
+/* ------------------------------------------------------------------ */
+
+/** Permission levels for tool operations. */
+export enum Permission {
+  READ = 'read',
+  WRITE = 'write',
+  DELETE = 'delete',
+  ADMIN = 'admin',
+}
+
+const PERMISSION_LEVELS: Record<Permission, number> = {
+  [Permission.READ]: 0,
+  [Permission.WRITE]: 1,
+  [Permission.DELETE]: 2,
+  [Permission.ADMIN]: 3,
+};
+
+/**
+ * Check whether a granted permission level covers the required level.
+ *
+ * Hierarchy: `admin > delete > write > read`
+ *
+ * - A `write` scope covers `read` + `write` tools.
+ * - A `delete` scope covers `read` + `write` + `delete` tools.
+ * - An `admin` scope covers everything.
+ */
+export function permissionCovers(granted: string, required: string): boolean {
+  const grantedLevel = PERMISSION_LEVELS[granted as Permission] ?? -1;
+  const requiredLevel = PERMISSION_LEVELS[required as Permission] ?? 99;
+  return grantedLevel >= requiredLevel;
+}
+
+/* ------------------------------------------------------------------ */
+/*  ToolManifest                                                       */
+/* ------------------------------------------------------------------ */
+
+export interface ToolManifestOptions {
+  /** Connector name (e.g., "salesforce", "hubspot"). */
+  connector: string;
+  /** Tool name → Permission mapping. */
+  tools: Record<string, Permission>;
+  /** Manifest version (default "1.0.0"). */
+  version?: string;
+  /** Human-readable description. */
+  description?: string;
+}
+
+/**
+ * Declares the required permission level for each tool on a connector.
+ *
+ * Load manifests via `grantex.loadManifest()` and they will be used
+ * automatically by `grantex.enforce()`.
+ */
+export class ToolManifest {
+  readonly connector: string;
+  readonly tools: Record<string, Permission>;
+  readonly version: string;
+  readonly description: string;
+
+  constructor(options: ToolManifestOptions) {
+    if (!options.connector) {
+      throw new Error('ToolManifest: connector name is required');
+    }
+    if (!options.tools || Object.keys(options.tools).length === 0) {
+      throw new Error('ToolManifest: at least one tool is required');
+    }
+    for (const [name, perm] of Object.entries(options.tools)) {
+      if (!Object.values(Permission).includes(perm as Permission)) {
+        throw new Error(
+          `ToolManifest: invalid permission "${perm}" for tool "${name}". Must be one of: ${Object.values(Permission).join(', ')}`,
+        );
+      }
+    }
+
+    this.connector = options.connector;
+    this.tools = { ...options.tools };
+    this.version = options.version ?? '1.0.0';
+    this.description = options.description ?? '';
+  }
+
+  /** Get the declared permission for a tool. Returns undefined if not found. */
+  getPermission(toolName: string): Permission | undefined {
+    return this.tools[toolName];
+  }
+
+  /** Add or update a tool's permission in this manifest. */
+  addTool(toolName: string, permission: Permission): void {
+    (this.tools as Record<string, Permission>)[toolName] = permission;
+  }
+
+  /** Number of tools in this manifest. */
+  get toolCount(): number {
+    return Object.keys(this.tools).length;
+  }
+
+  /**
+   * Create a ToolManifest from a JSON object (e.g., loaded from file).
+   *
+   * Expected shape:
+   * ```json
+   * { "connector": "salesforce", "tools": { "query": "read", ... } }
+   * ```
+   */
+  static fromJSON(data: Record<string, unknown>): ToolManifest {
+    const connector = data['connector'] as string | undefined;
+    const tools = data['tools'] as Record<string, string> | undefined;
+    if (!connector || !tools) {
+      throw new Error('ToolManifest.fromJSON: missing "connector" or "tools" field');
+    }
+    return new ToolManifest({
+      connector,
+      tools: tools as Record<string, Permission>,
+      version: (data['version'] as string) ?? '1.0.0',
+      description: (data['description'] as string) ?? '',
+    });
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  EnforceResult                                                      */
+/* ------------------------------------------------------------------ */
+
+/** Result of a `grantex.enforce()` call. */
+export interface EnforceResult {
+  /** Whether the tool call is permitted. */
+  allowed: boolean;
+  /** Human-readable reason if denied. */
+  reason: string;
+  /** Grant ID from the JWT (empty if token invalid). */
+  grantId: string;
+  /** Agent DID from the JWT (empty if token invalid). */
+  agentDid: string;
+  /** All scopes from the grant token. */
+  scopes: string[];
+  /** Resolved permission for the requested tool. */
+  permission: string;
+  /** Connector name. */
+  connector: string;
+  /** Tool name. */
+  tool: string;
+}
+
+/** Options for `grantex.enforce()`. */
+export interface EnforceOptions {
+  /** The Grantex grant token (JWT). */
+  grantToken: string;
+  /** Connector name (e.g., "salesforce"). */
+  connector: string;
+  /** Tool name (e.g., "delete_contact"). */
+  tool: string;
+  /** Amount for capped scope enforcement (optional). */
+  amount?: number;
+}

--- a/packages/sdk-ts/src/manifests/ahrefs.ts
+++ b/packages/sdk-ts/src/manifests/ahrefs.ts
@@ -1,0 +1,13 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const ahrefsManifest = new ToolManifest({
+  connector: 'ahrefs',
+  description: 'Ahrefs SEO API',
+  tools: {
+    get_domain_rating: Permission.READ,
+    get_backlinks: Permission.READ,
+    get_organic_keywords: Permission.READ,
+    get_content_gap: Permission.READ,
+    get_site_audit: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/banking_aa.ts
+++ b/packages/sdk-ts/src/manifests/banking_aa.ts
@@ -1,0 +1,13 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const bankingAaManifest = new ToolManifest({
+  connector: 'banking_aa',
+  description: 'Banking Account Aggregator API',
+  tools: {
+    fetch_bank_statement: Permission.READ,
+    check_account_balance: Permission.READ,
+    get_transaction_list: Permission.READ,
+    request_consent: Permission.WRITE,
+    fetch_fi_data: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/bombora.ts
+++ b/packages/sdk-ts/src/manifests/bombora.ts
@@ -1,0 +1,12 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const bomboraManifest = new ToolManifest({
+  connector: 'bombora',
+  description: 'Bombora Intent Data API',
+  tools: {
+    get_surge_scores: Permission.READ,
+    get_topic_clusters: Permission.READ,
+    get_weekly_report: Permission.READ,
+    search_companies: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/brandwatch.ts
+++ b/packages/sdk-ts/src/manifests/brandwatch.ts
@@ -1,0 +1,13 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const brandwatchManifest = new ToolManifest({
+  connector: 'brandwatch',
+  description: 'Brandwatch Social Listening API',
+  tools: {
+    get_mentions: Permission.READ,
+    get_mention_summary: Permission.READ,
+    get_share_of_voice: Permission.READ,
+    create_alert: Permission.WRITE,
+    export_report: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/buffer.ts
+++ b/packages/sdk-ts/src/manifests/buffer.ts
@@ -1,0 +1,13 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const bufferManifest = new ToolManifest({
+  connector: 'buffer',
+  description: 'Buffer Social Media Management API',
+  tools: {
+    create_update: Permission.WRITE,
+    get_update_analytics: Permission.READ,
+    get_pending_updates: Permission.READ,
+    list_profiles: Permission.READ,
+    move_to_top: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/confluence.ts
+++ b/packages/sdk-ts/src/manifests/confluence.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const confluenceManifest = new ToolManifest({
+  connector: 'confluence',
+  description: 'Confluence Wiki REST API',
+  tools: {
+    create_page: Permission.WRITE,
+    update_page: Permission.WRITE,
+    search_content: Permission.READ,
+    get_page: Permission.READ,
+    get_page_tree: Permission.READ,
+    list_spaces: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/darwinbox.ts
+++ b/packages/sdk-ts/src/manifests/darwinbox.ts
@@ -1,0 +1,18 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const darwinboxManifest = new ToolManifest({
+  connector: 'darwinbox',
+  description: 'Darwinbox HRMS API',
+  tools: {
+    get_employee: Permission.READ,
+    create_employee: Permission.WRITE,
+    run_payroll: Permission.ADMIN,
+    get_attendance: Permission.READ,
+    apply_leave: Permission.WRITE,
+    get_org_chart: Permission.READ,
+    update_performance: Permission.WRITE,
+    terminate_employee: Permission.DELETE,
+    transfer_employee: Permission.WRITE,
+    get_payslip: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/docusign.ts
+++ b/packages/sdk-ts/src/manifests/docusign.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const docusignManifest = new ToolManifest({
+  connector: 'docusign',
+  description: 'DocuSign eSignature API',
+  tools: {
+    send_envelope: Permission.WRITE,
+    get_envelope_status: Permission.READ,
+    void_envelope: Permission.DELETE,
+    download_document: Permission.READ,
+    list_templates: Permission.READ,
+    create_envelope_from_template: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/epfo.ts
+++ b/packages/sdk-ts/src/manifests/epfo.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const epfoManifest = new ToolManifest({
+  connector: 'epfo',
+  description: 'EPFO (Employees Provident Fund Organisation) API',
+  tools: {
+    file_ecr: Permission.WRITE,
+    get_uan: Permission.READ,
+    check_claim_status: Permission.READ,
+    download_passbook: Permission.READ,
+    generate_trrn: Permission.WRITE,
+    verify_member: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/g2.ts
+++ b/packages/sdk-ts/src/manifests/g2.ts
@@ -1,0 +1,12 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const g2Manifest = new ToolManifest({
+  connector: 'g2',
+  description: 'G2 Buyer Intent API',
+  tools: {
+    get_intent_signals: Permission.READ,
+    get_product_reviews: Permission.READ,
+    get_comparison_data: Permission.READ,
+    get_category_leaders: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/ga4.ts
+++ b/packages/sdk-ts/src/manifests/ga4.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const ga4Manifest = new ToolManifest({
+  connector: 'ga4',
+  description: 'Google Analytics 4 Data API',
+  tools: {
+    run_report: Permission.READ,
+    run_realtime_report: Permission.READ,
+    get_conversions: Permission.READ,
+    get_user_acquisition: Permission.READ,
+    get_page_analytics: Permission.READ,
+    get_metadata: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/github.ts
+++ b/packages/sdk-ts/src/manifests/github.ts
@@ -1,0 +1,17 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const githubManifest = new ToolManifest({
+  connector: 'github',
+  description: 'GitHub REST API',
+  tools: {
+    list_repos: Permission.READ,
+    get_repo: Permission.READ,
+    list_repository_issues: Permission.READ,
+    create_issue: Permission.WRITE,
+    create_pull_request: Permission.WRITE,
+    get_repository_statistics: Permission.READ,
+    search_code: Permission.READ,
+    create_release: Permission.WRITE,
+    trigger_github_action_workflow: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/gmail.ts
+++ b/packages/sdk-ts/src/manifests/gmail.ts
@@ -1,0 +1,12 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const gmailManifest = new ToolManifest({
+  connector: 'gmail',
+  description: 'Gmail API',
+  tools: {
+    send_email: Permission.WRITE,
+    read_inbox: Permission.READ,
+    search_emails: Permission.READ,
+    get_thread: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/google_ads.ts
+++ b/packages/sdk-ts/src/manifests/google_ads.ts
@@ -1,0 +1,13 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const googleAdsManifest = new ToolManifest({
+  connector: 'google_ads',
+  description: 'Google Ads API',
+  tools: {
+    search_campaigns: Permission.READ,
+    get_campaign_performance: Permission.READ,
+    mutate_campaign_budget: Permission.WRITE,
+    get_search_terms: Permission.READ,
+    create_user_list: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/google_calendar.ts
+++ b/packages/sdk-ts/src/manifests/google_calendar.ts
@@ -1,0 +1,13 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const googleCalendarManifest = new ToolManifest({
+  connector: 'google_calendar',
+  description: 'Google Calendar API',
+  tools: {
+    create_event: Permission.WRITE,
+    list_events: Permission.READ,
+    check_availability: Permission.READ,
+    delete_event: Permission.DELETE,
+    find_free_slot: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/greenhouse.ts
+++ b/packages/sdk-ts/src/manifests/greenhouse.ts
@@ -1,0 +1,16 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const greenhouseManifest = new ToolManifest({
+  connector: 'greenhouse',
+  description: 'Greenhouse Recruiting API',
+  tools: {
+    list_jobs: Permission.READ,
+    get_candidate: Permission.READ,
+    list_applications: Permission.READ,
+    schedule_interview: Permission.WRITE,
+    create_candidate: Permission.WRITE,
+    advance_application: Permission.WRITE,
+    reject_application: Permission.DELETE,
+    get_scorecards: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/gstn.ts
+++ b/packages/sdk-ts/src/manifests/gstn.ts
@@ -1,0 +1,16 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const gstnManifest = new ToolManifest({
+  connector: 'gstn',
+  description: 'GST Network API',
+  tools: {
+    fetch_gstr2a: Permission.READ,
+    push_gstr1_data: Permission.WRITE,
+    file_gstr3b: Permission.WRITE,
+    file_gstr9: Permission.WRITE,
+    generate_eway_bill: Permission.WRITE,
+    generate_einvoice_irn: Permission.WRITE,
+    check_filing_status: Permission.READ,
+    get_compliance_notice: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/hubspot.ts
+++ b/packages/sdk-ts/src/manifests/hubspot.ts
@@ -1,0 +1,21 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const hubspotManifest = new ToolManifest({
+  connector: 'hubspot',
+  description: 'HubSpot CRM API',
+  tools: {
+    list_contacts: Permission.READ,
+    search_contacts: Permission.READ,
+    create_contact: Permission.WRITE,
+    get_contact: Permission.READ,
+    update_contact: Permission.WRITE,
+    list_deals: Permission.READ,
+    create_deal: Permission.WRITE,
+    get_deal: Permission.READ,
+    update_deal: Permission.WRITE,
+    list_pipelines: Permission.READ,
+    list_companies: Permission.READ,
+    create_company: Permission.WRITE,
+    get_campaign_analytics: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/income_tax_india.ts
+++ b/packages/sdk-ts/src/manifests/income_tax_india.ts
@@ -1,0 +1,15 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const incomeTaxIndiaManifest = new ToolManifest({
+  connector: 'income_tax_india',
+  description: 'Income Tax India e-Filing API',
+  tools: {
+    file_26q_return: Permission.WRITE,
+    file_24q_return: Permission.WRITE,
+    check_tds_credit_in_26as: Permission.READ,
+    download_form_16a: Permission.READ,
+    file_itr: Permission.WRITE,
+    get_compliance_notice: Permission.READ,
+    pay_tax_challan: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/index.ts
+++ b/packages/sdk-ts/src/manifests/index.ts
@@ -1,0 +1,62 @@
+// Finance
+export { bankingAaManifest } from './banking_aa.js';
+export { gstnManifest } from './gstn.js';
+export { netsuiteManifest } from './netsuite.js';
+export { oracleFusionManifest } from './oracle_fusion.js';
+export { quickbooksManifest } from './quickbooks.js';
+export { sapManifest } from './sap.js';
+export { stripeManifest } from './stripe.js';
+export { tallyManifest } from './tally.js';
+export { zohoBooksManifest } from './zoho_books.js';
+export { pinelabsPluralManifest } from './pinelabs_plural.js';
+export { incomeTaxIndiaManifest } from './income_tax_india.js';
+
+// HR
+export { darwinboxManifest } from './darwinbox.js';
+export { docusignManifest } from './docusign.js';
+export { epfoManifest } from './epfo.js';
+export { greenhouseManifest } from './greenhouse.js';
+export { kekaManifest } from './keka.js';
+export { linkedinTalentManifest } from './linkedin_talent.js';
+export { oktaManifest } from './okta.js';
+export { zoomManifest } from './zoom.js';
+
+// Marketing
+export { salesforceManifest } from './salesforce.js';
+export { hubspotManifest } from './hubspot.js';
+export { mailchimpManifest } from './mailchimp.js';
+export { googleAdsManifest } from './google_ads.js';
+export { metaAdsManifest } from './meta_ads.js';
+export { linkedinAdsManifest } from './linkedin_ads.js';
+export { ga4Manifest } from './ga4.js';
+export { mixpanelManifest } from './mixpanel.js';
+export { moengageManifest } from './moengage.js';
+export { ahrefsManifest } from './ahrefs.js';
+export { bomboraManifest } from './bombora.js';
+export { brandwatchManifest } from './brandwatch.js';
+export { bufferManifest } from './buffer.js';
+export { g2Manifest } from './g2.js';
+export { trustradiusManifest } from './trustradius.js';
+export { wordpressManifest } from './wordpress.js';
+
+// Ops
+export { jiraManifest } from './jira.js';
+export { confluenceManifest } from './confluence.js';
+export { servicenowManifest } from './servicenow.js';
+export { zendeskManifest } from './zendesk.js';
+export { pagerdutyManifest } from './pagerduty.js';
+export { sanctionsApiManifest } from './sanctions_api.js';
+export { mcaPortalManifest } from './mca_portal.js';
+
+// Comms
+export { gmailManifest } from './gmail.js';
+export { slackManifest } from './slack.js';
+export { githubManifest } from './github.js';
+export { googleCalendarManifest } from './google_calendar.js';
+export { s3Manifest } from './s3.js';
+export { sendgridManifest } from './sendgrid.js';
+export { twilioManifest } from './twilio.js';
+export { twitterManifest } from './twitter.js';
+export { whatsappManifest } from './whatsapp.js';
+export { youtubeManifest } from './youtube.js';
+export { langsmithManifest } from './langsmith.js';

--- a/packages/sdk-ts/src/manifests/jira.ts
+++ b/packages/sdk-ts/src/manifests/jira.ts
@@ -1,0 +1,19 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const jiraManifest = new ToolManifest({
+  connector: 'jira',
+  description: 'Jira Software REST API',
+  tools: {
+    list_projects: Permission.READ,
+    get_project: Permission.READ,
+    search_issues: Permission.READ,
+    get_issue: Permission.READ,
+    create_issue: Permission.WRITE,
+    update_issue: Permission.WRITE,
+    transition_issue: Permission.WRITE,
+    get_transitions: Permission.READ,
+    add_comment: Permission.WRITE,
+    get_sprint_data: Permission.READ,
+    get_project_metrics: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/keka.ts
+++ b/packages/sdk-ts/src/manifests/keka.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const kekaManifest = new ToolManifest({
+  connector: 'keka',
+  description: 'Keka HR API',
+  tools: {
+    get_employee: Permission.READ,
+    list_employees: Permission.READ,
+    run_payroll: Permission.ADMIN,
+    get_leave_balance: Permission.READ,
+    post_reimbursement: Permission.WRITE,
+    get_attendance_summary: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/langsmith.ts
+++ b/packages/sdk-ts/src/manifests/langsmith.ts
@@ -1,0 +1,13 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const langsmithManifest = new ToolManifest({
+  connector: 'langsmith',
+  description: 'LangSmith Observability API',
+  tools: {
+    list_runs: Permission.READ,
+    get_run: Permission.READ,
+    get_run_stats: Permission.READ,
+    list_datasets: Permission.READ,
+    create_feedback: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/linkedin_ads.ts
+++ b/packages/sdk-ts/src/manifests/linkedin_ads.ts
@@ -1,0 +1,12 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const linkedinAdsManifest = new ToolManifest({
+  connector: 'linkedin_ads',
+  description: 'LinkedIn Ads API',
+  tools: {
+    create_campaign: Permission.WRITE,
+    get_analytics: Permission.READ,
+    create_lead_gen_form: Permission.WRITE,
+    get_targeting_criteria: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/linkedin_talent.ts
+++ b/packages/sdk-ts/src/manifests/linkedin_talent.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const linkedinTalentManifest = new ToolManifest({
+  connector: 'linkedin_talent',
+  description: 'LinkedIn Talent Solutions API',
+  tools: {
+    post_job: Permission.WRITE,
+    search_candidates: Permission.READ,
+    send_inmail: Permission.WRITE,
+    get_applicants: Permission.READ,
+    get_analytics: Permission.READ,
+    get_job_insights: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/mailchimp.ts
+++ b/packages/sdk-ts/src/manifests/mailchimp.ts
@@ -1,0 +1,18 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const mailchimpManifest = new ToolManifest({
+  connector: 'mailchimp',
+  description: 'Mailchimp Email Marketing API',
+  tools: {
+    list_campaigns: Permission.READ,
+    create_campaign: Permission.WRITE,
+    send_campaign: Permission.WRITE,
+    get_campaign_report: Permission.READ,
+    add_list_member: Permission.WRITE,
+    search_members: Permission.READ,
+    create_template: Permission.WRITE,
+    create_ab_campaign: Permission.WRITE,
+    get_ab_results: Permission.READ,
+    send_winner: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/mca_portal.ts
+++ b/packages/sdk-ts/src/manifests/mca_portal.ts
@@ -1,0 +1,12 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const mcaPortalManifest = new ToolManifest({
+  connector: 'mca_portal',
+  description: 'MCA (Ministry of Corporate Affairs) Portal API',
+  tools: {
+    file_annual_return: Permission.WRITE,
+    complete_director_kyc: Permission.WRITE,
+    fetch_company_master_data: Permission.READ,
+    file_charge_satisfaction: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/meta_ads.ts
+++ b/packages/sdk-ts/src/manifests/meta_ads.ts
@@ -1,0 +1,13 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const metaAdsManifest = new ToolManifest({
+  connector: 'meta_ads',
+  description: 'Meta Ads (Facebook/Instagram) API',
+  tools: {
+    get_campaign_insights: Permission.READ,
+    update_campaign_budget: Permission.WRITE,
+    create_custom_audience: Permission.WRITE,
+    update_adset_status: Permission.WRITE,
+    get_ad_account_info: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/mixpanel.ts
+++ b/packages/sdk-ts/src/manifests/mixpanel.ts
@@ -1,0 +1,13 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const mixpanelManifest = new ToolManifest({
+  connector: 'mixpanel',
+  description: 'Mixpanel Analytics API',
+  tools: {
+    get_funnel: Permission.READ,
+    get_retention: Permission.READ,
+    query_jql: Permission.READ,
+    get_segmentation: Permission.READ,
+    export_events: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/moengage.ts
+++ b/packages/sdk-ts/src/manifests/moengage.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const moengageManifest = new ToolManifest({
+  connector: 'moengage',
+  description: 'MoEngage Customer Engagement API',
+  tools: {
+    create_campaign: Permission.WRITE,
+    get_campaign_stats: Permission.READ,
+    create_segment: Permission.WRITE,
+    send_push_notification: Permission.WRITE,
+    get_user_profile: Permission.READ,
+    track_event: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/netsuite.ts
+++ b/packages/sdk-ts/src/manifests/netsuite.ts
@@ -1,0 +1,16 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const netsuiteManifest = new ToolManifest({
+  connector: 'netsuite',
+  description: 'NetSuite ERP API',
+  tools: {
+    create_invoice: Permission.WRITE,
+    get_invoice: Permission.READ,
+    create_journal_entry: Permission.WRITE,
+    get_account_balance: Permission.READ,
+    create_vendor_bill: Permission.WRITE,
+    create_purchase_order: Permission.WRITE,
+    get_trial_balance: Permission.READ,
+    search_records: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/okta.ts
+++ b/packages/sdk-ts/src/manifests/okta.ts
@@ -1,0 +1,16 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const oktaManifest = new ToolManifest({
+  connector: 'okta',
+  description: 'Okta Identity Management API',
+  tools: {
+    provision_user: Permission.WRITE,
+    deactivate_user: Permission.DELETE,
+    assign_group: Permission.WRITE,
+    remove_group: Permission.DELETE,
+    get_access_log: Permission.READ,
+    reset_mfa: Permission.ADMIN,
+    list_active_sessions: Permission.READ,
+    suspend_user: Permission.DELETE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/oracle_fusion.ts
+++ b/packages/sdk-ts/src/manifests/oracle_fusion.ts
@@ -1,0 +1,18 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const oracleFusionManifest = new ToolManifest({
+  connector: 'oracle_fusion',
+  description: 'Oracle Fusion Cloud ERP API',
+  tools: {
+    post_journal_entry: Permission.WRITE,
+    get_gl_balance: Permission.READ,
+    create_ap_invoice: Permission.WRITE,
+    approve_payment: Permission.WRITE,
+    get_budget: Permission.READ,
+    create_po: Permission.WRITE,
+    get_trial_balance: Permission.READ,
+    run_period_close: Permission.ADMIN,
+    get_cash_position: Permission.READ,
+    run_reconciliation: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/pagerduty.ts
+++ b/packages/sdk-ts/src/manifests/pagerduty.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const pagerdutyManifest = new ToolManifest({
+  connector: 'pagerduty',
+  description: 'PagerDuty Incident Management API',
+  tools: {
+    create_incident: Permission.WRITE,
+    acknowledge_incident: Permission.WRITE,
+    resolve_incident: Permission.WRITE,
+    get_on_call: Permission.READ,
+    list_incidents: Permission.READ,
+    create_postmortem: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/pinelabs_plural.ts
+++ b/packages/sdk-ts/src/manifests/pinelabs_plural.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const pinelabsPluralManifest = new ToolManifest({
+  connector: 'pinelabs_plural',
+  description: 'Pine Labs Plural Payments API',
+  tools: {
+    create_order: Permission.WRITE,
+    check_order_status: Permission.READ,
+    create_payment_link: Permission.WRITE,
+    initiate_refund: Permission.WRITE,
+    get_settlement_report: Permission.READ,
+    get_payout_analytics: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/quickbooks.ts
+++ b/packages/sdk-ts/src/manifests/quickbooks.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const quickbooksManifest = new ToolManifest({
+  connector: 'quickbooks',
+  description: 'QuickBooks Online API',
+  tools: {
+    create_invoice: Permission.WRITE,
+    record_payment: Permission.WRITE,
+    get_profit_loss: Permission.READ,
+    get_balance_sheet: Permission.READ,
+    query: Permission.READ,
+    get_company_info: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/s3.ts
+++ b/packages/sdk-ts/src/manifests/s3.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const s3Manifest = new ToolManifest({
+  connector: 's3',
+  description: 'Amazon S3 API',
+  tools: {
+    upload_document: Permission.WRITE,
+    download_document: Permission.READ,
+    list_objects: Permission.READ,
+    generate_signed_url: Permission.READ,
+    delete_object: Permission.DELETE,
+    copy_object: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/salesforce.ts
+++ b/packages/sdk-ts/src/manifests/salesforce.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const salesforceManifest = new ToolManifest({
+  connector: 'salesforce',
+  description: 'Salesforce CRM REST API',
+  tools: {
+    create_lead: Permission.WRITE,
+    update_opportunity: Permission.WRITE,
+    query: Permission.READ,
+    create_task: Permission.WRITE,
+    get_account: Permission.READ,
+    list_opportunities: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/sanctions_api.ts
+++ b/packages/sdk-ts/src/manifests/sanctions_api.ts
@@ -1,0 +1,13 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const sanctionsApiManifest = new ToolManifest({
+  connector: 'sanctions_api',
+  description: 'Sanctions Screening API',
+  tools: {
+    screen_entity: Permission.READ,
+    screen_transaction: Permission.READ,
+    get_alert: Permission.READ,
+    batch_screen: Permission.READ,
+    generate_report: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/sap.ts
+++ b/packages/sdk-ts/src/manifests/sap.ts
@@ -1,0 +1,15 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const sapManifest = new ToolManifest({
+  connector: 'sap',
+  description: 'SAP S/4HANA API',
+  tools: {
+    post_journal_entry: Permission.WRITE,
+    get_gl_balance: Permission.READ,
+    create_purchase_order: Permission.WRITE,
+    post_goods_receipt: Permission.WRITE,
+    run_payment_run: Permission.ADMIN,
+    get_vendor_master: Permission.READ,
+    get_cost_center: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/sendgrid.ts
+++ b/packages/sdk-ts/src/manifests/sendgrid.ts
@@ -1,0 +1,15 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const sendgridManifest = new ToolManifest({
+  connector: 'sendgrid',
+  description: 'SendGrid Email API',
+  tools: {
+    send_email: Permission.WRITE,
+    create_template: Permission.WRITE,
+    get_stats: Permission.READ,
+    get_bounces: Permission.READ,
+    validate_email: Permission.READ,
+    send_email_with_tracking: Permission.WRITE,
+    get_email_activity: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/servicenow.ts
+++ b/packages/sdk-ts/src/manifests/servicenow.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const servicenowManifest = new ToolManifest({
+  connector: 'servicenow',
+  description: 'ServiceNow ITSM API',
+  tools: {
+    create_incident: Permission.WRITE,
+    update_incident: Permission.WRITE,
+    submit_change_request: Permission.WRITE,
+    get_cmdb_ci: Permission.READ,
+    check_sla_status: Permission.READ,
+    get_kb_article: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/slack.ts
+++ b/packages/sdk-ts/src/manifests/slack.ts
@@ -1,0 +1,15 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const slackManifest = new ToolManifest({
+  connector: 'slack',
+  description: 'Slack Web API',
+  tools: {
+    send_message: Permission.WRITE,
+    create_channel: Permission.WRITE,
+    upload_file: Permission.WRITE,
+    search_messages: Permission.READ,
+    list_channels: Permission.READ,
+    set_reminder: Permission.WRITE,
+    post_alert: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/stripe.ts
+++ b/packages/sdk-ts/src/manifests/stripe.ts
@@ -1,0 +1,16 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const stripeManifest = new ToolManifest({
+  connector: 'stripe',
+  description: 'Stripe Payments API',
+  tools: {
+    create_payment_intent: Permission.WRITE,
+    list_charges: Permission.READ,
+    create_payout: Permission.WRITE,
+    get_balance: Permission.READ,
+    list_invoices: Permission.READ,
+    create_customer: Permission.WRITE,
+    list_disputes: Permission.READ,
+    create_refund: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/tally.ts
+++ b/packages/sdk-ts/src/manifests/tally.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const tallyManifest = new ToolManifest({
+  connector: 'tally',
+  description: 'Tally ERP API',
+  tools: {
+    post_voucher: Permission.WRITE,
+    get_ledger_balance: Permission.READ,
+    generate_gst_report: Permission.READ,
+    export_tally_xml_data: Permission.READ,
+    get_trial_balance: Permission.READ,
+    get_stock_summary: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/trustradius.ts
+++ b/packages/sdk-ts/src/manifests/trustradius.ts
@@ -1,0 +1,12 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const trustradiusManifest = new ToolManifest({
+  connector: 'trustradius',
+  description: 'TrustRadius Buyer Intent API',
+  tools: {
+    get_buyer_intent: Permission.READ,
+    get_product_reviews: Permission.READ,
+    get_comparison_traffic: Permission.READ,
+    search_vendors: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/twilio.ts
+++ b/packages/sdk-ts/src/manifests/twilio.ts
@@ -1,0 +1,13 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const twilioManifest = new ToolManifest({
+  connector: 'twilio',
+  description: 'Twilio Communications API',
+  tools: {
+    send_sms: Permission.WRITE,
+    make_call: Permission.WRITE,
+    send_whatsapp: Permission.WRITE,
+    get_recordings: Permission.READ,
+    get_message_status: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/twitter.ts
+++ b/packages/sdk-ts/src/manifests/twitter.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const twitterManifest = new ToolManifest({
+  connector: 'twitter',
+  description: 'Twitter/X API v2',
+  tools: {
+    create_tweet: Permission.WRITE,
+    get_tweet: Permission.READ,
+    search_recent: Permission.READ,
+    get_user_tweets: Permission.READ,
+    get_user_by_username: Permission.READ,
+    get_tweet_metrics: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/whatsapp.ts
+++ b/packages/sdk-ts/src/manifests/whatsapp.ts
@@ -1,0 +1,13 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const whatsappManifest = new ToolManifest({
+  connector: 'whatsapp',
+  description: 'WhatsApp Business API',
+  tools: {
+    send_template_message: Permission.WRITE,
+    send_text_message: Permission.WRITE,
+    send_media_message: Permission.WRITE,
+    get_message_templates: Permission.READ,
+    get_business_profile: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/wordpress.ts
+++ b/packages/sdk-ts/src/manifests/wordpress.ts
@@ -1,0 +1,15 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const wordpressManifest = new ToolManifest({
+  connector: 'wordpress',
+  description: 'WordPress REST API',
+  tools: {
+    create_post: Permission.WRITE,
+    update_post: Permission.WRITE,
+    list_posts: Permission.READ,
+    get_post: Permission.READ,
+    upload_media: Permission.WRITE,
+    list_categories: Permission.READ,
+    create_page: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/youtube.ts
+++ b/packages/sdk-ts/src/manifests/youtube.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const youtubeManifest = new ToolManifest({
+  connector: 'youtube',
+  description: 'YouTube Data API v3',
+  tools: {
+    list_videos: Permission.READ,
+    get_video_stats: Permission.READ,
+    list_channel_videos: Permission.READ,
+    get_channel_stats: Permission.READ,
+    list_playlists: Permission.READ,
+    get_video_analytics: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/zendesk.ts
+++ b/packages/sdk-ts/src/manifests/zendesk.ts
@@ -1,0 +1,16 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const zendeskManifest = new ToolManifest({
+  connector: 'zendesk',
+  description: 'Zendesk Support API',
+  tools: {
+    create_ticket: Permission.WRITE,
+    update_ticket: Permission.WRITE,
+    get_ticket: Permission.READ,
+    apply_macro: Permission.WRITE,
+    get_csat_score: Permission.READ,
+    escalate_ticket: Permission.WRITE,
+    merge_tickets: Permission.WRITE,
+    get_sla_status: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/src/manifests/zoho_books.ts
+++ b/packages/sdk-ts/src/manifests/zoho_books.ts
@@ -1,0 +1,15 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const zohoBooksManifest = new ToolManifest({
+  connector: 'zoho_books',
+  description: 'Zoho Books API',
+  tools: {
+    create_invoice: Permission.WRITE,
+    list_invoices: Permission.READ,
+    record_expense: Permission.WRITE,
+    get_balance_sheet: Permission.READ,
+    get_profit_loss: Permission.READ,
+    list_chartofaccounts: Permission.READ,
+    reconcile_transaction: Permission.WRITE,
+  },
+});

--- a/packages/sdk-ts/src/manifests/zoom.ts
+++ b/packages/sdk-ts/src/manifests/zoom.ts
@@ -1,0 +1,14 @@
+import { ToolManifest, Permission } from '../manifest.js';
+
+export const zoomManifest = new ToolManifest({
+  connector: 'zoom',
+  description: 'Zoom Video Communications API',
+  tools: {
+    create_meeting: Permission.WRITE,
+    get_recording: Permission.READ,
+    cancel_meeting: Permission.DELETE,
+    get_attendance_report: Permission.READ,
+    add_panelist: Permission.WRITE,
+    get_transcript: Permission.READ,
+  },
+});

--- a/packages/sdk-ts/tests/enforce.test.ts
+++ b/packages/sdk-ts/tests/enforce.test.ts
@@ -1,0 +1,557 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ToolManifest, Permission } from '../src/manifest.js';
+import type { VerifiedGrant } from '../src/types.js';
+
+// Mock verifyGrantToken before importing client
+vi.mock('../src/verify.js', () => ({
+  verifyGrantToken: vi.fn(),
+  mapOnlineVerifyToVerifiedGrant: vi.fn(),
+}));
+
+const { verifyGrantToken } = await import('../src/verify.js');
+const { Grantex } = await import('../src/client.js');
+
+function makeFetch(status: number, body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+function makeGrant(overrides: Partial<VerifiedGrant> = {}): VerifiedGrant {
+  return {
+    tokenId: 'tok_01',
+    grantId: 'grant_01',
+    principalId: 'user_abc',
+    agentDid: 'did:grantex:ag_01',
+    developerId: 'org_test',
+    scopes: ['tool:salesforce:write'],
+    issuedAt: Math.floor(Date.now() / 1000),
+    expiresAt: Math.floor(Date.now() / 1000) + 86400,
+    ...overrides,
+  };
+}
+
+const salesforceManifest = new ToolManifest({
+  connector: 'salesforce',
+  tools: {
+    query: Permission.READ,
+    create_lead: Permission.WRITE,
+    delete_contact: Permission.DELETE,
+    manage_org: Permission.ADMIN,
+  },
+});
+
+const hubspotManifest = new ToolManifest({
+  connector: 'hubspot',
+  tools: {
+    search: Permission.READ,
+    create_deal: Permission.WRITE,
+  },
+});
+
+describe('enforce()', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns allowed when scope matches tool permission', async () => {
+    vi.mocked(verifyGrantToken).mockResolvedValue(
+      makeGrant({ scopes: ['tool:salesforce:write'] }),
+    );
+    vi.stubGlobal('fetch', makeFetch(200, {}));
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    grantex.loadManifest(salesforceManifest);
+
+    const result = await grantex.enforce({
+      grantToken: 'fake.token',
+      connector: 'salesforce',
+      tool: 'create_lead',
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe('');
+    expect(result.grantId).toBe('grant_01');
+    expect(result.agentDid).toBe('did:grantex:ag_01');
+    expect(result.connector).toBe('salesforce');
+    expect(result.tool).toBe('create_lead');
+    expect(result.permission).toBe(Permission.WRITE);
+  });
+
+  it('returns denied when scope is insufficient (read scope, write tool)', async () => {
+    vi.mocked(verifyGrantToken).mockResolvedValue(
+      makeGrant({ scopes: ['tool:salesforce:read'] }),
+    );
+    vi.stubGlobal('fetch', makeFetch(200, {}));
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    grantex.loadManifest(salesforceManifest);
+
+    const result = await grantex.enforce({
+      grantToken: 'fake.token',
+      connector: 'salesforce',
+      tool: 'create_lead',
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('read scope does not permit write');
+  });
+
+  it('returns denied for unknown connector (no manifest loaded)', async () => {
+    vi.mocked(verifyGrantToken).mockResolvedValue(
+      makeGrant({ scopes: ['tool:unknown:write'] }),
+    );
+    vi.stubGlobal('fetch', makeFetch(200, {}));
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    // No manifest loaded for "unknown"
+
+    const result = await grantex.enforce({
+      grantToken: 'fake.token',
+      connector: 'unknown',
+      tool: 'some_tool',
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("No manifest loaded for connector 'unknown'");
+  });
+
+  it('returns denied for unknown tool', async () => {
+    vi.mocked(verifyGrantToken).mockResolvedValue(
+      makeGrant({ scopes: ['tool:salesforce:admin'] }),
+    );
+    vi.stubGlobal('fetch', makeFetch(200, {}));
+
+    const grantex = new Grantex({ apiKey: 'test_key' });
+    grantex.loadManifest(salesforceManifest);
+
+    const result = await grantex.enforce({
+      grantToken: 'fake.token',
+      connector: 'salesforce',
+      tool: 'nonexistent_tool',
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("Unknown tool 'nonexistent_tool'");
+    expect(result.reason).toContain("connector 'salesforce'");
+  });
+
+  describe('permission hierarchy', () => {
+    it('write scope allows read tool', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(
+        makeGrant({ scopes: ['tool:salesforce:write'] }),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      const result = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'salesforce',
+        tool: 'query',
+      });
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it('delete scope allows write tool', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(
+        makeGrant({ scopes: ['tool:salesforce:delete'] }),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      const result = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'salesforce',
+        tool: 'create_lead',
+      });
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it('admin scope allows delete tool', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(
+        makeGrant({ scopes: ['tool:salesforce:admin'] }),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      const result = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'salesforce',
+        tool: 'delete_contact',
+      });
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it('read scope cannot access delete tool', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(
+        makeGrant({ scopes: ['tool:salesforce:read'] }),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      const result = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'salesforce',
+        tool: 'delete_contact',
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('read scope does not permit delete');
+    });
+
+    it('write scope cannot access admin tool', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(
+        makeGrant({ scopes: ['tool:salesforce:write'] }),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      const result = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'salesforce',
+        tool: 'manage_org',
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('write scope does not permit admin');
+    });
+  });
+
+  describe('token failures', () => {
+    it('returns denied for expired token', async () => {
+      vi.mocked(verifyGrantToken).mockRejectedValue(
+        new Error('JWTExpired: token has expired'),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      const result = await grantex.enforce({
+        grantToken: 'expired.token',
+        connector: 'salesforce',
+        tool: 'query',
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('Token verification failed');
+      expect(result.reason).toContain('expired');
+      expect(result.grantId).toBe('');
+      expect(result.agentDid).toBe('');
+      expect(result.scopes).toEqual([]);
+    });
+
+    it('returns denied for invalid token', async () => {
+      vi.mocked(verifyGrantToken).mockRejectedValue(
+        new Error('JWSInvalid: invalid signature'),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      const result = await grantex.enforce({
+        grantToken: 'bad.token',
+        connector: 'salesforce',
+        tool: 'query',
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('Token verification failed');
+      expect(result.reason).toContain('invalid signature');
+    });
+
+    it('handles non-Error rejection from verifyGrantToken', async () => {
+      vi.mocked(verifyGrantToken).mockRejectedValue('unexpected string error');
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      const result = await grantex.enforce({
+        grantToken: 'weird.token',
+        connector: 'salesforce',
+        tool: 'query',
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('Token verification failed');
+      expect(result.reason).toContain('unexpected string error');
+    });
+  });
+
+  describe('capped scopes', () => {
+    it('allows when amount is under the cap', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(
+        makeGrant({ scopes: ['tool:salesforce:write:leads:capped:500'] }),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      const result = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'salesforce',
+        tool: 'create_lead',
+        amount: 100,
+      });
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it('allows when amount equals the cap', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(
+        makeGrant({ scopes: ['tool:salesforce:write:leads:capped:500'] }),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      const result = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'salesforce',
+        tool: 'create_lead',
+        amount: 500,
+      });
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it('denies when amount exceeds the cap', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(
+        makeGrant({ scopes: ['tool:salesforce:write:leads:capped:500'] }),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      const result = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'salesforce',
+        tool: 'create_lead',
+        amount: 1000,
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('Amount 1000 exceeds budget cap of 500');
+    });
+
+    it('allows any amount when no cap is specified', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(
+        makeGrant({ scopes: ['tool:salesforce:write'] }),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      const result = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'salesforce',
+        tool: 'create_lead',
+        amount: 999999,
+      });
+
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe('scope resolution', () => {
+    it('returns denied when token has no scope for the connector', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(
+        makeGrant({ scopes: ['tool:hubspot:admin'] }),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      const result = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'salesforce',
+        tool: 'query',
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("No scope grants access to connector 'salesforce'");
+    });
+
+    it('resolves highest permission when multiple scopes match', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(
+        makeGrant({
+          scopes: ['tool:salesforce:read', 'tool:salesforce:admin'],
+        }),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      const result = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'salesforce',
+        tool: 'manage_org',
+      });
+
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe('loadManifest and loadManifests', () => {
+    it('loadManifest makes connector available for enforce', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(
+        makeGrant({ scopes: ['tool:hubspot:write'] }),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+
+      // Before loading, enforce denies
+      const before = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'hubspot',
+        tool: 'create_deal',
+      });
+      expect(before.allowed).toBe(false);
+      expect(before.reason).toContain("No manifest loaded for connector 'hubspot'");
+
+      // After loading, enforce allows
+      grantex.loadManifest(hubspotManifest);
+      const after = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'hubspot',
+        tool: 'create_deal',
+      });
+      expect(after.allowed).toBe(true);
+    });
+
+    it('loadManifests loads multiple manifests at once', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(
+        makeGrant({
+          scopes: ['tool:salesforce:write', 'tool:hubspot:read'],
+        }),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifests([salesforceManifest, hubspotManifest]);
+
+      const sfResult = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'salesforce',
+        tool: 'create_lead',
+      });
+      expect(sfResult.allowed).toBe(true);
+
+      const hsResult = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'hubspot',
+        tool: 'search',
+      });
+      expect(hsResult.allowed).toBe(true);
+    });
+
+    it('loadManifest overwrites previous manifest for same connector', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(
+        makeGrant({ scopes: ['tool:salesforce:write'] }),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      // manage_org requires admin, so write scope should deny it
+      const before = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'salesforce',
+        tool: 'manage_org',
+      });
+      expect(before.allowed).toBe(false);
+
+      // Replace manifest: now manage_org only requires write
+      const relaxedManifest = new ToolManifest({
+        connector: 'salesforce',
+        tools: { manage_org: Permission.WRITE },
+      });
+      grantex.loadManifest(relaxedManifest);
+
+      const after = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'salesforce',
+        tool: 'manage_org',
+      });
+      expect(after.allowed).toBe(true);
+    });
+  });
+
+  describe('EnforceResult fields', () => {
+    it('populates all fields on allowed result', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(
+        makeGrant({
+          grantId: 'grant_42',
+          agentDid: 'did:grantex:ag_42',
+          scopes: ['tool:salesforce:admin'],
+        }),
+      );
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+      grantex.loadManifest(salesforceManifest);
+
+      const result = await grantex.enforce({
+        grantToken: 'fake.token',
+        connector: 'salesforce',
+        tool: 'manage_org',
+      });
+
+      expect(result).toEqual({
+        allowed: true,
+        reason: '',
+        grantId: 'grant_42',
+        agentDid: 'did:grantex:ag_42',
+        scopes: ['tool:salesforce:admin'],
+        permission: Permission.ADMIN,
+        connector: 'salesforce',
+        tool: 'manage_org',
+      });
+    });
+
+    it('populates connector and tool fields even on denial', async () => {
+      vi.mocked(verifyGrantToken).mockRejectedValue(new Error('bad token'));
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+
+      const grantex = new Grantex({ apiKey: 'test_key' });
+
+      const result = await grantex.enforce({
+        grantToken: 'bad.token',
+        connector: 'salesforce',
+        tool: 'query',
+      });
+
+      expect(result.connector).toBe('salesforce');
+      expect(result.tool).toBe('query');
+      expect(result.allowed).toBe(false);
+    });
+  });
+});

--- a/packages/sdk-ts/tests/manifest.test.ts
+++ b/packages/sdk-ts/tests/manifest.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import { ToolManifest, Permission, permissionCovers } from '../src/manifest.js';
+
+describe('ToolManifest', () => {
+  const validOptions = {
+    connector: 'salesforce',
+    tools: {
+      query: Permission.READ,
+      create_lead: Permission.WRITE,
+      delete_contact: Permission.DELETE,
+      manage_org: Permission.ADMIN,
+    },
+  };
+
+  describe('construction', () => {
+    it('creates a manifest with valid options', () => {
+      const manifest = new ToolManifest(validOptions);
+      expect(manifest.connector).toBe('salesforce');
+      expect(manifest.tools).toEqual(validOptions.tools);
+      expect(manifest.version).toBe('1.0.0');
+      expect(manifest.description).toBe('');
+    });
+
+    it('accepts optional version and description', () => {
+      const manifest = new ToolManifest({
+        ...validOptions,
+        version: '2.0.0',
+        description: 'Salesforce connector manifest',
+      });
+      expect(manifest.version).toBe('2.0.0');
+      expect(manifest.description).toBe('Salesforce connector manifest');
+    });
+
+    it('throws on empty connector name', () => {
+      expect(
+        () => new ToolManifest({ connector: '', tools: { query: Permission.READ } }),
+      ).toThrow('ToolManifest: connector name is required');
+    });
+
+    it('throws on empty tools', () => {
+      expect(
+        () => new ToolManifest({ connector: 'salesforce', tools: {} }),
+      ).toThrow('ToolManifest: at least one tool is required');
+    });
+
+    it('throws on invalid permission value', () => {
+      expect(
+        () =>
+          new ToolManifest({
+            connector: 'salesforce',
+            tools: { query: 'execute' as Permission },
+          }),
+      ).toThrow(/invalid permission "execute" for tool "query"/);
+    });
+
+    it('copies tools object to avoid external mutation', () => {
+      const tools = { query: Permission.READ };
+      const manifest = new ToolManifest({ connector: 'test', tools });
+      tools['query'] = Permission.ADMIN;
+      expect(manifest.tools['query']).toBe(Permission.READ);
+    });
+  });
+
+  describe('getPermission()', () => {
+    it('returns correct permission for known tool', () => {
+      const manifest = new ToolManifest(validOptions);
+      expect(manifest.getPermission('query')).toBe(Permission.READ);
+      expect(manifest.getPermission('create_lead')).toBe(Permission.WRITE);
+      expect(manifest.getPermission('delete_contact')).toBe(Permission.DELETE);
+      expect(manifest.getPermission('manage_org')).toBe(Permission.ADMIN);
+    });
+
+    it('returns undefined for unknown tool', () => {
+      const manifest = new ToolManifest(validOptions);
+      expect(manifest.getPermission('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('addTool()', () => {
+    it('adds a new tool', () => {
+      const manifest = new ToolManifest(validOptions);
+      manifest.addTool('export_data', Permission.READ);
+      expect(manifest.getPermission('export_data')).toBe(Permission.READ);
+    });
+
+    it('overwrites existing tool permission', () => {
+      const manifest = new ToolManifest(validOptions);
+      expect(manifest.getPermission('query')).toBe(Permission.READ);
+      manifest.addTool('query', Permission.WRITE);
+      expect(manifest.getPermission('query')).toBe(Permission.WRITE);
+    });
+  });
+
+  describe('toolCount', () => {
+    it('returns correct count', () => {
+      const manifest = new ToolManifest(validOptions);
+      expect(manifest.toolCount).toBe(4);
+    });
+
+    it('reflects added tools', () => {
+      const manifest = new ToolManifest({
+        connector: 'test',
+        tools: { query: Permission.READ },
+      });
+      expect(manifest.toolCount).toBe(1);
+      manifest.addTool('create', Permission.WRITE);
+      expect(manifest.toolCount).toBe(2);
+    });
+  });
+
+  describe('fromJSON()', () => {
+    it('creates manifest from plain object', () => {
+      const data = {
+        connector: 'hubspot',
+        tools: {
+          search_contacts: 'read',
+          create_deal: 'write',
+        },
+        version: '1.2.0',
+        description: 'HubSpot tools',
+      };
+      const manifest = ToolManifest.fromJSON(data);
+      expect(manifest.connector).toBe('hubspot');
+      expect(manifest.getPermission('search_contacts')).toBe(Permission.READ);
+      expect(manifest.getPermission('create_deal')).toBe(Permission.WRITE);
+      expect(manifest.version).toBe('1.2.0');
+      expect(manifest.description).toBe('HubSpot tools');
+    });
+
+    it('uses default version and description when absent', () => {
+      const manifest = ToolManifest.fromJSON({
+        connector: 'slack',
+        tools: { send_message: 'write' },
+      });
+      expect(manifest.version).toBe('1.0.0');
+      expect(manifest.description).toBe('');
+    });
+
+    it('throws on missing connector', () => {
+      expect(() =>
+        ToolManifest.fromJSON({ tools: { query: 'read' } }),
+      ).toThrow('ToolManifest.fromJSON: missing "connector" or "tools" field');
+    });
+
+    it('throws on missing tools', () => {
+      expect(() =>
+        ToolManifest.fromJSON({ connector: 'salesforce' }),
+      ).toThrow('ToolManifest.fromJSON: missing "connector" or "tools" field');
+    });
+
+    it('throws on missing both connector and tools', () => {
+      expect(() => ToolManifest.fromJSON({})).toThrow(
+        'ToolManifest.fromJSON: missing "connector" or "tools" field',
+      );
+    });
+  });
+});
+
+describe('permissionCovers', () => {
+  it('admin covers all permission levels', () => {
+    expect(permissionCovers('admin', 'read')).toBe(true);
+    expect(permissionCovers('admin', 'write')).toBe(true);
+    expect(permissionCovers('admin', 'delete')).toBe(true);
+    expect(permissionCovers('admin', 'admin')).toBe(true);
+  });
+
+  it('delete covers read, write, and delete but not admin', () => {
+    expect(permissionCovers('delete', 'read')).toBe(true);
+    expect(permissionCovers('delete', 'write')).toBe(true);
+    expect(permissionCovers('delete', 'delete')).toBe(true);
+    expect(permissionCovers('delete', 'admin')).toBe(false);
+  });
+
+  it('write covers read and write but not delete or admin', () => {
+    expect(permissionCovers('write', 'read')).toBe(true);
+    expect(permissionCovers('write', 'write')).toBe(true);
+    expect(permissionCovers('write', 'delete')).toBe(false);
+    expect(permissionCovers('write', 'admin')).toBe(false);
+  });
+
+  it('read covers only read', () => {
+    expect(permissionCovers('read', 'read')).toBe(true);
+    expect(permissionCovers('read', 'write')).toBe(false);
+    expect(permissionCovers('read', 'delete')).toBe(false);
+    expect(permissionCovers('read', 'admin')).toBe(false);
+  });
+
+  it('returns false for unknown granted permission', () => {
+    expect(permissionCovers('execute', 'read')).toBe(false);
+  });
+
+  it('returns false for unknown required permission', () => {
+    expect(permissionCovers('admin', 'execute')).toBe(false);
+  });
+});

--- a/web/llms.txt
+++ b/web/llms.txt
@@ -77,6 +77,21 @@ Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, hum
 - SOC 2 Type I certified
 - Full compliance matrix: https://docs.grantex.dev/guides/compliance-matrix
 
+## Scope Enforcement (v0.3.0+)
+
+- `grantex.enforce(grant_token, connector, tool)` — verify JWT + check tool permission via manifest
+- `grantex.load_manifest(manifest)` / `load_manifests([...])` — load tool permission definitions
+- `grantex.wrap_tool(langchain_tool, connector, tool, grant_token)` — auto-enforce on LangChain tools
+- `ToolManifest(connector, tools)` — define custom connector permissions
+- `Permission.READ/WRITE/DELETE/ADMIN` — hierarchy: admin > delete > write > read
+- 54 pre-built manifests: from grantex.manifests.salesforce import manifest
+- CLI: grantex manifest generate ./connectors/ — auto-generate from code
+- CLI: grantex manifest list — browse bundled manifests
+- CLI: grantex enforce test --token X --connector Y --tool Z — dry-run
+- Unknown tools denied by default (fail closed)
+- Custom manifests: inline, JSON file, or extend pre-built
+- Case study: AgenticOrg — 35 agents, 54 connectors, 340+ tools, all enforced
+
 ## Comparisons
 
 - vs OAuth 2.0: Grantex adds cryptographic agent identity, delegation chains, action-level audit, and sub-second revocation


### PR DESCRIPTION
## Summary
Grantex v0.3.0 scope enforcement system — verify grant token + check tool-level permissions via manifests.

**New SDK methods (TS + Python):**
- `enforce(grantToken, connector, tool)` — offline JWKS verification + manifest permission check, <1ms
- `loadManifest()` / `loadManifests()` — load tool permission definitions
- `ToolManifest` class with `Permission` hierarchy (admin > delete > write > read)

**54 pre-built manifests** for enterprise connectors (340+ tools mapped):
- Finance (11): Stripe, SAP, NetSuite, Oracle Fusion, QuickBooks, Tally, Zoho Books, GSTN, Banking AA, Pinelabs, Income Tax
- HR (8): Darwinbox, DocuSign, EPFO, Greenhouse, Keka, LinkedIn Talent, Okta, Zoom
- Marketing (16): Salesforce, HubSpot, Mailchimp, Google Ads, Meta Ads, LinkedIn Ads, GA4, Mixpanel, MoEngage, Ahrefs, Bombora, Brandwatch, Buffer, G2, TrustRadius, WordPress
- Ops (7): Jira, Confluence, ServiceNow, Zendesk, PagerDuty, Sanctions API, MCA Portal
- Comms (11): Gmail, Slack, GitHub, Google Calendar, S3, SendGrid, Twilio, Twitter, WhatsApp, YouTube, LangSmith

**CLI commands:** `manifest list/show/validate`, `enforce test`

**Version bumps:** SDK 0.2.6→0.3.0 (TS), 0.2.5→0.3.0 (Python), CLI 0.1.8→0.2.0

## Test plan
- [x] TS SDK: 46 tests passing (manifest + enforce)
- [x] Python SDK: 66 tests passing (manifest + enforce)
- [x] TS SDK typecheck: zero errors
- [x] Python manifest imports verified
- [x] Permission hierarchy verified: write covers read, delete covers write+read, admin covers all