### PR TITLE
fix(docs): address Codex review on scope enforcement docs

### DIFF
--- a/docs/concepts/tool-manifests.mdx
+++ b/docs/concepts/tool-manifests.mdx
@@ -143,7 +143,7 @@ For internal APIs, connectors Grantex does not ship, or extensions to pre-built 
 - **Inline** — define in code with `ToolManifest(...)`
 - **JSON file** — load from disk with `ToolManifest.from_file("./manifests/my-service.json")`
 - **Extend pre-built** — add tools to an existing manifest with `manifest.add_tool("new_tool", Permission.WRITE)`
-- **CLI generate** — auto-generate from source code with `grantex manifest generate ./connectors/`
+- **CLI inspect** — browse and validate manifests with `grantex manifest list` and `grantex manifest validate`
 
 ---
 

--- a/docs/guides/scope-enforcement.mdx
+++ b/docs/guides/scope-enforcement.mdx
@@ -33,7 +33,7 @@ import { salesforceManifest } from '@grantex/sdk/manifests/salesforce';
 const grantex = new Grantex({ apiKey: 'gx_...' });
 grantex.loadManifest(salesforceManifest);
 
-const result = grantex.enforce({ grantToken: token, connector: 'salesforce', tool: 'delete_contact' });
+const result = await grantex.enforce({ grantToken: token, connector: 'salesforce', tool: 'delete_contact' });
 if (!result.allowed) throw new Error(result.reason);
 ```
 
@@ -154,6 +154,8 @@ grantex.loadManifest(salesforceManifest);
 
 ## LangChain Integration
 
+<Note>Coming in v0.3.1. The `wrap_tool()` / `wrapTool()` method is not yet available on the SDK client.</Note>
+
 Wrap any LangChain tool with `wrap_tool()` to enforce scope checks automatically on every invocation:
 
 <CodeGroup>
@@ -187,6 +189,8 @@ const protectedTool = grantex.wrapTool(myLangChainTool, {
 
 ## Express / FastAPI Middleware
 
+<Note>Coming in v0.3.1. The `enforceMiddleware()` (Express) and `GrantexAuth` (FastAPI) enforce middleware are not yet available.</Note>
+
 Add one-line enforcement to your tool execution endpoints:
 
 <CodeGroup>
@@ -206,9 +210,9 @@ app.use('/api/tools/*', grantex.enforceMiddleware({
 ```
 
 ```python FastAPI
-from grantex.fastapi import GrantexEnforcer
+from grantex_fastapi import GrantexAuth
 
-enforcer = GrantexEnforcer(grantex)
+enforcer = GrantexAuth(grantex)
 
 @app.post("/api/tools/{connector}/{tool}")
 async def execute_tool(
@@ -243,9 +247,6 @@ grantex manifest validate --agent-tools create_lead,query,delete_contact --conne
 
 # Dry-run enforcement against a real token
 grantex enforce test --token "eyJ..." --connector salesforce --tool delete_contact
-
-# Generate a manifest from your connector source code
-grantex manifest generate ./connectors/inventory_service.py
 ```
 
 See [CLI manifest reference](/cli/manifest) and [CLI enforce reference](/cli/enforce) for full details.
@@ -359,7 +360,7 @@ const grantToken = tokenResponse.grantToken;
 
 // 3. Before every tool call, enforce scope
 async function callTool(connector: string, tool: string, params: any) {
-  const result = grantex.enforce({ grantToken, connector, tool });
+  const result = await grantex.enforce({ grantToken, connector, tool });
   if (!result.allowed) throw new Error(`Agent denied: ${result.reason}`);
 
   return executeConnectorTool(connector, tool, params);

--- a/docs/sdks/python/enforce.mdx
+++ b/docs/sdks/python/enforce.mdx
@@ -286,6 +286,8 @@ Permission.is_valid("execute")  # False
 
 ## wrap_tool()
 
+<Note>Coming in v0.3.1. This method is not yet available on the SDK client.</Note>
+
 Wrap a LangChain `StructuredTool` so that enforcement runs automatically before every invocation.
 
 ```python
@@ -317,12 +319,14 @@ protected_tool = grantex.wrap_tool(
 
 ## FastAPI Integration
 
-Use `GrantexEnforcer` as a FastAPI dependency for automatic enforcement on tool execution routes:
+<Note>Coming in v0.3.1. The FastAPI enforce dependency is not yet available.</Note>
+
+Use `GrantexAuth` from `grantex_fastapi` as a FastAPI dependency for automatic enforcement on tool execution routes:
 
 ```python
-from grantex.fastapi import GrantexEnforcer
+from grantex_fastapi import GrantexAuth
 
-enforcer = GrantexEnforcer(grantex)
+enforcer = GrantexAuth(grantex)
 
 @app.post("/api/tools/{connector}/{tool}")
 async def execute_tool(

--- a/docs/sdks/typescript/enforce.mdx
+++ b/docs/sdks/typescript/enforce.mdx
@@ -15,7 +15,7 @@ import { salesforceManifest } from '@grantex/sdk/manifests/salesforce';
 const grantex = new Grantex({ apiKey: 'gx_...' });
 grantex.loadManifest(salesforceManifest);
 
-const result = grantex.enforce({
+const result = await grantex.enforce({
   grantToken: token,
   connector: 'salesforce',
   tool: 'delete_contact',
@@ -33,7 +33,7 @@ if (!result.allowed) {
 Check whether a grant token permits a tool call.
 
 ```typescript
-enforce(options: EnforceOptions): EnforceResult
+enforce(options: EnforceOptions): Promise<EnforceResult>
 ```
 
 ### Parameters: `EnforceOptions`
@@ -91,7 +91,7 @@ enforce(options: EnforceOptions): EnforceResult
 ### Example
 
 ```typescript
-const result = grantex.enforce({
+const result = await grantex.enforce({
   grantToken: 'eyJhbGciOiJSUzI1NiIs...',
   connector: 'salesforce',
   tool: 'create_lead',
@@ -110,7 +110,7 @@ if (result.allowed) {
 When a token includes a capped scope, pass the `amount` to enforce against the cap:
 
 ```typescript
-const result = grantex.enforce({
+const result = await grantex.enforce({
   grantToken: token,
   connector: 'stripe',
   tool: 'create_payment_intent',
@@ -287,6 +287,8 @@ permissionCovers(Permission.READ, Permission.READ);     // true  — exact match
 
 ## wrapTool()
 
+<Note>Coming in v0.3.1. This method is not yet available on the SDK client.</Note>
+
 Wrap a LangChain `StructuredTool` so that enforcement runs automatically before every invocation.
 
 ```typescript
@@ -317,6 +319,8 @@ const protectedTool = grantex.wrapTool(myLangChainTool, {
 ---
 
 ## enforceMiddleware()
+
+<Note>Coming in v0.3.1. This method is not yet available on the SDK client.</Note>
 
 Express middleware that enforces scope on every request to a route.
 


### PR DESCRIPTION
## Summary
Fixes 4 P1 issues flagged by Codex on PR #248:

1. **Async enforce()** — added `await` to all TS examples, fixed return type to `Promise<EnforceResult>`
2. **Unshipped APIs** — marked `wrapTool()` and `enforceMiddleware()` as "Coming in v0.3.1"
3. **Missing CLI command** — removed `manifest generate` references (not yet implemented)
4. **Wrong FastAPI import** — corrected to `from grantex_fastapi import GrantexAuth`

## Test plan
- [ ] TS code examples compile with await
- [ ] No references to nonexistent methods without "Coming Soon" notes