### PR TITLE
fix: remaining review findings — API docs, tests, SDK parity

### DIFF
--- a/apps/auth-service/src/db/migrations/030_drop_signing_keys.sql
+++ b/apps/auth-service/src/db/migrations/030_drop_signing_keys.sql
@@ -1,0 +1,5 @@
+-- Drop orphaned signing_keys table (created in 019_did_keys.sql but never
+-- referenced by any route, service, or query — DID key management uses the
+-- Ed25519 key pair from env/crypto module instead).
+
+DROP TABLE IF EXISTS signing_keys;

--- a/apps/auth-service/tests/anomalies.test.ts
+++ b/apps/auth-service/tests/anomalies.test.ts
@@ -209,3 +209,363 @@ describe('PATCH /v1/anomalies/:id/acknowledge', () => {
     expect(res.statusCode).toBe(404);
   });
 });
+
+// ─── GET /v1/anomaly/alerts ──────────────────────────────────────────────────
+
+describe('GET /v1/anomaly/alerts', () => {
+  it('returns alerts list', async () => {
+    const alert = {
+      id: 'anm_alert_01',
+      type: 'rate_spike',
+      severity: 'high',
+      status: 'open',
+      rule_id: 'AD-001',
+      rule_name: 'Velocity spike',
+      agent_id: 'ag_01',
+      description: 'Velocity spike detected',
+      context: { count: 100 },
+      metadata: {},
+      detected_at: '2026-03-01T00:00:00Z',
+      acknowledged_at: null,
+      resolved_at: null,
+    };
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([alert]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/anomaly/alerts',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: Array<{ alertId: string; status: string }> }>();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]!.alertId).toBe('anm_alert_01');
+    expect(body.data[0]!.status).toBe('open');
+  });
+});
+
+// ─── POST /v1/anomaly/alerts/:alertId/resolve ────────────────────────────────
+
+describe('POST /v1/anomaly/alerts/:alertId/resolve', () => {
+  it('resolves an alert and returns resolvedAt', async () => {
+    const resolved = {
+      id: 'anm_alert_01',
+      type: 'rate_spike',
+      severity: 'high',
+      status: 'resolved',
+      rule_id: null,
+      rule_name: null,
+      agent_id: 'ag_01',
+      description: 'Velocity spike detected',
+      context: {},
+      metadata: {},
+      detected_at: '2026-03-01T00:00:00Z',
+      acknowledged_at: null,
+      resolved_at: '2026-03-01T02:00:00Z',
+    };
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([resolved]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/anomaly/alerts/anm_alert_01/resolve',
+      headers: authHeader(),
+      payload: { note: 'False positive' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ alertId: string; status: string; resolvedAt: string }>();
+    expect(body.alertId).toBe('anm_alert_01');
+    expect(body.status).toBe('resolved');
+    expect(body.resolvedAt).toBe('2026-03-01T02:00:00Z');
+  });
+
+  it('returns 404 when alert not found', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/anomaly/alerts/anm_missing/resolve',
+      headers: authHeader(),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ─── GET /v1/anomaly/metrics ─────────────────────────────────────────────────
+
+describe('GET /v1/anomaly/metrics', () => {
+  it('returns metrics for the default 24h window', async () => {
+    const metricsRow = {
+      total: 5,
+      open: 3,
+      acknowledged: 1,
+      resolved: 1,
+      critical: 1,
+      high: 2,
+      medium: 1,
+      low: 1,
+    };
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([metricsRow]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/anomaly/metrics',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      window: string;
+      total: number;
+      byStatus: { open: number; acknowledged: number; resolved: number };
+      bySeverity: { critical: number; high: number; medium: number; low: number };
+    }>();
+    expect(body.window).toBe('24h');
+    expect(body.total).toBe(5);
+    expect(body.byStatus.open).toBe(3);
+    expect(body.bySeverity.critical).toBe(1);
+  });
+
+  it('rejects invalid window', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/anomaly/metrics?window=99h',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// ─── POST /v1/anomaly/rules ─────────────────────────────────────────────────
+
+describe('POST /v1/anomaly/rules', () => {
+  it('creates a custom rule and returns 201', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]); // INSERT
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/anomaly/rules',
+      headers: authHeader(),
+      payload: {
+        ruleId: 'CUSTOM-001',
+        name: 'My custom rule',
+        description: 'Fires on custom condition',
+        condition: { metric: 'grant_rate', threshold: 100, window: '5m' },
+        severity: 'high',
+        alertChannels: ['ch_01'],
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{
+      id: string;
+      ruleId: string;
+      name: string;
+      severity: string;
+      enabled: boolean;
+    }>();
+    expect(body.ruleId).toBe('CUSTOM-001');
+    expect(body.name).toBe('My custom rule');
+    expect(body.severity).toBe('high');
+    expect(body.enabled).toBe(true);
+  });
+
+  it('returns 400 when ruleId or name is missing', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/anomaly/rules',
+      headers: authHeader(),
+      payload: { condition: { metric: 'x' } },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// ─── GET /v1/anomaly/rules ──────────────────────────────────────────────────
+
+describe('GET /v1/anomaly/rules', () => {
+  it('returns built-in rules plus custom rules', async () => {
+    const customRule = {
+      id: 'ar_custom01',
+      rule_id: 'CUSTOM-001',
+      name: 'My custom rule',
+      description: 'Fires on custom condition',
+      condition: { metric: 'grant_rate', threshold: 100 },
+      severity: 'high',
+      alert_channels: ['ch_01'],
+      enabled: true,
+      created_at: '2026-03-01T00:00:00Z',
+    };
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([customRule]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/anomaly/rules',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ rules: Array<{ ruleId: string; builtIn: boolean }> }>();
+    // 10 built-in + 1 custom
+    expect(body.rules).toHaveLength(11);
+    // First 10 are built-in
+    expect(body.rules[0]!.builtIn).toBe(true);
+    // Last one is the custom rule
+    expect(body.rules[10]!.ruleId).toBe('CUSTOM-001');
+    expect(body.rules[10]!.builtIn).toBe(false);
+  });
+});
+
+// ─── DELETE /v1/anomaly/rules/:ruleId ───────────────────────────────────────
+
+describe('DELETE /v1/anomaly/rules/:ruleId', () => {
+  it('deletes a custom rule and returns 204', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ id: 'ar_custom01' }]); // DELETE RETURNING
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/v1/anomaly/rules/ar_custom01',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+  });
+
+  it('returns 404 when rule not found', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/v1/anomaly/rules/ar_missing',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ─── POST /v1/anomaly/channels ──────────────────────────────────────────────
+
+describe('POST /v1/anomaly/channels', () => {
+  it('creates a notification channel and returns 201', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]); // INSERT
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/anomaly/channels',
+      headers: authHeader(),
+      payload: {
+        type: 'slack',
+        name: 'Security alerts',
+        config: { webhookUrl: 'https://hooks.slack.com/services/T00/B00/xxx' },
+        severities: ['critical', 'high'],
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{
+      id: string;
+      type: string;
+      name: string;
+      enabled: boolean;
+    }>();
+    expect(body.type).toBe('slack');
+    expect(body.name).toBe('Security alerts');
+    expect(body.enabled).toBe(true);
+  });
+
+  it('returns 400 for invalid channel type', async () => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/anomaly/channels',
+      headers: authHeader(),
+      payload: {
+        type: 'sms',
+        name: 'Bad channel',
+        config: { phone: '+1234567890' },
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// ─── GET /v1/anomaly/channels ───────────────────────────────────────────────
+
+describe('GET /v1/anomaly/channels', () => {
+  it('returns notification channels', async () => {
+    const channel = {
+      id: 'ach_01',
+      type: 'slack',
+      name: 'Security alerts',
+      config: { webhookUrl: 'https://hooks.slack.com/services/T00/B00/xxx' },
+      severities: ['critical', 'high'],
+      enabled: true,
+      created_at: '2026-03-01T00:00:00Z',
+    };
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([channel]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/anomaly/channels',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ channels: Array<{ id: string; type: string }> }>();
+    expect(body.channels).toHaveLength(1);
+    expect(body.channels[0]!.id).toBe('ach_01');
+    expect(body.channels[0]!.type).toBe('slack');
+  });
+});
+
+// ─── DELETE /v1/anomaly/channels/:channelId ─────────────────────────────────
+
+describe('DELETE /v1/anomaly/channels/:channelId', () => {
+  it('deletes a channel and returns 204', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ id: 'ach_01' }]); // DELETE RETURNING
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/v1/anomaly/channels/ach_01',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+  });
+
+  it('returns 404 when channel not found', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/v1/anomaly/channels/ach_missing',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/docs/api-reference/anomalies/acknowledge-alert.mdx
+++ b/docs/api-reference/anomalies/acknowledge-alert.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/anomaly/alerts/{alertId}/acknowledge
+---

--- a/docs/api-reference/anomalies/create-channel.mdx
+++ b/docs/api-reference/anomalies/create-channel.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/anomaly/channels
+---

--- a/docs/api-reference/anomalies/create-rule.mdx
+++ b/docs/api-reference/anomalies/create-rule.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/anomaly/rules
+---

--- a/docs/api-reference/anomalies/delete-channel.mdx
+++ b/docs/api-reference/anomalies/delete-channel.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/anomaly/channels/{channelId}
+---

--- a/docs/api-reference/anomalies/delete-rule.mdx
+++ b/docs/api-reference/anomalies/delete-rule.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/anomaly/rules/{ruleId}
+---

--- a/docs/api-reference/anomalies/get-metrics.mdx
+++ b/docs/api-reference/anomalies/get-metrics.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/anomaly/metrics
+---

--- a/docs/api-reference/anomalies/list-alerts.mdx
+++ b/docs/api-reference/anomalies/list-alerts.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/anomaly/alerts
+---

--- a/docs/api-reference/anomalies/list-channels.mdx
+++ b/docs/api-reference/anomalies/list-channels.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/anomaly/channels
+---

--- a/docs/api-reference/anomalies/list-rules.mdx
+++ b/docs/api-reference/anomalies/list-rules.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/anomaly/rules
+---

--- a/docs/api-reference/anomalies/resolve-alert.mdx
+++ b/docs/api-reference/anomalies/resolve-alert.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/anomaly/alerts/{alertId}/resolve
+---

--- a/docs/api-reference/budgets/allocate.mdx
+++ b/docs/api-reference/budgets/allocate.mdx
@@ -1,0 +1,106 @@
+---
+title: "Allocate Budget"
+sidebarTitle: "Allocate Budget"
+description: "Create a budget allocation for a grant, setting a spending cap for the agent."
+---
+
+## Endpoint
+
+```
+POST /v1/budget/allocate
+```
+
+## Authentication
+
+Requires a developer API key in the `Authorization` header.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <api_key>` |
+| `Content-Type` | `application/json` |
+
+## Request Body
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `grantId` | `string` | Yes | The grant to attach a budget to |
+| `initialBudget` | `number` | Yes | The initial budget amount (must be positive) |
+| `currency` | `string` | No | Currency code (default `"USD"`) |
+
+## Example Request
+
+```bash
+curl -X POST https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/budget/allocate \
+  -H "Authorization: Bearer gx_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "grantId": "grnt_01HXYZ...",
+    "initialBudget": 100.00,
+    "currency": "USD"
+  }'
+```
+
+## Response -- 201 Created
+
+```json
+{
+  "id": "ba_01HXYZ...",
+  "grantId": "grnt_01HXYZ...",
+  "initialBudget": 100.00,
+  "remainingBudget": 100.00,
+  "currency": "USD",
+  "createdAt": "2026-04-05T12:00:00.000Z"
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` | Unique budget allocation ID |
+| `grantId` | `string` | The grant this budget is attached to |
+| `initialBudget` | `number` | The initial budget amount |
+| `remainingBudget` | `number` | Current remaining budget (equals `initialBudget` on creation) |
+| `currency` | `string` | Currency code |
+| `createdAt` | `string` | ISO-8601 creation timestamp |
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 400 | `BAD_REQUEST` | Missing `grantId` or `initialBudget` not positive |
+| 401 | `UNAUTHORIZED` | Invalid or missing API key |
+| 404 | `NOT_FOUND` | Grant not found or does not belong to developer |
+| 409 | `CONFLICT` | Budget allocation already exists for this grant |
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+const allocation = await grantex.budgets.allocate({
+  grantId: 'grnt_01HXYZ...',
+  initialBudget: 100.00,
+  currency: 'USD',
+});
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+allocation = grantex.budgets.allocate(
+    grant_id="grnt_01HXYZ...",
+    initial_budget=100.00,
+    currency="USD",
+)
+```
+
+</CodeGroup>

--- a/docs/api-reference/budgets/allocations.mdx
+++ b/docs/api-reference/budgets/allocations.mdx
@@ -1,0 +1,92 @@
+---
+title: "List Budget Allocations"
+sidebarTitle: "List Allocations"
+description: "List all budget allocations for the authenticated developer."
+---
+
+## Endpoint
+
+```
+GET /v1/budget/allocations
+```
+
+## Authentication
+
+Requires a developer API key in the `Authorization` header.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <api_key>` |
+
+## Example Request
+
+```bash
+curl https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/budget/allocations \
+  -H "Authorization: Bearer gx_..."
+```
+
+## Response -- 200 OK
+
+```json
+{
+  "allocations": [
+    {
+      "id": "ba_01HXYZ...",
+      "grantId": "grnt_01HXYZ...",
+      "initialBudget": 100.00,
+      "remainingBudget": 94.50,
+      "currency": "USD",
+      "createdAt": "2026-04-05T12:00:00.000Z",
+      "updatedAt": "2026-04-05T14:30:00.000Z"
+    }
+  ]
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `allocations` | `array` | Array of budget allocation objects |
+| `allocations[].id` | `string` | Unique budget allocation ID |
+| `allocations[].grantId` | `string` | The grant this budget is attached to |
+| `allocations[].initialBudget` | `number` | The original budget amount |
+| `allocations[].remainingBudget` | `number` | Current remaining budget |
+| `allocations[].currency` | `string` | Currency code |
+| `allocations[].createdAt` | `string` | ISO-8601 creation timestamp |
+| `allocations[].updatedAt` | `string` | ISO-8601 last update timestamp |
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 401 | `UNAUTHORIZED` | Invalid or missing API key |
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+const { allocations } = await grantex.budgets.allocations();
+for (const a of allocations) {
+  console.log(`${a.grantId}: ${a.remainingBudget}/${a.initialBudget} ${a.currency}`);
+}
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+result = grantex.budgets.allocations()
+for a in result.allocations:
+    print(f"{a.grant_id}: {a.remaining_budget}/{a.initial_budget} {a.currency}")
+```
+
+</CodeGroup>

--- a/docs/api-reference/budgets/balance.mdx
+++ b/docs/api-reference/budgets/balance.mdx
@@ -1,0 +1,91 @@
+---
+title: "Get Budget Balance"
+sidebarTitle: "Get Balance"
+description: "Retrieve the current budget balance for a grant."
+---
+
+## Endpoint
+
+```
+GET /v1/budget/balance/:grantId
+```
+
+## Authentication
+
+Requires a developer API key in the `Authorization` header.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <api_key>` |
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `grantId` | `string` | The grant ID to look up |
+
+## Example Request
+
+```bash
+curl https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/budget/balance/grnt_01HXYZ... \
+  -H "Authorization: Bearer gx_..."
+```
+
+## Response -- 200 OK
+
+```json
+{
+  "id": "ba_01HXYZ...",
+  "grantId": "grnt_01HXYZ...",
+  "initialBudget": 100.00,
+  "remainingBudget": 94.50,
+  "currency": "USD",
+  "createdAt": "2026-04-05T12:00:00.000Z",
+  "updatedAt": "2026-04-05T14:30:00.000Z"
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` | Budget allocation ID |
+| `grantId` | `string` | The grant this budget is attached to |
+| `initialBudget` | `number` | The original budget amount |
+| `remainingBudget` | `number` | Current remaining budget |
+| `currency` | `string` | Currency code |
+| `createdAt` | `string` | ISO-8601 creation timestamp |
+| `updatedAt` | `string` | ISO-8601 last update timestamp |
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 401 | `UNAUTHORIZED` | Invalid or missing API key |
+| 404 | `NOT_FOUND` | No budget allocation found for this grant |
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+const balance = await grantex.budgets.balance('grnt_01HXYZ...');
+console.log(balance.remainingBudget); // 94.50
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+balance = grantex.budgets.balance("grnt_01HXYZ...")
+print(balance.remaining_budget)  # 94.50
+```
+
+</CodeGroup>

--- a/docs/api-reference/budgets/debit.mdx
+++ b/docs/api-reference/budgets/debit.mdx
@@ -1,0 +1,103 @@
+---
+title: "Debit Budget"
+sidebarTitle: "Debit Budget"
+description: "Debit an amount from a grant's budget allocation. Returns 402 if the budget is insufficient."
+---
+
+## Endpoint
+
+```
+POST /v1/budget/debit
+```
+
+## Authentication
+
+Requires a developer API key in the `Authorization` header.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <api_key>` |
+| `Content-Type` | `application/json` |
+
+## Request Body
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `grantId` | `string` | Yes | The grant whose budget to debit |
+| `amount` | `number` | Yes | The amount to debit (must be positive) |
+| `description` | `string` | No | Human-readable description of the charge |
+| `metadata` | `object` | No | Arbitrary metadata to attach to the transaction |
+
+## Example Request
+
+```bash
+curl -X POST https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/budget/debit \
+  -H "Authorization: Bearer gx_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "grantId": "grnt_01HXYZ...",
+    "amount": 5.50,
+    "description": "GPT-4 API call",
+    "metadata": { "model": "gpt-4", "tokens": 1500 }
+  }'
+```
+
+## Response -- 200 OK
+
+```json
+{
+  "remaining": 94.50,
+  "transactionId": "txn_01HXYZ...",
+  "grantId": "grnt_01HXYZ..."
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `remaining` | `number` | Budget remaining after the debit |
+| `transactionId` | `string` | Unique transaction ID for this debit |
+| `grantId` | `string` | The grant that was debited |
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 400 | `BAD_REQUEST` | Missing `grantId` or `amount` not positive |
+| 401 | `UNAUTHORIZED` | Invalid or missing API key |
+| 402 | `INSUFFICIENT_BUDGET` | The grant's remaining budget is less than the requested amount |
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+const result = await grantex.budgets.debit({
+  grantId: 'grnt_01HXYZ...',
+  amount: 5.50,
+  description: 'GPT-4 API call',
+});
+// result.remaining === 94.50
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+result = grantex.budgets.debit(
+    grant_id="grnt_01HXYZ...",
+    amount=5.50,
+    description="GPT-4 API call",
+)
+# result.remaining == 94.50
+```
+
+</CodeGroup>

--- a/docs/api-reference/budgets/transactions.mdx
+++ b/docs/api-reference/budgets/transactions.mdx
@@ -1,0 +1,106 @@
+---
+title: "List Budget Transactions"
+sidebarTitle: "List Transactions"
+description: "Retrieve paginated transaction history for a grant's budget."
+---
+
+## Endpoint
+
+```
+GET /v1/budget/transactions/:grantId
+```
+
+## Authentication
+
+Requires a developer API key in the `Authorization` header.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <api_key>` |
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `grantId` | `string` | The grant ID to look up transactions for |
+
+## Query Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `page` | `number` | No | Page number (default `1`) |
+| `pageSize` | `number` | No | Results per page (default `50`) |
+
+## Example Request
+
+```bash
+curl "https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/budget/transactions/grnt_01HXYZ...?page=1&pageSize=20" \
+  -H "Authorization: Bearer gx_..."
+```
+
+## Response -- 200 OK
+
+```json
+{
+  "transactions": [
+    {
+      "id": "txn_01HXYZ...",
+      "grantId": "grnt_01HXYZ...",
+      "amount": 5.50,
+      "description": "GPT-4 API call",
+      "metadata": { "model": "gpt-4", "tokens": 1500 },
+      "balanceAfter": 94.50,
+      "createdAt": "2026-04-05T14:30:00.000Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `transactions` | `array` | Array of transaction objects |
+| `transactions[].id` | `string` | Unique transaction ID |
+| `transactions[].grantId` | `string` | The grant this transaction belongs to |
+| `transactions[].amount` | `number` | Amount debited |
+| `transactions[].description` | `string \| null` | Human-readable description |
+| `transactions[].metadata` | `object` | Arbitrary metadata |
+| `transactions[].balanceAfter` | `number` | Remaining balance after this transaction |
+| `transactions[].createdAt` | `string` | ISO-8601 timestamp |
+| `total` | `number` | Total number of transactions |
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 401 | `UNAUTHORIZED` | Invalid or missing API key |
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+const result = await grantex.budgets.transactions('grnt_01HXYZ...');
+console.log(result.transactions);
+console.log(result.total);
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+result = grantex.budgets.transactions("grnt_01HXYZ...")
+print(result.transactions)
+print(result.total)
+```
+
+</CodeGroup>

--- a/docs/api-reference/domains/create.mdx
+++ b/docs/api-reference/domains/create.mdx
@@ -1,0 +1,96 @@
+---
+title: "Register Custom Domain"
+sidebarTitle: "Register Domain"
+description: "Register a custom domain for your Grantex deployment. Requires Enterprise plan."
+---
+
+## Endpoint
+
+```
+POST /v1/domains
+```
+
+## Authentication
+
+Requires a developer API key in the `Authorization` header.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <api_key>` |
+| `Content-Type` | `application/json` |
+
+## Request Body
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `domain` | `string` | Yes | The custom domain to register (e.g. `auth.example.com`) |
+
+## Example Request
+
+```bash
+curl -X POST https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/domains \
+  -H "Authorization: Bearer gx_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "domain": "auth.example.com"
+  }'
+```
+
+## Response -- 201 Created
+
+```json
+{
+  "id": "dom_01HXYZ...",
+  "domain": "auth.example.com",
+  "verified": false,
+  "verificationToken": "grantex-verify-a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "instructions": "Add a DNS TXT record: _grantex.auth.example.com = grantex-verify-a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` | Unique domain ID |
+| `domain` | `string` | The registered domain |
+| `verified` | `boolean` | Whether the domain has been verified (always `false` on creation) |
+| `verificationToken` | `string` | Token to add as a DNS TXT record for verification |
+| `instructions` | `string` | Human-readable DNS configuration instructions |
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 400 | `BAD_REQUEST` | Missing `domain` field |
+| 401 | `UNAUTHORIZED` | Invalid or missing API key |
+| 402 | `PLAN_LIMIT_EXCEEDED` | Custom domains require Enterprise plan |
+| 409 | `CONFLICT` | Domain already registered |
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+const domain = await grantex.domains.create({ domain: 'auth.example.com' });
+console.log(domain.verificationToken);
+console.log(domain.instructions);
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+domain = grantex.domains.create(domain="auth.example.com")
+print(domain.verification_token)
+print(domain.instructions)
+```
+
+</CodeGroup>

--- a/docs/api-reference/domains/delete.mdx
+++ b/docs/api-reference/domains/delete.mdx
@@ -1,0 +1,67 @@
+---
+title: "Delete Custom Domain"
+sidebarTitle: "Delete Domain"
+description: "Remove a custom domain registration."
+---
+
+## Endpoint
+
+```
+DELETE /v1/domains/:id
+```
+
+## Authentication
+
+Requires a developer API key in the `Authorization` header.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <api_key>` |
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `id` | `string` | The domain ID to delete (e.g. `dom_01HXYZ...`) |
+
+## Example Request
+
+```bash
+curl -X DELETE https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/domains/dom_01HXYZ... \
+  -H "Authorization: Bearer gx_..."
+```
+
+## Response -- 204 No Content
+
+No response body is returned on success.
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 401 | `UNAUTHORIZED` | Invalid or missing API key |
+| 404 | `NOT_FOUND` | Domain not found or does not belong to developer |
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+await grantex.domains.delete('dom_01HXYZ...');
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+grantex.domains.delete("dom_01HXYZ...")
+```
+
+</CodeGroup>

--- a/docs/api-reference/domains/list.mdx
+++ b/docs/api-reference/domains/list.mdx
@@ -1,0 +1,95 @@
+---
+title: "List Custom Domains"
+sidebarTitle: "List Domains"
+description: "List all custom domains registered by the authenticated developer."
+---
+
+## Endpoint
+
+```
+GET /v1/domains
+```
+
+## Authentication
+
+Requires a developer API key in the `Authorization` header.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <api_key>` |
+
+## Example Request
+
+```bash
+curl https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/domains \
+  -H "Authorization: Bearer gx_..."
+```
+
+## Response -- 200 OK
+
+```json
+{
+  "domains": [
+    {
+      "id": "dom_01HXYZ...",
+      "domain": "auth.example.com",
+      "verified": true,
+      "verifiedAt": "2026-04-05T15:00:00.000Z",
+      "createdAt": "2026-04-05T12:00:00.000Z"
+    },
+    {
+      "id": "dom_02ABCD...",
+      "domain": "agents.example.com",
+      "verified": false,
+      "verifiedAt": null,
+      "createdAt": "2026-04-05T13:00:00.000Z"
+    }
+  ]
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `domains` | `array` | Array of domain objects |
+| `domains[].id` | `string` | Unique domain ID |
+| `domains[].domain` | `string` | The domain name |
+| `domains[].verified` | `boolean` | Whether DNS verification has passed |
+| `domains[].verifiedAt` | `string \| null` | ISO-8601 timestamp of verification, or `null` |
+| `domains[].createdAt` | `string` | ISO-8601 creation timestamp |
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 401 | `UNAUTHORIZED` | Invalid or missing API key |
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+const { domains } = await grantex.domains.list();
+for (const d of domains) {
+  console.log(`${d.domain} — verified: ${d.verified}`);
+}
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+result = grantex.domains.list()
+for d in result.domains:
+    print(f"{d.domain} — verified: {d.verified}")
+```
+
+</CodeGroup>

--- a/docs/api-reference/domains/verify.mdx
+++ b/docs/api-reference/domains/verify.mdx
@@ -1,0 +1,107 @@
+---
+title: "Verify Domain DNS"
+sidebarTitle: "Verify Domain"
+description: "Trigger DNS verification for a registered custom domain."
+---
+
+## Endpoint
+
+```
+POST /v1/domains/:id/verify
+```
+
+## Authentication
+
+Requires a developer API key in the `Authorization` header.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <api_key>` |
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `id` | `string` | The domain ID to verify (e.g. `dom_01HXYZ...`) |
+
+## Example Request
+
+```bash
+curl -X POST https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/domains/dom_01HXYZ.../verify \
+  -H "Authorization: Bearer gx_..."
+```
+
+## Response -- 200 OK
+
+When DNS verification succeeds:
+
+```json
+{
+  "verified": true,
+  "message": "Domain verified successfully"
+}
+```
+
+If the domain was already verified:
+
+```json
+{
+  "verified": true,
+  "message": "Domain already verified"
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `verified` | `boolean` | Whether the domain is now verified |
+| `message` | `string` | Human-readable status message |
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 400 | `VERIFICATION_FAILED` | DNS verification failed -- ensure the TXT record is set correctly |
+| 401 | `UNAUTHORIZED` | Invalid or missing API key |
+| 404 | `NOT_FOUND` | Domain not found or does not belong to developer |
+
+## Rate Limits
+
+This endpoint is limited to **10 requests per minute** to prevent abuse of DNS lookups.
+
+## DNS Setup
+
+Before calling this endpoint, add a DNS TXT record:
+
+```
+_grantex.<your-domain> = <verificationToken>
+```
+
+The `verificationToken` is returned by the [Register Domain](/api-reference/domains/create) endpoint. DNS propagation may take up to 24 hours.
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+const result = await grantex.domains.verify('dom_01HXYZ...');
+console.log(result.verified); // true
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+result = grantex.domains.verify("dom_01HXYZ...")
+print(result.verified)  # True
+```
+
+</CodeGroup>

--- a/docs/api-reference/events/stream.mdx
+++ b/docs/api-reference/events/stream.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/events/stream
+---

--- a/docs/api-reference/events/websocket.mdx
+++ b/docs/api-reference/events/websocket.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/events/ws
+---

--- a/docs/api-reference/policies/active-bundle.mdx
+++ b/docs/api-reference/policies/active-bundle.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/policies/bundles/active
+---

--- a/docs/api-reference/policies/list-bundles.mdx
+++ b/docs/api-reference/policies/list-bundles.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/policies/bundles
+---

--- a/docs/api-reference/policies/sync-policy-bundle.mdx
+++ b/docs/api-reference/policies/sync-policy-bundle.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/policies/sync
+---

--- a/docs/api-reference/policies/sync-webhook.mdx
+++ b/docs/api-reference/policies/sync-webhook.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/policies/sync/webhook
+---

--- a/docs/api-reference/signup/send-verification.mdx
+++ b/docs/api-reference/signup/send-verification.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/signup/verify
+---

--- a/docs/api-reference/signup/verify-token.mdx
+++ b/docs/api-reference/signup/verify-token.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/signup/verify/{token}
+---

--- a/docs/api-reference/tokens/refresh-a-grant-token.mdx
+++ b/docs/api-reference/tokens/refresh-a-grant-token.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/token/refresh
+---

--- a/docs/api-reference/usage/current.mdx
+++ b/docs/api-reference/usage/current.mdx
@@ -1,0 +1,88 @@
+---
+title: "Get Current Usage"
+sidebarTitle: "Current Usage"
+description: "Retrieve real-time usage metrics for the current period."
+---
+
+## Endpoint
+
+```
+GET /v1/usage
+```
+
+## Authentication
+
+Requires a developer API key in the `Authorization` header.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <api_key>` |
+
+## Example Request
+
+```bash
+curl https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/usage \
+  -H "Authorization: Bearer gx_..."
+```
+
+## Response -- 200 OK
+
+```json
+{
+  "developerId": "dev_01HXYZ...",
+  "period": "2026-04-05",
+  "tokenExchanges": 142,
+  "authorizations": 58,
+  "verifications": 1203,
+  "totalRequests": 1403
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `developerId` | `string` | The authenticated developer's ID |
+| `period` | `string` | Current date in `YYYY-MM-DD` format |
+| `tokenExchanges` | `number` | Number of token exchange requests today |
+| `authorizations` | `number` | Number of authorization requests today |
+| `verifications` | `number` | Number of token verification requests today |
+| `totalRequests` | `number` | Sum of all request types |
+
+<Note>
+Usage counters are served from Redis for real-time accuracy. They reset at midnight UTC.
+</Note>
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 401 | `UNAUTHORIZED` | Invalid or missing API key |
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+const usage = await grantex.usage.current();
+console.log(`Total requests today: ${usage.totalRequests}`);
+console.log(`Token exchanges: ${usage.tokenExchanges}`);
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+usage = grantex.usage.current()
+print(f"Total requests today: {usage.total_requests}")
+print(f"Token exchanges: {usage.token_exchanges}")
+```
+
+</CodeGroup>

--- a/docs/api-reference/usage/history.mdx
+++ b/docs/api-reference/usage/history.mdx
@@ -1,0 +1,109 @@
+---
+title: "Get Usage History"
+sidebarTitle: "Usage History"
+description: "Retrieve daily usage breakdown over a specified number of days."
+---
+
+## Endpoint
+
+```
+GET /v1/usage/history
+```
+
+## Authentication
+
+Requires a developer API key in the `Authorization` header.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <api_key>` |
+
+## Query Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `days` | `number` | No | Number of days to look back (default `30`, maximum `90`) |
+
+## Example Request
+
+```bash
+curl "https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/usage/history?days=7" \
+  -H "Authorization: Bearer gx_..."
+```
+
+## Response -- 200 OK
+
+```json
+{
+  "developerId": "dev_01HXYZ...",
+  "days": 7,
+  "entries": [
+    {
+      "date": "2026-04-05",
+      "tokenExchanges": 142,
+      "authorizations": 58,
+      "verifications": 1203,
+      "totalRequests": 1403
+    },
+    {
+      "date": "2026-04-04",
+      "tokenExchanges": 130,
+      "authorizations": 45,
+      "verifications": 1100,
+      "totalRequests": 1275
+    }
+  ]
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `developerId` | `string` | The authenticated developer's ID |
+| `days` | `number` | The number of days included in the response |
+| `entries` | `array` | Array of daily usage entries, sorted by date descending |
+| `entries[].date` | `string` | Date in `YYYY-MM-DD` format |
+| `entries[].tokenExchanges` | `number` | Number of token exchange requests that day |
+| `entries[].authorizations` | `number` | Number of authorization requests that day |
+| `entries[].verifications` | `number` | Number of token verification requests that day |
+| `entries[].totalRequests` | `number` | Sum of all request types for that day |
+
+<Note>
+Historical usage data is read from PostgreSQL. Days with no activity may be omitted from the response.
+</Note>
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 401 | `UNAUTHORIZED` | Invalid or missing API key |
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+const history = await grantex.usage.history({ days: 7 });
+for (const entry of history.entries) {
+  console.log(`${entry.date}: ${entry.totalRequests} requests`);
+}
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+history = grantex.usage.history(days=7)
+for entry in history.entries:
+    print(f"{entry.date}: {entry.total_requests} requests")
+```
+
+</CodeGroup>

--- a/docs/api-reference/vault/delete.mdx
+++ b/docs/api-reference/vault/delete.mdx
@@ -1,0 +1,67 @@
+---
+title: "Delete Vault Credential"
+sidebarTitle: "Delete Credential"
+description: "Permanently delete a vault credential."
+---
+
+## Endpoint
+
+```
+DELETE /v1/vault/credentials/:id
+```
+
+## Authentication
+
+Requires a developer API key in the `Authorization` header.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <api_key>` |
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `id` | `string` | The vault credential ID to delete (e.g. `vc_01HXYZ...`) |
+
+## Example Request
+
+```bash
+curl -X DELETE https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/vault/credentials/vc_01HXYZ... \
+  -H "Authorization: Bearer gx_..."
+```
+
+## Response -- 204 No Content
+
+No response body is returned on success.
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 401 | `UNAUTHORIZED` | Invalid or missing API key |
+| 404 | `NOT_FOUND` | Credential not found or does not belong to developer |
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+await grantex.vault.delete('vc_01HXYZ...');
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+grantex.vault.delete("vc_01HXYZ...")
+```
+
+</CodeGroup>

--- a/docs/api-reference/vault/exchange.mdx
+++ b/docs/api-reference/vault/exchange.mdx
@@ -1,0 +1,117 @@
+---
+title: "Exchange Grant Token for Service Credential"
+sidebarTitle: "Exchange Credential"
+description: "Exchange a valid Grantex grant token for a stored upstream service credential."
+---
+
+## Endpoint
+
+```
+POST /v1/vault/credentials/exchange
+```
+
+## Authentication
+
+Requires a **Grantex grant token** (not an API key) in the `Authorization` header. This is a public endpoint -- no developer API key is needed.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <grant_token>` |
+| `Content-Type` | `application/json` |
+
+## Request Body
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `service` | `string` | Yes | The service whose credential to retrieve (e.g. `"github"`, `"slack"`) |
+
+## Example Request
+
+```bash
+curl -X POST https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/vault/credentials/exchange \
+  -H "Authorization: Bearer eyJhbGciOiJSUzI1NiIs..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "service": "github"
+  }'
+```
+
+## Response -- 200 OK
+
+```json
+{
+  "accessToken": "ghp_xxxxxxxxxxxx",
+  "service": "github",
+  "credentialType": "oauth2",
+  "tokenExpiresAt": "2026-04-06T12:00:00.000Z",
+  "metadata": { "scopes": ["repo", "read:org"] }
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `accessToken` | `string` | The decrypted upstream access token |
+| `service` | `string` | Service identifier |
+| `credentialType` | `string` | Credential type (e.g. `"oauth2"`) |
+| `tokenExpiresAt` | `string \| null` | ISO-8601 token expiry, or `null` |
+| `metadata` | `object` | Arbitrary metadata stored with the credential |
+
+<Warning>
+This endpoint returns the raw access token. The grant token's `sub` (principal) and `dev` (developer) claims are used to look up the credential. Ensure your grant tokens have appropriate scopes and expiry to limit exposure.
+</Warning>
+
+## Rate Limits
+
+This endpoint is limited to **20 requests per minute** per grant token.
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 400 | `BAD_REQUEST` | Missing `service` field |
+| 401 | `UNAUTHORIZED` | Missing, invalid, or expired grant token |
+| 404 | `NOT_FOUND` | No credential found for this principal and service |
+
+## How It Works
+
+1. The agent presents its Grantex grant token.
+2. The server verifies the JWT signature and extracts the `sub` (principal ID) and `dev` (developer ID) claims.
+3. The server looks up the vault credential matching `(developerId, principalId, service)`.
+4. If found, the encrypted access token is decrypted and returned.
+
+This allows agents to access upstream services without ever seeing the raw credentials at configuration time -- credentials are stored once by the developer and retrieved at runtime by authorized agents.
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+// The agent calls this with its grant token
+const cred = await grantex.vault.exchange({
+  grantToken: 'eyJhbGciOiJSUzI1NiIs...',
+  service: 'github',
+});
+console.log(cred.accessToken); // "ghp_xxxxxxxxxxxx"
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+cred = grantex.vault.exchange(
+    grant_token="eyJhbGciOiJSUzI1NiIs...",
+    service="github",
+)
+print(cred.access_token)  # "ghp_xxxxxxxxxxxx"
+```
+
+</CodeGroup>

--- a/docs/api-reference/vault/get.mdx
+++ b/docs/api-reference/vault/get.mdx
@@ -1,0 +1,95 @@
+---
+title: "Get Vault Credential"
+sidebarTitle: "Get Credential"
+description: "Retrieve metadata for a specific vault credential. Does not return raw tokens."
+---
+
+## Endpoint
+
+```
+GET /v1/vault/credentials/:id
+```
+
+## Authentication
+
+Requires a developer API key in the `Authorization` header.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <api_key>` |
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `id` | `string` | The vault credential ID (e.g. `vc_01HXYZ...`) |
+
+## Example Request
+
+```bash
+curl https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/vault/credentials/vc_01HXYZ... \
+  -H "Authorization: Bearer gx_..."
+```
+
+## Response -- 200 OK
+
+```json
+{
+  "id": "vc_01HXYZ...",
+  "principalId": "user_abc123",
+  "service": "github",
+  "credentialType": "oauth2",
+  "tokenExpiresAt": "2026-04-06T12:00:00.000Z",
+  "metadata": { "scopes": ["repo", "read:org"] },
+  "createdAt": "2026-04-05T12:00:00.000Z",
+  "updatedAt": "2026-04-05T12:00:00.000Z"
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` | Unique vault credential ID |
+| `principalId` | `string` | The principal who owns this credential |
+| `service` | `string` | Service identifier |
+| `credentialType` | `string` | Credential type (e.g. `"oauth2"`) |
+| `tokenExpiresAt` | `string \| null` | ISO-8601 token expiry, or `null` if not set |
+| `metadata` | `object` | Arbitrary metadata |
+| `createdAt` | `string` | ISO-8601 creation timestamp |
+| `updatedAt` | `string` | ISO-8601 last update timestamp |
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 401 | `UNAUTHORIZED` | Invalid or missing API key |
+| 404 | `NOT_FOUND` | Credential not found or does not belong to developer |
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+const cred = await grantex.vault.get('vc_01HXYZ...');
+console.log(cred.service);       // "github"
+console.log(cred.tokenExpiresAt); // "2026-04-06T12:00:00.000Z"
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+cred = grantex.vault.get("vc_01HXYZ...")
+print(cred.service)           # "github"
+print(cred.token_expires_at)  # "2026-04-06T12:00:00.000Z"
+```
+
+</CodeGroup>

--- a/docs/api-reference/vault/list.mdx
+++ b/docs/api-reference/vault/list.mdx
@@ -1,0 +1,105 @@
+---
+title: "List Vault Credentials"
+sidebarTitle: "List Credentials"
+description: "List vault credential metadata for the authenticated developer. Does not return raw tokens."
+---
+
+## Endpoint
+
+```
+GET /v1/vault/credentials
+```
+
+## Authentication
+
+Requires a developer API key in the `Authorization` header.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <api_key>` |
+
+## Query Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `principalId` | `string` | No | Filter by principal ID |
+| `service` | `string` | No | Filter by service name |
+
+## Example Request
+
+```bash
+curl "https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/vault/credentials?principalId=user_abc123" \
+  -H "Authorization: Bearer gx_..."
+```
+
+## Response -- 200 OK
+
+```json
+{
+  "credentials": [
+    {
+      "id": "vc_01HXYZ...",
+      "principalId": "user_abc123",
+      "service": "github",
+      "credentialType": "oauth2",
+      "tokenExpiresAt": "2026-04-06T12:00:00.000Z",
+      "metadata": { "scopes": ["repo", "read:org"] },
+      "createdAt": "2026-04-05T12:00:00.000Z",
+      "updatedAt": "2026-04-05T12:00:00.000Z"
+    }
+  ]
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `credentials` | `array` | Array of credential metadata objects |
+| `credentials[].id` | `string` | Unique vault credential ID |
+| `credentials[].principalId` | `string` | The principal who owns this credential |
+| `credentials[].service` | `string` | Service identifier |
+| `credentials[].credentialType` | `string` | Credential type (e.g. `"oauth2"`) |
+| `credentials[].tokenExpiresAt` | `string \| null` | ISO-8601 token expiry, or `null` if not set |
+| `credentials[].metadata` | `object` | Arbitrary metadata |
+| `credentials[].createdAt` | `string` | ISO-8601 creation timestamp |
+| `credentials[].updatedAt` | `string` | ISO-8601 last update timestamp |
+
+<Note>
+Raw access tokens and refresh tokens are never included in list responses. Use the [Exchange](/api-reference/vault/exchange) endpoint to retrieve a decrypted access token with a valid grant token.
+</Note>
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 401 | `UNAUTHORIZED` | Invalid or missing API key |
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+const { credentials } = await grantex.vault.list({ principalId: 'user_abc123' });
+for (const c of credentials) {
+  console.log(`${c.service} — expires: ${c.tokenExpiresAt}`);
+}
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+result = grantex.vault.list(principal_id="user_abc123")
+for c in result.credentials:
+    print(f"{c.service} — expires: {c.token_expires_at}")
+```
+
+</CodeGroup>

--- a/docs/api-reference/vault/store.mdx
+++ b/docs/api-reference/vault/store.mdx
@@ -1,0 +1,117 @@
+---
+title: "Store Vault Credential"
+sidebarTitle: "Store Credential"
+description: "Store an encrypted service credential in the Grantex Vault for a principal."
+---
+
+## Endpoint
+
+```
+POST /v1/vault/credentials
+```
+
+## Authentication
+
+Requires a developer API key in the `Authorization` header.
+
+## Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <api_key>` |
+| `Content-Type` | `application/json` |
+
+## Request Body
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `principalId` | `string` | Yes | The principal (end-user) who owns this credential |
+| `service` | `string` | Yes | Service identifier (e.g. `"github"`, `"slack"`, `"google"`) |
+| `accessToken` | `string` | Yes | The access token to store (encrypted at rest) |
+| `credentialType` | `string` | No | Credential type (default `"oauth2"`) |
+| `refreshToken` | `string` | No | Optional refresh token (encrypted at rest) |
+| `tokenExpiresAt` | `string` | No | ISO-8601 expiry timestamp for the access token |
+| `metadata` | `object` | No | Arbitrary metadata (e.g. scopes, account info) |
+
+## Example Request
+
+```bash
+curl -X POST https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/vault/credentials \
+  -H "Authorization: Bearer gx_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "principalId": "user_abc123",
+    "service": "github",
+    "accessToken": "ghp_xxxxxxxxxxxx",
+    "refreshToken": "ghr_xxxxxxxxxxxx",
+    "tokenExpiresAt": "2026-04-06T12:00:00.000Z",
+    "metadata": { "scopes": ["repo", "read:org"] }
+  }'
+```
+
+## Response -- 201 Created
+
+```json
+{
+  "id": "vc_01HXYZ...",
+  "principalId": "user_abc123",
+  "service": "github",
+  "credentialType": "oauth2",
+  "createdAt": "2026-04-05T12:00:00.000Z"
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` | Unique vault credential ID |
+| `principalId` | `string` | The principal who owns this credential |
+| `service` | `string` | Service identifier |
+| `credentialType` | `string` | Credential type |
+| `createdAt` | `string` | ISO-8601 creation timestamp |
+
+<Note>
+If a credential already exists for the same `(developerId, principalId, service)` combination, it will be updated (upsert behavior). The raw access token and refresh token are never returned in any response -- they are stored encrypted and only retrievable via the [Exchange](/api-reference/vault/exchange) endpoint.
+</Note>
+
+## Error Responses
+
+| Status | Code | Description |
+|---|---|---|
+| 400 | `BAD_REQUEST` | Missing `principalId`, `service`, or `accessToken` |
+| 401 | `UNAUTHORIZED` | Invalid or missing API key |
+
+## SDK Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import Grantex from '@grantex/sdk';
+
+const grantex = new Grantex({ apiKey: 'gx_...' });
+
+const cred = await grantex.vault.store({
+  principalId: 'user_abc123',
+  service: 'github',
+  accessToken: 'ghp_xxxxxxxxxxxx',
+  refreshToken: 'ghr_xxxxxxxxxxxx',
+  metadata: { scopes: ['repo', 'read:org'] },
+});
+```
+
+```python Python
+from grantex import Grantex
+
+grantex = Grantex(api_key="gx_...")
+
+cred = grantex.vault.store(
+    principal_id="user_abc123",
+    service="github",
+    access_token="ghp_xxxxxxxxxxxx",
+    refresh_token="ghr_xxxxxxxxxxxx",
+    metadata={"scopes": ["repo", "read:org"]},
+)
+```
+
+</CodeGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -400,7 +400,9 @@
             "pages": [
               "api-reference/authentication/register-a-new-developer-account",
               "api-reference/authentication/get-current-developer-profile",
-              "api-reference/authentication/rotate-api-key"
+              "api-reference/authentication/rotate-api-key",
+              "api-reference/signup/send-verification",
+              "api-reference/signup/verify-token"
             ]
           },
           {
@@ -425,8 +427,16 @@
             "group": "Tokens",
             "pages": [
               "api-reference/tokens/exchange-authorization-code-for-grant-token",
+              "api-reference/tokens/refresh-a-grant-token",
               "api-reference/tokens/verify-a-grant-token-online",
               "api-reference/tokens/revoke-a-grant-token"
+            ]
+          },
+          {
+            "group": "Events",
+            "pages": [
+              "api-reference/events/stream",
+              "api-reference/events/websocket"
             ]
           },
           {
@@ -454,7 +464,11 @@
               "api-reference/policies/list-access-policies",
               "api-reference/policies/get-policy-by-id",
               "api-reference/policies/update-a-policy",
-              "api-reference/policies/delete-a-policy"
+              "api-reference/policies/delete-a-policy",
+              "api-reference/policies/sync-policy-bundle",
+              "api-reference/policies/list-bundles",
+              "api-reference/policies/active-bundle",
+              "api-reference/policies/sync-webhook"
             ]
           },
           {
@@ -479,7 +493,17 @@
             "pages": [
               "api-reference/anomalies/run-anomaly-detection",
               "api-reference/anomalies/list-detected-anomalies",
-              "api-reference/anomalies/acknowledge-an-anomaly"
+              "api-reference/anomalies/acknowledge-an-anomaly",
+              "api-reference/anomalies/list-alerts",
+              "api-reference/anomalies/acknowledge-alert",
+              "api-reference/anomalies/resolve-alert",
+              "api-reference/anomalies/get-metrics",
+              "api-reference/anomalies/list-rules",
+              "api-reference/anomalies/create-rule",
+              "api-reference/anomalies/delete-rule",
+              "api-reference/anomalies/list-channels",
+              "api-reference/anomalies/create-channel",
+              "api-reference/anomalies/delete-channel"
             ]
           },
           {
@@ -554,6 +578,42 @@
               "api-reference/webauthn/delete-credential",
               "api-reference/webauthn/generate-assertion-options",
               "api-reference/webauthn/verify-assertion"
+            ]
+          },
+          {
+            "group": "Budgets",
+            "pages": [
+              "api-reference/budgets/allocate",
+              "api-reference/budgets/debit",
+              "api-reference/budgets/balance",
+              "api-reference/budgets/transactions",
+              "api-reference/budgets/allocations"
+            ]
+          },
+          {
+            "group": "Domains",
+            "pages": [
+              "api-reference/domains/create",
+              "api-reference/domains/list",
+              "api-reference/domains/verify",
+              "api-reference/domains/delete"
+            ]
+          },
+          {
+            "group": "Usage",
+            "pages": [
+              "api-reference/usage/current",
+              "api-reference/usage/history"
+            ]
+          },
+          {
+            "group": "Vault",
+            "pages": [
+              "api-reference/vault/store",
+              "api-reference/vault/list",
+              "api-reference/vault/get",
+              "api-reference/vault/delete",
+              "api-reference/vault/exchange"
             ]
           },
           {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4088,3 +4088,936 @@ paths:
                           type: string
                         serviceEndpoint:
                           type: string
+
+  # ─── Events ────────────────────────────────────────────────────────────────────
+
+  /v1/events/stream:
+    get:
+      operationId: eventStream
+      tags: [Events]
+      summary: Server-Sent Events stream
+      description: |
+        Opens a persistent SSE connection that receives real-time events for the authenticated developer.
+        Events are forwarded from the Redis pub/sub channel `grantex:events:{developerId}`.
+
+        **Max 5 concurrent SSE connections per developer.**
+
+        Send a `types` query parameter (comma-separated) to filter by event type.
+        The stream sends `: keepalive` comments every 30 seconds to prevent timeouts.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: types
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Comma-separated event types to filter (e.g. `grant.created,token.issued`)
+      responses:
+        "200":
+          description: SSE stream opened
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: Newline-delimited SSE events (`data: {JSON}\n\n`)
+        "429":
+          description: Too many concurrent connections
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                    example: TOO_MANY_CONNECTIONS
+
+  /v1/events/ws:
+    get:
+      operationId: eventWebSocket
+      tags: [Events]
+      summary: WebSocket event stream
+      description: |
+        Opens a WebSocket connection that receives real-time events for the authenticated developer.
+        Events are forwarded from the Redis pub/sub channel `grantex:events:{developerId}`.
+
+        **Max 5 concurrent WebSocket connections per developer.**
+
+        Send a JSON message `{ "types": ["grant.created", "token.issued"] }` to filter event types dynamically.
+        The server sends WebSocket pings every 30 seconds as keepalive.
+      security:
+        - bearerAuth: []
+      responses:
+        "101":
+          description: WebSocket upgrade successful
+        "1013":
+          description: Too many connections (WebSocket close code)
+
+  # ─── Email Verification ────────────────────────────────────────────────────────
+
+  /v1/signup/verify:
+    post:
+      operationId: sendVerificationEmail
+      tags: [Authentication]
+      summary: Send verification email
+      description: |
+        Sends a verification email to the specified address. The email contains a link
+        with a unique token that expires after 24 hours. The developer must be authenticated.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                  description: Email address to verify
+              required: [email]
+      responses:
+        "201":
+          description: Verification email sent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Verification email sent
+                  expiresAt:
+                    type: string
+                    format: date-time
+                    description: When the verification token expires
+        "400":
+          description: Missing email
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/signup/verify/{token}:
+    get:
+      operationId: verifyEmailToken
+      tags: [Authentication]
+      summary: Verify email token
+      description: |
+        Verifies an email verification token received via email. This is a public endpoint
+        (no authentication required). On success, marks the developer's email as verified.
+      parameters:
+        - name: token
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Verification token from the email link
+      responses:
+        "200":
+          description: Email verified successfully (or already verified)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Email verified successfully
+        "400":
+          description: Token expired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Invalid token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  # ─── Policy Sync & Bundles ─────────────────────────────────────────────────────
+
+  /v1/policies/sync:
+    post:
+      operationId: syncPolicyBundle
+      tags: [Policies]
+      summary: Upload a policy bundle
+      description: |
+        Uploads a policy bundle (Rego or Cedar format) as base64-encoded content.
+        The bundle can optionally be activated immediately.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                format:
+                  type: string
+                  enum: [rego, cedar]
+                  description: Policy language format
+                version:
+                  type: string
+                  description: Semantic version of the bundle
+                content:
+                  type: string
+                  description: Base64-encoded bundle content
+                fileCount:
+                  type: integer
+                  description: Number of files in the bundle (default 1)
+                activate:
+                  type: boolean
+                  description: Whether to activate the bundle immediately (default true)
+              required: [format, version, content]
+      responses:
+        "201":
+          description: Policy bundle uploaded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  format:
+                    type: string
+                  version:
+                    type: string
+                  fileCount:
+                    type: integer
+                  active:
+                    type: boolean
+                  uploadedAt:
+                    type: string
+                    format: date-time
+        "400":
+          description: Invalid format, missing fields
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/policies/bundles:
+    get:
+      operationId: listPolicyBundles
+      tags: [Policies]
+      summary: List policy bundles
+      description: |
+        Returns all policy bundles uploaded by the authenticated developer.
+        Optionally filter by format (rego or cedar).
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: format
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [rego, cedar]
+          description: Filter by policy language format
+      responses:
+        "200":
+          description: List of policy bundles
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  bundles:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        format:
+                          type: string
+                        version:
+                          type: string
+                        fileCount:
+                          type: integer
+                        active:
+                          type: boolean
+                        uploadedAt:
+                          type: string
+                          format: date-time
+
+  /v1/policies/bundles/active:
+    get:
+      operationId: getActivePolicyBundle
+      tags: [Policies]
+      summary: Get active policy bundle
+      description: |
+        Returns the currently active policy bundle for the specified format.
+        Returns 404 if no active bundle exists for the given format.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: format
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [rego, cedar]
+          description: Policy language format (required)
+      responses:
+        "200":
+          description: Active policy bundle
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  format:
+                    type: string
+                  version:
+                    type: string
+                  fileCount:
+                    type: integer
+                  active:
+                    type: boolean
+                  uploadedAt:
+                    type: string
+                    format: date-time
+        "400":
+          description: Missing or invalid format parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No active bundle found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/policies/sync/webhook:
+    post:
+      operationId: policySyncWebhook
+      tags: [Policies]
+      summary: Git webhook trigger for policy sync
+      description: |
+        Receives a git webhook payload (e.g. from GitHub/GitLab push events) to trigger
+        policy bundle synchronization. Intended for CI/CD pipeline integration.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ref:
+                  type: string
+                  description: Git ref (e.g. `refs/heads/main`)
+                repository:
+                  type: object
+                  properties:
+                    full_name:
+                      type: string
+                      description: Repository full name (e.g. `org/repo`)
+      responses:
+        "200":
+          description: Webhook received
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Webhook received
+                  ref:
+                    type: string
+                  repository:
+                    type: string
+
+  # ─── Anomaly Alerts ────────────────────────────────────────────────────────────
+
+  /v1/anomaly/alerts:
+    get:
+      operationId: listAnomalyAlerts
+      tags: [Anomalies]
+      summary: List anomaly alerts
+      description: |
+        Returns anomaly alerts with optional filters for status, severity, and agent.
+        Results are ordered by detection time (newest first).
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [open, acknowledged, resolved]
+          description: Filter by alert status
+        - name: severity
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+          description: Filter by severity level
+        - name: agentId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by agent ID
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+          description: Maximum number of alerts to return
+      responses:
+        "200":
+          description: List of anomaly alerts
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        alertId:
+                          type: string
+                        ruleId:
+                          type: string
+                          nullable: true
+                        ruleName:
+                          type: string
+                        severity:
+                          type: string
+                          enum: [critical, high, medium, low]
+                        status:
+                          type: string
+                          enum: [open, acknowledged, resolved]
+                        agentId:
+                          type: string
+                          nullable: true
+                        detectedAt:
+                          type: string
+                          format: date-time
+                        description:
+                          type: string
+                        context:
+                          type: object
+                        acknowledgedAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        resolvedAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+
+  /v1/anomaly/alerts/{alertId}/acknowledge:
+    post:
+      operationId: acknowledgeAlert
+      tags: [Anomalies]
+      summary: Acknowledge an anomaly alert
+      description: |
+        Marks an anomaly alert as acknowledged. Optionally include a resolution note.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: alertId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Alert ID to acknowledge
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                note:
+                  type: string
+                  description: Optional resolution note
+      responses:
+        "200":
+          description: Alert acknowledged
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  alertId:
+                    type: string
+                  ruleId:
+                    type: string
+                    nullable: true
+                  ruleName:
+                    type: string
+                  severity:
+                    type: string
+                  status:
+                    type: string
+                    example: acknowledged
+                  agentId:
+                    type: string
+                    nullable: true
+                  detectedAt:
+                    type: string
+                    format: date-time
+                  description:
+                    type: string
+                  context:
+                    type: object
+                  acknowledgedAt:
+                    type: string
+                    format: date-time
+                  resolvedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+        "404":
+          description: Alert not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/anomaly/alerts/{alertId}/resolve:
+    post:
+      operationId: resolveAlert
+      tags: [Anomalies]
+      summary: Resolve an anomaly alert
+      description: |
+        Marks an anomaly alert as resolved. Optionally include a resolution note.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: alertId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Alert ID to resolve
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                note:
+                  type: string
+                  description: Optional resolution note
+      responses:
+        "200":
+          description: Alert resolved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  alertId:
+                    type: string
+                  ruleId:
+                    type: string
+                    nullable: true
+                  ruleName:
+                    type: string
+                  severity:
+                    type: string
+                  status:
+                    type: string
+                    example: resolved
+                  agentId:
+                    type: string
+                    nullable: true
+                  detectedAt:
+                    type: string
+                    format: date-time
+                  description:
+                    type: string
+                  context:
+                    type: object
+                  acknowledgedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  resolvedAt:
+                    type: string
+                    format: date-time
+        "404":
+          description: Alert not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  # ─── Anomaly Metrics ───────────────────────────────────────────────────────────
+
+  /v1/anomaly/metrics:
+    get:
+      operationId: getAnomalyMetrics
+      tags: [Anomalies]
+      summary: Get anomaly metrics
+      description: |
+        Returns aggregated anomaly metrics broken down by status and severity
+        within a configurable time window.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: window
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: ["1h", "6h", "24h"]
+            default: "24h"
+          description: Time window for metrics aggregation
+        - name: agentId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter metrics by agent ID
+      responses:
+        "200":
+          description: Anomaly metrics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  window:
+                    type: string
+                  total:
+                    type: integer
+                  byStatus:
+                    type: object
+                    properties:
+                      open:
+                        type: integer
+                      acknowledged:
+                        type: integer
+                      resolved:
+                        type: integer
+                  bySeverity:
+                    type: object
+                    properties:
+                      critical:
+                        type: integer
+                      high:
+                        type: integer
+                      medium:
+                        type: integer
+                      low:
+                        type: integer
+
+  # ─── Anomaly Rules ─────────────────────────────────────────────────────────────
+
+  /v1/anomaly/rules:
+    get:
+      operationId: listAnomalyRules
+      tags: [Anomalies]
+      summary: List detection rules
+      description: |
+        Returns all built-in and custom anomaly detection rules for the authenticated developer.
+        Built-in rules (AD-001 through AD-010) are always included and cannot be deleted.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: List of detection rules
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  rules:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          description: Internal ID (custom rules only)
+                        ruleId:
+                          type: string
+                          description: Rule identifier (e.g. AD-001)
+                        name:
+                          type: string
+                        description:
+                          type: string
+                          nullable: true
+                        condition:
+                          type: object
+                          description: Rule condition (custom rules only)
+                        severity:
+                          type: string
+                          enum: [critical, high, medium, low]
+                        alertChannels:
+                          type: array
+                          items:
+                            type: string
+                          description: Channel IDs to notify (custom rules only)
+                        enabled:
+                          type: boolean
+                        builtIn:
+                          type: boolean
+                        createdAt:
+                          type: string
+                          format: date-time
+                          description: Creation timestamp (custom rules only)
+
+    post:
+      operationId: createAnomalyRule
+      tags: [Anomalies]
+      summary: Create a custom detection rule
+      description: |
+        Creates a custom anomaly detection rule with a condition object and optional alert channels.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ruleId:
+                  type: string
+                  description: Unique rule identifier (e.g. CUSTOM-001)
+                name:
+                  type: string
+                  description: Human-readable rule name
+                description:
+                  type: string
+                  description: Optional description of what the rule detects
+                condition:
+                  type: object
+                  description: Rule condition definition
+                severity:
+                  type: string
+                  enum: [critical, high, medium, low]
+                  default: medium
+                  description: Alert severity when the rule triggers
+                alertChannels:
+                  type: array
+                  items:
+                    type: string
+                  description: Notification channel IDs to alert
+              required: [ruleId, name, condition]
+      responses:
+        "201":
+          description: Custom rule created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  ruleId:
+                    type: string
+                  name:
+                    type: string
+                  description:
+                    type: string
+                    nullable: true
+                  condition:
+                    type: object
+                  severity:
+                    type: string
+                  alertChannels:
+                    type: array
+                    items:
+                      type: string
+                  enabled:
+                    type: boolean
+        "400":
+          description: Missing required fields or invalid severity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/anomaly/rules/{ruleId}:
+    delete:
+      operationId: deleteAnomalyRule
+      tags: [Anomalies]
+      summary: Delete a custom detection rule
+      description: |
+        Deletes a custom anomaly detection rule. Built-in rules cannot be deleted.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: ruleId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Internal ID of the custom rule to delete
+      responses:
+        "204":
+          description: Rule deleted
+        "404":
+          description: Rule not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  # ─── Anomaly Channels ─────────────────────────────────────────────────────────
+
+  /v1/anomaly/channels:
+    get:
+      operationId: listAnomalyChannels
+      tags: [Anomalies]
+      summary: List notification channels
+      description: |
+        Returns all notification channels configured for the authenticated developer.
+        Channels receive alerts when detection rules fire.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: List of notification channels
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  channels:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          type: string
+                          enum: [slack, webhook, email]
+                        name:
+                          type: string
+                        config:
+                          type: object
+                          description: Channel-specific configuration (e.g. URL, email)
+                        severities:
+                          type: array
+                          items:
+                            type: string
+                          description: Severity levels this channel receives
+                        enabled:
+                          type: boolean
+                        createdAt:
+                          type: string
+                          format: date-time
+
+    post:
+      operationId: createAnomalyChannel
+      tags: [Anomalies]
+      summary: Create a notification channel
+      description: |
+        Creates a notification channel for anomaly alerts. Supported types: slack, webhook, email.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum: [slack, webhook, email]
+                  description: Channel type
+                name:
+                  type: string
+                  description: Human-readable channel name
+                config:
+                  type: object
+                  description: |
+                    Channel-specific configuration.
+                    - **slack**: `{ "webhookUrl": "https://hooks.slack.com/..." }`
+                    - **webhook**: `{ "url": "https://example.com/hook", "secret": "..." }`
+                    - **email**: `{ "to": "alerts@example.com" }`
+                severities:
+                  type: array
+                  items:
+                    type: string
+                    enum: [critical, high, medium, low]
+                  default: [critical, high]
+                  description: Severity levels to receive (defaults to critical and high)
+              required: [type, name, config]
+      responses:
+        "201":
+          description: Notification channel created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  type:
+                    type: string
+                  name:
+                    type: string
+                  config:
+                    type: object
+                  severities:
+                    type: array
+                    items:
+                      type: string
+                  enabled:
+                    type: boolean
+        "400":
+          description: Missing or invalid fields
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/anomaly/channels/{channelId}:
+    delete:
+      operationId: deleteAnomalyChannel
+      tags: [Anomalies]
+      summary: Delete a notification channel
+      description: |
+        Deletes a notification channel.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: channelId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Channel ID to delete
+      responses:
+        "204":
+          description: Channel deleted
+        "404":
+          description: Channel not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"

--- a/packages/go-sdk/http.go
+++ b/packages/go-sdk/http.go
@@ -163,6 +163,20 @@ func unmarshal[T any](data []byte, err error) (*T, error) {
 	return &result, nil
 }
 
+func unmarshalSlice[T any](data []byte, err error) ([]T, error) {
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, nil
+	}
+	var result []T
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, &NetworkError{Message: fmt.Sprintf("failed to decode response: %s", string(data)), Cause: err}
+	}
+	return result, nil
+}
+
 func buildQueryString(params map[string]string) string {
 	if len(params) == 0 {
 		return ""

--- a/packages/go-sdk/passports.go
+++ b/packages/go-sdk/passports.go
@@ -55,10 +55,6 @@ type ListPassportsParams struct {
 	Status  string
 }
 
-type listPassportsResponse struct {
-	Passports []IssuedPassportResponse `json:"passports"`
-}
-
 // Issue creates a new Agent Passport Credential.
 func (s *PassportsService) Issue(ctx context.Context, params IssuePassportParams) (*IssuedPassportResponse, error) {
 	return unmarshal[IssuedPassportResponse](s.http.post(ctx, "/v1/passport/issue", params))
@@ -92,9 +88,10 @@ func (s *PassportsService) List(ctx context.Context, params *ListPassportsParams
 			path += "?" + qs
 		}
 	}
-	resp, err := unmarshal[listPassportsResponse](s.http.get(ctx, path))
+	// API returns a bare JSON array, not a wrapped object
+	resp, err := unmarshalSlice[IssuedPassportResponse](s.http.get(ctx, path))
 	if err != nil {
 		return nil, err
 	}
-	return resp.Passports, nil
+	return resp, nil
 }

--- a/packages/sdk-py/src/grantex/resources/_budgets.py
+++ b/packages/sdk-py/src/grantex/resources/_budgets.py
@@ -34,13 +34,23 @@ class BudgetsClient:
     def transactions(
         self,
         grant_id: str,
-        page: int = 1,
-        page_size: int = 20,
+        page: int | None = None,
+        page_size: int | None = None,
     ) -> BudgetTransactionsResponse:
-        """List budget transactions for a grant."""
+        """List budget transactions for a grant.
+
+        Args:
+            grant_id: The grant to list transactions for.
+            page: Page number. If omitted, the server decides the default.
+            page_size: Number of items per page. If omitted, the server
+                       decides the default.
+        """
         params: list[str] = []
-        params.append(f"page={page}")
-        params.append(f"pageSize={page_size}")
+        if page is not None:
+            params.append(f"page={page}")
+        if page_size is not None:
+            params.append(f"pageSize={page_size}")
         qs = "&".join(params)
-        data = self._http.get(f"/v1/budget/transactions/{grant_id}?{qs}")
+        url = f"/v1/budget/transactions/{grant_id}{('?' + qs) if qs else ''}"
+        data = self._http.get(url)
         return BudgetTransactionsResponse.from_dict(data)

--- a/packages/sdk-py/src/grantex/resources/_events.py
+++ b/packages/sdk-py/src/grantex/resources/_events.py
@@ -93,9 +93,10 @@ class EventsClient:
     ) -> Subscription:
         """Subscribe to events with a callback handler.
 
-        Starts a background thread that calls ``stream()`` and invokes
-        *handler* for each event.  Returns a :class:`Subscription` whose
-        ``unsubscribe()`` method stops the thread.
+        Starts a background thread that connects to the SSE stream and
+        invokes *handler* for each event.  Returns a :class:`Subscription`
+        whose ``unsubscribe()`` method cancels the HTTP connection and
+        stops the thread.
 
         Args:
             handler: Called with each :class:`GrantexEvent` received.
@@ -105,17 +106,52 @@ class EventsClient:
                 and the stream stops.
         """
         stop = threading.Event()
+        # Dedicated client so unsubscribe() can close() it to cancel blocked reads
+        cancel_client = httpx.Client()
 
         def _run() -> None:
+            params: dict[str, str] = {}
+            if options and options.types:
+                params["types"] = ",".join(options.types)
+            url = f"{self._base_url}/v1/events/stream"
             try:
-                for event in self.stream(options):
-                    if stop.is_set():
-                        break
-                    handler(event)
+                with cancel_client.stream(
+                    "GET",
+                    url,
+                    params=params,
+                    headers={"Authorization": f"Bearer {self._api_key}"},
+                    timeout=None,
+                ) as response:
+                    response.raise_for_status()
+                    buffer = ""
+                    for chunk in response.iter_text():
+                        if stop.is_set():
+                            break
+                        buffer += chunk
+                        while "\n" in buffer:
+                            line, buffer = buffer.split("\n", 1)
+                            if line.startswith("data: "):
+                                try:
+                                    data = json.loads(line[6:])
+                                    handler(GrantexEvent.from_dict(data))
+                                except (json.JSONDecodeError, KeyError):
+                                    pass
             except Exception as exc:  # noqa: BLE001
-                if on_error is not None:
+                if not stop.is_set() and on_error is not None:
                     on_error(exc)
+
+        old_unsubscribe = Subscription.unsubscribe
 
         thread = threading.Thread(target=_run, daemon=True)
         thread.start()
-        return Subscription(thread=thread, stop_event=stop)
+        sub = Subscription(thread=thread, stop_event=stop)
+
+        # Override unsubscribe to also close the HTTP client, canceling blocked reads
+        def _cancel_unsubscribe(self_sub: Subscription) -> None:
+            self_sub._stop_event.set()
+            cancel_client.close()
+            self_sub._thread.join(timeout=5)
+
+        import types as _types
+        sub.unsubscribe = _types.MethodType(_cancel_unsubscribe, sub)  # type: ignore[method-assign]
+        return sub

--- a/packages/sdk-py/src/grantex/resources/_usage.py
+++ b/packages/sdk-py/src/grantex/resources/_usage.py
@@ -89,7 +89,17 @@ class UsageClient:
         data = self._http.get("/v1/usage")
         return UsageResponse.from_dict(data)
 
-    def history(self, days: int = 30) -> UsageHistoryResponse:
-        """Get daily usage history."""
-        data = self._http.get(f"/v1/usage/history?days={days}")
+    def history(self, days: int | None = None) -> UsageHistoryResponse:
+        """Get daily usage history.
+
+        Args:
+            days: Number of days of history to retrieve. If omitted, the
+                  server decides the default.
+        """
+        params: list[str] = []
+        if days is not None:
+            params.append(f"days={days}")
+        qs = "&".join(params)
+        url = f"/v1/usage/history{('?' + qs) if qs else ''}"
+        data = self._http.get(url)
         return UsageHistoryResponse.from_dict(data)

--- a/packages/sdk-py/tests/test_budgets.py
+++ b/packages/sdk-py/tests/test_budgets.py
@@ -121,7 +121,7 @@ def test_balance() -> None:
 
 @respx.mock
 def test_transactions() -> None:
-    respx.get(f"{BASE_URL}/v1/budget/transactions/grant_01?page=1&pageSize=20").mock(
+    respx.get(f"{BASE_URL}/v1/budget/transactions/grant_01").mock(
         return_value=httpx.Response(200, json={
             "transactions": [MOCK_TRANSACTION],
             "total": 1,

--- a/packages/sdk-py/tests/test_usage.py
+++ b/packages/sdk-py/tests/test_usage.py
@@ -141,12 +141,15 @@ def test_current_usage_unauthorized(client: Grantex) -> None:
 
 @respx.mock
 def test_usage_history_default_days(client: Grantex) -> None:
-    route = respx.get(f"{BASE_URL}/v1/usage/history?days=30").mock(
+    route = respx.get(f"{BASE_URL}/v1/usage/history").mock(
         return_value=httpx.Response(200, json=MOCK_HISTORY)
     )
     result = client.usage.history()
 
     assert route.called
+    # When called without args, no query params should be sent
+    request_url = str(route.calls[0].request.url)
+    assert "days=" not in request_url
     assert result.developer_id == "dev_01"
     assert result.days == 7  # from mock response
     assert len(result.entries) == 3
@@ -225,7 +228,7 @@ def test_usage_history_url_format(client: Grantex) -> None:
 
 @respx.mock
 def test_usage_history_server_error(client: Grantex) -> None:
-    respx.get(f"{BASE_URL}/v1/usage/history?days=30").mock(
+    respx.get(f"{BASE_URL}/v1/usage/history").mock(
         return_value=httpx.Response(
             500, json={"message": "Internal server error", "code": "INTERNAL_ERROR"}
         )


### PR DESCRIPTION
## Summary
Addresses remaining issues #6, #8, #11, #12 from codebase review.

### API Documentation — 35 new pages for 29 previously undocumented endpoints
| Group | Pages | Endpoints |
|-------|-------|-----------|
| Budgets | 5 | allocate, debit, balance, transactions, allocations |
| Domains | 4 | create, list, verify, delete |
| Usage | 2 | current, history |
| Vault | 5 | store, list, get, delete, exchange |
| Events | 2 | SSE stream, WebSocket |
| Tokens | 1 | refresh |
| Signup | 2 | send-verification, verify-token |
| Policies | 4 | sync-bundle, list-bundles, active-bundle, sync-webhook |
| Anomalies | 10 | alerts, rules, channels, metrics CRUD |

Updated OpenAPI spec + docs.json navigation.

### Python SDK parity
- `usage.history()` — `days` param now truly optional (was hardcoded to 30)
- `budgets.transactions()` — pagination params now truly optional (was hardcoded defaults)

### Testing
- 15 new anomalies tests covering all untested endpoints (24 total, up from 9)

### Database
- Migration 030: drop orphaned `signing_keys` table (created in 019 but never used)

## Test plan
- [ ] `cd apps/auth-service && npx vitest run tests/anomalies.test.ts`
- [ ] `cd packages/sdk-py && python -m pytest tests/test_usage.py tests/test_budgets.py`
- [ ] Verify docs build: `cd docs && mintlify dev`