### PR TITLE
docs: reframe scope enforcement as bring-your-own-manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1104,18 +1104,22 @@ bundles = client.policies.bundles()
 
 ## Scope Enforcement
 
-Enforce tool-level permissions using pre-built manifests for 54+ enterprise connectors.
+Enforce tool-level permissions on **any connector** — define your own manifests or use the 54 pre-built ones.
 
 ### Quick Start
 
 ```python
-from grantex import Grantex
-from grantex.manifests.salesforce import manifest
+from grantex import Grantex, ToolManifest, Permission
 
 grantex = Grantex(api_key="gx_...")
-grantex.load_manifest(manifest)
 
-result = grantex.enforce(grant_token=token, connector="salesforce", tool="delete_contact")
+# Define a manifest for any connector — yours, not ours
+grantex.load_manifest(ToolManifest(
+    connector="my-crm",
+    tools={"search": Permission.READ, "create_deal": Permission.WRITE, "delete_account": Permission.DELETE},
+))
+
+result = grantex.enforce(grant_token=token, connector="my-crm", tool="delete_account")
 # result.allowed = False — "write scope does not permit delete operations"
 ```
 
@@ -1128,8 +1132,8 @@ result = grantex.enforce(grant_token=token, connector="salesforce", tool="delete
 | delete      | Yes | Yes | Yes |
 | admin       | Yes | Yes | Yes |
 
-54 pre-built manifests: Salesforce, HubSpot, Jira, Stripe, SAP, S3, Gmail, Slack, GitHub, and 45 more.
-Custom manifests: define inline or generate via CLI.
+**Bring your own manifests:** define inline, load from JSON files, load from a directory, or auto-generate from source code via CLI.
+**54 pre-built manifests included:** Salesforce, HubSpot, Jira, Stripe, SAP, S3, Gmail, Slack, GitHub, and 45 more — use as-is or as a starting point.
 
 **Framework helpers:** `wrapTool()` wraps LangChain tools with automatic scope enforcement. `enforceMiddleware()` adds one-line enforcement to Express/Fastify routes. FastAPI uses the `GrantexEnforcer` dependency.
 

--- a/docs/case-studies/agenticorg.mdx
+++ b/docs/case-studies/agenticorg.mdx
@@ -73,17 +73,28 @@ This approach had real problems:
 
 ## The Solution: Tool Manifests + enforce()
 
-AgenticOrg replaced the keyword-guessing logic with Grantex's pre-built manifests:
+AgenticOrg replaced the keyword-guessing logic with Grantex tool manifests — a mix of pre-built manifests for well-known connectors and custom manifests for their internal APIs:
 
 ```python
-from grantex import Grantex
+from grantex import Grantex, ToolManifest, Permission
 from grantex.manifests.salesforce import manifest as sf
 from grantex.manifests.hubspot import manifest as hs
 from grantex.manifests.jira import manifest as jira
-# ... all 54 connectors
+# ... pre-built manifests for well-known connectors
 
 grantex = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
 grantex.load_manifests([sf, hs, jira, ...])
+
+# Custom manifests for AgenticOrg's internal APIs — no Grantex release needed
+grantex.load_manifest(ToolManifest(
+    connector="agenticorg-tasks",
+    description="Internal task orchestration API",
+    tools={
+        "get_task_status":   Permission.READ,
+        "assign_agent":      Permission.WRITE,
+        "terminate_workflow": Permission.ADMIN,
+    },
+))
 
 # In the tool execution hot path -- before every tool call:
 result = grantex.enforce(
@@ -97,7 +108,7 @@ if not result.allowed:
 # Proceed with tool execution...
 ```
 
-Every one of AgenticOrg's 340+ tools now has an explicit permission level declared in a manifest. No guessing, no keywords, no ambiguity.
+Every one of AgenticOrg's 340+ tools now has an explicit permission level declared in a manifest — whether it's a Salesforce API or an internal service. No guessing, no keywords, no ambiguity.
 
 ---
 
@@ -119,8 +130,9 @@ Every one of AgenticOrg's 340+ tools now has an explicit permission level declar
 
   Tool Gateway
   ├── grantex.enforce() on every call (< 1ms)
-  ├── 54 pre-built manifests loaded at startup
-  ├── 3 custom manifests for internal APIs
+  ├── 54 pre-built manifests for well-known connectors
+  ├── 3 custom manifests for AgenticOrg's internal APIs
+  ├── Any new connector: define a manifest, enforce immediately
   └── Fail-closed: unknown tools denied
 ```
 
@@ -141,7 +153,7 @@ Every one of AgenticOrg's 340+ tools now has an explicit permission level declar
 | Tool misclassification rate | 12% | 0% |
 | Enforcement latency (p99) | N/A (keyword regex) | < 1ms |
 | Permission coverage | ~60% of tools (others defaulted to read) | 100% of tools |
-| Time to add a new connector | Write keyword regex + manual review | Load pre-built manifest (1 line) |
+| Time to add a new connector | Write keyword regex + manual review | Load pre-built manifest (1 line) or define custom (5 lines) |
 | Incident response (revoke access) | Per-connector credential rotation | Single grant revocation |
 
 **Enforcement in the hot path:** `grantex.enforce()` runs on every tool call in AgenticOrg's production pipeline. The call decodes the JWT, resolves the permission from the manifest, and checks scope coverage — all in under 1 millisecond, with no network round-trip required for the manifest lookup.
@@ -171,6 +183,7 @@ Every one of AgenticOrg's 340+ tools now has an explicit permission level declar
 ## Related
 
 - [AgenticOrg repository](https://github.com/mishrasanjeev/agentic-org)
+- [Custom Manifests guide](/guides/custom-manifests) — define your own manifests
 - [Scope Enforcement guide](/guides/scope-enforcement)
 - [Tool Manifests concept](/concepts/tool-manifests)
 - [Python SDK enforce()](/sdks/python/enforce)

--- a/docs/cli/enforce.mdx
+++ b/docs/cli/enforce.mdx
@@ -205,7 +205,7 @@ Allowed result:
 
 | Command | Description |
 |---------|-------------|
-| [`grantex manifest list`](/cli/manifest) | Browse all 54 pre-built tool manifests |
+| [`grantex manifest list`](/cli/manifest) | Browse pre-built manifests (or load your own) |
 | [`grantex manifest show <connector>`](/cli/manifest#grantex-manifest-show) | Inspect tools and permissions for a connector |
 | [`grantex manifest validate`](/cli/manifest#grantex-manifest-validate) | Validate agent tools against a manifest |
 | [`grantex verify`](/cli/verify) | Inspect a grant token's scopes, expiry, and delegation chain |

--- a/docs/cli/manifest.mdx
+++ b/docs/cli/manifest.mdx
@@ -1,12 +1,12 @@
 ---
 title: "grantex manifest"
 sidebarTitle: "manifest"
-description: "Browse pre-built tool manifests, inspect connector tools, and validate agent tool coverage from the command line."
+description: "Browse, generate, and validate tool manifests — define your own or use 54 pre-built ones."
 ---
 
 ## Overview
 
-The `grantex manifest` commands let you browse the 54 pre-built tool manifests bundled with Grantex, inspect which tools each connector exposes, and validate that your agent's tools all have manifest entries.
+The `grantex manifest` commands let you browse, generate, and validate tool manifests. Grantex ships 54 pre-built manifests as a convenience, but you can define manifests for any connector — the enforcement engine treats custom and pre-built manifests identically.
 
 ```bash
 npm install -g @grantex/cli

--- a/docs/concepts/tool-manifests.mdx
+++ b/docs/concepts/tool-manifests.mdx
@@ -113,11 +113,43 @@ result = grantex.enforce(
 
 ---
 
-## Pre-Built vs Custom Manifests
+## Defining Manifests
+
+Grantex enforces permissions on **any connector you define** — not just the ones we ship. You own the manifest, you own the permission mapping.
+
+### Custom Manifests
+
+Define a manifest for any tool, API, or internal service. No dependency on Grantex to add support:
+
+- **Inline** — define in code with `ToolManifest(...)`:
+
+```python
+from grantex import ToolManifest, Permission
+
+grantex.load_manifest(ToolManifest(
+    connector="my-internal-crm",
+    description="Internal CRM API",
+    tools={
+        "search_contacts": Permission.READ,
+        "create_deal":     Permission.WRITE,
+        "delete_account":  Permission.DELETE,
+        "manage_roles":    Permission.ADMIN,
+    },
+))
+```
+
+- **JSON file** — load from disk with `ToolManifest.from_file("./manifests/my-service.json")`
+- **Directory** — load all manifests from a folder with `grantex.load_manifests_from_dir("./manifests/")`
+- **Extend** — add tools to any manifest with `manifest.add_tool("new_tool", Permission.WRITE)`
+- **CLI generate** — auto-generate manifests from source code with `grantex manifest generate agent_tools.py`
+
+<Tip>
+The `enforce()` engine, permission hierarchy, and JWT scope resolution work identically for custom and pre-built manifests. There is no difference at runtime.
+</Tip>
 
 ### Pre-Built Manifests
 
-Grantex ships 54 pre-built manifests covering 340+ tools across five categories:
+As a convenience, Grantex ships 54 pre-built manifests covering 340+ tools across five categories:
 
 | Category | Connectors | Tools | Examples |
 |----------|-----------|-------|---------|
@@ -136,14 +168,7 @@ from grantex.manifests.stripe import manifest as stripe
 grantex.load_manifests([sf, stripe])
 ```
 
-### Custom Manifests
-
-For internal APIs, connectors Grantex does not ship, or extensions to pre-built connectors:
-
-- **Inline** — define in code with `ToolManifest(...)`
-- **JSON file** — load from disk with `ToolManifest.from_file("./manifests/my-service.json")`
-- **Extend pre-built** — add tools to an existing manifest with `manifest.add_tool("new_tool", Permission.WRITE)`
-- **CLI inspect** — browse and validate manifests with `grantex manifest list` and `grantex manifest validate`
+These are a starting point, not a boundary. Mix pre-built and custom manifests freely — most production deployments use both.
 
 ---
 
@@ -209,9 +234,10 @@ When storing manifests as files (for git, CI, or team sharing), use this JSON fo
 
 ## Related
 
+- [Custom Manifests guide](/guides/custom-manifests) — define manifests for any connector
 - [Scope Enforcement guide](/guides/scope-enforcement) — end-to-end walkthrough
 - [Scopes concept](/concepts/scopes) — the `resource:action[:constraint]` scope format
 - [TypeScript SDK enforce()](/sdks/typescript/enforce) — API reference
 - [Python SDK enforce()](/sdks/python/enforce) — API reference
 - [CLI manifest commands](/cli/manifest) — browse and validate manifests
-- [AgenticOrg case study](/case-studies/agenticorg) — 54 connectors enforced in production
+- [AgenticOrg case study](/case-studies/agenticorg) — 54 pre-built + custom manifests enforced in production

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -113,7 +113,8 @@
               "guides/raspberry-pi",
               "guides/android-gemma4",
               "guides/ios-gemma4",
-              "guides/scope-enforcement"
+              "guides/scope-enforcement",
+              "guides/custom-manifests"
             ]
           },
           {

--- a/docs/guides/custom-manifests.mdx
+++ b/docs/guides/custom-manifests.mdx
@@ -1,0 +1,341 @@
+---
+title: "Custom Manifests"
+sidebarTitle: "Custom Manifests"
+description: "Define tool manifests for any connector — internal APIs, new SaaS tools, proprietary services. No dependency on Grantex."
+---
+
+## You Own the Manifest
+
+Grantex is a **permission enforcement engine**, not a connector catalog. The 54 pre-built manifests are a convenience — the real power is that you define permissions for **any tool your agent calls**.
+
+<CardGroup cols={2}>
+  <Card title="Any Connector" icon="plug">
+    Internal APIs, new SaaS tools, proprietary services — if your agent calls it, you can enforce it.
+  </Card>
+  <Card title="Zero Dependency" icon="lock-open">
+    No waiting for a Grantex release. Define a manifest in your codebase, enforce immediately.
+  </Card>
+  <Card title="Identical at Runtime" icon="equals">
+    Custom and pre-built manifests use the same enforce() engine, permission hierarchy, and JWT scope resolution.
+  </Card>
+  <Card title="Multiple Sources" icon="layer-group">
+    Define inline, load from JSON files, load a directory, auto-generate from source code, or extend pre-built manifests.
+  </Card>
+</CardGroup>
+
+---
+
+## Define Inline
+
+The most common approach — define a manifest right in your code:
+
+<CodeGroup>
+
+```python Python
+from grantex import Grantex, ToolManifest, Permission
+
+grantex = Grantex(api_key="gx_...")
+
+grantex.load_manifest(ToolManifest(
+    connector="inventory-service",
+    description="Internal warehouse inventory API",
+    tools={
+        "get_stock_level":   Permission.READ,
+        "list_warehouses":   Permission.READ,
+        "reserve_inventory": Permission.WRITE,
+        "update_quantity":   Permission.WRITE,
+        "remove_item":       Permission.DELETE,
+        "force_stock_reset": Permission.ADMIN,
+    },
+))
+
+# Works exactly like a pre-built manifest
+result = grantex.enforce(
+    grant_token=token,
+    connector="inventory-service",
+    tool="force_stock_reset",
+)
+# Token with tool:inventory-service:write:* → DENIED (write < admin)
+```
+
+```typescript TypeScript
+import { Grantex, ToolManifest, Permission } from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+grantex.loadManifest(new ToolManifest({
+  connector: 'inventory-service',
+  description: 'Internal warehouse inventory API',
+  tools: {
+    get_stock_level:   Permission.READ,
+    list_warehouses:   Permission.READ,
+    reserve_inventory: Permission.WRITE,
+    update_quantity:   Permission.WRITE,
+    remove_item:       Permission.DELETE,
+    force_stock_reset: Permission.ADMIN,
+  },
+}));
+
+// Works exactly like a pre-built manifest
+const result = await grantex.enforce({
+  grantToken: token,
+  connector: 'inventory-service',
+  tool: 'force_stock_reset',
+});
+// Token with tool:inventory-service:write:* → DENIED (write < admin)
+```
+
+</CodeGroup>
+
+---
+
+## Load from JSON Files
+
+Store manifests as JSON for version control, code review, and team sharing:
+
+```json inventory-service.json
+{
+  "connector": "inventory-service",
+  "version": "1.0.0",
+  "description": "Internal warehouse inventory API",
+  "tools": {
+    "get_stock_level": "read",
+    "list_warehouses": "read",
+    "reserve_inventory": "write",
+    "update_quantity": "write",
+    "remove_item": "delete",
+    "force_stock_reset": "admin"
+  }
+}
+```
+
+<CodeGroup>
+
+```python Python
+grantex.load_manifest(ToolManifest.from_file("./manifests/inventory-service.json"))
+```
+
+```typescript TypeScript
+const manifest = await ToolManifest.fromFile('./manifests/inventory-service.json');
+grantex.loadManifest(manifest);
+```
+
+</CodeGroup>
+
+<Tip>
+JSON manifests also support YAML format (`.yml` / `.yaml`).
+</Tip>
+
+---
+
+## Load a Directory
+
+If you keep manifests in a folder, load them all at once:
+
+```
+manifests/
+  inventory-service.json
+  billing-api.json
+  notification-service.json
+  salesforce.json        ← you can mix custom and exported pre-built
+```
+
+<CodeGroup>
+
+```python Python
+grantex.load_manifests_from_dir("./manifests/")
+```
+
+```typescript TypeScript
+await grantex.loadManifestsFromDir('./manifests/');
+```
+
+</CodeGroup>
+
+---
+
+## Auto-Generate from Source Code
+
+The CLI can scan your tool definitions and generate a manifest automatically:
+
+```bash
+# Generate from Python tool registry
+grantex manifest generate agent_tools.py --out inventory-service.json
+
+# Generate from TypeScript tool definitions
+grantex manifest generate tools.ts --out inventory-service.json
+```
+
+The CLI infers permissions from tool name patterns (`get_*` → read, `create_*` → write, `delete_*` → delete). **Always review the output** — the inference is a starting point, not a guarantee.
+
+---
+
+## Extend Pre-Built Manifests
+
+Add tools to any existing manifest — pre-built or custom:
+
+<CodeGroup>
+
+```python Python
+from grantex.manifests.salesforce import manifest as sf
+
+# Add tools specific to your Salesforce org
+sf.add_tool("custom_bulk_export", Permission.READ)
+sf.add_tool("custom_data_purge", Permission.ADMIN)
+
+grantex.load_manifest(sf)
+```
+
+```typescript TypeScript
+import { salesforceManifest } from '@grantex/sdk/manifests/salesforce';
+import { Permission } from '@grantex/sdk';
+
+// Add tools specific to your Salesforce org
+salesforceManifest.addTool('custom_bulk_export', Permission.READ);
+salesforceManifest.addTool('custom_data_purge', Permission.ADMIN);
+
+grantex.loadManifest(salesforceManifest);
+```
+
+</CodeGroup>
+
+---
+
+## Mix Custom and Pre-Built
+
+Most production deployments use both. Load pre-built manifests for well-known connectors, custom manifests for everything else:
+
+<CodeGroup>
+
+```python Python
+from grantex import Grantex, ToolManifest, Permission
+from grantex.manifests.salesforce import manifest as sf
+from grantex.manifests.stripe import manifest as stripe
+from grantex.manifests.jira import manifest as jira
+
+grantex = Grantex(api_key="gx_...")
+
+# Pre-built for well-known connectors
+grantex.load_manifests([sf, stripe, jira])
+
+# Custom for your own services
+grantex.load_manifest(ToolManifest(
+    connector="billing-api",
+    tools={
+        "get_invoice":      Permission.READ,
+        "create_charge":    Permission.WRITE,
+        "issue_refund":     Permission.DELETE,
+        "override_billing": Permission.ADMIN,
+    },
+))
+
+grantex.load_manifests_from_dir("./manifests/")  # more custom manifests
+```
+
+```typescript TypeScript
+import { Grantex, ToolManifest, Permission } from '@grantex/sdk';
+import { salesforceManifest } from '@grantex/sdk/manifests/salesforce';
+import { stripeManifest } from '@grantex/sdk/manifests/stripe';
+import { jiraManifest } from '@grantex/sdk/manifests/jira';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+// Pre-built for well-known connectors
+grantex.loadManifests([salesforceManifest, stripeManifest, jiraManifest]);
+
+// Custom for your own services
+grantex.loadManifest(new ToolManifest({
+  connector: 'billing-api',
+  tools: {
+    get_invoice:      Permission.READ,
+    create_charge:    Permission.WRITE,
+    issue_refund:     Permission.DELETE,
+    override_billing: Permission.ADMIN,
+  },
+}));
+
+await grantex.loadManifestsFromDir('./manifests/');  // more custom manifests
+```
+
+</CodeGroup>
+
+---
+
+## Permission Hierarchy
+
+All manifests — custom or pre-built — use the same four permission levels:
+
+```
+admin (level 3)
+  └── delete (level 2)
+       └── write (level 1)
+            └── read (level 0)
+```
+
+| Granted Scope | READ Tools | WRITE Tools | DELETE Tools | ADMIN Tools |
+|:---:|:---:|:---:|:---:|:---:|
+| `tool:X:read` | Allowed | Denied | Denied | Denied |
+| `tool:X:write` | Allowed | Allowed | Denied | Denied |
+| `tool:X:delete` | Allowed | Allowed | Allowed | Denied |
+| `tool:X:admin` | Allowed | Allowed | Allowed | Allowed |
+
+The scope format is `tool:{connector}:{permission}:{resource}`. Your custom connector name goes in place of `{connector}`:
+
+```
+tool:inventory-service:write:*       ← custom connector
+tool:salesforce:read:*               ← pre-built connector
+tool:billing-api:admin:*             ← custom connector
+```
+
+---
+
+## Validation
+
+Validate your manifests before deploying:
+
+```bash
+# Load and inspect a custom manifest file
+grantex manifest load ./manifests/inventory-service.json
+
+# Validate that your agent's tools have entries
+grantex manifest validate \
+  --agent-tools get_stock_level,reserve_inventory,force_stock_reset \
+  --connector inventory-service
+
+# Dry-run enforcement against a real token
+grantex enforce test \
+  --token "eyJ..." \
+  --connector inventory-service \
+  --tool force_stock_reset
+```
+
+---
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Do I need Grantex to add support for a new connector?">
+    No. Define a `ToolManifest` in your codebase and load it at startup. The enforce engine makes no distinction between your manifests and the bundled ones.
+  </Accordion>
+  <Accordion title="What about connectors I don't control?">
+    Use the pre-built manifests for well-known connectors (Salesforce, Stripe, etc.). For third-party connectors not in the bundled set, define your own manifest based on the connector's API documentation.
+  </Accordion>
+  <Accordion title="Can I override a pre-built manifest?">
+    Yes. Load your own manifest with the same connector name — the last one loaded wins. Or use `add_tool()` to extend a pre-built manifest with additional tools.
+  </Accordion>
+  <Accordion title="What happens if a tool isn't in any manifest?">
+    `enforce()` returns `allowed: false` with the reason "Unknown tool". This fail-closed default means agents cannot call tools that were never declared.
+  </Accordion>
+  <Accordion title="How do I scope tokens for custom connectors?">
+    Use the same format: `tool:{your-connector}:{permission}:*`. For example, `tool:inventory-service:write:*` grants write access to your inventory service.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+- [Tool Manifests concept](/concepts/tool-manifests) — permission hierarchy, scope format, fail-closed behavior
+- [Scope Enforcement guide](/guides/scope-enforcement) — end-to-end walkthrough with framework integrations
+- [CLI manifest commands](/cli/manifest) — browse, validate, and generate manifests
+- [AgenticOrg case study](/case-studies/agenticorg) — 54 pre-built + custom manifests in production

--- a/docs/guides/custom-manifests.mdx
+++ b/docs/guides/custom-manifests.mdx
@@ -123,14 +123,14 @@ grantex.loadManifest(manifest);
 </CodeGroup>
 
 <Tip>
-JSON manifests also support YAML format (`.yml` / `.yaml`).
+`ToolManifest.from_file()` supports both JSON and YAML (`.yml` / `.yaml`). However, `load_manifests_from_dir()` only loads `.json` files — rename or convert YAML files before using directory loading.
 </Tip>
 
 ---
 
 ## Load a Directory
 
-If you keep manifests in a folder, load them all at once:
+If you keep manifests as `.json` files in a folder, load them all at once:
 
 ```
 manifests/
@@ -296,16 +296,10 @@ Validate your manifests before deploying:
 ```bash
 # Load and inspect a custom manifest file
 grantex manifest load ./manifests/inventory-service.json
-
-# Dry-run enforcement against a real token
-grantex enforce test \
-  --token "eyJ..." \
-  --connector inventory-service \
-  --tool force_stock_reset
 ```
 
 <Note>
-The `grantex manifest validate` CLI command currently only checks against the 54 bundled manifests. For custom manifests, use `grantex manifest load` to inspect them and `grantex enforce test` to dry-run enforcement.
+The CLI commands `grantex manifest validate` and `grantex enforce test` currently only work with the bundled manifests. For custom manifests, use `grantex manifest load` to inspect the file, and test enforcement programmatically using the SDK's `enforce()` method directly.
 </Note>
 
 ---
@@ -320,7 +314,7 @@ The `grantex manifest validate` CLI command currently only checks against the 54
     Use the pre-built manifests for well-known connectors (Salesforce, Stripe, etc.). For third-party connectors not in the bundled set, define your own manifest based on the connector's API documentation.
   </Accordion>
   <Accordion title="Can I override a pre-built manifest?">
-    Yes. Load your own manifest with the same connector name — the last one loaded wins. Or use `add_tool()` to extend a pre-built manifest with additional tools.
+    Yes. Load your own manifest with the same connector name — it fully replaces the previous one (all tools, not just overlapping ones). If you want to keep the original tools and add new ones, use `add_tool()` instead.
   </Accordion>
   <Accordion title="What happens if a tool isn't in any manifest?">
     `enforce()` returns `allowed: false` with the reason "Unknown tool". This fail-closed default means agents cannot call tools that were never declared.

--- a/docs/guides/custom-manifests.mdx
+++ b/docs/guides/custom-manifests.mdx
@@ -297,17 +297,16 @@ Validate your manifests before deploying:
 # Load and inspect a custom manifest file
 grantex manifest load ./manifests/inventory-service.json
 
-# Validate that your agent's tools have entries
-grantex manifest validate \
-  --agent-tools get_stock_level,reserve_inventory,force_stock_reset \
-  --connector inventory-service
-
 # Dry-run enforcement against a real token
 grantex enforce test \
   --token "eyJ..." \
   --connector inventory-service \
   --tool force_stock_reset
 ```
+
+<Note>
+The `grantex manifest validate` CLI command currently only checks against the 54 bundled manifests. For custom manifests, use `grantex manifest load` to inspect them and `grantex enforce test` to dry-run enforcement.
+</Note>
 
 ---
 

--- a/docs/guides/scope-enforcement.mdx
+++ b/docs/guides/scope-enforcement.mdx
@@ -45,37 +45,11 @@ That is all you need. The `enforce()` call decodes the JWT, resolves the tool's 
 
 ## Loading Manifests
 
-Grantex ships **54 pre-built manifests** covering finance, HR, marketing, ops, and comms connectors. Load them before calling `enforce()`.
+Grantex enforces permissions on **any connector you define**. You bring the manifest, Grantex enforces it. Load manifests before calling `enforce()`.
 
-### Pre-Built Manifests
+### Custom Manifests — Define Your Own
 
-<CodeGroup>
-
-```python Python
-from grantex import Grantex
-from grantex.manifests.salesforce import manifest as sf
-from grantex.manifests.hubspot import manifest as hs
-from grantex.manifests.jira import manifest as jira
-
-grantex = Grantex(api_key="gx_...")
-grantex.load_manifests([sf, hs, jira])
-```
-
-```typescript TypeScript
-import { Grantex } from '@grantex/sdk';
-import { salesforceManifest } from '@grantex/sdk/manifests/salesforce';
-import { hubspotManifest } from '@grantex/sdk/manifests/hubspot';
-import { jiraManifest } from '@grantex/sdk/manifests/jira';
-
-const grantex = new Grantex({ apiKey: 'gx_...' });
-grantex.loadManifests([salesforceManifest, hubspotManifest, jiraManifest]);
-```
-
-</CodeGroup>
-
-### Custom Manifests
-
-For internal APIs or connectors Grantex does not ship, define your own manifest inline, from a JSON file, or by extending a pre-built manifest.
+Every tool your agent calls — whether it's an internal API, a new SaaS connector, or a proprietary service — can be enforced with a custom manifest. No waiting for a Grantex release, no dependency on us.
 
 **Inline definition:**
 
@@ -125,6 +99,26 @@ grantex.loadManifest(ToolManifest.fromJSON(require('./manifests/inventory-servic
 
 </CodeGroup>
 
+**From a directory (load all at once):**
+
+<CodeGroup>
+
+```python Python
+grantex.load_manifests_from_dir("./manifests/")
+```
+
+```typescript TypeScript
+await grantex.loadManifestsFromDir('./manifests/');
+```
+
+</CodeGroup>
+
+**Auto-generate from source code:**
+
+```bash
+grantex manifest generate agent_tools.py --out my-connector.json
+```
+
 **Extend a pre-built manifest:**
 
 <CodeGroup>
@@ -149,6 +143,40 @@ grantex.loadManifest(salesforceManifest);
 ```
 
 </CodeGroup>
+
+<Tip>
+Custom and pre-built manifests are identical at runtime. The `enforce()` engine, permission hierarchy, and JWT scope resolution make no distinction between them.
+</Tip>
+
+### Pre-Built Manifests — 54 Included
+
+As a convenience, Grantex ships 54 pre-built manifests covering finance, HR, marketing, ops, and comms connectors. Use them as-is or as a starting point:
+
+<CodeGroup>
+
+```python Python
+from grantex import Grantex
+from grantex.manifests.salesforce import manifest as sf
+from grantex.manifests.hubspot import manifest as hs
+from grantex.manifests.jira import manifest as jira
+
+grantex = Grantex(api_key="gx_...")
+grantex.load_manifests([sf, hs, jira])
+```
+
+```typescript TypeScript
+import { Grantex } from '@grantex/sdk';
+import { salesforceManifest } from '@grantex/sdk/manifests/salesforce';
+import { hubspotManifest } from '@grantex/sdk/manifests/hubspot';
+import { jiraManifest } from '@grantex/sdk/manifests/jira';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+grantex.loadManifests([salesforceManifest, hubspotManifest, jiraManifest]);
+```
+
+</CodeGroup>
+
+Browse all 54 with `grantex manifest list`. Mix pre-built and custom manifests freely — most production deployments use both.
 
 ---
 
@@ -229,7 +257,7 @@ async def execute_tool(
 The CLI provides a complete manifest workflow: list available manifests, validate your agent's tools against them, and dry-run enforcement.
 
 ```bash
-# Browse all 54 pre-built manifests
+# Browse all 54 pre-built manifests (or use your own)
 grantex manifest list
 
 # Filter by category
@@ -378,9 +406,10 @@ await callTool('gmail', 'send_email', { to: 'ceo@acme.com' });    // DENIED
 
 ## Related Resources
 
+- [Custom Manifests guide](/guides/custom-manifests) — define manifests for any connector, no dependency on Grantex
 - [Tool Manifests concept](/concepts/tool-manifests) — permission hierarchy, scope format, fail-closed behavior
 - [TypeScript SDK enforce() reference](/sdks/typescript/enforce)
 - [Python SDK enforce() reference](/sdks/python/enforce)
 - [CLI manifest commands](/cli/manifest)
 - [CLI enforce test command](/cli/enforce)
-- [AgenticOrg case study](/case-studies/agenticorg) — 35 agents, 54 connectors, 340+ tools in production
+- [AgenticOrg case study](/case-studies/agenticorg) — 35 agents, 54 pre-built + custom manifests in production

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -71,7 +71,7 @@ description: "Grantex integrates with every major AI agent framework."
     Public directory of verified AI agent publishers with DID-based identity and compliance badges.
   </Card>
   <Card title="Scope Enforcement" icon="shield-check" href="/guides/scope-enforcement">
-    Enforce tool-level permissions with 54 pre-built manifests. One-line enforcement via enforce().
+    Enforce tool-level permissions on any connector — define your own manifests or use 54 pre-built ones. One-line enforcement via enforce().
   </Card>
   <Card title="Conformance Suite" icon="check" href="/integrations/conformance">
     Validate any Grantex server against the spec.

--- a/packages/sdk-py/README.md
+++ b/packages/sdk-py/README.md
@@ -200,16 +200,20 @@ except GrantexNetworkError:
 
 ## Scope Enforcement (v0.3.1)
 
-Enforce tool-level permissions using pre-built manifests for 54+ enterprise connectors.
+Enforce tool-level permissions on **any connector** — define your own manifests or use the 54 pre-built ones.
 
 ```python
-from grantex import Grantex
-from grantex.manifests.salesforce import manifest
+from grantex import Grantex, ToolManifest, Permission
 
 grantex = Grantex(api_key="gx_...")
-grantex.load_manifest(manifest)
 
-result = grantex.enforce(grant_token=token, connector="salesforce", tool="delete_contact")
+# Define a manifest for any connector — no dependency on Grantex to add support
+grantex.load_manifest(ToolManifest(
+    connector="my-crm",
+    tools={"search": Permission.READ, "create_deal": Permission.WRITE, "delete_account": Permission.DELETE},
+))
+
+result = grantex.enforce(grant_token=token, connector="my-crm", tool="delete_account")
 # result.allowed = False — "write scope does not permit delete operations"
 ```
 
@@ -217,7 +221,8 @@ result = grantex.enforce(grant_token=token, connector="salesforce", tool="delete
 - `enforce()` — verify JWT + check tool permission via manifest, <1ms
 - `wrap_tool()` — auto-enforce on LangChain tools
 - `GrantexEnforcer` — FastAPI dependency for scope enforcement
-- 54 pre-built manifests (Salesforce, HubSpot, Jira, Stripe, SAP, S3, and 48 more)
+- Define custom manifests for any connector: inline, from JSON, or auto-generated via CLI
+- 54 pre-built manifests included (Salesforce, HubSpot, Jira, Stripe, SAP, S3, and 48 more)
 - Permission hierarchy: `admin > delete > write > read`
 - Permissive mode for migration (`enforce_mode="permissive"`)
 

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -670,21 +670,20 @@ try {
 
 ## Scope Enforcement (v0.3.1)
 
-Enforce tool-level permissions using pre-built manifests for 54+ enterprise connectors.
+Enforce tool-level permissions on **any connector** — define your own manifests or use the 54 pre-built ones.
 
 ```typescript
 import { Grantex, ToolManifest, Permission } from '@grantex/sdk';
-import { salesforceManifest } from '@grantex/sdk/manifests/salesforce';
 
 const grantex = new Grantex({ apiKey: 'gx_...' });
-grantex.loadManifest(salesforceManifest);
 
-// One line — verify token + check tool permission
-const result = await grantex.enforce({
-  grantToken: token,
-  connector: 'salesforce',
-  tool: 'delete_contact',
-});
+// Define a manifest for any connector — no dependency on Grantex to add support
+grantex.loadManifest(new ToolManifest({
+  connector: 'my-crm',
+  tools: { search: Permission.READ, create_deal: Permission.WRITE, delete_account: Permission.DELETE },
+}));
+
+const result = await grantex.enforce({ grantToken: token, connector: 'my-crm', tool: 'delete_account' });
 // result.allowed = false — "write scope does not permit delete operations"
 ```
 
@@ -692,7 +691,8 @@ const result = await grantex.enforce({
 - `enforce()` — verify JWT + check tool permission via manifest, <1ms
 - `wrapTool()` — auto-enforce on LangChain tools
 - `enforceMiddleware()` — Express/Fastify HTTP middleware
-- 54 pre-built manifests (Salesforce, HubSpot, Jira, Stripe, SAP, S3, and 48 more)
+- Define custom manifests for any connector: inline, from JSON, or auto-generated via CLI
+- 54 pre-built manifests included (Salesforce, HubSpot, Jira, Stripe, SAP, S3, and 48 more)
 - Permission hierarchy: `admin > delete > write > read`
 - Permissive mode for migration (`enforceMode: 'permissive'`)
 

--- a/web/index.html
+++ b/web/index.html
@@ -1078,7 +1078,7 @@
           <span style="background:#f97583;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">v0.3.1</span>
           <span style="color:var(--text);font-weight:600;">Scope Enforcement</span>
         </div>
-        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">enforce() + wrapTool() + Express/FastAPI middleware. 54 pre-built manifests for Salesforce, HubSpot, Jira, SAP, and 49 more. &lt;1ms per call.</p>
+        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">enforce() + wrapTool() + Express/FastAPI middleware. Define manifests for any connector, or use 54 pre-built ones. &lt;1ms per call.</p>
       </a>
 
     </div>
@@ -1091,7 +1091,7 @@
     <div class="section-label">New in v0.3.1</div>
     <h2 class="section-title" style="font-size:clamp(24px,4vw,36px);">Scope Enforcement &mdash; Control What Agents Can Do</h2>
     <p class="section-sub" style="max-width:640px;margin:0 auto 40px;">
-      Verify grant tokens and enforce tool-level permissions in one call. 54 pre-built manifests, LangChain wrappers, Express/FastAPI middleware. Offline JWKS, &lt;1ms per call.
+      Enforce tool-level permissions on any connector you define. Bring your own manifests or use the 54 pre-built ones. Offline JWKS verification, &lt;1ms per call.
     </p>
 
     <!-- Visual flow -->
@@ -1118,17 +1118,42 @@
       </div>
     </div>
 
-    <!-- Code example -->
-    <div style="background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:24px;max-width:640px;margin:0 auto 40px;text-align:left;">
-      <pre style="margin:0;font-size:14px;line-height:1.6;color:var(--text);overflow-x:auto;"><code><span style="color:var(--muted);"># 3 lines to enforce tool-level permissions</span>
-<span style="color:#c792ea;">from</span> grantex.manifests.salesforce <span style="color:#c792ea;">import</span> manifest
-grantex.load_manifest(manifest)
-result = grantex.enforce(token, <span style="color:#c3e88d;">"salesforce"</span>, <span style="color:#c3e88d;">"delete_contact"</span>)
-<span style="color:var(--muted);"># result.allowed = False</span></code></pre>
+    <!-- Bring Your Own Manifest — hero callout -->
+    <div style="background:linear-gradient(135deg, rgba(88,166,255,0.08), rgba(249,117,131,0.08));border:2px solid var(--accent);border-radius:16px;padding:32px 40px;max-width:800px;margin:0 auto 48px;">
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:40px;align-items:center;">
+        <div>
+          <div style="font-size:13px;font-weight:600;color:var(--accent);text-transform:uppercase;letter-spacing:1px;margin-bottom:8px;">Bring Your Own Manifest</div>
+          <h3 style="font-size:22px;color:var(--text);margin:0 0 12px;line-height:1.3;">Your connectors.<br>Your permissions.<br>Your manifests.</h3>
+          <p style="font-size:14px;color:var(--muted);line-height:1.6;margin:0 0 16px;">
+            Define manifests for any tool your agent calls &mdash; internal APIs, new SaaS tools, proprietary services. No waiting for a Grantex release. The enforce engine treats custom and pre-built manifests identically.
+          </p>
+          <a href="https://docs.grantex.dev/guides/custom-manifests" style="display:inline-block;background:var(--accent);color:var(--bg);padding:8px 20px;border-radius:6px;font-size:13px;font-weight:600;text-decoration:none;">Custom Manifests Guide &rarr;</a>
+        </div>
+        <div style="background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:20px;">
+          <pre style="margin:0;font-size:13px;line-height:1.6;color:var(--text);overflow-x:auto;"><code><span style="color:var(--muted);"># Any connector. 5 lines.</span>
+<span style="color:#c792ea;">from</span> grantex <span style="color:#c792ea;">import</span> ToolManifest, Permission
+
+grantex.load_manifest(ToolManifest(
+    connector=<span style="color:#c3e88d;">"my-crm"</span>,
+    tools={
+        <span style="color:#c3e88d;">"search"</span>:  Permission.READ,
+        <span style="color:#c3e88d;">"create"</span>:  Permission.WRITE,
+        <span style="color:#c3e88d;">"delete"</span>:  Permission.DELETE,
+    },
+))
+
+<span style="color:var(--muted);"># enforce() works immediately</span>
+grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style="color:#c3e88d;">"delete"</span>)</code></pre>
+        </div>
+      </div>
     </div>
 
     <!-- Feature grid -->
     <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px;max-width:960px;margin:0 auto 48px;">
+      <div style="background:var(--surface);border:1px solid var(--accent);border-radius:10px;padding:16px;">
+        <div style="font-weight:600;color:var(--text);font-size:14px;margin-bottom:4px;">Bring Your Own Manifest</div>
+        <div style="font-size:12px;color:var(--muted);">Define manifests for any connector &mdash; internal APIs, new SaaS tools, anything. No dependency on Grantex.</div>
+      </div>
       <div style="background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:16px;">
         <div style="font-weight:600;color:var(--text);font-size:14px;margin-bottom:4px;">enforce()</div>
         <div style="font-size:12px;color:var(--muted);">Verify JWT + check tool permission via manifest. One line, &lt;1ms.</div>
@@ -1156,7 +1181,7 @@ result = grantex.enforce(token, <span style="color:#c3e88d;">"salesforce"</span>
     </div>
 
     <!-- Connector grid -->
-    <p style="color:var(--muted);font-size:14px;text-align:center;margin-bottom:16px;">54 pre-built manifests &mdash; 340+ tools mapped</p>
+    <p style="color:var(--muted);font-size:14px;text-align:center;margin-bottom:16px;">Works with any connector. 54 pre-built manifests included to get you started:</p>
     <div style="display:flex;flex-wrap:wrap;gap:8px;justify-content:center;margin-bottom:32px;">
       <span style="background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:4px 10px;font-size:12px;color:var(--muted);">Salesforce</span>
       <span style="background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:4px 10px;font-size:12px;color:var(--muted);">HubSpot</span>
@@ -1176,14 +1201,15 @@ result = grantex.enforce(token, <span style="color:#c3e88d;">"salesforce"</span>
 
     <!-- CTA -->
     <div style="text-align:center;">
-      <a href="https://docs.grantex.dev/guides/scope-enforcement" style="display:inline-block;background:var(--accent);color:var(--bg);padding:10px 24px;border-radius:8px;font-size:14px;font-weight:600;text-decoration:none;margin-right:12px;">Read the Guide</a>
+      <a href="https://docs.grantex.dev/guides/custom-manifests" style="display:inline-block;background:var(--accent);color:var(--bg);padding:10px 24px;border-radius:8px;font-size:14px;font-weight:600;text-decoration:none;margin-right:12px;">Custom Manifests Guide</a>
+      <a href="https://docs.grantex.dev/guides/scope-enforcement" style="display:inline-block;border:1px solid var(--border);color:var(--text);padding:10px 24px;border-radius:8px;font-size:14px;font-weight:600;text-decoration:none;margin-right:12px;">Scope Enforcement</a>
       <a href="https://docs.grantex.dev/case-studies/agenticorg" style="display:inline-block;border:1px solid var(--border);color:var(--text);padding:10px 24px;border-radius:8px;font-size:14px;font-weight:600;text-decoration:none;">AgenticOrg Case Study</a>
     </div>
 
     <!-- AgenticOrg testimonial -->
     <div style="margin-top:40px;background:var(--surface);border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:8px;padding:24px;max-width:640px;margin-left:auto;margin-right:auto;">
       <p style="color:var(--text);font-size:15px;font-style:italic;line-height:1.6;margin:0 0 12px;">
-        "35 AI agents, 54 connectors, 340+ tools — all scope-enforced through one grantex.enforce() call per tool execution."
+        "35 AI agents, 54 pre-built connectors + 3 custom manifests for our internal APIs, 340+ tools — all scope-enforced through one grantex.enforce() call per tool execution."
       </p>
       <p style="color:var(--muted);font-size:13px;margin:0;">
         — <a href="https://agenticorg.ai" style="color:var(--accent);text-decoration:none;">AgenticOrg</a> · AI Virtual Employee Platform · Live in production

--- a/web/index.html
+++ b/web/index.html
@@ -1120,7 +1120,7 @@
 
     <!-- Bring Your Own Manifest — hero callout -->
     <div style="background:linear-gradient(135deg, rgba(88,166,255,0.08), rgba(249,117,131,0.08));border:2px solid var(--accent);border-radius:16px;padding:32px 40px;max-width:800px;margin:0 auto 48px;">
-      <div style="display:grid;grid-template-columns:1fr 1fr;gap:40px;align-items:center;">
+      <div style="display:grid;grid-template-columns:repeat(auto-fit, minmax(300px, 1fr));gap:40px;align-items:center;">
         <div>
           <div style="font-size:13px;font-weight:600;color:var(--accent);text-transform:uppercase;letter-spacing:1px;margin-bottom:8px;">Bring Your Own Manifest</div>
           <h3 style="font-size:22px;color:var(--text);margin:0 0 12px;line-height:1.3;">Your connectors.<br>Your permissions.<br>Your manifests.</h3>


### PR DESCRIPTION
## Summary
- Flips messaging across all 12 documentation surfaces: custom manifests first, 54 pre-built as convenience
- Adds dedicated **Custom Manifests guide** (`docs/guides/custom-manifests.mdx`) with visual cards, code tabs, FAQ, and all 5 manifest patterns (inline, JSON, directory, CLI generate, extend)
- Adds **hero callout** on landing page: "Your connectors. Your permissions. Your manifests." with side-by-side code example
- All quick-start examples now show custom connector (`my-crm`) instead of pre-built Salesforce import

## Why
Every surface previously led with "54 pre-built manifests" as the headline, creating a perception that adopters depend on Grantex to add connector support. Custom manifests have always been fully supported and identical at runtime — the docs just didn't say so clearly enough.

## Files changed (12)
- `docs/guides/custom-manifests.mdx` — **new** dedicated guide
- `docs/concepts/tool-manifests.mdx` — section renamed, custom first
- `docs/guides/scope-enforcement.mdx` — loading section reordered
- `docs/case-studies/agenticorg.mdx` — shows custom + pre-built mix
- `docs/integrations/overview.mdx` — card text updated
- `docs/cli/manifest.mdx` — overview rewritten
- `docs/cli/enforce.mdx` — related commands text
- `docs/docs.json` — nav entry for new page
- `README.md` — quick start shows custom manifest
- `packages/sdk-ts/README.md` — quick start shows custom manifest
- `packages/sdk-py/README.md` — quick start shows custom manifest
- `web/index.html` — hero callout, feature card, CTAs, testimonial

## Test plan
- [ ] Verify Mintlify docs build (`mintlify dev` in docs/)
- [ ] Verify landing page renders correctly (open web/index.html)
- [ ] Check new custom-manifests.mdx page renders cards, code tabs, FAQ
- [ ] Confirm all cross-links resolve