### PR TITLE
fix(sdk): add manifests export subpath + scope enforcement README sections

### DIFF
--- a/packages/sdk-py/README.md
+++ b/packages/sdk-py/README.md
@@ -198,6 +198,31 @@ except GrantexNetworkError:
 | [`@grantex/mcp`](https://www.npmjs.com/package/@grantex/mcp) | MCP server for Claude Desktop / Cursor / Windsurf |
 | [`@grantex/cli`](https://www.npmjs.com/package/@grantex/cli) | Command-line tool |
 
+## Scope Enforcement (v0.3.1)
+
+Enforce tool-level permissions using pre-built manifests for 54+ enterprise connectors.
+
+```python
+from grantex import Grantex
+from grantex.manifests.salesforce import manifest
+
+grantex = Grantex(api_key="gx_...")
+grantex.load_manifest(manifest)
+
+result = grantex.enforce(grant_token=token, connector="salesforce", tool="delete_contact")
+# result.allowed = False — "write scope does not permit delete operations"
+```
+
+**Features:**
+- `enforce()` — verify JWT + check tool permission via manifest, <1ms
+- `wrap_tool()` — auto-enforce on LangChain tools
+- `GrantexEnforcer` — FastAPI dependency for scope enforcement
+- 54 pre-built manifests (Salesforce, HubSpot, Jira, Stripe, SAP, S3, and 48 more)
+- Permission hierarchy: `admin > delete > write > read`
+- Permissive mode for migration (`enforce_mode="permissive"`)
+
+[Full Guide](https://docs.grantex.dev/guides/scope-enforcement) | [API Reference](https://docs.grantex.dev/sdks/python/enforce)
+
 ## License
 
 Apache 2.0

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -668,6 +668,36 @@ try {
 - [Python SDK](https://pypi.org/project/grantex/)
 - [API Reference](https://api.grantex.dev/.well-known/jwks.json)
 
+## Scope Enforcement (v0.3.1)
+
+Enforce tool-level permissions using pre-built manifests for 54+ enterprise connectors.
+
+```typescript
+import { Grantex, ToolManifest, Permission } from '@grantex/sdk';
+import { salesforceManifest } from '@grantex/sdk/manifests/salesforce';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+grantex.loadManifest(salesforceManifest);
+
+// One line — verify token + check tool permission
+const result = await grantex.enforce({
+  grantToken: token,
+  connector: 'salesforce',
+  tool: 'delete_contact',
+});
+// result.allowed = false — "write scope does not permit delete operations"
+```
+
+**Features:**
+- `enforce()` — verify JWT + check tool permission via manifest, <1ms
+- `wrapTool()` — auto-enforce on LangChain tools
+- `enforceMiddleware()` — Express/Fastify HTTP middleware
+- 54 pre-built manifests (Salesforce, HubSpot, Jira, Stripe, SAP, S3, and 48 more)
+- Permission hierarchy: `admin > delete > write > read`
+- Permissive mode for migration (`enforce_mode: 'permissive'`)
+
+[Full Guide](https://docs.grantex.dev/guides/scope-enforcement) | [API Reference](https://docs.grantex.dev/sdks/typescript/enforce)
+
 ## Grantex Ecosystem
 
 | Package | Description |

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -11,6 +11,14 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./manifests/*": {
+      "import": "./dist/manifests/*.js",
+      "types": "./dist/manifests/*.d.ts"
+    },
+    "./manifests": {
+      "import": "./dist/manifests/index.js",
+      "types": "./dist/manifests/index.d.ts"
     }
   },
   "main": "./dist/index.js",


### PR DESCRIPTION
Adds `./manifests/*` export subpath to package.json so consumers can `import { salesforceManifest } from '@grantex/sdk/manifests/salesforce'`. Adds scope enforcement sections to both SDK READMEs (shown on npm/PyPI package pages).