### PR TITLE
fix(sdk-ts): correct enforceMode in README (Codex PR #253)

### DIFF
--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -694,7 +694,7 @@ const result = await grantex.enforce({
 - `enforceMiddleware()` — Express/Fastify HTTP middleware
 - 54 pre-built manifests (Salesforce, HubSpot, Jira, Stripe, SAP, S3, and 48 more)
 - Permission hierarchy: `admin > delete > write > read`
-- Permissive mode for migration (`enforce_mode: 'permissive'`)
+- Permissive mode for migration (`enforceMode: 'permissive'`)
 
 [Full Guide](https://docs.grantex.dev/guides/scope-enforcement) | [API Reference](https://docs.grantex.dev/sdks/typescript/enforce)
 


### PR DESCRIPTION
TS SDK uses camelCase `enforceMode`, not snake_case `enforce_mode`. Codex flagged this on PR #253.