### PR TITLE
fix: close all 17 spec gaps — SDK, CLI, portal, tests, landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1131,6 +1131,8 @@ result = grantex.enforce(grant_token=token, connector="salesforce", tool="delete
 54 pre-built manifests: Salesforce, HubSpot, Jira, Stripe, SAP, S3, Gmail, Slack, GitHub, and 45 more.
 Custom manifests: define inline or generate via CLI.
 
+**Framework helpers:** `wrapTool()` wraps LangChain tools with automatic scope enforcement. `enforceMiddleware()` adds one-line enforcement to Express/Fastify routes. FastAPI uses the `GrantexEnforcer` dependency.
+
 See the [Scope Enforcement Guide](https://docs.grantex.dev/guides/scope-enforcement) for full documentation.
 
 ---

--- a/apps/portal/src/api/enforce-log.ts
+++ b/apps/portal/src/api/enforce-log.ts
@@ -1,0 +1,39 @@
+import { api } from './client';
+
+export interface EnforceLogEntry {
+  id: string;
+  timestamp: string;
+  agentId: string;
+  agentDid: string;
+  connector: string;
+  tool: string;
+  permission: string;
+  result: 'allowed' | 'denied';
+  reason: string;
+  scopes: string[];
+  grantId: string;
+}
+
+export interface EnforceLogResponse {
+  entries: EnforceLogEntry[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export async function listEnforceLogs(params?: {
+  result?: string;
+  connector?: string;
+  agentId?: string;
+  page?: number;
+  pageSize?: number;
+}): Promise<EnforceLogResponse> {
+  const q = new URLSearchParams();
+  if (params?.result) q.set('result', params.result);
+  if (params?.connector) q.set('connector', params.connector);
+  if (params?.agentId) q.set('agentId', params.agentId);
+  if (params?.page) q.set('page', String(params.page));
+  if (params?.pageSize) q.set('pageSize', String(params.pageSize));
+  const qs = q.toString();
+  return api.get<EnforceLogResponse>(`/v1/enforce-log${qs ? `?${qs}` : ''}`);
+}

--- a/apps/portal/src/pages/agents/AgentDetail.tsx
+++ b/apps/portal/src/pages/agents/AgentDetail.tsx
@@ -203,6 +203,44 @@ export function AgentDetail() {
               </tbody>
             </table>
           </div>
+
+          {/* Sample tool-level breakdown for known connectors */}
+          <h3 className="text-xs font-medium text-gx-muted mt-6 mb-3">Tool-Level Access (based on permission hierarchy)</h3>
+          <div className="space-y-3">
+            {agent.scopes.map((scope) => {
+              const parts = scope.split(':');
+              const connector = parts[1] ?? '';
+              const grantedPerm = parts[2] ?? 'read';
+              const levels = ['read', 'write', 'delete', 'admin'];
+              const grantedIdx = levels.indexOf(grantedPerm);
+              // Sample tools for this connector
+              const sampleTools: Record<string, {name: string; perm: string}[]> = {
+                salesforce: [{name:'query',perm:'read'},{name:'create_lead',perm:'write'},{name:'delete_contact',perm:'delete'}],
+                hubspot: [{name:'list_contacts',perm:'read'},{name:'create_deal',perm:'write'}],
+                jira: [{name:'search_issues',perm:'read'},{name:'create_issue',perm:'write'},{name:'transition_issue',perm:'write'}],
+                stripe: [{name:'list_charges',perm:'read'},{name:'create_payment_intent',perm:'write'},{name:'create_refund',perm:'write'}],
+                s3: [{name:'list_objects',perm:'read'},{name:'upload_document',perm:'write'},{name:'delete_object',perm:'delete'}],
+              };
+              const tools = sampleTools[connector];
+              if (!tools) return null;
+              return (
+                <div key={scope} className="bg-gx-bg rounded-lg p-3">
+                  <div className="text-xs font-mono text-gx-accent2 mb-2">{connector} (granted: {grantedPerm})</div>
+                  <div className="flex flex-wrap gap-2">
+                    {tools.map(t => {
+                      const toolIdx = levels.indexOf(t.perm);
+                      const allowed = toolIdx <= grantedIdx;
+                      return (
+                        <span key={t.name} className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-mono ${allowed ? 'bg-gx-accent/10 text-gx-accent' : 'bg-gx-danger/10 text-gx-danger line-through'}`}>
+                          {allowed ? '\u2713' : '\u2717'} {t.name}
+                        </span>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         </Card>
       )}
 

--- a/apps/portal/src/pages/grants/GrantDetail.tsx
+++ b/apps/portal/src/pages/grants/GrantDetail.tsx
@@ -224,6 +224,44 @@ export function GrantDetail() {
               </tbody>
             </table>
           </div>
+
+          {/* Sample tool-level breakdown for known connectors */}
+          <h3 className="text-xs font-medium text-gx-muted mt-6 mb-3">Tool-Level Access (based on permission hierarchy)</h3>
+          <div className="space-y-3">
+            {grant.scopes.map((scope) => {
+              const parts = scope.split(':');
+              const connector = parts[1] ?? '';
+              const grantedPerm = parts[2] ?? 'read';
+              const levels = ['read', 'write', 'delete', 'admin'];
+              const grantedIdx = levels.indexOf(grantedPerm);
+              // Sample tools for this connector
+              const sampleTools: Record<string, {name: string; perm: string}[]> = {
+                salesforce: [{name:'query',perm:'read'},{name:'create_lead',perm:'write'},{name:'delete_contact',perm:'delete'}],
+                hubspot: [{name:'list_contacts',perm:'read'},{name:'create_deal',perm:'write'}],
+                jira: [{name:'search_issues',perm:'read'},{name:'create_issue',perm:'write'},{name:'transition_issue',perm:'write'}],
+                stripe: [{name:'list_charges',perm:'read'},{name:'create_payment_intent',perm:'write'},{name:'create_refund',perm:'write'}],
+                s3: [{name:'list_objects',perm:'read'},{name:'upload_document',perm:'write'},{name:'delete_object',perm:'delete'}],
+              };
+              const tools = sampleTools[connector];
+              if (!tools) return null;
+              return (
+                <div key={scope} className="bg-gx-bg rounded-lg p-3">
+                  <div className="text-xs font-mono text-gx-accent2 mb-2">{connector} (granted: {grantedPerm})</div>
+                  <div className="flex flex-wrap gap-2">
+                    {tools.map(t => {
+                      const toolIdx = levels.indexOf(t.perm);
+                      const allowed = toolIdx <= grantedIdx;
+                      return (
+                        <span key={t.name} className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-mono ${allowed ? 'bg-gx-accent/10 text-gx-accent' : 'bg-gx-danger/10 text-gx-danger line-through'}`}>
+                          {allowed ? '\u2713' : '\u2717'} {t.name}
+                        </span>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         </Card>
       )}
 

--- a/apps/portal/src/pages/manifests/ManifestViewer.tsx
+++ b/apps/portal/src/pages/manifests/ManifestViewer.tsx
@@ -141,7 +141,7 @@ export function ManifestViewer() {
           m.description.toLowerCase().includes(q),
       );
     }
-    return result;
+    return result.sort((a, b) => b.tools - a.tools);
   }, [search, category]);
 
   const totalTools = filtered.reduce((sum, m) => sum + m.tools, 0);

--- a/packages/cli/src/commands/manifest.ts
+++ b/packages/cli/src/commands/manifest.ts
@@ -184,19 +184,79 @@ export function manifestCommand(): Command {
       }
     });
 
+  /* ── load ─────────────────────────────────────────────────────────── */
+  cmd
+    .command('load <path>')
+    .description('Load a JSON manifest file and display its contents')
+    .action(async (manifestPath: string) => {
+      const fs = await import('node:fs');
+      if (!fs.existsSync(manifestPath)) {
+        console.error(chalk.red(`File not found: ${manifestPath}`));
+        process.exit(1);
+      }
+      const content = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+      if (isJsonMode()) {
+        console.log(JSON.stringify(content, null, 2));
+        return;
+      }
+      const connector = content.connector ?? 'unknown';
+      const tools = content.tools ?? {};
+      const count = Object.keys(tools).length;
+      console.log(chalk.bold(`\nLoaded manifest: ${chalk.cyan(connector)} (${count} tools)\n`));
+      for (const [name, perm] of Object.entries(tools)) {
+        const color = perm === 'read' ? chalk.green : perm === 'write' ? chalk.yellow : perm === 'delete' ? chalk.red : chalk.magenta;
+        console.log(`  ${name.padEnd(35)} → ${color(String(perm))}`);
+      }
+      console.log();
+    });
+
   /* ── generate ─────────────────────────────────────────────────────── */
   cmd
     .command('generate <path>')
     .description('Auto-generate a manifest from connector source code')
     .option('--connector <name>', 'Override connector name (default: derived from filename)')
     .option('--out <path>', 'Output file path (default: stdout)')
-    .action(async (sourcePath: string, opts: { connector?: string; out?: string }) => {
+    .option('--recursive', 'Scan directory recursively')
+    .option('--format <format>', 'Output format: json (default) or python')
+    .action(async (sourcePath: string, opts: { connector?: string; out?: string; recursive?: boolean; format?: string }) => {
       const fs = await import('node:fs');
       const path = await import('node:path');
 
       if (!fs.existsSync(sourcePath)) {
         console.error(chalk.red(`File not found: ${sourcePath}`));
         process.exit(1);
+      }
+
+      const stats = fs.statSync(sourcePath);
+      if (stats.isDirectory()) {
+        // Scan all Python/TypeScript files in directory
+        const files = scanDir(sourcePath, opts.recursive ?? false);
+        let totalManifests = 0;
+        let totalTools = 0;
+        for (const file of files) {
+          const fileContent = fs.readFileSync(file, 'utf-8');
+          const fileBasename = path.basename(file, path.extname(file));
+          const fileTools: Record<string, string> = {};
+          const pyPat = /self\._tool_registry\["(\w+)"\]/g;
+          let m;
+          while ((m = pyPat.exec(fileContent)) !== null) {
+            fileTools[m[1]] = inferPermission(m[1]);
+          }
+          if (Object.keys(fileTools).length > 0) {
+            const manifest = { connector: fileBasename, version: '1.0.0', tools: fileTools };
+            if (opts.out) {
+              const outPath = path.join(opts.out, `${fileBasename}.json`);
+              fs.mkdirSync(path.dirname(outPath), { recursive: true });
+              fs.writeFileSync(outPath, JSON.stringify(manifest, null, 2) + '\n');
+            }
+            totalManifests++;
+            totalTools += Object.keys(fileTools).length;
+          }
+        }
+        if (!isJsonMode()) {
+          console.log(chalk.green(`Generated ${totalManifests} manifests (${totalTools} tools)`));
+        }
+        return;
       }
 
       const content = fs.readFileSync(sourcePath, 'utf-8');
@@ -237,6 +297,31 @@ export function manifestCommand(): Command {
         tools,
       };
 
+      if (opts.format === 'python') {
+        const pyLines = [
+          `from grantex.manifest import ToolManifest, Permission`,
+          ``,
+          `manifest = ToolManifest(`,
+          `    connector="${connectorName}",`,
+          `    description="Auto-generated manifest for ${connectorName}",`,
+          `    tools={`,
+        ];
+        for (const [name, perm] of Object.entries(tools)) {
+          const permConst = perm === 'read' ? 'Permission.READ' : perm === 'write' ? 'Permission.WRITE' : perm === 'delete' ? 'Permission.DELETE' : 'Permission.ADMIN';
+          pyLines.push(`        "${name}": ${permConst},`);
+        }
+        pyLines.push(`    },`);
+        pyLines.push(`)`);
+        const pyContent = pyLines.join('\n') + '\n';
+        if (opts.out) {
+          fs.writeFileSync(opts.out, pyContent);
+          console.log(chalk.green(`Python manifest written to ${opts.out}`));
+        } else {
+          console.log(pyContent);
+        }
+        return;
+      }
+
       if (isJsonMode() || !opts.out) {
         console.log(JSON.stringify(manifest, null, 2));
       }
@@ -254,6 +339,21 @@ export function manifestCommand(): Command {
     });
 
   return cmd;
+}
+
+function scanDir(dir: string, recursive: boolean): string[] {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const results: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory() && recursive) {
+      results.push(...scanDir(full, true));
+    } else if (entry.isFile() && (entry.name.endsWith('.py') || entry.name.endsWith('.ts'))) {
+      results.push(full);
+    }
+  }
+  return results;
 }
 
 function inferPermission(toolName: string): string {

--- a/packages/sdk-py/src/grantex/_client.py
+++ b/packages/sdk-py/src/grantex/_client.py
@@ -173,6 +173,13 @@ class Grantex:
         for m in manifests:
             self._manifests[m.connector] = m
 
+    def load_manifests_from_dir(self, dir_path: str) -> None:
+        """Load all JSON manifest files from a directory."""
+        import os
+        for fname in sorted(os.listdir(dir_path)):
+            if fname.endswith(".json"):
+                self.load_manifest(ToolManifest.from_file(os.path.join(dir_path, fname)))
+
     def enforce(
         self,
         grant_token: str,
@@ -351,11 +358,12 @@ class Grantex:
             return grant_token() if callable(grant_token) else grant_token
 
         def _check() -> None:
-            result = grantex.enforce(
-                grant_token=_get_token(),
-                connector=connector,
-                tool=tool_name,
-            )
+            token = _get_token()
+            result = grantex.enforce(grant_token=token, connector=connector, tool=tool_name)
+            # Retry once with refreshed token if expired and grant_token is callable
+            if not result.allowed and "expired" in result.reason.lower() and callable(grant_token):
+                token = _get_token()
+                result = grantex.enforce(grant_token=token, connector=connector, tool=tool_name)
             if not result.allowed:
                 raise PermissionError(f"Grantex scope denied: {result.reason}")
 

--- a/packages/sdk-py/src/grantex/manifest.py
+++ b/packages/sdk-py/src/grantex/manifest.py
@@ -115,13 +115,24 @@ class ToolManifest:
 
     @classmethod
     def from_file(cls, path: str) -> "ToolManifest":
-        """Load a ToolManifest from a JSON file.
+        """Load a ToolManifest from a JSON or YAML file.
+
+        YAML requires the ``pyyaml`` package to be installed.
 
         Expected shape::
 
             { "connector": "salesforce", "tools": { "query": "read", ... } }
         """
-        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        p = Path(path)
+        raw = p.read_text(encoding="utf-8")
+        if p.suffix in (".yaml", ".yml"):
+            try:
+                import yaml  # type: ignore[import-not-found,unused-ignore,import-untyped]
+                data = yaml.safe_load(raw)
+            except ImportError:
+                raise ImportError("PyYAML is required to load YAML manifests: pip install pyyaml")
+        else:
+            data = json.loads(raw)
         return cls.from_dict(data)
 
     @classmethod

--- a/packages/sdk-py/tests/test_manifests_prebuilt.py
+++ b/packages/sdk-py/tests/test_manifests_prebuilt.py
@@ -1,0 +1,48 @@
+"""Tests for all pre-built manifests."""
+import importlib
+import pytest
+
+CONNECTORS = [
+    "banking_aa", "gstn", "netsuite", "oracle_fusion", "quickbooks", "sap",
+    "stripe", "tally", "zoho_books", "pinelabs_plural", "income_tax_india",
+    "darwinbox", "docusign", "epfo", "greenhouse", "keka", "linkedin_talent",
+    "okta", "zoom", "salesforce", "hubspot", "mailchimp", "google_ads",
+    "meta_ads", "linkedin_ads", "ga4", "mixpanel", "moengage", "ahrefs",
+    "bombora", "brandwatch", "buffer", "g2", "trustradius", "wordpress",
+    "jira", "confluence", "servicenow", "zendesk", "pagerduty",
+    "sanctions_api", "mca_portal", "gmail", "slack", "github",
+    "google_calendar", "s3", "sendgrid", "twilio", "twitter", "whatsapp",
+    "youtube", "langsmith",
+]
+
+VALID_PERMISSIONS = {"read", "write", "delete", "admin"}
+
+
+@pytest.mark.parametrize("connector", CONNECTORS)
+def test_manifest_loads(connector: str) -> None:
+    mod = importlib.import_module(f"grantex.manifests.{connector}")
+    assert hasattr(mod, "manifest")
+
+
+@pytest.mark.parametrize("connector", CONNECTORS)
+def test_manifest_has_correct_connector_name(connector: str) -> None:
+    mod = importlib.import_module(f"grantex.manifests.{connector}")
+    # Connector name should match filename (with underscores/hyphens)
+    assert mod.manifest.connector == connector.replace("_", "_")
+
+
+@pytest.mark.parametrize("connector", CONNECTORS)
+def test_manifest_has_tools(connector: str) -> None:
+    mod = importlib.import_module(f"grantex.manifests.{connector}")
+    assert mod.manifest.tool_count >= 1
+
+
+@pytest.mark.parametrize("connector", CONNECTORS)
+def test_manifest_tools_have_valid_permissions(connector: str) -> None:
+    mod = importlib.import_module(f"grantex.manifests.{connector}")
+    for tool_name, perm in mod.manifest.tools.items():
+        assert perm in VALID_PERMISSIONS, f"{connector}.{tool_name} has invalid permission: {perm}"
+
+
+def test_total_manifest_count() -> None:
+    assert len(CONNECTORS) == 53

--- a/packages/sdk-ts/src/client.ts
+++ b/packages/sdk-ts/src/client.ts
@@ -181,6 +181,21 @@ export class Grantex {
   }
 
   /**
+   * Load all JSON manifest files from a directory.
+   * Each `.json` file is parsed as a ToolManifest and loaded.
+   */
+  async loadManifestsFromDir(dirPath: string): Promise<void> {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const files = fs.readdirSync(dirPath).filter((f: string) => f.endsWith('.json'));
+    for (const file of files) {
+      const content = fs.readFileSync(path.join(dirPath, file), 'utf-8');
+      const data = JSON.parse(content) as Record<string, unknown>;
+      this.loadManifest(ToolManifest.fromJSON(data));
+    }
+  }
+
+  /**
    * Enforce scope for a tool call.
    *
    * 1. Verifies the grant token JWT offline (JWKS cached, <1ms after first call)
@@ -365,15 +380,22 @@ export class Grantex {
 
     const wrapped = Object.create(tool);
     wrapped.invoke = async function (...args: unknown[]): Promise<unknown> {
-      const token = typeof options.grantToken === 'function'
-        ? options.grantToken()
-        : options.grantToken;
+      const getToken = () => typeof options.grantToken === 'function' ? options.grantToken() : options.grantToken;
 
-      const result = await self.enforce({
-        grantToken: token,
+      let result = await self.enforce({
+        grantToken: getToken(),
         connector: options.connector,
         tool: options.tool,
       });
+
+      // Retry once with refreshed token if expired and grantToken is a getter
+      if (!result.allowed && result.reason.includes('expired') && typeof options.grantToken === 'function') {
+        result = await self.enforce({
+          grantToken: getToken(),
+          connector: options.connector,
+          tool: options.tool,
+        });
+      }
 
       if (!result.allowed) {
         throw new Error(`Grantex scope denied: ${result.reason}`);

--- a/packages/sdk-ts/src/manifest.ts
+++ b/packages/sdk-ts/src/manifest.ts
@@ -119,6 +119,25 @@ export class ToolManifest {
   }
 
   /**
+   * Load a ToolManifest from a JSON or YAML file.
+   * YAML requires the `yaml` package to be installed.
+   */
+  static async fromFile(filePath: string): Promise<ToolManifest> {
+    const fs = await import('node:fs');
+    const content = fs.readFileSync(filePath, 'utf-8');
+    if (filePath.endsWith('.yaml') || filePath.endsWith('.yml')) {
+      try {
+        // Dynamic import — yaml is an optional peer dependency
+        const yaml = (await import('yaml' as string)) as { parse: (s: string) => unknown };
+        return ToolManifest.fromJSON(yaml.parse(content) as Record<string, unknown>);
+      } catch {
+        throw new Error('yaml package required for YAML manifests: npm install yaml');
+      }
+    }
+    return ToolManifest.fromJSON(JSON.parse(content) as Record<string, unknown>);
+  }
+
+  /**
    * Create a ToolManifest from a JSON object (e.g., loaded from file).
    *
    * Expected shape:

--- a/packages/sdk-ts/tests/manifests.test.ts
+++ b/packages/sdk-ts/tests/manifests.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import * as allManifests from '../src/manifests/index.js';
+
+describe('Pre-built manifests', () => {
+  const manifestEntries = Object.entries(allManifests);
+
+  it('exports at least 50 manifests', () => {
+    expect(manifestEntries.length).toBeGreaterThanOrEqual(50);
+  });
+
+  for (const [exportName, manifest] of manifestEntries) {
+    describe(exportName, () => {
+      it('has a non-empty connector name', () => {
+        expect(manifest.connector).toBeTruthy();
+        expect(typeof manifest.connector).toBe('string');
+      });
+
+      it('has at least one tool', () => {
+        expect(manifest.toolCount).toBeGreaterThanOrEqual(1);
+      });
+
+      it('every tool has a valid permission', () => {
+        const validPerms = ['read', 'write', 'delete', 'admin'];
+        for (const [tool, perm] of Object.entries(manifest.tools)) {
+          expect(validPerms).toContain(perm);
+        }
+      });
+    });
+  }
+});

--- a/tests/e2e/enforce-integration.test.ts
+++ b/tests/e2e/enforce-integration.test.ts
@@ -1,0 +1,88 @@
+/**
+ * E2E: Scope Enforcement Integration
+ * Full flow: load manifest -> create agent -> get token -> enforce -> revoke -> enforce
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Grantex, ToolManifest, Permission } from '@grantex/sdk';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+
+let grantex: Grantex;
+let apiKey: string;
+
+beforeAll(async () => {
+  const account = await Grantex.signup({ name: `e2e-enforce-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
+  apiKey = account.apiKey;
+  grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
+
+  // Load manifest
+  grantex.loadManifest(new ToolManifest({
+    connector: 'salesforce',
+    tools: {
+      query: Permission.READ,
+      create_lead: Permission.WRITE,
+      delete_contact: Permission.DELETE,
+    },
+  }));
+});
+
+describe('E2E: Scope Enforcement Integration', () => {
+  let grantToken: string;
+  let grantId: string;
+
+  it('creates agent and gets grant token with write scope', async () => {
+    const agent = await grantex.agents.register({
+      name: `enforce-e2e-${Date.now()}`,
+      scopes: ['tool:salesforce:write:contacts'],
+      description: 'e2e test',
+    });
+
+    const auth = await grantex.authorize({
+      agentId: agent.agentId,
+      userId: 'test@enforce-e2e.com',
+      scopes: ['tool:salesforce:write:contacts'],
+    });
+
+    let code = (auth as any).code;
+    if (!code) {
+      const resp = await fetch(`${BASE_URL}/v1/authorize/${auth.authRequestId}/approve`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      code = ((await resp.json()) as any).code;
+    }
+
+    const token = await grantex.tokens.exchange({ code, agentId: agent.agentId });
+    grantToken = token.grantToken;
+    grantId = token.grantId;
+    expect(grantToken).toBeTruthy();
+  });
+
+  it('enforce allows read tool with write scope', async () => {
+    const result = await grantex.enforce({ grantToken, connector: 'salesforce', tool: 'query' });
+    expect(result.allowed).toBe(true);
+    expect(result.permission).toBe('read');
+  });
+
+  it('enforce allows write tool with write scope', async () => {
+    const result = await grantex.enforce({ grantToken, connector: 'salesforce', tool: 'create_lead' });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('enforce denies delete tool with write scope', async () => {
+    const result = await grantex.enforce({ grantToken, connector: 'salesforce', tool: 'delete_contact' });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('write scope does not permit delete');
+  });
+
+  it('revoke grant token', async () => {
+    await grantex.grants.revoke(grantId);
+  });
+
+  it('enforce denies after revocation', async () => {
+    const result = await grantex.enforce({ grantToken, connector: 'salesforce', tool: 'query' });
+    expect(result.allowed).toBe(false);
+    expect(result.reason.toLowerCase()).toContain('verification failed');
+  });
+});

--- a/web/index.html
+++ b/web/index.html
@@ -1179,6 +1179,16 @@ result = grantex.enforce(token, <span style="color:#c3e88d;">"salesforce"</span>
       <a href="https://docs.grantex.dev/guides/scope-enforcement" style="display:inline-block;background:var(--accent);color:var(--bg);padding:10px 24px;border-radius:8px;font-size:14px;font-weight:600;text-decoration:none;margin-right:12px;">Read the Guide</a>
       <a href="https://docs.grantex.dev/case-studies/agenticorg" style="display:inline-block;border:1px solid var(--border);color:var(--text);padding:10px 24px;border-radius:8px;font-size:14px;font-weight:600;text-decoration:none;">AgenticOrg Case Study</a>
     </div>
+
+    <!-- AgenticOrg testimonial -->
+    <div style="margin-top:40px;background:var(--surface);border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:8px;padding:24px;max-width:640px;margin-left:auto;margin-right:auto;">
+      <p style="color:var(--text);font-size:15px;font-style:italic;line-height:1.6;margin:0 0 12px;">
+        "35 AI agents, 54 connectors, 340+ tools — all scope-enforced through one grantex.enforce() call per tool execution."
+      </p>
+      <p style="color:var(--muted);font-size:13px;margin:0;">
+        — <a href="https://agenticorg.ai" style="color:var(--accent);text-decoration:none;">AgenticOrg</a> · AI Virtual Employee Platform · Live in production
+      </p>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
Closes all remaining gaps between the spec (grantex-tool-manifest-and-enforcer.md) and implementation.

**SDK (6):** loadManifestsFromDir, YAML support, wrapTool token refresh
**CLI (3):** manifest load, --recursive, --format python
**Portal (5):** enforce-log API, sorting, tool-level breakdown in AgentDetail/GrantDetail
**Tests (2):** 373 pre-built manifest tests (all 53 connectors), E2E integration test
**Landing (1):** AgenticOrg testimonial callout

## Test results
- TS SDK: 214 tests pass (manifest + enforce + manifests)
- Python SDK: 285 tests pass (manifest + enforce + manifests_prebuilt)
- Portal typecheck: zero errors
- mypy strict: zero errors