### PR TITLE
fix: low-priority review items — 233 new tests, docs, version constraints

### DIFF
--- a/docs/features/mpp-agent-passport.mdx
+++ b/docs/features/mpp-agent-passport.mdx
@@ -125,6 +125,16 @@ Trust levels: `basic` (self-declared), `verified` (DNS-TXT proof), `soc2` (SOC 2
 | `GET` | `/v1/trust-registry/:orgDID` | None | Look up org trust record (public) |
 | `GET` | `/v1/trust-registry` | API key | List all trust records (admin) |
 
+## SDK Support
+
+The PassportsClient / PassportsService is available across all three SDKs:
+
+| SDK | Access | Since |
+|-----|--------|-------|
+| **TypeScript** (`@grantex/sdk`) | `client.passports.issue(...)` | 0.3.3 |
+| **Python** (`grantex`) | `client.passports.issue(...)` | 0.3.3 |
+| **Go** (`grantex-go`) | `client.Passports.Issue(ctx, ...)` | 0.1.3 |
+
 ## Next Steps
 
 - **[MPP Integration Guide](/guides/mpp-integration)** — step-by-step setup for agents and merchants

--- a/docs/sdks/go/overview.mdx
+++ b/docs/sdks/go/overview.mdx
@@ -109,6 +109,8 @@ func main() {
 | `client.SCIM` | SCIM 2.0 user provisioning |
 | `client.SSO` | SSO configuration |
 | `client.PrincipalSessions` | End-user dashboard sessions |
+| `client.Passports` | Issue, list, get, and revoke MPP agent passports |
+| `client.Vault` | Store, list, get, delete, and exchange service credentials |
 
 ## Standalone Functions
 

--- a/docs/sdks/python/overview.mdx
+++ b/docs/sdks/python/overview.mdx
@@ -122,6 +122,7 @@ The `Grantex` client exposes the following resource clients as attributes:
 | `anomalies`   | `AnomaliesClient`  | Detect, list, and acknowledge anomalies  |
 | `scim`        | `ScimClient`       | SCIM 2.0 user provisioning and tokens    |
 | `sso`         | `SsoClient`        | OIDC SSO configuration and login         |
+| `passports`   | `PassportsClient`  | Issue, list, get, and revoke MPP agent passports |
 
 ## Standalone Functions
 

--- a/packages/a2a-py/pyproject.toml
+++ b/packages/a2a-py/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "grantex>=0.1.0",
+    "grantex>=0.3.0",
 ]
 
 [project.urls]

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -26,7 +26,7 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@grantex/sdk": ">=0.1.0"
+    "@grantex/sdk": ">=0.3.0"
   },
   "devDependencies": {
     "@grantex/sdk": "file:../sdk-ts",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -24,7 +24,7 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@grantex/sdk": ">=0.1.0"
+    "@grantex/sdk": ">=0.3.0"
   },
   "devDependencies": {
     "@grantex/sdk": "^0.1.5",

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -26,7 +26,7 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@grantex/sdk": ">=0.1.0",
+    "@grantex/sdk": ">=0.3.0",
     "@anthropic-ai/sdk": ">=0.30.0"
   },
   "devDependencies": {

--- a/packages/anthropic/tests/jwt.test.ts
+++ b/packages/anthropic/tests/jwt.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { decodeJwtPayload } from '../src/_jwt.js';
+
+/** Build a minimal JWT with the given payload claims. */
+function createTestToken(payload: Record<string, unknown> = {}): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify({
+    iss: 'https://grantex.dev',
+    sub: 'user_123',
+    agt: 'did:grantex:ag_TEST',
+    dev: 'dev_TEST',
+    scp: ['read', 'write'],
+    jti: 'tok_TEST',
+    grnt: 'grnt_TEST',
+    iat: 1700000000,
+    exp: 1700003600,
+    ...payload,
+  })).toString('base64url');
+  const sig = Buffer.from('test-signature').toString('base64url');
+  return `${header}.${body}.${sig}`;
+}
+
+describe('decodeJwtPayload', () => {
+  it('decodes a valid JWT payload', () => {
+    const token = createTestToken();
+    const payload = decodeJwtPayload(token);
+
+    expect(payload.iss).toBe('https://grantex.dev');
+    expect(payload.sub).toBe('user_123');
+    expect(payload.agt).toBe('did:grantex:ag_TEST');
+    expect(payload.dev).toBe('dev_TEST');
+    expect(payload.scp).toEqual(['read', 'write']);
+    expect(payload.jti).toBe('tok_TEST');
+    expect(payload.grnt).toBe('grnt_TEST');
+    expect(payload.iat).toBe(1700000000);
+    expect(payload.exp).toBe(1700003600);
+  });
+
+  it('extracts scopes from the scp claim', () => {
+    const token = createTestToken({ scp: ['calendar:read', 'profile:read', 'email:write'] });
+    const payload = decodeJwtPayload(token);
+
+    expect(payload.scp).toEqual(['calendar:read', 'profile:read', 'email:write']);
+  });
+
+  it('decodes delegation claims', () => {
+    const token = createTestToken({
+      parentAgt: 'did:grantex:ag_PARENT',
+      parentGrnt: 'grnt_PARENT',
+      delegationDepth: 1,
+    });
+    const payload = decodeJwtPayload(token);
+
+    expect(payload.parentAgt).toBe('did:grantex:ag_PARENT');
+    expect(payload.parentGrnt).toBe('grnt_PARENT');
+    expect(payload.delegationDepth).toBe(1);
+  });
+
+  it('decodes budget claim', () => {
+    const token = createTestToken({ bdg: 42.50 });
+    const payload = decodeJwtPayload(token);
+    expect(payload.bdg).toBe(42.50);
+  });
+
+  it('decodes audience claim', () => {
+    const token = createTestToken({ aud: 'https://api.example.com' });
+    const payload = decodeJwtPayload(token);
+    expect(payload.aud).toBe('https://api.example.com');
+  });
+
+  it('handles base64url characters (+ and /) correctly', () => {
+    const token = createTestToken({ note: '>>>???<<<' });
+    const payload = decodeJwtPayload(token);
+    expect(payload.note).toBe('>>>???<<<');
+  });
+
+  it('throws on empty string', () => {
+    expect(() => decodeJwtPayload('')).toThrow('invalid JWT format');
+  });
+
+  it('throws on string with only one part', () => {
+    expect(() => decodeJwtPayload('header-only')).toThrow('invalid JWT format');
+  });
+
+  it('throws on string with empty second part', () => {
+    expect(() => decodeJwtPayload('header.')).toThrow('invalid JWT format');
+  });
+
+  it('throws on malformed base64 in payload', () => {
+    expect(() => decodeJwtPayload('eyJhbGciOiJSUzI1NiJ9.!!!invalid!!!.fakesig')).toThrow();
+  });
+
+  it('returns Record<string, unknown> type', () => {
+    const token = createTestToken({ custom: 'value' });
+    const payload = decodeJwtPayload(token);
+    expect(typeof payload).toBe('object');
+    expect(payload.custom).toBe('value');
+  });
+});

--- a/packages/autogen/package.json
+++ b/packages/autogen/package.json
@@ -26,7 +26,7 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@grantex/sdk": ">=0.1.0"
+    "@grantex/sdk": ">=0.3.0"
   },
   "overrides": {
     "esbuild": ">=0.25.0"

--- a/packages/autogen/tests/jwt.test.ts
+++ b/packages/autogen/tests/jwt.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { decodeJwtPayload } from '../src/_jwt.js';
+
+/** Build a minimal JWT with the given payload claims. */
+function createTestToken(payload: Record<string, unknown> = {}): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify({
+    iss: 'https://grantex.dev',
+    sub: 'user_123',
+    agt: 'did:grantex:ag_TEST',
+    dev: 'dev_TEST',
+    scp: ['read', 'write'],
+    jti: 'tok_TEST',
+    grnt: 'grnt_TEST',
+    iat: 1700000000,
+    exp: 1700003600,
+    ...payload,
+  })).toString('base64url');
+  const sig = Buffer.from('test-signature').toString('base64url');
+  return `${header}.${body}.${sig}`;
+}
+
+describe('decodeJwtPayload', () => {
+  it('decodes a valid JWT payload', () => {
+    const token = createTestToken();
+    const payload = decodeJwtPayload(token);
+
+    expect(payload.iss).toBe('https://grantex.dev');
+    expect(payload.sub).toBe('user_123');
+    expect(payload.agt).toBe('did:grantex:ag_TEST');
+    expect(payload.dev).toBe('dev_TEST');
+    expect(payload.scp).toEqual(['read', 'write']);
+    expect(payload.jti).toBe('tok_TEST');
+    expect(payload.grnt).toBe('grnt_TEST');
+    expect(payload.iat).toBe(1700000000);
+    expect(payload.exp).toBe(1700003600);
+  });
+
+  it('extracts scopes from the scp claim', () => {
+    const token = createTestToken({ scp: ['calendar:read', 'profile:read', 'email:write'] });
+    const payload = decodeJwtPayload(token);
+
+    expect(payload.scp).toEqual(['calendar:read', 'profile:read', 'email:write']);
+  });
+
+  it('decodes delegation claims', () => {
+    const token = createTestToken({
+      parentAgt: 'did:grantex:ag_PARENT',
+      parentGrnt: 'grnt_PARENT',
+      delegationDepth: 1,
+    });
+    const payload = decodeJwtPayload(token);
+
+    expect(payload.parentAgt).toBe('did:grantex:ag_PARENT');
+    expect(payload.parentGrnt).toBe('grnt_PARENT');
+    expect(payload.delegationDepth).toBe(1);
+  });
+
+  it('decodes budget claim', () => {
+    const token = createTestToken({ bdg: 42.50 });
+    const payload = decodeJwtPayload(token);
+    expect(payload.bdg).toBe(42.50);
+  });
+
+  it('decodes audience claim', () => {
+    const token = createTestToken({ aud: 'https://api.example.com' });
+    const payload = decodeJwtPayload(token);
+    expect(payload.aud).toBe('https://api.example.com');
+  });
+
+  it('handles base64url characters (+ and /) correctly', () => {
+    const token = createTestToken({ note: '>>>???<<<' });
+    const payload = decodeJwtPayload(token);
+    expect(payload.note).toBe('>>>???<<<');
+  });
+
+  it('throws on empty string', () => {
+    expect(() => decodeJwtPayload('')).toThrow('invalid JWT format');
+  });
+
+  it('throws on string with only one part', () => {
+    expect(() => decodeJwtPayload('header-only')).toThrow('invalid JWT format');
+  });
+
+  it('throws on string with empty second part', () => {
+    expect(() => decodeJwtPayload('header.')).toThrow('invalid JWT format');
+  });
+
+  it('throws on malformed base64 in payload', () => {
+    expect(() => decodeJwtPayload('eyJhbGciOiJSUzI1NiJ9.!!!invalid!!!.fakesig')).toThrow();
+  });
+
+  it('returns Record<string, unknown> type', () => {
+    const token = createTestToken({ custom: 'value' });
+    const payload = decodeJwtPayload(token);
+    expect(typeof payload).toBe('object');
+    expect(payload.custom).toBe('value');
+  });
+});

--- a/packages/crewai/pyproject.toml
+++ b/packages/crewai/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "grantex>=0.1.0",
+    "grantex>=0.3.0",
 ]
 
 [project.urls]

--- a/packages/dpdp/tests/consent.test.ts
+++ b/packages/dpdp/tests/consent.test.ts
@@ -1,0 +1,446 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  computeNoticeHash,
+  validateNotice,
+  createConsentNotice,
+} from '../src/consent/consent-notice.js';
+import { ConsentRegistry } from '../src/consent/consent-registry.js';
+import { DpdpError } from '../src/errors.js';
+import type { ConsentNotice, DPDPConsentRecord } from '../src/types.js';
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function makeNotice(overrides?: Partial<ConsentNotice>): ConsentNotice {
+  return {
+    noticeId: 'notice_01',
+    language: 'en',
+    version: '1.0',
+    title: 'Data Processing Notice',
+    content: 'We process your data for the following purposes.',
+    purposes: [
+      {
+        purposeId: 'p1',
+        name: 'Email Access',
+        description: 'Read and send emails',
+        legalBasis: 'consent',
+        dataCategories: ['email'],
+        retentionPeriod: '1 year',
+        thirdPartySharing: false,
+      },
+    ],
+    dataFiduciaryContact: 'privacy@example.com',
+    contentHash: 'hash_placeholder',
+    ...overrides,
+  };
+}
+
+function makeRecord(overrides?: Partial<DPDPConsentRecord>): DPDPConsentRecord {
+  return {
+    recordId: 'rec_001',
+    grantId: 'grant_abc',
+    dataPrincipalId: 'principal_1',
+    dataFiduciaryId: 'fid_1',
+    dataFiduciaryName: 'Acme Corp',
+    purposes: [
+      {
+        purposeId: 'p1',
+        name: 'Email Access',
+        description: 'Read and send emails on behalf of the user',
+        legalBasis: 'consent',
+        dataCategories: ['email', 'contacts'],
+        retentionPeriod: '1 year',
+        thirdPartySharing: false,
+      },
+    ],
+    scopes: ['email:read', 'email:send'],
+    consentNoticeId: 'notice_1',
+    consentNoticeHash: 'abc123hash',
+    consentGivenAt: new Date('2026-01-01T00:00:00Z'),
+    consentMethod: 'explicit-click',
+    processingExpiresAt: new Date('2027-01-01T00:00:00Z'),
+    retentionUntil: new Date('2028-01-01T00:00:00Z'),
+    consentProof: {
+      signedAt: new Date('2026-01-01T00:00:00Z'),
+      signature: 'ed25519sig==',
+    },
+    status: 'active',
+    accessCount: 0,
+    actions: [],
+    ...overrides,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  consent-notice tests                                               */
+/* ------------------------------------------------------------------ */
+
+describe('consent-notice', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('computeNoticeHash', () => {
+    it('produces a 64-char hex SHA-256 hash', async () => {
+      const hash = await computeNoticeHash('test content');
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('produces deterministic output', async () => {
+      const h1 = await computeNoticeHash('same input');
+      const h2 = await computeNoticeHash('same input');
+      expect(h1).toBe(h2);
+    });
+
+    it('produces different hashes for different content', async () => {
+      const h1 = await computeNoticeHash('content A');
+      const h2 = await computeNoticeHash('content B');
+      expect(h1).not.toBe(h2);
+    });
+
+    it('handles empty string', async () => {
+      const hash = await computeNoticeHash('');
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('handles Unicode content', async () => {
+      const hash = await computeNoticeHash('हम आपका डेटा प्रोसेस करते हैं');
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+  });
+
+  describe('validateNotice', () => {
+    it('returns empty array for valid notice', () => {
+      const errors = validateNotice(makeNotice());
+      expect(errors).toEqual([]);
+    });
+
+    it('reports missing noticeId', () => {
+      const errors = validateNotice(makeNotice({ noticeId: '' }));
+      expect(errors).toContain('noticeId is required');
+    });
+
+    it('reports missing language', () => {
+      const errors = validateNotice(makeNotice({ language: '' }));
+      expect(errors).toContain('language is required');
+    });
+
+    it('reports missing version', () => {
+      const errors = validateNotice(makeNotice({ version: '' }));
+      expect(errors).toContain('version is required');
+    });
+
+    it('reports missing title', () => {
+      const errors = validateNotice(makeNotice({ title: '' }));
+      expect(errors).toContain('title is required');
+    });
+
+    it('reports missing content', () => {
+      const errors = validateNotice(makeNotice({ content: '' }));
+      expect(errors).toContain('content is required');
+    });
+
+    it('reports missing dataFiduciaryContact', () => {
+      const errors = validateNotice(makeNotice({ dataFiduciaryContact: '' }));
+      expect(errors).toContain('dataFiduciaryContact is required');
+    });
+
+    it('reports missing contentHash', () => {
+      const errors = validateNotice(makeNotice({ contentHash: '' }));
+      expect(errors).toContain('contentHash is required');
+    });
+
+    it('reports when purposes array is empty', () => {
+      const errors = validateNotice(makeNotice({ purposes: [] }));
+      expect(errors).toContain('At least one purpose must be specified');
+    });
+
+    it('reports missing purpose fields', () => {
+      const errors = validateNotice(
+        makeNotice({
+          purposes: [
+            {
+              purposeId: '',
+              name: '',
+              description: '',
+              legalBasis: 'consent',
+              dataCategories: [],
+              retentionPeriod: '',
+              thirdPartySharing: false,
+            },
+          ],
+        }),
+      );
+
+      expect(errors.some((e) => e.includes('purposeId'))).toBe(true);
+      expect(errors.some((e) => e.includes('name'))).toBe(true);
+      expect(errors.some((e) => e.includes('description'))).toBe(true);
+    });
+
+    it('reports multiple errors at once', () => {
+      const errors = validateNotice(
+        makeNotice({ noticeId: '', language: '', version: '' }),
+      );
+      expect(errors.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('createConsentNotice', () => {
+    it('sends correct request body to the API', async () => {
+      const serverResponse = makeNotice({ noticeId: 'notice_from_server' });
+
+      let capturedBody: Record<string, unknown> | null = null;
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (_url: string, init: RequestInit) => {
+          capturedBody = JSON.parse(init.body as string);
+          return {
+            ok: true,
+            json: () => Promise.resolve(serverResponse),
+          };
+        }),
+      );
+
+      const result = await createConsentNotice({
+        language: 'en',
+        version: '1.0',
+        title: 'Data Processing Notice',
+        content: 'We process your data.',
+        purposes: [
+          {
+            purposeId: 'p1',
+            name: 'Email',
+            description: 'Read email',
+            legalBasis: 'consent',
+            dataCategories: ['email'],
+            retentionPeriod: '1 year',
+            thirdPartySharing: false,
+          },
+        ],
+        dataFiduciaryContact: 'privacy@example.com',
+        apiKey: 'test-key',
+        baseUrl: 'https://api.test.local',
+      });
+
+      expect(result.noticeId).toBe('notice_from_server');
+      expect(capturedBody!.language).toBe('en');
+      expect(capturedBody!.contentHash).toBeTruthy();
+      expect(typeof capturedBody!.contentHash).toBe('string');
+    });
+
+    it('throws DpdpError for invalid notice', async () => {
+      await expect(
+        createConsentNotice({
+          language: 'en',
+          version: '1.0',
+          title: '',
+          content: '',
+          purposes: [],
+          dataFiduciaryContact: '',
+          apiKey: 'key',
+          baseUrl: 'https://api.test.local',
+        }),
+      ).rejects.toThrow(DpdpError);
+    });
+
+    it('throws DpdpError on HTTP error', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          ok: false,
+          status: 500,
+          json: () => Promise.resolve({ message: 'Internal error' }),
+        })),
+      );
+
+      await expect(
+        createConsentNotice({
+          language: 'en',
+          version: '1.0',
+          title: 'Notice',
+          content: 'Content',
+          purposes: [
+            {
+              purposeId: 'p1',
+              name: 'Purpose',
+              description: 'Desc',
+              legalBasis: 'consent',
+              dataCategories: ['data'],
+              retentionPeriod: '1y',
+              thirdPartySharing: false,
+            },
+          ],
+          dataFiduciaryContact: 'contact@test.com',
+          apiKey: 'key',
+          baseUrl: 'https://api.test.local',
+        }),
+      ).rejects.toThrow(DpdpError);
+    });
+
+    it('includes grievanceOfficer when provided', async () => {
+      const serverResponse = makeNotice();
+
+      let capturedBody: Record<string, unknown> | null = null;
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (_url: string, init: RequestInit) => {
+          capturedBody = JSON.parse(init.body as string);
+          return {
+            ok: true,
+            json: () => Promise.resolve(serverResponse),
+          };
+        }),
+      );
+
+      await createConsentNotice({
+        language: 'en',
+        version: '1.0',
+        title: 'Notice',
+        content: 'Content',
+        purposes: [
+          {
+            purposeId: 'p1',
+            name: 'Purpose',
+            description: 'Desc',
+            legalBasis: 'consent',
+            dataCategories: ['data'],
+            retentionPeriod: '1y',
+            thirdPartySharing: false,
+          },
+        ],
+        dataFiduciaryContact: 'contact@test.com',
+        grievanceOfficer: {
+          name: 'Officer Name',
+          email: 'grievance@test.com',
+          address: '123 Street',
+        },
+        apiKey: 'key',
+        baseUrl: 'https://api.test.local',
+      });
+
+      expect(capturedBody!.grievanceOfficer).toEqual({
+        name: 'Officer Name',
+        email: 'grievance@test.com',
+        address: '123 Street',
+      });
+    });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  consent-registry tests                                             */
+/* ------------------------------------------------------------------ */
+
+describe('consent-registry', () => {
+  it('registers and retrieves a record by ID', () => {
+    const registry = new ConsentRegistry();
+    const record = makeRecord();
+    registry.register(record);
+
+    const retrieved = registry.get('rec_001');
+    expect(retrieved).toBeDefined();
+    expect(retrieved!.recordId).toBe('rec_001');
+    expect(retrieved!.grantId).toBe('grant_abc');
+  });
+
+  it('freezes registered records (immutable)', () => {
+    const registry = new ConsentRegistry();
+    registry.register(makeRecord());
+
+    const retrieved = registry.get('rec_001');
+    expect(Object.isFrozen(retrieved)).toBe(true);
+  });
+
+  it('rejects duplicate registration', () => {
+    const registry = new ConsentRegistry();
+    registry.register(makeRecord());
+
+    expect(() => registry.register(makeRecord())).toThrow('immutable');
+  });
+
+  it('returns undefined for non-existent record', () => {
+    const registry = new ConsentRegistry();
+    expect(registry.get('nonexistent')).toBeUndefined();
+  });
+
+  it('lists records for a given principal', () => {
+    const registry = new ConsentRegistry();
+    registry.register(makeRecord({ recordId: 'r1', dataPrincipalId: 'alice' }));
+    registry.register(makeRecord({ recordId: 'r2', dataPrincipalId: 'alice' }));
+    registry.register(makeRecord({ recordId: 'r3', dataPrincipalId: 'bob' }));
+
+    const aliceRecords = registry.listForPrincipal('alice');
+    expect(aliceRecords).toHaveLength(2);
+    expect(aliceRecords.map((r) => r.recordId).sort()).toEqual(['r1', 'r2']);
+
+    const bobRecords = registry.listForPrincipal('bob');
+    expect(bobRecords).toHaveLength(1);
+    expect(bobRecords[0]!.recordId).toBe('r3');
+  });
+
+  it('returns empty array for principal with no records', () => {
+    const registry = new ConsentRegistry();
+    expect(registry.listForPrincipal('unknown')).toEqual([]);
+  });
+
+  it('marks a record as withdrawn', () => {
+    const registry = new ConsentRegistry();
+    registry.register(makeRecord({ recordId: 'w1', status: 'active' }));
+
+    registry.markWithdrawn('w1', 'User requested deletion');
+
+    const updated = registry.get('w1');
+    expect(updated!.status).toBe('withdrawn');
+    expect(updated!.withdrawnReason).toBe('User requested deletion');
+    expect(updated!.withdrawnAt).toBeInstanceOf(Date);
+    expect(Object.isFrozen(updated)).toBe(true);
+  });
+
+  it('throws when marking non-existent record as withdrawn', () => {
+    const registry = new ConsentRegistry();
+    expect(() => registry.markWithdrawn('missing', 'reason')).toThrow('not found');
+  });
+
+  describe('getStats', () => {
+    it('counts all record statuses', () => {
+      const registry = new ConsentRegistry();
+      registry.register(makeRecord({ recordId: 'r1', dataPrincipalId: 'a', status: 'active' }));
+      registry.register(makeRecord({ recordId: 'r2', dataPrincipalId: 'b', status: 'active' }));
+      registry.register(makeRecord({ recordId: 'r3', dataPrincipalId: 'a', status: 'expired' }));
+      registry.register(makeRecord({ recordId: 'r4', dataPrincipalId: 'c', status: 'withdrawn' }));
+
+      const stats = registry.getStats();
+      expect(stats.totalRecords).toBe(4);
+      expect(stats.activeRecords).toBe(2);
+      expect(stats.expiredRecords).toBe(1);
+      expect(stats.withdrawnRecords).toBe(1);
+      expect(stats.principalCount).toBe(3);
+    });
+
+    it('returns zeros for empty registry', () => {
+      const registry = new ConsentRegistry();
+      const stats = registry.getStats();
+      expect(stats.totalRecords).toBe(0);
+      expect(stats.activeRecords).toBe(0);
+      expect(stats.withdrawnRecords).toBe(0);
+      expect(stats.expiredRecords).toBe(0);
+      expect(stats.principalCount).toBe(0);
+    });
+
+    it('updates stats after withdrawal', () => {
+      const registry = new ConsentRegistry();
+      registry.register(makeRecord({ recordId: 'r1', status: 'active' }));
+
+      let stats = registry.getStats();
+      expect(stats.activeRecords).toBe(1);
+      expect(stats.withdrawnRecords).toBe(0);
+
+      registry.markWithdrawn('r1', 'reason');
+
+      stats = registry.getStats();
+      expect(stats.activeRecords).toBe(0);
+      expect(stats.withdrawnRecords).toBe(1);
+    });
+  });
+});

--- a/packages/dpdp/tests/export.test.ts
+++ b/packages/dpdp/tests/export.test.ts
@@ -1,0 +1,444 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { requestDpdpExport, getExportStatus } from '../src/export/dpdp-export.js';
+import { requestEuAiActExport, EU_AI_ACT_ARTICLES } from '../src/export/eu-ai-act-export.js';
+import { requestGdprExport } from '../src/export/gdpr-export.js';
+import { ExportError } from '../src/errors.js';
+import type { ComplianceExportRequest } from '../src/types.js';
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function makeExportParams(): Omit<ComplianceExportRequest, 'type'> {
+  return {
+    dateFrom: new Date('2026-01-01T00:00:00Z'),
+    dateTo: new Date('2026-03-31T23:59:59Z'),
+    format: 'json',
+    includeActionLog: true,
+    includeConsentRecords: true,
+    dataPrincipalId: 'principal_1',
+  };
+}
+
+function mockFetchOk(data: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  });
+}
+
+function mockFetchError(status: number, body?: Record<string, unknown>) {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: () => Promise.resolve(body ?? {}),
+    text: () => Promise.resolve(JSON.stringify(body ?? {})),
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  DPDP export tests                                                  */
+/* ------------------------------------------------------------------ */
+
+describe('dpdp-export', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('requestDpdpExport', () => {
+    it('sends type "dpdp-audit" in request body', async () => {
+      let capturedBody: Record<string, unknown> | null = null;
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (_url: string, init: RequestInit) => {
+          capturedBody = JSON.parse(init.body as string);
+          return {
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                exportId: 'exp_01',
+                type: 'dpdp-audit',
+                status: 'complete',
+                recordCount: 10,
+                data: {},
+              }),
+          };
+        }),
+      );
+
+      await requestDpdpExport(makeExportParams(), 'api-key', 'https://api.test.local');
+      expect(capturedBody!.type).toBe('dpdp-audit');
+    });
+
+    it('calls correct endpoint with auth header', async () => {
+      let calledUrl = '';
+      let authHeader = '';
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (url: string, init: RequestInit) => {
+          calledUrl = url;
+          authHeader = (init.headers as Record<string, string>)['Authorization'];
+          return {
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                exportId: 'exp_01',
+                type: 'dpdp-audit',
+                status: 'complete',
+                recordCount: 0,
+                data: null,
+              }),
+          };
+        }),
+      );
+
+      await requestDpdpExport(makeExportParams(), 'my-key', 'https://api.test.local');
+      expect(calledUrl).toBe('https://api.test.local/v1/dpdp/exports');
+      expect(authHeader).toBe('Bearer my-key');
+    });
+
+    it('serializes dates to ISO strings', async () => {
+      let capturedBody: Record<string, unknown> | null = null;
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (_url: string, init: RequestInit) => {
+          capturedBody = JSON.parse(init.body as string);
+          return {
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                exportId: 'e',
+                type: 'dpdp-audit',
+                status: 'complete',
+                recordCount: 0,
+                data: null,
+              }),
+          };
+        }),
+      );
+
+      await requestDpdpExport(makeExportParams(), 'key', 'https://api.test.local');
+      expect(capturedBody!.dateFrom).toBe('2026-01-01T00:00:00.000Z');
+      expect(capturedBody!.dateTo).toBe('2026-03-31T23:59:59.000Z');
+    });
+
+    it('returns deserialized export result with downloadExpiresAt as Date', async () => {
+      const expiresAt = new Date(Date.now() + 24 * 3600_000).toISOString();
+
+      vi.stubGlobal(
+        'fetch',
+        mockFetchOk({
+          exportId: 'exp_01',
+          type: 'dpdp-audit',
+          status: 'complete',
+          recordCount: 42,
+          data: { records: [] },
+          downloadUrl: 'https://downloads.test/exp_01',
+          downloadExpiresAt: expiresAt,
+        }),
+      );
+
+      const result = await requestDpdpExport(makeExportParams(), 'key', 'https://api.test.local');
+      expect(result.exportId).toBe('exp_01');
+      expect(result.recordCount).toBe(42);
+      expect(result.downloadUrl).toBe('https://downloads.test/exp_01');
+      expect(result.downloadExpiresAt).toBeInstanceOf(Date);
+    });
+
+    it('throws ExportError on HTTP error', async () => {
+      vi.stubGlobal('fetch', mockFetchError(500, { message: 'Server error' }));
+
+      await expect(
+        requestDpdpExport(makeExportParams(), 'key', 'https://api.test.local'),
+      ).rejects.toThrow(ExportError);
+    });
+
+    it('throws ExportError with server message', async () => {
+      vi.stubGlobal('fetch', mockFetchError(403, { message: 'Forbidden' }));
+
+      await expect(
+        requestDpdpExport(makeExportParams(), 'key', 'https://api.test.local'),
+      ).rejects.toThrow('Forbidden');
+    });
+  });
+
+  describe('getExportStatus', () => {
+    it('fetches export by ID with GET request', async () => {
+      let calledUrl = '';
+      let calledMethod = '';
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (url: string, init?: RequestInit) => {
+          calledUrl = url;
+          calledMethod = init?.method ?? 'GET';
+          return {
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                exportId: 'exp_42',
+                type: 'dpdp-audit',
+                status: 'complete',
+                recordCount: 5,
+                data: {},
+              }),
+          };
+        }),
+      );
+
+      const result = await getExportStatus('exp_42', 'key', 'https://api.test.local');
+      expect(calledUrl).toBe('https://api.test.local/v1/dpdp/exports/exp_42');
+      expect(result.exportId).toBe('exp_42');
+    });
+
+    it('URL-encodes exportId', async () => {
+      let calledUrl = '';
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (url: string) => {
+          calledUrl = url;
+          return {
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                exportId: 'exp/special',
+                type: 'dpdp-audit',
+                status: 'complete',
+                recordCount: 0,
+                data: null,
+              }),
+          };
+        }),
+      );
+
+      await getExportStatus('exp/special', 'key', 'https://api.test.local');
+      expect(calledUrl).toContain('exp%2Fspecial');
+    });
+
+    it('throws ExportError on HTTP error', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          ok: false,
+          status: 404,
+        })),
+      );
+
+      await expect(
+        getExportStatus('missing', 'key', 'https://api.test.local'),
+      ).rejects.toThrow(ExportError);
+    });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  EU AI Act export tests                                             */
+/* ------------------------------------------------------------------ */
+
+describe('eu-ai-act-export', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('EU_AI_ACT_ARTICLES has expected articles', () => {
+    expect(EU_AI_ACT_ARTICLES.length).toBe(9);
+
+    const articleNumbers = EU_AI_ACT_ARTICLES.map((a) => a.article);
+    expect(articleNumbers).toContain('9');
+    expect(articleNumbers).toContain('12');
+    expect(articleNumbers).toContain('13');
+    expect(articleNumbers).toContain('14');
+    expect(articleNumbers).toContain('50');
+  });
+
+  it('each article has article, title, and description', () => {
+    for (const art of EU_AI_ACT_ARTICLES) {
+      expect(art.article).toBeTruthy();
+      expect(art.title).toBeTruthy();
+      expect(art.description).toBeTruthy();
+    }
+  });
+
+  it('sends type "eu-ai-act-conformance" in request body', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: RequestInit) => {
+        capturedBody = JSON.parse(init.body as string);
+        return {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              exportId: 'exp_eu',
+              type: 'eu-ai-act-conformance',
+              status: 'complete',
+              recordCount: 1,
+              data: {},
+            }),
+        };
+      }),
+    );
+
+    await requestEuAiActExport(makeExportParams(), 'key', 'https://api.test.local');
+    expect(capturedBody!.type).toBe('eu-ai-act-conformance');
+  });
+
+  it('returns deserialized result', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchOk({
+        exportId: 'exp_eu',
+        type: 'eu-ai-act-conformance',
+        status: 'complete',
+        recordCount: 1,
+        data: { overallStatus: 'compliant' },
+        downloadUrl: 'https://downloads.test/eu',
+      }),
+    );
+
+    const result = await requestEuAiActExport(makeExportParams(), 'key', 'https://api.test.local');
+    expect(result.type).toBe('eu-ai-act-conformance');
+    expect(result.downloadUrl).toBe('https://downloads.test/eu');
+  });
+
+  it('throws ExportError on HTTP error', async () => {
+    vi.stubGlobal('fetch', mockFetchError(502, { message: 'Bad Gateway' }));
+
+    await expect(
+      requestEuAiActExport(makeExportParams(), 'key', 'https://api.test.local'),
+    ).rejects.toThrow(ExportError);
+  });
+
+  it('deserializes downloadExpiresAt as Date', async () => {
+    const expires = new Date(Date.now() + 86400_000).toISOString();
+
+    vi.stubGlobal(
+      'fetch',
+      mockFetchOk({
+        exportId: 'exp_eu',
+        type: 'eu-ai-act-conformance',
+        status: 'complete',
+        recordCount: 1,
+        data: {},
+        downloadExpiresAt: expires,
+      }),
+    );
+
+    const result = await requestEuAiActExport(makeExportParams(), 'key', 'https://api.test.local');
+    expect(result.downloadExpiresAt).toBeInstanceOf(Date);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  GDPR export tests                                                  */
+/* ------------------------------------------------------------------ */
+
+describe('gdpr-export', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends type "gdpr-article-15" in request body', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: RequestInit) => {
+        capturedBody = JSON.parse(init.body as string);
+        return {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              exportId: 'exp_gdpr',
+              type: 'gdpr-article-15',
+              status: 'complete',
+              recordCount: 5,
+              data: {},
+            }),
+        };
+      }),
+    );
+
+    await requestGdprExport(makeExportParams(), 'key', 'https://api.test.local');
+    expect(capturedBody!.type).toBe('gdpr-article-15');
+  });
+
+  it('returns deserialized result', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchOk({
+        exportId: 'exp_gdpr',
+        type: 'gdpr-article-15',
+        status: 'complete',
+        recordCount: 10,
+        data: { dataSubject: { id: 'principal_1' } },
+      }),
+    );
+
+    const result = await requestGdprExport(makeExportParams(), 'key', 'https://api.test.local');
+    expect(result.type).toBe('gdpr-article-15');
+    expect(result.recordCount).toBe(10);
+    const data = result.data as Record<string, unknown>;
+    expect(data.dataSubject).toEqual({ id: 'principal_1' });
+  });
+
+  it('throws ExportError on HTTP error', async () => {
+    vi.stubGlobal('fetch', mockFetchError(401, { message: 'Unauthorized' }));
+
+    await expect(
+      requestGdprExport(makeExportParams(), 'key', 'https://api.test.local'),
+    ).rejects.toThrow(ExportError);
+
+    await expect(
+      requestGdprExport(makeExportParams(), 'key', 'https://api.test.local'),
+    ).rejects.toThrow('Unauthorized');
+  });
+
+  it('serializes dates to ISO strings', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: RequestInit) => {
+        capturedBody = JSON.parse(init.body as string);
+        return {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              exportId: 'e',
+              type: 'gdpr-article-15',
+              status: 'complete',
+              recordCount: 0,
+              data: null,
+            }),
+        };
+      }),
+    );
+
+    await requestGdprExport(makeExportParams(), 'key', 'https://api.test.local');
+    expect(typeof capturedBody!.dateFrom).toBe('string');
+    expect(typeof capturedBody!.dateTo).toBe('string');
+  });
+
+  it('handles export without downloadUrl', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchOk({
+        exportId: 'exp_no_url',
+        type: 'gdpr-article-15',
+        status: 'complete',
+        recordCount: 0,
+        data: null,
+      }),
+    );
+
+    const result = await requestGdprExport(makeExportParams(), 'key', 'https://api.test.local');
+    expect(result.downloadUrl).toBeUndefined();
+    expect(result.downloadExpiresAt).toBeUndefined();
+  });
+});

--- a/packages/dpdp/tests/purpose.test.ts
+++ b/packages/dpdp/tests/purpose.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import { PurposeRegistry } from '../src/purpose/purpose-registry.js';
+import type { RegisteredPurpose, ConsentPurpose } from '../src/types.js';
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function makePurpose(overrides?: Partial<RegisteredPurpose>): RegisteredPurpose {
+  return {
+    purposeId: 'email-access',
+    name: 'Email Access',
+    description: 'Read and send emails on behalf of the user',
+    requiredScopes: ['email:read', 'email:send'],
+    legalBasis: 'consent',
+    dataCategories: ['email', 'contacts'],
+    retentionPeriod: '1 year',
+    thirdPartySharing: false,
+    ...overrides,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+describe('PurposeRegistry', () => {
+  describe('register and get', () => {
+    it('registers and retrieves a purpose by ID', () => {
+      const registry = new PurposeRegistry();
+      registry.register(makePurpose());
+
+      const purpose = registry.get('email-access');
+      expect(purpose).toBeDefined();
+      expect(purpose!.name).toBe('Email Access');
+      expect(purpose!.requiredScopes).toEqual(['email:read', 'email:send']);
+    });
+
+    it('returns undefined for non-existent purpose', () => {
+      const registry = new PurposeRegistry();
+      expect(registry.get('nonexistent')).toBeUndefined();
+    });
+
+    it('overwrites purpose with same ID on re-register', () => {
+      const registry = new PurposeRegistry();
+      registry.register(makePurpose({ name: 'Original' }));
+      registry.register(makePurpose({ name: 'Updated' }));
+
+      const purpose = registry.get('email-access');
+      expect(purpose!.name).toBe('Updated');
+    });
+
+    it('stores a defensive copy (original mutation does not affect stored)', () => {
+      const registry = new PurposeRegistry();
+      const original = makePurpose();
+      registry.register(original);
+
+      // Mutate the original object
+      original.name = 'Mutated';
+
+      const stored = registry.get('email-access');
+      expect(stored!.name).toBe('Email Access');
+    });
+  });
+
+  describe('listAll', () => {
+    it('returns empty array when no purposes registered', () => {
+      const registry = new PurposeRegistry();
+      expect(registry.listAll()).toEqual([]);
+    });
+
+    it('returns all registered purposes', () => {
+      const registry = new PurposeRegistry();
+      registry.register(makePurpose({ purposeId: 'p1', name: 'Purpose 1' }));
+      registry.register(makePurpose({ purposeId: 'p2', name: 'Purpose 2' }));
+      registry.register(makePurpose({ purposeId: 'p3', name: 'Purpose 3' }));
+
+      const all = registry.listAll();
+      expect(all).toHaveLength(3);
+      expect(all.map((p) => p.purposeId).sort()).toEqual(['p1', 'p2', 'p3']);
+    });
+  });
+
+  describe('getScopesForPurpose', () => {
+    it('returns scopes for a registered purpose', () => {
+      const registry = new PurposeRegistry();
+      registry.register(
+        makePurpose({
+          purposeId: 'calendar',
+          requiredScopes: ['calendar:read', 'calendar:write'],
+        }),
+      );
+
+      expect(registry.getScopesForPurpose('calendar')).toEqual([
+        'calendar:read',
+        'calendar:write',
+      ]);
+    });
+
+    it('returns undefined for unregistered purpose', () => {
+      const registry = new PurposeRegistry();
+      expect(registry.getScopesForPurpose('missing')).toBeUndefined();
+    });
+
+    it('returns empty array for purpose with no required scopes', () => {
+      const registry = new PurposeRegistry();
+      registry.register(makePurpose({ purposeId: 'no-scopes', requiredScopes: [] }));
+      expect(registry.getScopesForPurpose('no-scopes')).toEqual([]);
+    });
+  });
+
+  describe('toConsentPurpose', () => {
+    it('converts registered purpose to ConsentPurpose', () => {
+      const registry = new PurposeRegistry();
+      registry.register(makePurpose());
+
+      const cp = registry.toConsentPurpose('email-access');
+      expect(cp).toBeDefined();
+      expect(cp!.purposeId).toBe('email-access');
+      expect(cp!.name).toBe('Email Access');
+      expect(cp!.description).toBe('Read and send emails on behalf of the user');
+      expect(cp!.legalBasis).toBe('consent');
+      expect(cp!.dataCategories).toEqual(['email', 'contacts']);
+      expect(cp!.retentionPeriod).toBe('1 year');
+      expect(cp!.thirdPartySharing).toBe(false);
+    });
+
+    it('returns undefined for non-existent purpose', () => {
+      const registry = new PurposeRegistry();
+      expect(registry.toConsentPurpose('missing')).toBeUndefined();
+    });
+
+    it('includes thirdParties when present', () => {
+      const registry = new PurposeRegistry();
+      registry.register(
+        makePurpose({
+          purposeId: 'sharing',
+          thirdPartySharing: true,
+          thirdParties: ['Analytics Corp', 'Ad Network'],
+        }),
+      );
+
+      const cp = registry.toConsentPurpose('sharing');
+      expect(cp!.thirdPartySharing).toBe(true);
+      expect(cp!.thirdParties).toEqual(['Analytics Corp', 'Ad Network']);
+    });
+
+    it('omits thirdParties when not present', () => {
+      const registry = new PurposeRegistry();
+      registry.register(makePurpose({ purposeId: 'no-third' }));
+
+      const cp = registry.toConsentPurpose('no-third');
+      expect(cp!.thirdParties).toBeUndefined();
+    });
+
+    it('maps all fields correctly for complex purpose', () => {
+      const registry = new PurposeRegistry();
+      registry.register({
+        purposeId: 'complex',
+        name: 'Complex Processing',
+        description: 'Multiple data categories with third parties',
+        requiredScopes: ['data:read', 'data:write', 'data:export'],
+        legalBasis: 'legitimate-interest',
+        dataCategories: ['personal', 'financial', 'health'],
+        retentionPeriod: '5 years',
+        thirdPartySharing: true,
+        thirdParties: ['Partner A', 'Partner B'],
+      });
+
+      const cp = registry.toConsentPurpose('complex');
+      expect(cp!.legalBasis).toBe('legitimate-interest');
+      expect(cp!.dataCategories).toEqual(['personal', 'financial', 'health']);
+      expect(cp!.retentionPeriod).toBe('5 years');
+      expect(cp!.thirdParties).toHaveLength(2);
+    });
+  });
+
+  describe('multiple registries are independent', () => {
+    it('registrations in one registry do not affect another', () => {
+      const r1 = new PurposeRegistry();
+      const r2 = new PurposeRegistry();
+
+      r1.register(makePurpose({ purposeId: 'only-in-r1' }));
+
+      expect(r1.get('only-in-r1')).toBeDefined();
+      expect(r2.get('only-in-r1')).toBeUndefined();
+      expect(r2.listAll()).toHaveLength(0);
+    });
+  });
+});

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -26,7 +26,7 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@grantex/sdk": ">=0.1.0",
+    "@grantex/sdk": ">=0.3.0",
     "express": ">=4.18.0"
   },
   "devDependencies": {

--- a/packages/fastapi/pyproject.toml
+++ b/packages/fastapi/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "grantex>=0.1.0",
+    "grantex>=0.3.0",
     "fastapi>=0.100.0",
 ]
 

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -32,7 +32,7 @@
     "yaml": "^2.3.4"
   },
   "peerDependencies": {
-    "@grantex/sdk": ">=0.1.0"
+    "@grantex/sdk": ">=0.3.0"
   },
   "devDependencies": {
     "@grantex/sdk": "^0.1.5",

--- a/packages/gemma/tests/adapters.test.ts
+++ b/packages/gemma/tests/adapters.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect, vi } from 'vitest';
+import { withGrantexAuth as withGoogleADKAuth } from '../src/adapters/google-adk.js';
+import { withGrantexAuth as withLangChainAuth } from '../src/adapters/langchain.js';
+import { GrantexAuthError, ScopeViolationError } from '../src/errors.js';
+import type { OfflineVerifier, VerifiedGrant } from '../src/verifier/offline-verifier.js';
+import type { OfflineAuditLog, AuditEntry } from '../src/audit/offline-audit-log.js';
+import type { SignedAuditEntry } from '../src/audit/hash-chain.js';
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function makeGrant(overrides?: Partial<VerifiedGrant>): VerifiedGrant {
+  return {
+    agentDID: 'did:key:z6MkAgent',
+    principalDID: 'user:alice',
+    scopes: ['calendar:read', 'email:send'],
+    expiresAt: new Date(Date.now() + 3600_000),
+    jti: 'jti_001',
+    grantId: 'grant_01',
+    depth: 0,
+    ...overrides,
+  };
+}
+
+function makeVerifier(grant: VerifiedGrant): OfflineVerifier {
+  return {
+    verify: vi.fn().mockResolvedValue(grant),
+  };
+}
+
+function makeFailingVerifier(error: Error): OfflineVerifier {
+  return {
+    verify: vi.fn().mockRejectedValue(error),
+  };
+}
+
+function makeAuditLog(): OfflineAuditLog & { calls: AuditEntry[] } {
+  const calls: AuditEntry[] = [];
+  return {
+    calls,
+    append: vi.fn(async (entry: AuditEntry) => {
+      calls.push(entry);
+      return { ...entry, seq: calls.length, timestamp: new Date().toISOString(), prevHash: '0', hash: 'h', signature: 's' } as SignedAuditEntry;
+    }),
+    entries: vi.fn().mockResolvedValue([]),
+    unsyncedCount: vi.fn().mockResolvedValue(0),
+    markSynced: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Google ADK Adapter Tests                                           */
+/* ------------------------------------------------------------------ */
+
+describe('Google ADK adapter — withGrantexAuth', () => {
+  it('wraps a tool with a "func" method', async () => {
+    const grant = makeGrant();
+    const verifier = makeVerifier(grant);
+    const auditLog = makeAuditLog();
+
+    const tool = { name: 'myTool', func: vi.fn().mockResolvedValue('result') };
+    const wrapped = withGoogleADKAuth(tool, {
+      verifier,
+      auditLog,
+      requiredScopes: ['calendar:read'],
+      grantToken: 'token-jwt',
+    });
+
+    const result = await (wrapped.func as (...args: unknown[]) => Promise<unknown>)('arg1');
+    expect(result).toBe('result');
+    expect(verifier.verify).toHaveBeenCalledWith('token-jwt');
+    expect(tool.func).toHaveBeenCalledWith('arg1');
+    expect(auditLog.append).toHaveBeenCalledTimes(1);
+    expect(auditLog.calls[0]!.result).toBe('success');
+  });
+
+  it('wraps a tool with a "run" method when "func" is absent', async () => {
+    const grant = makeGrant();
+    const verifier = makeVerifier(grant);
+    const auditLog = makeAuditLog();
+
+    const tool = { name: 'runTool', run: vi.fn().mockResolvedValue(42) };
+    const wrapped = withGoogleADKAuth(tool, {
+      verifier,
+      auditLog,
+      requiredScopes: ['calendar:read'],
+      grantToken: 'token-jwt',
+    });
+
+    const result = await (wrapped.run as (...args: unknown[]) => Promise<unknown>)();
+    expect(result).toBe(42);
+    expect(tool.run).toHaveBeenCalled();
+  });
+
+  it('throws INVALID_TOOL when tool has neither "func" nor "run"', () => {
+    const verifier = makeVerifier(makeGrant());
+    const auditLog = makeAuditLog();
+
+    expect(() =>
+      withGoogleADKAuth({ name: 'bad' }, {
+        verifier,
+        auditLog,
+        requiredScopes: [],
+        grantToken: 'token',
+      }),
+    ).toThrow(GrantexAuthError);
+
+    expect(() =>
+      withGoogleADKAuth({ name: 'bad' }, {
+        verifier,
+        auditLog,
+        requiredScopes: [],
+        grantToken: 'token',
+      }),
+    ).toThrow('Tool must have a "func" or "run" method');
+  });
+
+  it('rejects and audits when token verification fails', async () => {
+    const verifier = makeFailingVerifier(new Error('Invalid signature'));
+    const auditLog = makeAuditLog();
+
+    const tool = { name: 'myTool', func: vi.fn() };
+    const wrapped = withGoogleADKAuth(tool, {
+      verifier,
+      auditLog,
+      requiredScopes: ['calendar:read'],
+      grantToken: 'bad-token',
+    });
+
+    await expect(
+      (wrapped.func as (...args: unknown[]) => Promise<unknown>)(),
+    ).rejects.toThrow(GrantexAuthError);
+
+    expect(tool.func).not.toHaveBeenCalled();
+    expect(auditLog.calls[0]!.result).toBe('auth_failure');
+    expect(auditLog.calls[0]!.agentDID).toBe('');
+  });
+
+  it('rejects and audits when required scopes are missing', async () => {
+    const grant = makeGrant({ scopes: ['calendar:read'] });
+    const verifier = makeVerifier(grant);
+    const auditLog = makeAuditLog();
+
+    const tool = { name: 'scopedTool', func: vi.fn() };
+    const wrapped = withGoogleADKAuth(tool, {
+      verifier,
+      auditLog,
+      requiredScopes: ['admin:write'],
+      grantToken: 'token',
+    });
+
+    await expect(
+      (wrapped.func as (...args: unknown[]) => Promise<unknown>)(),
+    ).rejects.toThrow(ScopeViolationError);
+
+    expect(tool.func).not.toHaveBeenCalled();
+    expect(auditLog.calls[0]!.result).toBe('scope_violation');
+  });
+
+  it('audits execution errors', async () => {
+    const grant = makeGrant();
+    const verifier = makeVerifier(grant);
+    const auditLog = makeAuditLog();
+
+    const tool = { name: 'crashTool', func: vi.fn().mockRejectedValue(new Error('boom')) };
+    const wrapped = withGoogleADKAuth(tool, {
+      verifier,
+      auditLog,
+      requiredScopes: ['calendar:read'],
+      grantToken: 'token',
+    });
+
+    await expect(
+      (wrapped.func as (...args: unknown[]) => Promise<unknown>)(),
+    ).rejects.toThrow('boom');
+
+    expect(auditLog.calls[0]!.result).toBe('execution_error');
+  });
+
+  it('preserves all other tool properties', () => {
+    const verifier = makeVerifier(makeGrant());
+    const auditLog = makeAuditLog();
+
+    const tool = {
+      name: 'preservedTool',
+      description: 'A test tool',
+      schema: { type: 'object' },
+      func: vi.fn(),
+    };
+
+    const wrapped = withGoogleADKAuth(tool, {
+      verifier,
+      auditLog,
+      requiredScopes: [],
+      grantToken: 'token',
+    });
+
+    expect(wrapped.name).toBe('preservedTool');
+    expect(wrapped.description).toBe('A test tool');
+    expect(wrapped.schema).toEqual({ type: 'object' });
+  });
+
+  it('uses "unknown" as tool name in audit when name is absent', async () => {
+    const grant = makeGrant();
+    const verifier = makeVerifier(grant);
+    const auditLog = makeAuditLog();
+
+    const tool = { func: vi.fn().mockResolvedValue('ok') };
+    const wrapped = withGoogleADKAuth(tool, {
+      verifier,
+      auditLog,
+      requiredScopes: ['calendar:read'],
+      grantToken: 'token',
+    });
+
+    await (wrapped.func as (...args: unknown[]) => Promise<unknown>)();
+    expect(auditLog.calls[0]!.action).toBe('tool:unknown');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  LangChain Adapter Tests                                            */
+/* ------------------------------------------------------------------ */
+
+describe('LangChain adapter — withGrantexAuth', () => {
+  it('wraps a tool with a "_call" method', async () => {
+    const grant = makeGrant();
+    const verifier = makeVerifier(grant);
+    const auditLog = makeAuditLog();
+
+    const tool = { name: 'lcTool', _call: vi.fn().mockResolvedValue('lc-result') };
+    const wrapped = withLangChainAuth(tool, {
+      verifier,
+      auditLog,
+      requiredScopes: ['email:send'],
+      grantToken: 'token-jwt',
+    });
+
+    const result = await (wrapped._call as (...args: unknown[]) => Promise<unknown>)('input');
+    expect(result).toBe('lc-result');
+    expect(verifier.verify).toHaveBeenCalledWith('token-jwt');
+    expect(tool._call).toHaveBeenCalledWith('input');
+    expect(auditLog.calls[0]!.result).toBe('success');
+  });
+
+  it('wraps a tool with "invoke" when "_call" is absent', async () => {
+    const grant = makeGrant();
+    const verifier = makeVerifier(grant);
+    const auditLog = makeAuditLog();
+
+    const tool = { name: 'invokeTool', invoke: vi.fn().mockResolvedValue('invoked') };
+    const wrapped = withLangChainAuth(tool, {
+      verifier,
+      auditLog,
+      requiredScopes: ['email:send'],
+      grantToken: 'token-jwt',
+    });
+
+    const result = await (wrapped.invoke as (...args: unknown[]) => Promise<unknown>)();
+    expect(result).toBe('invoked');
+    expect(tool.invoke).toHaveBeenCalled();
+  });
+
+  it('throws INVALID_TOOL when tool has neither "_call" nor "invoke"', () => {
+    const verifier = makeVerifier(makeGrant());
+    const auditLog = makeAuditLog();
+
+    expect(() =>
+      withLangChainAuth({ name: 'bad' }, {
+        verifier,
+        auditLog,
+        requiredScopes: [],
+        grantToken: 'token',
+      }),
+    ).toThrow(GrantexAuthError);
+
+    expect(() =>
+      withLangChainAuth({ name: 'bad' }, {
+        verifier,
+        auditLog,
+        requiredScopes: [],
+        grantToken: 'token',
+      }),
+    ).toThrow('Tool must have a "_call" or "invoke" method');
+  });
+
+  it('rejects and audits when token verification fails', async () => {
+    const verifier = makeFailingVerifier(new Error('Expired'));
+    const auditLog = makeAuditLog();
+
+    const tool = { name: 'lcTool', _call: vi.fn() };
+    const wrapped = withLangChainAuth(tool, {
+      verifier,
+      auditLog,
+      requiredScopes: ['email:send'],
+      grantToken: 'expired-token',
+    });
+
+    await expect(
+      (wrapped._call as (...args: unknown[]) => Promise<unknown>)(),
+    ).rejects.toThrow(GrantexAuthError);
+
+    expect(tool._call).not.toHaveBeenCalled();
+    expect(auditLog.calls[0]!.result).toBe('auth_failure');
+  });
+
+  it('rejects and audits scope violations', async () => {
+    const grant = makeGrant({ scopes: ['email:send'] });
+    const verifier = makeVerifier(grant);
+    const auditLog = makeAuditLog();
+
+    const tool = { name: 'lcScopedTool', _call: vi.fn() };
+    const wrapped = withLangChainAuth(tool, {
+      verifier,
+      auditLog,
+      requiredScopes: ['admin:write'],
+      grantToken: 'token',
+    });
+
+    await expect(
+      (wrapped._call as (...args: unknown[]) => Promise<unknown>)(),
+    ).rejects.toThrow(ScopeViolationError);
+
+    expect(auditLog.calls[0]!.result).toBe('scope_violation');
+  });
+
+  it('audits execution errors from the underlying tool', async () => {
+    const grant = makeGrant();
+    const verifier = makeVerifier(grant);
+    const auditLog = makeAuditLog();
+
+    const tool = { name: 'errTool', _call: vi.fn().mockRejectedValue(new Error('lc-fail')) };
+    const wrapped = withLangChainAuth(tool, {
+      verifier,
+      auditLog,
+      requiredScopes: ['calendar:read'],
+      grantToken: 'token',
+    });
+
+    await expect(
+      (wrapped._call as (...args: unknown[]) => Promise<unknown>)(),
+    ).rejects.toThrow('lc-fail');
+
+    expect(auditLog.calls[0]!.result).toBe('execution_error');
+  });
+
+  it('preserves all other tool properties', () => {
+    const verifier = makeVerifier(makeGrant());
+    const auditLog = makeAuditLog();
+
+    const tool = {
+      name: 'richTool',
+      description: 'Has metadata',
+      schema: { foo: 'bar' },
+      returnDirect: true,
+      _call: vi.fn(),
+    };
+
+    const wrapped = withLangChainAuth(tool, {
+      verifier,
+      auditLog,
+      requiredScopes: [],
+      grantToken: 'token',
+    });
+
+    expect(wrapped.name).toBe('richTool');
+    expect(wrapped.description).toBe('Has metadata');
+    expect(wrapped.schema).toEqual({ foo: 'bar' });
+    expect(wrapped.returnDirect).toBe(true);
+  });
+
+  it('passes multiple arguments through to the underlying function', async () => {
+    const grant = makeGrant();
+    const verifier = makeVerifier(grant);
+    const auditLog = makeAuditLog();
+
+    const tool = {
+      name: 'multiArgTool',
+      _call: vi.fn(async (a: unknown, b: unknown) => `${a}-${b}`),
+    };
+
+    const wrapped = withLangChainAuth(tool, {
+      verifier,
+      auditLog,
+      requiredScopes: ['calendar:read'],
+      grantToken: 'token',
+    });
+
+    const result = await (wrapped._call as (...args: unknown[]) => Promise<unknown>)('hello', 'world');
+    expect(result).toBe('hello-world');
+    expect(tool._call).toHaveBeenCalledWith('hello', 'world');
+  });
+});

--- a/packages/gemma/tests/audit.test.ts
+++ b/packages/gemma/tests/audit.test.ts
@@ -1,0 +1,439 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { generateKeyPairSync } from 'node:crypto';
+import {
+  computeEntryHash,
+  verifyChain,
+  GENESIS_HASH,
+  type SignedAuditEntry,
+} from '../src/audit/hash-chain.js';
+import {
+  createOfflineAuditLog,
+  verifyEntrySignature,
+} from '../src/audit/offline-audit-log.js';
+import { syncAuditLog, type SyncOptions } from '../src/audit/audit-sync.js';
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function generateEdKey() {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  return {
+    publicKey: publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+    privateKey: privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+    algorithm: 'Ed25519',
+  };
+}
+
+const sampleEntry = {
+  action: 'tool:read_calendar',
+  agentDID: 'did:key:z6MkAgent',
+  grantId: 'grant_01',
+  scopes: ['calendar:read'],
+  result: 'success',
+};
+
+/* ------------------------------------------------------------------ */
+/*  audit-sync tests                                                   */
+/* ------------------------------------------------------------------ */
+
+describe('audit-sync', () => {
+  let tmpDir: string;
+  let logPath: string;
+  let signingKey: ReturnType<typeof generateEdKey>;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'gemma-sync-'));
+    logPath = join(tmpDir, 'audit.jsonl');
+    signingKey = generateEdKey();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns zero synced when there are no entries', async () => {
+    const log = createOfflineAuditLog({ signingKey, logPath });
+
+    const result = await syncAuditLog(log, {
+      endpoint: 'https://api.grantex.dev',
+      apiKey: 'key',
+      bundleId: 'b1',
+    });
+
+    expect(result.syncedCount).toBe(0);
+    expect(result.hasErrors).toBe(false);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('sends correct Authorization header and bundleId', async () => {
+    const log = createOfflineAuditLog({ signingKey, logPath });
+    await log.append(sampleEntry);
+
+    const fetchCalls: { url: string; headers: Record<string, string>; body: Record<string, unknown> }[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url, init) => {
+      const parsed = JSON.parse((init as RequestInit).body as string);
+      const headers = (init as RequestInit).headers as Record<string, string>;
+      fetchCalls.push({ url: url as string, headers, body: parsed });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      await syncAuditLog(log, {
+        endpoint: 'https://api.grantex.dev',
+        apiKey: 'my-api-key',
+        bundleId: 'bundle_42',
+      });
+
+      expect(fetchCalls.length).toBe(1);
+      expect(fetchCalls[0]!.url).toBe('https://api.grantex.dev/v1/audit/offline-sync');
+      expect(fetchCalls[0]!.headers['Authorization']).toBe('Bearer my-api-key');
+      expect(fetchCalls[0]!.body.bundleId).toBe('bundle_42');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('strips trailing slash from endpoint URL', async () => {
+    const log = createOfflineAuditLog({ signingKey, logPath });
+    await log.append(sampleEntry);
+
+    let calledUrl = '';
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url) => {
+      calledUrl = url as string;
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      await syncAuditLog(log, {
+        endpoint: 'https://api.grantex.dev/',
+        apiKey: 'key',
+        bundleId: 'b1',
+      });
+
+      expect(calledUrl).toBe('https://api.grantex.dev/v1/audit/offline-sync');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('reports errors after max retries exhausted', async () => {
+    const log = createOfflineAuditLog({ signingKey, logPath });
+    await log.append(sampleEntry);
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('Connection refused');
+    }) as typeof fetch;
+
+    try {
+      const result = await syncAuditLog(log, {
+        endpoint: 'https://api.grantex.dev',
+        apiKey: 'key',
+        bundleId: 'b1',
+      });
+
+      expect(result.syncedCount).toBe(0);
+      expect(result.hasErrors).toBe(true);
+      expect(result.errors.length).toBe(1);
+      expect(result.errors[0]).toContain('Connection refused');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('handles HTTP error responses', async () => {
+    const log = createOfflineAuditLog({ signingKey, logPath });
+    await log.append(sampleEntry);
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () =>
+      new Response('Unauthorized', { status: 401 }),
+    ) as typeof fetch;
+
+    try {
+      const result = await syncAuditLog(log, {
+        endpoint: 'https://api.grantex.dev',
+        apiKey: 'bad-key',
+        bundleId: 'b1',
+      });
+
+      expect(result.syncedCount).toBe(0);
+      expect(result.hasErrors).toBe(true);
+      expect(result.errors[0]).toContain('401');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('respects custom batchSize option', async () => {
+    const log = createOfflineAuditLog({ signingKey, logPath });
+    for (let i = 0; i < 7; i++) {
+      await log.append({ ...sampleEntry, action: `tool:op${i}` });
+    }
+
+    let batchCount = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => {
+      batchCount++;
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const result = await syncAuditLog(log, {
+        endpoint: 'https://api.grantex.dev',
+        apiKey: 'key',
+        batchSize: 3,
+        bundleId: 'b1',
+      });
+
+      expect(result.syncedCount).toBe(7);
+      // 7 entries / batch 3 = 3 batches (3 + 3 + 1)
+      expect(batchCount).toBe(3);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('uses default batchSize of 100 when not specified', async () => {
+    const log = createOfflineAuditLog({ signingKey, logPath });
+    // Add just a few entries — they should all go in one batch
+    for (let i = 0; i < 5; i++) {
+      await log.append({ ...sampleEntry, action: `tool:op${i}` });
+    }
+
+    let batchCount = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => {
+      batchCount++;
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      await syncAuditLog(log, {
+        endpoint: 'https://api.grantex.dev',
+        apiKey: 'key',
+        bundleId: 'b1',
+      });
+
+      // All 5 entries in one batch (< 100)
+      expect(batchCount).toBe(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  hash-chain additional tests                                        */
+/* ------------------------------------------------------------------ */
+
+describe('hash-chain (additional)', () => {
+  it('computeEntryHash includes metadata when present', () => {
+    const base = {
+      seq: 1,
+      timestamp: '2026-01-01T00:00:00.000Z',
+      action: 'tool:test',
+      agentDID: 'did:key:z6MkA',
+      grantId: 'g1',
+      scopes: ['a'],
+      result: 'success',
+      prevHash: GENESIS_HASH,
+    };
+
+    const hashWithout = computeEntryHash(base);
+    const hashWith = computeEntryHash({ ...base, metadata: { key: 'value' } });
+
+    expect(hashWithout).not.toBe(hashWith);
+  });
+
+  it('produces different hashes for different scopes', () => {
+    const base = {
+      seq: 1,
+      timestamp: '2026-01-01T00:00:00.000Z',
+      action: 'tool:test',
+      agentDID: 'did:key:z6MkA',
+      grantId: 'g1',
+      scopes: ['read'],
+      result: 'success',
+      prevHash: GENESIS_HASH,
+    };
+
+    const h1 = computeEntryHash(base);
+    const h2 = computeEntryHash({ ...base, scopes: ['read', 'write'] });
+    expect(h1).not.toBe(h2);
+  });
+
+  it('produces different hashes for different seq numbers', () => {
+    const base = {
+      seq: 1,
+      timestamp: '2026-01-01T00:00:00.000Z',
+      action: 'tool:test',
+      agentDID: 'did:key:z6MkA',
+      grantId: 'g1',
+      scopes: ['read'],
+      result: 'success',
+      prevHash: GENESIS_HASH,
+    };
+
+    const h1 = computeEntryHash(base);
+    const h2 = computeEntryHash({ ...base, seq: 2 });
+    expect(h1).not.toBe(h2);
+  });
+
+  it('verifyChain detects non-consecutive sequence numbers', () => {
+    const e1 = makeChainEntry(1, GENESIS_HASH);
+    const e2 = makeChainEntry(3, e1.hash); // skips seq 2
+
+    const result = verifyChain([e1, e2]);
+    expect(result.valid).toBe(false);
+    expect(result.brokenAt).toBe(1);
+  });
+
+  it('GENESIS_HASH is the expected sentinel value', () => {
+    expect(GENESIS_HASH).toBe('0000000000000000');
+  });
+});
+
+/* Chain entry helper */
+function makeChainEntry(seq: number, prevHash: string): SignedAuditEntry {
+  const partial = {
+    seq,
+    timestamp: new Date(Date.now() + seq * 1000).toISOString(),
+    action: `tool:op${seq}`,
+    agentDID: 'did:key:z6MkTest',
+    grantId: 'grant_01',
+    scopes: ['read'],
+    result: 'success',
+    prevHash,
+  };
+  const hash = computeEntryHash(partial);
+  return { ...partial, hash, signature: 'fake-sig' };
+}
+
+/* ------------------------------------------------------------------ */
+/*  offline-audit-log additional tests                                 */
+/* ------------------------------------------------------------------ */
+
+describe('offline-audit-log (additional)', () => {
+  let tmpDir: string;
+  let logPath: string;
+  let signingKey: ReturnType<typeof generateEdKey>;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'gemma-audit2-'));
+    logPath = join(tmpDir, 'audit.jsonl');
+    signingKey = generateEdKey();
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('appends entry with metadata', async () => {
+    const log = createOfflineAuditLog({ signingKey, logPath });
+    const entry = await log.append({
+      ...sampleEntry,
+      metadata: { toolInput: 'test' },
+    });
+
+    expect(entry.metadata).toEqual({ toolInput: 'test' });
+    const entries = await log.entries();
+    expect(entries[0]!.metadata).toEqual({ toolInput: 'test' });
+  });
+
+  it('entries are persisted to disk as JSONL', async () => {
+    const log = createOfflineAuditLog({ signingKey, logPath });
+    await log.append(sampleEntry);
+    await log.append({ ...sampleEntry, action: 'tool:write' });
+
+    const raw = await readFile(logPath, 'utf-8');
+    const lines = raw.trim().split('\n');
+    expect(lines.length).toBe(2);
+
+    const parsed = lines.map((l) => JSON.parse(l) as SignedAuditEntry);
+    expect(parsed[0]!.action).toBe('tool:read_calendar');
+    expect(parsed[1]!.action).toBe('tool:write');
+  });
+
+  it('initialises from existing log on disk', async () => {
+    // Write some entries with first log instance
+    const log1 = createOfflineAuditLog({ signingKey, logPath });
+    await log1.append(sampleEntry);
+    await log1.append({ ...sampleEntry, action: 'tool:second' });
+
+    // Create a new log instance (simulates process restart)
+    const log2 = createOfflineAuditLog({ signingKey, logPath });
+    const e3 = await log2.append({ ...sampleEntry, action: 'tool:third' });
+
+    expect(e3.seq).toBe(3);
+
+    // Full chain should be valid
+    const entries = await log2.entries();
+    expect(entries.length).toBe(3);
+    expect(verifyChain(entries).valid).toBe(true);
+  });
+
+  it('unsyncedCount tracks sync state correctly', async () => {
+    const log = createOfflineAuditLog({ signingKey, logPath });
+    await log.append(sampleEntry);
+    await log.append({ ...sampleEntry, action: 'tool:b' });
+    await log.append({ ...sampleEntry, action: 'tool:c' });
+
+    expect(await log.unsyncedCount()).toBe(3);
+
+    await log.markSynced(2);
+    expect(await log.unsyncedCount()).toBe(1);
+
+    await log.markSynced(3);
+    expect(await log.unsyncedCount()).toBe(0);
+  });
+
+  it('markSynced persists sync marker to disk', async () => {
+    const log = createOfflineAuditLog({ signingKey, logPath });
+    await log.append(sampleEntry);
+    await log.markSynced(1);
+
+    const markerContent = await readFile(logPath + '.synced', 'utf-8');
+    expect(markerContent.trim()).toBe('1');
+  });
+
+  it('returns empty entries array for missing log file', async () => {
+    const missingPath = join(tmpDir, 'missing.jsonl');
+    const log = createOfflineAuditLog({ signingKey, logPath: missingPath });
+    const entries = await log.entries();
+    expect(entries).toEqual([]);
+  });
+
+  it('verifyEntrySignature rejects with wrong public key', async () => {
+    const log = createOfflineAuditLog({ signingKey, logPath });
+    const entry = await log.append(sampleEntry);
+
+    const otherKey = generateEdKey();
+    expect(verifyEntrySignature(entry, otherKey.publicKey)).toBe(false);
+  });
+
+  it('does not rotate when rotateOnSize is false', async () => {
+    const log = createOfflineAuditLog({
+      signingKey,
+      logPath,
+      maxSizeMB: 0.0001,
+      rotateOnSize: false,
+    });
+
+    await log.append(sampleEntry);
+    await log.append(sampleEntry);
+    await log.append(sampleEntry);
+
+    const { readdir } = await import('node:fs/promises');
+    const files = await readdir(tmpDir);
+    const backups = files.filter((f) => f.endsWith('.bak'));
+    expect(backups.length).toBe(0);
+  });
+});

--- a/packages/gemma/tests/consent.test.ts
+++ b/packages/gemma/tests/consent.test.ts
@@ -1,0 +1,472 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  createConsentBundle,
+  type ConsentBundle,
+  type CreateConsentBundleOptions,
+} from '../src/consent/consent-bundle.js';
+import { storeBundle, loadBundle } from '../src/consent/bundle-storage.js';
+import { shouldRefresh, refreshBundle } from '../src/consent/bundle-refresh.js';
+import { BundleTamperedError } from '../src/errors.js';
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function makeBundleFixture(overrides?: Partial<ConsentBundle>): ConsentBundle {
+  return {
+    bundleId: 'bnd_01',
+    grantToken: 'eyJhbGciOiJSUzI1NiJ9.test.sig',
+    jwksSnapshot: {
+      keys: [{ kty: 'RSA', kid: 'k1' }],
+      fetchedAt: new Date().toISOString(),
+      validUntil: new Date(Date.now() + 86_400_000).toISOString(),
+    },
+    offlineAuditKey: {
+      publicKey: 'pub-key-pem',
+      privateKey: 'priv-key-pem',
+      algorithm: 'Ed25519',
+    },
+    checkpointAt: Date.now(),
+    syncEndpoint: 'https://api.grantex.dev/v1/audit/offline-sync',
+    offlineExpiresAt: new Date(Date.now() + 72 * 3600 * 1000).toISOString(),
+    ...overrides,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  bundle-refresh tests                                               */
+/* ------------------------------------------------------------------ */
+
+describe('bundle-refresh', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('shouldRefresh', () => {
+    it('returns true when less than 20% TTL remaining', () => {
+      const totalTTL = 72 * 3600 * 1000; // 72h
+      const bundle = makeBundleFixture({
+        checkpointAt: Date.now() - totalTTL,
+        offlineExpiresAt: new Date(Date.now() + totalTTL * 0.1).toISOString(), // 10% remaining
+      });
+
+      expect(shouldRefresh(bundle)).toBe(true);
+    });
+
+    it('returns false when more than 20% TTL remaining', () => {
+      const totalTTL = 72 * 3600 * 1000;
+      const bundle = makeBundleFixture({
+        checkpointAt: Date.now() - totalTTL * 0.5,
+        offlineExpiresAt: new Date(Date.now() + totalTTL * 0.5).toISOString(), // 50% remaining
+      });
+
+      expect(shouldRefresh(bundle)).toBe(false);
+    });
+
+    it('returns true when bundle is already expired', () => {
+      const bundle = makeBundleFixture({
+        checkpointAt: Date.now() - 100_000,
+        offlineExpiresAt: new Date(Date.now() - 1000).toISOString(), // already expired
+      });
+
+      expect(shouldRefresh(bundle)).toBe(true);
+    });
+
+    it('returns true when totalTTL is zero or negative', () => {
+      const bundle = makeBundleFixture({
+        checkpointAt: Date.now(),
+        offlineExpiresAt: new Date(Date.now() - 1).toISOString(),
+      });
+
+      expect(shouldRefresh(bundle)).toBe(true);
+    });
+
+    it('returns false at exactly 20% boundary', () => {
+      // At exactly 20%, remaining/total = 0.2, so < 0.2 is false
+      const totalTTL = 100_000;
+      const now = Date.now();
+      const bundle = makeBundleFixture({
+        checkpointAt: now - totalTTL * 0.8,
+        offlineExpiresAt: new Date(now + totalTTL * 0.2 + 1).toISOString(), // just above 20%
+      });
+
+      expect(shouldRefresh(bundle)).toBe(false);
+    });
+  });
+
+  describe('refreshBundle', () => {
+    it('calls correct endpoint with POST and Bearer auth', async () => {
+      const oldBundle = makeBundleFixture();
+      const newBundle = makeBundleFixture({ bundleId: 'bnd_refreshed' });
+
+      const originalFetch = globalThis.fetch;
+      const fetchSpy = vi.fn(async () =>
+        new Response(JSON.stringify(newBundle), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      globalThis.fetch = fetchSpy as typeof fetch;
+
+      try {
+        const result = await refreshBundle(oldBundle, 'test-api-key');
+
+        expect(result.bundleId).toBe('bnd_refreshed');
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        const [url, init] = fetchSpy.mock.calls[0]!;
+        expect(url).toBe('https://api.grantex.dev/v1/consent-bundles/bnd_01/refresh');
+        expect((init as RequestInit).method).toBe('POST');
+        expect((init as RequestInit).headers).toEqual(
+          expect.objectContaining({
+            Authorization: 'Bearer test-api-key',
+          }),
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('uses custom baseUrl when provided', async () => {
+      const bundle = makeBundleFixture();
+      const newBundle = makeBundleFixture();
+
+      const originalFetch = globalThis.fetch;
+      let calledUrl = '';
+      globalThis.fetch = vi.fn(async (url) => {
+        calledUrl = url as string;
+        return new Response(JSON.stringify(newBundle), { status: 200 });
+      }) as typeof fetch;
+
+      try {
+        await refreshBundle(bundle, 'key', 'https://custom.api.dev');
+        expect(calledUrl).toBe('https://custom.api.dev/v1/consent-bundles/bnd_01/refresh');
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('strips trailing slash from baseUrl', async () => {
+      const bundle = makeBundleFixture();
+      const newBundle = makeBundleFixture();
+
+      const originalFetch = globalThis.fetch;
+      let calledUrl = '';
+      globalThis.fetch = vi.fn(async (url) => {
+        calledUrl = url as string;
+        return new Response(JSON.stringify(newBundle), { status: 200 });
+      }) as typeof fetch;
+
+      try {
+        await refreshBundle(bundle, 'key', 'https://api.grantex.dev/');
+        expect(calledUrl).toBe('https://api.grantex.dev/v1/consent-bundles/bnd_01/refresh');
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('throws on HTTP error response', async () => {
+      const bundle = makeBundleFixture();
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async () =>
+        new Response('Server Error', { status: 500 }),
+      ) as typeof fetch;
+
+      try {
+        await expect(refreshBundle(bundle, 'key')).rejects.toThrow(
+          'Failed to refresh consent bundle: HTTP 500',
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  bundle-storage tests                                               */
+/* ------------------------------------------------------------------ */
+
+describe('bundle-storage', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'gemma-storage-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('round-trips a bundle through encrypt/decrypt', async () => {
+    const bundle = makeBundleFixture();
+    const path = join(tmpDir, 'bundle.enc');
+    const key = 'test-passphrase';
+
+    await storeBundle(bundle, path, key);
+    const loaded = await loadBundle(path, key);
+
+    expect(loaded.bundleId).toBe(bundle.bundleId);
+    expect(loaded.grantToken).toBe(bundle.grantToken);
+    expect(loaded.jwksSnapshot.keys).toEqual(bundle.jwksSnapshot.keys);
+    expect(loaded.offlineAuditKey.algorithm).toBe('Ed25519');
+  });
+
+  it('encrypted file does not contain plaintext fields', async () => {
+    const bundle = makeBundleFixture({
+      bundleId: 'super_secret_id',
+      grantToken: 'jwt_highly_sensitive',
+    });
+    const path = join(tmpDir, 'bundle-plain.enc');
+
+    await storeBundle(bundle, path, 'key');
+    const raw = await readFile(path, 'utf-8');
+
+    expect(raw).not.toContain('super_secret_id');
+    expect(raw).not.toContain('jwt_highly_sensitive');
+  });
+
+  it('fails to decrypt with wrong key', async () => {
+    const bundle = makeBundleFixture();
+    const path = join(tmpDir, 'wrong-key.enc');
+
+    await storeBundle(bundle, path, 'correct-key');
+    await expect(loadBundle(path, 'wrong-key')).rejects.toThrow(BundleTamperedError);
+  });
+
+  it('throws BundleTamperedError for truncated file', async () => {
+    const path = join(tmpDir, 'truncated.enc');
+    // Write a file shorter than IV_BYTES + TAG_BYTES (12 + 16 = 28)
+    await writeFile(path, Buffer.alloc(10));
+
+    await expect(loadBundle(path, 'key')).rejects.toThrow(BundleTamperedError);
+    await expect(loadBundle(path, 'key')).rejects.toThrow('Bundle file too short');
+  });
+
+  it('throws BundleTamperedError when ciphertext is corrupted', async () => {
+    const bundle = makeBundleFixture();
+    const path = join(tmpDir, 'corrupted.enc');
+
+    await storeBundle(bundle, path, 'key');
+
+    // Corrupt the ciphertext portion (after IV + tag)
+    const raw = await readFile(path);
+    const corrupted = Buffer.from(raw);
+    for (let i = 28; i < corrupted.length; i++) {
+      corrupted[i] = (corrupted[i]! ^ 0xff);
+    }
+    await writeFile(path, corrupted);
+
+    await expect(loadBundle(path, 'key')).rejects.toThrow(BundleTamperedError);
+  });
+
+  it('handles bundles with complex nested data', async () => {
+    const bundle = makeBundleFixture({
+      jwksSnapshot: {
+        keys: [
+          { kty: 'RSA', kid: 'k1', n: 'long-modulus-value', e: 'AQAB' },
+          { kty: 'RSA', kid: 'k2', n: 'another-modulus', e: 'AQAB' },
+        ],
+        fetchedAt: new Date().toISOString(),
+        validUntil: new Date(Date.now() + 86_400_000).toISOString(),
+      },
+    });
+    const path = join(tmpDir, 'complex.enc');
+
+    await storeBundle(bundle, path, 'pass');
+    const loaded = await loadBundle(path, 'pass');
+    expect(loaded.jwksSnapshot.keys).toHaveLength(2);
+    expect(loaded.jwksSnapshot.keys[1]!.kid).toBe('k2');
+  });
+
+  it('uses different IV for each encryption', async () => {
+    const bundle = makeBundleFixture();
+    const path1 = join(tmpDir, 'iv1.enc');
+    const path2 = join(tmpDir, 'iv2.enc');
+
+    await storeBundle(bundle, path1, 'key');
+    await storeBundle(bundle, path2, 'key');
+
+    const raw1 = await readFile(path1);
+    const raw2 = await readFile(path2);
+
+    // IVs (first 12 bytes) should differ
+    const iv1 = raw1.subarray(0, 12);
+    const iv2 = raw2.subarray(0, 12);
+    expect(Buffer.compare(iv1, iv2)).not.toBe(0);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  consent-bundle tests                                               */
+/* ------------------------------------------------------------------ */
+
+describe('consent-bundle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('createConsentBundle', () => {
+    it('sends correct request body to the API', async () => {
+      const mockBundle = makeBundleFixture();
+      let capturedBody: Record<string, unknown> | null = null;
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async (_url, init) => {
+        capturedBody = JSON.parse((init as RequestInit).body as string);
+        return new Response(JSON.stringify(mockBundle), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }) as typeof fetch;
+
+      try {
+        await createConsentBundle({
+          apiKey: 'dev-key',
+          agentId: 'agent_01',
+          userId: 'user_01',
+          scopes: ['calendar:read', 'email:send'],
+          offlineTTL: '48h',
+        });
+
+        expect(capturedBody).not.toBeNull();
+        expect(capturedBody!.agentId).toBe('agent_01');
+        expect(capturedBody!.userId).toBe('user_01');
+        expect(capturedBody!.scopes).toEqual(['calendar:read', 'email:send']);
+        expect(capturedBody!.offlineTTL).toBe('48h');
+        expect(capturedBody!.offlineAuditKeyAlgorithm).toBe('Ed25519');
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('uses default baseUrl and offlineTTL when not specified', async () => {
+      const mockBundle = makeBundleFixture();
+
+      const originalFetch = globalThis.fetch;
+      let calledUrl = '';
+      let capturedBody: Record<string, unknown> | null = null;
+      globalThis.fetch = vi.fn(async (url, init) => {
+        calledUrl = url as string;
+        capturedBody = JSON.parse((init as RequestInit).body as string);
+        return new Response(JSON.stringify(mockBundle), { status: 200 });
+      }) as typeof fetch;
+
+      try {
+        await createConsentBundle({
+          apiKey: 'key',
+          agentId: 'agent_01',
+          userId: 'user_01',
+          scopes: ['read'],
+        });
+
+        expect(calledUrl).toBe('https://api.grantex.dev/v1/consent-bundles');
+        expect(capturedBody!.offlineTTL).toBe('72h');
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('uses custom baseUrl', async () => {
+      const mockBundle = makeBundleFixture();
+
+      const originalFetch = globalThis.fetch;
+      let calledUrl = '';
+      globalThis.fetch = vi.fn(async (url) => {
+        calledUrl = url as string;
+        return new Response(JSON.stringify(mockBundle), { status: 200 });
+      }) as typeof fetch;
+
+      try {
+        await createConsentBundle({
+          apiKey: 'key',
+          baseUrl: 'https://custom.api.dev',
+          agentId: 'a',
+          userId: 'u',
+          scopes: [],
+        });
+
+        expect(calledUrl).toBe('https://custom.api.dev/v1/consent-bundles');
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('strips trailing slash from baseUrl', async () => {
+      const mockBundle = makeBundleFixture();
+
+      const originalFetch = globalThis.fetch;
+      let calledUrl = '';
+      globalThis.fetch = vi.fn(async (url) => {
+        calledUrl = url as string;
+        return new Response(JSON.stringify(mockBundle), { status: 200 });
+      }) as typeof fetch;
+
+      try {
+        await createConsentBundle({
+          apiKey: 'key',
+          baseUrl: 'https://api.grantex.dev/',
+          agentId: 'a',
+          userId: 'u',
+          scopes: [],
+        });
+
+        expect(calledUrl).toBe('https://api.grantex.dev/v1/consent-bundles');
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('throws on HTTP error', async () => {
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async () =>
+        new Response('Bad Request', { status: 400 }),
+      ) as typeof fetch;
+
+      try {
+        await expect(
+          createConsentBundle({
+            apiKey: 'key',
+            agentId: 'a',
+            userId: 'u',
+            scopes: [],
+          }),
+        ).rejects.toThrow('Failed to create consent bundle: HTTP 400');
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('returns bundle with all required fields', async () => {
+      const mockBundle = makeBundleFixture();
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async () =>
+        new Response(JSON.stringify(mockBundle), { status: 200 }),
+      ) as typeof fetch;
+
+      try {
+        const bundle = await createConsentBundle({
+          apiKey: 'key',
+          agentId: 'a',
+          userId: 'u',
+          scopes: ['read'],
+        });
+
+        expect(bundle.bundleId).toBeTruthy();
+        expect(bundle.grantToken).toBeTruthy();
+        expect(bundle.jwksSnapshot).toBeDefined();
+        expect(bundle.offlineAuditKey).toBeDefined();
+        expect(bundle.syncEndpoint).toBeTruthy();
+        expect(bundle.offlineExpiresAt).toBeTruthy();
+        expect(typeof bundle.checkpointAt).toBe('number');
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
+});

--- a/packages/gemma/tests/verifier.test.ts
+++ b/packages/gemma/tests/verifier.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect } from 'vitest';
+import * as jose from 'jose';
+import { importKeyByKid, isSnapshotExpired, type JWKSSnapshot } from '../src/verifier/jwks-cache.js';
+import { createOfflineVerifier } from '../src/verifier/offline-verifier.js';
+import { hasScope, enforceScopes } from '../src/verifier/scope-enforcer.js';
+import {
+  OfflineVerificationError,
+  ScopeViolationError,
+  TokenExpiredError,
+} from '../src/errors.js';
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+async function generateTestKeyPair(kid: string) {
+  const { publicKey, privateKey } = await jose.generateKeyPair('RS256');
+  const jwk = await jose.exportJWK(publicKey);
+  jwk.kid = kid;
+  jwk.alg = 'RS256';
+  return { publicKey, privateKey, jwk };
+}
+
+function makeSnapshot(keys: jose.JWK[], validUntilOffset = 86_400_000): JWKSSnapshot {
+  return {
+    keys,
+    fetchedAt: new Date().toISOString(),
+    validUntil: new Date(Date.now() + validUntilOffset).toISOString(),
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  jwks-cache tests                                                   */
+/* ------------------------------------------------------------------ */
+
+describe('jwks-cache', () => {
+  describe('importKeyByKid', () => {
+    it('imports a key matching the given kid', async () => {
+      const { jwk } = await generateTestKeyPair('target-kid');
+      const snapshot = makeSnapshot([jwk]);
+
+      const key = await importKeyByKid(snapshot, 'target-kid');
+      expect(key).not.toBeNull();
+    });
+
+    it('returns null when kid is not found', async () => {
+      const { jwk } = await generateTestKeyPair('existing-kid');
+      const snapshot = makeSnapshot([jwk]);
+
+      const key = await importKeyByKid(snapshot, 'nonexistent-kid');
+      expect(key).toBeNull();
+    });
+
+    it('selects correct key from multiple keys', async () => {
+      const k1 = await generateTestKeyPair('kid-A');
+      const k2 = await generateTestKeyPair('kid-B');
+      const k3 = await generateTestKeyPair('kid-C');
+      const snapshot = makeSnapshot([k1.jwk, k2.jwk, k3.jwk]);
+
+      const key = await importKeyByKid(snapshot, 'kid-B');
+      expect(key).not.toBeNull();
+
+      // The key should work for verification with k2's private key
+      const token = await new jose.SignJWT({ test: true })
+        .setProtectedHeader({ alg: 'RS256', kid: 'kid-B' })
+        .setIssuedAt()
+        .setExpirationTime('1h')
+        .sign(k2.privateKey);
+
+      const result = await jose.jwtVerify(token, key!);
+      expect(result.payload.test).toBe(true);
+    });
+
+    it('returns null for empty snapshot', async () => {
+      const snapshot = makeSnapshot([]);
+      const key = await importKeyByKid(snapshot, 'any-kid');
+      expect(key).toBeNull();
+    });
+  });
+
+  describe('isSnapshotExpired', () => {
+    it('returns false for valid snapshot', () => {
+      const snapshot = makeSnapshot([], 86_400_000); // valid for 24h
+      expect(isSnapshotExpired(snapshot)).toBe(false);
+    });
+
+    it('returns true for expired snapshot', () => {
+      const snapshot = makeSnapshot([], -1000); // expired 1s ago
+      expect(isSnapshotExpired(snapshot)).toBe(true);
+    });
+
+    it('returns true for snapshot expiring exactly now', () => {
+      const snapshot: JWKSSnapshot = {
+        keys: [],
+        fetchedAt: new Date().toISOString(),
+        validUntil: new Date(Date.now() - 1).toISOString(),
+      };
+      expect(isSnapshotExpired(snapshot)).toBe(true);
+    });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  offline-verifier additional tests                                  */
+/* ------------------------------------------------------------------ */
+
+describe('offline-verifier (additional)', () => {
+  it('falls back to jti when grnt claim is absent', async () => {
+    const { privateKey, jwk } = await generateTestKeyPair('fb-1');
+    const snapshot = makeSnapshot([jwk]);
+    const verifier = createOfflineVerifier({ jwksSnapshot: snapshot });
+
+    const token = await new jose.SignJWT({
+      sub: 'user:alice',
+      agt: 'did:key:z6MkA',
+      scp: ['read'],
+      jti: 'my-jti-value',
+      // no grnt claim
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'fb-1' })
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(privateKey);
+
+    const grant = await verifier.verify(token);
+    expect(grant.grantId).toBe('my-jti-value');
+    expect(grant.jti).toBe('my-jti-value');
+  });
+
+  it('extracts delegationDepth from token', async () => {
+    const { privateKey, jwk } = await generateTestKeyPair('del-1');
+    const snapshot = makeSnapshot([jwk]);
+    const verifier = createOfflineVerifier({ jwksSnapshot: snapshot });
+
+    const token = await new jose.SignJWT({
+      sub: 'u',
+      agt: 'did:key:z6Mk',
+      scp: [],
+      delegationDepth: 3,
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'del-1' })
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(privateKey);
+
+    const grant = await verifier.verify(token);
+    expect(grant.depth).toBe(3);
+  });
+
+  it('defaults delegationDepth to 0 when absent', async () => {
+    const { privateKey, jwk } = await generateTestKeyPair('del-2');
+    const snapshot = makeSnapshot([jwk]);
+    const verifier = createOfflineVerifier({ jwksSnapshot: snapshot });
+
+    const token = await new jose.SignJWT({
+      sub: 'u',
+      scp: [],
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'del-2' })
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(privateKey);
+
+    const grant = await verifier.verify(token);
+    expect(grant.depth).toBe(0);
+  });
+
+  it('rejects JWT missing kid in header', async () => {
+    const { privateKey, jwk } = await generateTestKeyPair('no-kid');
+    const snapshot = makeSnapshot([jwk]);
+    const verifier = createOfflineVerifier({ jwksSnapshot: snapshot });
+
+    // Build a JWT without kid in the header
+    const token = await new jose.SignJWT({ sub: 'u', scp: [] })
+      .setProtectedHeader({ alg: 'RS256' }) // no kid
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(privateKey);
+
+    await expect(verifier.verify(token)).rejects.toThrow(OfflineVerificationError);
+    await expect(verifier.verify(token)).rejects.toThrow('missing "kid"');
+  });
+
+  it('scope violation mode "log" logs instead of throwing', async () => {
+    const { privateKey, jwk } = await generateTestKeyPair('log-1');
+    const snapshot = makeSnapshot([jwk]);
+
+    const verifier = createOfflineVerifier({
+      jwksSnapshot: snapshot,
+      requireScopes: ['admin:write'],
+      onScopeViolation: 'log',
+    });
+
+    const token = await new jose.SignJWT({
+      sub: 'u',
+      agt: 'did:key:z6Mk',
+      scp: ['read'],
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'log-1' })
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(privateKey);
+
+    // Should NOT throw — logs instead
+    const grant = await verifier.verify(token);
+    expect(grant.scopes).toEqual(['read']);
+  });
+
+  it('handles empty scp claim gracefully', async () => {
+    const { privateKey, jwk } = await generateTestKeyPair('empty-1');
+    const snapshot = makeSnapshot([jwk]);
+    const verifier = createOfflineVerifier({ jwksSnapshot: snapshot });
+
+    const token = await new jose.SignJWT({
+      sub: 'u',
+      // no scp claim
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'empty-1' })
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(privateKey);
+
+    const grant = await verifier.verify(token);
+    expect(grant.scopes).toEqual([]);
+  });
+
+  it('handles missing sub claim gracefully', async () => {
+    const { privateKey, jwk } = await generateTestKeyPair('nosub-1');
+    const snapshot = makeSnapshot([jwk]);
+    const verifier = createOfflineVerifier({ jwksSnapshot: snapshot });
+
+    const token = await new jose.SignJWT({
+      scp: ['read'],
+      agt: 'did:key:z6Mk',
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'nosub-1' })
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(privateKey);
+
+    const grant = await verifier.verify(token);
+    expect(grant.principalDID).toBe('');
+  });
+
+  it('handles missing agt claim gracefully', async () => {
+    const { privateKey, jwk } = await generateTestKeyPair('noagt-1');
+    const snapshot = makeSnapshot([jwk]);
+    const verifier = createOfflineVerifier({ jwksSnapshot: snapshot });
+
+    const token = await new jose.SignJWT({
+      sub: 'user:test',
+      scp: [],
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'noagt-1' })
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(privateKey);
+
+    const grant = await verifier.verify(token);
+    expect(grant.agentDID).toBe('');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  scope-enforcer additional tests                                    */
+/* ------------------------------------------------------------------ */
+
+describe('scope-enforcer (additional)', () => {
+  describe('hasScope', () => {
+    it('is case-sensitive', () => {
+      expect(hasScope(['Calendar:Read'], 'calendar:read')).toBe(false);
+    });
+
+    it('does not match partial scope strings', () => {
+      expect(hasScope(['calendar:read:all'], 'calendar:read')).toBe(false);
+    });
+  });
+
+  describe('enforceScopes', () => {
+    it('reports all missing scopes in error', () => {
+      try {
+        enforceScopes(['a'], ['b', 'c', 'd']);
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const err = e as ScopeViolationError;
+        expect(err.requiredScopes).toEqual(['b', 'c', 'd']);
+        expect(err.grantScopes).toEqual(['a']);
+      }
+    });
+
+    it('passes when grant scopes are a superset of required', () => {
+      expect(() =>
+        enforceScopes(
+          ['admin:write', 'calendar:read', 'email:send', 'files:delete'],
+          ['calendar:read', 'email:send'],
+        ),
+      ).not.toThrow();
+    });
+
+    it('handles duplicate scopes in grant', () => {
+      expect(() =>
+        enforceScopes(['read', 'read', 'write'], ['read', 'write']),
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/gemma/tests/verifier.test.ts
+++ b/packages/gemma/tests/verifier.test.ts
@@ -6,7 +6,6 @@ import { hasScope, enforceScopes } from '../src/verifier/scope-enforcer.js';
 import {
   OfflineVerificationError,
   ScopeViolationError,
-  TokenExpiredError,
 } from '../src/errors.js';
 
 /* ------------------------------------------------------------------ */

--- a/packages/google-adk/pyproject.toml
+++ b/packages/google-adk/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "grantex>=0.1.0",
+    "grantex>=0.3.0",
 ]
 
 [project.urls]

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -26,7 +26,7 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@grantex/sdk": ">=0.1.0",
+    "@grantex/sdk": ">=0.3.0",
     "@langchain/core": ">=0.3.0"
   },
   "overrides": {

--- a/packages/langchain/tests/jwt.test.ts
+++ b/packages/langchain/tests/jwt.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { decodeJwtPayload } from '../src/_jwt.js';
+
+/** Build a minimal JWT with the given payload claims. */
+function createTestToken(payload: Record<string, unknown> = {}): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify({
+    iss: 'https://grantex.dev',
+    sub: 'user_123',
+    agt: 'did:grantex:ag_TEST',
+    dev: 'dev_TEST',
+    scp: ['read', 'write'],
+    jti: 'tok_TEST',
+    grnt: 'grnt_TEST',
+    iat: 1700000000,
+    exp: 1700003600,
+    ...payload,
+  })).toString('base64url');
+  const sig = Buffer.from('test-signature').toString('base64url');
+  return `${header}.${body}.${sig}`;
+}
+
+describe('decodeJwtPayload', () => {
+  it('decodes a valid JWT payload', () => {
+    const token = createTestToken();
+    const payload = decodeJwtPayload(token);
+
+    expect(payload.iss).toBe('https://grantex.dev');
+    expect(payload.sub).toBe('user_123');
+    expect(payload.agt).toBe('did:grantex:ag_TEST');
+    expect(payload.dev).toBe('dev_TEST');
+    expect(payload.scp).toEqual(['read', 'write']);
+    expect(payload.jti).toBe('tok_TEST');
+    expect(payload.grnt).toBe('grnt_TEST');
+    expect(payload.iat).toBe(1700000000);
+    expect(payload.exp).toBe(1700003600);
+  });
+
+  it('extracts scopes from the scp claim', () => {
+    const token = createTestToken({ scp: ['calendar:read', 'profile:read', 'email:write'] });
+    const payload = decodeJwtPayload(token);
+
+    expect(payload.scp).toEqual(['calendar:read', 'profile:read', 'email:write']);
+  });
+
+  it('decodes delegation claims', () => {
+    const token = createTestToken({
+      parentAgt: 'did:grantex:ag_PARENT',
+      parentGrnt: 'grnt_PARENT',
+      delegationDepth: 1,
+    });
+    const payload = decodeJwtPayload(token);
+
+    expect(payload.parentAgt).toBe('did:grantex:ag_PARENT');
+    expect(payload.parentGrnt).toBe('grnt_PARENT');
+    expect(payload.delegationDepth).toBe(1);
+  });
+
+  it('decodes budget claim', () => {
+    const token = createTestToken({ bdg: 42.50 });
+    const payload = decodeJwtPayload(token);
+    expect(payload.bdg).toBe(42.50);
+  });
+
+  it('decodes audience claim', () => {
+    const token = createTestToken({ aud: 'https://api.example.com' });
+    const payload = decodeJwtPayload(token);
+    expect(payload.aud).toBe('https://api.example.com');
+  });
+
+  it('handles base64url characters (+ and /) correctly', () => {
+    // Payload that, when base64-encoded, would produce + and / characters
+    const token = createTestToken({ note: '>>>???<<<' });
+    const payload = decodeJwtPayload(token);
+    expect(payload.note).toBe('>>>???<<<');
+  });
+
+  it('throws on empty string', () => {
+    expect(() => decodeJwtPayload('')).toThrow('invalid JWT format');
+  });
+
+  it('throws on string with only one part', () => {
+    expect(() => decodeJwtPayload('header-only')).toThrow('invalid JWT format');
+  });
+
+  it('throws on string with empty second part', () => {
+    expect(() => decodeJwtPayload('header.')).toThrow('invalid JWT format');
+  });
+
+  it('throws on malformed base64 in payload', () => {
+    // The middle segment is not valid base64/JSON
+    expect(() => decodeJwtPayload('eyJhbGciOiJSUzI1NiJ9.!!!invalid!!!.fakesig')).toThrow();
+  });
+
+  it('returns Record<string, unknown> type', () => {
+    const token = createTestToken({ custom: 'value' });
+    const payload = decodeJwtPayload(token);
+    expect(typeof payload).toBe('object');
+    expect(payload.custom).toBe('value');
+  });
+});

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -1,17 +1,39 @@
-import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { buildServer } from '../src/server.js';
 
-// Minimal stub — we only need the shape so buildServer() can register tools.
-const grantex = {
-  agents: { register: vi.fn(), list: vi.fn(), get: vi.fn(), update: vi.fn(), delete: vi.fn() },
-  authorize: vi.fn(),
-  tokens: { exchange: vi.fn(), verify: vi.fn(), revoke: vi.fn(), refresh: vi.fn() },
-  grants: { list: vi.fn(), get: vi.fn(), revoke: vi.fn(), delegate: vi.fn() },
-  audit: { log: vi.fn(), list: vi.fn() },
-  principalSessions: { create: vi.fn() },
-} as never;
+// ---------------------------------------------------------------------------
+// Mock SDK client
+// ---------------------------------------------------------------------------
+function createMockGrantex() {
+  return {
+    agents: {
+      register: vi.fn(),
+      list: vi.fn(),
+      get: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    authorize: vi.fn(),
+    tokens: {
+      exchange: vi.fn(),
+      verify: vi.fn(),
+      revoke: vi.fn(),
+      refresh: vi.fn(),
+    },
+    grants: {
+      list: vi.fn(),
+      get: vi.fn(),
+      revoke: vi.fn(),
+      delegate: vi.fn(),
+    },
+    audit: { log: vi.fn(), list: vi.fn() },
+    principalSessions: { create: vi.fn() },
+  };
+}
+
+type MockGrantex = ReturnType<typeof createMockGrantex>;
 
 const EXPECTED_TOOLS = [
   'grantex_agent_register',
@@ -33,18 +55,38 @@ const EXPECTED_TOOLS = [
   'grantex_principal_session_create',
 ];
 
-describe('buildServer()', () => {
+// ---------------------------------------------------------------------------
+// Helper: create a connected client + server pair
+// ---------------------------------------------------------------------------
+async function createClientServer(grantex: MockGrantex) {
+  const server = buildServer(grantex as never);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  const client = new Client({ name: 'test-client', version: '0.0.1' });
+  await Promise.all([
+    client.connect(clientTransport),
+    server.connect(serverTransport),
+  ]);
+
+  return { client, server };
+}
+
+// Helper to extract text from a tool call result
+function textOf(result: { content: Array<{ type: string; text?: string }> }): string {
+  const item = result.content[0];
+  if (item && 'text' in item) return item.text as string;
+  throw new Error('No text content');
+}
+
+// ---------------------------------------------------------------------------
+// Tool registration (smoke tests)
+// ---------------------------------------------------------------------------
+describe('buildServer() — tool registration', () => {
   let toolNames: string[];
 
   beforeAll(async () => {
-    const server = buildServer(grantex);
-    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-
-    const client = new Client({ name: 'test-client', version: '0.0.1' });
-    await Promise.all([
-      client.connect(clientTransport),
-      server.connect(serverTransport),
-    ]);
+    const grantex = createMockGrantex();
+    const { client, server } = await createClientServer(grantex);
 
     const { tools } = await client.listTools();
     toolNames = tools.map((t) => t.name);
@@ -59,5 +101,597 @@ describe('buildServer()', () => {
 
   it.each(EXPECTED_TOOLS)('registers %s', (name) => {
     expect(toolNames).toContain(name);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool handler tests
+// ---------------------------------------------------------------------------
+describe('tool handlers', () => {
+  let grantex: MockGrantex;
+  let client: Client;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    grantex = createMockGrantex();
+    const pair = await createClientServer(grantex);
+    client = pair.client;
+    cleanup = async () => {
+      await pair.client.close();
+      await pair.server.close();
+    };
+  });
+
+  // We need to cleanup after each to avoid port/transport leaks.
+  // vitest doesn't have afterEach in the same scope easily, so we call it inline.
+
+  // -----------------------------------------------------------------------
+  // Agent tools
+  // -----------------------------------------------------------------------
+  describe('grantex_agent_register', () => {
+    it('returns registered agent as JSON', async () => {
+      const agent = { id: 'ag_123', name: 'TestBot', scopes: ['read'] };
+      grantex.agents.register.mockResolvedValue(agent);
+
+      const result = await client.callTool({
+        name: 'grantex_agent_register',
+        arguments: { name: 'TestBot', description: 'A test bot', scopes: ['read'] },
+      });
+
+      expect(grantex.agents.register).toHaveBeenCalledWith({
+        name: 'TestBot',
+        description: 'A test bot',
+        scopes: ['read'],
+      });
+      expect(JSON.parse(textOf(result as never))).toEqual(agent);
+
+      await cleanup();
+    });
+
+    it('returns isError when SDK throws', async () => {
+      grantex.agents.register.mockRejectedValue(new Error('Forbidden'));
+
+      const result = await client.callTool({
+        name: 'grantex_agent_register',
+        arguments: { name: 'X', description: 'Y', scopes: [] },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(textOf(result as never)).toBe('Forbidden');
+
+      await cleanup();
+    });
+  });
+
+  describe('grantex_agent_list', () => {
+    it('returns agents array as JSON', async () => {
+      const agents = { agents: [{ id: 'ag_1' }, { id: 'ag_2' }] };
+      grantex.agents.list.mockResolvedValue(agents);
+
+      const result = await client.callTool({
+        name: 'grantex_agent_list',
+        arguments: {},
+      });
+
+      expect(grantex.agents.list).toHaveBeenCalled();
+      expect(JSON.parse(textOf(result as never))).toEqual(agents);
+
+      await cleanup();
+    });
+  });
+
+  describe('grantex_agent_get', () => {
+    it('returns a single agent', async () => {
+      const agent = { id: 'ag_42', name: 'Agent42' };
+      grantex.agents.get.mockResolvedValue(agent);
+
+      const result = await client.callTool({
+        name: 'grantex_agent_get',
+        arguments: { agentId: 'ag_42' },
+      });
+
+      expect(grantex.agents.get).toHaveBeenCalledWith('ag_42');
+      expect(JSON.parse(textOf(result as never))).toEqual(agent);
+
+      await cleanup();
+    });
+
+    it('returns isError for not-found', async () => {
+      grantex.agents.get.mockRejectedValue(new Error('Not found'));
+
+      const result = await client.callTool({
+        name: 'grantex_agent_get',
+        arguments: { agentId: 'ag_missing' },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(textOf(result as never)).toBe('Not found');
+
+      await cleanup();
+    });
+  });
+
+  describe('grantex_agent_update', () => {
+    it('sends only provided fields', async () => {
+      const updated = { id: 'ag_1', name: 'Renamed' };
+      grantex.agents.update.mockResolvedValue(updated);
+
+      const result = await client.callTool({
+        name: 'grantex_agent_update',
+        arguments: { agentId: 'ag_1', name: 'Renamed' },
+      });
+
+      expect(grantex.agents.update).toHaveBeenCalledWith('ag_1', { name: 'Renamed' });
+      expect(JSON.parse(textOf(result as never))).toEqual(updated);
+
+      await cleanup();
+    });
+
+    it('sends all fields when provided', async () => {
+      const updated = { id: 'ag_1', name: 'New', description: 'Desc', scopes: ['write'] };
+      grantex.agents.update.mockResolvedValue(updated);
+
+      await client.callTool({
+        name: 'grantex_agent_update',
+        arguments: { agentId: 'ag_1', name: 'New', description: 'Desc', scopes: ['write'] },
+      });
+
+      expect(grantex.agents.update).toHaveBeenCalledWith('ag_1', {
+        name: 'New',
+        description: 'Desc',
+        scopes: ['write'],
+      });
+
+      await cleanup();
+    });
+  });
+
+  describe('grantex_agent_delete', () => {
+    it('returns success message', async () => {
+      grantex.agents.delete.mockResolvedValue(undefined);
+
+      const result = await client.callTool({
+        name: 'grantex_agent_delete',
+        arguments: { agentId: 'ag_99' },
+      });
+
+      expect(grantex.agents.delete).toHaveBeenCalledWith('ag_99');
+      expect(textOf(result as never)).toBe('Agent ag_99 deleted successfully.');
+
+      await cleanup();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Authorize tool
+  // -----------------------------------------------------------------------
+  describe('grantex_authorize', () => {
+    it('returns consent URL and auth request id', async () => {
+      const authResult = {
+        authRequestId: 'ar_abc',
+        consentUrl: 'https://example.com/consent',
+        expiresAt: '2026-12-31T00:00:00Z',
+      };
+      grantex.authorize.mockResolvedValue(authResult);
+
+      const result = await client.callTool({
+        name: 'grantex_authorize',
+        arguments: {
+          agentId: 'ag_1',
+          userId: 'user_1',
+          scopes: ['read', 'write'],
+        },
+      });
+
+      expect(grantex.authorize).toHaveBeenCalledWith({
+        agentId: 'ag_1',
+        userId: 'user_1',
+        scopes: ['read', 'write'],
+      });
+      expect(JSON.parse(textOf(result as never))).toEqual(authResult);
+
+      await cleanup();
+    });
+
+    it('passes optional expiresIn and redirectUri', async () => {
+      grantex.authorize.mockResolvedValue({ authRequestId: 'ar_1' });
+
+      await client.callTool({
+        name: 'grantex_authorize',
+        arguments: {
+          agentId: 'ag_1',
+          userId: 'user_1',
+          scopes: ['read'],
+          expiresIn: '24h',
+          redirectUri: 'https://app.test/callback',
+        },
+      });
+
+      expect(grantex.authorize).toHaveBeenCalledWith({
+        agentId: 'ag_1',
+        userId: 'user_1',
+        scopes: ['read'],
+        expiresIn: '24h',
+        redirectUri: 'https://app.test/callback',
+      });
+
+      await cleanup();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Token tools
+  // -----------------------------------------------------------------------
+  describe('grantex_token_exchange', () => {
+    it('returns token response', async () => {
+      const tokenResponse = {
+        grantToken: 'jwt.token.here',
+        expiresAt: '2026-12-31T00:00:00Z',
+        scopes: ['read'],
+        refreshToken: 'rt_abc',
+        grantId: 'grnt_1',
+      };
+      grantex.tokens.exchange.mockResolvedValue(tokenResponse);
+
+      const result = await client.callTool({
+        name: 'grantex_token_exchange',
+        arguments: { code: 'auth_code_abc', agentId: 'ag_1' },
+      });
+
+      expect(grantex.tokens.exchange).toHaveBeenCalledWith({
+        code: 'auth_code_abc',
+        agentId: 'ag_1',
+      });
+      expect(JSON.parse(textOf(result as never))).toEqual(tokenResponse);
+
+      await cleanup();
+    });
+  });
+
+  describe('grantex_token_verify', () => {
+    it('returns verification result', async () => {
+      const verifyResult = {
+        valid: true,
+        grantId: 'grnt_1',
+        scopes: ['read'],
+        principal: 'user_1',
+        agent: 'ag_1',
+        expiresAt: '2026-12-31T00:00:00Z',
+      };
+      grantex.tokens.verify.mockResolvedValue(verifyResult);
+
+      const result = await client.callTool({
+        name: 'grantex_token_verify',
+        arguments: { token: 'jwt.token.here' },
+      });
+
+      expect(grantex.tokens.verify).toHaveBeenCalledWith('jwt.token.here');
+      expect(JSON.parse(textOf(result as never))).toEqual(verifyResult);
+
+      await cleanup();
+    });
+
+    it('returns valid=false for invalid tokens', async () => {
+      const verifyResult = { valid: false };
+      grantex.tokens.verify.mockResolvedValue(verifyResult);
+
+      const result = await client.callTool({
+        name: 'grantex_token_verify',
+        arguments: { token: 'bad.token' },
+      });
+
+      expect(JSON.parse(textOf(result as never))).toEqual(verifyResult);
+
+      await cleanup();
+    });
+  });
+
+  describe('grantex_token_revoke', () => {
+    it('returns success message', async () => {
+      grantex.tokens.revoke.mockResolvedValue(undefined);
+
+      const result = await client.callTool({
+        name: 'grantex_token_revoke',
+        arguments: { tokenId: 'jti_abc' },
+      });
+
+      expect(grantex.tokens.revoke).toHaveBeenCalledWith('jti_abc');
+      expect(textOf(result as never)).toBe('Token revoked successfully.');
+
+      await cleanup();
+    });
+  });
+
+  describe('grantex_token_refresh', () => {
+    it('returns refreshed token response', async () => {
+      const refreshResult = {
+        grantToken: 'new.jwt.token',
+        expiresAt: '2026-12-31T00:00:00Z',
+        scopes: ['read'],
+        refreshToken: 'rt_new',
+        grantId: 'grnt_1',
+      };
+      grantex.tokens.refresh.mockResolvedValue(refreshResult);
+
+      const result = await client.callTool({
+        name: 'grantex_token_refresh',
+        arguments: { refreshToken: 'rt_old', agentId: 'ag_1' },
+      });
+
+      expect(grantex.tokens.refresh).toHaveBeenCalledWith({
+        refreshToken: 'rt_old',
+        agentId: 'ag_1',
+      });
+      expect(JSON.parse(textOf(result as never))).toEqual(refreshResult);
+
+      await cleanup();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Grant tools
+  // -----------------------------------------------------------------------
+  describe('grantex_grant_list', () => {
+    it('returns grants with no filters', async () => {
+      const grants = { grants: [{ id: 'grnt_1' }] };
+      grantex.grants.list.mockResolvedValue(grants);
+
+      const result = await client.callTool({
+        name: 'grantex_grant_list',
+        arguments: {},
+      });
+
+      expect(grantex.grants.list).toHaveBeenCalledWith({});
+      expect(JSON.parse(textOf(result as never))).toEqual(grants);
+
+      await cleanup();
+    });
+
+    it('passes optional filters', async () => {
+      grantex.grants.list.mockResolvedValue({ grants: [] });
+
+      await client.callTool({
+        name: 'grantex_grant_list',
+        arguments: { agentId: 'ag_1', status: 'active' },
+      });
+
+      expect(grantex.grants.list).toHaveBeenCalledWith({
+        agentId: 'ag_1',
+        status: 'active',
+      });
+
+      await cleanup();
+    });
+  });
+
+  describe('grantex_grant_get', () => {
+    it('returns a single grant', async () => {
+      const grant = { id: 'grnt_1', status: 'active', scopes: ['read'] };
+      grantex.grants.get.mockResolvedValue(grant);
+
+      const result = await client.callTool({
+        name: 'grantex_grant_get',
+        arguments: { grantId: 'grnt_1' },
+      });
+
+      expect(grantex.grants.get).toHaveBeenCalledWith('grnt_1');
+      expect(JSON.parse(textOf(result as never))).toEqual(grant);
+
+      await cleanup();
+    });
+  });
+
+  describe('grantex_grant_revoke', () => {
+    it('returns success message', async () => {
+      grantex.grants.revoke.mockResolvedValue(undefined);
+
+      const result = await client.callTool({
+        name: 'grantex_grant_revoke',
+        arguments: { grantId: 'grnt_42' },
+      });
+
+      expect(grantex.grants.revoke).toHaveBeenCalledWith('grnt_42');
+      expect(textOf(result as never)).toBe('Grant grnt_42 revoked successfully.');
+
+      await cleanup();
+    });
+  });
+
+  describe('grantex_grant_delegate', () => {
+    it('returns delegated grant response', async () => {
+      const delegated = {
+        grantToken: 'delegated.jwt',
+        expiresAt: '2026-12-31T00:00:00Z',
+        scopes: ['read'],
+        grantId: 'grnt_child',
+      };
+      grantex.grants.delegate.mockResolvedValue(delegated);
+
+      const result = await client.callTool({
+        name: 'grantex_grant_delegate',
+        arguments: {
+          parentGrantToken: 'parent.jwt',
+          subAgentId: 'ag_sub',
+          scopes: ['read'],
+        },
+      });
+
+      expect(grantex.grants.delegate).toHaveBeenCalledWith({
+        parentGrantToken: 'parent.jwt',
+        subAgentId: 'ag_sub',
+        scopes: ['read'],
+      });
+      expect(JSON.parse(textOf(result as never))).toEqual(delegated);
+
+      await cleanup();
+    });
+
+    it('passes optional expiresIn', async () => {
+      grantex.grants.delegate.mockResolvedValue({ grantToken: 'x' });
+
+      await client.callTool({
+        name: 'grantex_grant_delegate',
+        arguments: {
+          parentGrantToken: 'parent.jwt',
+          subAgentId: 'ag_sub',
+          scopes: ['read'],
+          expiresIn: '1h',
+        },
+      });
+
+      expect(grantex.grants.delegate).toHaveBeenCalledWith({
+        parentGrantToken: 'parent.jwt',
+        subAgentId: 'ag_sub',
+        scopes: ['read'],
+        expiresIn: '1h',
+      });
+
+      await cleanup();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Audit tools
+  // -----------------------------------------------------------------------
+  describe('grantex_audit_log', () => {
+    it('logs an audit entry with required fields', async () => {
+      const entry = { id: 'aud_1', action: 'read_email', status: 'success' };
+      grantex.audit.log.mockResolvedValue(entry);
+
+      const result = await client.callTool({
+        name: 'grantex_audit_log',
+        arguments: {
+          agentId: 'ag_1',
+          agentDid: 'did:key:z6Mk123',
+          grantId: 'grnt_1',
+          principalId: 'user_1',
+          action: 'read_email',
+        },
+      });
+
+      expect(grantex.audit.log).toHaveBeenCalledWith({
+        agentId: 'ag_1',
+        agentDid: 'did:key:z6Mk123',
+        grantId: 'grnt_1',
+        principalId: 'user_1',
+        action: 'read_email',
+      });
+      expect(JSON.parse(textOf(result as never))).toEqual(entry);
+
+      await cleanup();
+    });
+
+    it('passes optional metadata and status', async () => {
+      grantex.audit.log.mockResolvedValue({ id: 'aud_2' });
+
+      await client.callTool({
+        name: 'grantex_audit_log',
+        arguments: {
+          agentId: 'ag_1',
+          agentDid: 'did:key:z6Mk123',
+          grantId: 'grnt_1',
+          principalId: 'user_1',
+          action: 'send_message',
+          metadata: { to: 'alice@example.com' },
+          status: 'success',
+        },
+      });
+
+      expect(grantex.audit.log).toHaveBeenCalledWith({
+        agentId: 'ag_1',
+        agentDid: 'did:key:z6Mk123',
+        grantId: 'grnt_1',
+        principalId: 'user_1',
+        action: 'send_message',
+        metadata: { to: 'alice@example.com' },
+        status: 'success',
+      });
+
+      await cleanup();
+    });
+  });
+
+  describe('grantex_audit_list', () => {
+    it('lists audit entries with no filters', async () => {
+      const entries = { entries: [{ id: 'aud_1' }] };
+      grantex.audit.list.mockResolvedValue(entries);
+
+      const result = await client.callTool({
+        name: 'grantex_audit_list',
+        arguments: {},
+      });
+
+      expect(grantex.audit.list).toHaveBeenCalledWith({});
+      expect(JSON.parse(textOf(result as never))).toEqual(entries);
+
+      await cleanup();
+    });
+
+    it('passes all optional filters', async () => {
+      grantex.audit.list.mockResolvedValue({ entries: [] });
+
+      await client.callTool({
+        name: 'grantex_audit_list',
+        arguments: {
+          agentId: 'ag_1',
+          grantId: 'grnt_1',
+          action: 'read_email',
+          since: '2026-01-01T00:00:00Z',
+          until: '2026-12-31T00:00:00Z',
+        },
+      });
+
+      expect(grantex.audit.list).toHaveBeenCalledWith({
+        agentId: 'ag_1',
+        grantId: 'grnt_1',
+        action: 'read_email',
+        since: '2026-01-01T00:00:00Z',
+        until: '2026-12-31T00:00:00Z',
+      });
+
+      await cleanup();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Principal session tool
+  // -----------------------------------------------------------------------
+  describe('grantex_principal_session_create', () => {
+    it('creates a session with required principalId', async () => {
+      const session = {
+        sessionToken: 'sess_jwt',
+        dashboardUrl: 'https://grantex.dev/dashboard?token=sess_jwt',
+        expiresAt: '2026-12-31T00:00:00Z',
+      };
+      grantex.principalSessions.create.mockResolvedValue(session);
+
+      const result = await client.callTool({
+        name: 'grantex_principal_session_create',
+        arguments: { principalId: 'user_1' },
+      });
+
+      expect(grantex.principalSessions.create).toHaveBeenCalledWith({
+        principalId: 'user_1',
+      });
+      expect(JSON.parse(textOf(result as never))).toEqual(session);
+
+      await cleanup();
+    });
+
+    it('passes optional expiresIn', async () => {
+      grantex.principalSessions.create.mockResolvedValue({ sessionToken: 'tok' });
+
+      await client.callTool({
+        name: 'grantex_principal_session_create',
+        arguments: { principalId: 'user_1', expiresIn: '30m' },
+      });
+
+      expect(grantex.principalSessions.create).toHaveBeenCalledWith({
+        principalId: 'user_1',
+        expiresIn: '30m',
+      });
+
+      await cleanup();
+    });
   });
 });

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+  },
+});

--- a/packages/openai-agents/pyproject.toml
+++ b/packages/openai-agents/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "grantex>=0.1.0",
+    "grantex>=0.3.0",
 ]
 
 [project.urls]

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -131,6 +131,14 @@ from ._types import (
 )
 from .resources._passports import PassportsClient
 from .resources._events import EventsClient, GrantexEvent as GrantexStreamEvent, StreamOptions, Subscription
+
+# ─── Aliases for cross-SDK naming consistency ────────────────────────────────
+# The TypeScript SDK uses SsoConnectionListResponse / SsoSessionListResponse
+# while the Python SDK uses ListSsoConnectionsResponse / ListSsoSessionsResponse.
+# Expose both names so consumers can use either convention.
+SsoConnectionListResponse = ListSsoConnectionsResponse
+SsoSessionListResponse = ListSsoSessionsResponse
+
 from ._pkce import PkceChallenge, generate_pkce
 from ._verify import verify_grant_token
 from ._webhook import verify_webhook_signature
@@ -236,6 +244,9 @@ __all__ = [
     "SsoSamlCallbackParams",
     "SsoLdapCallbackParams",
     "SsoCallbackResult",
+    # Enterprise SSO aliases (match TypeScript SDK naming)
+    "SsoConnectionListResponse",
+    "SsoSessionListResponse",
     # Budgets
     "AllocateBudgetParams",
     "BudgetAllocation",

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -26,7 +26,7 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@grantex/sdk": ">=0.1.0",
+    "@grantex/sdk": ">=0.3.0",
     "ai": ">=4.0.0",
     "zod": ">=3.0.0"
   },

--- a/packages/vercel-ai/tests/jwt.test.ts
+++ b/packages/vercel-ai/tests/jwt.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { decodeJwtPayload } from '../src/_jwt.js';
+
+/** Build a minimal JWT with the given payload claims. */
+function createTestToken(payload: Record<string, unknown> = {}): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify({
+    iss: 'https://grantex.dev',
+    sub: 'user_123',
+    agt: 'did:grantex:ag_TEST',
+    dev: 'dev_TEST',
+    scp: ['read', 'write'],
+    jti: 'tok_TEST',
+    grnt: 'grnt_TEST',
+    iat: 1700000000,
+    exp: 1700003600,
+    ...payload,
+  })).toString('base64url');
+  const sig = Buffer.from('test-signature').toString('base64url');
+  return `${header}.${body}.${sig}`;
+}
+
+describe('decodeJwtPayload', () => {
+  it('decodes a valid JWT payload', () => {
+    const token = createTestToken();
+    const payload = decodeJwtPayload(token);
+
+    expect(payload.iss).toBe('https://grantex.dev');
+    expect(payload.sub).toBe('user_123');
+    expect(payload.agt).toBe('did:grantex:ag_TEST');
+    expect(payload.dev).toBe('dev_TEST');
+    expect(payload.scp).toEqual(['read', 'write']);
+    expect(payload.jti).toBe('tok_TEST');
+    expect(payload.grnt).toBe('grnt_TEST');
+    expect(payload.iat).toBe(1700000000);
+    expect(payload.exp).toBe(1700003600);
+  });
+
+  it('extracts scopes from the scp claim', () => {
+    const token = createTestToken({ scp: ['calendar:read', 'profile:read', 'email:write'] });
+    const payload = decodeJwtPayload(token);
+
+    expect(payload.scp).toEqual(['calendar:read', 'profile:read', 'email:write']);
+  });
+
+  it('decodes delegation claims', () => {
+    const token = createTestToken({
+      parentAgt: 'did:grantex:ag_PARENT',
+      parentGrnt: 'grnt_PARENT',
+      delegationDepth: 1,
+    });
+    const payload = decodeJwtPayload(token);
+
+    expect(payload.parentAgt).toBe('did:grantex:ag_PARENT');
+    expect(payload.parentGrnt).toBe('grnt_PARENT');
+    expect(payload.delegationDepth).toBe(1);
+  });
+
+  it('decodes budget claim', () => {
+    const token = createTestToken({ bdg: 42.50 });
+    const payload = decodeJwtPayload(token);
+    expect(payload.bdg).toBe(42.50);
+  });
+
+  it('decodes audience claim', () => {
+    const token = createTestToken({ aud: 'https://api.example.com' });
+    const payload = decodeJwtPayload(token);
+    expect(payload.aud).toBe('https://api.example.com');
+  });
+
+  it('handles base64url characters (+ and /) correctly', () => {
+    const token = createTestToken({ note: '>>>???<<<' });
+    const payload = decodeJwtPayload(token);
+    expect(payload.note).toBe('>>>???<<<');
+  });
+
+  it('throws on empty string', () => {
+    expect(() => decodeJwtPayload('')).toThrow('invalid JWT format');
+  });
+
+  it('throws on string with only one part', () => {
+    expect(() => decodeJwtPayload('header-only')).toThrow('invalid JWT format');
+  });
+
+  it('throws on string with empty second part', () => {
+    expect(() => decodeJwtPayload('header.')).toThrow('invalid JWT format');
+  });
+
+  it('throws on malformed base64 in payload', () => {
+    expect(() => decodeJwtPayload('eyJhbGciOiJSUzI1NiJ9.!!!invalid!!!.fakesig')).toThrow();
+  });
+
+  it('returns Record<string, unknown> type', () => {
+    const token = createTestToken({ custom: 'value' });
+    const payload = decodeJwtPayload(token);
+    expect(typeof payload).toBe('object');
+    expect(payload.custom).toBe('value');
+  });
+});

--- a/packages/vercel-ai/vitest.config.ts
+++ b/packages/vercel-ai/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+  },
+});

--- a/web/index.html
+++ b/web/index.html
@@ -1036,7 +1036,7 @@
       <a href="/mcp" style="text-decoration:none;display:block;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:24px;transition:border-color .2s;" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
         <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
           <span style="background:#3fb950;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">GA</span>
-          <span style="color:var(--text);font-weight:600;">MCP Auth Server v2.0</span>
+          <span style="color:var(--text);font-weight:600;">MCP Auth Server v2.0.1</span>
         </div>
         <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">OAuth 2.1 + PKCE for any MCP server. Managed + self-hosted. Bronze/Silver/Gold certification program.</p>
       </a>
@@ -1075,7 +1075,7 @@
 
       <a href="#scope-enforcement" style="text-decoration:none;display:block;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:24px;transition:border-color .2s;" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
         <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
-          <span style="background:#f97583;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">v0.3.1</span>
+          <span style="background:#f97583;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">v0.3.4</span>
           <span style="color:var(--text);font-weight:600;">Scope Enforcement</span>
         </div>
         <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">enforce() + wrapTool() + Express/FastAPI middleware. Define manifests for any connector, or use 53 pre-built ones. &lt;1ms per call.</p>
@@ -1088,7 +1088,7 @@
 <!-- ── Scope Enforcement ──────────────────────────────────────────────────── -->
 <section id="scope-enforcement" style="padding:64px 0;border-bottom:1px solid var(--border);">
   <div class="container">
-    <div class="section-label">New in v0.3.1</div>
+    <div class="section-label">New in v0.3.4</div>
     <h2 class="section-title" style="font-size:clamp(24px,4vw,36px);">Scope Enforcement &mdash; Control What Agents Can Do</h2>
     <p class="section-sub" style="max-width:640px;margin:0 auto 40px;">
       Enforce tool-level permissions on any connector you define. Bring your own manifests or use the 53 pre-built ones. Offline JWKS verification, &lt;1ms per call.


### PR DESCRIPTION
## Summary
Addresses remaining low-priority items from codebase review.

### Test coverage — 233 new tests
- JWT tests for langchain, anthropic, vercel-ai, autogen (44)
- MCP server: all 17 tools tested (43 tests, up from 2)
- Gemma: adapters, audit, consent, verifier (78)
- DPDP: consent, export, purpose (66)

### Version constraints — 13 packages
All >=0.1.0 to >=0.3.0 for @grantex/sdk and grantex.

### SDK parity
Python SSO type aliases matching TypeScript naming.

### Documentation
PassportsClient/VaultService added to Python/Go SDK overview docs + MPP feature page.

### Landing page
Version badges: v0.3.1 to v0.3.4, MCP Auth v2.0 to v2.0.1.