### PR TITLE
chore: bump SDK 0.3.2, CLI 0.2.2 — includes manifests export fix

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "CLI tool for local Grantex development",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,7 +38,7 @@ export function createProgram(): Command {
   program
     .name('grantex')
     .description('CLI for the Grantex delegated authorization protocol')
-    .version('0.2.1')
+    .version('0.2.2')
     .option('--json', 'Output results as JSON (machine-readable)')
     .hook('preAction', () => {
       if (program.opts().json) {

--- a/packages/cli/tests/index.test.ts
+++ b/packages/cli/tests/index.test.ts
@@ -40,7 +40,7 @@ describe('createProgram()', () => {
 
   it('has the correct version', () => {
     const program = createProgram();
-    expect(program.version()).toBe('0.2.0');
+    expect(program.version()).toBe('0.2.2');
   });
 
   it('has a --json global option', () => {

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.3.1"
+version = "0.3.2"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev",
   "bugs": {


### PR DESCRIPTION
## Summary
Version bump to publish changes since 0.3.1/0.2.1:

**Critical:** `./manifests/*` export subpath in TS SDK package.json — consumers couldn't import pre-built manifests from 0.3.1.

Also includes: unused import fix, README updates, mypy fix, category filter fix.

| Package | Old | New |
|---------|-----|-----|
| @grantex/sdk | 0.3.1 | 0.3.2 |
| grantex (PyPI) | 0.3.1 | 0.3.2 |
| @grantex/cli | 0.2.1 | 0.2.2 |