### PR TITLE
fix(docs): correct manifest counts — 53 connectors, 339 tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1104,7 +1104,7 @@ bundles = client.policies.bundles()
 
 ## Scope Enforcement
 
-Enforce tool-level permissions on **any connector** — define your own manifests or use the 54 pre-built ones.
+Enforce tool-level permissions on **any connector** — define your own manifests or use the 53 pre-built ones.
 
 ### Quick Start
 
@@ -1133,7 +1133,7 @@ result = grantex.enforce(grant_token=token, connector="my-crm", tool="delete_acc
 | admin       | Yes | Yes | Yes |
 
 **Bring your own manifests:** define inline, load from JSON files, load from a directory, or auto-generate from source code via CLI.
-**54 pre-built manifests included:** Salesforce, HubSpot, Jira, Stripe, SAP, S3, Gmail, Slack, GitHub, and 45 more — use as-is or as a starting point.
+**53 pre-built manifests included:** Salesforce, HubSpot, Jira, Stripe, SAP, S3, Gmail, Slack, GitHub, and 44 more — use as-is or as a starting point.
 
 **Framework helpers:** `wrapTool()` wraps LangChain tools with automatic scope enforcement. `enforceMiddleware()` adds one-line enforcement to Express/Fastify routes. FastAPI uses the `GrantexEnforcer` dependency.
 

--- a/docs/case-studies/agenticorg.mdx
+++ b/docs/case-studies/agenticorg.mdx
@@ -1,12 +1,12 @@
 ---
 title: "AgenticOrg Case Study"
 sidebarTitle: "AgenticOrg"
-description: "How AgenticOrg enforces scope on 35 AI agents, 54 connectors, and 340+ tools using Grantex tool manifests."
+description: "How AgenticOrg enforces scope on 35 AI agents, 53+ connectors, and 339+ tools using Grantex tool manifests."
 ---
 
 ## Overview
 
-[AgenticOrg](https://github.com/mishrasanjeev/agentic-org) is an enterprise AI agent orchestration platform with **35 agents** across 6 domains, connected to **54 enterprise systems** via **340+ tools**. It is live at [agenticorg.ai](https://agenticorg.ai).
+[AgenticOrg](https://github.com/mishrasanjeev/agentic-org) is an enterprise AI agent orchestration platform with **35 agents** across 6 domains, connected to **56 enterprise systems** via **339+ tools**. It is live at [agenticorg.ai](https://agenticorg.ai).
 
 AgenticOrg agents call real APIs — Salesforce, Jira, HubSpot, SAP, S3, Gmail, Stripe, and 47 more. Each agent has a shared service account credential for each system. The challenge: how do you prevent an AP Processor agent from deleting contacts when it should only read invoices?
 
@@ -130,7 +130,7 @@ Every one of AgenticOrg's 340+ tools now has an explicit permission level declar
 
   Tool Gateway
   ├── grantex.enforce() on every call (< 1ms)
-  ├── 54 pre-built manifests for well-known connectors
+  ├── 53 pre-built manifests for well-known connectors
   ├── 3 custom manifests for AgenticOrg's internal APIs
   ├── Any new connector: define a manifest, enforce immediately
   └── Fail-closed: unknown tools denied
@@ -141,7 +141,7 @@ Every one of AgenticOrg's 340+ tools now has an explicit permission level declar
 ## Results
 
 <Note>
-"35 AI agents, 54 connectors, 340+ tools -- all scope-enforced through one grantex.enforce() call per tool execution. The keyword-guessing approach misclassified 12% of our tools. With manifests, it is zero."
+"35 AI agents, 53 pre-built + 3 custom connectors, 339+ tools -- all scope-enforced through one grantex.enforce() call per tool execution. The keyword-guessing approach misclassified 12% of our tools. With manifests, it is zero."
 
 -- AgenticOrg engineering team
 </Note>
@@ -162,7 +162,7 @@ Every one of AgenticOrg's 340+ tools now has an explicit permission level declar
 
 ## Try It Yourself
 
-1. **Browse the manifests** — see all 54 connectors and their tools:
+1. **Browse the manifests** — see all 53 bundled connectors and their tools:
    ```bash
    grantex manifest list
    ```

--- a/docs/cli/manifest.mdx
+++ b/docs/cli/manifest.mdx
@@ -1,12 +1,12 @@
 ---
 title: "grantex manifest"
 sidebarTitle: "manifest"
-description: "Browse, generate, and validate tool manifests — define your own or use 54 pre-built ones."
+description: "Browse, generate, and validate tool manifests — define your own or use 53 pre-built ones."
 ---
 
 ## Overview
 
-The `grantex manifest` commands let you browse, generate, and validate tool manifests. Grantex ships 54 pre-built manifests as a convenience, but you can define manifests for any connector — the enforcement engine treats custom and pre-built manifests identically.
+The `grantex manifest` commands let you browse, generate, and validate tool manifests. Grantex ships 53 pre-built manifests as a convenience, but you can define manifests for any connector — the enforcement engine treats custom and pre-built manifests identically.
 
 ```bash
 npm install -g @grantex/cli
@@ -25,9 +25,9 @@ grantex manifest list
 ### Output
 
 ```
-Available manifests (54 connectors, 340+ tools):
+Available manifests (53 connectors, 339 tools):
 
-  FINANCE (14 connectors, 88 tools)
+  FINANCE (11 connectors, 78 tools)
     banking_aa          5 tools
     gstn                8 tools
     netsuite            8 tools
@@ -39,32 +39,33 @@ Available manifests (54 connectors, 340+ tools):
     zoho_books          7 tools
     pinelabs_plural     6 tools
     income_tax_india    7 tools
-    epfo                6 tools
-    mca_portal          4 tools
-    sanctions_api       5 tools
 
   HR (8 connectors, 56 tools)
     darwinbox          10 tools
     docusign            6 tools
+    epfo                6 tools
     greenhouse          8 tools
     keka                6 tools
     linkedin_talent     6 tools
     okta                8 tools
     zoom                6 tools
-    ...
 
-  MARKETING (16 connectors, 107 tools)
+  MARKETING (16 connectors, 94 tools)
     salesforce          6 tools
     hubspot            13 tools
     mailchimp          10 tools
     ...
 
-  OPS (7 connectors, 48 tools)
+  OPS (7 connectors, 46 tools)
     jira               11 tools
     confluence          6 tools
-    ...
+    servicenow          6 tools
+    zendesk             8 tools
+    pagerduty           6 tools
+    sanctions_api       5 tools
+    mca_portal          4 tools
 
-  COMMS (11 connectors, 67 tools)
+  COMMS (11 connectors, 65 tools)
     gmail               4 tools
     slack               7 tools
     github              9 tools
@@ -78,7 +79,7 @@ grantex manifest list --category finance
 ```
 
 ```
-Finance manifests (14 connectors, 88 tools):
+Finance manifests (11 connectors, 78 tools):
 
   banking_aa          5 tools
   gstn                8 tools
@@ -91,9 +92,6 @@ Finance manifests (14 connectors, 88 tools):
   zoho_books          7 tools
   pinelabs_plural     6 tools
   income_tax_india    7 tools
-  epfo                6 tools
-  mca_portal          4 tools
-  sanctions_api       5 tools
 ```
 
 ### JSON Output
@@ -118,8 +116,8 @@ grantex manifest list --json
       "tools": ["create_lead", "update_opportunity", "query", "create_task", "get_account", "list_opportunities"]
     }
   ],
-  "totalConnectors": 54,
-  "totalTools": 340
+  "totalConnectors": 53,
+  "totalTools": 339
 }
 ```
 

--- a/docs/concepts/tool-manifests.mdx
+++ b/docs/concepts/tool-manifests.mdx
@@ -149,15 +149,15 @@ The `enforce()` engine, permission hierarchy, and JWT scope resolution work iden
 
 ### Pre-Built Manifests
 
-As a convenience, Grantex ships 54 pre-built manifests covering 340+ tools across five categories:
+As a convenience, Grantex ships 53 pre-built manifests covering 339 tools across five categories:
 
 | Category | Connectors | Tools | Examples |
 |----------|-----------|-------|---------|
-| Finance | 14 | 88 | Stripe, SAP, QuickBooks, NetSuite |
+| Finance | 11 | 78 | Stripe, SAP, QuickBooks, NetSuite |
 | HR | 8 | 56 | Darwinbox, Okta, DocuSign, Greenhouse |
-| Marketing | 16 | 107 | Salesforce, HubSpot, Mailchimp, Google Ads |
-| Ops | 7 | 48 | Jira, Confluence, ServiceNow, Zendesk |
-| Comms | 11 | 67 | Gmail, Slack, GitHub, S3, Twilio |
+| Marketing | 16 | 94 | Salesforce, HubSpot, Mailchimp, Google Ads |
+| Ops | 7 | 46 | Jira, Confluence, ServiceNow, Zendesk |
+| Comms | 11 | 65 | Gmail, Slack, GitHub, S3, Twilio |
 
 Import and load them directly:
 
@@ -240,4 +240,4 @@ When storing manifests as files (for git, CI, or team sharing), use this JSON fo
 - [TypeScript SDK enforce()](/sdks/typescript/enforce) — API reference
 - [Python SDK enforce()](/sdks/python/enforce) — API reference
 - [CLI manifest commands](/cli/manifest) — browse and validate manifests
-- [AgenticOrg case study](/case-studies/agenticorg) — 54 pre-built + custom manifests enforced in production
+- [AgenticOrg case study](/case-studies/agenticorg) — 53 pre-built + custom manifests enforced in production

--- a/docs/guides/custom-manifests.mdx
+++ b/docs/guides/custom-manifests.mdx
@@ -6,7 +6,7 @@ description: "Define tool manifests for any connector — internal APIs, new Saa
 
 ## You Own the Manifest
 
-Grantex is a **permission enforcement engine**, not a connector catalog. The 54 pre-built manifests are a convenience — the real power is that you define permissions for **any tool your agent calls**.
+Grantex is a **permission enforcement engine**, not a connector catalog. The 53 pre-built manifests are a convenience — the real power is that you define permissions for **any tool your agent calls**.
 
 <CardGroup cols={2}>
   <Card title="Any Connector" icon="plug">
@@ -299,7 +299,7 @@ grantex manifest load ./manifests/inventory-service.json
 ```
 
 <Note>
-The CLI commands `grantex manifest validate` and `grantex enforce test` currently only work with the bundled manifests. For custom manifests, use `grantex manifest load` to inspect the file, and test enforcement programmatically using the SDK's `enforce()` method directly.
+The CLI commands `grantex manifest validate` and `grantex enforce test` currently only work with the 53 bundled manifests. For custom manifests, use `grantex manifest load` to inspect the file, and test enforcement programmatically using the SDK's `enforce()` method directly.
 </Note>
 
 ---
@@ -331,4 +331,4 @@ The CLI commands `grantex manifest validate` and `grantex enforce test` currentl
 - [Tool Manifests concept](/concepts/tool-manifests) — permission hierarchy, scope format, fail-closed behavior
 - [Scope Enforcement guide](/guides/scope-enforcement) — end-to-end walkthrough with framework integrations
 - [CLI manifest commands](/cli/manifest) — browse, validate, and generate manifests
-- [AgenticOrg case study](/case-studies/agenticorg) — 54 pre-built + custom manifests in production
+- [AgenticOrg case study](/case-studies/agenticorg) — 53 pre-built + custom manifests in production

--- a/docs/guides/scope-enforcement.mdx
+++ b/docs/guides/scope-enforcement.mdx
@@ -150,7 +150,7 @@ Custom and pre-built manifests are identical at runtime. The `enforce()` engine,
 
 ### Pre-Built Manifests — 54 Included
 
-As a convenience, Grantex ships 54 pre-built manifests covering finance, HR, marketing, ops, and comms connectors. Use them as-is or as a starting point:
+As a convenience, Grantex ships 53 pre-built manifests covering finance, HR, marketing, ops, and comms connectors. Use them as-is or as a starting point:
 
 <CodeGroup>
 
@@ -257,7 +257,7 @@ async def execute_tool(
 The CLI provides a complete manifest workflow: list available manifests, validate your agent's tools against them, and dry-run enforcement.
 
 ```bash
-# Browse all 54 pre-built manifests (or use your own)
+# Browse all 53 pre-built manifests (or use your own)
 grantex manifest list
 
 # Filter by category
@@ -412,4 +412,4 @@ await callTool('gmail', 'send_email', { to: 'ceo@acme.com' });    // DENIED
 - [Python SDK enforce() reference](/sdks/python/enforce)
 - [CLI manifest commands](/cli/manifest)
 - [CLI enforce test command](/cli/enforce)
-- [AgenticOrg case study](/case-studies/agenticorg) — 35 agents, 54 pre-built + custom manifests in production
+- [AgenticOrg case study](/case-studies/agenticorg) — 35 agents, 53 pre-built + custom manifests in production

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -71,7 +71,7 @@ description: "Grantex integrates with every major AI agent framework."
     Public directory of verified AI agent publishers with DID-based identity and compliance badges.
   </Card>
   <Card title="Scope Enforcement" icon="shield-check" href="/guides/scope-enforcement">
-    Enforce tool-level permissions on any connector — define your own manifests or use 54 pre-built ones. One-line enforcement via enforce().
+    Enforce tool-level permissions on any connector — define your own manifests or use 53 pre-built ones. One-line enforcement via enforce().
   </Card>
   <Card title="Conformance Suite" icon="check" href="/integrations/conformance">
     Validate any Grantex server against the spec.

--- a/packages/sdk-py/README.md
+++ b/packages/sdk-py/README.md
@@ -200,7 +200,7 @@ except GrantexNetworkError:
 
 ## Scope Enforcement (v0.3.1)
 
-Enforce tool-level permissions on **any connector** — define your own manifests or use the 54 pre-built ones.
+Enforce tool-level permissions on **any connector** — define your own manifests or use the 53 pre-built ones.
 
 ```python
 from grantex import Grantex, ToolManifest, Permission
@@ -222,7 +222,7 @@ result = grantex.enforce(grant_token=token, connector="my-crm", tool="delete_acc
 - `wrap_tool()` — auto-enforce on LangChain tools
 - `GrantexEnforcer` — FastAPI dependency for scope enforcement
 - Define custom manifests for any connector: inline, from JSON, or auto-generated via CLI
-- 54 pre-built manifests included (Salesforce, HubSpot, Jira, Stripe, SAP, S3, and 48 more)
+- 53 pre-built manifests included (Salesforce, HubSpot, Jira, Stripe, SAP, S3, and 47 more)
 - Permission hierarchy: `admin > delete > write > read`
 - Permissive mode for migration (`enforce_mode="permissive"`)
 

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -670,7 +670,7 @@ try {
 
 ## Scope Enforcement (v0.3.1)
 
-Enforce tool-level permissions on **any connector** — define your own manifests or use the 54 pre-built ones.
+Enforce tool-level permissions on **any connector** — define your own manifests or use the 53 pre-built ones.
 
 ```typescript
 import { Grantex, ToolManifest, Permission } from '@grantex/sdk';
@@ -692,7 +692,7 @@ const result = await grantex.enforce({ grantToken: token, connector: 'my-crm', t
 - `wrapTool()` — auto-enforce on LangChain tools
 - `enforceMiddleware()` — Express/Fastify HTTP middleware
 - Define custom manifests for any connector: inline, from JSON, or auto-generated via CLI
-- 54 pre-built manifests included (Salesforce, HubSpot, Jira, Stripe, SAP, S3, and 48 more)
+- 53 pre-built manifests included (Salesforce, HubSpot, Jira, Stripe, SAP, S3, and 47 more)
 - Permission hierarchy: `admin > delete > write > read`
 - Permissive mode for migration (`enforceMode: 'permissive'`)
 

--- a/web/index.html
+++ b/web/index.html
@@ -1078,7 +1078,7 @@
           <span style="background:#f97583;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">v0.3.1</span>
           <span style="color:var(--text);font-weight:600;">Scope Enforcement</span>
         </div>
-        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">enforce() + wrapTool() + Express/FastAPI middleware. Define manifests for any connector, or use 54 pre-built ones. &lt;1ms per call.</p>
+        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">enforce() + wrapTool() + Express/FastAPI middleware. Define manifests for any connector, or use 53 pre-built ones. &lt;1ms per call.</p>
       </a>
 
     </div>
@@ -1091,7 +1091,7 @@
     <div class="section-label">New in v0.3.1</div>
     <h2 class="section-title" style="font-size:clamp(24px,4vw,36px);">Scope Enforcement &mdash; Control What Agents Can Do</h2>
     <p class="section-sub" style="max-width:640px;margin:0 auto 40px;">
-      Enforce tool-level permissions on any connector you define. Bring your own manifests or use the 54 pre-built ones. Offline JWKS verification, &lt;1ms per call.
+      Enforce tool-level permissions on any connector you define. Bring your own manifests or use the 53 pre-built ones. Offline JWKS verification, &lt;1ms per call.
     </p>
 
     <!-- Visual flow -->
@@ -1181,7 +1181,7 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
     </div>
 
     <!-- Connector grid -->
-    <p style="color:var(--muted);font-size:14px;text-align:center;margin-bottom:16px;">Works with any connector. 54 pre-built manifests included to get you started:</p>
+    <p style="color:var(--muted);font-size:14px;text-align:center;margin-bottom:16px;">Works with any connector. 53 pre-built manifests included to get you started:</p>
     <div style="display:flex;flex-wrap:wrap;gap:8px;justify-content:center;margin-bottom:32px;">
       <span style="background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:4px 10px;font-size:12px;color:var(--muted);">Salesforce</span>
       <span style="background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:4px 10px;font-size:12px;color:var(--muted);">HubSpot</span>
@@ -1209,7 +1209,7 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
     <!-- AgenticOrg testimonial -->
     <div style="margin-top:40px;background:var(--surface);border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:8px;padding:24px;max-width:640px;margin-left:auto;margin-right:auto;">
       <p style="color:var(--text);font-size:15px;font-style:italic;line-height:1.6;margin:0 0 12px;">
-        "35 AI agents, 54 pre-built connectors + 3 custom manifests for our internal APIs, 340+ tools — all scope-enforced through one grantex.enforce() call per tool execution."
+        "35 AI agents, 53 pre-built connectors + 3 custom manifests for our internal APIs, 339+ tools — all scope-enforced through one grantex.enforce() call per tool execution."
       </p>
       <p style="color:var(--muted);font-size:13px;margin:0;">
         — <a href="https://agenticorg.ai" style="color:var(--accent);text-decoration:none;">AgenticOrg</a> · AI Virtual Employee Platform · Live in production


### PR DESCRIPTION
## Summary
- Corrects manifest count from "54" to **53** across all user-facing docs (actual count from CLI metadata array and SDK manifest files)
- Fixes Finance category: was listed as 14 connectors / 88 tools, actually **11 / 78** (epfo, mca_portal, sanctions_api were miscategorized under Finance in docs but are actually HR and Ops)
- Fixes Marketing from 107 to **94**, Ops from 48 to **46**, Comms from 67 to **65** tools
- Fixes CLI manifest.mdx output examples to match actual `grantex manifest list` output
- Historical planning doc (`grantex-tool-manifest-and-enforcer.md`) left untouched

## Verification
```bash
# Manifest files: 53
ls packages/sdk-ts/src/manifests/*.ts | grep -v index | wc -l  # → 53
ls packages/sdk-py/src/grantex/manifests/*.py | grep -v __init__ | wc -l  # → 53

# Total tools: 339
grep "tools:" packages/cli/src/commands/manifest.ts | grep -oP 'tools: \K\d+' | awk '{s+=$1} END {print s}'  # → 339

# Finance tools: 78
grep "category: 'finance'" packages/cli/src/commands/manifest.ts | grep -oP 'tools: \K\d+' | awk '{s+=$1} END {print s}'  # → 78
```

## Test plan
- [x] Verify numbers match `grantex manifest list` output
- [x] Verify docs build cleanly

Stacked on #260.