### PR TITLE
chore: bump SDK 0.3.3, CLI 0.2.3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "CLI tool for local Grantex development",
   "homepage": "https://grantex.dev",
   "bugs": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,7 +38,7 @@ export function createProgram(): Command {
   program
     .name('grantex')
     .description('CLI for the Grantex delegated authorization protocol')
-    .version('0.2.2')
+    .version('0.2.3')
     .option('--json', 'Output results as JSON (machine-readable)')
     .hook('preAction', () => {
       if (program.opts().json) {

--- a/packages/cli/tests/index.test.ts
+++ b/packages/cli/tests/index.test.ts
@@ -40,7 +40,7 @@ describe('createProgram()', () => {
 
   it('has the correct version', () => {
     const program = createProgram();
-    expect(program.version()).toBe('0.2.2');
+    expect(program.version()).toBe('0.2.3');
   });
 
   it('has a --json global option', () => {

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.3.2"
+version = "0.3.3"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev",
   "bugs": {


### PR DESCRIPTION
Includes: loadManifestsFromDir, YAML support, wrapTool token refresh, manifest load/recursive/format-python CLI, portal tool-level breakdown, enforce-log API, 373 manifest tests, E2E integration test, testimonial, TOCTOU fix.