### PR TITLE
fix: address critical review findings across all SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![IETF Draft](https://img.shields.io/badge/IETF-draft--mishra--oauth--agent--grants-blue)](https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/)
 [![SOC 2 Type I](https://img.shields.io/badge/SOC%202-Type%20I%20Certified-brightgreen)](https://docs.grantex.dev/security)
 [![CI](https://img.shields.io/github/actions/workflow/status/mishrasanjeev/grantex/ci.yml?branch=main&label=CI)](https://github.com/mishrasanjeev/grantex/actions/workflows/ci.yml)
-[![679+ Tests](https://img.shields.io/badge/tests-679%2B%20passing-brightgreen)](https://github.com/mishrasanjeev/grantex/actions/workflows/ci.yml)
+[![3,900+ Tests](https://img.shields.io/badge/tests-3%2C900%2B%20passing-brightgreen)](https://github.com/mishrasanjeev/grantex/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@grantex/sdk)](https://www.npmjs.com/package/@grantex/sdk)
 [![PyPI](https://img.shields.io/pypi/v/grantex)](https://pypi.org/project/grantex/)
 [![npm downloads](https://img.shields.io/npm/dm/@grantex/sdk?label=npm%20downloads)](https://www.npmjs.com/package/@grantex/sdk)
@@ -74,7 +74,7 @@ go get github.com/mishrasanjeev/grantex-go  # Go
 npm install -g @grantex/cli     # CLI
 ```
 
-> **30+ packages** across TypeScript, Python, and Go. Integrations for **Anthropic SDK, LangChain, OpenAI Agents SDK, Google ADK, CrewAI, Vercel AI, AutoGen, MCP, Express.js, FastAPI**, and **Terraform**. 679+ tests. Fully self-hostable. Apache 2.0.
+> **27 packages** across TypeScript, Python, and Go. Integrations for **Anthropic SDK, LangChain, OpenAI Agents SDK, Google ADK, CrewAI, Vercel AI, AutoGen, MCP, Express.js, FastAPI**, and **Terraform**. 3,900+ tests. Fully self-hostable. Apache 2.0.
 
 ---
 

--- a/apps/auth-service/tests/passport.test.ts
+++ b/apps/auth-service/tests/passport.test.ts
@@ -1,0 +1,574 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { buildTestApp, seedAuth, authHeader, sqlMock, TEST_DEVELOPER, TEST_AGENT } from './helpers.js';
+import type { FastifyInstance } from 'fastify';
+import { gzipSync } from 'node:zlib';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const now = new Date();
+const future = new Date(Date.now() + 86400_000);
+const past = new Date(Date.now() - 86400_000);
+
+const TEST_GRANT_WITH_MPP_SCOPES = {
+  id: 'grnt_MPP01',
+  scopes: ['payments:mpp:inference', 'payments:mpp:compute', 'payments:mpp:general'],
+  principal_id: 'user_123',
+  status: 'active',
+  expires_at: future.toISOString(),
+  delegation_depth: 0,
+};
+
+const TEST_PASSPORT = {
+  id: 'urn:grantex:passport:01PASSPORT01',
+  developer_id: TEST_DEVELOPER.id,
+  agent_id: TEST_AGENT.id,
+  grant_id: 'grnt_MPP01',
+  status: 'active',
+  expires_at: future,
+  issued_at: now,
+  status_list_idx: 0,
+};
+
+const TEST_CREDENTIAL_JSON = {
+  '@context': [
+    'https://www.w3.org/ns/credentials/v2',
+    'https://grantex.dev/contexts/mpp/v1',
+  ],
+  type: ['VerifiableCredential', 'AgentPassportCredential'],
+  id: 'urn:grantex:passport:01PASSPORT01',
+  issuer: 'did:web:grantex.dev',
+  credentialSubject: {
+    id: TEST_AGENT.did,
+    type: 'AIAgent',
+    humanPrincipal: 'did:grantex:user_123',
+    grantId: 'grnt_MPP01',
+    allowedMPPCategories: ['inference'],
+    maxTransactionAmount: { amount: 100, currency: 'USDC' },
+  },
+};
+
+const TEST_ENCODED_CREDENTIAL = Buffer.from(
+  JSON.stringify(TEST_CREDENTIAL_JSON),
+).toString('base64url');
+
+function createEmptyEncodedList(): string {
+  const bits = Buffer.alloc(16384, 0);
+  return gzipSync(bits).toString('base64url');
+}
+
+// ── POST /v1/passport/issue ─────────────────────────────────────────────────
+
+describe('POST /v1/passport/issue', () => {
+  it('issues a passport credential successfully', async () => {
+    seedAuth();
+    // Agent lookup
+    sqlMock.mockResolvedValueOnce([{ id: TEST_AGENT.id, did: TEST_AGENT.did }]);
+    // Grant lookup
+    sqlMock.mockResolvedValueOnce([TEST_GRANT_WITH_MPP_SCOPES]);
+    // Budget check
+    sqlMock.mockResolvedValueOnce([]);
+    // getOrCreateStatusList
+    sqlMock.mockResolvedValueOnce([{ id: 'vcsl_PP01', nextIndex: 0, next_index: 0 }]);
+    // UPDATE next_index
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT mpp_passports
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT verifiable_credentials
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/passport/issue',
+      headers: authHeader(),
+      payload: {
+        agentId: TEST_AGENT.id,
+        grantId: 'grnt_MPP01',
+        allowedMPPCategories: ['inference', 'compute'],
+        maxTransactionAmount: { amount: 100, currency: 'USDC' },
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.passportId).toBeDefined();
+    expect(body.passportId).toMatch(/^urn:grantex:passport:/);
+    expect(body.credential).toBeDefined();
+    expect(body.credential.type).toContain('AgentPassportCredential');
+    expect(body.encodedCredential).toBeDefined();
+    expect(body.expiresAt).toBeDefined();
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/passport/issue',
+      headers: authHeader(),
+      payload: {
+        agentId: TEST_AGENT.id,
+        // missing grantId, allowedMPPCategories, maxTransactionAmount
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('BAD_REQUEST');
+  });
+
+  it('returns 400 for invalid MPP categories', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/passport/issue',
+      headers: authHeader(),
+      payload: {
+        agentId: TEST_AGENT.id,
+        grantId: 'grnt_MPP01',
+        allowedMPPCategories: ['inference', 'teleportation'],
+        maxTransactionAmount: { amount: 100, currency: 'USDC' },
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('BAD_REQUEST');
+    expect(res.json().message).toContain('Invalid MPP categories');
+    expect(res.json().message).toContain('teleportation');
+  });
+
+  it('returns 400 when agent not found', async () => {
+    seedAuth();
+    // Agent lookup returns empty
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/passport/issue',
+      headers: authHeader(),
+      payload: {
+        agentId: 'ag_NONEXISTENT',
+        grantId: 'grnt_MPP01',
+        allowedMPPCategories: ['inference'],
+        maxTransactionAmount: { amount: 100, currency: 'USDC' },
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('INVALID_AGENT');
+  });
+
+  it('returns 400 when grant not found', async () => {
+    seedAuth();
+    // Agent lookup
+    sqlMock.mockResolvedValueOnce([{ id: TEST_AGENT.id, did: TEST_AGENT.did }]);
+    // Grant lookup returns empty
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/passport/issue',
+      headers: authHeader(),
+      payload: {
+        agentId: TEST_AGENT.id,
+        grantId: 'grnt_NONEXISTENT',
+        allowedMPPCategories: ['inference'],
+        maxTransactionAmount: { amount: 100, currency: 'USDC' },
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('INVALID_GRANT');
+  });
+
+  it('returns 400 when grant is revoked', async () => {
+    seedAuth();
+    // Agent lookup
+    sqlMock.mockResolvedValueOnce([{ id: TEST_AGENT.id, did: TEST_AGENT.did }]);
+    // Grant lookup — revoked
+    sqlMock.mockResolvedValueOnce([{ ...TEST_GRANT_WITH_MPP_SCOPES, status: 'revoked' }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/passport/issue',
+      headers: authHeader(),
+      payload: {
+        agentId: TEST_AGENT.id,
+        grantId: 'grnt_MPP01',
+        allowedMPPCategories: ['inference'],
+        maxTransactionAmount: { amount: 100, currency: 'USDC' },
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('INVALID_GRANT');
+    expect(res.json().message).toContain('revoked');
+  });
+
+  it('returns 400 when grant lacks required MPP scopes', async () => {
+    seedAuth();
+    // Agent lookup
+    sqlMock.mockResolvedValueOnce([{ id: TEST_AGENT.id, did: TEST_AGENT.did }]);
+    // Grant with only inference scope
+    sqlMock.mockResolvedValueOnce([{
+      ...TEST_GRANT_WITH_MPP_SCOPES,
+      scopes: ['payments:mpp:inference'],
+    }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/passport/issue',
+      headers: authHeader(),
+      payload: {
+        agentId: TEST_AGENT.id,
+        grantId: 'grnt_MPP01',
+        allowedMPPCategories: ['inference', 'compute'],
+        maxTransactionAmount: { amount: 100, currency: 'USDC' },
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('SCOPE_INSUFFICIENT');
+    expect(res.json().message).toContain('payments:mpp:compute');
+  });
+
+  it('returns 400 when maxTransactionAmount exceeds remaining budget', async () => {
+    seedAuth();
+    // Agent lookup
+    sqlMock.mockResolvedValueOnce([{ id: TEST_AGENT.id, did: TEST_AGENT.did }]);
+    // Grant lookup
+    sqlMock.mockResolvedValueOnce([TEST_GRANT_WITH_MPP_SCOPES]);
+    // Budget check — remaining is less than requested
+    sqlMock.mockResolvedValueOnce([{ remaining_budget: '50.00' }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/passport/issue',
+      headers: authHeader(),
+      payload: {
+        agentId: TEST_AGENT.id,
+        grantId: 'grnt_MPP01',
+        allowedMPPCategories: ['inference'],
+        maxTransactionAmount: { amount: 100, currency: 'USDC' },
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('AMOUNT_EXCEEDS_BUDGET');
+  });
+
+  it('returns 422 for invalid expiresIn format', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/passport/issue',
+      headers: authHeader(),
+      payload: {
+        agentId: TEST_AGENT.id,
+        grantId: 'grnt_MPP01',
+        allowedMPPCategories: ['inference'],
+        maxTransactionAmount: { amount: 100, currency: 'USDC' },
+        expiresIn: 'not-a-duration',
+      },
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe('INVALID_EXPIRY');
+  });
+
+  it('requires authentication', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/passport/issue',
+      payload: {
+        agentId: TEST_AGENT.id,
+        grantId: 'grnt_MPP01',
+        allowedMPPCategories: ['inference'],
+        maxTransactionAmount: { amount: 100, currency: 'USDC' },
+      },
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// ── GET /v1/passports ───────────────────────────────────────────────────────
+
+describe('GET /v1/passports', () => {
+  it('lists passports without filters', async () => {
+    seedAuth();
+    // The passport list query uses nested sql`` fragments for conditionals;
+    // each fragment invocation consumes one sqlMock slot. With no filters,
+    // 3 empty sql`` fragments + 1 outer query = 4 mock calls total.
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (agentId)
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (grantId)
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (status)
+    sqlMock.mockResolvedValueOnce([TEST_PASSPORT]); // outer query result
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/passports',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].passportId).toBe(TEST_PASSPORT.id);
+    expect(body[0].agentId).toBe(TEST_AGENT.id);
+    expect(body[0].status).toBe('active');
+  });
+
+  it('filters by agentId', async () => {
+    seedAuth();
+    // With agentId filter: 1 sql`` for agentId condition + 2 empty sql``
+    // fragments for grantId/status + 1 outer query
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (agentId condition)
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (grantId)
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (status)
+    sqlMock.mockResolvedValueOnce([TEST_PASSPORT]); // outer query result
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/v1/passports?agentId=${TEST_AGENT.id}`,
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveLength(1);
+  });
+
+  it('filters by grantId', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (agentId)
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (grantId condition)
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (status)
+    sqlMock.mockResolvedValueOnce([TEST_PASSPORT]); // outer query result
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/passports?grantId=grnt_MPP01',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveLength(1);
+  });
+
+  it('filters by status', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (agentId)
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (grantId)
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (status condition)
+    sqlMock.mockResolvedValueOnce([{ ...TEST_PASSPORT, status: 'revoked' }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/passports?status=revoked',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()[0].status).toBe('revoked');
+  });
+
+  it('marks expired passports in response', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (agentId)
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (grantId)
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (status)
+    sqlMock.mockResolvedValueOnce([{ ...TEST_PASSPORT, status: 'active', expires_at: past }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/passports',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()[0].status).toBe('expired');
+  });
+
+  it('returns empty array when no passports match', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (agentId)
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (grantId)
+    sqlMock.mockResolvedValueOnce([]); // sql`` fragment (status)
+    sqlMock.mockResolvedValueOnce([]); // outer query result
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/passports',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+  });
+
+  it('requires authentication', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/passports',
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// ── GET /v1/passport/:id ────────────────────────────────────────────────────
+
+describe('GET /v1/passport/:id', () => {
+  it('returns a passport by ID', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{
+      ...TEST_PASSPORT,
+      credential_jwt: 'eyJ...',
+      encoded_credential: TEST_ENCODED_CREDENTIAL,
+      revoked_at: null,
+    }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/v1/passport/${TEST_PASSPORT.id}`,
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.status).toBe('active');
+    expect(body.type).toContain('AgentPassportCredential');
+    expect(body.credentialSubject).toBeDefined();
+  });
+
+  it('returns 404 when passport not found', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/passport/urn:grantex:passport:NONEXISTENT',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('NOT_FOUND');
+  });
+
+  it('marks expired passports in get response', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{
+      ...TEST_PASSPORT,
+      status: 'active',
+      expires_at: past,
+      credential_jwt: 'eyJ...',
+      encoded_credential: TEST_ENCODED_CREDENTIAL,
+      revoked_at: null,
+    }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/v1/passport/${TEST_PASSPORT.id}`,
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().status).toBe('expired');
+  });
+
+  it('requires authentication', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/v1/passport/${TEST_PASSPORT.id}`,
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// ── POST /v1/passport/:id/revoke ────────────────────────────────────────────
+
+describe('POST /v1/passport/:id/revoke', () => {
+  it('revokes an active passport', async () => {
+    seedAuth();
+    // Passport lookup
+    sqlMock.mockResolvedValueOnce([{
+      id: TEST_PASSPORT.id,
+      status: 'active',
+      status_list_idx: 0,
+    }]);
+    // UPDATE mpp_passports
+    sqlMock.mockResolvedValueOnce([]);
+    // UPDATE verifiable_credentials
+    sqlMock.mockResolvedValueOnce([]);
+    // SELECT status list
+    const encodedList = createEmptyEncodedList();
+    sqlMock.mockResolvedValueOnce([{
+      id: 'vcsl_PP01',
+      encoded_list: encodedList,
+    }]);
+    // UPDATE status list
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/v1/passport/${TEST_PASSPORT.id}/revoke`,
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.revoked).toBe(true);
+    expect(body.revokedAt).toBeDefined();
+  });
+
+  it('returns success for already revoked passport', async () => {
+    seedAuth();
+    // Passport lookup — already revoked
+    sqlMock.mockResolvedValueOnce([{
+      id: TEST_PASSPORT.id,
+      status: 'revoked',
+      status_list_idx: 0,
+    }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/v1/passport/${TEST_PASSPORT.id}/revoke`,
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.revoked).toBe(true);
+    expect(body.revokedAt).toBeDefined();
+  });
+
+  it('returns 404 when passport not found', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/passport/urn:grantex:passport:NONEXISTENT/revoke',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('NOT_FOUND');
+  });
+
+  it('requires authentication', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/v1/passport/${TEST_PASSPORT.id}/revoke`,
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/packages/go-sdk/grantex.go
+++ b/packages/go-sdk/grantex.go
@@ -40,6 +40,8 @@ type Client struct {
 	Domains           *DomainsService
 	WebAuthn          *WebAuthnService
 	Credentials       *CredentialsService
+	Passports         *PassportsService
+	Vault             *VaultService
 
 	http *httpClient
 }
@@ -84,6 +86,8 @@ func NewClient(apiKey string, opts ...Option) *Client {
 	c.Domains = &DomainsService{http: h}
 	c.WebAuthn = &WebAuthnService{http: h}
 	c.Credentials = &CredentialsService{http: h}
+	c.Passports = &PassportsService{http: h}
+	c.Vault = &VaultService{http: h}
 
 	return c
 }

--- a/packages/go-sdk/passports.go
+++ b/packages/go-sdk/passports.go
@@ -1,0 +1,100 @@
+package grantex
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// PassportsService handles Agent Passport Credential operations.
+type PassportsService struct {
+	http *httpClient
+}
+
+// IssuePassportParams contains the parameters for issuing an agent passport.
+type IssuePassportParams struct {
+	AgentID               string              `json:"agentId"`
+	GrantID               string              `json:"grantId"`
+	AllowedMPPCategories  []string            `json:"allowedMPPCategories"`
+	MaxTransactionAmount  TransactionAmount   `json:"maxTransactionAmount"`
+	PaymentRails          []string            `json:"paymentRails,omitempty"`
+	ExpiresIn             string              `json:"expiresIn,omitempty"`
+	ParentPassportID      string              `json:"parentPassportId,omitempty"`
+}
+
+// TransactionAmount represents a monetary amount with currency.
+type TransactionAmount struct {
+	Amount   float64 `json:"amount"`
+	Currency string  `json:"currency"`
+}
+
+// IssuedPassportResponse is the response from issuing an agent passport.
+type IssuedPassportResponse struct {
+	PassportID        string                 `json:"passportId"`
+	Credential        map[string]interface{} `json:"credential"`
+	EncodedCredential string                 `json:"encodedCredential"`
+	ExpiresAt         string                 `json:"expiresAt"`
+}
+
+// GetPassportResponse is the response from getting a passport by ID.
+type GetPassportResponse struct {
+	Status string `json:"status"`
+	// Additional dynamic fields are not mapped; use raw JSON if needed.
+}
+
+// RevokePassportResponse is the response from revoking a passport.
+type RevokePassportResponse struct {
+	Revoked   bool   `json:"revoked"`
+	RevokedAt string `json:"revokedAt"`
+}
+
+// ListPassportsParams contains optional filters for listing passports.
+type ListPassportsParams struct {
+	AgentID string
+	GrantID string
+	Status  string
+}
+
+type listPassportsResponse struct {
+	Passports []IssuedPassportResponse `json:"passports"`
+}
+
+// Issue creates a new Agent Passport Credential.
+func (s *PassportsService) Issue(ctx context.Context, params IssuePassportParams) (*IssuedPassportResponse, error) {
+	return unmarshal[IssuedPassportResponse](s.http.post(ctx, "/v1/passport/issue", params))
+}
+
+// Get retrieves a passport by ID.
+func (s *PassportsService) Get(ctx context.Context, passportID string) (*GetPassportResponse, error) {
+	return unmarshal[GetPassportResponse](s.http.get(ctx, fmt.Sprintf("/v1/passport/%s", url.PathEscape(passportID))))
+}
+
+// Revoke revokes a passport by ID.
+func (s *PassportsService) Revoke(ctx context.Context, passportID string) (*RevokePassportResponse, error) {
+	return unmarshal[RevokePassportResponse](s.http.post(ctx, fmt.Sprintf("/v1/passport/%s/revoke", url.PathEscape(passportID)), nil))
+}
+
+// List retrieves passports with optional filters.
+func (s *PassportsService) List(ctx context.Context, params *ListPassportsParams) ([]IssuedPassportResponse, error) {
+	path := "/v1/passports"
+	if params != nil {
+		q := url.Values{}
+		if params.AgentID != "" {
+			q.Set("agentId", params.AgentID)
+		}
+		if params.GrantID != "" {
+			q.Set("grantId", params.GrantID)
+		}
+		if params.Status != "" {
+			q.Set("status", params.Status)
+		}
+		if qs := q.Encode(); qs != "" {
+			path += "?" + qs
+		}
+	}
+	resp, err := unmarshal[listPassportsResponse](s.http.get(ctx, path))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Passports, nil
+}

--- a/packages/go-sdk/passports_test.go
+++ b/packages/go-sdk/passports_test.go
@@ -1,0 +1,162 @@
+package grantex
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPassportsIssue(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/passport/issue" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		var params IssuePassportParams
+		json.NewDecoder(r.Body).Decode(&params)
+		if params.AgentID != "agent-1" {
+			t.Errorf("expected agent-1, got %s", params.AgentID)
+		}
+		if params.GrantID != "grant-1" {
+			t.Errorf("expected grant-1, got %s", params.GrantID)
+		}
+		if len(params.AllowedMPPCategories) != 2 {
+			t.Errorf("expected 2 categories, got %d", len(params.AllowedMPPCategories))
+		}
+		if params.MaxTransactionAmount.Amount != 100.0 {
+			t.Errorf("expected amount 100, got %f", params.MaxTransactionAmount.Amount)
+		}
+		if params.MaxTransactionAmount.Currency != "USD" {
+			t.Errorf("expected USD, got %s", params.MaxTransactionAmount.Currency)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(IssuedPassportResponse{
+			PassportID:        "passport-1",
+			Credential:        map[string]interface{}{"type": "AgentPassportCredential"},
+			EncodedCredential: "eyJ...",
+			ExpiresAt:         "2026-04-01T00:00:00Z",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	resp, err := client.Passports.Issue(context.Background(), IssuePassportParams{
+		AgentID:              "agent-1",
+		GrantID:              "grant-1",
+		AllowedMPPCategories: []string{"compute", "storage"},
+		MaxTransactionAmount: TransactionAmount{Amount: 100.0, Currency: "USD"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.PassportID != "passport-1" {
+		t.Errorf("expected passport-1, got %s", resp.PassportID)
+	}
+	if resp.EncodedCredential != "eyJ..." {
+		t.Errorf("expected eyJ..., got %s", resp.EncodedCredential)
+	}
+}
+
+func TestPassportsGet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/passport/passport-1" || r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(GetPassportResponse{
+			Status: "active",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	resp, err := client.Passports.Get(context.Background(), "passport-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Status != "active" {
+		t.Errorf("expected active, got %s", resp.Status)
+	}
+}
+
+func TestPassportsRevoke(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/passport/passport-1/revoke" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(RevokePassportResponse{
+			Revoked:   true,
+			RevokedAt: "2026-04-01T12:00:00Z",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	resp, err := client.Passports.Revoke(context.Background(), "passport-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Revoked {
+		t.Error("expected passport to be revoked")
+	}
+	if resp.RevokedAt != "2026-04-01T12:00:00Z" {
+		t.Errorf("expected 2026-04-01T12:00:00Z, got %s", resp.RevokedAt)
+	}
+}
+
+func TestPassportsList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/passports" || r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(listPassportsResponse{
+			Passports: []IssuedPassportResponse{
+				{PassportID: "passport-1", ExpiresAt: "2026-04-01T00:00:00Z"},
+				{PassportID: "passport-2", ExpiresAt: "2026-05-01T00:00:00Z"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	passports, err := client.Passports.List(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(passports) != 2 {
+		t.Errorf("expected 2 passports, got %d", len(passports))
+	}
+}
+
+func TestPassportsListWithParams(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("agentId") != "agent-1" {
+			t.Errorf("expected agentId=agent-1, got %s", r.URL.Query().Get("agentId"))
+		}
+		if r.URL.Query().Get("status") != "active" {
+			t.Errorf("expected status=active, got %s", r.URL.Query().Get("status"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(listPassportsResponse{
+			Passports: []IssuedPassportResponse{
+				{PassportID: "passport-1"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	passports, err := client.Passports.List(context.Background(), &ListPassportsParams{
+		AgentID: "agent-1",
+		Status:  "active",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(passports) != 1 {
+		t.Errorf("expected 1 passport, got %d", len(passports))
+	}
+}

--- a/packages/go-sdk/vault.go
+++ b/packages/go-sdk/vault.go
@@ -1,0 +1,149 @@
+package grantex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// VaultService handles credential vault operations.
+type VaultService struct {
+	http *httpClient
+}
+
+// StoreCredentialParams contains the parameters for storing a credential in the vault.
+type StoreCredentialParams struct {
+	PrincipalID    string                 `json:"principalId"`
+	Service        string                 `json:"service"`
+	CredentialType string                 `json:"credentialType,omitempty"`
+	AccessToken    string                 `json:"accessToken"`
+	RefreshToken   string                 `json:"refreshToken,omitempty"`
+	TokenExpiresAt string                 `json:"tokenExpiresAt,omitempty"`
+	Metadata       map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// StoreCredentialResponse is the response from storing a credential.
+type StoreCredentialResponse struct {
+	ID             string `json:"id"`
+	PrincipalID    string `json:"principalId"`
+	Service        string `json:"service"`
+	CredentialType string `json:"credentialType"`
+	CreatedAt      string `json:"createdAt"`
+}
+
+// VaultCredential represents a credential record in the vault.
+type VaultCredential struct {
+	ID             string                 `json:"id"`
+	PrincipalID    string                 `json:"principalId"`
+	Service        string                 `json:"service"`
+	CredentialType string                 `json:"credentialType"`
+	TokenExpiresAt *string                `json:"tokenExpiresAt"`
+	Metadata       map[string]interface{} `json:"metadata"`
+	CreatedAt      string                 `json:"createdAt"`
+	UpdatedAt      string                 `json:"updatedAt"`
+}
+
+// ListVaultCredentialsParams contains optional filters for listing vault credentials.
+type ListVaultCredentialsParams struct {
+	PrincipalID string
+	Service     string
+}
+
+type listVaultCredentialsResponse struct {
+	Credentials []VaultCredential `json:"credentials"`
+}
+
+// ExchangeCredentialParams contains the parameters for exchanging a grant token for a credential.
+type ExchangeCredentialParams struct {
+	Service string `json:"service"`
+}
+
+// ExchangeCredentialResponse is the response from exchanging a grant token for a credential.
+type ExchangeCredentialResponse struct {
+	AccessToken    string                 `json:"accessToken"`
+	Service        string                 `json:"service"`
+	CredentialType string                 `json:"credentialType"`
+	TokenExpiresAt *string                `json:"tokenExpiresAt"`
+	Metadata       map[string]interface{} `json:"metadata"`
+}
+
+// Store saves an encrypted credential in the vault (upserts on principal+service).
+func (s *VaultService) Store(ctx context.Context, params StoreCredentialParams) (*StoreCredentialResponse, error) {
+	return unmarshal[StoreCredentialResponse](s.http.post(ctx, "/v1/vault/credentials", params))
+}
+
+// List retrieves credential metadata (no raw tokens).
+func (s *VaultService) List(ctx context.Context, params *ListVaultCredentialsParams) ([]VaultCredential, error) {
+	path := "/v1/vault/credentials"
+	if params != nil {
+		q := url.Values{}
+		if params.PrincipalID != "" {
+			q.Set("principalId", params.PrincipalID)
+		}
+		if params.Service != "" {
+			q.Set("service", params.Service)
+		}
+		if qs := q.Encode(); qs != "" {
+			path += "?" + qs
+		}
+	}
+	resp, err := unmarshal[listVaultCredentialsResponse](s.http.get(ctx, path))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Credentials, nil
+}
+
+// Get retrieves credential metadata by ID (no raw token).
+func (s *VaultService) Get(ctx context.Context, credentialID string) (*VaultCredential, error) {
+	return unmarshal[VaultCredential](s.http.get(ctx, fmt.Sprintf("/v1/vault/credentials/%s", credentialID)))
+}
+
+// Delete removes a credential from the vault.
+func (s *VaultService) Delete(ctx context.Context, credentialID string) error {
+	_, err := s.http.del(ctx, fmt.Sprintf("/v1/vault/credentials/%s", credentialID))
+	return err
+}
+
+// Exchange trades a grant token for an upstream service credential.
+// Unlike other methods, this uses the grant token (not the API key) as the Bearer token.
+func (s *VaultService) Exchange(ctx context.Context, grantToken string, params ExchangeCredentialParams) (*ExchangeCredentialResponse, error) {
+	reqURL := strings.TrimRight(s.http.baseURL, "/") + "/v1/vault/credentials/exchange"
+
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, &NetworkError{Message: "failed to marshal request body", Cause: err}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, &NetworkError{Message: "failed to create request", Cause: err}
+	}
+
+	req.Header.Set("Authorization", "Bearer "+grantToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "grantex-go/"+sdkVersion)
+
+	resp, err := s.http.client.Do(req)
+	if err != nil {
+		return nil, &NetworkError{Message: "request failed", Cause: err}
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, &NetworkError{Message: "failed to read response body", Cause: err}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, s.http.parseError(resp.StatusCode, respBody, parseRateLimitHeaders(resp.Header))
+	}
+
+	return unmarshal[ExchangeCredentialResponse](respBody, nil)
+}

--- a/packages/go-sdk/vault_test.go
+++ b/packages/go-sdk/vault_test.go
@@ -1,0 +1,220 @@
+package grantex
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestVaultStore(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vault/credentials" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		var params StoreCredentialParams
+		json.NewDecoder(r.Body).Decode(&params)
+		if params.PrincipalID != "principal-1" {
+			t.Errorf("expected principal-1, got %s", params.PrincipalID)
+		}
+		if params.Service != "github" {
+			t.Errorf("expected github, got %s", params.Service)
+		}
+		if params.AccessToken != "ghp_xxx" {
+			t.Errorf("expected ghp_xxx, got %s", params.AccessToken)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(StoreCredentialResponse{
+			ID:             "cred-1",
+			PrincipalID:    "principal-1",
+			Service:        "github",
+			CredentialType: "oauth2",
+			CreatedAt:      "2026-04-01T00:00:00Z",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	resp, err := client.Vault.Store(context.Background(), StoreCredentialParams{
+		PrincipalID: "principal-1",
+		Service:     "github",
+		AccessToken: "ghp_xxx",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.ID != "cred-1" {
+		t.Errorf("expected cred-1, got %s", resp.ID)
+	}
+	if resp.Service != "github" {
+		t.Errorf("expected github, got %s", resp.Service)
+	}
+}
+
+func TestVaultList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vault/credentials" || r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(listVaultCredentialsResponse{
+			Credentials: []VaultCredential{
+				{ID: "cred-1", PrincipalID: "principal-1", Service: "github", CredentialType: "oauth2", CreatedAt: "2026-04-01T00:00:00Z", UpdatedAt: "2026-04-01T00:00:00Z"},
+				{ID: "cred-2", PrincipalID: "principal-1", Service: "slack", CredentialType: "oauth2", CreatedAt: "2026-04-01T00:00:00Z", UpdatedAt: "2026-04-01T00:00:00Z"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	creds, err := client.Vault.List(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(creds) != 2 {
+		t.Errorf("expected 2 credentials, got %d", len(creds))
+	}
+}
+
+func TestVaultListWithParams(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("principalId") != "principal-1" {
+			t.Errorf("expected principalId=principal-1, got %s", r.URL.Query().Get("principalId"))
+		}
+		if r.URL.Query().Get("service") != "github" {
+			t.Errorf("expected service=github, got %s", r.URL.Query().Get("service"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(listVaultCredentialsResponse{
+			Credentials: []VaultCredential{
+				{ID: "cred-1", PrincipalID: "principal-1", Service: "github"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	creds, err := client.Vault.List(context.Background(), &ListVaultCredentialsParams{
+		PrincipalID: "principal-1",
+		Service:     "github",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(creds) != 1 {
+		t.Errorf("expected 1 credential, got %d", len(creds))
+	}
+}
+
+func TestVaultGet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vault/credentials/cred-1" || r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(VaultCredential{
+			ID:             "cred-1",
+			PrincipalID:    "principal-1",
+			Service:        "github",
+			CredentialType: "oauth2",
+			CreatedAt:      "2026-04-01T00:00:00Z",
+			UpdatedAt:      "2026-04-01T00:00:00Z",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	cred, err := client.Vault.Get(context.Background(), "cred-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cred.ID != "cred-1" {
+		t.Errorf("expected cred-1, got %s", cred.ID)
+	}
+	if cred.Service != "github" {
+		t.Errorf("expected github, got %s", cred.Service)
+	}
+}
+
+func TestVaultDelete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vault/credentials/cred-1" || r.Method != http.MethodDelete {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	err := client.Vault.Delete(context.Background(), "cred-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestVaultExchange(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vault/credentials/exchange" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		// Verify that the grant token is used as the Bearer token (not the API key)
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer grant-token-xyz" {
+			t.Errorf("expected Bearer grant-token-xyz, got %s", auth)
+		}
+		var params ExchangeCredentialParams
+		json.NewDecoder(r.Body).Decode(&params)
+		if params.Service != "github" {
+			t.Errorf("expected github, got %s", params.Service)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ExchangeCredentialResponse{
+			AccessToken:    "ghp_exchanged",
+			Service:        "github",
+			CredentialType: "oauth2",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	resp, err := client.Vault.Exchange(context.Background(), "grant-token-xyz", ExchangeCredentialParams{
+		Service: "github",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.AccessToken != "ghp_exchanged" {
+		t.Errorf("expected ghp_exchanged, got %s", resp.AccessToken)
+	}
+	if resp.Service != "github" {
+		t.Errorf("expected github, got %s", resp.Service)
+	}
+}
+
+func TestVaultExchangeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error":   "FORBIDDEN",
+			"message": "insufficient scopes",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	_, err := client.Vault.Exchange(context.Background(), "bad-token", ExchangeCredentialParams{
+		Service: "github",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	authErr, ok := err.(*AuthError)
+	if !ok {
+		t.Fatalf("expected AuthError, got %T", err)
+	}
+	if authErr.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", authErr.StatusCode)
+	}
+}

--- a/packages/mcp-auth/package.json
+++ b/packages/mcp-auth/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fastify/rate-limit": "^10.2.1",
-    "@grantex/sdk": "^0.1.8",
+    "@grantex/sdk": ">=0.1.8",
     "fastify": "^5.2.1",
     "jose": "^5.10.0"
   },

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -120,8 +120,17 @@ from ._types import (
     # Developer Settings
     UpdateDeveloperSettingsParams,
     UpdateDeveloperSettingsResponse,
+    # Passports (MPP Agent Identity)
+    MaxTransactionAmount,
+    IssuePassportParams,
+    IssuedPassportResponse,
+    GetPassportResponse,
+    RevokePassportResponse,
+    ListPassportsParams,
+    ListPassportsResponse,
 )
-from .resources._events import EventsClient, GrantexEvent as GrantexStreamEvent, StreamOptions
+from .resources._passports import PassportsClient
+from .resources._events import EventsClient, GrantexEvent as GrantexStreamEvent, StreamOptions, Subscription
 from ._pkce import PkceChallenge, generate_pkce
 from ._verify import verify_grant_token
 from ._webhook import verify_webhook_signature
@@ -258,10 +267,20 @@ __all__ = [
     # Developer Settings
     "UpdateDeveloperSettingsParams",
     "UpdateDeveloperSettingsResponse",
+    # Passports (MPP Agent Identity)
+    "PassportsClient",
+    "MaxTransactionAmount",
+    "IssuePassportParams",
+    "IssuedPassportResponse",
+    "GetPassportResponse",
+    "RevokePassportResponse",
+    "ListPassportsParams",
+    "ListPassportsResponse",
     # Events
     "EventsClient",
     "GrantexStreamEvent",
     "StreamOptions",
+    "Subscription",
     # Scope Enforcement / Manifests
     "ToolManifest",
     "Permission",

--- a/packages/sdk-py/src/grantex/_client.py
+++ b/packages/sdk-py/src/grantex/_client.py
@@ -35,6 +35,7 @@ from .resources._usage import UsageClient
 from .resources._domains import DomainsClient
 from .resources._webauthn import WebAuthnClient
 from .resources._credentials import CredentialsClient
+from .resources._passports import PassportsClient
 from .manifest import ToolManifest, Permission, EnforceResult
 from ._verify import verify_grant_token
 from ._types import VerifyGrantTokenOptions
@@ -64,6 +65,7 @@ class Grantex:
     domains: DomainsClient
     webauthn: WebAuthnClient
     credentials: CredentialsClient
+    passports: PassportsClient
 
     @property
     def last_rate_limit(self) -> RateLimit | None:
@@ -111,6 +113,7 @@ class Grantex:
         self.domains = DomainsClient(self._http)
         self.webauthn = WebAuthnClient(self._http)
         self.credentials = CredentialsClient(self._http)
+        self.passports = PassportsClient(self._http)
         self._manifests: dict[str, ToolManifest] = {}
         self._jwks_uri = f"{base_url.rstrip('/')}/.well-known/jwks.json"
 

--- a/packages/sdk-py/src/grantex/_types.py
+++ b/packages/sdk-py/src/grantex/_types.py
@@ -153,6 +153,9 @@ class AuthorizationRequest:
     status: str
     created_at: str
     code: str | None = None
+    sandbox: bool | None = None
+    policy_enforced: bool | None = None
+    effect: str | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> AuthorizationRequest:
@@ -167,6 +170,9 @@ class AuthorizationRequest:
             status=data.get("status", ""),
             created_at=data.get("createdAt", ""),
             code=data.get("code"),
+            sandbox=data.get("sandbox"),
+            policy_enforced=data.get("policyEnforced"),
+            effect=data.get("effect"),
         )
 
 
@@ -1973,3 +1979,118 @@ class UpdateDeveloperSettingsResponse:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "UpdateDeveloperSettingsResponse":
         return cls(updated=data["updated"])
+
+
+# ─── Passports (MPP Agent Identity) ─────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class MaxTransactionAmount:
+    amount: float
+    currency: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"amount": self.amount, "currency": self.currency}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MaxTransactionAmount":
+        return cls(amount=data["amount"], currency=data["currency"])
+
+
+@dataclass
+class IssuePassportParams:
+    agent_id: str
+    grant_id: str
+    allowed_mpp_categories: list[str]
+    max_transaction_amount: MaxTransactionAmount
+    payment_rails: list[str] | None = None
+    expires_in: str | None = None
+    parent_passport_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "agentId": self.agent_id,
+            "grantId": self.grant_id,
+            "allowedMPPCategories": self.allowed_mpp_categories,
+            "maxTransactionAmount": self.max_transaction_amount.to_dict(),
+        }
+        if self.payment_rails is not None:
+            body["paymentRails"] = self.payment_rails
+        if self.expires_in is not None:
+            body["expiresIn"] = self.expires_in
+        if self.parent_passport_id is not None:
+            body["parentPassportId"] = self.parent_passport_id
+        return body
+
+
+@dataclass(frozen=True)
+class IssuedPassportResponse:
+    passport_id: str
+    credential: dict[str, Any]
+    encoded_credential: str
+    expires_at: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "IssuedPassportResponse":
+        return cls(
+            passport_id=data["passportId"],
+            credential=data.get("credential", {}),
+            encoded_credential=data.get("encodedCredential", ""),
+            expires_at=data["expiresAt"],
+        )
+
+
+@dataclass(frozen=True)
+class GetPassportResponse:
+    status: str
+    raw: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "GetPassportResponse":
+        return cls(
+            status=data["status"],
+            raw=data,
+        )
+
+
+@dataclass(frozen=True)
+class RevokePassportResponse:
+    revoked: bool
+    revoked_at: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "RevokePassportResponse":
+        return cls(
+            revoked=data["revoked"],
+            revoked_at=data["revokedAt"],
+        )
+
+
+@dataclass
+class ListPassportsParams:
+    agent_id: str | None = None
+    grant_id: str | None = None
+    status: str | None = None
+
+    def to_query(self) -> dict[str, str]:
+        result: dict[str, str] = {}
+        if self.agent_id is not None:
+            result["agentId"] = self.agent_id
+        if self.grant_id is not None:
+            result["grantId"] = self.grant_id
+        if self.status is not None:
+            result["status"] = self.status
+        return result
+
+
+@dataclass(frozen=True)
+class ListPassportsResponse:
+    passports: tuple[IssuedPassportResponse, ...]
+
+    @classmethod
+    def from_list(cls, data: list[dict[str, Any]]) -> "ListPassportsResponse":
+        return cls(
+            passports=tuple(
+                IssuedPassportResponse.from_dict(p) for p in data
+            ),
+        )

--- a/packages/sdk-py/src/grantex/resources/_events.py
+++ b/packages/sdk-py/src/grantex/resources/_events.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Iterator, Optional, Sequence
 import json
+import threading
+
 import httpx
+
+
+EventHandler = Callable[["GrantexEvent"], None]
+ErrorHandler = Callable[[Exception], None]
 
 
 @dataclass(frozen=True)
@@ -26,6 +32,24 @@ class GrantexEvent:
 @dataclass(frozen=True)
 class StreamOptions:
     types: Optional[Sequence[str]] = None
+
+
+class Subscription:
+    """Handle returned by ``EventsClient.subscribe`` to control the background stream."""
+
+    def __init__(self, thread: threading.Thread, stop_event: threading.Event) -> None:
+        self._thread = thread
+        self._stop_event = stop_event
+
+    @property
+    def active(self) -> bool:
+        """Return ``True`` if the subscription is still running."""
+        return self._thread.is_alive()
+
+    def unsubscribe(self) -> None:
+        """Stop the background stream and wait for the thread to exit."""
+        self._stop_event.set()
+        self._thread.join(timeout=5)
 
 
 class EventsClient:
@@ -59,3 +83,39 @@ class EventsClient:
                             yield GrantexEvent.from_dict(data)
                         except (json.JSONDecodeError, KeyError):
                             pass
+
+    def subscribe(
+        self,
+        handler: EventHandler,
+        options: Optional[StreamOptions] = None,
+        *,
+        on_error: Optional[ErrorHandler] = None,
+    ) -> Subscription:
+        """Subscribe to events with a callback handler.
+
+        Starts a background thread that calls ``stream()`` and invokes
+        *handler* for each event.  Returns a :class:`Subscription` whose
+        ``unsubscribe()`` method stops the thread.
+
+        Args:
+            handler: Called with each :class:`GrantexEvent` received.
+            options: Optional :class:`StreamOptions` to filter event types.
+            on_error: Optional callback invoked when the stream raises an
+                exception.  If not provided, errors are silently swallowed
+                and the stream stops.
+        """
+        stop = threading.Event()
+
+        def _run() -> None:
+            try:
+                for event in self.stream(options):
+                    if stop.is_set():
+                        break
+                    handler(event)
+            except Exception as exc:  # noqa: BLE001
+                if on_error is not None:
+                    on_error(exc)
+
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
+        return Subscription(thread=thread, stop_event=stop)

--- a/packages/sdk-py/src/grantex/resources/_passports.py
+++ b/packages/sdk-py/src/grantex/resources/_passports.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from .._http import HttpClient
+from .._types import (
+    GetPassportResponse,
+    IssuedPassportResponse,
+    IssuePassportParams,
+    ListPassportsParams,
+    ListPassportsResponse,
+    RevokePassportResponse,
+)
+
+
+class PassportsClient:
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def issue(self, params: IssuePassportParams) -> IssuedPassportResponse:
+        data = self._http.post("/v1/passport/issue", params.to_dict())
+        return IssuedPassportResponse.from_dict(data)
+
+    def get(self, passport_id: str) -> GetPassportResponse:
+        from urllib.parse import quote
+
+        data = self._http.get(f"/v1/passport/{quote(passport_id, safe='')}")
+        return GetPassportResponse.from_dict(data)
+
+    def revoke(self, passport_id: str) -> RevokePassportResponse:
+        from urllib.parse import quote
+
+        data = self._http.post(
+            f"/v1/passport/{quote(passport_id, safe='')}/revoke"
+        )
+        return RevokePassportResponse.from_dict(data)
+
+    def list(
+        self, params: ListPassportsParams | None = None
+    ) -> ListPassportsResponse:
+        path = "/v1/passports"
+        if params is not None:
+            query = params.to_query()
+            if query:
+                from urllib.parse import urlencode
+
+                path = f"{path}?{urlencode(query)}"
+        data = self._http.get(path)
+        # Server returns a bare JSON array
+        return ListPassportsResponse.from_list(data)

--- a/packages/sdk-py/tests/test_events.py
+++ b/packages/sdk-py/tests/test_events.py
@@ -1,5 +1,9 @@
+import threading
+import time
+from unittest.mock import patch
+
 import pytest
-from grantex.resources._events import EventsClient, GrantexEvent, StreamOptions
+from grantex.resources._events import EventsClient, GrantexEvent, StreamOptions, Subscription
 
 
 class TestGrantexEvent:
@@ -32,8 +36,137 @@ class TestStreamOptions:
         assert opts.types == ["grant.created", "token.issued"]
 
 
+def _make_events(count: int) -> list[GrantexEvent]:
+    """Helper to create a list of test events."""
+    return [
+        GrantexEvent(
+            id=f"evt_{i}",
+            type="grant.created",
+            created_at="2026-03-01T00:00:00Z",
+            data={"n": i},
+        )
+        for i in range(count)
+    ]
+
+
 class TestEventsClient:
     def test_constructor(self):
         client = EventsClient("https://api.grantex.dev", "test-key")
         assert client._base_url == "https://api.grantex.dev"
         assert client._api_key == "test-key"
+
+
+class TestSubscription:
+    def test_active_property(self):
+        stop = threading.Event()
+        stop.set()  # thread will exit immediately
+        t = threading.Thread(target=lambda: None, daemon=True)
+        t.start()
+        t.join()
+        sub = Subscription(thread=t, stop_event=stop)
+        assert sub.active is False
+
+    def test_unsubscribe_sets_stop(self):
+        stop = threading.Event()
+        t = threading.Thread(target=lambda: stop.wait(), daemon=True)
+        t.start()
+        sub = Subscription(thread=t, stop_event=stop)
+        assert sub.active is True
+        sub.unsubscribe()
+        assert stop.is_set()
+        assert sub.active is False
+
+
+class TestSubscribe:
+    def test_subscribe_receives_events(self):
+        """subscribe() should deliver every event from stream() to the handler."""
+        events = _make_events(3)
+        client = EventsClient("https://api.grantex.dev", "test-key")
+
+        with patch.object(client, "stream", return_value=iter(events)):
+            received: list[GrantexEvent] = []
+            sub = client.subscribe(lambda e: received.append(e))
+            # Wait for the background thread to finish consuming the iterator
+            sub._thread.join(timeout=2)
+
+        assert received == events
+
+    def test_subscribe_with_options(self):
+        """subscribe() should forward StreamOptions to stream()."""
+        events = _make_events(1)
+        client = EventsClient("https://api.grantex.dev", "test-key")
+        opts = StreamOptions(types=["grant.created"])
+
+        with patch.object(client, "stream", return_value=iter(events)) as mock_stream:
+            sub = client.subscribe(lambda e: None, options=opts)
+            sub._thread.join(timeout=2)
+            mock_stream.assert_called_once_with(opts)
+
+    def test_unsubscribe_stops_stream(self):
+        """unsubscribe() should stop processing events mid-stream."""
+        client = EventsClient("https://api.grantex.dev", "test-key")
+        received: list[GrantexEvent] = []
+        barrier = threading.Event()
+
+        def slow_generator():
+            for evt in _make_events(10):
+                yield evt
+                # After yielding each event, give the test a chance to unsubscribe
+                barrier.wait(timeout=2)
+                barrier.clear()
+
+        with patch.object(client, "stream", return_value=slow_generator()):
+            sub = client.subscribe(lambda e: received.append(e))
+            # Wait for first event to be processed
+            for _ in range(50):
+                if len(received) >= 1:
+                    break
+                time.sleep(0.01)
+            # Unsubscribe after the first event
+            sub.unsubscribe()
+            barrier.set()  # unblock generator in case it's waiting
+
+        # Should have received at most a couple of events, not all 10
+        assert 1 <= len(received) < 10
+
+    def test_subscribe_error_calls_on_error(self):
+        """When stream() raises, the on_error callback should be invoked."""
+        client = EventsClient("https://api.grantex.dev", "test-key")
+        error_holder: list[Exception] = []
+
+        def failing_stream(options=None):
+            raise ConnectionError("SSE connection lost")
+
+        with patch.object(client, "stream", side_effect=failing_stream):
+            sub = client.subscribe(
+                lambda e: None,
+                on_error=lambda exc: error_holder.append(exc),
+            )
+            sub._thread.join(timeout=2)
+
+        assert len(error_holder) == 1
+        assert isinstance(error_holder[0], ConnectionError)
+        assert "SSE connection lost" in str(error_holder[0])
+
+    def test_subscribe_error_no_callback_swallowed(self):
+        """When stream() raises and no on_error is given, the error is silently swallowed."""
+        client = EventsClient("https://api.grantex.dev", "test-key")
+
+        def failing_stream(options=None):
+            raise RuntimeError("boom")
+
+        with patch.object(client, "stream", side_effect=failing_stream):
+            sub = client.subscribe(lambda e: None)
+            sub._thread.join(timeout=2)
+
+        # Thread exited cleanly without propagating
+        assert sub.active is False
+
+    def test_subscribe_returns_subscription(self):
+        """subscribe() should return a Subscription instance."""
+        client = EventsClient("https://api.grantex.dev", "test-key")
+
+        with patch.object(client, "stream", return_value=iter([])):
+            sub = client.subscribe(lambda e: None)
+            assert isinstance(sub, Subscription)
+            sub._thread.join(timeout=2)

--- a/packages/sdk-py/tests/test_passports.py
+++ b/packages/sdk-py/tests/test_passports.py
@@ -1,0 +1,176 @@
+"""Tests for PassportsClient."""
+from __future__ import annotations
+
+import json
+
+import pytest
+import respx
+import httpx
+
+from grantex import (
+    Grantex,
+    IssuePassportParams,
+    ListPassportsParams,
+    MaxTransactionAmount,
+)
+
+MOCK_ISSUED_PASSPORT = {
+    "passportId": "urn:grantex:passport:01HXYZ",
+    "credential": {
+        "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "https://grantex.dev/contexts/mpp/v1",
+        ],
+        "type": ["VerifiableCredential", "AgentPassportCredential"],
+        "id": "urn:grantex:passport:01HXYZ",
+    },
+    "encodedCredential": "eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnM...",
+    "expiresAt": "2026-04-06T00:00:00Z",
+}
+
+MOCK_GET_PASSPORT = {
+    "status": "active",
+    "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://grantex.dev/contexts/mpp/v1",
+    ],
+    "type": ["VerifiableCredential", "AgentPassportCredential"],
+    "id": "urn:grantex:passport:01HXYZ",
+    "issuer": "did:web:grantex.dev",
+}
+
+MOCK_REVOKE_RESPONSE = {
+    "revoked": True,
+    "revokedAt": "2026-04-05T12:00:00Z",
+}
+
+
+@pytest.fixture
+def client() -> Grantex:
+    return Grantex(api_key="test-key")
+
+
+@respx.mock
+def test_issue_passport(client: Grantex) -> None:
+    route = respx.post("https://api.grantex.dev/v1/passport/issue").mock(
+        return_value=httpx.Response(201, json=MOCK_ISSUED_PASSPORT)
+    )
+    result = client.passports.issue(
+        IssuePassportParams(
+            agent_id="ag_01",
+            grant_id="grant_01",
+            allowed_mpp_categories=["inference", "compute"],
+            max_transaction_amount=MaxTransactionAmount(amount=100.0, currency="USDC"),
+            payment_rails=["tempo"],
+            expires_in="24h",
+        )
+    )
+
+    assert result.passport_id == "urn:grantex:passport:01HXYZ"
+    assert result.encoded_credential.startswith("eyJ")
+    assert result.expires_at == "2026-04-06T00:00:00Z"
+    assert "AgentPassportCredential" in result.credential.get("type", [])
+
+    body = json.loads(route.calls[0].request.content)
+    assert body["agentId"] == "ag_01"
+    assert body["grantId"] == "grant_01"
+    assert body["allowedMPPCategories"] == ["inference", "compute"]
+    assert body["maxTransactionAmount"] == {"amount": 100.0, "currency": "USDC"}
+    assert body["paymentRails"] == ["tempo"]
+    assert body["expiresIn"] == "24h"
+
+
+@respx.mock
+def test_issue_passport_minimal(client: Grantex) -> None:
+    route = respx.post("https://api.grantex.dev/v1/passport/issue").mock(
+        return_value=httpx.Response(201, json=MOCK_ISSUED_PASSPORT)
+    )
+    result = client.passports.issue(
+        IssuePassportParams(
+            agent_id="ag_01",
+            grant_id="grant_01",
+            allowed_mpp_categories=["general"],
+            max_transaction_amount=MaxTransactionAmount(amount=50.0, currency="USD"),
+        )
+    )
+
+    assert result.passport_id == "urn:grantex:passport:01HXYZ"
+
+    body = json.loads(route.calls[0].request.content)
+    assert "paymentRails" not in body
+    assert "expiresIn" not in body
+    assert "parentPassportId" not in body
+
+
+@respx.mock
+def test_get_passport(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/passport/urn%3Agrantex%3Apassport%3A01HXYZ").mock(
+        return_value=httpx.Response(200, json=MOCK_GET_PASSPORT)
+    )
+    result = client.passports.get("urn:grantex:passport:01HXYZ")
+
+    assert result.status == "active"
+    assert result.raw["issuer"] == "did:web:grantex.dev"
+    assert "AgentPassportCredential" in result.raw["type"]
+
+
+@respx.mock
+def test_revoke_passport(client: Grantex) -> None:
+    route = respx.post(
+        "https://api.grantex.dev/v1/passport/urn%3Agrantex%3Apassport%3A01HXYZ/revoke"
+    ).mock(return_value=httpx.Response(200, json=MOCK_REVOKE_RESPONSE))
+
+    result = client.passports.revoke("urn:grantex:passport:01HXYZ")
+
+    assert result.revoked is True
+    assert result.revoked_at == "2026-04-05T12:00:00Z"
+
+
+@respx.mock
+def test_list_passports_with_params(client: Grantex) -> None:
+    mock_list = [
+        {
+            "passportId": "urn:grantex:passport:01HXYZ",
+            "credential": {},
+            "encodedCredential": "",
+            "expiresAt": "2026-04-06T00:00:00Z",
+        },
+    ]
+    respx.get(url__regex=r"/v1/passports\?.*agentId=ag_01").mock(
+        return_value=httpx.Response(200, json=mock_list)
+    )
+
+    result = client.passports.list(
+        ListPassportsParams(agent_id="ag_01", status="active")
+    )
+
+    assert len(result.passports) == 1
+    assert result.passports[0].passport_id == "urn:grantex:passport:01HXYZ"
+
+
+@respx.mock
+def test_list_passports_without_params(client: Grantex) -> None:
+    respx.get("https://api.grantex.dev/v1/passports").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    result = client.passports.list()
+    assert len(result.passports) == 0
+
+
+@respx.mock
+def test_issue_passport_with_parent(client: Grantex) -> None:
+    route = respx.post("https://api.grantex.dev/v1/passport/issue").mock(
+        return_value=httpx.Response(201, json=MOCK_ISSUED_PASSPORT)
+    )
+    client.passports.issue(
+        IssuePassportParams(
+            agent_id="ag_02",
+            grant_id="grant_02",
+            allowed_mpp_categories=["inference"],
+            max_transaction_amount=MaxTransactionAmount(amount=25.0, currency="USDC"),
+            parent_passport_id="urn:grantex:passport:PARENT",
+        )
+    )
+
+    body = json.loads(route.calls[0].request.content)
+    assert body["parentPassportId"] == "urn:grantex:passport:PARENT"

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -98,6 +98,14 @@ export interface AuthorizationRequest {
   expiresAt: string;
   status: 'pending' | 'approved' | 'denied' | 'expired';
   createdAt: string;
+  /** Returned when sandbox mode or policy auto-approve */
+  code?: string;
+  /** Returned when sandbox mode is active */
+  sandbox?: boolean;
+  /** Returned when a policy was enforced */
+  policyEnforced?: boolean;
+  /** Returned when a policy was enforced */
+  effect?: 'allow' | 'deny';
 }
 
 // ─── Grants ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Fixes 10 issues found during comprehensive codebase review.

### Critical fixes
- **Python SDK**: Add `PassportsClient` (4 methods + 8 types + 7 tests) — was completely missing
- **Python SDK**: Add `EventsClient.subscribe()` with `Subscription` class + 8 tests — was missing
- **TypeScript SDK**: Add missing `sandbox`, `policyEnforced`, `effect` fields to `AuthorizationRequest` type
- **mcp-auth**: Fix peer dep `@grantex/sdk` from `^0.1.8` to `>=0.1.8` (was rejecting SDK 0.3.3)

### High-priority fixes
- **Go SDK**: Add `PassportsService` (4 methods) + `VaultService` (5 methods) + 12 tests — Go SDK now 20/20 services
- **Auth service**: Add `passport.test.ts` — 25 tests for the only untested route (4 endpoints)
- **README**: Fix badge counts — 3,900+ tests (was 679+), 27 packages (was 30+)

### Files changed (16)
| Area | Files | New Tests |
|------|-------|-----------|
| Python SDK | 7 files (new PassportsClient, subscribe, types, exports) | 15 |
| Go SDK | 5 files (new passports, vault services + client update) | 12 |
| TypeScript SDK | 1 file (AuthorizationRequest type) | — |
| Auth service | 1 file (new passport.test.ts) | 25 |
| mcp-auth | 1 file (package.json peer dep) | — |
| README | 1 file (badge corrections) | — |

**Total: 52 new tests, 1,782 lines added**

## Test plan
- [ ] `cd packages/sdk-py && python -m pytest tests/test_passports.py tests/test_events.py`
- [ ] `cd packages/go-sdk && go test ./...`
- [ ] `cd apps/auth-service && npx vitest run tests/passport.test.ts`
- [ ] `cd packages/sdk-ts && npx tsc --noEmit` (verify AuthorizationRequest type)
- [ ] `cd packages/mcp-auth && npm install` (verify peer dep resolves with SDK 0.3.3)