### PR TITLE
chore: bump SDK 0.3.4, mcp-auth 2.0.1

### DIFF
--- a/packages/mcp-auth/package.json
+++ b/packages/mcp-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/mcp-auth",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "OAuth 2.1 + PKCE authorization server for MCP servers, powered by Grantex",
   "homepage": "https://grantex.dev/for/mcp",
   "bugs": {

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.3.3"
+version = "0.3.4"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev",
   "bugs": {


### PR DESCRIPTION
## Summary
Version bumps for packages with code changes from review fixes (#262, #263).

| Package | Old | New | Changes |
|---------|-----|-----|---------|
| `@grantex/sdk` | 0.3.3 | 0.3.4 | AuthorizationRequest fields |
| `grantex` (PyPI) | 0.3.3 | 0.3.4 | PassportsClient, subscribe(), param fixes |
| `@grantex/mcp-auth` | 2.0.0 | 2.0.1 | Peer dep constraint fix |

Go SDK version bump handled separately via git tag.

## Test results (all local, all passing)
- TypeScript SDK: 386 passed
- Python SDK: 562 passed
- Go SDK: passed
- Auth Service: 974 passed

## Publish plan
After merge:
1. `npm publish` for `@grantex/sdk` and `@grantex/mcp-auth` (PowerShell, OTP)
2. `twine upload` for `grantex` Python package
3. `git tag v0.1.4` on go-sdk for Go module