### PR TITLE
fix: landing page content + SEO audit — 15 pre-rendered pages, examples expanded, GA4 coverage

### DIFF
--- a/web/for/anthropic/index.html
+++ b/web/for/anthropic/index.html
@@ -1,0 +1,787 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
+  <!-- Dynamic meta tags set by JS below -->
+  <title>Grantex for Anthropic SDK — Secure Claude Tool Use Authorization</title>
+  <meta name="description" content="Add scoped permissions and audit trails to Claude tool use. Offline JWT verification, tool registry, and instant revocation. Open source.">
+  <link rel="canonical" href="https://grantex.dev/for/anthropic/">
+  <meta property="og:title" content="Grantex for Anthropic SDK — Secure Claude Tool Use Authorization">
+  <meta property="og:description" content="Add scoped permissions and audit trails to Claude tool use. Offline JWT verification, tool registry, and instant revocation. Open source.">
+  <meta property="og:url" content="https://grantex.dev/for/anthropic/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Grantex">
+  <meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grantex for Anthropic SDK — Secure Claude Tool Use Authorization">
+  <meta name="twitter:description" content="Add scoped permissions and audit trails to Claude tool use. Offline JWT verification, tool registry, and instant revocation. Open source.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
+  <style>
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --border:   #30363d;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --accent:   #3fb950;
+      --accent2:  #58a6ff;
+      --mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+      --sans:     'Inter', system-ui, -apple-system, sans-serif;
+      --radius:   8px;
+      --max-w:    900px;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: var(--sans); line-height: 1.6; }
+    a { color: var(--accent2); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { font-family: var(--mono); background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+    pre { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; overflow-x: auto; font-family: var(--mono); font-size: 0.875rem; line-height: 1.5; }
+    pre code { background: none; padding: 0; }
+
+    /* Nav */
+    .nav { display: flex; align-items: center; justify-content: space-between; max-width: var(--max-w); margin: 0 auto; padding: 1rem 1.5rem; }
+    .nav-logo { font-weight: 700; font-size: 1.25rem; color: var(--text); }
+    .nav-links { list-style: none; display: flex; gap: 1.5rem; }
+    .nav-links a { color: var(--muted); font-size: 0.9rem; }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+
+    /* Hero */
+    .hero { text-align: center; padding: 4rem 1.5rem 3rem; max-width: var(--max-w); margin: 0 auto; }
+    .hero-badge { display: inline-block; background: rgba(63,185,80,0.15); color: var(--accent); padding: 0.25rem 0.75rem; border-radius: 999px; font-size: 0.8rem; font-weight: 600; margin-bottom: 1rem; }
+    .hero h1 { font-size: 2.5rem; line-height: 1.2; margin-bottom: 1rem; }
+    .hero h1 .highlight { color: var(--accent); }
+    .hero p { color: var(--muted); font-size: 1.1rem; max-width: 650px; margin: 0 auto 2rem; }
+    .hero-ctas { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
+    .btn { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.65rem 1.25rem; border-radius: var(--radius); font-weight: 600; font-size: 0.9rem; text-decoration: none; transition: all 0.2s; }
+    .btn-primary { background: var(--accent); color: #0d1117; }
+    .btn-primary:hover { background: #2ea043; text-decoration: none; }
+    .btn-secondary { background: var(--surface); color: var(--text); border: 1px solid var(--border); }
+    .btn-secondary:hover { border-color: var(--muted); text-decoration: none; }
+
+    /* Sections */
+    .section { max-width: var(--max-w); margin: 0 auto; padding: 3rem 1.5rem; }
+    .section h2 { font-size: 1.75rem; margin-bottom: 1rem; }
+    .section h3 { font-size: 1.15rem; margin-bottom: 0.5rem; color: var(--accent); }
+    .section p, .section li { color: var(--muted); }
+    .section ul { padding-left: 1.25rem; }
+    .section li { margin-bottom: 0.5rem; }
+
+    /* Problem cards */
+    .problem-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; margin: 1.5rem 0; }
+    .problem-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .problem-card.bad { border-color: #f8514933; }
+    .problem-card.good { border-color: #3fb95033; }
+    .problem-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .problem-card.bad h3 { color: #f85149; }
+    .problem-card.good h3 { color: var(--accent); }
+
+    /* Steps */
+    .steps { counter-reset: step; margin: 1.5rem 0; }
+    .step { display: flex; gap: 1rem; margin-bottom: 1.5rem; }
+    .step::before { counter-increment: step; content: counter(step); display: flex; align-items: center; justify-content: center; min-width: 32px; height: 32px; background: rgba(63,185,80,0.15); color: var(--accent); border-radius: 50%; font-weight: 700; font-size: 0.85rem; }
+    .step-content h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.25rem; }
+    .step-content p { font-size: 0.9rem; }
+
+    /* Features */
+    .feature-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.25rem; margin: 1.5rem 0; }
+    .feature-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .feature-card h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; }
+
+    /* Install */
+    .install-box { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.25rem; display: flex; align-items: center; justify-content: space-between; margin: 1rem 0; font-family: var(--mono); font-size: 0.9rem; }
+    .install-box button { background: var(--accent); color: #0d1117; border: none; padding: 0.35rem 0.75rem; border-radius: 4px; font-weight: 600; cursor: pointer; font-size: 0.8rem; }
+
+    /* Footer */
+    .footer { max-width: var(--max-w); margin: 0 auto; padding: 2rem 1.5rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; }
+    .footer-links { list-style: none; display: flex; gap: 1.5rem; }
+    .footer-links a { color: var(--muted); font-size: 0.85rem; }
+
+    @media (max-width: 640px) {
+      .hero h1 { font-size: 1.75rem; }
+      .problem-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Grantex for Anthropic SDK","applicationCategory":"DeveloperApplication","operatingSystem":"Any","url":"https://grantex.dev/for/anthropic/","description":"Add scoped permissions and audit trails to Claude tool use. Offline JWT verification, tool registry, and instant revocation. Open source.","license":"https://www.apache.org/licenses/LICENSE-2.0"}</script>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/" class="nav-logo">Grantex</a>
+  <ul class="nav-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="/playground">Playground</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+  </ul>
+</nav>
+
+<div id="app">
+  <section class="hero">
+    <span class="hero-badge" id="badge"></span>
+    <h1 id="heroTitle"></h1>
+    <p id="heroDesc"></p>
+    <div class="hero-ctas">
+      <a href="" id="ctaDocs" class="btn btn-primary">View Integration Docs</a>
+      <a href="" id="ctaInstall" class="btn btn-secondary">Get Started</a>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2>The Problem</h2>
+    <div class="problem-grid">
+      <div class="problem-card bad">
+        <h3>Without Grantex</h3>
+        <p id="problemBad"></p>
+      </div>
+      <div class="problem-card good">
+        <h3>With Grantex</h3>
+        <p id="problemGood"></p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2 id="howTitle">How It Works</h2>
+    <div class="steps" id="steps"></div>
+  </section>
+
+  <section class="section">
+    <h2>Quick Start</h2>
+    <div class="install-box">
+      <span id="installCmd"></span>
+      <button onclick="navigator.clipboard.writeText(document.getElementById('installCmd').textContent);this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)">Copy</button>
+    </div>
+    <pre><code id="codeExample"></code></pre>
+  </section>
+
+  <section class="section">
+    <h2 id="featuresTitle">Why Grantex</h2>
+    <div class="feature-grid" id="features"></div>
+  </section>
+
+  <section class="section" style="text-align:center">
+    <h2>Ready to secure your <span id="ctaFramework"></span> agents?</h2>
+    <p style="margin-bottom:1.5rem;color:var(--muted)">Get started in under 5 minutes. Open source, Apache 2.0.</p>
+    <div class="hero-ctas">
+      <a href="https://grantex.dev/dashboard/signup" class="btn btn-primary">Sign Up Free</a>
+      <a href="" id="ctaDocsBottom" class="btn btn-secondary">Read the Docs</a>
+    </div>
+  </section>
+</div>
+
+<footer class="footer">
+  <span style="color:var(--muted);font-size:0.85rem">Grantex — Open authorization for AI agents</span>
+  <ul class="footer-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+    <li><a href="/">Home</a></li>
+  </ul>
+</footer>
+
+<script>
+const frameworks = {
+  langchain: {
+    name: 'LangChain',
+    badge: 'LangChain + Grantex',
+    title: 'Authorization for <span class="highlight">LangChain</span> Agents',
+    desc: 'Add scoped, revocable permissions to your LangChain agents. Grantex integrates natively with LangChain tools — your agents get signed JWTs instead of raw API keys.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    install: 'npm install @grantex/langchain @grantex/sdk',
+    problemBad: 'Your LangChain agents use raw API keys with full access. No scoping, no audit trail, no way to revoke access if an agent goes rogue. One compromised key exposes everything.',
+    problemGood: 'Each LangChain agent gets a scoped, time-limited JWT. Tools verify permissions offline. You can revoke any agent instantly. Every action is audit-logged with a hash chain.',
+    howTitle: 'How Grantex Works with LangChain',
+    steps: [
+      ['Install the integration', 'npm install @grantex/langchain — wraps LangChain tools with automatic grant verification.'],
+      ['Register your agent', 'Create an agent identity with specific scopes like "email:send" or "calendar:read".'],
+      ['Get user consent', 'Redirect the user to a consent page. They approve exactly which permissions the agent gets.'],
+      ['Agent receives a JWT', 'The agent gets a signed token it presents to any service. Services verify offline via JWKS.'],
+      ['Audit & revoke', 'Every action is logged. Revoke access in under 1 second if something goes wrong.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexToolkit } from '@grantex/langchain';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap your LangChain tools with Grantex authorization
+const toolkit = new GrantexToolkit({
+  client: gx,
+  grantToken: token,  // JWT from the consent flow
+  tools: [searchTool, emailTool],
+});
+
+// Tools now automatically verify scopes before executing
+const agent = createToolCallingAgent({ llm, tools: toolkit.tools });`,
+    features: [
+      ['Native LangChain Integration', 'Drop-in toolkit that wraps your existing LangChain tools with automatic scope verification.'],
+      ['Scoped Permissions', 'Define exactly what each agent can do — "email:read" vs "email:send". No more all-or-nothing API keys.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS without calling Grantex. Zero latency overhead on your LangChain pipeline.'],
+      ['Multi-Agent Delegation', 'Parent agents delegate narrower scopes to sub-agents. Revoking the parent cascades to all children.'],
+      ['Hash-Chained Audit Trail', 'Every tool invocation is logged in an append-only, tamper-evident audit trail.'],
+      ['Real-Time Revocation', 'Kill a misbehaving agent\'s access in under 1 second. No waiting for token expiry.'],
+    ],
+    ctaFramework: 'LangChain',
+    metaTitle: 'Grantex for LangChain — Authorization for LangChain AI Agents',
+    metaDesc: 'Add scoped, revocable permissions to LangChain agents. Drop-in toolkit for authorization with signed JWTs, audit trails, and real-time revocation. Open source.',
+  },
+  crewai: {
+    name: 'CrewAI',
+    badge: 'CrewAI + Grantex',
+    title: 'Authorization for <span class="highlight">CrewAI</span> Agents',
+    desc: 'Secure your CrewAI crews with scoped, revocable permissions. Each crew member gets exactly the access it needs — nothing more.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    install: 'pip install grantex-crewai grantex',
+    problemBad: 'Your CrewAI agents share the same API keys. If one crew member is compromised, the entire crew\'s access is exposed. No way to scope or revoke individual agent access.',
+    problemGood: 'Each crew member gets its own scoped JWT. The researcher can only read, the writer can only draft, the publisher can only post. Revoke any member instantly.',
+    howTitle: 'How Grantex Works with CrewAI',
+    steps: [
+      ['Install the integration', 'pip install grantex-crewai — Python-native integration for CrewAI crews.'],
+      ['Register each crew member', 'Create agent identities with role-specific scopes for each crew member.'],
+      ['Authorize the crew', 'Users approve scoped permissions for each role in the crew.'],
+      ['Crew operates with scoped tokens', 'Each crew member presents its own JWT. Services verify independently.'],
+      ['Monitor & control', 'Audit every crew action. Revoke individual members without stopping the whole crew.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_crewai import GrantexCrewTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Each crew member gets scoped authorization
+researcher_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=researcher_token,  # scoped to "search:read"
+    tools=[search_tool],
+)
+
+writer_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=writer_token,  # scoped to "docs:write"
+    tools=[write_tool],
+)`,
+    features: [
+      ['Per-Agent Scoping', 'Each crew member gets exactly the permissions it needs. Researcher reads, writer writes, publisher posts.'],
+      ['Role-Based Access', 'Map CrewAI roles to Grantex scopes. Define authorization policies per role, not per API key.'],
+      ['Crew-Wide Audit Trail', 'See what every crew member did, when, and with what permissions. Hash-chained for tamper evidence.'],
+      ['Delegation Chains', 'A lead agent can delegate narrower permissions to sub-agents. Revoking the lead cascades to all.'],
+      ['Python Native', 'Pure Python integration. pip install and go — works with any CrewAI version.'],
+      ['Instant Revocation', 'Revoke any crew member\'s access in under 1 second without disrupting the rest of the crew.'],
+    ],
+    ctaFramework: 'CrewAI',
+    metaTitle: 'Grantex for CrewAI — Secure Multi-Agent Crew Permissions',
+    metaDesc: 'Scope and control permissions for CrewAI agents. Each crew member gets its own signed JWT with role-specific access. Audit trails, delegation, real-time revocation.',
+  },
+  'openai-agents': {
+    name: 'OpenAI Agents SDK',
+    badge: 'OpenAI Agents + Grantex',
+    title: 'Authorization for <span class="highlight">OpenAI Agents SDK</span>',
+    desc: 'Add enterprise-grade authorization to your OpenAI agents. Scoped permissions, audit trails, and instant revocation — built for the Agents SDK.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    install: 'pip install grantex-openai-agents grantex',
+    problemBad: 'Your OpenAI agents operate with full API access. No scoping, no audit trail, no revocation. You can\'t tell which agent did what or limit what it can do.',
+    problemGood: 'Each agent gets a scoped, time-limited JWT. Every tool call is authorized and logged. Revoke access instantly if an agent behaves unexpectedly.',
+    howTitle: 'How Grantex Works with OpenAI Agents SDK',
+    steps: [
+      ['Install the integration', 'pip install grantex-openai-agents — wraps OpenAI agent tools with authorization.'],
+      ['Register your agent', 'Create an agent identity with scopes matching its capabilities.'],
+      ['Get user approval', 'Users approve exactly which permissions the agent receives via a consent page.'],
+      ['Agent operates with JWT', 'The agent\'s tools automatically verify permissions before executing.'],
+      ['Full audit trail', 'Every tool invocation is logged with the agent identity, scopes used, and timestamp.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_openai_agents import GrantexTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap OpenAI agent tools with Grantex authorization
+tools = GrantexTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, email_tool],
+)
+
+# Tools automatically check scopes before execution
+agent = Agent(
+    name="assistant",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['OpenAI Agents SDK Integration', 'Drop-in wrapper for OpenAI agent tools. Add authorization without changing your agent logic.'],
+      ['Scoped Tool Access', 'Define which tools each agent can use and with what parameters. Enforced at the protocol level.'],
+      ['Enterprise Audit Trail', 'Every tool call logged with agent identity, scopes, and hash-chained integrity.'],
+      ['Multi-Agent Pipelines', 'Parent agents delegate narrower access to sub-agents. Full delegation chain tracking.'],
+      ['Budget Controls', 'Set spending limits per agent. Automatic cutoff when budget is exhausted.'],
+      ['Compliance Ready', 'SOC 2 compatible audit logging. SCIM/SSO for enterprise identity management.'],
+    ],
+    ctaFramework: 'OpenAI Agents',
+    metaTitle: 'Grantex for OpenAI Agents SDK — Enterprise Agent Authorization',
+    metaDesc: 'Add scoped permissions, audit trails, and real-time revocation to OpenAI Agents SDK. Enterprise-grade authorization for AI agents. Open source.',
+  },
+  anthropic: {
+    name: 'Anthropic SDK',
+    badge: 'Anthropic + Grantex',
+    title: 'Authorization for <span class="highlight">Anthropic SDK</span> Tool Use',
+    desc: 'Enforce scoped permissions on Claude tool calls. Offline JWT verification, automatic audit logging, and instant revocation for Anthropic SDK apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    installUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    install: 'npm install @grantex/anthropic @grantex/sdk',
+    problemBad: 'Your Claude-powered agents call tools with no authorization layer. Any tool can be invoked with full access. No scoping, no consent, no audit trail of what the agent did.',
+    problemGood: 'Grantex wraps each tool with scope enforcement. The agent\'s JWT is checked offline before execution. Every tool call is audit-logged. Revoke access in under 1 second.',
+    howTitle: 'How Grantex Works with the Anthropic SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/anthropic — wraps Anthropic tool definitions with authorization.'],
+      ['Create scoped tools', 'Use createGrantexTool() to define tools with required scopes and JSON Schema input.'],
+      ['Pass tools to Claude', 'tool.definition is type-compatible with client.messages.create({ tools }).'],
+      ['Dispatch tool_use blocks', 'Use GrantexToolRegistry or handleToolCall() to execute with automatic audit logging.'],
+      ['Monitor everything', 'Hash-chained audit trail of every tool call. Revoke access in under 1 second.'],
+    ],
+    code: `import Anthropic from '@anthropic-ai/sdk';
+import { createGrantexTool, GrantexToolRegistry } from '@grantex/anthropic';
+
+const client = new Anthropic();
+
+const readFile = createGrantexTool({
+  name: 'read_file',
+  description: 'Read a file from disk',
+  inputSchema: {
+    type: 'object',
+    properties: { path: { type: 'string' } },
+    required: ['path'],
+  },
+  grantToken,
+  requiredScope: 'file:read',
+  execute: async ({ path }) => fs.readFile(path, 'utf-8'),
+});
+
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  tools: [readFile.definition],
+  messages,
+});`,
+    features: [
+      ['Anthropic SDK Native', 'Type-compatible with client.messages.create(). tool.definition drops in directly.'],
+      ['Offline Scope Checks', 'JWT scp claim verified locally. No network call to Grantex during execution.'],
+      ['Tool Registry', 'GrantexToolRegistry manages multiple tools and dispatches tool_use blocks by name.'],
+      ['Audit Logging', 'withAuditLogging() and handleToolCall() log every success/failure automatically.'],
+      ['GrantexScopeError', 'Typed error with requiredScope and grantedScopes for clean error handling.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Anthropic SDK',
+    metaTitle: 'Grantex for Anthropic SDK — Secure Claude Tool Use Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Claude tool use. Offline JWT verification, tool registry, and instant revocation. Open source.',
+  },
+  'google-adk': {
+    name: 'Google ADK',
+    badge: 'Google ADK + Grantex',
+    title: 'Authorization for <span class="highlight">Google ADK</span> Agents',
+    desc: 'Secure your Google Agent Development Kit agents with scoped, human-approved permissions and full audit trails.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    install: 'pip install grantex-adk grantex',
+    problemBad: 'Your ADK agents access services with broad credentials. No fine-grained scoping, no delegation control, no tamper-proof audit log of agent actions.',
+    problemGood: 'Each ADK agent gets cryptographic identity and scoped JWTs. Delegation chains track multi-agent workflows. Every action is audit-logged.',
+    howTitle: 'How Grantex Works with Google ADK',
+    steps: [
+      ['Install the integration', 'pip install grantex-adk — Python-native integration for Google ADK.'],
+      ['Register your agent', 'Create an agent identity with specific scopes matching your ADK agent\'s capabilities.'],
+      ['Authorize via consent', 'Users approve scoped permissions through a consent flow.'],
+      ['Agent operates securely', 'ADK tools verify permissions via JWT before executing any action.'],
+      ['Monitor everything', 'Hash-chained audit trail of every action. Revoke access in under 1 second.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_adk import GrantexADKTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap ADK tools with Grantex authorization
+tools = GrantexADKTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, calendar_tool],
+)
+
+# Tools verify scopes automatically
+agent = Agent(
+    model="gemini-2.0-flash",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['Google ADK Native', 'Built for the Agent Development Kit. Wraps ADK tools with automatic authorization.'],
+      ['Scoped Permissions', 'Fine-grained scopes for each capability. "calendar:read" vs "calendar:write".'],
+      ['Delegation Chains', 'Multi-agent ADK pipelines with tracked delegation. Revoke parent to cascade.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS. No network calls to Grantex during execution.'],
+      ['Audit & Compliance', 'Tamper-proof audit trail. SOC 2 compatible. Enterprise compliance exports.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Google ADK',
+    metaTitle: 'Grantex for Google ADK — Secure Agent Development Kit Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Google ADK agents. Delegation chains, real-time revocation, and enterprise compliance. Open source.',
+  },
+  'vercel-ai': {
+    name: 'Vercel AI SDK',
+    badge: 'Vercel AI + Grantex',
+    title: 'Authorization for <span class="highlight">Vercel AI SDK</span>',
+    desc: 'Add scoped authorization to your Vercel AI SDK tools. Signed JWTs, audit trails, and instant revocation for AI-powered apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    install: 'npm install @grantex/vercel-ai @grantex/sdk',
+    problemBad: 'Your Vercel AI tools run with full access. Users can\'t see or control what the AI does on their behalf. No audit trail, no revocation.',
+    problemGood: 'Each AI tool call is authorized with a scoped JWT. Users approve permissions upfront. Every action is logged. Revoke instantly.',
+    howTitle: 'How Grantex Works with Vercel AI SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/vercel-ai — TypeScript-native integration for Vercel AI SDK.'],
+      ['Define authorized tools', 'Wrap your AI SDK tools with Grantex scope requirements.'],
+      ['User consents', 'Users approve specific scopes before the AI can act on their behalf.'],
+      ['Tools verify automatically', 'Each tool call checks the JWT scopes before execution.'],
+      ['Full observability', 'Audit trail of every tool invocation. Real-time event streaming.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createGrantexTools } from '@grantex/vercel-ai';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap Vercel AI SDK tools with authorization
+const tools = createGrantexTools({
+  client: gx,
+  grantToken: token,
+  tools: { search: searchTool, email: emailTool },
+});
+
+// Use with generateText or streamText
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prompt: 'Search for flights and send the results',
+});`,
+    features: [
+      ['Vercel AI SDK Native', 'Works with generateText, streamText, and all AI SDK tool patterns.'],
+      ['TypeScript First', 'Full type safety. Scopes are checked at compile time and runtime.'],
+      ['Edge Compatible', 'Works in Vercel Edge Functions. JWT verification is local — no external calls.'],
+      ['Streaming Support', 'Compatible with streaming responses. Authorization doesn\'t block the stream.'],
+      ['Multi-Step Flows', 'Authorize multi-step AI workflows where each step requires different scopes.'],
+      ['Next.js Ready', 'Drop into your Next.js app with zero configuration beyond the SDK.'],
+    ],
+    ctaFramework: 'Vercel AI',
+    metaTitle: 'Grantex for Vercel AI SDK — Authorization for AI-Powered Apps',
+    metaDesc: 'Add scoped permissions to Vercel AI SDK tools. TypeScript-native, Edge-compatible, with audit trails and real-time revocation. Open source.',
+  },
+  autogen: {
+    name: 'AutoGen',
+    badge: 'AutoGen + Grantex',
+    title: 'Authorization for <span class="highlight">AutoGen</span> Multi-Agent Systems',
+    desc: 'Secure your AutoGen conversations with per-agent permissions. Each agent in the group gets exactly the scopes it needs.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    install: 'npm install @grantex/autogen @grantex/sdk',
+    problemBad: 'AutoGen agents in a group chat share credentials. If one agent is compromised or hallucinates, it has access to everything the others can do.',
+    problemGood: 'Each AutoGen agent gets its own scoped JWT. The coder can only write code, the executor can only run tests. Isolated, audited, revocable.',
+    howTitle: 'How Grantex Works with AutoGen',
+    steps: [
+      ['Install the integration', 'npm install @grantex/autogen — wraps AutoGen function maps with authorization.'],
+      ['Register each agent', 'Create identities with role-specific scopes for each agent in the group.'],
+      ['Scope per conversation', 'Users approve what each agent can do before the conversation starts.'],
+      ['Agents operate independently', 'Each agent presents its own JWT. Function calls are scope-checked automatically.'],
+      ['Trace everything', 'Full audit trail across the multi-agent conversation. Attribute actions to specific agents.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexAutoGen } from '@grantex/autogen';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Each agent in the group gets scoped authorization
+const coderTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: coderToken,  // scoped to "code:write"
+  functionMap: { write_code: writeCodeFn },
+});
+
+const executorTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: executorToken,  // scoped to "code:execute"
+  functionMap: { run_code: runCodeFn },
+});`,
+    features: [
+      ['Per-Agent Authorization', 'Each agent in the AutoGen group gets its own scoped token and identity.'],
+      ['Group Chat Security', 'Prevent agents from accessing tools outside their role. Enforced at the protocol level.'],
+      ['Conversation Auditing', 'Track which agent called which function, with what scopes, across the entire conversation.'],
+      ['Delegation Support', 'Agents can delegate narrower scopes to spawned sub-agents with depth tracking.'],
+      ['Function Map Wrapping', 'Drop-in wrapper for AutoGen function maps. No changes to your agent logic.'],
+      ['Real-Time Control', 'Revoke any agent mid-conversation. Access is denied within 1 second.'],
+    ],
+    ctaFramework: 'AutoGen',
+    metaTitle: 'Grantex for AutoGen — Secure Multi-Agent Group Chat Authorization',
+    metaDesc: 'Per-agent scoped permissions for AutoGen multi-agent systems. Each agent gets its own JWT. Audit trails, delegation chains, instant revocation.',
+  },
+  mcp: {
+    name: 'Model Context Protocol',
+    badge: 'MCP + Grantex',
+    title: 'Authorization for <span class="highlight">MCP</span> Servers',
+    desc: 'Add enterprise-grade authorization to any MCP server. 13 built-in tools for managing agents, grants, and tokens from Claude Desktop, Cursor, or Windsurf.',
+    docsUrl: 'https://docs.grantex.dev/integrations/mcp',
+    installUrl: 'https://docs.grantex.dev/integrations/mcp',
+    install: 'npm install @grantex/mcp',
+    problemBad: 'MCP servers expose tools to AI assistants with no authorization layer. Any connected client can call any tool with full access. No scoping, no consent, no audit trail.',
+    problemGood: 'Grantex adds OAuth 2.1-style authorization to MCP. Users approve scoped access per tool. Every invocation is logged. Revoke access from the permission dashboard.',
+    howTitle: 'How Grantex Works with MCP',
+    steps: [
+      ['Install the MCP server', 'npm install @grantex/mcp — adds 13 Grantex tools to any MCP-compatible client.'],
+      ['Connect to Claude Desktop', 'Add Grantex to your MCP config. Works with Claude Desktop, Cursor, and Windsurf.'],
+      ['Manage via natural language', 'Ask Claude to "register an agent", "create a grant", or "check the audit log".'],
+      ['Or add MCP Auth', 'Use @grantex/mcp-auth to add OAuth 2.1 + PKCE to your own MCP servers.'],
+      ['Full protocol access', 'All 13 Grantex operations available as MCP tools — agents, grants, tokens, audit, budgets.'],
+    ],
+    code: `// claude_desktop_config.json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "npx",
+      "args": ["@grantex/mcp"],
+      "env": {
+        "GRANTEX_API_KEY": "gx_live_..."
+      }
+    }
+  }
+}
+
+// Then in Claude Desktop:
+// "Register a new agent called travel-bot with flights:book scope"
+// "Create a grant for user alice on travel-bot"
+// "Show me the audit log for the last hour"`,
+    features: [
+      ['13 MCP Tools', 'Full Grantex protocol access: agents, grants, tokens, audit, budgets, verification — all as MCP tools.'],
+      ['Claude Desktop Ready', 'Works out of the box with Claude Desktop, Cursor, and Windsurf.'],
+      ['MCP Auth Server', 'Separate @grantex/mcp-auth package adds OAuth 2.1 + PKCE to any MCP server.'],
+      ['Natural Language Control', 'Manage authorization through conversation. "Revoke all grants for agent X."'],
+      ['Zero Code Setup', 'npx @grantex/mcp — no code required. Just add to your MCP config and go.'],
+      ['Enterprise Grade', 'Budget controls, policy engine, SCIM/SSO — all accessible via MCP tools.'],
+    ],
+    ctaFramework: 'MCP',
+    metaTitle: 'Grantex for MCP — Authorization for Model Context Protocol Servers',
+    metaDesc: 'Add OAuth 2.1 authorization to MCP servers. 13 tools for Claude Desktop, Cursor, and Windsurf. Scoped grants, audit trails, real-time revocation.',
+  },
+  express: {
+    name: 'Express.js',
+    badge: 'Express + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">Express.js</span>',
+    desc: 'Protect your Express.js APIs with Grantex grant tokens. Drop-in middleware that verifies JWTs, enforces scopes, and logs every request.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    install: 'npm install @grantex/express',
+    problemBad: 'Your Express APIs accept API keys or bearer tokens with no scope enforcement. Any valid token can access any endpoint. No agent identity tracking.',
+    problemGood: 'Grantex middleware verifies JWTs offline via JWKS, enforces scopes per route, and identifies the calling agent. Zero external network calls.',
+    howTitle: 'How Grantex Works with Express.js',
+    steps: [
+      ['Install the middleware', 'npm install @grantex/express — one package, zero external dependencies at runtime.'],
+      ['Add to your app', 'One line to protect your routes. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs are verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'req.grantex gives you the agent DID, scopes, principal, and grant ID.'],
+      ['Production ready', 'JWKS caching, key rotation, scope enforcement, and error handling built in.'],
+    ],
+    code: `import express from 'express';
+import { grantexMiddleware, requireScopes } from '@grantex/express';
+
+const app = express();
+
+// Verify Grantex JWTs on all /api routes
+app.use('/api', grantexMiddleware({
+  jwksUrl: 'https://grantex-auth-....a.run.app/.well-known/jwks.json',
+}));
+
+// Enforce specific scopes per route
+app.get('/api/emails', requireScopes(['email:read']), (req, res) => {
+  console.log(req.grantex.agent);  // agent DID
+  console.log(req.grantex.scopes); // ['email:read']
+  res.json({ emails: [] });
+});`,
+    features: [
+      ['Drop-In Middleware', 'One line to protect your Express routes. Works with any Express 4+ app.'],
+      ['Offline JWT Verification', 'JWKS-based verification. No network calls to Grantex on each request. Sub-millisecond overhead.'],
+      ['Per-Route Scopes', 'requireScopes() enforces specific permissions per endpoint. Returns 403 if scopes don\'t match.'],
+      ['Agent Identity', 'req.grantex provides agent DID, scopes, principal ID, grant ID on every request.'],
+      ['JWKS Caching', 'Automatic key caching and rotation. Handles key rollover transparently.'],
+      ['TypeScript Support', 'Full type definitions. req.grantex is fully typed.'],
+    ],
+    ctaFramework: 'Express.js',
+    metaTitle: 'Grantex for Express.js — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Drop-in Express.js middleware for Grantex JWT verification. Offline JWKS verification, per-route scope enforcement, and agent identity. Open source.',
+  },
+  fastapi: {
+    name: 'FastAPI',
+    badge: 'FastAPI + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">FastAPI</span>',
+    desc: 'Protect your FastAPI endpoints with Grantex grant tokens. Dependency-injection middleware that verifies JWTs, enforces scopes, and identifies agents.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    install: 'pip install grantex-fastapi',
+    problemBad: 'Your FastAPI endpoints accept bearer tokens with no scope enforcement. Any valid token accesses any route. No way to identify which AI agent made the request.',
+    problemGood: 'Grantex dependency verifies JWTs offline via JWKS, enforces scopes per route, and provides the agent identity. Pythonic, async, and type-safe.',
+    howTitle: 'How Grantex Works with FastAPI',
+    steps: [
+      ['Install the middleware', 'pip install grantex-fastapi — async-native, works with FastAPI\'s dependency injection.'],
+      ['Add the dependency', 'Use GrantexAuth as a FastAPI dependency. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'The dependency returns the full grant context: agent DID, scopes, principal, grant ID.'],
+      ['Production ready', 'Async JWKS fetching, key caching, automatic rotation, and proper error responses.'],
+    ],
+    code: `from fastapi import FastAPI, Depends
+from grantex_fastapi import GrantexAuth, GrantContext
+
+app = FastAPI()
+auth = GrantexAuth(
+    jwks_url="https://grantex-auth-....a.run.app/.well-known/jwks.json"
+)
+
+@app.get("/api/emails")
+async def list_emails(
+    grant: GrantContext = Depends(auth.require_scopes(["email:read"]))
+):
+    print(grant.agent)   # agent DID
+    print(grant.scopes)  # ["email:read"]
+    return {"emails": []}`,
+    features: [
+      ['FastAPI Dependency Injection', 'Works with FastAPI\'s Depends() pattern. Pythonic and type-safe.'],
+      ['Async Native', 'Fully async JWKS fetching and JWT verification. No blocking calls.'],
+      ['Per-Route Scopes', 'require_scopes() enforces specific permissions per endpoint. Returns 403 on mismatch.'],
+      ['Typed Grant Context', 'Full Pydantic model for grant context: agent DID, scopes, principal, grant ID.'],
+      ['JWKS Caching', 'Automatic async key caching and rotation. Handles key rollover transparently.'],
+      ['OpenAPI Integration', 'Scopes appear in your FastAPI OpenAPI docs automatically.'],
+    ],
+    ctaFramework: 'FastAPI',
+    metaTitle: 'Grantex for FastAPI — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.',
+  },
+  mpp: {
+    name: 'MPP (Machine Payments Protocol)',
+    badge: 'MPP + Grantex',
+    title: 'Agent Identity for <span class="highlight">Machine Payments</span>',
+    desc: 'MPP defines how AI agents pay for services. Grantex adds the missing identity layer — verifiable agent passports that let merchants know exactly who authorized every payment, with offline verification in under 50ms.',
+    docsUrl: 'https://docs.grantex.dev/features/mpp-agent-passport',
+    installUrl: 'https://docs.grantex.dev/guides/mpp-integration',
+    install: 'npm install @grantex/mpp @grantex/sdk',
+    problemBad: 'When an agent makes an MPP payment, the source is just a wallet address. No human name, no org, no authorization chain. For $0.10 API calls nobody cares. For $500 B2B procurement, it\'s a compliance blocker.',
+    problemGood: 'Every MPP payment carries an AgentPassportCredential — a W3C VC 2.0 credential with the human principal, org DID, spending limits, and allowed categories. Merchants verify in <50ms, offline.',
+    howTitle: 'How Grantex Works with MPP',
+    steps: [
+      ['Install the package', 'npm install @grantex/mpp — agent-side middleware + merchant-side verification in one package.'],
+      ['Issue an agent passport', 'Call grantex.passports.issue() with categories (inference, compute, data), spending limits, and expiry.'],
+      ['Attach to MPP requests', 'createMppPassportMiddleware() injects the X-Grantex-Passport header on every outgoing fetch.'],
+      ['Verify on the merchant side', 'requireAgentPassport() Express middleware — one line to verify identity, categories, and amounts.'],
+      ['Check the trust registry', 'lookupOrgTrust() returns verified org status (basic, verified, SOC 2) from the public registry.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createMppPassportMiddleware, requireAgentPassport } from '@grantex/mpp';
+
+// Agent side: issue passport and attach to requests
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const passport = await grantex.passports.issue({
+  agentId: 'ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  allowedMPPCategories: ['inference', 'compute'],
+  maxTransactionAmount: { amount: 50, currency: 'USDC' },
+  expiresIn: '24h',
+});
+
+const middleware = createMppPassportMiddleware({ passport });
+const enriched = await middleware(new Request(url));
+// X-Grantex-Passport header attached
+
+// Merchant side: one-line verification
+app.use('/api/inference', requireAgentPassport({
+  requiredCategories: ['inference'],
+  maxAmount: 10,
+}));
+// req.agentPassport → { humanDID, orgDID, categories, maxAmount, ... }`,
+    features: [
+      ['AgentPassportCredential', 'W3C VC 2.0 with agent DID, human principal, org, categories, spending limits, and delegation depth.'],
+      ['<50ms Verification', 'Offline verification using cached JWKS. No API roundtrip to Grantex servers needed.'],
+      ['9 MPP Categories', 'inference, compute, data, storage, search, media, delivery, browser, general — each maps to a Grantex scope.'],
+      ['StatusList2021 Revocation', 'Revoke any passport instantly. Bit-flip propagation, no polling required.'],
+      ['Trust Registry', 'Public org trust lookup by DID. DNS-TXT, manual, or SOC 2 verification levels.'],
+      ['Auto-Refresh', 'Middleware proactively refreshes passports before expiry via onRefresh callback.'],
+    ],
+    ctaFramework: 'MPP',
+    metaTitle: 'Grantex for MPP — Agent Identity for Machine Payments Protocol',
+    metaDesc: 'Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.',
+  },
+};
+
+// Determine framework from URL
+const path = window.location.pathname.replace(/\/$/, '');
+const slug = path.split('/').pop();
+const fw = frameworks[slug];
+
+if (!fw) {
+  // Redirect to homepage if unknown framework
+  window.location.href = '/';
+} else {
+  // Set meta tags
+  document.title = fw.metaTitle;
+  document.querySelector('meta[name="description"]').content = fw.metaDesc;
+  document.querySelector('link[rel="canonical"]').href = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[property="og:title"]').content = fw.metaTitle;
+  document.querySelector('meta[property="og:description"]').content = fw.metaDesc;
+  document.querySelector('meta[property="og:url"]').content = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[name="twitter:title"]').content = fw.metaTitle;
+  document.querySelector('meta[name="twitter:description"]').content = fw.metaDesc;
+
+  // Populate content
+  document.getElementById('badge').textContent = fw.badge;
+  document.getElementById('heroTitle').innerHTML = fw.title;
+  document.getElementById('heroDesc').textContent = fw.desc;
+  document.getElementById('ctaDocs').href = fw.docsUrl;
+  document.getElementById('ctaInstall').href = fw.installUrl;
+  document.getElementById('problemBad').textContent = fw.problemBad;
+  document.getElementById('problemGood').textContent = fw.problemGood;
+  document.getElementById('howTitle').textContent = fw.howTitle;
+  document.getElementById('installCmd').textContent = fw.install;
+  document.getElementById('codeExample').textContent = fw.code;
+  document.getElementById('ctaFramework').textContent = fw.ctaFramework;
+  document.getElementById('ctaDocsBottom').href = fw.docsUrl;
+  document.getElementById('featuresTitle').textContent = 'Why Grantex for ' + fw.name;
+
+  // Steps
+  const stepsEl = document.getElementById('steps');
+  fw.steps.forEach(([title, desc]) => {
+    stepsEl.innerHTML += `<div class="step"><div class="step-content"><h3>${title}</h3><p>${desc}</p></div></div>`;
+  });
+
+  // Features
+  const featuresEl = document.getElementById('features');
+  fw.features.forEach(([title, desc]) => {
+    featuresEl.innerHTML += `<div class="feature-card"><h3>${title}</h3><p>${desc}</p></div>`;
+  });
+
+  // Add JSON-LD structured data
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Grantex for " + fw.name,
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Any",
+    "url": "https://grantex.dev/for/" + slug,
+    "description": fw.metaDesc,
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  };
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.textContent = JSON.stringify(jsonLd);
+  document.head.appendChild(script);
+
+  // Track page view
+  gtag('event', 'page_view', { page_title: fw.metaTitle, page_location: window.location.href });
+}
+</script>
+</body>
+</html>

--- a/web/for/autogen/index.html
+++ b/web/for/autogen/index.html
@@ -1,0 +1,787 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
+  <!-- Dynamic meta tags set by JS below -->
+  <title>Grantex for AutoGen — Secure Multi-Agent Group Chat Authorization</title>
+  <meta name="description" content="Per-agent scoped permissions for AutoGen multi-agent systems. Each agent gets its own JWT. Audit trails, delegation chains, instant revocation.">
+  <link rel="canonical" href="https://grantex.dev/for/autogen/">
+  <meta property="og:title" content="Grantex for AutoGen — Secure Multi-Agent Group Chat Authorization">
+  <meta property="og:description" content="Per-agent scoped permissions for AutoGen multi-agent systems. Each agent gets its own JWT. Audit trails, delegation chains, instant revocation.">
+  <meta property="og:url" content="https://grantex.dev/for/autogen/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Grantex">
+  <meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grantex for AutoGen — Secure Multi-Agent Group Chat Authorization">
+  <meta name="twitter:description" content="Per-agent scoped permissions for AutoGen multi-agent systems. Each agent gets its own JWT. Audit trails, delegation chains, instant revocation.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
+  <style>
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --border:   #30363d;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --accent:   #3fb950;
+      --accent2:  #58a6ff;
+      --mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+      --sans:     'Inter', system-ui, -apple-system, sans-serif;
+      --radius:   8px;
+      --max-w:    900px;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: var(--sans); line-height: 1.6; }
+    a { color: var(--accent2); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { font-family: var(--mono); background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+    pre { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; overflow-x: auto; font-family: var(--mono); font-size: 0.875rem; line-height: 1.5; }
+    pre code { background: none; padding: 0; }
+
+    /* Nav */
+    .nav { display: flex; align-items: center; justify-content: space-between; max-width: var(--max-w); margin: 0 auto; padding: 1rem 1.5rem; }
+    .nav-logo { font-weight: 700; font-size: 1.25rem; color: var(--text); }
+    .nav-links { list-style: none; display: flex; gap: 1.5rem; }
+    .nav-links a { color: var(--muted); font-size: 0.9rem; }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+
+    /* Hero */
+    .hero { text-align: center; padding: 4rem 1.5rem 3rem; max-width: var(--max-w); margin: 0 auto; }
+    .hero-badge { display: inline-block; background: rgba(63,185,80,0.15); color: var(--accent); padding: 0.25rem 0.75rem; border-radius: 999px; font-size: 0.8rem; font-weight: 600; margin-bottom: 1rem; }
+    .hero h1 { font-size: 2.5rem; line-height: 1.2; margin-bottom: 1rem; }
+    .hero h1 .highlight { color: var(--accent); }
+    .hero p { color: var(--muted); font-size: 1.1rem; max-width: 650px; margin: 0 auto 2rem; }
+    .hero-ctas { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
+    .btn { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.65rem 1.25rem; border-radius: var(--radius); font-weight: 600; font-size: 0.9rem; text-decoration: none; transition: all 0.2s; }
+    .btn-primary { background: var(--accent); color: #0d1117; }
+    .btn-primary:hover { background: #2ea043; text-decoration: none; }
+    .btn-secondary { background: var(--surface); color: var(--text); border: 1px solid var(--border); }
+    .btn-secondary:hover { border-color: var(--muted); text-decoration: none; }
+
+    /* Sections */
+    .section { max-width: var(--max-w); margin: 0 auto; padding: 3rem 1.5rem; }
+    .section h2 { font-size: 1.75rem; margin-bottom: 1rem; }
+    .section h3 { font-size: 1.15rem; margin-bottom: 0.5rem; color: var(--accent); }
+    .section p, .section li { color: var(--muted); }
+    .section ul { padding-left: 1.25rem; }
+    .section li { margin-bottom: 0.5rem; }
+
+    /* Problem cards */
+    .problem-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; margin: 1.5rem 0; }
+    .problem-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .problem-card.bad { border-color: #f8514933; }
+    .problem-card.good { border-color: #3fb95033; }
+    .problem-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .problem-card.bad h3 { color: #f85149; }
+    .problem-card.good h3 { color: var(--accent); }
+
+    /* Steps */
+    .steps { counter-reset: step; margin: 1.5rem 0; }
+    .step { display: flex; gap: 1rem; margin-bottom: 1.5rem; }
+    .step::before { counter-increment: step; content: counter(step); display: flex; align-items: center; justify-content: center; min-width: 32px; height: 32px; background: rgba(63,185,80,0.15); color: var(--accent); border-radius: 50%; font-weight: 700; font-size: 0.85rem; }
+    .step-content h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.25rem; }
+    .step-content p { font-size: 0.9rem; }
+
+    /* Features */
+    .feature-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.25rem; margin: 1.5rem 0; }
+    .feature-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .feature-card h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; }
+
+    /* Install */
+    .install-box { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.25rem; display: flex; align-items: center; justify-content: space-between; margin: 1rem 0; font-family: var(--mono); font-size: 0.9rem; }
+    .install-box button { background: var(--accent); color: #0d1117; border: none; padding: 0.35rem 0.75rem; border-radius: 4px; font-weight: 600; cursor: pointer; font-size: 0.8rem; }
+
+    /* Footer */
+    .footer { max-width: var(--max-w); margin: 0 auto; padding: 2rem 1.5rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; }
+    .footer-links { list-style: none; display: flex; gap: 1.5rem; }
+    .footer-links a { color: var(--muted); font-size: 0.85rem; }
+
+    @media (max-width: 640px) {
+      .hero h1 { font-size: 1.75rem; }
+      .problem-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Grantex for AutoGen","applicationCategory":"DeveloperApplication","operatingSystem":"Any","url":"https://grantex.dev/for/autogen/","description":"Per-agent scoped permissions for AutoGen multi-agent systems. Each agent gets its own JWT. Audit trails, delegation chains, instant revocation.","license":"https://www.apache.org/licenses/LICENSE-2.0"}</script>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/" class="nav-logo">Grantex</a>
+  <ul class="nav-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="/playground">Playground</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+  </ul>
+</nav>
+
+<div id="app">
+  <section class="hero">
+    <span class="hero-badge" id="badge"></span>
+    <h1 id="heroTitle"></h1>
+    <p id="heroDesc"></p>
+    <div class="hero-ctas">
+      <a href="" id="ctaDocs" class="btn btn-primary">View Integration Docs</a>
+      <a href="" id="ctaInstall" class="btn btn-secondary">Get Started</a>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2>The Problem</h2>
+    <div class="problem-grid">
+      <div class="problem-card bad">
+        <h3>Without Grantex</h3>
+        <p id="problemBad"></p>
+      </div>
+      <div class="problem-card good">
+        <h3>With Grantex</h3>
+        <p id="problemGood"></p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2 id="howTitle">How It Works</h2>
+    <div class="steps" id="steps"></div>
+  </section>
+
+  <section class="section">
+    <h2>Quick Start</h2>
+    <div class="install-box">
+      <span id="installCmd"></span>
+      <button onclick="navigator.clipboard.writeText(document.getElementById('installCmd').textContent);this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)">Copy</button>
+    </div>
+    <pre><code id="codeExample"></code></pre>
+  </section>
+
+  <section class="section">
+    <h2 id="featuresTitle">Why Grantex</h2>
+    <div class="feature-grid" id="features"></div>
+  </section>
+
+  <section class="section" style="text-align:center">
+    <h2>Ready to secure your <span id="ctaFramework"></span> agents?</h2>
+    <p style="margin-bottom:1.5rem;color:var(--muted)">Get started in under 5 minutes. Open source, Apache 2.0.</p>
+    <div class="hero-ctas">
+      <a href="https://grantex.dev/dashboard/signup" class="btn btn-primary">Sign Up Free</a>
+      <a href="" id="ctaDocsBottom" class="btn btn-secondary">Read the Docs</a>
+    </div>
+  </section>
+</div>
+
+<footer class="footer">
+  <span style="color:var(--muted);font-size:0.85rem">Grantex — Open authorization for AI agents</span>
+  <ul class="footer-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+    <li><a href="/">Home</a></li>
+  </ul>
+</footer>
+
+<script>
+const frameworks = {
+  langchain: {
+    name: 'LangChain',
+    badge: 'LangChain + Grantex',
+    title: 'Authorization for <span class="highlight">LangChain</span> Agents',
+    desc: 'Add scoped, revocable permissions to your LangChain agents. Grantex integrates natively with LangChain tools — your agents get signed JWTs instead of raw API keys.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    install: 'npm install @grantex/langchain @grantex/sdk',
+    problemBad: 'Your LangChain agents use raw API keys with full access. No scoping, no audit trail, no way to revoke access if an agent goes rogue. One compromised key exposes everything.',
+    problemGood: 'Each LangChain agent gets a scoped, time-limited JWT. Tools verify permissions offline. You can revoke any agent instantly. Every action is audit-logged with a hash chain.',
+    howTitle: 'How Grantex Works with LangChain',
+    steps: [
+      ['Install the integration', 'npm install @grantex/langchain — wraps LangChain tools with automatic grant verification.'],
+      ['Register your agent', 'Create an agent identity with specific scopes like "email:send" or "calendar:read".'],
+      ['Get user consent', 'Redirect the user to a consent page. They approve exactly which permissions the agent gets.'],
+      ['Agent receives a JWT', 'The agent gets a signed token it presents to any service. Services verify offline via JWKS.'],
+      ['Audit & revoke', 'Every action is logged. Revoke access in under 1 second if something goes wrong.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexToolkit } from '@grantex/langchain';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap your LangChain tools with Grantex authorization
+const toolkit = new GrantexToolkit({
+  client: gx,
+  grantToken: token,  // JWT from the consent flow
+  tools: [searchTool, emailTool],
+});
+
+// Tools now automatically verify scopes before executing
+const agent = createToolCallingAgent({ llm, tools: toolkit.tools });`,
+    features: [
+      ['Native LangChain Integration', 'Drop-in toolkit that wraps your existing LangChain tools with automatic scope verification.'],
+      ['Scoped Permissions', 'Define exactly what each agent can do — "email:read" vs "email:send". No more all-or-nothing API keys.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS without calling Grantex. Zero latency overhead on your LangChain pipeline.'],
+      ['Multi-Agent Delegation', 'Parent agents delegate narrower scopes to sub-agents. Revoking the parent cascades to all children.'],
+      ['Hash-Chained Audit Trail', 'Every tool invocation is logged in an append-only, tamper-evident audit trail.'],
+      ['Real-Time Revocation', 'Kill a misbehaving agent\'s access in under 1 second. No waiting for token expiry.'],
+    ],
+    ctaFramework: 'LangChain',
+    metaTitle: 'Grantex for LangChain — Authorization for LangChain AI Agents',
+    metaDesc: 'Add scoped, revocable permissions to LangChain agents. Drop-in toolkit for authorization with signed JWTs, audit trails, and real-time revocation. Open source.',
+  },
+  crewai: {
+    name: 'CrewAI',
+    badge: 'CrewAI + Grantex',
+    title: 'Authorization for <span class="highlight">CrewAI</span> Agents',
+    desc: 'Secure your CrewAI crews with scoped, revocable permissions. Each crew member gets exactly the access it needs — nothing more.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    install: 'pip install grantex-crewai grantex',
+    problemBad: 'Your CrewAI agents share the same API keys. If one crew member is compromised, the entire crew\'s access is exposed. No way to scope or revoke individual agent access.',
+    problemGood: 'Each crew member gets its own scoped JWT. The researcher can only read, the writer can only draft, the publisher can only post. Revoke any member instantly.',
+    howTitle: 'How Grantex Works with CrewAI',
+    steps: [
+      ['Install the integration', 'pip install grantex-crewai — Python-native integration for CrewAI crews.'],
+      ['Register each crew member', 'Create agent identities with role-specific scopes for each crew member.'],
+      ['Authorize the crew', 'Users approve scoped permissions for each role in the crew.'],
+      ['Crew operates with scoped tokens', 'Each crew member presents its own JWT. Services verify independently.'],
+      ['Monitor & control', 'Audit every crew action. Revoke individual members without stopping the whole crew.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_crewai import GrantexCrewTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Each crew member gets scoped authorization
+researcher_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=researcher_token,  # scoped to "search:read"
+    tools=[search_tool],
+)
+
+writer_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=writer_token,  # scoped to "docs:write"
+    tools=[write_tool],
+)`,
+    features: [
+      ['Per-Agent Scoping', 'Each crew member gets exactly the permissions it needs. Researcher reads, writer writes, publisher posts.'],
+      ['Role-Based Access', 'Map CrewAI roles to Grantex scopes. Define authorization policies per role, not per API key.'],
+      ['Crew-Wide Audit Trail', 'See what every crew member did, when, and with what permissions. Hash-chained for tamper evidence.'],
+      ['Delegation Chains', 'A lead agent can delegate narrower permissions to sub-agents. Revoking the lead cascades to all.'],
+      ['Python Native', 'Pure Python integration. pip install and go — works with any CrewAI version.'],
+      ['Instant Revocation', 'Revoke any crew member\'s access in under 1 second without disrupting the rest of the crew.'],
+    ],
+    ctaFramework: 'CrewAI',
+    metaTitle: 'Grantex for CrewAI — Secure Multi-Agent Crew Permissions',
+    metaDesc: 'Scope and control permissions for CrewAI agents. Each crew member gets its own signed JWT with role-specific access. Audit trails, delegation, real-time revocation.',
+  },
+  'openai-agents': {
+    name: 'OpenAI Agents SDK',
+    badge: 'OpenAI Agents + Grantex',
+    title: 'Authorization for <span class="highlight">OpenAI Agents SDK</span>',
+    desc: 'Add enterprise-grade authorization to your OpenAI agents. Scoped permissions, audit trails, and instant revocation — built for the Agents SDK.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    install: 'pip install grantex-openai-agents grantex',
+    problemBad: 'Your OpenAI agents operate with full API access. No scoping, no audit trail, no revocation. You can\'t tell which agent did what or limit what it can do.',
+    problemGood: 'Each agent gets a scoped, time-limited JWT. Every tool call is authorized and logged. Revoke access instantly if an agent behaves unexpectedly.',
+    howTitle: 'How Grantex Works with OpenAI Agents SDK',
+    steps: [
+      ['Install the integration', 'pip install grantex-openai-agents — wraps OpenAI agent tools with authorization.'],
+      ['Register your agent', 'Create an agent identity with scopes matching its capabilities.'],
+      ['Get user approval', 'Users approve exactly which permissions the agent receives via a consent page.'],
+      ['Agent operates with JWT', 'The agent\'s tools automatically verify permissions before executing.'],
+      ['Full audit trail', 'Every tool invocation is logged with the agent identity, scopes used, and timestamp.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_openai_agents import GrantexTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap OpenAI agent tools with Grantex authorization
+tools = GrantexTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, email_tool],
+)
+
+# Tools automatically check scopes before execution
+agent = Agent(
+    name="assistant",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['OpenAI Agents SDK Integration', 'Drop-in wrapper for OpenAI agent tools. Add authorization without changing your agent logic.'],
+      ['Scoped Tool Access', 'Define which tools each agent can use and with what parameters. Enforced at the protocol level.'],
+      ['Enterprise Audit Trail', 'Every tool call logged with agent identity, scopes, and hash-chained integrity.'],
+      ['Multi-Agent Pipelines', 'Parent agents delegate narrower access to sub-agents. Full delegation chain tracking.'],
+      ['Budget Controls', 'Set spending limits per agent. Automatic cutoff when budget is exhausted.'],
+      ['Compliance Ready', 'SOC 2 compatible audit logging. SCIM/SSO for enterprise identity management.'],
+    ],
+    ctaFramework: 'OpenAI Agents',
+    metaTitle: 'Grantex for OpenAI Agents SDK — Enterprise Agent Authorization',
+    metaDesc: 'Add scoped permissions, audit trails, and real-time revocation to OpenAI Agents SDK. Enterprise-grade authorization for AI agents. Open source.',
+  },
+  anthropic: {
+    name: 'Anthropic SDK',
+    badge: 'Anthropic + Grantex',
+    title: 'Authorization for <span class="highlight">Anthropic SDK</span> Tool Use',
+    desc: 'Enforce scoped permissions on Claude tool calls. Offline JWT verification, automatic audit logging, and instant revocation for Anthropic SDK apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    installUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    install: 'npm install @grantex/anthropic @grantex/sdk',
+    problemBad: 'Your Claude-powered agents call tools with no authorization layer. Any tool can be invoked with full access. No scoping, no consent, no audit trail of what the agent did.',
+    problemGood: 'Grantex wraps each tool with scope enforcement. The agent\'s JWT is checked offline before execution. Every tool call is audit-logged. Revoke access in under 1 second.',
+    howTitle: 'How Grantex Works with the Anthropic SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/anthropic — wraps Anthropic tool definitions with authorization.'],
+      ['Create scoped tools', 'Use createGrantexTool() to define tools with required scopes and JSON Schema input.'],
+      ['Pass tools to Claude', 'tool.definition is type-compatible with client.messages.create({ tools }).'],
+      ['Dispatch tool_use blocks', 'Use GrantexToolRegistry or handleToolCall() to execute with automatic audit logging.'],
+      ['Monitor everything', 'Hash-chained audit trail of every tool call. Revoke access in under 1 second.'],
+    ],
+    code: `import Anthropic from '@anthropic-ai/sdk';
+import { createGrantexTool, GrantexToolRegistry } from '@grantex/anthropic';
+
+const client = new Anthropic();
+
+const readFile = createGrantexTool({
+  name: 'read_file',
+  description: 'Read a file from disk',
+  inputSchema: {
+    type: 'object',
+    properties: { path: { type: 'string' } },
+    required: ['path'],
+  },
+  grantToken,
+  requiredScope: 'file:read',
+  execute: async ({ path }) => fs.readFile(path, 'utf-8'),
+});
+
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  tools: [readFile.definition],
+  messages,
+});`,
+    features: [
+      ['Anthropic SDK Native', 'Type-compatible with client.messages.create(). tool.definition drops in directly.'],
+      ['Offline Scope Checks', 'JWT scp claim verified locally. No network call to Grantex during execution.'],
+      ['Tool Registry', 'GrantexToolRegistry manages multiple tools and dispatches tool_use blocks by name.'],
+      ['Audit Logging', 'withAuditLogging() and handleToolCall() log every success/failure automatically.'],
+      ['GrantexScopeError', 'Typed error with requiredScope and grantedScopes for clean error handling.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Anthropic SDK',
+    metaTitle: 'Grantex for Anthropic SDK — Secure Claude Tool Use Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Claude tool use. Offline JWT verification, tool registry, and instant revocation. Open source.',
+  },
+  'google-adk': {
+    name: 'Google ADK',
+    badge: 'Google ADK + Grantex',
+    title: 'Authorization for <span class="highlight">Google ADK</span> Agents',
+    desc: 'Secure your Google Agent Development Kit agents with scoped, human-approved permissions and full audit trails.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    install: 'pip install grantex-adk grantex',
+    problemBad: 'Your ADK agents access services with broad credentials. No fine-grained scoping, no delegation control, no tamper-proof audit log of agent actions.',
+    problemGood: 'Each ADK agent gets cryptographic identity and scoped JWTs. Delegation chains track multi-agent workflows. Every action is audit-logged.',
+    howTitle: 'How Grantex Works with Google ADK',
+    steps: [
+      ['Install the integration', 'pip install grantex-adk — Python-native integration for Google ADK.'],
+      ['Register your agent', 'Create an agent identity with specific scopes matching your ADK agent\'s capabilities.'],
+      ['Authorize via consent', 'Users approve scoped permissions through a consent flow.'],
+      ['Agent operates securely', 'ADK tools verify permissions via JWT before executing any action.'],
+      ['Monitor everything', 'Hash-chained audit trail of every action. Revoke access in under 1 second.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_adk import GrantexADKTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap ADK tools with Grantex authorization
+tools = GrantexADKTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, calendar_tool],
+)
+
+# Tools verify scopes automatically
+agent = Agent(
+    model="gemini-2.0-flash",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['Google ADK Native', 'Built for the Agent Development Kit. Wraps ADK tools with automatic authorization.'],
+      ['Scoped Permissions', 'Fine-grained scopes for each capability. "calendar:read" vs "calendar:write".'],
+      ['Delegation Chains', 'Multi-agent ADK pipelines with tracked delegation. Revoke parent to cascade.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS. No network calls to Grantex during execution.'],
+      ['Audit & Compliance', 'Tamper-proof audit trail. SOC 2 compatible. Enterprise compliance exports.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Google ADK',
+    metaTitle: 'Grantex for Google ADK — Secure Agent Development Kit Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Google ADK agents. Delegation chains, real-time revocation, and enterprise compliance. Open source.',
+  },
+  'vercel-ai': {
+    name: 'Vercel AI SDK',
+    badge: 'Vercel AI + Grantex',
+    title: 'Authorization for <span class="highlight">Vercel AI SDK</span>',
+    desc: 'Add scoped authorization to your Vercel AI SDK tools. Signed JWTs, audit trails, and instant revocation for AI-powered apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    install: 'npm install @grantex/vercel-ai @grantex/sdk',
+    problemBad: 'Your Vercel AI tools run with full access. Users can\'t see or control what the AI does on their behalf. No audit trail, no revocation.',
+    problemGood: 'Each AI tool call is authorized with a scoped JWT. Users approve permissions upfront. Every action is logged. Revoke instantly.',
+    howTitle: 'How Grantex Works with Vercel AI SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/vercel-ai — TypeScript-native integration for Vercel AI SDK.'],
+      ['Define authorized tools', 'Wrap your AI SDK tools with Grantex scope requirements.'],
+      ['User consents', 'Users approve specific scopes before the AI can act on their behalf.'],
+      ['Tools verify automatically', 'Each tool call checks the JWT scopes before execution.'],
+      ['Full observability', 'Audit trail of every tool invocation. Real-time event streaming.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createGrantexTools } from '@grantex/vercel-ai';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap Vercel AI SDK tools with authorization
+const tools = createGrantexTools({
+  client: gx,
+  grantToken: token,
+  tools: { search: searchTool, email: emailTool },
+});
+
+// Use with generateText or streamText
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prompt: 'Search for flights and send the results',
+});`,
+    features: [
+      ['Vercel AI SDK Native', 'Works with generateText, streamText, and all AI SDK tool patterns.'],
+      ['TypeScript First', 'Full type safety. Scopes are checked at compile time and runtime.'],
+      ['Edge Compatible', 'Works in Vercel Edge Functions. JWT verification is local — no external calls.'],
+      ['Streaming Support', 'Compatible with streaming responses. Authorization doesn\'t block the stream.'],
+      ['Multi-Step Flows', 'Authorize multi-step AI workflows where each step requires different scopes.'],
+      ['Next.js Ready', 'Drop into your Next.js app with zero configuration beyond the SDK.'],
+    ],
+    ctaFramework: 'Vercel AI',
+    metaTitle: 'Grantex for Vercel AI SDK — Authorization for AI-Powered Apps',
+    metaDesc: 'Add scoped permissions to Vercel AI SDK tools. TypeScript-native, Edge-compatible, with audit trails and real-time revocation. Open source.',
+  },
+  autogen: {
+    name: 'AutoGen',
+    badge: 'AutoGen + Grantex',
+    title: 'Authorization for <span class="highlight">AutoGen</span> Multi-Agent Systems',
+    desc: 'Secure your AutoGen conversations with per-agent permissions. Each agent in the group gets exactly the scopes it needs.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    install: 'npm install @grantex/autogen @grantex/sdk',
+    problemBad: 'AutoGen agents in a group chat share credentials. If one agent is compromised or hallucinates, it has access to everything the others can do.',
+    problemGood: 'Each AutoGen agent gets its own scoped JWT. The coder can only write code, the executor can only run tests. Isolated, audited, revocable.',
+    howTitle: 'How Grantex Works with AutoGen',
+    steps: [
+      ['Install the integration', 'npm install @grantex/autogen — wraps AutoGen function maps with authorization.'],
+      ['Register each agent', 'Create identities with role-specific scopes for each agent in the group.'],
+      ['Scope per conversation', 'Users approve what each agent can do before the conversation starts.'],
+      ['Agents operate independently', 'Each agent presents its own JWT. Function calls are scope-checked automatically.'],
+      ['Trace everything', 'Full audit trail across the multi-agent conversation. Attribute actions to specific agents.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexAutoGen } from '@grantex/autogen';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Each agent in the group gets scoped authorization
+const coderTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: coderToken,  // scoped to "code:write"
+  functionMap: { write_code: writeCodeFn },
+});
+
+const executorTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: executorToken,  // scoped to "code:execute"
+  functionMap: { run_code: runCodeFn },
+});`,
+    features: [
+      ['Per-Agent Authorization', 'Each agent in the AutoGen group gets its own scoped token and identity.'],
+      ['Group Chat Security', 'Prevent agents from accessing tools outside their role. Enforced at the protocol level.'],
+      ['Conversation Auditing', 'Track which agent called which function, with what scopes, across the entire conversation.'],
+      ['Delegation Support', 'Agents can delegate narrower scopes to spawned sub-agents with depth tracking.'],
+      ['Function Map Wrapping', 'Drop-in wrapper for AutoGen function maps. No changes to your agent logic.'],
+      ['Real-Time Control', 'Revoke any agent mid-conversation. Access is denied within 1 second.'],
+    ],
+    ctaFramework: 'AutoGen',
+    metaTitle: 'Grantex for AutoGen — Secure Multi-Agent Group Chat Authorization',
+    metaDesc: 'Per-agent scoped permissions for AutoGen multi-agent systems. Each agent gets its own JWT. Audit trails, delegation chains, instant revocation.',
+  },
+  mcp: {
+    name: 'Model Context Protocol',
+    badge: 'MCP + Grantex',
+    title: 'Authorization for <span class="highlight">MCP</span> Servers',
+    desc: 'Add enterprise-grade authorization to any MCP server. 13 built-in tools for managing agents, grants, and tokens from Claude Desktop, Cursor, or Windsurf.',
+    docsUrl: 'https://docs.grantex.dev/integrations/mcp',
+    installUrl: 'https://docs.grantex.dev/integrations/mcp',
+    install: 'npm install @grantex/mcp',
+    problemBad: 'MCP servers expose tools to AI assistants with no authorization layer. Any connected client can call any tool with full access. No scoping, no consent, no audit trail.',
+    problemGood: 'Grantex adds OAuth 2.1-style authorization to MCP. Users approve scoped access per tool. Every invocation is logged. Revoke access from the permission dashboard.',
+    howTitle: 'How Grantex Works with MCP',
+    steps: [
+      ['Install the MCP server', 'npm install @grantex/mcp — adds 13 Grantex tools to any MCP-compatible client.'],
+      ['Connect to Claude Desktop', 'Add Grantex to your MCP config. Works with Claude Desktop, Cursor, and Windsurf.'],
+      ['Manage via natural language', 'Ask Claude to "register an agent", "create a grant", or "check the audit log".'],
+      ['Or add MCP Auth', 'Use @grantex/mcp-auth to add OAuth 2.1 + PKCE to your own MCP servers.'],
+      ['Full protocol access', 'All 13 Grantex operations available as MCP tools — agents, grants, tokens, audit, budgets.'],
+    ],
+    code: `// claude_desktop_config.json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "npx",
+      "args": ["@grantex/mcp"],
+      "env": {
+        "GRANTEX_API_KEY": "gx_live_..."
+      }
+    }
+  }
+}
+
+// Then in Claude Desktop:
+// "Register a new agent called travel-bot with flights:book scope"
+// "Create a grant for user alice on travel-bot"
+// "Show me the audit log for the last hour"`,
+    features: [
+      ['13 MCP Tools', 'Full Grantex protocol access: agents, grants, tokens, audit, budgets, verification — all as MCP tools.'],
+      ['Claude Desktop Ready', 'Works out of the box with Claude Desktop, Cursor, and Windsurf.'],
+      ['MCP Auth Server', 'Separate @grantex/mcp-auth package adds OAuth 2.1 + PKCE to any MCP server.'],
+      ['Natural Language Control', 'Manage authorization through conversation. "Revoke all grants for agent X."'],
+      ['Zero Code Setup', 'npx @grantex/mcp — no code required. Just add to your MCP config and go.'],
+      ['Enterprise Grade', 'Budget controls, policy engine, SCIM/SSO — all accessible via MCP tools.'],
+    ],
+    ctaFramework: 'MCP',
+    metaTitle: 'Grantex for MCP — Authorization for Model Context Protocol Servers',
+    metaDesc: 'Add OAuth 2.1 authorization to MCP servers. 13 tools for Claude Desktop, Cursor, and Windsurf. Scoped grants, audit trails, real-time revocation.',
+  },
+  express: {
+    name: 'Express.js',
+    badge: 'Express + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">Express.js</span>',
+    desc: 'Protect your Express.js APIs with Grantex grant tokens. Drop-in middleware that verifies JWTs, enforces scopes, and logs every request.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    install: 'npm install @grantex/express',
+    problemBad: 'Your Express APIs accept API keys or bearer tokens with no scope enforcement. Any valid token can access any endpoint. No agent identity tracking.',
+    problemGood: 'Grantex middleware verifies JWTs offline via JWKS, enforces scopes per route, and identifies the calling agent. Zero external network calls.',
+    howTitle: 'How Grantex Works with Express.js',
+    steps: [
+      ['Install the middleware', 'npm install @grantex/express — one package, zero external dependencies at runtime.'],
+      ['Add to your app', 'One line to protect your routes. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs are verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'req.grantex gives you the agent DID, scopes, principal, and grant ID.'],
+      ['Production ready', 'JWKS caching, key rotation, scope enforcement, and error handling built in.'],
+    ],
+    code: `import express from 'express';
+import { grantexMiddleware, requireScopes } from '@grantex/express';
+
+const app = express();
+
+// Verify Grantex JWTs on all /api routes
+app.use('/api', grantexMiddleware({
+  jwksUrl: 'https://grantex-auth-....a.run.app/.well-known/jwks.json',
+}));
+
+// Enforce specific scopes per route
+app.get('/api/emails', requireScopes(['email:read']), (req, res) => {
+  console.log(req.grantex.agent);  // agent DID
+  console.log(req.grantex.scopes); // ['email:read']
+  res.json({ emails: [] });
+});`,
+    features: [
+      ['Drop-In Middleware', 'One line to protect your Express routes. Works with any Express 4+ app.'],
+      ['Offline JWT Verification', 'JWKS-based verification. No network calls to Grantex on each request. Sub-millisecond overhead.'],
+      ['Per-Route Scopes', 'requireScopes() enforces specific permissions per endpoint. Returns 403 if scopes don\'t match.'],
+      ['Agent Identity', 'req.grantex provides agent DID, scopes, principal ID, grant ID on every request.'],
+      ['JWKS Caching', 'Automatic key caching and rotation. Handles key rollover transparently.'],
+      ['TypeScript Support', 'Full type definitions. req.grantex is fully typed.'],
+    ],
+    ctaFramework: 'Express.js',
+    metaTitle: 'Grantex for Express.js — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Drop-in Express.js middleware for Grantex JWT verification. Offline JWKS verification, per-route scope enforcement, and agent identity. Open source.',
+  },
+  fastapi: {
+    name: 'FastAPI',
+    badge: 'FastAPI + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">FastAPI</span>',
+    desc: 'Protect your FastAPI endpoints with Grantex grant tokens. Dependency-injection middleware that verifies JWTs, enforces scopes, and identifies agents.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    install: 'pip install grantex-fastapi',
+    problemBad: 'Your FastAPI endpoints accept bearer tokens with no scope enforcement. Any valid token accesses any route. No way to identify which AI agent made the request.',
+    problemGood: 'Grantex dependency verifies JWTs offline via JWKS, enforces scopes per route, and provides the agent identity. Pythonic, async, and type-safe.',
+    howTitle: 'How Grantex Works with FastAPI',
+    steps: [
+      ['Install the middleware', 'pip install grantex-fastapi — async-native, works with FastAPI\'s dependency injection.'],
+      ['Add the dependency', 'Use GrantexAuth as a FastAPI dependency. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'The dependency returns the full grant context: agent DID, scopes, principal, grant ID.'],
+      ['Production ready', 'Async JWKS fetching, key caching, automatic rotation, and proper error responses.'],
+    ],
+    code: `from fastapi import FastAPI, Depends
+from grantex_fastapi import GrantexAuth, GrantContext
+
+app = FastAPI()
+auth = GrantexAuth(
+    jwks_url="https://grantex-auth-....a.run.app/.well-known/jwks.json"
+)
+
+@app.get("/api/emails")
+async def list_emails(
+    grant: GrantContext = Depends(auth.require_scopes(["email:read"]))
+):
+    print(grant.agent)   # agent DID
+    print(grant.scopes)  # ["email:read"]
+    return {"emails": []}`,
+    features: [
+      ['FastAPI Dependency Injection', 'Works with FastAPI\'s Depends() pattern. Pythonic and type-safe.'],
+      ['Async Native', 'Fully async JWKS fetching and JWT verification. No blocking calls.'],
+      ['Per-Route Scopes', 'require_scopes() enforces specific permissions per endpoint. Returns 403 on mismatch.'],
+      ['Typed Grant Context', 'Full Pydantic model for grant context: agent DID, scopes, principal, grant ID.'],
+      ['JWKS Caching', 'Automatic async key caching and rotation. Handles key rollover transparently.'],
+      ['OpenAPI Integration', 'Scopes appear in your FastAPI OpenAPI docs automatically.'],
+    ],
+    ctaFramework: 'FastAPI',
+    metaTitle: 'Grantex for FastAPI — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.',
+  },
+  mpp: {
+    name: 'MPP (Machine Payments Protocol)',
+    badge: 'MPP + Grantex',
+    title: 'Agent Identity for <span class="highlight">Machine Payments</span>',
+    desc: 'MPP defines how AI agents pay for services. Grantex adds the missing identity layer — verifiable agent passports that let merchants know exactly who authorized every payment, with offline verification in under 50ms.',
+    docsUrl: 'https://docs.grantex.dev/features/mpp-agent-passport',
+    installUrl: 'https://docs.grantex.dev/guides/mpp-integration',
+    install: 'npm install @grantex/mpp @grantex/sdk',
+    problemBad: 'When an agent makes an MPP payment, the source is just a wallet address. No human name, no org, no authorization chain. For $0.10 API calls nobody cares. For $500 B2B procurement, it\'s a compliance blocker.',
+    problemGood: 'Every MPP payment carries an AgentPassportCredential — a W3C VC 2.0 credential with the human principal, org DID, spending limits, and allowed categories. Merchants verify in <50ms, offline.',
+    howTitle: 'How Grantex Works with MPP',
+    steps: [
+      ['Install the package', 'npm install @grantex/mpp — agent-side middleware + merchant-side verification in one package.'],
+      ['Issue an agent passport', 'Call grantex.passports.issue() with categories (inference, compute, data), spending limits, and expiry.'],
+      ['Attach to MPP requests', 'createMppPassportMiddleware() injects the X-Grantex-Passport header on every outgoing fetch.'],
+      ['Verify on the merchant side', 'requireAgentPassport() Express middleware — one line to verify identity, categories, and amounts.'],
+      ['Check the trust registry', 'lookupOrgTrust() returns verified org status (basic, verified, SOC 2) from the public registry.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createMppPassportMiddleware, requireAgentPassport } from '@grantex/mpp';
+
+// Agent side: issue passport and attach to requests
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const passport = await grantex.passports.issue({
+  agentId: 'ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  allowedMPPCategories: ['inference', 'compute'],
+  maxTransactionAmount: { amount: 50, currency: 'USDC' },
+  expiresIn: '24h',
+});
+
+const middleware = createMppPassportMiddleware({ passport });
+const enriched = await middleware(new Request(url));
+// X-Grantex-Passport header attached
+
+// Merchant side: one-line verification
+app.use('/api/inference', requireAgentPassport({
+  requiredCategories: ['inference'],
+  maxAmount: 10,
+}));
+// req.agentPassport → { humanDID, orgDID, categories, maxAmount, ... }`,
+    features: [
+      ['AgentPassportCredential', 'W3C VC 2.0 with agent DID, human principal, org, categories, spending limits, and delegation depth.'],
+      ['<50ms Verification', 'Offline verification using cached JWKS. No API roundtrip to Grantex servers needed.'],
+      ['9 MPP Categories', 'inference, compute, data, storage, search, media, delivery, browser, general — each maps to a Grantex scope.'],
+      ['StatusList2021 Revocation', 'Revoke any passport instantly. Bit-flip propagation, no polling required.'],
+      ['Trust Registry', 'Public org trust lookup by DID. DNS-TXT, manual, or SOC 2 verification levels.'],
+      ['Auto-Refresh', 'Middleware proactively refreshes passports before expiry via onRefresh callback.'],
+    ],
+    ctaFramework: 'MPP',
+    metaTitle: 'Grantex for MPP — Agent Identity for Machine Payments Protocol',
+    metaDesc: 'Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.',
+  },
+};
+
+// Determine framework from URL
+const path = window.location.pathname.replace(/\/$/, '');
+const slug = path.split('/').pop();
+const fw = frameworks[slug];
+
+if (!fw) {
+  // Redirect to homepage if unknown framework
+  window.location.href = '/';
+} else {
+  // Set meta tags
+  document.title = fw.metaTitle;
+  document.querySelector('meta[name="description"]').content = fw.metaDesc;
+  document.querySelector('link[rel="canonical"]').href = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[property="og:title"]').content = fw.metaTitle;
+  document.querySelector('meta[property="og:description"]').content = fw.metaDesc;
+  document.querySelector('meta[property="og:url"]').content = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[name="twitter:title"]').content = fw.metaTitle;
+  document.querySelector('meta[name="twitter:description"]').content = fw.metaDesc;
+
+  // Populate content
+  document.getElementById('badge').textContent = fw.badge;
+  document.getElementById('heroTitle').innerHTML = fw.title;
+  document.getElementById('heroDesc').textContent = fw.desc;
+  document.getElementById('ctaDocs').href = fw.docsUrl;
+  document.getElementById('ctaInstall').href = fw.installUrl;
+  document.getElementById('problemBad').textContent = fw.problemBad;
+  document.getElementById('problemGood').textContent = fw.problemGood;
+  document.getElementById('howTitle').textContent = fw.howTitle;
+  document.getElementById('installCmd').textContent = fw.install;
+  document.getElementById('codeExample').textContent = fw.code;
+  document.getElementById('ctaFramework').textContent = fw.ctaFramework;
+  document.getElementById('ctaDocsBottom').href = fw.docsUrl;
+  document.getElementById('featuresTitle').textContent = 'Why Grantex for ' + fw.name;
+
+  // Steps
+  const stepsEl = document.getElementById('steps');
+  fw.steps.forEach(([title, desc]) => {
+    stepsEl.innerHTML += `<div class="step"><div class="step-content"><h3>${title}</h3><p>${desc}</p></div></div>`;
+  });
+
+  // Features
+  const featuresEl = document.getElementById('features');
+  fw.features.forEach(([title, desc]) => {
+    featuresEl.innerHTML += `<div class="feature-card"><h3>${title}</h3><p>${desc}</p></div>`;
+  });
+
+  // Add JSON-LD structured data
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Grantex for " + fw.name,
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Any",
+    "url": "https://grantex.dev/for/" + slug,
+    "description": fw.metaDesc,
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  };
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.textContent = JSON.stringify(jsonLd);
+  document.head.appendChild(script);
+
+  // Track page view
+  gtag('event', 'page_view', { page_title: fw.metaTitle, page_location: window.location.href });
+}
+</script>
+</body>
+</html>

--- a/web/for/crewai/index.html
+++ b/web/for/crewai/index.html
@@ -1,0 +1,787 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
+  <!-- Dynamic meta tags set by JS below -->
+  <title>Grantex for CrewAI — Secure Multi-Agent Crew Permissions</title>
+  <meta name="description" content="Scope and control permissions for CrewAI agents. Each crew member gets its own signed JWT with role-specific access. Audit trails, delegation, real-time revocation.">
+  <link rel="canonical" href="https://grantex.dev/for/crewai/">
+  <meta property="og:title" content="Grantex for CrewAI — Secure Multi-Agent Crew Permissions">
+  <meta property="og:description" content="Scope and control permissions for CrewAI agents. Each crew member gets its own signed JWT with role-specific access. Audit trails, delegation, real-time revocation.">
+  <meta property="og:url" content="https://grantex.dev/for/crewai/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Grantex">
+  <meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grantex for CrewAI — Secure Multi-Agent Crew Permissions">
+  <meta name="twitter:description" content="Scope and control permissions for CrewAI agents. Each crew member gets its own signed JWT with role-specific access. Audit trails, delegation, real-time revocation.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
+  <style>
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --border:   #30363d;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --accent:   #3fb950;
+      --accent2:  #58a6ff;
+      --mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+      --sans:     'Inter', system-ui, -apple-system, sans-serif;
+      --radius:   8px;
+      --max-w:    900px;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: var(--sans); line-height: 1.6; }
+    a { color: var(--accent2); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { font-family: var(--mono); background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+    pre { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; overflow-x: auto; font-family: var(--mono); font-size: 0.875rem; line-height: 1.5; }
+    pre code { background: none; padding: 0; }
+
+    /* Nav */
+    .nav { display: flex; align-items: center; justify-content: space-between; max-width: var(--max-w); margin: 0 auto; padding: 1rem 1.5rem; }
+    .nav-logo { font-weight: 700; font-size: 1.25rem; color: var(--text); }
+    .nav-links { list-style: none; display: flex; gap: 1.5rem; }
+    .nav-links a { color: var(--muted); font-size: 0.9rem; }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+
+    /* Hero */
+    .hero { text-align: center; padding: 4rem 1.5rem 3rem; max-width: var(--max-w); margin: 0 auto; }
+    .hero-badge { display: inline-block; background: rgba(63,185,80,0.15); color: var(--accent); padding: 0.25rem 0.75rem; border-radius: 999px; font-size: 0.8rem; font-weight: 600; margin-bottom: 1rem; }
+    .hero h1 { font-size: 2.5rem; line-height: 1.2; margin-bottom: 1rem; }
+    .hero h1 .highlight { color: var(--accent); }
+    .hero p { color: var(--muted); font-size: 1.1rem; max-width: 650px; margin: 0 auto 2rem; }
+    .hero-ctas { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
+    .btn { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.65rem 1.25rem; border-radius: var(--radius); font-weight: 600; font-size: 0.9rem; text-decoration: none; transition: all 0.2s; }
+    .btn-primary { background: var(--accent); color: #0d1117; }
+    .btn-primary:hover { background: #2ea043; text-decoration: none; }
+    .btn-secondary { background: var(--surface); color: var(--text); border: 1px solid var(--border); }
+    .btn-secondary:hover { border-color: var(--muted); text-decoration: none; }
+
+    /* Sections */
+    .section { max-width: var(--max-w); margin: 0 auto; padding: 3rem 1.5rem; }
+    .section h2 { font-size: 1.75rem; margin-bottom: 1rem; }
+    .section h3 { font-size: 1.15rem; margin-bottom: 0.5rem; color: var(--accent); }
+    .section p, .section li { color: var(--muted); }
+    .section ul { padding-left: 1.25rem; }
+    .section li { margin-bottom: 0.5rem; }
+
+    /* Problem cards */
+    .problem-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; margin: 1.5rem 0; }
+    .problem-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .problem-card.bad { border-color: #f8514933; }
+    .problem-card.good { border-color: #3fb95033; }
+    .problem-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .problem-card.bad h3 { color: #f85149; }
+    .problem-card.good h3 { color: var(--accent); }
+
+    /* Steps */
+    .steps { counter-reset: step; margin: 1.5rem 0; }
+    .step { display: flex; gap: 1rem; margin-bottom: 1.5rem; }
+    .step::before { counter-increment: step; content: counter(step); display: flex; align-items: center; justify-content: center; min-width: 32px; height: 32px; background: rgba(63,185,80,0.15); color: var(--accent); border-radius: 50%; font-weight: 700; font-size: 0.85rem; }
+    .step-content h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.25rem; }
+    .step-content p { font-size: 0.9rem; }
+
+    /* Features */
+    .feature-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.25rem; margin: 1.5rem 0; }
+    .feature-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .feature-card h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; }
+
+    /* Install */
+    .install-box { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.25rem; display: flex; align-items: center; justify-content: space-between; margin: 1rem 0; font-family: var(--mono); font-size: 0.9rem; }
+    .install-box button { background: var(--accent); color: #0d1117; border: none; padding: 0.35rem 0.75rem; border-radius: 4px; font-weight: 600; cursor: pointer; font-size: 0.8rem; }
+
+    /* Footer */
+    .footer { max-width: var(--max-w); margin: 0 auto; padding: 2rem 1.5rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; }
+    .footer-links { list-style: none; display: flex; gap: 1.5rem; }
+    .footer-links a { color: var(--muted); font-size: 0.85rem; }
+
+    @media (max-width: 640px) {
+      .hero h1 { font-size: 1.75rem; }
+      .problem-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Grantex for CrewAI","applicationCategory":"DeveloperApplication","operatingSystem":"Any","url":"https://grantex.dev/for/crewai/","description":"Scope and control permissions for CrewAI agents. Each crew member gets its own signed JWT with role-specific access. Audit trails, delegation, real-time revocation.","license":"https://www.apache.org/licenses/LICENSE-2.0"}</script>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/" class="nav-logo">Grantex</a>
+  <ul class="nav-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="/playground">Playground</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+  </ul>
+</nav>
+
+<div id="app">
+  <section class="hero">
+    <span class="hero-badge" id="badge"></span>
+    <h1 id="heroTitle"></h1>
+    <p id="heroDesc"></p>
+    <div class="hero-ctas">
+      <a href="" id="ctaDocs" class="btn btn-primary">View Integration Docs</a>
+      <a href="" id="ctaInstall" class="btn btn-secondary">Get Started</a>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2>The Problem</h2>
+    <div class="problem-grid">
+      <div class="problem-card bad">
+        <h3>Without Grantex</h3>
+        <p id="problemBad"></p>
+      </div>
+      <div class="problem-card good">
+        <h3>With Grantex</h3>
+        <p id="problemGood"></p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2 id="howTitle">How It Works</h2>
+    <div class="steps" id="steps"></div>
+  </section>
+
+  <section class="section">
+    <h2>Quick Start</h2>
+    <div class="install-box">
+      <span id="installCmd"></span>
+      <button onclick="navigator.clipboard.writeText(document.getElementById('installCmd').textContent);this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)">Copy</button>
+    </div>
+    <pre><code id="codeExample"></code></pre>
+  </section>
+
+  <section class="section">
+    <h2 id="featuresTitle">Why Grantex</h2>
+    <div class="feature-grid" id="features"></div>
+  </section>
+
+  <section class="section" style="text-align:center">
+    <h2>Ready to secure your <span id="ctaFramework"></span> agents?</h2>
+    <p style="margin-bottom:1.5rem;color:var(--muted)">Get started in under 5 minutes. Open source, Apache 2.0.</p>
+    <div class="hero-ctas">
+      <a href="https://grantex.dev/dashboard/signup" class="btn btn-primary">Sign Up Free</a>
+      <a href="" id="ctaDocsBottom" class="btn btn-secondary">Read the Docs</a>
+    </div>
+  </section>
+</div>
+
+<footer class="footer">
+  <span style="color:var(--muted);font-size:0.85rem">Grantex — Open authorization for AI agents</span>
+  <ul class="footer-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+    <li><a href="/">Home</a></li>
+  </ul>
+</footer>
+
+<script>
+const frameworks = {
+  langchain: {
+    name: 'LangChain',
+    badge: 'LangChain + Grantex',
+    title: 'Authorization for <span class="highlight">LangChain</span> Agents',
+    desc: 'Add scoped, revocable permissions to your LangChain agents. Grantex integrates natively with LangChain tools — your agents get signed JWTs instead of raw API keys.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    install: 'npm install @grantex/langchain @grantex/sdk',
+    problemBad: 'Your LangChain agents use raw API keys with full access. No scoping, no audit trail, no way to revoke access if an agent goes rogue. One compromised key exposes everything.',
+    problemGood: 'Each LangChain agent gets a scoped, time-limited JWT. Tools verify permissions offline. You can revoke any agent instantly. Every action is audit-logged with a hash chain.',
+    howTitle: 'How Grantex Works with LangChain',
+    steps: [
+      ['Install the integration', 'npm install @grantex/langchain — wraps LangChain tools with automatic grant verification.'],
+      ['Register your agent', 'Create an agent identity with specific scopes like "email:send" or "calendar:read".'],
+      ['Get user consent', 'Redirect the user to a consent page. They approve exactly which permissions the agent gets.'],
+      ['Agent receives a JWT', 'The agent gets a signed token it presents to any service. Services verify offline via JWKS.'],
+      ['Audit & revoke', 'Every action is logged. Revoke access in under 1 second if something goes wrong.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexToolkit } from '@grantex/langchain';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap your LangChain tools with Grantex authorization
+const toolkit = new GrantexToolkit({
+  client: gx,
+  grantToken: token,  // JWT from the consent flow
+  tools: [searchTool, emailTool],
+});
+
+// Tools now automatically verify scopes before executing
+const agent = createToolCallingAgent({ llm, tools: toolkit.tools });`,
+    features: [
+      ['Native LangChain Integration', 'Drop-in toolkit that wraps your existing LangChain tools with automatic scope verification.'],
+      ['Scoped Permissions', 'Define exactly what each agent can do — "email:read" vs "email:send". No more all-or-nothing API keys.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS without calling Grantex. Zero latency overhead on your LangChain pipeline.'],
+      ['Multi-Agent Delegation', 'Parent agents delegate narrower scopes to sub-agents. Revoking the parent cascades to all children.'],
+      ['Hash-Chained Audit Trail', 'Every tool invocation is logged in an append-only, tamper-evident audit trail.'],
+      ['Real-Time Revocation', 'Kill a misbehaving agent\'s access in under 1 second. No waiting for token expiry.'],
+    ],
+    ctaFramework: 'LangChain',
+    metaTitle: 'Grantex for LangChain — Authorization for LangChain AI Agents',
+    metaDesc: 'Add scoped, revocable permissions to LangChain agents. Drop-in toolkit for authorization with signed JWTs, audit trails, and real-time revocation. Open source.',
+  },
+  crewai: {
+    name: 'CrewAI',
+    badge: 'CrewAI + Grantex',
+    title: 'Authorization for <span class="highlight">CrewAI</span> Agents',
+    desc: 'Secure your CrewAI crews with scoped, revocable permissions. Each crew member gets exactly the access it needs — nothing more.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    install: 'pip install grantex-crewai grantex',
+    problemBad: 'Your CrewAI agents share the same API keys. If one crew member is compromised, the entire crew\'s access is exposed. No way to scope or revoke individual agent access.',
+    problemGood: 'Each crew member gets its own scoped JWT. The researcher can only read, the writer can only draft, the publisher can only post. Revoke any member instantly.',
+    howTitle: 'How Grantex Works with CrewAI',
+    steps: [
+      ['Install the integration', 'pip install grantex-crewai — Python-native integration for CrewAI crews.'],
+      ['Register each crew member', 'Create agent identities with role-specific scopes for each crew member.'],
+      ['Authorize the crew', 'Users approve scoped permissions for each role in the crew.'],
+      ['Crew operates with scoped tokens', 'Each crew member presents its own JWT. Services verify independently.'],
+      ['Monitor & control', 'Audit every crew action. Revoke individual members without stopping the whole crew.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_crewai import GrantexCrewTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Each crew member gets scoped authorization
+researcher_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=researcher_token,  # scoped to "search:read"
+    tools=[search_tool],
+)
+
+writer_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=writer_token,  # scoped to "docs:write"
+    tools=[write_tool],
+)`,
+    features: [
+      ['Per-Agent Scoping', 'Each crew member gets exactly the permissions it needs. Researcher reads, writer writes, publisher posts.'],
+      ['Role-Based Access', 'Map CrewAI roles to Grantex scopes. Define authorization policies per role, not per API key.'],
+      ['Crew-Wide Audit Trail', 'See what every crew member did, when, and with what permissions. Hash-chained for tamper evidence.'],
+      ['Delegation Chains', 'A lead agent can delegate narrower permissions to sub-agents. Revoking the lead cascades to all.'],
+      ['Python Native', 'Pure Python integration. pip install and go — works with any CrewAI version.'],
+      ['Instant Revocation', 'Revoke any crew member\'s access in under 1 second without disrupting the rest of the crew.'],
+    ],
+    ctaFramework: 'CrewAI',
+    metaTitle: 'Grantex for CrewAI — Secure Multi-Agent Crew Permissions',
+    metaDesc: 'Scope and control permissions for CrewAI agents. Each crew member gets its own signed JWT with role-specific access. Audit trails, delegation, real-time revocation.',
+  },
+  'openai-agents': {
+    name: 'OpenAI Agents SDK',
+    badge: 'OpenAI Agents + Grantex',
+    title: 'Authorization for <span class="highlight">OpenAI Agents SDK</span>',
+    desc: 'Add enterprise-grade authorization to your OpenAI agents. Scoped permissions, audit trails, and instant revocation — built for the Agents SDK.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    install: 'pip install grantex-openai-agents grantex',
+    problemBad: 'Your OpenAI agents operate with full API access. No scoping, no audit trail, no revocation. You can\'t tell which agent did what or limit what it can do.',
+    problemGood: 'Each agent gets a scoped, time-limited JWT. Every tool call is authorized and logged. Revoke access instantly if an agent behaves unexpectedly.',
+    howTitle: 'How Grantex Works with OpenAI Agents SDK',
+    steps: [
+      ['Install the integration', 'pip install grantex-openai-agents — wraps OpenAI agent tools with authorization.'],
+      ['Register your agent', 'Create an agent identity with scopes matching its capabilities.'],
+      ['Get user approval', 'Users approve exactly which permissions the agent receives via a consent page.'],
+      ['Agent operates with JWT', 'The agent\'s tools automatically verify permissions before executing.'],
+      ['Full audit trail', 'Every tool invocation is logged with the agent identity, scopes used, and timestamp.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_openai_agents import GrantexTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap OpenAI agent tools with Grantex authorization
+tools = GrantexTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, email_tool],
+)
+
+# Tools automatically check scopes before execution
+agent = Agent(
+    name="assistant",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['OpenAI Agents SDK Integration', 'Drop-in wrapper for OpenAI agent tools. Add authorization without changing your agent logic.'],
+      ['Scoped Tool Access', 'Define which tools each agent can use and with what parameters. Enforced at the protocol level.'],
+      ['Enterprise Audit Trail', 'Every tool call logged with agent identity, scopes, and hash-chained integrity.'],
+      ['Multi-Agent Pipelines', 'Parent agents delegate narrower access to sub-agents. Full delegation chain tracking.'],
+      ['Budget Controls', 'Set spending limits per agent. Automatic cutoff when budget is exhausted.'],
+      ['Compliance Ready', 'SOC 2 compatible audit logging. SCIM/SSO for enterprise identity management.'],
+    ],
+    ctaFramework: 'OpenAI Agents',
+    metaTitle: 'Grantex for OpenAI Agents SDK — Enterprise Agent Authorization',
+    metaDesc: 'Add scoped permissions, audit trails, and real-time revocation to OpenAI Agents SDK. Enterprise-grade authorization for AI agents. Open source.',
+  },
+  anthropic: {
+    name: 'Anthropic SDK',
+    badge: 'Anthropic + Grantex',
+    title: 'Authorization for <span class="highlight">Anthropic SDK</span> Tool Use',
+    desc: 'Enforce scoped permissions on Claude tool calls. Offline JWT verification, automatic audit logging, and instant revocation for Anthropic SDK apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    installUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    install: 'npm install @grantex/anthropic @grantex/sdk',
+    problemBad: 'Your Claude-powered agents call tools with no authorization layer. Any tool can be invoked with full access. No scoping, no consent, no audit trail of what the agent did.',
+    problemGood: 'Grantex wraps each tool with scope enforcement. The agent\'s JWT is checked offline before execution. Every tool call is audit-logged. Revoke access in under 1 second.',
+    howTitle: 'How Grantex Works with the Anthropic SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/anthropic — wraps Anthropic tool definitions with authorization.'],
+      ['Create scoped tools', 'Use createGrantexTool() to define tools with required scopes and JSON Schema input.'],
+      ['Pass tools to Claude', 'tool.definition is type-compatible with client.messages.create({ tools }).'],
+      ['Dispatch tool_use blocks', 'Use GrantexToolRegistry or handleToolCall() to execute with automatic audit logging.'],
+      ['Monitor everything', 'Hash-chained audit trail of every tool call. Revoke access in under 1 second.'],
+    ],
+    code: `import Anthropic from '@anthropic-ai/sdk';
+import { createGrantexTool, GrantexToolRegistry } from '@grantex/anthropic';
+
+const client = new Anthropic();
+
+const readFile = createGrantexTool({
+  name: 'read_file',
+  description: 'Read a file from disk',
+  inputSchema: {
+    type: 'object',
+    properties: { path: { type: 'string' } },
+    required: ['path'],
+  },
+  grantToken,
+  requiredScope: 'file:read',
+  execute: async ({ path }) => fs.readFile(path, 'utf-8'),
+});
+
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  tools: [readFile.definition],
+  messages,
+});`,
+    features: [
+      ['Anthropic SDK Native', 'Type-compatible with client.messages.create(). tool.definition drops in directly.'],
+      ['Offline Scope Checks', 'JWT scp claim verified locally. No network call to Grantex during execution.'],
+      ['Tool Registry', 'GrantexToolRegistry manages multiple tools and dispatches tool_use blocks by name.'],
+      ['Audit Logging', 'withAuditLogging() and handleToolCall() log every success/failure automatically.'],
+      ['GrantexScopeError', 'Typed error with requiredScope and grantedScopes for clean error handling.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Anthropic SDK',
+    metaTitle: 'Grantex for Anthropic SDK — Secure Claude Tool Use Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Claude tool use. Offline JWT verification, tool registry, and instant revocation. Open source.',
+  },
+  'google-adk': {
+    name: 'Google ADK',
+    badge: 'Google ADK + Grantex',
+    title: 'Authorization for <span class="highlight">Google ADK</span> Agents',
+    desc: 'Secure your Google Agent Development Kit agents with scoped, human-approved permissions and full audit trails.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    install: 'pip install grantex-adk grantex',
+    problemBad: 'Your ADK agents access services with broad credentials. No fine-grained scoping, no delegation control, no tamper-proof audit log of agent actions.',
+    problemGood: 'Each ADK agent gets cryptographic identity and scoped JWTs. Delegation chains track multi-agent workflows. Every action is audit-logged.',
+    howTitle: 'How Grantex Works with Google ADK',
+    steps: [
+      ['Install the integration', 'pip install grantex-adk — Python-native integration for Google ADK.'],
+      ['Register your agent', 'Create an agent identity with specific scopes matching your ADK agent\'s capabilities.'],
+      ['Authorize via consent', 'Users approve scoped permissions through a consent flow.'],
+      ['Agent operates securely', 'ADK tools verify permissions via JWT before executing any action.'],
+      ['Monitor everything', 'Hash-chained audit trail of every action. Revoke access in under 1 second.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_adk import GrantexADKTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap ADK tools with Grantex authorization
+tools = GrantexADKTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, calendar_tool],
+)
+
+# Tools verify scopes automatically
+agent = Agent(
+    model="gemini-2.0-flash",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['Google ADK Native', 'Built for the Agent Development Kit. Wraps ADK tools with automatic authorization.'],
+      ['Scoped Permissions', 'Fine-grained scopes for each capability. "calendar:read" vs "calendar:write".'],
+      ['Delegation Chains', 'Multi-agent ADK pipelines with tracked delegation. Revoke parent to cascade.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS. No network calls to Grantex during execution.'],
+      ['Audit & Compliance', 'Tamper-proof audit trail. SOC 2 compatible. Enterprise compliance exports.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Google ADK',
+    metaTitle: 'Grantex for Google ADK — Secure Agent Development Kit Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Google ADK agents. Delegation chains, real-time revocation, and enterprise compliance. Open source.',
+  },
+  'vercel-ai': {
+    name: 'Vercel AI SDK',
+    badge: 'Vercel AI + Grantex',
+    title: 'Authorization for <span class="highlight">Vercel AI SDK</span>',
+    desc: 'Add scoped authorization to your Vercel AI SDK tools. Signed JWTs, audit trails, and instant revocation for AI-powered apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    install: 'npm install @grantex/vercel-ai @grantex/sdk',
+    problemBad: 'Your Vercel AI tools run with full access. Users can\'t see or control what the AI does on their behalf. No audit trail, no revocation.',
+    problemGood: 'Each AI tool call is authorized with a scoped JWT. Users approve permissions upfront. Every action is logged. Revoke instantly.',
+    howTitle: 'How Grantex Works with Vercel AI SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/vercel-ai — TypeScript-native integration for Vercel AI SDK.'],
+      ['Define authorized tools', 'Wrap your AI SDK tools with Grantex scope requirements.'],
+      ['User consents', 'Users approve specific scopes before the AI can act on their behalf.'],
+      ['Tools verify automatically', 'Each tool call checks the JWT scopes before execution.'],
+      ['Full observability', 'Audit trail of every tool invocation. Real-time event streaming.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createGrantexTools } from '@grantex/vercel-ai';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap Vercel AI SDK tools with authorization
+const tools = createGrantexTools({
+  client: gx,
+  grantToken: token,
+  tools: { search: searchTool, email: emailTool },
+});
+
+// Use with generateText or streamText
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prompt: 'Search for flights and send the results',
+});`,
+    features: [
+      ['Vercel AI SDK Native', 'Works with generateText, streamText, and all AI SDK tool patterns.'],
+      ['TypeScript First', 'Full type safety. Scopes are checked at compile time and runtime.'],
+      ['Edge Compatible', 'Works in Vercel Edge Functions. JWT verification is local — no external calls.'],
+      ['Streaming Support', 'Compatible with streaming responses. Authorization doesn\'t block the stream.'],
+      ['Multi-Step Flows', 'Authorize multi-step AI workflows where each step requires different scopes.'],
+      ['Next.js Ready', 'Drop into your Next.js app with zero configuration beyond the SDK.'],
+    ],
+    ctaFramework: 'Vercel AI',
+    metaTitle: 'Grantex for Vercel AI SDK — Authorization for AI-Powered Apps',
+    metaDesc: 'Add scoped permissions to Vercel AI SDK tools. TypeScript-native, Edge-compatible, with audit trails and real-time revocation. Open source.',
+  },
+  autogen: {
+    name: 'AutoGen',
+    badge: 'AutoGen + Grantex',
+    title: 'Authorization for <span class="highlight">AutoGen</span> Multi-Agent Systems',
+    desc: 'Secure your AutoGen conversations with per-agent permissions. Each agent in the group gets exactly the scopes it needs.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    install: 'npm install @grantex/autogen @grantex/sdk',
+    problemBad: 'AutoGen agents in a group chat share credentials. If one agent is compromised or hallucinates, it has access to everything the others can do.',
+    problemGood: 'Each AutoGen agent gets its own scoped JWT. The coder can only write code, the executor can only run tests. Isolated, audited, revocable.',
+    howTitle: 'How Grantex Works with AutoGen',
+    steps: [
+      ['Install the integration', 'npm install @grantex/autogen — wraps AutoGen function maps with authorization.'],
+      ['Register each agent', 'Create identities with role-specific scopes for each agent in the group.'],
+      ['Scope per conversation', 'Users approve what each agent can do before the conversation starts.'],
+      ['Agents operate independently', 'Each agent presents its own JWT. Function calls are scope-checked automatically.'],
+      ['Trace everything', 'Full audit trail across the multi-agent conversation. Attribute actions to specific agents.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexAutoGen } from '@grantex/autogen';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Each agent in the group gets scoped authorization
+const coderTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: coderToken,  // scoped to "code:write"
+  functionMap: { write_code: writeCodeFn },
+});
+
+const executorTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: executorToken,  // scoped to "code:execute"
+  functionMap: { run_code: runCodeFn },
+});`,
+    features: [
+      ['Per-Agent Authorization', 'Each agent in the AutoGen group gets its own scoped token and identity.'],
+      ['Group Chat Security', 'Prevent agents from accessing tools outside their role. Enforced at the protocol level.'],
+      ['Conversation Auditing', 'Track which agent called which function, with what scopes, across the entire conversation.'],
+      ['Delegation Support', 'Agents can delegate narrower scopes to spawned sub-agents with depth tracking.'],
+      ['Function Map Wrapping', 'Drop-in wrapper for AutoGen function maps. No changes to your agent logic.'],
+      ['Real-Time Control', 'Revoke any agent mid-conversation. Access is denied within 1 second.'],
+    ],
+    ctaFramework: 'AutoGen',
+    metaTitle: 'Grantex for AutoGen — Secure Multi-Agent Group Chat Authorization',
+    metaDesc: 'Per-agent scoped permissions for AutoGen multi-agent systems. Each agent gets its own JWT. Audit trails, delegation chains, instant revocation.',
+  },
+  mcp: {
+    name: 'Model Context Protocol',
+    badge: 'MCP + Grantex',
+    title: 'Authorization for <span class="highlight">MCP</span> Servers',
+    desc: 'Add enterprise-grade authorization to any MCP server. 13 built-in tools for managing agents, grants, and tokens from Claude Desktop, Cursor, or Windsurf.',
+    docsUrl: 'https://docs.grantex.dev/integrations/mcp',
+    installUrl: 'https://docs.grantex.dev/integrations/mcp',
+    install: 'npm install @grantex/mcp',
+    problemBad: 'MCP servers expose tools to AI assistants with no authorization layer. Any connected client can call any tool with full access. No scoping, no consent, no audit trail.',
+    problemGood: 'Grantex adds OAuth 2.1-style authorization to MCP. Users approve scoped access per tool. Every invocation is logged. Revoke access from the permission dashboard.',
+    howTitle: 'How Grantex Works with MCP',
+    steps: [
+      ['Install the MCP server', 'npm install @grantex/mcp — adds 13 Grantex tools to any MCP-compatible client.'],
+      ['Connect to Claude Desktop', 'Add Grantex to your MCP config. Works with Claude Desktop, Cursor, and Windsurf.'],
+      ['Manage via natural language', 'Ask Claude to "register an agent", "create a grant", or "check the audit log".'],
+      ['Or add MCP Auth', 'Use @grantex/mcp-auth to add OAuth 2.1 + PKCE to your own MCP servers.'],
+      ['Full protocol access', 'All 13 Grantex operations available as MCP tools — agents, grants, tokens, audit, budgets.'],
+    ],
+    code: `// claude_desktop_config.json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "npx",
+      "args": ["@grantex/mcp"],
+      "env": {
+        "GRANTEX_API_KEY": "gx_live_..."
+      }
+    }
+  }
+}
+
+// Then in Claude Desktop:
+// "Register a new agent called travel-bot with flights:book scope"
+// "Create a grant for user alice on travel-bot"
+// "Show me the audit log for the last hour"`,
+    features: [
+      ['13 MCP Tools', 'Full Grantex protocol access: agents, grants, tokens, audit, budgets, verification — all as MCP tools.'],
+      ['Claude Desktop Ready', 'Works out of the box with Claude Desktop, Cursor, and Windsurf.'],
+      ['MCP Auth Server', 'Separate @grantex/mcp-auth package adds OAuth 2.1 + PKCE to any MCP server.'],
+      ['Natural Language Control', 'Manage authorization through conversation. "Revoke all grants for agent X."'],
+      ['Zero Code Setup', 'npx @grantex/mcp — no code required. Just add to your MCP config and go.'],
+      ['Enterprise Grade', 'Budget controls, policy engine, SCIM/SSO — all accessible via MCP tools.'],
+    ],
+    ctaFramework: 'MCP',
+    metaTitle: 'Grantex for MCP — Authorization for Model Context Protocol Servers',
+    metaDesc: 'Add OAuth 2.1 authorization to MCP servers. 13 tools for Claude Desktop, Cursor, and Windsurf. Scoped grants, audit trails, real-time revocation.',
+  },
+  express: {
+    name: 'Express.js',
+    badge: 'Express + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">Express.js</span>',
+    desc: 'Protect your Express.js APIs with Grantex grant tokens. Drop-in middleware that verifies JWTs, enforces scopes, and logs every request.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    install: 'npm install @grantex/express',
+    problemBad: 'Your Express APIs accept API keys or bearer tokens with no scope enforcement. Any valid token can access any endpoint. No agent identity tracking.',
+    problemGood: 'Grantex middleware verifies JWTs offline via JWKS, enforces scopes per route, and identifies the calling agent. Zero external network calls.',
+    howTitle: 'How Grantex Works with Express.js',
+    steps: [
+      ['Install the middleware', 'npm install @grantex/express — one package, zero external dependencies at runtime.'],
+      ['Add to your app', 'One line to protect your routes. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs are verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'req.grantex gives you the agent DID, scopes, principal, and grant ID.'],
+      ['Production ready', 'JWKS caching, key rotation, scope enforcement, and error handling built in.'],
+    ],
+    code: `import express from 'express';
+import { grantexMiddleware, requireScopes } from '@grantex/express';
+
+const app = express();
+
+// Verify Grantex JWTs on all /api routes
+app.use('/api', grantexMiddleware({
+  jwksUrl: 'https://grantex-auth-....a.run.app/.well-known/jwks.json',
+}));
+
+// Enforce specific scopes per route
+app.get('/api/emails', requireScopes(['email:read']), (req, res) => {
+  console.log(req.grantex.agent);  // agent DID
+  console.log(req.grantex.scopes); // ['email:read']
+  res.json({ emails: [] });
+});`,
+    features: [
+      ['Drop-In Middleware', 'One line to protect your Express routes. Works with any Express 4+ app.'],
+      ['Offline JWT Verification', 'JWKS-based verification. No network calls to Grantex on each request. Sub-millisecond overhead.'],
+      ['Per-Route Scopes', 'requireScopes() enforces specific permissions per endpoint. Returns 403 if scopes don\'t match.'],
+      ['Agent Identity', 'req.grantex provides agent DID, scopes, principal ID, grant ID on every request.'],
+      ['JWKS Caching', 'Automatic key caching and rotation. Handles key rollover transparently.'],
+      ['TypeScript Support', 'Full type definitions. req.grantex is fully typed.'],
+    ],
+    ctaFramework: 'Express.js',
+    metaTitle: 'Grantex for Express.js — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Drop-in Express.js middleware for Grantex JWT verification. Offline JWKS verification, per-route scope enforcement, and agent identity. Open source.',
+  },
+  fastapi: {
+    name: 'FastAPI',
+    badge: 'FastAPI + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">FastAPI</span>',
+    desc: 'Protect your FastAPI endpoints with Grantex grant tokens. Dependency-injection middleware that verifies JWTs, enforces scopes, and identifies agents.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    install: 'pip install grantex-fastapi',
+    problemBad: 'Your FastAPI endpoints accept bearer tokens with no scope enforcement. Any valid token accesses any route. No way to identify which AI agent made the request.',
+    problemGood: 'Grantex dependency verifies JWTs offline via JWKS, enforces scopes per route, and provides the agent identity. Pythonic, async, and type-safe.',
+    howTitle: 'How Grantex Works with FastAPI',
+    steps: [
+      ['Install the middleware', 'pip install grantex-fastapi — async-native, works with FastAPI\'s dependency injection.'],
+      ['Add the dependency', 'Use GrantexAuth as a FastAPI dependency. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'The dependency returns the full grant context: agent DID, scopes, principal, grant ID.'],
+      ['Production ready', 'Async JWKS fetching, key caching, automatic rotation, and proper error responses.'],
+    ],
+    code: `from fastapi import FastAPI, Depends
+from grantex_fastapi import GrantexAuth, GrantContext
+
+app = FastAPI()
+auth = GrantexAuth(
+    jwks_url="https://grantex-auth-....a.run.app/.well-known/jwks.json"
+)
+
+@app.get("/api/emails")
+async def list_emails(
+    grant: GrantContext = Depends(auth.require_scopes(["email:read"]))
+):
+    print(grant.agent)   # agent DID
+    print(grant.scopes)  # ["email:read"]
+    return {"emails": []}`,
+    features: [
+      ['FastAPI Dependency Injection', 'Works with FastAPI\'s Depends() pattern. Pythonic and type-safe.'],
+      ['Async Native', 'Fully async JWKS fetching and JWT verification. No blocking calls.'],
+      ['Per-Route Scopes', 'require_scopes() enforces specific permissions per endpoint. Returns 403 on mismatch.'],
+      ['Typed Grant Context', 'Full Pydantic model for grant context: agent DID, scopes, principal, grant ID.'],
+      ['JWKS Caching', 'Automatic async key caching and rotation. Handles key rollover transparently.'],
+      ['OpenAPI Integration', 'Scopes appear in your FastAPI OpenAPI docs automatically.'],
+    ],
+    ctaFramework: 'FastAPI',
+    metaTitle: 'Grantex for FastAPI — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.',
+  },
+  mpp: {
+    name: 'MPP (Machine Payments Protocol)',
+    badge: 'MPP + Grantex',
+    title: 'Agent Identity for <span class="highlight">Machine Payments</span>',
+    desc: 'MPP defines how AI agents pay for services. Grantex adds the missing identity layer — verifiable agent passports that let merchants know exactly who authorized every payment, with offline verification in under 50ms.',
+    docsUrl: 'https://docs.grantex.dev/features/mpp-agent-passport',
+    installUrl: 'https://docs.grantex.dev/guides/mpp-integration',
+    install: 'npm install @grantex/mpp @grantex/sdk',
+    problemBad: 'When an agent makes an MPP payment, the source is just a wallet address. No human name, no org, no authorization chain. For $0.10 API calls nobody cares. For $500 B2B procurement, it\'s a compliance blocker.',
+    problemGood: 'Every MPP payment carries an AgentPassportCredential — a W3C VC 2.0 credential with the human principal, org DID, spending limits, and allowed categories. Merchants verify in <50ms, offline.',
+    howTitle: 'How Grantex Works with MPP',
+    steps: [
+      ['Install the package', 'npm install @grantex/mpp — agent-side middleware + merchant-side verification in one package.'],
+      ['Issue an agent passport', 'Call grantex.passports.issue() with categories (inference, compute, data), spending limits, and expiry.'],
+      ['Attach to MPP requests', 'createMppPassportMiddleware() injects the X-Grantex-Passport header on every outgoing fetch.'],
+      ['Verify on the merchant side', 'requireAgentPassport() Express middleware — one line to verify identity, categories, and amounts.'],
+      ['Check the trust registry', 'lookupOrgTrust() returns verified org status (basic, verified, SOC 2) from the public registry.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createMppPassportMiddleware, requireAgentPassport } from '@grantex/mpp';
+
+// Agent side: issue passport and attach to requests
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const passport = await grantex.passports.issue({
+  agentId: 'ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  allowedMPPCategories: ['inference', 'compute'],
+  maxTransactionAmount: { amount: 50, currency: 'USDC' },
+  expiresIn: '24h',
+});
+
+const middleware = createMppPassportMiddleware({ passport });
+const enriched = await middleware(new Request(url));
+// X-Grantex-Passport header attached
+
+// Merchant side: one-line verification
+app.use('/api/inference', requireAgentPassport({
+  requiredCategories: ['inference'],
+  maxAmount: 10,
+}));
+// req.agentPassport → { humanDID, orgDID, categories, maxAmount, ... }`,
+    features: [
+      ['AgentPassportCredential', 'W3C VC 2.0 with agent DID, human principal, org, categories, spending limits, and delegation depth.'],
+      ['<50ms Verification', 'Offline verification using cached JWKS. No API roundtrip to Grantex servers needed.'],
+      ['9 MPP Categories', 'inference, compute, data, storage, search, media, delivery, browser, general — each maps to a Grantex scope.'],
+      ['StatusList2021 Revocation', 'Revoke any passport instantly. Bit-flip propagation, no polling required.'],
+      ['Trust Registry', 'Public org trust lookup by DID. DNS-TXT, manual, or SOC 2 verification levels.'],
+      ['Auto-Refresh', 'Middleware proactively refreshes passports before expiry via onRefresh callback.'],
+    ],
+    ctaFramework: 'MPP',
+    metaTitle: 'Grantex for MPP — Agent Identity for Machine Payments Protocol',
+    metaDesc: 'Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.',
+  },
+};
+
+// Determine framework from URL
+const path = window.location.pathname.replace(/\/$/, '');
+const slug = path.split('/').pop();
+const fw = frameworks[slug];
+
+if (!fw) {
+  // Redirect to homepage if unknown framework
+  window.location.href = '/';
+} else {
+  // Set meta tags
+  document.title = fw.metaTitle;
+  document.querySelector('meta[name="description"]').content = fw.metaDesc;
+  document.querySelector('link[rel="canonical"]').href = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[property="og:title"]').content = fw.metaTitle;
+  document.querySelector('meta[property="og:description"]').content = fw.metaDesc;
+  document.querySelector('meta[property="og:url"]').content = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[name="twitter:title"]').content = fw.metaTitle;
+  document.querySelector('meta[name="twitter:description"]').content = fw.metaDesc;
+
+  // Populate content
+  document.getElementById('badge').textContent = fw.badge;
+  document.getElementById('heroTitle').innerHTML = fw.title;
+  document.getElementById('heroDesc').textContent = fw.desc;
+  document.getElementById('ctaDocs').href = fw.docsUrl;
+  document.getElementById('ctaInstall').href = fw.installUrl;
+  document.getElementById('problemBad').textContent = fw.problemBad;
+  document.getElementById('problemGood').textContent = fw.problemGood;
+  document.getElementById('howTitle').textContent = fw.howTitle;
+  document.getElementById('installCmd').textContent = fw.install;
+  document.getElementById('codeExample').textContent = fw.code;
+  document.getElementById('ctaFramework').textContent = fw.ctaFramework;
+  document.getElementById('ctaDocsBottom').href = fw.docsUrl;
+  document.getElementById('featuresTitle').textContent = 'Why Grantex for ' + fw.name;
+
+  // Steps
+  const stepsEl = document.getElementById('steps');
+  fw.steps.forEach(([title, desc]) => {
+    stepsEl.innerHTML += `<div class="step"><div class="step-content"><h3>${title}</h3><p>${desc}</p></div></div>`;
+  });
+
+  // Features
+  const featuresEl = document.getElementById('features');
+  fw.features.forEach(([title, desc]) => {
+    featuresEl.innerHTML += `<div class="feature-card"><h3>${title}</h3><p>${desc}</p></div>`;
+  });
+
+  // Add JSON-LD structured data
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Grantex for " + fw.name,
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Any",
+    "url": "https://grantex.dev/for/" + slug,
+    "description": fw.metaDesc,
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  };
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.textContent = JSON.stringify(jsonLd);
+  document.head.appendChild(script);
+
+  // Track page view
+  gtag('event', 'page_view', { page_title: fw.metaTitle, page_location: window.location.href });
+}
+</script>
+</body>
+</html>

--- a/web/for/express/index.html
+++ b/web/for/express/index.html
@@ -1,0 +1,787 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
+  <!-- Dynamic meta tags set by JS below -->
+  <title>Grantex for Express.js — JWT Middleware for AI Agent Authorization</title>
+  <meta name="description" content="Drop-in Express.js middleware for Grantex JWT verification. Offline JWKS verification, per-route scope enforcement, and agent identity. Open source.">
+  <link rel="canonical" href="https://grantex.dev/for/express/">
+  <meta property="og:title" content="Grantex for Express.js — JWT Middleware for AI Agent Authorization">
+  <meta property="og:description" content="Drop-in Express.js middleware for Grantex JWT verification. Offline JWKS verification, per-route scope enforcement, and agent identity. Open source.">
+  <meta property="og:url" content="https://grantex.dev/for/express/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Grantex">
+  <meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grantex for Express.js — JWT Middleware for AI Agent Authorization">
+  <meta name="twitter:description" content="Drop-in Express.js middleware for Grantex JWT verification. Offline JWKS verification, per-route scope enforcement, and agent identity. Open source.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
+  <style>
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --border:   #30363d;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --accent:   #3fb950;
+      --accent2:  #58a6ff;
+      --mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+      --sans:     'Inter', system-ui, -apple-system, sans-serif;
+      --radius:   8px;
+      --max-w:    900px;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: var(--sans); line-height: 1.6; }
+    a { color: var(--accent2); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { font-family: var(--mono); background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+    pre { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; overflow-x: auto; font-family: var(--mono); font-size: 0.875rem; line-height: 1.5; }
+    pre code { background: none; padding: 0; }
+
+    /* Nav */
+    .nav { display: flex; align-items: center; justify-content: space-between; max-width: var(--max-w); margin: 0 auto; padding: 1rem 1.5rem; }
+    .nav-logo { font-weight: 700; font-size: 1.25rem; color: var(--text); }
+    .nav-links { list-style: none; display: flex; gap: 1.5rem; }
+    .nav-links a { color: var(--muted); font-size: 0.9rem; }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+
+    /* Hero */
+    .hero { text-align: center; padding: 4rem 1.5rem 3rem; max-width: var(--max-w); margin: 0 auto; }
+    .hero-badge { display: inline-block; background: rgba(63,185,80,0.15); color: var(--accent); padding: 0.25rem 0.75rem; border-radius: 999px; font-size: 0.8rem; font-weight: 600; margin-bottom: 1rem; }
+    .hero h1 { font-size: 2.5rem; line-height: 1.2; margin-bottom: 1rem; }
+    .hero h1 .highlight { color: var(--accent); }
+    .hero p { color: var(--muted); font-size: 1.1rem; max-width: 650px; margin: 0 auto 2rem; }
+    .hero-ctas { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
+    .btn { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.65rem 1.25rem; border-radius: var(--radius); font-weight: 600; font-size: 0.9rem; text-decoration: none; transition: all 0.2s; }
+    .btn-primary { background: var(--accent); color: #0d1117; }
+    .btn-primary:hover { background: #2ea043; text-decoration: none; }
+    .btn-secondary { background: var(--surface); color: var(--text); border: 1px solid var(--border); }
+    .btn-secondary:hover { border-color: var(--muted); text-decoration: none; }
+
+    /* Sections */
+    .section { max-width: var(--max-w); margin: 0 auto; padding: 3rem 1.5rem; }
+    .section h2 { font-size: 1.75rem; margin-bottom: 1rem; }
+    .section h3 { font-size: 1.15rem; margin-bottom: 0.5rem; color: var(--accent); }
+    .section p, .section li { color: var(--muted); }
+    .section ul { padding-left: 1.25rem; }
+    .section li { margin-bottom: 0.5rem; }
+
+    /* Problem cards */
+    .problem-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; margin: 1.5rem 0; }
+    .problem-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .problem-card.bad { border-color: #f8514933; }
+    .problem-card.good { border-color: #3fb95033; }
+    .problem-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .problem-card.bad h3 { color: #f85149; }
+    .problem-card.good h3 { color: var(--accent); }
+
+    /* Steps */
+    .steps { counter-reset: step; margin: 1.5rem 0; }
+    .step { display: flex; gap: 1rem; margin-bottom: 1.5rem; }
+    .step::before { counter-increment: step; content: counter(step); display: flex; align-items: center; justify-content: center; min-width: 32px; height: 32px; background: rgba(63,185,80,0.15); color: var(--accent); border-radius: 50%; font-weight: 700; font-size: 0.85rem; }
+    .step-content h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.25rem; }
+    .step-content p { font-size: 0.9rem; }
+
+    /* Features */
+    .feature-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.25rem; margin: 1.5rem 0; }
+    .feature-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .feature-card h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; }
+
+    /* Install */
+    .install-box { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.25rem; display: flex; align-items: center; justify-content: space-between; margin: 1rem 0; font-family: var(--mono); font-size: 0.9rem; }
+    .install-box button { background: var(--accent); color: #0d1117; border: none; padding: 0.35rem 0.75rem; border-radius: 4px; font-weight: 600; cursor: pointer; font-size: 0.8rem; }
+
+    /* Footer */
+    .footer { max-width: var(--max-w); margin: 0 auto; padding: 2rem 1.5rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; }
+    .footer-links { list-style: none; display: flex; gap: 1.5rem; }
+    .footer-links a { color: var(--muted); font-size: 0.85rem; }
+
+    @media (max-width: 640px) {
+      .hero h1 { font-size: 1.75rem; }
+      .problem-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Grantex for Express.js","applicationCategory":"DeveloperApplication","operatingSystem":"Any","url":"https://grantex.dev/for/express/","description":"Drop-in Express.js middleware for Grantex JWT verification. Offline JWKS verification, per-route scope enforcement, and agent identity. Open source.","license":"https://www.apache.org/licenses/LICENSE-2.0"}</script>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/" class="nav-logo">Grantex</a>
+  <ul class="nav-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="/playground">Playground</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+  </ul>
+</nav>
+
+<div id="app">
+  <section class="hero">
+    <span class="hero-badge" id="badge"></span>
+    <h1 id="heroTitle"></h1>
+    <p id="heroDesc"></p>
+    <div class="hero-ctas">
+      <a href="" id="ctaDocs" class="btn btn-primary">View Integration Docs</a>
+      <a href="" id="ctaInstall" class="btn btn-secondary">Get Started</a>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2>The Problem</h2>
+    <div class="problem-grid">
+      <div class="problem-card bad">
+        <h3>Without Grantex</h3>
+        <p id="problemBad"></p>
+      </div>
+      <div class="problem-card good">
+        <h3>With Grantex</h3>
+        <p id="problemGood"></p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2 id="howTitle">How It Works</h2>
+    <div class="steps" id="steps"></div>
+  </section>
+
+  <section class="section">
+    <h2>Quick Start</h2>
+    <div class="install-box">
+      <span id="installCmd"></span>
+      <button onclick="navigator.clipboard.writeText(document.getElementById('installCmd').textContent);this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)">Copy</button>
+    </div>
+    <pre><code id="codeExample"></code></pre>
+  </section>
+
+  <section class="section">
+    <h2 id="featuresTitle">Why Grantex</h2>
+    <div class="feature-grid" id="features"></div>
+  </section>
+
+  <section class="section" style="text-align:center">
+    <h2>Ready to secure your <span id="ctaFramework"></span> agents?</h2>
+    <p style="margin-bottom:1.5rem;color:var(--muted)">Get started in under 5 minutes. Open source, Apache 2.0.</p>
+    <div class="hero-ctas">
+      <a href="https://grantex.dev/dashboard/signup" class="btn btn-primary">Sign Up Free</a>
+      <a href="" id="ctaDocsBottom" class="btn btn-secondary">Read the Docs</a>
+    </div>
+  </section>
+</div>
+
+<footer class="footer">
+  <span style="color:var(--muted);font-size:0.85rem">Grantex — Open authorization for AI agents</span>
+  <ul class="footer-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+    <li><a href="/">Home</a></li>
+  </ul>
+</footer>
+
+<script>
+const frameworks = {
+  langchain: {
+    name: 'LangChain',
+    badge: 'LangChain + Grantex',
+    title: 'Authorization for <span class="highlight">LangChain</span> Agents',
+    desc: 'Add scoped, revocable permissions to your LangChain agents. Grantex integrates natively with LangChain tools — your agents get signed JWTs instead of raw API keys.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    install: 'npm install @grantex/langchain @grantex/sdk',
+    problemBad: 'Your LangChain agents use raw API keys with full access. No scoping, no audit trail, no way to revoke access if an agent goes rogue. One compromised key exposes everything.',
+    problemGood: 'Each LangChain agent gets a scoped, time-limited JWT. Tools verify permissions offline. You can revoke any agent instantly. Every action is audit-logged with a hash chain.',
+    howTitle: 'How Grantex Works with LangChain',
+    steps: [
+      ['Install the integration', 'npm install @grantex/langchain — wraps LangChain tools with automatic grant verification.'],
+      ['Register your agent', 'Create an agent identity with specific scopes like "email:send" or "calendar:read".'],
+      ['Get user consent', 'Redirect the user to a consent page. They approve exactly which permissions the agent gets.'],
+      ['Agent receives a JWT', 'The agent gets a signed token it presents to any service. Services verify offline via JWKS.'],
+      ['Audit & revoke', 'Every action is logged. Revoke access in under 1 second if something goes wrong.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexToolkit } from '@grantex/langchain';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap your LangChain tools with Grantex authorization
+const toolkit = new GrantexToolkit({
+  client: gx,
+  grantToken: token,  // JWT from the consent flow
+  tools: [searchTool, emailTool],
+});
+
+// Tools now automatically verify scopes before executing
+const agent = createToolCallingAgent({ llm, tools: toolkit.tools });`,
+    features: [
+      ['Native LangChain Integration', 'Drop-in toolkit that wraps your existing LangChain tools with automatic scope verification.'],
+      ['Scoped Permissions', 'Define exactly what each agent can do — "email:read" vs "email:send". No more all-or-nothing API keys.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS without calling Grantex. Zero latency overhead on your LangChain pipeline.'],
+      ['Multi-Agent Delegation', 'Parent agents delegate narrower scopes to sub-agents. Revoking the parent cascades to all children.'],
+      ['Hash-Chained Audit Trail', 'Every tool invocation is logged in an append-only, tamper-evident audit trail.'],
+      ['Real-Time Revocation', 'Kill a misbehaving agent\'s access in under 1 second. No waiting for token expiry.'],
+    ],
+    ctaFramework: 'LangChain',
+    metaTitle: 'Grantex for LangChain — Authorization for LangChain AI Agents',
+    metaDesc: 'Add scoped, revocable permissions to LangChain agents. Drop-in toolkit for authorization with signed JWTs, audit trails, and real-time revocation. Open source.',
+  },
+  crewai: {
+    name: 'CrewAI',
+    badge: 'CrewAI + Grantex',
+    title: 'Authorization for <span class="highlight">CrewAI</span> Agents',
+    desc: 'Secure your CrewAI crews with scoped, revocable permissions. Each crew member gets exactly the access it needs — nothing more.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    install: 'pip install grantex-crewai grantex',
+    problemBad: 'Your CrewAI agents share the same API keys. If one crew member is compromised, the entire crew\'s access is exposed. No way to scope or revoke individual agent access.',
+    problemGood: 'Each crew member gets its own scoped JWT. The researcher can only read, the writer can only draft, the publisher can only post. Revoke any member instantly.',
+    howTitle: 'How Grantex Works with CrewAI',
+    steps: [
+      ['Install the integration', 'pip install grantex-crewai — Python-native integration for CrewAI crews.'],
+      ['Register each crew member', 'Create agent identities with role-specific scopes for each crew member.'],
+      ['Authorize the crew', 'Users approve scoped permissions for each role in the crew.'],
+      ['Crew operates with scoped tokens', 'Each crew member presents its own JWT. Services verify independently.'],
+      ['Monitor & control', 'Audit every crew action. Revoke individual members without stopping the whole crew.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_crewai import GrantexCrewTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Each crew member gets scoped authorization
+researcher_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=researcher_token,  # scoped to "search:read"
+    tools=[search_tool],
+)
+
+writer_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=writer_token,  # scoped to "docs:write"
+    tools=[write_tool],
+)`,
+    features: [
+      ['Per-Agent Scoping', 'Each crew member gets exactly the permissions it needs. Researcher reads, writer writes, publisher posts.'],
+      ['Role-Based Access', 'Map CrewAI roles to Grantex scopes. Define authorization policies per role, not per API key.'],
+      ['Crew-Wide Audit Trail', 'See what every crew member did, when, and with what permissions. Hash-chained for tamper evidence.'],
+      ['Delegation Chains', 'A lead agent can delegate narrower permissions to sub-agents. Revoking the lead cascades to all.'],
+      ['Python Native', 'Pure Python integration. pip install and go — works with any CrewAI version.'],
+      ['Instant Revocation', 'Revoke any crew member\'s access in under 1 second without disrupting the rest of the crew.'],
+    ],
+    ctaFramework: 'CrewAI',
+    metaTitle: 'Grantex for CrewAI — Secure Multi-Agent Crew Permissions',
+    metaDesc: 'Scope and control permissions for CrewAI agents. Each crew member gets its own signed JWT with role-specific access. Audit trails, delegation, real-time revocation.',
+  },
+  'openai-agents': {
+    name: 'OpenAI Agents SDK',
+    badge: 'OpenAI Agents + Grantex',
+    title: 'Authorization for <span class="highlight">OpenAI Agents SDK</span>',
+    desc: 'Add enterprise-grade authorization to your OpenAI agents. Scoped permissions, audit trails, and instant revocation — built for the Agents SDK.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    install: 'pip install grantex-openai-agents grantex',
+    problemBad: 'Your OpenAI agents operate with full API access. No scoping, no audit trail, no revocation. You can\'t tell which agent did what or limit what it can do.',
+    problemGood: 'Each agent gets a scoped, time-limited JWT. Every tool call is authorized and logged. Revoke access instantly if an agent behaves unexpectedly.',
+    howTitle: 'How Grantex Works with OpenAI Agents SDK',
+    steps: [
+      ['Install the integration', 'pip install grantex-openai-agents — wraps OpenAI agent tools with authorization.'],
+      ['Register your agent', 'Create an agent identity with scopes matching its capabilities.'],
+      ['Get user approval', 'Users approve exactly which permissions the agent receives via a consent page.'],
+      ['Agent operates with JWT', 'The agent\'s tools automatically verify permissions before executing.'],
+      ['Full audit trail', 'Every tool invocation is logged with the agent identity, scopes used, and timestamp.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_openai_agents import GrantexTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap OpenAI agent tools with Grantex authorization
+tools = GrantexTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, email_tool],
+)
+
+# Tools automatically check scopes before execution
+agent = Agent(
+    name="assistant",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['OpenAI Agents SDK Integration', 'Drop-in wrapper for OpenAI agent tools. Add authorization without changing your agent logic.'],
+      ['Scoped Tool Access', 'Define which tools each agent can use and with what parameters. Enforced at the protocol level.'],
+      ['Enterprise Audit Trail', 'Every tool call logged with agent identity, scopes, and hash-chained integrity.'],
+      ['Multi-Agent Pipelines', 'Parent agents delegate narrower access to sub-agents. Full delegation chain tracking.'],
+      ['Budget Controls', 'Set spending limits per agent. Automatic cutoff when budget is exhausted.'],
+      ['Compliance Ready', 'SOC 2 compatible audit logging. SCIM/SSO for enterprise identity management.'],
+    ],
+    ctaFramework: 'OpenAI Agents',
+    metaTitle: 'Grantex for OpenAI Agents SDK — Enterprise Agent Authorization',
+    metaDesc: 'Add scoped permissions, audit trails, and real-time revocation to OpenAI Agents SDK. Enterprise-grade authorization for AI agents. Open source.',
+  },
+  anthropic: {
+    name: 'Anthropic SDK',
+    badge: 'Anthropic + Grantex',
+    title: 'Authorization for <span class="highlight">Anthropic SDK</span> Tool Use',
+    desc: 'Enforce scoped permissions on Claude tool calls. Offline JWT verification, automatic audit logging, and instant revocation for Anthropic SDK apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    installUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    install: 'npm install @grantex/anthropic @grantex/sdk',
+    problemBad: 'Your Claude-powered agents call tools with no authorization layer. Any tool can be invoked with full access. No scoping, no consent, no audit trail of what the agent did.',
+    problemGood: 'Grantex wraps each tool with scope enforcement. The agent\'s JWT is checked offline before execution. Every tool call is audit-logged. Revoke access in under 1 second.',
+    howTitle: 'How Grantex Works with the Anthropic SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/anthropic — wraps Anthropic tool definitions with authorization.'],
+      ['Create scoped tools', 'Use createGrantexTool() to define tools with required scopes and JSON Schema input.'],
+      ['Pass tools to Claude', 'tool.definition is type-compatible with client.messages.create({ tools }).'],
+      ['Dispatch tool_use blocks', 'Use GrantexToolRegistry or handleToolCall() to execute with automatic audit logging.'],
+      ['Monitor everything', 'Hash-chained audit trail of every tool call. Revoke access in under 1 second.'],
+    ],
+    code: `import Anthropic from '@anthropic-ai/sdk';
+import { createGrantexTool, GrantexToolRegistry } from '@grantex/anthropic';
+
+const client = new Anthropic();
+
+const readFile = createGrantexTool({
+  name: 'read_file',
+  description: 'Read a file from disk',
+  inputSchema: {
+    type: 'object',
+    properties: { path: { type: 'string' } },
+    required: ['path'],
+  },
+  grantToken,
+  requiredScope: 'file:read',
+  execute: async ({ path }) => fs.readFile(path, 'utf-8'),
+});
+
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  tools: [readFile.definition],
+  messages,
+});`,
+    features: [
+      ['Anthropic SDK Native', 'Type-compatible with client.messages.create(). tool.definition drops in directly.'],
+      ['Offline Scope Checks', 'JWT scp claim verified locally. No network call to Grantex during execution.'],
+      ['Tool Registry', 'GrantexToolRegistry manages multiple tools and dispatches tool_use blocks by name.'],
+      ['Audit Logging', 'withAuditLogging() and handleToolCall() log every success/failure automatically.'],
+      ['GrantexScopeError', 'Typed error with requiredScope and grantedScopes for clean error handling.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Anthropic SDK',
+    metaTitle: 'Grantex for Anthropic SDK — Secure Claude Tool Use Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Claude tool use. Offline JWT verification, tool registry, and instant revocation. Open source.',
+  },
+  'google-adk': {
+    name: 'Google ADK',
+    badge: 'Google ADK + Grantex',
+    title: 'Authorization for <span class="highlight">Google ADK</span> Agents',
+    desc: 'Secure your Google Agent Development Kit agents with scoped, human-approved permissions and full audit trails.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    install: 'pip install grantex-adk grantex',
+    problemBad: 'Your ADK agents access services with broad credentials. No fine-grained scoping, no delegation control, no tamper-proof audit log of agent actions.',
+    problemGood: 'Each ADK agent gets cryptographic identity and scoped JWTs. Delegation chains track multi-agent workflows. Every action is audit-logged.',
+    howTitle: 'How Grantex Works with Google ADK',
+    steps: [
+      ['Install the integration', 'pip install grantex-adk — Python-native integration for Google ADK.'],
+      ['Register your agent', 'Create an agent identity with specific scopes matching your ADK agent\'s capabilities.'],
+      ['Authorize via consent', 'Users approve scoped permissions through a consent flow.'],
+      ['Agent operates securely', 'ADK tools verify permissions via JWT before executing any action.'],
+      ['Monitor everything', 'Hash-chained audit trail of every action. Revoke access in under 1 second.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_adk import GrantexADKTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap ADK tools with Grantex authorization
+tools = GrantexADKTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, calendar_tool],
+)
+
+# Tools verify scopes automatically
+agent = Agent(
+    model="gemini-2.0-flash",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['Google ADK Native', 'Built for the Agent Development Kit. Wraps ADK tools with automatic authorization.'],
+      ['Scoped Permissions', 'Fine-grained scopes for each capability. "calendar:read" vs "calendar:write".'],
+      ['Delegation Chains', 'Multi-agent ADK pipelines with tracked delegation. Revoke parent to cascade.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS. No network calls to Grantex during execution.'],
+      ['Audit & Compliance', 'Tamper-proof audit trail. SOC 2 compatible. Enterprise compliance exports.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Google ADK',
+    metaTitle: 'Grantex for Google ADK — Secure Agent Development Kit Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Google ADK agents. Delegation chains, real-time revocation, and enterprise compliance. Open source.',
+  },
+  'vercel-ai': {
+    name: 'Vercel AI SDK',
+    badge: 'Vercel AI + Grantex',
+    title: 'Authorization for <span class="highlight">Vercel AI SDK</span>',
+    desc: 'Add scoped authorization to your Vercel AI SDK tools. Signed JWTs, audit trails, and instant revocation for AI-powered apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    install: 'npm install @grantex/vercel-ai @grantex/sdk',
+    problemBad: 'Your Vercel AI tools run with full access. Users can\'t see or control what the AI does on their behalf. No audit trail, no revocation.',
+    problemGood: 'Each AI tool call is authorized with a scoped JWT. Users approve permissions upfront. Every action is logged. Revoke instantly.',
+    howTitle: 'How Grantex Works with Vercel AI SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/vercel-ai — TypeScript-native integration for Vercel AI SDK.'],
+      ['Define authorized tools', 'Wrap your AI SDK tools with Grantex scope requirements.'],
+      ['User consents', 'Users approve specific scopes before the AI can act on their behalf.'],
+      ['Tools verify automatically', 'Each tool call checks the JWT scopes before execution.'],
+      ['Full observability', 'Audit trail of every tool invocation. Real-time event streaming.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createGrantexTools } from '@grantex/vercel-ai';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap Vercel AI SDK tools with authorization
+const tools = createGrantexTools({
+  client: gx,
+  grantToken: token,
+  tools: { search: searchTool, email: emailTool },
+});
+
+// Use with generateText or streamText
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prompt: 'Search for flights and send the results',
+});`,
+    features: [
+      ['Vercel AI SDK Native', 'Works with generateText, streamText, and all AI SDK tool patterns.'],
+      ['TypeScript First', 'Full type safety. Scopes are checked at compile time and runtime.'],
+      ['Edge Compatible', 'Works in Vercel Edge Functions. JWT verification is local — no external calls.'],
+      ['Streaming Support', 'Compatible with streaming responses. Authorization doesn\'t block the stream.'],
+      ['Multi-Step Flows', 'Authorize multi-step AI workflows where each step requires different scopes.'],
+      ['Next.js Ready', 'Drop into your Next.js app with zero configuration beyond the SDK.'],
+    ],
+    ctaFramework: 'Vercel AI',
+    metaTitle: 'Grantex for Vercel AI SDK — Authorization for AI-Powered Apps',
+    metaDesc: 'Add scoped permissions to Vercel AI SDK tools. TypeScript-native, Edge-compatible, with audit trails and real-time revocation. Open source.',
+  },
+  autogen: {
+    name: 'AutoGen',
+    badge: 'AutoGen + Grantex',
+    title: 'Authorization for <span class="highlight">AutoGen</span> Multi-Agent Systems',
+    desc: 'Secure your AutoGen conversations with per-agent permissions. Each agent in the group gets exactly the scopes it needs.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    install: 'npm install @grantex/autogen @grantex/sdk',
+    problemBad: 'AutoGen agents in a group chat share credentials. If one agent is compromised or hallucinates, it has access to everything the others can do.',
+    problemGood: 'Each AutoGen agent gets its own scoped JWT. The coder can only write code, the executor can only run tests. Isolated, audited, revocable.',
+    howTitle: 'How Grantex Works with AutoGen',
+    steps: [
+      ['Install the integration', 'npm install @grantex/autogen — wraps AutoGen function maps with authorization.'],
+      ['Register each agent', 'Create identities with role-specific scopes for each agent in the group.'],
+      ['Scope per conversation', 'Users approve what each agent can do before the conversation starts.'],
+      ['Agents operate independently', 'Each agent presents its own JWT. Function calls are scope-checked automatically.'],
+      ['Trace everything', 'Full audit trail across the multi-agent conversation. Attribute actions to specific agents.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexAutoGen } from '@grantex/autogen';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Each agent in the group gets scoped authorization
+const coderTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: coderToken,  // scoped to "code:write"
+  functionMap: { write_code: writeCodeFn },
+});
+
+const executorTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: executorToken,  // scoped to "code:execute"
+  functionMap: { run_code: runCodeFn },
+});`,
+    features: [
+      ['Per-Agent Authorization', 'Each agent in the AutoGen group gets its own scoped token and identity.'],
+      ['Group Chat Security', 'Prevent agents from accessing tools outside their role. Enforced at the protocol level.'],
+      ['Conversation Auditing', 'Track which agent called which function, with what scopes, across the entire conversation.'],
+      ['Delegation Support', 'Agents can delegate narrower scopes to spawned sub-agents with depth tracking.'],
+      ['Function Map Wrapping', 'Drop-in wrapper for AutoGen function maps. No changes to your agent logic.'],
+      ['Real-Time Control', 'Revoke any agent mid-conversation. Access is denied within 1 second.'],
+    ],
+    ctaFramework: 'AutoGen',
+    metaTitle: 'Grantex for AutoGen — Secure Multi-Agent Group Chat Authorization',
+    metaDesc: 'Per-agent scoped permissions for AutoGen multi-agent systems. Each agent gets its own JWT. Audit trails, delegation chains, instant revocation.',
+  },
+  mcp: {
+    name: 'Model Context Protocol',
+    badge: 'MCP + Grantex',
+    title: 'Authorization for <span class="highlight">MCP</span> Servers',
+    desc: 'Add enterprise-grade authorization to any MCP server. 13 built-in tools for managing agents, grants, and tokens from Claude Desktop, Cursor, or Windsurf.',
+    docsUrl: 'https://docs.grantex.dev/integrations/mcp',
+    installUrl: 'https://docs.grantex.dev/integrations/mcp',
+    install: 'npm install @grantex/mcp',
+    problemBad: 'MCP servers expose tools to AI assistants with no authorization layer. Any connected client can call any tool with full access. No scoping, no consent, no audit trail.',
+    problemGood: 'Grantex adds OAuth 2.1-style authorization to MCP. Users approve scoped access per tool. Every invocation is logged. Revoke access from the permission dashboard.',
+    howTitle: 'How Grantex Works with MCP',
+    steps: [
+      ['Install the MCP server', 'npm install @grantex/mcp — adds 13 Grantex tools to any MCP-compatible client.'],
+      ['Connect to Claude Desktop', 'Add Grantex to your MCP config. Works with Claude Desktop, Cursor, and Windsurf.'],
+      ['Manage via natural language', 'Ask Claude to "register an agent", "create a grant", or "check the audit log".'],
+      ['Or add MCP Auth', 'Use @grantex/mcp-auth to add OAuth 2.1 + PKCE to your own MCP servers.'],
+      ['Full protocol access', 'All 13 Grantex operations available as MCP tools — agents, grants, tokens, audit, budgets.'],
+    ],
+    code: `// claude_desktop_config.json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "npx",
+      "args": ["@grantex/mcp"],
+      "env": {
+        "GRANTEX_API_KEY": "gx_live_..."
+      }
+    }
+  }
+}
+
+// Then in Claude Desktop:
+// "Register a new agent called travel-bot with flights:book scope"
+// "Create a grant for user alice on travel-bot"
+// "Show me the audit log for the last hour"`,
+    features: [
+      ['13 MCP Tools', 'Full Grantex protocol access: agents, grants, tokens, audit, budgets, verification — all as MCP tools.'],
+      ['Claude Desktop Ready', 'Works out of the box with Claude Desktop, Cursor, and Windsurf.'],
+      ['MCP Auth Server', 'Separate @grantex/mcp-auth package adds OAuth 2.1 + PKCE to any MCP server.'],
+      ['Natural Language Control', 'Manage authorization through conversation. "Revoke all grants for agent X."'],
+      ['Zero Code Setup', 'npx @grantex/mcp — no code required. Just add to your MCP config and go.'],
+      ['Enterprise Grade', 'Budget controls, policy engine, SCIM/SSO — all accessible via MCP tools.'],
+    ],
+    ctaFramework: 'MCP',
+    metaTitle: 'Grantex for MCP — Authorization for Model Context Protocol Servers',
+    metaDesc: 'Add OAuth 2.1 authorization to MCP servers. 13 tools for Claude Desktop, Cursor, and Windsurf. Scoped grants, audit trails, real-time revocation.',
+  },
+  express: {
+    name: 'Express.js',
+    badge: 'Express + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">Express.js</span>',
+    desc: 'Protect your Express.js APIs with Grantex grant tokens. Drop-in middleware that verifies JWTs, enforces scopes, and logs every request.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    install: 'npm install @grantex/express',
+    problemBad: 'Your Express APIs accept API keys or bearer tokens with no scope enforcement. Any valid token can access any endpoint. No agent identity tracking.',
+    problemGood: 'Grantex middleware verifies JWTs offline via JWKS, enforces scopes per route, and identifies the calling agent. Zero external network calls.',
+    howTitle: 'How Grantex Works with Express.js',
+    steps: [
+      ['Install the middleware', 'npm install @grantex/express — one package, zero external dependencies at runtime.'],
+      ['Add to your app', 'One line to protect your routes. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs are verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'req.grantex gives you the agent DID, scopes, principal, and grant ID.'],
+      ['Production ready', 'JWKS caching, key rotation, scope enforcement, and error handling built in.'],
+    ],
+    code: `import express from 'express';
+import { grantexMiddleware, requireScopes } from '@grantex/express';
+
+const app = express();
+
+// Verify Grantex JWTs on all /api routes
+app.use('/api', grantexMiddleware({
+  jwksUrl: 'https://grantex-auth-....a.run.app/.well-known/jwks.json',
+}));
+
+// Enforce specific scopes per route
+app.get('/api/emails', requireScopes(['email:read']), (req, res) => {
+  console.log(req.grantex.agent);  // agent DID
+  console.log(req.grantex.scopes); // ['email:read']
+  res.json({ emails: [] });
+});`,
+    features: [
+      ['Drop-In Middleware', 'One line to protect your Express routes. Works with any Express 4+ app.'],
+      ['Offline JWT Verification', 'JWKS-based verification. No network calls to Grantex on each request. Sub-millisecond overhead.'],
+      ['Per-Route Scopes', 'requireScopes() enforces specific permissions per endpoint. Returns 403 if scopes don\'t match.'],
+      ['Agent Identity', 'req.grantex provides agent DID, scopes, principal ID, grant ID on every request.'],
+      ['JWKS Caching', 'Automatic key caching and rotation. Handles key rollover transparently.'],
+      ['TypeScript Support', 'Full type definitions. req.grantex is fully typed.'],
+    ],
+    ctaFramework: 'Express.js',
+    metaTitle: 'Grantex for Express.js — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Drop-in Express.js middleware for Grantex JWT verification. Offline JWKS verification, per-route scope enforcement, and agent identity. Open source.',
+  },
+  fastapi: {
+    name: 'FastAPI',
+    badge: 'FastAPI + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">FastAPI</span>',
+    desc: 'Protect your FastAPI endpoints with Grantex grant tokens. Dependency-injection middleware that verifies JWTs, enforces scopes, and identifies agents.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    install: 'pip install grantex-fastapi',
+    problemBad: 'Your FastAPI endpoints accept bearer tokens with no scope enforcement. Any valid token accesses any route. No way to identify which AI agent made the request.',
+    problemGood: 'Grantex dependency verifies JWTs offline via JWKS, enforces scopes per route, and provides the agent identity. Pythonic, async, and type-safe.',
+    howTitle: 'How Grantex Works with FastAPI',
+    steps: [
+      ['Install the middleware', 'pip install grantex-fastapi — async-native, works with FastAPI\'s dependency injection.'],
+      ['Add the dependency', 'Use GrantexAuth as a FastAPI dependency. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'The dependency returns the full grant context: agent DID, scopes, principal, grant ID.'],
+      ['Production ready', 'Async JWKS fetching, key caching, automatic rotation, and proper error responses.'],
+    ],
+    code: `from fastapi import FastAPI, Depends
+from grantex_fastapi import GrantexAuth, GrantContext
+
+app = FastAPI()
+auth = GrantexAuth(
+    jwks_url="https://grantex-auth-....a.run.app/.well-known/jwks.json"
+)
+
+@app.get("/api/emails")
+async def list_emails(
+    grant: GrantContext = Depends(auth.require_scopes(["email:read"]))
+):
+    print(grant.agent)   # agent DID
+    print(grant.scopes)  # ["email:read"]
+    return {"emails": []}`,
+    features: [
+      ['FastAPI Dependency Injection', 'Works with FastAPI\'s Depends() pattern. Pythonic and type-safe.'],
+      ['Async Native', 'Fully async JWKS fetching and JWT verification. No blocking calls.'],
+      ['Per-Route Scopes', 'require_scopes() enforces specific permissions per endpoint. Returns 403 on mismatch.'],
+      ['Typed Grant Context', 'Full Pydantic model for grant context: agent DID, scopes, principal, grant ID.'],
+      ['JWKS Caching', 'Automatic async key caching and rotation. Handles key rollover transparently.'],
+      ['OpenAPI Integration', 'Scopes appear in your FastAPI OpenAPI docs automatically.'],
+    ],
+    ctaFramework: 'FastAPI',
+    metaTitle: 'Grantex for FastAPI — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.',
+  },
+  mpp: {
+    name: 'MPP (Machine Payments Protocol)',
+    badge: 'MPP + Grantex',
+    title: 'Agent Identity for <span class="highlight">Machine Payments</span>',
+    desc: 'MPP defines how AI agents pay for services. Grantex adds the missing identity layer — verifiable agent passports that let merchants know exactly who authorized every payment, with offline verification in under 50ms.',
+    docsUrl: 'https://docs.grantex.dev/features/mpp-agent-passport',
+    installUrl: 'https://docs.grantex.dev/guides/mpp-integration',
+    install: 'npm install @grantex/mpp @grantex/sdk',
+    problemBad: 'When an agent makes an MPP payment, the source is just a wallet address. No human name, no org, no authorization chain. For $0.10 API calls nobody cares. For $500 B2B procurement, it\'s a compliance blocker.',
+    problemGood: 'Every MPP payment carries an AgentPassportCredential — a W3C VC 2.0 credential with the human principal, org DID, spending limits, and allowed categories. Merchants verify in <50ms, offline.',
+    howTitle: 'How Grantex Works with MPP',
+    steps: [
+      ['Install the package', 'npm install @grantex/mpp — agent-side middleware + merchant-side verification in one package.'],
+      ['Issue an agent passport', 'Call grantex.passports.issue() with categories (inference, compute, data), spending limits, and expiry.'],
+      ['Attach to MPP requests', 'createMppPassportMiddleware() injects the X-Grantex-Passport header on every outgoing fetch.'],
+      ['Verify on the merchant side', 'requireAgentPassport() Express middleware — one line to verify identity, categories, and amounts.'],
+      ['Check the trust registry', 'lookupOrgTrust() returns verified org status (basic, verified, SOC 2) from the public registry.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createMppPassportMiddleware, requireAgentPassport } from '@grantex/mpp';
+
+// Agent side: issue passport and attach to requests
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const passport = await grantex.passports.issue({
+  agentId: 'ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  allowedMPPCategories: ['inference', 'compute'],
+  maxTransactionAmount: { amount: 50, currency: 'USDC' },
+  expiresIn: '24h',
+});
+
+const middleware = createMppPassportMiddleware({ passport });
+const enriched = await middleware(new Request(url));
+// X-Grantex-Passport header attached
+
+// Merchant side: one-line verification
+app.use('/api/inference', requireAgentPassport({
+  requiredCategories: ['inference'],
+  maxAmount: 10,
+}));
+// req.agentPassport → { humanDID, orgDID, categories, maxAmount, ... }`,
+    features: [
+      ['AgentPassportCredential', 'W3C VC 2.0 with agent DID, human principal, org, categories, spending limits, and delegation depth.'],
+      ['<50ms Verification', 'Offline verification using cached JWKS. No API roundtrip to Grantex servers needed.'],
+      ['9 MPP Categories', 'inference, compute, data, storage, search, media, delivery, browser, general — each maps to a Grantex scope.'],
+      ['StatusList2021 Revocation', 'Revoke any passport instantly. Bit-flip propagation, no polling required.'],
+      ['Trust Registry', 'Public org trust lookup by DID. DNS-TXT, manual, or SOC 2 verification levels.'],
+      ['Auto-Refresh', 'Middleware proactively refreshes passports before expiry via onRefresh callback.'],
+    ],
+    ctaFramework: 'MPP',
+    metaTitle: 'Grantex for MPP — Agent Identity for Machine Payments Protocol',
+    metaDesc: 'Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.',
+  },
+};
+
+// Determine framework from URL
+const path = window.location.pathname.replace(/\/$/, '');
+const slug = path.split('/').pop();
+const fw = frameworks[slug];
+
+if (!fw) {
+  // Redirect to homepage if unknown framework
+  window.location.href = '/';
+} else {
+  // Set meta tags
+  document.title = fw.metaTitle;
+  document.querySelector('meta[name="description"]').content = fw.metaDesc;
+  document.querySelector('link[rel="canonical"]').href = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[property="og:title"]').content = fw.metaTitle;
+  document.querySelector('meta[property="og:description"]').content = fw.metaDesc;
+  document.querySelector('meta[property="og:url"]').content = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[name="twitter:title"]').content = fw.metaTitle;
+  document.querySelector('meta[name="twitter:description"]').content = fw.metaDesc;
+
+  // Populate content
+  document.getElementById('badge').textContent = fw.badge;
+  document.getElementById('heroTitle').innerHTML = fw.title;
+  document.getElementById('heroDesc').textContent = fw.desc;
+  document.getElementById('ctaDocs').href = fw.docsUrl;
+  document.getElementById('ctaInstall').href = fw.installUrl;
+  document.getElementById('problemBad').textContent = fw.problemBad;
+  document.getElementById('problemGood').textContent = fw.problemGood;
+  document.getElementById('howTitle').textContent = fw.howTitle;
+  document.getElementById('installCmd').textContent = fw.install;
+  document.getElementById('codeExample').textContent = fw.code;
+  document.getElementById('ctaFramework').textContent = fw.ctaFramework;
+  document.getElementById('ctaDocsBottom').href = fw.docsUrl;
+  document.getElementById('featuresTitle').textContent = 'Why Grantex for ' + fw.name;
+
+  // Steps
+  const stepsEl = document.getElementById('steps');
+  fw.steps.forEach(([title, desc]) => {
+    stepsEl.innerHTML += `<div class="step"><div class="step-content"><h3>${title}</h3><p>${desc}</p></div></div>`;
+  });
+
+  // Features
+  const featuresEl = document.getElementById('features');
+  fw.features.forEach(([title, desc]) => {
+    featuresEl.innerHTML += `<div class="feature-card"><h3>${title}</h3><p>${desc}</p></div>`;
+  });
+
+  // Add JSON-LD structured data
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Grantex for " + fw.name,
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Any",
+    "url": "https://grantex.dev/for/" + slug,
+    "description": fw.metaDesc,
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  };
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.textContent = JSON.stringify(jsonLd);
+  document.head.appendChild(script);
+
+  // Track page view
+  gtag('event', 'page_view', { page_title: fw.metaTitle, page_location: window.location.href });
+}
+</script>
+</body>
+</html>

--- a/web/for/fastapi/index.html
+++ b/web/for/fastapi/index.html
@@ -1,0 +1,787 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
+  <!-- Dynamic meta tags set by JS below -->
+  <title>Grantex for FastAPI — JWT Middleware for AI Agent Authorization</title>
+  <meta name="description" content="Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.">
+  <link rel="canonical" href="https://grantex.dev/for/fastapi/">
+  <meta property="og:title" content="Grantex for FastAPI — JWT Middleware for AI Agent Authorization">
+  <meta property="og:description" content="Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.">
+  <meta property="og:url" content="https://grantex.dev/for/fastapi/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Grantex">
+  <meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grantex for FastAPI — JWT Middleware for AI Agent Authorization">
+  <meta name="twitter:description" content="Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
+  <style>
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --border:   #30363d;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --accent:   #3fb950;
+      --accent2:  #58a6ff;
+      --mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+      --sans:     'Inter', system-ui, -apple-system, sans-serif;
+      --radius:   8px;
+      --max-w:    900px;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: var(--sans); line-height: 1.6; }
+    a { color: var(--accent2); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { font-family: var(--mono); background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+    pre { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; overflow-x: auto; font-family: var(--mono); font-size: 0.875rem; line-height: 1.5; }
+    pre code { background: none; padding: 0; }
+
+    /* Nav */
+    .nav { display: flex; align-items: center; justify-content: space-between; max-width: var(--max-w); margin: 0 auto; padding: 1rem 1.5rem; }
+    .nav-logo { font-weight: 700; font-size: 1.25rem; color: var(--text); }
+    .nav-links { list-style: none; display: flex; gap: 1.5rem; }
+    .nav-links a { color: var(--muted); font-size: 0.9rem; }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+
+    /* Hero */
+    .hero { text-align: center; padding: 4rem 1.5rem 3rem; max-width: var(--max-w); margin: 0 auto; }
+    .hero-badge { display: inline-block; background: rgba(63,185,80,0.15); color: var(--accent); padding: 0.25rem 0.75rem; border-radius: 999px; font-size: 0.8rem; font-weight: 600; margin-bottom: 1rem; }
+    .hero h1 { font-size: 2.5rem; line-height: 1.2; margin-bottom: 1rem; }
+    .hero h1 .highlight { color: var(--accent); }
+    .hero p { color: var(--muted); font-size: 1.1rem; max-width: 650px; margin: 0 auto 2rem; }
+    .hero-ctas { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
+    .btn { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.65rem 1.25rem; border-radius: var(--radius); font-weight: 600; font-size: 0.9rem; text-decoration: none; transition: all 0.2s; }
+    .btn-primary { background: var(--accent); color: #0d1117; }
+    .btn-primary:hover { background: #2ea043; text-decoration: none; }
+    .btn-secondary { background: var(--surface); color: var(--text); border: 1px solid var(--border); }
+    .btn-secondary:hover { border-color: var(--muted); text-decoration: none; }
+
+    /* Sections */
+    .section { max-width: var(--max-w); margin: 0 auto; padding: 3rem 1.5rem; }
+    .section h2 { font-size: 1.75rem; margin-bottom: 1rem; }
+    .section h3 { font-size: 1.15rem; margin-bottom: 0.5rem; color: var(--accent); }
+    .section p, .section li { color: var(--muted); }
+    .section ul { padding-left: 1.25rem; }
+    .section li { margin-bottom: 0.5rem; }
+
+    /* Problem cards */
+    .problem-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; margin: 1.5rem 0; }
+    .problem-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .problem-card.bad { border-color: #f8514933; }
+    .problem-card.good { border-color: #3fb95033; }
+    .problem-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .problem-card.bad h3 { color: #f85149; }
+    .problem-card.good h3 { color: var(--accent); }
+
+    /* Steps */
+    .steps { counter-reset: step; margin: 1.5rem 0; }
+    .step { display: flex; gap: 1rem; margin-bottom: 1.5rem; }
+    .step::before { counter-increment: step; content: counter(step); display: flex; align-items: center; justify-content: center; min-width: 32px; height: 32px; background: rgba(63,185,80,0.15); color: var(--accent); border-radius: 50%; font-weight: 700; font-size: 0.85rem; }
+    .step-content h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.25rem; }
+    .step-content p { font-size: 0.9rem; }
+
+    /* Features */
+    .feature-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.25rem; margin: 1.5rem 0; }
+    .feature-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .feature-card h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; }
+
+    /* Install */
+    .install-box { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.25rem; display: flex; align-items: center; justify-content: space-between; margin: 1rem 0; font-family: var(--mono); font-size: 0.9rem; }
+    .install-box button { background: var(--accent); color: #0d1117; border: none; padding: 0.35rem 0.75rem; border-radius: 4px; font-weight: 600; cursor: pointer; font-size: 0.8rem; }
+
+    /* Footer */
+    .footer { max-width: var(--max-w); margin: 0 auto; padding: 2rem 1.5rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; }
+    .footer-links { list-style: none; display: flex; gap: 1.5rem; }
+    .footer-links a { color: var(--muted); font-size: 0.85rem; }
+
+    @media (max-width: 640px) {
+      .hero h1 { font-size: 1.75rem; }
+      .problem-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Grantex for FastAPI","applicationCategory":"DeveloperApplication","operatingSystem":"Any","url":"https://grantex.dev/for/fastapi/","description":"Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.","license":"https://www.apache.org/licenses/LICENSE-2.0"}</script>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/" class="nav-logo">Grantex</a>
+  <ul class="nav-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="/playground">Playground</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+  </ul>
+</nav>
+
+<div id="app">
+  <section class="hero">
+    <span class="hero-badge" id="badge"></span>
+    <h1 id="heroTitle"></h1>
+    <p id="heroDesc"></p>
+    <div class="hero-ctas">
+      <a href="" id="ctaDocs" class="btn btn-primary">View Integration Docs</a>
+      <a href="" id="ctaInstall" class="btn btn-secondary">Get Started</a>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2>The Problem</h2>
+    <div class="problem-grid">
+      <div class="problem-card bad">
+        <h3>Without Grantex</h3>
+        <p id="problemBad"></p>
+      </div>
+      <div class="problem-card good">
+        <h3>With Grantex</h3>
+        <p id="problemGood"></p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2 id="howTitle">How It Works</h2>
+    <div class="steps" id="steps"></div>
+  </section>
+
+  <section class="section">
+    <h2>Quick Start</h2>
+    <div class="install-box">
+      <span id="installCmd"></span>
+      <button onclick="navigator.clipboard.writeText(document.getElementById('installCmd').textContent);this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)">Copy</button>
+    </div>
+    <pre><code id="codeExample"></code></pre>
+  </section>
+
+  <section class="section">
+    <h2 id="featuresTitle">Why Grantex</h2>
+    <div class="feature-grid" id="features"></div>
+  </section>
+
+  <section class="section" style="text-align:center">
+    <h2>Ready to secure your <span id="ctaFramework"></span> agents?</h2>
+    <p style="margin-bottom:1.5rem;color:var(--muted)">Get started in under 5 minutes. Open source, Apache 2.0.</p>
+    <div class="hero-ctas">
+      <a href="https://grantex.dev/dashboard/signup" class="btn btn-primary">Sign Up Free</a>
+      <a href="" id="ctaDocsBottom" class="btn btn-secondary">Read the Docs</a>
+    </div>
+  </section>
+</div>
+
+<footer class="footer">
+  <span style="color:var(--muted);font-size:0.85rem">Grantex — Open authorization for AI agents</span>
+  <ul class="footer-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+    <li><a href="/">Home</a></li>
+  </ul>
+</footer>
+
+<script>
+const frameworks = {
+  langchain: {
+    name: 'LangChain',
+    badge: 'LangChain + Grantex',
+    title: 'Authorization for <span class="highlight">LangChain</span> Agents',
+    desc: 'Add scoped, revocable permissions to your LangChain agents. Grantex integrates natively with LangChain tools — your agents get signed JWTs instead of raw API keys.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    install: 'npm install @grantex/langchain @grantex/sdk',
+    problemBad: 'Your LangChain agents use raw API keys with full access. No scoping, no audit trail, no way to revoke access if an agent goes rogue. One compromised key exposes everything.',
+    problemGood: 'Each LangChain agent gets a scoped, time-limited JWT. Tools verify permissions offline. You can revoke any agent instantly. Every action is audit-logged with a hash chain.',
+    howTitle: 'How Grantex Works with LangChain',
+    steps: [
+      ['Install the integration', 'npm install @grantex/langchain — wraps LangChain tools with automatic grant verification.'],
+      ['Register your agent', 'Create an agent identity with specific scopes like "email:send" or "calendar:read".'],
+      ['Get user consent', 'Redirect the user to a consent page. They approve exactly which permissions the agent gets.'],
+      ['Agent receives a JWT', 'The agent gets a signed token it presents to any service. Services verify offline via JWKS.'],
+      ['Audit & revoke', 'Every action is logged. Revoke access in under 1 second if something goes wrong.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexToolkit } from '@grantex/langchain';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap your LangChain tools with Grantex authorization
+const toolkit = new GrantexToolkit({
+  client: gx,
+  grantToken: token,  // JWT from the consent flow
+  tools: [searchTool, emailTool],
+});
+
+// Tools now automatically verify scopes before executing
+const agent = createToolCallingAgent({ llm, tools: toolkit.tools });`,
+    features: [
+      ['Native LangChain Integration', 'Drop-in toolkit that wraps your existing LangChain tools with automatic scope verification.'],
+      ['Scoped Permissions', 'Define exactly what each agent can do — "email:read" vs "email:send". No more all-or-nothing API keys.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS without calling Grantex. Zero latency overhead on your LangChain pipeline.'],
+      ['Multi-Agent Delegation', 'Parent agents delegate narrower scopes to sub-agents. Revoking the parent cascades to all children.'],
+      ['Hash-Chained Audit Trail', 'Every tool invocation is logged in an append-only, tamper-evident audit trail.'],
+      ['Real-Time Revocation', 'Kill a misbehaving agent\'s access in under 1 second. No waiting for token expiry.'],
+    ],
+    ctaFramework: 'LangChain',
+    metaTitle: 'Grantex for LangChain — Authorization for LangChain AI Agents',
+    metaDesc: 'Add scoped, revocable permissions to LangChain agents. Drop-in toolkit for authorization with signed JWTs, audit trails, and real-time revocation. Open source.',
+  },
+  crewai: {
+    name: 'CrewAI',
+    badge: 'CrewAI + Grantex',
+    title: 'Authorization for <span class="highlight">CrewAI</span> Agents',
+    desc: 'Secure your CrewAI crews with scoped, revocable permissions. Each crew member gets exactly the access it needs — nothing more.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    install: 'pip install grantex-crewai grantex',
+    problemBad: 'Your CrewAI agents share the same API keys. If one crew member is compromised, the entire crew\'s access is exposed. No way to scope or revoke individual agent access.',
+    problemGood: 'Each crew member gets its own scoped JWT. The researcher can only read, the writer can only draft, the publisher can only post. Revoke any member instantly.',
+    howTitle: 'How Grantex Works with CrewAI',
+    steps: [
+      ['Install the integration', 'pip install grantex-crewai — Python-native integration for CrewAI crews.'],
+      ['Register each crew member', 'Create agent identities with role-specific scopes for each crew member.'],
+      ['Authorize the crew', 'Users approve scoped permissions for each role in the crew.'],
+      ['Crew operates with scoped tokens', 'Each crew member presents its own JWT. Services verify independently.'],
+      ['Monitor & control', 'Audit every crew action. Revoke individual members without stopping the whole crew.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_crewai import GrantexCrewTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Each crew member gets scoped authorization
+researcher_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=researcher_token,  # scoped to "search:read"
+    tools=[search_tool],
+)
+
+writer_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=writer_token,  # scoped to "docs:write"
+    tools=[write_tool],
+)`,
+    features: [
+      ['Per-Agent Scoping', 'Each crew member gets exactly the permissions it needs. Researcher reads, writer writes, publisher posts.'],
+      ['Role-Based Access', 'Map CrewAI roles to Grantex scopes. Define authorization policies per role, not per API key.'],
+      ['Crew-Wide Audit Trail', 'See what every crew member did, when, and with what permissions. Hash-chained for tamper evidence.'],
+      ['Delegation Chains', 'A lead agent can delegate narrower permissions to sub-agents. Revoking the lead cascades to all.'],
+      ['Python Native', 'Pure Python integration. pip install and go — works with any CrewAI version.'],
+      ['Instant Revocation', 'Revoke any crew member\'s access in under 1 second without disrupting the rest of the crew.'],
+    ],
+    ctaFramework: 'CrewAI',
+    metaTitle: 'Grantex for CrewAI — Secure Multi-Agent Crew Permissions',
+    metaDesc: 'Scope and control permissions for CrewAI agents. Each crew member gets its own signed JWT with role-specific access. Audit trails, delegation, real-time revocation.',
+  },
+  'openai-agents': {
+    name: 'OpenAI Agents SDK',
+    badge: 'OpenAI Agents + Grantex',
+    title: 'Authorization for <span class="highlight">OpenAI Agents SDK</span>',
+    desc: 'Add enterprise-grade authorization to your OpenAI agents. Scoped permissions, audit trails, and instant revocation — built for the Agents SDK.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    install: 'pip install grantex-openai-agents grantex',
+    problemBad: 'Your OpenAI agents operate with full API access. No scoping, no audit trail, no revocation. You can\'t tell which agent did what or limit what it can do.',
+    problemGood: 'Each agent gets a scoped, time-limited JWT. Every tool call is authorized and logged. Revoke access instantly if an agent behaves unexpectedly.',
+    howTitle: 'How Grantex Works with OpenAI Agents SDK',
+    steps: [
+      ['Install the integration', 'pip install grantex-openai-agents — wraps OpenAI agent tools with authorization.'],
+      ['Register your agent', 'Create an agent identity with scopes matching its capabilities.'],
+      ['Get user approval', 'Users approve exactly which permissions the agent receives via a consent page.'],
+      ['Agent operates with JWT', 'The agent\'s tools automatically verify permissions before executing.'],
+      ['Full audit trail', 'Every tool invocation is logged with the agent identity, scopes used, and timestamp.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_openai_agents import GrantexTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap OpenAI agent tools with Grantex authorization
+tools = GrantexTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, email_tool],
+)
+
+# Tools automatically check scopes before execution
+agent = Agent(
+    name="assistant",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['OpenAI Agents SDK Integration', 'Drop-in wrapper for OpenAI agent tools. Add authorization without changing your agent logic.'],
+      ['Scoped Tool Access', 'Define which tools each agent can use and with what parameters. Enforced at the protocol level.'],
+      ['Enterprise Audit Trail', 'Every tool call logged with agent identity, scopes, and hash-chained integrity.'],
+      ['Multi-Agent Pipelines', 'Parent agents delegate narrower access to sub-agents. Full delegation chain tracking.'],
+      ['Budget Controls', 'Set spending limits per agent. Automatic cutoff when budget is exhausted.'],
+      ['Compliance Ready', 'SOC 2 compatible audit logging. SCIM/SSO for enterprise identity management.'],
+    ],
+    ctaFramework: 'OpenAI Agents',
+    metaTitle: 'Grantex for OpenAI Agents SDK — Enterprise Agent Authorization',
+    metaDesc: 'Add scoped permissions, audit trails, and real-time revocation to OpenAI Agents SDK. Enterprise-grade authorization for AI agents. Open source.',
+  },
+  anthropic: {
+    name: 'Anthropic SDK',
+    badge: 'Anthropic + Grantex',
+    title: 'Authorization for <span class="highlight">Anthropic SDK</span> Tool Use',
+    desc: 'Enforce scoped permissions on Claude tool calls. Offline JWT verification, automatic audit logging, and instant revocation for Anthropic SDK apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    installUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    install: 'npm install @grantex/anthropic @grantex/sdk',
+    problemBad: 'Your Claude-powered agents call tools with no authorization layer. Any tool can be invoked with full access. No scoping, no consent, no audit trail of what the agent did.',
+    problemGood: 'Grantex wraps each tool with scope enforcement. The agent\'s JWT is checked offline before execution. Every tool call is audit-logged. Revoke access in under 1 second.',
+    howTitle: 'How Grantex Works with the Anthropic SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/anthropic — wraps Anthropic tool definitions with authorization.'],
+      ['Create scoped tools', 'Use createGrantexTool() to define tools with required scopes and JSON Schema input.'],
+      ['Pass tools to Claude', 'tool.definition is type-compatible with client.messages.create({ tools }).'],
+      ['Dispatch tool_use blocks', 'Use GrantexToolRegistry or handleToolCall() to execute with automatic audit logging.'],
+      ['Monitor everything', 'Hash-chained audit trail of every tool call. Revoke access in under 1 second.'],
+    ],
+    code: `import Anthropic from '@anthropic-ai/sdk';
+import { createGrantexTool, GrantexToolRegistry } from '@grantex/anthropic';
+
+const client = new Anthropic();
+
+const readFile = createGrantexTool({
+  name: 'read_file',
+  description: 'Read a file from disk',
+  inputSchema: {
+    type: 'object',
+    properties: { path: { type: 'string' } },
+    required: ['path'],
+  },
+  grantToken,
+  requiredScope: 'file:read',
+  execute: async ({ path }) => fs.readFile(path, 'utf-8'),
+});
+
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  tools: [readFile.definition],
+  messages,
+});`,
+    features: [
+      ['Anthropic SDK Native', 'Type-compatible with client.messages.create(). tool.definition drops in directly.'],
+      ['Offline Scope Checks', 'JWT scp claim verified locally. No network call to Grantex during execution.'],
+      ['Tool Registry', 'GrantexToolRegistry manages multiple tools and dispatches tool_use blocks by name.'],
+      ['Audit Logging', 'withAuditLogging() and handleToolCall() log every success/failure automatically.'],
+      ['GrantexScopeError', 'Typed error with requiredScope and grantedScopes for clean error handling.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Anthropic SDK',
+    metaTitle: 'Grantex for Anthropic SDK — Secure Claude Tool Use Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Claude tool use. Offline JWT verification, tool registry, and instant revocation. Open source.',
+  },
+  'google-adk': {
+    name: 'Google ADK',
+    badge: 'Google ADK + Grantex',
+    title: 'Authorization for <span class="highlight">Google ADK</span> Agents',
+    desc: 'Secure your Google Agent Development Kit agents with scoped, human-approved permissions and full audit trails.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    install: 'pip install grantex-adk grantex',
+    problemBad: 'Your ADK agents access services with broad credentials. No fine-grained scoping, no delegation control, no tamper-proof audit log of agent actions.',
+    problemGood: 'Each ADK agent gets cryptographic identity and scoped JWTs. Delegation chains track multi-agent workflows. Every action is audit-logged.',
+    howTitle: 'How Grantex Works with Google ADK',
+    steps: [
+      ['Install the integration', 'pip install grantex-adk — Python-native integration for Google ADK.'],
+      ['Register your agent', 'Create an agent identity with specific scopes matching your ADK agent\'s capabilities.'],
+      ['Authorize via consent', 'Users approve scoped permissions through a consent flow.'],
+      ['Agent operates securely', 'ADK tools verify permissions via JWT before executing any action.'],
+      ['Monitor everything', 'Hash-chained audit trail of every action. Revoke access in under 1 second.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_adk import GrantexADKTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap ADK tools with Grantex authorization
+tools = GrantexADKTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, calendar_tool],
+)
+
+# Tools verify scopes automatically
+agent = Agent(
+    model="gemini-2.0-flash",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['Google ADK Native', 'Built for the Agent Development Kit. Wraps ADK tools with automatic authorization.'],
+      ['Scoped Permissions', 'Fine-grained scopes for each capability. "calendar:read" vs "calendar:write".'],
+      ['Delegation Chains', 'Multi-agent ADK pipelines with tracked delegation. Revoke parent to cascade.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS. No network calls to Grantex during execution.'],
+      ['Audit & Compliance', 'Tamper-proof audit trail. SOC 2 compatible. Enterprise compliance exports.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Google ADK',
+    metaTitle: 'Grantex for Google ADK — Secure Agent Development Kit Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Google ADK agents. Delegation chains, real-time revocation, and enterprise compliance. Open source.',
+  },
+  'vercel-ai': {
+    name: 'Vercel AI SDK',
+    badge: 'Vercel AI + Grantex',
+    title: 'Authorization for <span class="highlight">Vercel AI SDK</span>',
+    desc: 'Add scoped authorization to your Vercel AI SDK tools. Signed JWTs, audit trails, and instant revocation for AI-powered apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    install: 'npm install @grantex/vercel-ai @grantex/sdk',
+    problemBad: 'Your Vercel AI tools run with full access. Users can\'t see or control what the AI does on their behalf. No audit trail, no revocation.',
+    problemGood: 'Each AI tool call is authorized with a scoped JWT. Users approve permissions upfront. Every action is logged. Revoke instantly.',
+    howTitle: 'How Grantex Works with Vercel AI SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/vercel-ai — TypeScript-native integration for Vercel AI SDK.'],
+      ['Define authorized tools', 'Wrap your AI SDK tools with Grantex scope requirements.'],
+      ['User consents', 'Users approve specific scopes before the AI can act on their behalf.'],
+      ['Tools verify automatically', 'Each tool call checks the JWT scopes before execution.'],
+      ['Full observability', 'Audit trail of every tool invocation. Real-time event streaming.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createGrantexTools } from '@grantex/vercel-ai';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap Vercel AI SDK tools with authorization
+const tools = createGrantexTools({
+  client: gx,
+  grantToken: token,
+  tools: { search: searchTool, email: emailTool },
+});
+
+// Use with generateText or streamText
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prompt: 'Search for flights and send the results',
+});`,
+    features: [
+      ['Vercel AI SDK Native', 'Works with generateText, streamText, and all AI SDK tool patterns.'],
+      ['TypeScript First', 'Full type safety. Scopes are checked at compile time and runtime.'],
+      ['Edge Compatible', 'Works in Vercel Edge Functions. JWT verification is local — no external calls.'],
+      ['Streaming Support', 'Compatible with streaming responses. Authorization doesn\'t block the stream.'],
+      ['Multi-Step Flows', 'Authorize multi-step AI workflows where each step requires different scopes.'],
+      ['Next.js Ready', 'Drop into your Next.js app with zero configuration beyond the SDK.'],
+    ],
+    ctaFramework: 'Vercel AI',
+    metaTitle: 'Grantex for Vercel AI SDK — Authorization for AI-Powered Apps',
+    metaDesc: 'Add scoped permissions to Vercel AI SDK tools. TypeScript-native, Edge-compatible, with audit trails and real-time revocation. Open source.',
+  },
+  autogen: {
+    name: 'AutoGen',
+    badge: 'AutoGen + Grantex',
+    title: 'Authorization for <span class="highlight">AutoGen</span> Multi-Agent Systems',
+    desc: 'Secure your AutoGen conversations with per-agent permissions. Each agent in the group gets exactly the scopes it needs.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    install: 'npm install @grantex/autogen @grantex/sdk',
+    problemBad: 'AutoGen agents in a group chat share credentials. If one agent is compromised or hallucinates, it has access to everything the others can do.',
+    problemGood: 'Each AutoGen agent gets its own scoped JWT. The coder can only write code, the executor can only run tests. Isolated, audited, revocable.',
+    howTitle: 'How Grantex Works with AutoGen',
+    steps: [
+      ['Install the integration', 'npm install @grantex/autogen — wraps AutoGen function maps with authorization.'],
+      ['Register each agent', 'Create identities with role-specific scopes for each agent in the group.'],
+      ['Scope per conversation', 'Users approve what each agent can do before the conversation starts.'],
+      ['Agents operate independently', 'Each agent presents its own JWT. Function calls are scope-checked automatically.'],
+      ['Trace everything', 'Full audit trail across the multi-agent conversation. Attribute actions to specific agents.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexAutoGen } from '@grantex/autogen';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Each agent in the group gets scoped authorization
+const coderTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: coderToken,  // scoped to "code:write"
+  functionMap: { write_code: writeCodeFn },
+});
+
+const executorTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: executorToken,  // scoped to "code:execute"
+  functionMap: { run_code: runCodeFn },
+});`,
+    features: [
+      ['Per-Agent Authorization', 'Each agent in the AutoGen group gets its own scoped token and identity.'],
+      ['Group Chat Security', 'Prevent agents from accessing tools outside their role. Enforced at the protocol level.'],
+      ['Conversation Auditing', 'Track which agent called which function, with what scopes, across the entire conversation.'],
+      ['Delegation Support', 'Agents can delegate narrower scopes to spawned sub-agents with depth tracking.'],
+      ['Function Map Wrapping', 'Drop-in wrapper for AutoGen function maps. No changes to your agent logic.'],
+      ['Real-Time Control', 'Revoke any agent mid-conversation. Access is denied within 1 second.'],
+    ],
+    ctaFramework: 'AutoGen',
+    metaTitle: 'Grantex for AutoGen — Secure Multi-Agent Group Chat Authorization',
+    metaDesc: 'Per-agent scoped permissions for AutoGen multi-agent systems. Each agent gets its own JWT. Audit trails, delegation chains, instant revocation.',
+  },
+  mcp: {
+    name: 'Model Context Protocol',
+    badge: 'MCP + Grantex',
+    title: 'Authorization for <span class="highlight">MCP</span> Servers',
+    desc: 'Add enterprise-grade authorization to any MCP server. 13 built-in tools for managing agents, grants, and tokens from Claude Desktop, Cursor, or Windsurf.',
+    docsUrl: 'https://docs.grantex.dev/integrations/mcp',
+    installUrl: 'https://docs.grantex.dev/integrations/mcp',
+    install: 'npm install @grantex/mcp',
+    problemBad: 'MCP servers expose tools to AI assistants with no authorization layer. Any connected client can call any tool with full access. No scoping, no consent, no audit trail.',
+    problemGood: 'Grantex adds OAuth 2.1-style authorization to MCP. Users approve scoped access per tool. Every invocation is logged. Revoke access from the permission dashboard.',
+    howTitle: 'How Grantex Works with MCP',
+    steps: [
+      ['Install the MCP server', 'npm install @grantex/mcp — adds 13 Grantex tools to any MCP-compatible client.'],
+      ['Connect to Claude Desktop', 'Add Grantex to your MCP config. Works with Claude Desktop, Cursor, and Windsurf.'],
+      ['Manage via natural language', 'Ask Claude to "register an agent", "create a grant", or "check the audit log".'],
+      ['Or add MCP Auth', 'Use @grantex/mcp-auth to add OAuth 2.1 + PKCE to your own MCP servers.'],
+      ['Full protocol access', 'All 13 Grantex operations available as MCP tools — agents, grants, tokens, audit, budgets.'],
+    ],
+    code: `// claude_desktop_config.json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "npx",
+      "args": ["@grantex/mcp"],
+      "env": {
+        "GRANTEX_API_KEY": "gx_live_..."
+      }
+    }
+  }
+}
+
+// Then in Claude Desktop:
+// "Register a new agent called travel-bot with flights:book scope"
+// "Create a grant for user alice on travel-bot"
+// "Show me the audit log for the last hour"`,
+    features: [
+      ['13 MCP Tools', 'Full Grantex protocol access: agents, grants, tokens, audit, budgets, verification — all as MCP tools.'],
+      ['Claude Desktop Ready', 'Works out of the box with Claude Desktop, Cursor, and Windsurf.'],
+      ['MCP Auth Server', 'Separate @grantex/mcp-auth package adds OAuth 2.1 + PKCE to any MCP server.'],
+      ['Natural Language Control', 'Manage authorization through conversation. "Revoke all grants for agent X."'],
+      ['Zero Code Setup', 'npx @grantex/mcp — no code required. Just add to your MCP config and go.'],
+      ['Enterprise Grade', 'Budget controls, policy engine, SCIM/SSO — all accessible via MCP tools.'],
+    ],
+    ctaFramework: 'MCP',
+    metaTitle: 'Grantex for MCP — Authorization for Model Context Protocol Servers',
+    metaDesc: 'Add OAuth 2.1 authorization to MCP servers. 13 tools for Claude Desktop, Cursor, and Windsurf. Scoped grants, audit trails, real-time revocation.',
+  },
+  express: {
+    name: 'Express.js',
+    badge: 'Express + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">Express.js</span>',
+    desc: 'Protect your Express.js APIs with Grantex grant tokens. Drop-in middleware that verifies JWTs, enforces scopes, and logs every request.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    install: 'npm install @grantex/express',
+    problemBad: 'Your Express APIs accept API keys or bearer tokens with no scope enforcement. Any valid token can access any endpoint. No agent identity tracking.',
+    problemGood: 'Grantex middleware verifies JWTs offline via JWKS, enforces scopes per route, and identifies the calling agent. Zero external network calls.',
+    howTitle: 'How Grantex Works with Express.js',
+    steps: [
+      ['Install the middleware', 'npm install @grantex/express — one package, zero external dependencies at runtime.'],
+      ['Add to your app', 'One line to protect your routes. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs are verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'req.grantex gives you the agent DID, scopes, principal, and grant ID.'],
+      ['Production ready', 'JWKS caching, key rotation, scope enforcement, and error handling built in.'],
+    ],
+    code: `import express from 'express';
+import { grantexMiddleware, requireScopes } from '@grantex/express';
+
+const app = express();
+
+// Verify Grantex JWTs on all /api routes
+app.use('/api', grantexMiddleware({
+  jwksUrl: 'https://grantex-auth-....a.run.app/.well-known/jwks.json',
+}));
+
+// Enforce specific scopes per route
+app.get('/api/emails', requireScopes(['email:read']), (req, res) => {
+  console.log(req.grantex.agent);  // agent DID
+  console.log(req.grantex.scopes); // ['email:read']
+  res.json({ emails: [] });
+});`,
+    features: [
+      ['Drop-In Middleware', 'One line to protect your Express routes. Works with any Express 4+ app.'],
+      ['Offline JWT Verification', 'JWKS-based verification. No network calls to Grantex on each request. Sub-millisecond overhead.'],
+      ['Per-Route Scopes', 'requireScopes() enforces specific permissions per endpoint. Returns 403 if scopes don\'t match.'],
+      ['Agent Identity', 'req.grantex provides agent DID, scopes, principal ID, grant ID on every request.'],
+      ['JWKS Caching', 'Automatic key caching and rotation. Handles key rollover transparently.'],
+      ['TypeScript Support', 'Full type definitions. req.grantex is fully typed.'],
+    ],
+    ctaFramework: 'Express.js',
+    metaTitle: 'Grantex for Express.js — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Drop-in Express.js middleware for Grantex JWT verification. Offline JWKS verification, per-route scope enforcement, and agent identity. Open source.',
+  },
+  fastapi: {
+    name: 'FastAPI',
+    badge: 'FastAPI + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">FastAPI</span>',
+    desc: 'Protect your FastAPI endpoints with Grantex grant tokens. Dependency-injection middleware that verifies JWTs, enforces scopes, and identifies agents.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    install: 'pip install grantex-fastapi',
+    problemBad: 'Your FastAPI endpoints accept bearer tokens with no scope enforcement. Any valid token accesses any route. No way to identify which AI agent made the request.',
+    problemGood: 'Grantex dependency verifies JWTs offline via JWKS, enforces scopes per route, and provides the agent identity. Pythonic, async, and type-safe.',
+    howTitle: 'How Grantex Works with FastAPI',
+    steps: [
+      ['Install the middleware', 'pip install grantex-fastapi — async-native, works with FastAPI\'s dependency injection.'],
+      ['Add the dependency', 'Use GrantexAuth as a FastAPI dependency. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'The dependency returns the full grant context: agent DID, scopes, principal, grant ID.'],
+      ['Production ready', 'Async JWKS fetching, key caching, automatic rotation, and proper error responses.'],
+    ],
+    code: `from fastapi import FastAPI, Depends
+from grantex_fastapi import GrantexAuth, GrantContext
+
+app = FastAPI()
+auth = GrantexAuth(
+    jwks_url="https://grantex-auth-....a.run.app/.well-known/jwks.json"
+)
+
+@app.get("/api/emails")
+async def list_emails(
+    grant: GrantContext = Depends(auth.require_scopes(["email:read"]))
+):
+    print(grant.agent)   # agent DID
+    print(grant.scopes)  # ["email:read"]
+    return {"emails": []}`,
+    features: [
+      ['FastAPI Dependency Injection', 'Works with FastAPI\'s Depends() pattern. Pythonic and type-safe.'],
+      ['Async Native', 'Fully async JWKS fetching and JWT verification. No blocking calls.'],
+      ['Per-Route Scopes', 'require_scopes() enforces specific permissions per endpoint. Returns 403 on mismatch.'],
+      ['Typed Grant Context', 'Full Pydantic model for grant context: agent DID, scopes, principal, grant ID.'],
+      ['JWKS Caching', 'Automatic async key caching and rotation. Handles key rollover transparently.'],
+      ['OpenAPI Integration', 'Scopes appear in your FastAPI OpenAPI docs automatically.'],
+    ],
+    ctaFramework: 'FastAPI',
+    metaTitle: 'Grantex for FastAPI — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.',
+  },
+  mpp: {
+    name: 'MPP (Machine Payments Protocol)',
+    badge: 'MPP + Grantex',
+    title: 'Agent Identity for <span class="highlight">Machine Payments</span>',
+    desc: 'MPP defines how AI agents pay for services. Grantex adds the missing identity layer — verifiable agent passports that let merchants know exactly who authorized every payment, with offline verification in under 50ms.',
+    docsUrl: 'https://docs.grantex.dev/features/mpp-agent-passport',
+    installUrl: 'https://docs.grantex.dev/guides/mpp-integration',
+    install: 'npm install @grantex/mpp @grantex/sdk',
+    problemBad: 'When an agent makes an MPP payment, the source is just a wallet address. No human name, no org, no authorization chain. For $0.10 API calls nobody cares. For $500 B2B procurement, it\'s a compliance blocker.',
+    problemGood: 'Every MPP payment carries an AgentPassportCredential — a W3C VC 2.0 credential with the human principal, org DID, spending limits, and allowed categories. Merchants verify in <50ms, offline.',
+    howTitle: 'How Grantex Works with MPP',
+    steps: [
+      ['Install the package', 'npm install @grantex/mpp — agent-side middleware + merchant-side verification in one package.'],
+      ['Issue an agent passport', 'Call grantex.passports.issue() with categories (inference, compute, data), spending limits, and expiry.'],
+      ['Attach to MPP requests', 'createMppPassportMiddleware() injects the X-Grantex-Passport header on every outgoing fetch.'],
+      ['Verify on the merchant side', 'requireAgentPassport() Express middleware — one line to verify identity, categories, and amounts.'],
+      ['Check the trust registry', 'lookupOrgTrust() returns verified org status (basic, verified, SOC 2) from the public registry.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createMppPassportMiddleware, requireAgentPassport } from '@grantex/mpp';
+
+// Agent side: issue passport and attach to requests
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const passport = await grantex.passports.issue({
+  agentId: 'ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  allowedMPPCategories: ['inference', 'compute'],
+  maxTransactionAmount: { amount: 50, currency: 'USDC' },
+  expiresIn: '24h',
+});
+
+const middleware = createMppPassportMiddleware({ passport });
+const enriched = await middleware(new Request(url));
+// X-Grantex-Passport header attached
+
+// Merchant side: one-line verification
+app.use('/api/inference', requireAgentPassport({
+  requiredCategories: ['inference'],
+  maxAmount: 10,
+}));
+// req.agentPassport → { humanDID, orgDID, categories, maxAmount, ... }`,
+    features: [
+      ['AgentPassportCredential', 'W3C VC 2.0 with agent DID, human principal, org, categories, spending limits, and delegation depth.'],
+      ['<50ms Verification', 'Offline verification using cached JWKS. No API roundtrip to Grantex servers needed.'],
+      ['9 MPP Categories', 'inference, compute, data, storage, search, media, delivery, browser, general — each maps to a Grantex scope.'],
+      ['StatusList2021 Revocation', 'Revoke any passport instantly. Bit-flip propagation, no polling required.'],
+      ['Trust Registry', 'Public org trust lookup by DID. DNS-TXT, manual, or SOC 2 verification levels.'],
+      ['Auto-Refresh', 'Middleware proactively refreshes passports before expiry via onRefresh callback.'],
+    ],
+    ctaFramework: 'MPP',
+    metaTitle: 'Grantex for MPP — Agent Identity for Machine Payments Protocol',
+    metaDesc: 'Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.',
+  },
+};
+
+// Determine framework from URL
+const path = window.location.pathname.replace(/\/$/, '');
+const slug = path.split('/').pop();
+const fw = frameworks[slug];
+
+if (!fw) {
+  // Redirect to homepage if unknown framework
+  window.location.href = '/';
+} else {
+  // Set meta tags
+  document.title = fw.metaTitle;
+  document.querySelector('meta[name="description"]').content = fw.metaDesc;
+  document.querySelector('link[rel="canonical"]').href = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[property="og:title"]').content = fw.metaTitle;
+  document.querySelector('meta[property="og:description"]').content = fw.metaDesc;
+  document.querySelector('meta[property="og:url"]').content = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[name="twitter:title"]').content = fw.metaTitle;
+  document.querySelector('meta[name="twitter:description"]').content = fw.metaDesc;
+
+  // Populate content
+  document.getElementById('badge').textContent = fw.badge;
+  document.getElementById('heroTitle').innerHTML = fw.title;
+  document.getElementById('heroDesc').textContent = fw.desc;
+  document.getElementById('ctaDocs').href = fw.docsUrl;
+  document.getElementById('ctaInstall').href = fw.installUrl;
+  document.getElementById('problemBad').textContent = fw.problemBad;
+  document.getElementById('problemGood').textContent = fw.problemGood;
+  document.getElementById('howTitle').textContent = fw.howTitle;
+  document.getElementById('installCmd').textContent = fw.install;
+  document.getElementById('codeExample').textContent = fw.code;
+  document.getElementById('ctaFramework').textContent = fw.ctaFramework;
+  document.getElementById('ctaDocsBottom').href = fw.docsUrl;
+  document.getElementById('featuresTitle').textContent = 'Why Grantex for ' + fw.name;
+
+  // Steps
+  const stepsEl = document.getElementById('steps');
+  fw.steps.forEach(([title, desc]) => {
+    stepsEl.innerHTML += `<div class="step"><div class="step-content"><h3>${title}</h3><p>${desc}</p></div></div>`;
+  });
+
+  // Features
+  const featuresEl = document.getElementById('features');
+  fw.features.forEach(([title, desc]) => {
+    featuresEl.innerHTML += `<div class="feature-card"><h3>${title}</h3><p>${desc}</p></div>`;
+  });
+
+  // Add JSON-LD structured data
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Grantex for " + fw.name,
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Any",
+    "url": "https://grantex.dev/for/" + slug,
+    "description": fw.metaDesc,
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  };
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.textContent = JSON.stringify(jsonLd);
+  document.head.appendChild(script);
+
+  // Track page view
+  gtag('event', 'page_view', { page_title: fw.metaTitle, page_location: window.location.href });
+}
+</script>
+</body>
+</html>

--- a/web/for/google-adk/index.html
+++ b/web/for/google-adk/index.html
@@ -1,0 +1,787 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
+  <!-- Dynamic meta tags set by JS below -->
+  <title>Grantex for Google ADK — Secure Agent Development Kit Authorization</title>
+  <meta name="description" content="Add scoped permissions and audit trails to Google ADK agents. Delegation chains, real-time revocation, and enterprise compliance. Open source.">
+  <link rel="canonical" href="https://grantex.dev/for/google-adk/">
+  <meta property="og:title" content="Grantex for Google ADK — Secure Agent Development Kit Authorization">
+  <meta property="og:description" content="Add scoped permissions and audit trails to Google ADK agents. Delegation chains, real-time revocation, and enterprise compliance. Open source.">
+  <meta property="og:url" content="https://grantex.dev/for/google-adk/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Grantex">
+  <meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grantex for Google ADK — Secure Agent Development Kit Authorization">
+  <meta name="twitter:description" content="Add scoped permissions and audit trails to Google ADK agents. Delegation chains, real-time revocation, and enterprise compliance. Open source.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
+  <style>
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --border:   #30363d;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --accent:   #3fb950;
+      --accent2:  #58a6ff;
+      --mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+      --sans:     'Inter', system-ui, -apple-system, sans-serif;
+      --radius:   8px;
+      --max-w:    900px;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: var(--sans); line-height: 1.6; }
+    a { color: var(--accent2); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { font-family: var(--mono); background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+    pre { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; overflow-x: auto; font-family: var(--mono); font-size: 0.875rem; line-height: 1.5; }
+    pre code { background: none; padding: 0; }
+
+    /* Nav */
+    .nav { display: flex; align-items: center; justify-content: space-between; max-width: var(--max-w); margin: 0 auto; padding: 1rem 1.5rem; }
+    .nav-logo { font-weight: 700; font-size: 1.25rem; color: var(--text); }
+    .nav-links { list-style: none; display: flex; gap: 1.5rem; }
+    .nav-links a { color: var(--muted); font-size: 0.9rem; }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+
+    /* Hero */
+    .hero { text-align: center; padding: 4rem 1.5rem 3rem; max-width: var(--max-w); margin: 0 auto; }
+    .hero-badge { display: inline-block; background: rgba(63,185,80,0.15); color: var(--accent); padding: 0.25rem 0.75rem; border-radius: 999px; font-size: 0.8rem; font-weight: 600; margin-bottom: 1rem; }
+    .hero h1 { font-size: 2.5rem; line-height: 1.2; margin-bottom: 1rem; }
+    .hero h1 .highlight { color: var(--accent); }
+    .hero p { color: var(--muted); font-size: 1.1rem; max-width: 650px; margin: 0 auto 2rem; }
+    .hero-ctas { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
+    .btn { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.65rem 1.25rem; border-radius: var(--radius); font-weight: 600; font-size: 0.9rem; text-decoration: none; transition: all 0.2s; }
+    .btn-primary { background: var(--accent); color: #0d1117; }
+    .btn-primary:hover { background: #2ea043; text-decoration: none; }
+    .btn-secondary { background: var(--surface); color: var(--text); border: 1px solid var(--border); }
+    .btn-secondary:hover { border-color: var(--muted); text-decoration: none; }
+
+    /* Sections */
+    .section { max-width: var(--max-w); margin: 0 auto; padding: 3rem 1.5rem; }
+    .section h2 { font-size: 1.75rem; margin-bottom: 1rem; }
+    .section h3 { font-size: 1.15rem; margin-bottom: 0.5rem; color: var(--accent); }
+    .section p, .section li { color: var(--muted); }
+    .section ul { padding-left: 1.25rem; }
+    .section li { margin-bottom: 0.5rem; }
+
+    /* Problem cards */
+    .problem-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; margin: 1.5rem 0; }
+    .problem-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .problem-card.bad { border-color: #f8514933; }
+    .problem-card.good { border-color: #3fb95033; }
+    .problem-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .problem-card.bad h3 { color: #f85149; }
+    .problem-card.good h3 { color: var(--accent); }
+
+    /* Steps */
+    .steps { counter-reset: step; margin: 1.5rem 0; }
+    .step { display: flex; gap: 1rem; margin-bottom: 1.5rem; }
+    .step::before { counter-increment: step; content: counter(step); display: flex; align-items: center; justify-content: center; min-width: 32px; height: 32px; background: rgba(63,185,80,0.15); color: var(--accent); border-radius: 50%; font-weight: 700; font-size: 0.85rem; }
+    .step-content h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.25rem; }
+    .step-content p { font-size: 0.9rem; }
+
+    /* Features */
+    .feature-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.25rem; margin: 1.5rem 0; }
+    .feature-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .feature-card h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; }
+
+    /* Install */
+    .install-box { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.25rem; display: flex; align-items: center; justify-content: space-between; margin: 1rem 0; font-family: var(--mono); font-size: 0.9rem; }
+    .install-box button { background: var(--accent); color: #0d1117; border: none; padding: 0.35rem 0.75rem; border-radius: 4px; font-weight: 600; cursor: pointer; font-size: 0.8rem; }
+
+    /* Footer */
+    .footer { max-width: var(--max-w); margin: 0 auto; padding: 2rem 1.5rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; }
+    .footer-links { list-style: none; display: flex; gap: 1.5rem; }
+    .footer-links a { color: var(--muted); font-size: 0.85rem; }
+
+    @media (max-width: 640px) {
+      .hero h1 { font-size: 1.75rem; }
+      .problem-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Grantex for Google ADK","applicationCategory":"DeveloperApplication","operatingSystem":"Any","url":"https://grantex.dev/for/google-adk/","description":"Add scoped permissions and audit trails to Google ADK agents. Delegation chains, real-time revocation, and enterprise compliance. Open source.","license":"https://www.apache.org/licenses/LICENSE-2.0"}</script>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/" class="nav-logo">Grantex</a>
+  <ul class="nav-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="/playground">Playground</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+  </ul>
+</nav>
+
+<div id="app">
+  <section class="hero">
+    <span class="hero-badge" id="badge"></span>
+    <h1 id="heroTitle"></h1>
+    <p id="heroDesc"></p>
+    <div class="hero-ctas">
+      <a href="" id="ctaDocs" class="btn btn-primary">View Integration Docs</a>
+      <a href="" id="ctaInstall" class="btn btn-secondary">Get Started</a>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2>The Problem</h2>
+    <div class="problem-grid">
+      <div class="problem-card bad">
+        <h3>Without Grantex</h3>
+        <p id="problemBad"></p>
+      </div>
+      <div class="problem-card good">
+        <h3>With Grantex</h3>
+        <p id="problemGood"></p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2 id="howTitle">How It Works</h2>
+    <div class="steps" id="steps"></div>
+  </section>
+
+  <section class="section">
+    <h2>Quick Start</h2>
+    <div class="install-box">
+      <span id="installCmd"></span>
+      <button onclick="navigator.clipboard.writeText(document.getElementById('installCmd').textContent);this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)">Copy</button>
+    </div>
+    <pre><code id="codeExample"></code></pre>
+  </section>
+
+  <section class="section">
+    <h2 id="featuresTitle">Why Grantex</h2>
+    <div class="feature-grid" id="features"></div>
+  </section>
+
+  <section class="section" style="text-align:center">
+    <h2>Ready to secure your <span id="ctaFramework"></span> agents?</h2>
+    <p style="margin-bottom:1.5rem;color:var(--muted)">Get started in under 5 minutes. Open source, Apache 2.0.</p>
+    <div class="hero-ctas">
+      <a href="https://grantex.dev/dashboard/signup" class="btn btn-primary">Sign Up Free</a>
+      <a href="" id="ctaDocsBottom" class="btn btn-secondary">Read the Docs</a>
+    </div>
+  </section>
+</div>
+
+<footer class="footer">
+  <span style="color:var(--muted);font-size:0.85rem">Grantex — Open authorization for AI agents</span>
+  <ul class="footer-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+    <li><a href="/">Home</a></li>
+  </ul>
+</footer>
+
+<script>
+const frameworks = {
+  langchain: {
+    name: 'LangChain',
+    badge: 'LangChain + Grantex',
+    title: 'Authorization for <span class="highlight">LangChain</span> Agents',
+    desc: 'Add scoped, revocable permissions to your LangChain agents. Grantex integrates natively with LangChain tools — your agents get signed JWTs instead of raw API keys.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    install: 'npm install @grantex/langchain @grantex/sdk',
+    problemBad: 'Your LangChain agents use raw API keys with full access. No scoping, no audit trail, no way to revoke access if an agent goes rogue. One compromised key exposes everything.',
+    problemGood: 'Each LangChain agent gets a scoped, time-limited JWT. Tools verify permissions offline. You can revoke any agent instantly. Every action is audit-logged with a hash chain.',
+    howTitle: 'How Grantex Works with LangChain',
+    steps: [
+      ['Install the integration', 'npm install @grantex/langchain — wraps LangChain tools with automatic grant verification.'],
+      ['Register your agent', 'Create an agent identity with specific scopes like "email:send" or "calendar:read".'],
+      ['Get user consent', 'Redirect the user to a consent page. They approve exactly which permissions the agent gets.'],
+      ['Agent receives a JWT', 'The agent gets a signed token it presents to any service. Services verify offline via JWKS.'],
+      ['Audit & revoke', 'Every action is logged. Revoke access in under 1 second if something goes wrong.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexToolkit } from '@grantex/langchain';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap your LangChain tools with Grantex authorization
+const toolkit = new GrantexToolkit({
+  client: gx,
+  grantToken: token,  // JWT from the consent flow
+  tools: [searchTool, emailTool],
+});
+
+// Tools now automatically verify scopes before executing
+const agent = createToolCallingAgent({ llm, tools: toolkit.tools });`,
+    features: [
+      ['Native LangChain Integration', 'Drop-in toolkit that wraps your existing LangChain tools with automatic scope verification.'],
+      ['Scoped Permissions', 'Define exactly what each agent can do — "email:read" vs "email:send". No more all-or-nothing API keys.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS without calling Grantex. Zero latency overhead on your LangChain pipeline.'],
+      ['Multi-Agent Delegation', 'Parent agents delegate narrower scopes to sub-agents. Revoking the parent cascades to all children.'],
+      ['Hash-Chained Audit Trail', 'Every tool invocation is logged in an append-only, tamper-evident audit trail.'],
+      ['Real-Time Revocation', 'Kill a misbehaving agent\'s access in under 1 second. No waiting for token expiry.'],
+    ],
+    ctaFramework: 'LangChain',
+    metaTitle: 'Grantex for LangChain — Authorization for LangChain AI Agents',
+    metaDesc: 'Add scoped, revocable permissions to LangChain agents. Drop-in toolkit for authorization with signed JWTs, audit trails, and real-time revocation. Open source.',
+  },
+  crewai: {
+    name: 'CrewAI',
+    badge: 'CrewAI + Grantex',
+    title: 'Authorization for <span class="highlight">CrewAI</span> Agents',
+    desc: 'Secure your CrewAI crews with scoped, revocable permissions. Each crew member gets exactly the access it needs — nothing more.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    install: 'pip install grantex-crewai grantex',
+    problemBad: 'Your CrewAI agents share the same API keys. If one crew member is compromised, the entire crew\'s access is exposed. No way to scope or revoke individual agent access.',
+    problemGood: 'Each crew member gets its own scoped JWT. The researcher can only read, the writer can only draft, the publisher can only post. Revoke any member instantly.',
+    howTitle: 'How Grantex Works with CrewAI',
+    steps: [
+      ['Install the integration', 'pip install grantex-crewai — Python-native integration for CrewAI crews.'],
+      ['Register each crew member', 'Create agent identities with role-specific scopes for each crew member.'],
+      ['Authorize the crew', 'Users approve scoped permissions for each role in the crew.'],
+      ['Crew operates with scoped tokens', 'Each crew member presents its own JWT. Services verify independently.'],
+      ['Monitor & control', 'Audit every crew action. Revoke individual members without stopping the whole crew.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_crewai import GrantexCrewTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Each crew member gets scoped authorization
+researcher_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=researcher_token,  # scoped to "search:read"
+    tools=[search_tool],
+)
+
+writer_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=writer_token,  # scoped to "docs:write"
+    tools=[write_tool],
+)`,
+    features: [
+      ['Per-Agent Scoping', 'Each crew member gets exactly the permissions it needs. Researcher reads, writer writes, publisher posts.'],
+      ['Role-Based Access', 'Map CrewAI roles to Grantex scopes. Define authorization policies per role, not per API key.'],
+      ['Crew-Wide Audit Trail', 'See what every crew member did, when, and with what permissions. Hash-chained for tamper evidence.'],
+      ['Delegation Chains', 'A lead agent can delegate narrower permissions to sub-agents. Revoking the lead cascades to all.'],
+      ['Python Native', 'Pure Python integration. pip install and go — works with any CrewAI version.'],
+      ['Instant Revocation', 'Revoke any crew member\'s access in under 1 second without disrupting the rest of the crew.'],
+    ],
+    ctaFramework: 'CrewAI',
+    metaTitle: 'Grantex for CrewAI — Secure Multi-Agent Crew Permissions',
+    metaDesc: 'Scope and control permissions for CrewAI agents. Each crew member gets its own signed JWT with role-specific access. Audit trails, delegation, real-time revocation.',
+  },
+  'openai-agents': {
+    name: 'OpenAI Agents SDK',
+    badge: 'OpenAI Agents + Grantex',
+    title: 'Authorization for <span class="highlight">OpenAI Agents SDK</span>',
+    desc: 'Add enterprise-grade authorization to your OpenAI agents. Scoped permissions, audit trails, and instant revocation — built for the Agents SDK.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    install: 'pip install grantex-openai-agents grantex',
+    problemBad: 'Your OpenAI agents operate with full API access. No scoping, no audit trail, no revocation. You can\'t tell which agent did what or limit what it can do.',
+    problemGood: 'Each agent gets a scoped, time-limited JWT. Every tool call is authorized and logged. Revoke access instantly if an agent behaves unexpectedly.',
+    howTitle: 'How Grantex Works with OpenAI Agents SDK',
+    steps: [
+      ['Install the integration', 'pip install grantex-openai-agents — wraps OpenAI agent tools with authorization.'],
+      ['Register your agent', 'Create an agent identity with scopes matching its capabilities.'],
+      ['Get user approval', 'Users approve exactly which permissions the agent receives via a consent page.'],
+      ['Agent operates with JWT', 'The agent\'s tools automatically verify permissions before executing.'],
+      ['Full audit trail', 'Every tool invocation is logged with the agent identity, scopes used, and timestamp.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_openai_agents import GrantexTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap OpenAI agent tools with Grantex authorization
+tools = GrantexTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, email_tool],
+)
+
+# Tools automatically check scopes before execution
+agent = Agent(
+    name="assistant",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['OpenAI Agents SDK Integration', 'Drop-in wrapper for OpenAI agent tools. Add authorization without changing your agent logic.'],
+      ['Scoped Tool Access', 'Define which tools each agent can use and with what parameters. Enforced at the protocol level.'],
+      ['Enterprise Audit Trail', 'Every tool call logged with agent identity, scopes, and hash-chained integrity.'],
+      ['Multi-Agent Pipelines', 'Parent agents delegate narrower access to sub-agents. Full delegation chain tracking.'],
+      ['Budget Controls', 'Set spending limits per agent. Automatic cutoff when budget is exhausted.'],
+      ['Compliance Ready', 'SOC 2 compatible audit logging. SCIM/SSO for enterprise identity management.'],
+    ],
+    ctaFramework: 'OpenAI Agents',
+    metaTitle: 'Grantex for OpenAI Agents SDK — Enterprise Agent Authorization',
+    metaDesc: 'Add scoped permissions, audit trails, and real-time revocation to OpenAI Agents SDK. Enterprise-grade authorization for AI agents. Open source.',
+  },
+  anthropic: {
+    name: 'Anthropic SDK',
+    badge: 'Anthropic + Grantex',
+    title: 'Authorization for <span class="highlight">Anthropic SDK</span> Tool Use',
+    desc: 'Enforce scoped permissions on Claude tool calls. Offline JWT verification, automatic audit logging, and instant revocation for Anthropic SDK apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    installUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    install: 'npm install @grantex/anthropic @grantex/sdk',
+    problemBad: 'Your Claude-powered agents call tools with no authorization layer. Any tool can be invoked with full access. No scoping, no consent, no audit trail of what the agent did.',
+    problemGood: 'Grantex wraps each tool with scope enforcement. The agent\'s JWT is checked offline before execution. Every tool call is audit-logged. Revoke access in under 1 second.',
+    howTitle: 'How Grantex Works with the Anthropic SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/anthropic — wraps Anthropic tool definitions with authorization.'],
+      ['Create scoped tools', 'Use createGrantexTool() to define tools with required scopes and JSON Schema input.'],
+      ['Pass tools to Claude', 'tool.definition is type-compatible with client.messages.create({ tools }).'],
+      ['Dispatch tool_use blocks', 'Use GrantexToolRegistry or handleToolCall() to execute with automatic audit logging.'],
+      ['Monitor everything', 'Hash-chained audit trail of every tool call. Revoke access in under 1 second.'],
+    ],
+    code: `import Anthropic from '@anthropic-ai/sdk';
+import { createGrantexTool, GrantexToolRegistry } from '@grantex/anthropic';
+
+const client = new Anthropic();
+
+const readFile = createGrantexTool({
+  name: 'read_file',
+  description: 'Read a file from disk',
+  inputSchema: {
+    type: 'object',
+    properties: { path: { type: 'string' } },
+    required: ['path'],
+  },
+  grantToken,
+  requiredScope: 'file:read',
+  execute: async ({ path }) => fs.readFile(path, 'utf-8'),
+});
+
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  tools: [readFile.definition],
+  messages,
+});`,
+    features: [
+      ['Anthropic SDK Native', 'Type-compatible with client.messages.create(). tool.definition drops in directly.'],
+      ['Offline Scope Checks', 'JWT scp claim verified locally. No network call to Grantex during execution.'],
+      ['Tool Registry', 'GrantexToolRegistry manages multiple tools and dispatches tool_use blocks by name.'],
+      ['Audit Logging', 'withAuditLogging() and handleToolCall() log every success/failure automatically.'],
+      ['GrantexScopeError', 'Typed error with requiredScope and grantedScopes for clean error handling.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Anthropic SDK',
+    metaTitle: 'Grantex for Anthropic SDK — Secure Claude Tool Use Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Claude tool use. Offline JWT verification, tool registry, and instant revocation. Open source.',
+  },
+  'google-adk': {
+    name: 'Google ADK',
+    badge: 'Google ADK + Grantex',
+    title: 'Authorization for <span class="highlight">Google ADK</span> Agents',
+    desc: 'Secure your Google Agent Development Kit agents with scoped, human-approved permissions and full audit trails.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    install: 'pip install grantex-adk grantex',
+    problemBad: 'Your ADK agents access services with broad credentials. No fine-grained scoping, no delegation control, no tamper-proof audit log of agent actions.',
+    problemGood: 'Each ADK agent gets cryptographic identity and scoped JWTs. Delegation chains track multi-agent workflows. Every action is audit-logged.',
+    howTitle: 'How Grantex Works with Google ADK',
+    steps: [
+      ['Install the integration', 'pip install grantex-adk — Python-native integration for Google ADK.'],
+      ['Register your agent', 'Create an agent identity with specific scopes matching your ADK agent\'s capabilities.'],
+      ['Authorize via consent', 'Users approve scoped permissions through a consent flow.'],
+      ['Agent operates securely', 'ADK tools verify permissions via JWT before executing any action.'],
+      ['Monitor everything', 'Hash-chained audit trail of every action. Revoke access in under 1 second.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_adk import GrantexADKTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap ADK tools with Grantex authorization
+tools = GrantexADKTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, calendar_tool],
+)
+
+# Tools verify scopes automatically
+agent = Agent(
+    model="gemini-2.0-flash",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['Google ADK Native', 'Built for the Agent Development Kit. Wraps ADK tools with automatic authorization.'],
+      ['Scoped Permissions', 'Fine-grained scopes for each capability. "calendar:read" vs "calendar:write".'],
+      ['Delegation Chains', 'Multi-agent ADK pipelines with tracked delegation. Revoke parent to cascade.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS. No network calls to Grantex during execution.'],
+      ['Audit & Compliance', 'Tamper-proof audit trail. SOC 2 compatible. Enterprise compliance exports.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Google ADK',
+    metaTitle: 'Grantex for Google ADK — Secure Agent Development Kit Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Google ADK agents. Delegation chains, real-time revocation, and enterprise compliance. Open source.',
+  },
+  'vercel-ai': {
+    name: 'Vercel AI SDK',
+    badge: 'Vercel AI + Grantex',
+    title: 'Authorization for <span class="highlight">Vercel AI SDK</span>',
+    desc: 'Add scoped authorization to your Vercel AI SDK tools. Signed JWTs, audit trails, and instant revocation for AI-powered apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    install: 'npm install @grantex/vercel-ai @grantex/sdk',
+    problemBad: 'Your Vercel AI tools run with full access. Users can\'t see or control what the AI does on their behalf. No audit trail, no revocation.',
+    problemGood: 'Each AI tool call is authorized with a scoped JWT. Users approve permissions upfront. Every action is logged. Revoke instantly.',
+    howTitle: 'How Grantex Works with Vercel AI SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/vercel-ai — TypeScript-native integration for Vercel AI SDK.'],
+      ['Define authorized tools', 'Wrap your AI SDK tools with Grantex scope requirements.'],
+      ['User consents', 'Users approve specific scopes before the AI can act on their behalf.'],
+      ['Tools verify automatically', 'Each tool call checks the JWT scopes before execution.'],
+      ['Full observability', 'Audit trail of every tool invocation. Real-time event streaming.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createGrantexTools } from '@grantex/vercel-ai';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap Vercel AI SDK tools with authorization
+const tools = createGrantexTools({
+  client: gx,
+  grantToken: token,
+  tools: { search: searchTool, email: emailTool },
+});
+
+// Use with generateText or streamText
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prompt: 'Search for flights and send the results',
+});`,
+    features: [
+      ['Vercel AI SDK Native', 'Works with generateText, streamText, and all AI SDK tool patterns.'],
+      ['TypeScript First', 'Full type safety. Scopes are checked at compile time and runtime.'],
+      ['Edge Compatible', 'Works in Vercel Edge Functions. JWT verification is local — no external calls.'],
+      ['Streaming Support', 'Compatible with streaming responses. Authorization doesn\'t block the stream.'],
+      ['Multi-Step Flows', 'Authorize multi-step AI workflows where each step requires different scopes.'],
+      ['Next.js Ready', 'Drop into your Next.js app with zero configuration beyond the SDK.'],
+    ],
+    ctaFramework: 'Vercel AI',
+    metaTitle: 'Grantex for Vercel AI SDK — Authorization for AI-Powered Apps',
+    metaDesc: 'Add scoped permissions to Vercel AI SDK tools. TypeScript-native, Edge-compatible, with audit trails and real-time revocation. Open source.',
+  },
+  autogen: {
+    name: 'AutoGen',
+    badge: 'AutoGen + Grantex',
+    title: 'Authorization for <span class="highlight">AutoGen</span> Multi-Agent Systems',
+    desc: 'Secure your AutoGen conversations with per-agent permissions. Each agent in the group gets exactly the scopes it needs.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    install: 'npm install @grantex/autogen @grantex/sdk',
+    problemBad: 'AutoGen agents in a group chat share credentials. If one agent is compromised or hallucinates, it has access to everything the others can do.',
+    problemGood: 'Each AutoGen agent gets its own scoped JWT. The coder can only write code, the executor can only run tests. Isolated, audited, revocable.',
+    howTitle: 'How Grantex Works with AutoGen',
+    steps: [
+      ['Install the integration', 'npm install @grantex/autogen — wraps AutoGen function maps with authorization.'],
+      ['Register each agent', 'Create identities with role-specific scopes for each agent in the group.'],
+      ['Scope per conversation', 'Users approve what each agent can do before the conversation starts.'],
+      ['Agents operate independently', 'Each agent presents its own JWT. Function calls are scope-checked automatically.'],
+      ['Trace everything', 'Full audit trail across the multi-agent conversation. Attribute actions to specific agents.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexAutoGen } from '@grantex/autogen';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Each agent in the group gets scoped authorization
+const coderTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: coderToken,  // scoped to "code:write"
+  functionMap: { write_code: writeCodeFn },
+});
+
+const executorTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: executorToken,  // scoped to "code:execute"
+  functionMap: { run_code: runCodeFn },
+});`,
+    features: [
+      ['Per-Agent Authorization', 'Each agent in the AutoGen group gets its own scoped token and identity.'],
+      ['Group Chat Security', 'Prevent agents from accessing tools outside their role. Enforced at the protocol level.'],
+      ['Conversation Auditing', 'Track which agent called which function, with what scopes, across the entire conversation.'],
+      ['Delegation Support', 'Agents can delegate narrower scopes to spawned sub-agents with depth tracking.'],
+      ['Function Map Wrapping', 'Drop-in wrapper for AutoGen function maps. No changes to your agent logic.'],
+      ['Real-Time Control', 'Revoke any agent mid-conversation. Access is denied within 1 second.'],
+    ],
+    ctaFramework: 'AutoGen',
+    metaTitle: 'Grantex for AutoGen — Secure Multi-Agent Group Chat Authorization',
+    metaDesc: 'Per-agent scoped permissions for AutoGen multi-agent systems. Each agent gets its own JWT. Audit trails, delegation chains, instant revocation.',
+  },
+  mcp: {
+    name: 'Model Context Protocol',
+    badge: 'MCP + Grantex',
+    title: 'Authorization for <span class="highlight">MCP</span> Servers',
+    desc: 'Add enterprise-grade authorization to any MCP server. 13 built-in tools for managing agents, grants, and tokens from Claude Desktop, Cursor, or Windsurf.',
+    docsUrl: 'https://docs.grantex.dev/integrations/mcp',
+    installUrl: 'https://docs.grantex.dev/integrations/mcp',
+    install: 'npm install @grantex/mcp',
+    problemBad: 'MCP servers expose tools to AI assistants with no authorization layer. Any connected client can call any tool with full access. No scoping, no consent, no audit trail.',
+    problemGood: 'Grantex adds OAuth 2.1-style authorization to MCP. Users approve scoped access per tool. Every invocation is logged. Revoke access from the permission dashboard.',
+    howTitle: 'How Grantex Works with MCP',
+    steps: [
+      ['Install the MCP server', 'npm install @grantex/mcp — adds 13 Grantex tools to any MCP-compatible client.'],
+      ['Connect to Claude Desktop', 'Add Grantex to your MCP config. Works with Claude Desktop, Cursor, and Windsurf.'],
+      ['Manage via natural language', 'Ask Claude to "register an agent", "create a grant", or "check the audit log".'],
+      ['Or add MCP Auth', 'Use @grantex/mcp-auth to add OAuth 2.1 + PKCE to your own MCP servers.'],
+      ['Full protocol access', 'All 13 Grantex operations available as MCP tools — agents, grants, tokens, audit, budgets.'],
+    ],
+    code: `// claude_desktop_config.json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "npx",
+      "args": ["@grantex/mcp"],
+      "env": {
+        "GRANTEX_API_KEY": "gx_live_..."
+      }
+    }
+  }
+}
+
+// Then in Claude Desktop:
+// "Register a new agent called travel-bot with flights:book scope"
+// "Create a grant for user alice on travel-bot"
+// "Show me the audit log for the last hour"`,
+    features: [
+      ['13 MCP Tools', 'Full Grantex protocol access: agents, grants, tokens, audit, budgets, verification — all as MCP tools.'],
+      ['Claude Desktop Ready', 'Works out of the box with Claude Desktop, Cursor, and Windsurf.'],
+      ['MCP Auth Server', 'Separate @grantex/mcp-auth package adds OAuth 2.1 + PKCE to any MCP server.'],
+      ['Natural Language Control', 'Manage authorization through conversation. "Revoke all grants for agent X."'],
+      ['Zero Code Setup', 'npx @grantex/mcp — no code required. Just add to your MCP config and go.'],
+      ['Enterprise Grade', 'Budget controls, policy engine, SCIM/SSO — all accessible via MCP tools.'],
+    ],
+    ctaFramework: 'MCP',
+    metaTitle: 'Grantex for MCP — Authorization for Model Context Protocol Servers',
+    metaDesc: 'Add OAuth 2.1 authorization to MCP servers. 13 tools for Claude Desktop, Cursor, and Windsurf. Scoped grants, audit trails, real-time revocation.',
+  },
+  express: {
+    name: 'Express.js',
+    badge: 'Express + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">Express.js</span>',
+    desc: 'Protect your Express.js APIs with Grantex grant tokens. Drop-in middleware that verifies JWTs, enforces scopes, and logs every request.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    install: 'npm install @grantex/express',
+    problemBad: 'Your Express APIs accept API keys or bearer tokens with no scope enforcement. Any valid token can access any endpoint. No agent identity tracking.',
+    problemGood: 'Grantex middleware verifies JWTs offline via JWKS, enforces scopes per route, and identifies the calling agent. Zero external network calls.',
+    howTitle: 'How Grantex Works with Express.js',
+    steps: [
+      ['Install the middleware', 'npm install @grantex/express — one package, zero external dependencies at runtime.'],
+      ['Add to your app', 'One line to protect your routes. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs are verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'req.grantex gives you the agent DID, scopes, principal, and grant ID.'],
+      ['Production ready', 'JWKS caching, key rotation, scope enforcement, and error handling built in.'],
+    ],
+    code: `import express from 'express';
+import { grantexMiddleware, requireScopes } from '@grantex/express';
+
+const app = express();
+
+// Verify Grantex JWTs on all /api routes
+app.use('/api', grantexMiddleware({
+  jwksUrl: 'https://grantex-auth-....a.run.app/.well-known/jwks.json',
+}));
+
+// Enforce specific scopes per route
+app.get('/api/emails', requireScopes(['email:read']), (req, res) => {
+  console.log(req.grantex.agent);  // agent DID
+  console.log(req.grantex.scopes); // ['email:read']
+  res.json({ emails: [] });
+});`,
+    features: [
+      ['Drop-In Middleware', 'One line to protect your Express routes. Works with any Express 4+ app.'],
+      ['Offline JWT Verification', 'JWKS-based verification. No network calls to Grantex on each request. Sub-millisecond overhead.'],
+      ['Per-Route Scopes', 'requireScopes() enforces specific permissions per endpoint. Returns 403 if scopes don\'t match.'],
+      ['Agent Identity', 'req.grantex provides agent DID, scopes, principal ID, grant ID on every request.'],
+      ['JWKS Caching', 'Automatic key caching and rotation. Handles key rollover transparently.'],
+      ['TypeScript Support', 'Full type definitions. req.grantex is fully typed.'],
+    ],
+    ctaFramework: 'Express.js',
+    metaTitle: 'Grantex for Express.js — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Drop-in Express.js middleware for Grantex JWT verification. Offline JWKS verification, per-route scope enforcement, and agent identity. Open source.',
+  },
+  fastapi: {
+    name: 'FastAPI',
+    badge: 'FastAPI + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">FastAPI</span>',
+    desc: 'Protect your FastAPI endpoints with Grantex grant tokens. Dependency-injection middleware that verifies JWTs, enforces scopes, and identifies agents.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    install: 'pip install grantex-fastapi',
+    problemBad: 'Your FastAPI endpoints accept bearer tokens with no scope enforcement. Any valid token accesses any route. No way to identify which AI agent made the request.',
+    problemGood: 'Grantex dependency verifies JWTs offline via JWKS, enforces scopes per route, and provides the agent identity. Pythonic, async, and type-safe.',
+    howTitle: 'How Grantex Works with FastAPI',
+    steps: [
+      ['Install the middleware', 'pip install grantex-fastapi — async-native, works with FastAPI\'s dependency injection.'],
+      ['Add the dependency', 'Use GrantexAuth as a FastAPI dependency. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'The dependency returns the full grant context: agent DID, scopes, principal, grant ID.'],
+      ['Production ready', 'Async JWKS fetching, key caching, automatic rotation, and proper error responses.'],
+    ],
+    code: `from fastapi import FastAPI, Depends
+from grantex_fastapi import GrantexAuth, GrantContext
+
+app = FastAPI()
+auth = GrantexAuth(
+    jwks_url="https://grantex-auth-....a.run.app/.well-known/jwks.json"
+)
+
+@app.get("/api/emails")
+async def list_emails(
+    grant: GrantContext = Depends(auth.require_scopes(["email:read"]))
+):
+    print(grant.agent)   # agent DID
+    print(grant.scopes)  # ["email:read"]
+    return {"emails": []}`,
+    features: [
+      ['FastAPI Dependency Injection', 'Works with FastAPI\'s Depends() pattern. Pythonic and type-safe.'],
+      ['Async Native', 'Fully async JWKS fetching and JWT verification. No blocking calls.'],
+      ['Per-Route Scopes', 'require_scopes() enforces specific permissions per endpoint. Returns 403 on mismatch.'],
+      ['Typed Grant Context', 'Full Pydantic model for grant context: agent DID, scopes, principal, grant ID.'],
+      ['JWKS Caching', 'Automatic async key caching and rotation. Handles key rollover transparently.'],
+      ['OpenAPI Integration', 'Scopes appear in your FastAPI OpenAPI docs automatically.'],
+    ],
+    ctaFramework: 'FastAPI',
+    metaTitle: 'Grantex for FastAPI — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.',
+  },
+  mpp: {
+    name: 'MPP (Machine Payments Protocol)',
+    badge: 'MPP + Grantex',
+    title: 'Agent Identity for <span class="highlight">Machine Payments</span>',
+    desc: 'MPP defines how AI agents pay for services. Grantex adds the missing identity layer — verifiable agent passports that let merchants know exactly who authorized every payment, with offline verification in under 50ms.',
+    docsUrl: 'https://docs.grantex.dev/features/mpp-agent-passport',
+    installUrl: 'https://docs.grantex.dev/guides/mpp-integration',
+    install: 'npm install @grantex/mpp @grantex/sdk',
+    problemBad: 'When an agent makes an MPP payment, the source is just a wallet address. No human name, no org, no authorization chain. For $0.10 API calls nobody cares. For $500 B2B procurement, it\'s a compliance blocker.',
+    problemGood: 'Every MPP payment carries an AgentPassportCredential — a W3C VC 2.0 credential with the human principal, org DID, spending limits, and allowed categories. Merchants verify in <50ms, offline.',
+    howTitle: 'How Grantex Works with MPP',
+    steps: [
+      ['Install the package', 'npm install @grantex/mpp — agent-side middleware + merchant-side verification in one package.'],
+      ['Issue an agent passport', 'Call grantex.passports.issue() with categories (inference, compute, data), spending limits, and expiry.'],
+      ['Attach to MPP requests', 'createMppPassportMiddleware() injects the X-Grantex-Passport header on every outgoing fetch.'],
+      ['Verify on the merchant side', 'requireAgentPassport() Express middleware — one line to verify identity, categories, and amounts.'],
+      ['Check the trust registry', 'lookupOrgTrust() returns verified org status (basic, verified, SOC 2) from the public registry.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createMppPassportMiddleware, requireAgentPassport } from '@grantex/mpp';
+
+// Agent side: issue passport and attach to requests
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const passport = await grantex.passports.issue({
+  agentId: 'ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  allowedMPPCategories: ['inference', 'compute'],
+  maxTransactionAmount: { amount: 50, currency: 'USDC' },
+  expiresIn: '24h',
+});
+
+const middleware = createMppPassportMiddleware({ passport });
+const enriched = await middleware(new Request(url));
+// X-Grantex-Passport header attached
+
+// Merchant side: one-line verification
+app.use('/api/inference', requireAgentPassport({
+  requiredCategories: ['inference'],
+  maxAmount: 10,
+}));
+// req.agentPassport → { humanDID, orgDID, categories, maxAmount, ... }`,
+    features: [
+      ['AgentPassportCredential', 'W3C VC 2.0 with agent DID, human principal, org, categories, spending limits, and delegation depth.'],
+      ['<50ms Verification', 'Offline verification using cached JWKS. No API roundtrip to Grantex servers needed.'],
+      ['9 MPP Categories', 'inference, compute, data, storage, search, media, delivery, browser, general — each maps to a Grantex scope.'],
+      ['StatusList2021 Revocation', 'Revoke any passport instantly. Bit-flip propagation, no polling required.'],
+      ['Trust Registry', 'Public org trust lookup by DID. DNS-TXT, manual, or SOC 2 verification levels.'],
+      ['Auto-Refresh', 'Middleware proactively refreshes passports before expiry via onRefresh callback.'],
+    ],
+    ctaFramework: 'MPP',
+    metaTitle: 'Grantex for MPP — Agent Identity for Machine Payments Protocol',
+    metaDesc: 'Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.',
+  },
+};
+
+// Determine framework from URL
+const path = window.location.pathname.replace(/\/$/, '');
+const slug = path.split('/').pop();
+const fw = frameworks[slug];
+
+if (!fw) {
+  // Redirect to homepage if unknown framework
+  window.location.href = '/';
+} else {
+  // Set meta tags
+  document.title = fw.metaTitle;
+  document.querySelector('meta[name="description"]').content = fw.metaDesc;
+  document.querySelector('link[rel="canonical"]').href = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[property="og:title"]').content = fw.metaTitle;
+  document.querySelector('meta[property="og:description"]').content = fw.metaDesc;
+  document.querySelector('meta[property="og:url"]').content = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[name="twitter:title"]').content = fw.metaTitle;
+  document.querySelector('meta[name="twitter:description"]').content = fw.metaDesc;
+
+  // Populate content
+  document.getElementById('badge').textContent = fw.badge;
+  document.getElementById('heroTitle').innerHTML = fw.title;
+  document.getElementById('heroDesc').textContent = fw.desc;
+  document.getElementById('ctaDocs').href = fw.docsUrl;
+  document.getElementById('ctaInstall').href = fw.installUrl;
+  document.getElementById('problemBad').textContent = fw.problemBad;
+  document.getElementById('problemGood').textContent = fw.problemGood;
+  document.getElementById('howTitle').textContent = fw.howTitle;
+  document.getElementById('installCmd').textContent = fw.install;
+  document.getElementById('codeExample').textContent = fw.code;
+  document.getElementById('ctaFramework').textContent = fw.ctaFramework;
+  document.getElementById('ctaDocsBottom').href = fw.docsUrl;
+  document.getElementById('featuresTitle').textContent = 'Why Grantex for ' + fw.name;
+
+  // Steps
+  const stepsEl = document.getElementById('steps');
+  fw.steps.forEach(([title, desc]) => {
+    stepsEl.innerHTML += `<div class="step"><div class="step-content"><h3>${title}</h3><p>${desc}</p></div></div>`;
+  });
+
+  // Features
+  const featuresEl = document.getElementById('features');
+  fw.features.forEach(([title, desc]) => {
+    featuresEl.innerHTML += `<div class="feature-card"><h3>${title}</h3><p>${desc}</p></div>`;
+  });
+
+  // Add JSON-LD structured data
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Grantex for " + fw.name,
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Any",
+    "url": "https://grantex.dev/for/" + slug,
+    "description": fw.metaDesc,
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  };
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.textContent = JSON.stringify(jsonLd);
+  document.head.appendChild(script);
+
+  // Track page view
+  gtag('event', 'page_view', { page_title: fw.metaTitle, page_location: window.location.href });
+}
+</script>
+</body>
+</html>

--- a/web/for/langchain/index.html
+++ b/web/for/langchain/index.html
@@ -1,0 +1,787 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
+  <!-- Dynamic meta tags set by JS below -->
+  <title>Grantex for LangChain — Authorization for LangChain AI Agents</title>
+  <meta name="description" content="Add scoped, revocable permissions to LangChain agents. Drop-in toolkit for authorization with signed JWTs, audit trails, and real-time revocation. Open source.">
+  <link rel="canonical" href="https://grantex.dev/for/langchain/">
+  <meta property="og:title" content="Grantex for LangChain — Authorization for LangChain AI Agents">
+  <meta property="og:description" content="Add scoped, revocable permissions to LangChain agents. Drop-in toolkit for authorization with signed JWTs, audit trails, and real-time revocation. Open source.">
+  <meta property="og:url" content="https://grantex.dev/for/langchain/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Grantex">
+  <meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grantex for LangChain — Authorization for LangChain AI Agents">
+  <meta name="twitter:description" content="Add scoped, revocable permissions to LangChain agents. Drop-in toolkit for authorization with signed JWTs, audit trails, and real-time revocation. Open source.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
+  <style>
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --border:   #30363d;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --accent:   #3fb950;
+      --accent2:  #58a6ff;
+      --mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+      --sans:     'Inter', system-ui, -apple-system, sans-serif;
+      --radius:   8px;
+      --max-w:    900px;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: var(--sans); line-height: 1.6; }
+    a { color: var(--accent2); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { font-family: var(--mono); background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+    pre { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; overflow-x: auto; font-family: var(--mono); font-size: 0.875rem; line-height: 1.5; }
+    pre code { background: none; padding: 0; }
+
+    /* Nav */
+    .nav { display: flex; align-items: center; justify-content: space-between; max-width: var(--max-w); margin: 0 auto; padding: 1rem 1.5rem; }
+    .nav-logo { font-weight: 700; font-size: 1.25rem; color: var(--text); }
+    .nav-links { list-style: none; display: flex; gap: 1.5rem; }
+    .nav-links a { color: var(--muted); font-size: 0.9rem; }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+
+    /* Hero */
+    .hero { text-align: center; padding: 4rem 1.5rem 3rem; max-width: var(--max-w); margin: 0 auto; }
+    .hero-badge { display: inline-block; background: rgba(63,185,80,0.15); color: var(--accent); padding: 0.25rem 0.75rem; border-radius: 999px; font-size: 0.8rem; font-weight: 600; margin-bottom: 1rem; }
+    .hero h1 { font-size: 2.5rem; line-height: 1.2; margin-bottom: 1rem; }
+    .hero h1 .highlight { color: var(--accent); }
+    .hero p { color: var(--muted); font-size: 1.1rem; max-width: 650px; margin: 0 auto 2rem; }
+    .hero-ctas { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
+    .btn { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.65rem 1.25rem; border-radius: var(--radius); font-weight: 600; font-size: 0.9rem; text-decoration: none; transition: all 0.2s; }
+    .btn-primary { background: var(--accent); color: #0d1117; }
+    .btn-primary:hover { background: #2ea043; text-decoration: none; }
+    .btn-secondary { background: var(--surface); color: var(--text); border: 1px solid var(--border); }
+    .btn-secondary:hover { border-color: var(--muted); text-decoration: none; }
+
+    /* Sections */
+    .section { max-width: var(--max-w); margin: 0 auto; padding: 3rem 1.5rem; }
+    .section h2 { font-size: 1.75rem; margin-bottom: 1rem; }
+    .section h3 { font-size: 1.15rem; margin-bottom: 0.5rem; color: var(--accent); }
+    .section p, .section li { color: var(--muted); }
+    .section ul { padding-left: 1.25rem; }
+    .section li { margin-bottom: 0.5rem; }
+
+    /* Problem cards */
+    .problem-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; margin: 1.5rem 0; }
+    .problem-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .problem-card.bad { border-color: #f8514933; }
+    .problem-card.good { border-color: #3fb95033; }
+    .problem-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .problem-card.bad h3 { color: #f85149; }
+    .problem-card.good h3 { color: var(--accent); }
+
+    /* Steps */
+    .steps { counter-reset: step; margin: 1.5rem 0; }
+    .step { display: flex; gap: 1rem; margin-bottom: 1.5rem; }
+    .step::before { counter-increment: step; content: counter(step); display: flex; align-items: center; justify-content: center; min-width: 32px; height: 32px; background: rgba(63,185,80,0.15); color: var(--accent); border-radius: 50%; font-weight: 700; font-size: 0.85rem; }
+    .step-content h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.25rem; }
+    .step-content p { font-size: 0.9rem; }
+
+    /* Features */
+    .feature-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.25rem; margin: 1.5rem 0; }
+    .feature-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .feature-card h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; }
+
+    /* Install */
+    .install-box { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.25rem; display: flex; align-items: center; justify-content: space-between; margin: 1rem 0; font-family: var(--mono); font-size: 0.9rem; }
+    .install-box button { background: var(--accent); color: #0d1117; border: none; padding: 0.35rem 0.75rem; border-radius: 4px; font-weight: 600; cursor: pointer; font-size: 0.8rem; }
+
+    /* Footer */
+    .footer { max-width: var(--max-w); margin: 0 auto; padding: 2rem 1.5rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; }
+    .footer-links { list-style: none; display: flex; gap: 1.5rem; }
+    .footer-links a { color: var(--muted); font-size: 0.85rem; }
+
+    @media (max-width: 640px) {
+      .hero h1 { font-size: 1.75rem; }
+      .problem-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Grantex for LangChain","applicationCategory":"DeveloperApplication","operatingSystem":"Any","url":"https://grantex.dev/for/langchain/","description":"Add scoped, revocable permissions to LangChain agents. Drop-in toolkit for authorization with signed JWTs, audit trails, and real-time revocation. Open source.","license":"https://www.apache.org/licenses/LICENSE-2.0"}</script>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/" class="nav-logo">Grantex</a>
+  <ul class="nav-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="/playground">Playground</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+  </ul>
+</nav>
+
+<div id="app">
+  <section class="hero">
+    <span class="hero-badge" id="badge"></span>
+    <h1 id="heroTitle"></h1>
+    <p id="heroDesc"></p>
+    <div class="hero-ctas">
+      <a href="" id="ctaDocs" class="btn btn-primary">View Integration Docs</a>
+      <a href="" id="ctaInstall" class="btn btn-secondary">Get Started</a>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2>The Problem</h2>
+    <div class="problem-grid">
+      <div class="problem-card bad">
+        <h3>Without Grantex</h3>
+        <p id="problemBad"></p>
+      </div>
+      <div class="problem-card good">
+        <h3>With Grantex</h3>
+        <p id="problemGood"></p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2 id="howTitle">How It Works</h2>
+    <div class="steps" id="steps"></div>
+  </section>
+
+  <section class="section">
+    <h2>Quick Start</h2>
+    <div class="install-box">
+      <span id="installCmd"></span>
+      <button onclick="navigator.clipboard.writeText(document.getElementById('installCmd').textContent);this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)">Copy</button>
+    </div>
+    <pre><code id="codeExample"></code></pre>
+  </section>
+
+  <section class="section">
+    <h2 id="featuresTitle">Why Grantex</h2>
+    <div class="feature-grid" id="features"></div>
+  </section>
+
+  <section class="section" style="text-align:center">
+    <h2>Ready to secure your <span id="ctaFramework"></span> agents?</h2>
+    <p style="margin-bottom:1.5rem;color:var(--muted)">Get started in under 5 minutes. Open source, Apache 2.0.</p>
+    <div class="hero-ctas">
+      <a href="https://grantex.dev/dashboard/signup" class="btn btn-primary">Sign Up Free</a>
+      <a href="" id="ctaDocsBottom" class="btn btn-secondary">Read the Docs</a>
+    </div>
+  </section>
+</div>
+
+<footer class="footer">
+  <span style="color:var(--muted);font-size:0.85rem">Grantex — Open authorization for AI agents</span>
+  <ul class="footer-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+    <li><a href="/">Home</a></li>
+  </ul>
+</footer>
+
+<script>
+const frameworks = {
+  langchain: {
+    name: 'LangChain',
+    badge: 'LangChain + Grantex',
+    title: 'Authorization for <span class="highlight">LangChain</span> Agents',
+    desc: 'Add scoped, revocable permissions to your LangChain agents. Grantex integrates natively with LangChain tools — your agents get signed JWTs instead of raw API keys.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    install: 'npm install @grantex/langchain @grantex/sdk',
+    problemBad: 'Your LangChain agents use raw API keys with full access. No scoping, no audit trail, no way to revoke access if an agent goes rogue. One compromised key exposes everything.',
+    problemGood: 'Each LangChain agent gets a scoped, time-limited JWT. Tools verify permissions offline. You can revoke any agent instantly. Every action is audit-logged with a hash chain.',
+    howTitle: 'How Grantex Works with LangChain',
+    steps: [
+      ['Install the integration', 'npm install @grantex/langchain — wraps LangChain tools with automatic grant verification.'],
+      ['Register your agent', 'Create an agent identity with specific scopes like "email:send" or "calendar:read".'],
+      ['Get user consent', 'Redirect the user to a consent page. They approve exactly which permissions the agent gets.'],
+      ['Agent receives a JWT', 'The agent gets a signed token it presents to any service. Services verify offline via JWKS.'],
+      ['Audit & revoke', 'Every action is logged. Revoke access in under 1 second if something goes wrong.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexToolkit } from '@grantex/langchain';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap your LangChain tools with Grantex authorization
+const toolkit = new GrantexToolkit({
+  client: gx,
+  grantToken: token,  // JWT from the consent flow
+  tools: [searchTool, emailTool],
+});
+
+// Tools now automatically verify scopes before executing
+const agent = createToolCallingAgent({ llm, tools: toolkit.tools });`,
+    features: [
+      ['Native LangChain Integration', 'Drop-in toolkit that wraps your existing LangChain tools with automatic scope verification.'],
+      ['Scoped Permissions', 'Define exactly what each agent can do — "email:read" vs "email:send". No more all-or-nothing API keys.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS without calling Grantex. Zero latency overhead on your LangChain pipeline.'],
+      ['Multi-Agent Delegation', 'Parent agents delegate narrower scopes to sub-agents. Revoking the parent cascades to all children.'],
+      ['Hash-Chained Audit Trail', 'Every tool invocation is logged in an append-only, tamper-evident audit trail.'],
+      ['Real-Time Revocation', 'Kill a misbehaving agent\'s access in under 1 second. No waiting for token expiry.'],
+    ],
+    ctaFramework: 'LangChain',
+    metaTitle: 'Grantex for LangChain — Authorization for LangChain AI Agents',
+    metaDesc: 'Add scoped, revocable permissions to LangChain agents. Drop-in toolkit for authorization with signed JWTs, audit trails, and real-time revocation. Open source.',
+  },
+  crewai: {
+    name: 'CrewAI',
+    badge: 'CrewAI + Grantex',
+    title: 'Authorization for <span class="highlight">CrewAI</span> Agents',
+    desc: 'Secure your CrewAI crews with scoped, revocable permissions. Each crew member gets exactly the access it needs — nothing more.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    install: 'pip install grantex-crewai grantex',
+    problemBad: 'Your CrewAI agents share the same API keys. If one crew member is compromised, the entire crew\'s access is exposed. No way to scope or revoke individual agent access.',
+    problemGood: 'Each crew member gets its own scoped JWT. The researcher can only read, the writer can only draft, the publisher can only post. Revoke any member instantly.',
+    howTitle: 'How Grantex Works with CrewAI',
+    steps: [
+      ['Install the integration', 'pip install grantex-crewai — Python-native integration for CrewAI crews.'],
+      ['Register each crew member', 'Create agent identities with role-specific scopes for each crew member.'],
+      ['Authorize the crew', 'Users approve scoped permissions for each role in the crew.'],
+      ['Crew operates with scoped tokens', 'Each crew member presents its own JWT. Services verify independently.'],
+      ['Monitor & control', 'Audit every crew action. Revoke individual members without stopping the whole crew.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_crewai import GrantexCrewTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Each crew member gets scoped authorization
+researcher_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=researcher_token,  # scoped to "search:read"
+    tools=[search_tool],
+)
+
+writer_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=writer_token,  # scoped to "docs:write"
+    tools=[write_tool],
+)`,
+    features: [
+      ['Per-Agent Scoping', 'Each crew member gets exactly the permissions it needs. Researcher reads, writer writes, publisher posts.'],
+      ['Role-Based Access', 'Map CrewAI roles to Grantex scopes. Define authorization policies per role, not per API key.'],
+      ['Crew-Wide Audit Trail', 'See what every crew member did, when, and with what permissions. Hash-chained for tamper evidence.'],
+      ['Delegation Chains', 'A lead agent can delegate narrower permissions to sub-agents. Revoking the lead cascades to all.'],
+      ['Python Native', 'Pure Python integration. pip install and go — works with any CrewAI version.'],
+      ['Instant Revocation', 'Revoke any crew member\'s access in under 1 second without disrupting the rest of the crew.'],
+    ],
+    ctaFramework: 'CrewAI',
+    metaTitle: 'Grantex for CrewAI — Secure Multi-Agent Crew Permissions',
+    metaDesc: 'Scope and control permissions for CrewAI agents. Each crew member gets its own signed JWT with role-specific access. Audit trails, delegation, real-time revocation.',
+  },
+  'openai-agents': {
+    name: 'OpenAI Agents SDK',
+    badge: 'OpenAI Agents + Grantex',
+    title: 'Authorization for <span class="highlight">OpenAI Agents SDK</span>',
+    desc: 'Add enterprise-grade authorization to your OpenAI agents. Scoped permissions, audit trails, and instant revocation — built for the Agents SDK.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    install: 'pip install grantex-openai-agents grantex',
+    problemBad: 'Your OpenAI agents operate with full API access. No scoping, no audit trail, no revocation. You can\'t tell which agent did what or limit what it can do.',
+    problemGood: 'Each agent gets a scoped, time-limited JWT. Every tool call is authorized and logged. Revoke access instantly if an agent behaves unexpectedly.',
+    howTitle: 'How Grantex Works with OpenAI Agents SDK',
+    steps: [
+      ['Install the integration', 'pip install grantex-openai-agents — wraps OpenAI agent tools with authorization.'],
+      ['Register your agent', 'Create an agent identity with scopes matching its capabilities.'],
+      ['Get user approval', 'Users approve exactly which permissions the agent receives via a consent page.'],
+      ['Agent operates with JWT', 'The agent\'s tools automatically verify permissions before executing.'],
+      ['Full audit trail', 'Every tool invocation is logged with the agent identity, scopes used, and timestamp.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_openai_agents import GrantexTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap OpenAI agent tools with Grantex authorization
+tools = GrantexTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, email_tool],
+)
+
+# Tools automatically check scopes before execution
+agent = Agent(
+    name="assistant",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['OpenAI Agents SDK Integration', 'Drop-in wrapper for OpenAI agent tools. Add authorization without changing your agent logic.'],
+      ['Scoped Tool Access', 'Define which tools each agent can use and with what parameters. Enforced at the protocol level.'],
+      ['Enterprise Audit Trail', 'Every tool call logged with agent identity, scopes, and hash-chained integrity.'],
+      ['Multi-Agent Pipelines', 'Parent agents delegate narrower access to sub-agents. Full delegation chain tracking.'],
+      ['Budget Controls', 'Set spending limits per agent. Automatic cutoff when budget is exhausted.'],
+      ['Compliance Ready', 'SOC 2 compatible audit logging. SCIM/SSO for enterprise identity management.'],
+    ],
+    ctaFramework: 'OpenAI Agents',
+    metaTitle: 'Grantex for OpenAI Agents SDK — Enterprise Agent Authorization',
+    metaDesc: 'Add scoped permissions, audit trails, and real-time revocation to OpenAI Agents SDK. Enterprise-grade authorization for AI agents. Open source.',
+  },
+  anthropic: {
+    name: 'Anthropic SDK',
+    badge: 'Anthropic + Grantex',
+    title: 'Authorization for <span class="highlight">Anthropic SDK</span> Tool Use',
+    desc: 'Enforce scoped permissions on Claude tool calls. Offline JWT verification, automatic audit logging, and instant revocation for Anthropic SDK apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    installUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    install: 'npm install @grantex/anthropic @grantex/sdk',
+    problemBad: 'Your Claude-powered agents call tools with no authorization layer. Any tool can be invoked with full access. No scoping, no consent, no audit trail of what the agent did.',
+    problemGood: 'Grantex wraps each tool with scope enforcement. The agent\'s JWT is checked offline before execution. Every tool call is audit-logged. Revoke access in under 1 second.',
+    howTitle: 'How Grantex Works with the Anthropic SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/anthropic — wraps Anthropic tool definitions with authorization.'],
+      ['Create scoped tools', 'Use createGrantexTool() to define tools with required scopes and JSON Schema input.'],
+      ['Pass tools to Claude', 'tool.definition is type-compatible with client.messages.create({ tools }).'],
+      ['Dispatch tool_use blocks', 'Use GrantexToolRegistry or handleToolCall() to execute with automatic audit logging.'],
+      ['Monitor everything', 'Hash-chained audit trail of every tool call. Revoke access in under 1 second.'],
+    ],
+    code: `import Anthropic from '@anthropic-ai/sdk';
+import { createGrantexTool, GrantexToolRegistry } from '@grantex/anthropic';
+
+const client = new Anthropic();
+
+const readFile = createGrantexTool({
+  name: 'read_file',
+  description: 'Read a file from disk',
+  inputSchema: {
+    type: 'object',
+    properties: { path: { type: 'string' } },
+    required: ['path'],
+  },
+  grantToken,
+  requiredScope: 'file:read',
+  execute: async ({ path }) => fs.readFile(path, 'utf-8'),
+});
+
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  tools: [readFile.definition],
+  messages,
+});`,
+    features: [
+      ['Anthropic SDK Native', 'Type-compatible with client.messages.create(). tool.definition drops in directly.'],
+      ['Offline Scope Checks', 'JWT scp claim verified locally. No network call to Grantex during execution.'],
+      ['Tool Registry', 'GrantexToolRegistry manages multiple tools and dispatches tool_use blocks by name.'],
+      ['Audit Logging', 'withAuditLogging() and handleToolCall() log every success/failure automatically.'],
+      ['GrantexScopeError', 'Typed error with requiredScope and grantedScopes for clean error handling.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Anthropic SDK',
+    metaTitle: 'Grantex for Anthropic SDK — Secure Claude Tool Use Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Claude tool use. Offline JWT verification, tool registry, and instant revocation. Open source.',
+  },
+  'google-adk': {
+    name: 'Google ADK',
+    badge: 'Google ADK + Grantex',
+    title: 'Authorization for <span class="highlight">Google ADK</span> Agents',
+    desc: 'Secure your Google Agent Development Kit agents with scoped, human-approved permissions and full audit trails.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    install: 'pip install grantex-adk grantex',
+    problemBad: 'Your ADK agents access services with broad credentials. No fine-grained scoping, no delegation control, no tamper-proof audit log of agent actions.',
+    problemGood: 'Each ADK agent gets cryptographic identity and scoped JWTs. Delegation chains track multi-agent workflows. Every action is audit-logged.',
+    howTitle: 'How Grantex Works with Google ADK',
+    steps: [
+      ['Install the integration', 'pip install grantex-adk — Python-native integration for Google ADK.'],
+      ['Register your agent', 'Create an agent identity with specific scopes matching your ADK agent\'s capabilities.'],
+      ['Authorize via consent', 'Users approve scoped permissions through a consent flow.'],
+      ['Agent operates securely', 'ADK tools verify permissions via JWT before executing any action.'],
+      ['Monitor everything', 'Hash-chained audit trail of every action. Revoke access in under 1 second.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_adk import GrantexADKTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap ADK tools with Grantex authorization
+tools = GrantexADKTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, calendar_tool],
+)
+
+# Tools verify scopes automatically
+agent = Agent(
+    model="gemini-2.0-flash",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['Google ADK Native', 'Built for the Agent Development Kit. Wraps ADK tools with automatic authorization.'],
+      ['Scoped Permissions', 'Fine-grained scopes for each capability. "calendar:read" vs "calendar:write".'],
+      ['Delegation Chains', 'Multi-agent ADK pipelines with tracked delegation. Revoke parent to cascade.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS. No network calls to Grantex during execution.'],
+      ['Audit & Compliance', 'Tamper-proof audit trail. SOC 2 compatible. Enterprise compliance exports.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Google ADK',
+    metaTitle: 'Grantex for Google ADK — Secure Agent Development Kit Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Google ADK agents. Delegation chains, real-time revocation, and enterprise compliance. Open source.',
+  },
+  'vercel-ai': {
+    name: 'Vercel AI SDK',
+    badge: 'Vercel AI + Grantex',
+    title: 'Authorization for <span class="highlight">Vercel AI SDK</span>',
+    desc: 'Add scoped authorization to your Vercel AI SDK tools. Signed JWTs, audit trails, and instant revocation for AI-powered apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    install: 'npm install @grantex/vercel-ai @grantex/sdk',
+    problemBad: 'Your Vercel AI tools run with full access. Users can\'t see or control what the AI does on their behalf. No audit trail, no revocation.',
+    problemGood: 'Each AI tool call is authorized with a scoped JWT. Users approve permissions upfront. Every action is logged. Revoke instantly.',
+    howTitle: 'How Grantex Works with Vercel AI SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/vercel-ai — TypeScript-native integration for Vercel AI SDK.'],
+      ['Define authorized tools', 'Wrap your AI SDK tools with Grantex scope requirements.'],
+      ['User consents', 'Users approve specific scopes before the AI can act on their behalf.'],
+      ['Tools verify automatically', 'Each tool call checks the JWT scopes before execution.'],
+      ['Full observability', 'Audit trail of every tool invocation. Real-time event streaming.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createGrantexTools } from '@grantex/vercel-ai';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap Vercel AI SDK tools with authorization
+const tools = createGrantexTools({
+  client: gx,
+  grantToken: token,
+  tools: { search: searchTool, email: emailTool },
+});
+
+// Use with generateText or streamText
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prompt: 'Search for flights and send the results',
+});`,
+    features: [
+      ['Vercel AI SDK Native', 'Works with generateText, streamText, and all AI SDK tool patterns.'],
+      ['TypeScript First', 'Full type safety. Scopes are checked at compile time and runtime.'],
+      ['Edge Compatible', 'Works in Vercel Edge Functions. JWT verification is local — no external calls.'],
+      ['Streaming Support', 'Compatible with streaming responses. Authorization doesn\'t block the stream.'],
+      ['Multi-Step Flows', 'Authorize multi-step AI workflows where each step requires different scopes.'],
+      ['Next.js Ready', 'Drop into your Next.js app with zero configuration beyond the SDK.'],
+    ],
+    ctaFramework: 'Vercel AI',
+    metaTitle: 'Grantex for Vercel AI SDK — Authorization for AI-Powered Apps',
+    metaDesc: 'Add scoped permissions to Vercel AI SDK tools. TypeScript-native, Edge-compatible, with audit trails and real-time revocation. Open source.',
+  },
+  autogen: {
+    name: 'AutoGen',
+    badge: 'AutoGen + Grantex',
+    title: 'Authorization for <span class="highlight">AutoGen</span> Multi-Agent Systems',
+    desc: 'Secure your AutoGen conversations with per-agent permissions. Each agent in the group gets exactly the scopes it needs.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    install: 'npm install @grantex/autogen @grantex/sdk',
+    problemBad: 'AutoGen agents in a group chat share credentials. If one agent is compromised or hallucinates, it has access to everything the others can do.',
+    problemGood: 'Each AutoGen agent gets its own scoped JWT. The coder can only write code, the executor can only run tests. Isolated, audited, revocable.',
+    howTitle: 'How Grantex Works with AutoGen',
+    steps: [
+      ['Install the integration', 'npm install @grantex/autogen — wraps AutoGen function maps with authorization.'],
+      ['Register each agent', 'Create identities with role-specific scopes for each agent in the group.'],
+      ['Scope per conversation', 'Users approve what each agent can do before the conversation starts.'],
+      ['Agents operate independently', 'Each agent presents its own JWT. Function calls are scope-checked automatically.'],
+      ['Trace everything', 'Full audit trail across the multi-agent conversation. Attribute actions to specific agents.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexAutoGen } from '@grantex/autogen';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Each agent in the group gets scoped authorization
+const coderTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: coderToken,  // scoped to "code:write"
+  functionMap: { write_code: writeCodeFn },
+});
+
+const executorTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: executorToken,  // scoped to "code:execute"
+  functionMap: { run_code: runCodeFn },
+});`,
+    features: [
+      ['Per-Agent Authorization', 'Each agent in the AutoGen group gets its own scoped token and identity.'],
+      ['Group Chat Security', 'Prevent agents from accessing tools outside their role. Enforced at the protocol level.'],
+      ['Conversation Auditing', 'Track which agent called which function, with what scopes, across the entire conversation.'],
+      ['Delegation Support', 'Agents can delegate narrower scopes to spawned sub-agents with depth tracking.'],
+      ['Function Map Wrapping', 'Drop-in wrapper for AutoGen function maps. No changes to your agent logic.'],
+      ['Real-Time Control', 'Revoke any agent mid-conversation. Access is denied within 1 second.'],
+    ],
+    ctaFramework: 'AutoGen',
+    metaTitle: 'Grantex for AutoGen — Secure Multi-Agent Group Chat Authorization',
+    metaDesc: 'Per-agent scoped permissions for AutoGen multi-agent systems. Each agent gets its own JWT. Audit trails, delegation chains, instant revocation.',
+  },
+  mcp: {
+    name: 'Model Context Protocol',
+    badge: 'MCP + Grantex',
+    title: 'Authorization for <span class="highlight">MCP</span> Servers',
+    desc: 'Add enterprise-grade authorization to any MCP server. 13 built-in tools for managing agents, grants, and tokens from Claude Desktop, Cursor, or Windsurf.',
+    docsUrl: 'https://docs.grantex.dev/integrations/mcp',
+    installUrl: 'https://docs.grantex.dev/integrations/mcp',
+    install: 'npm install @grantex/mcp',
+    problemBad: 'MCP servers expose tools to AI assistants with no authorization layer. Any connected client can call any tool with full access. No scoping, no consent, no audit trail.',
+    problemGood: 'Grantex adds OAuth 2.1-style authorization to MCP. Users approve scoped access per tool. Every invocation is logged. Revoke access from the permission dashboard.',
+    howTitle: 'How Grantex Works with MCP',
+    steps: [
+      ['Install the MCP server', 'npm install @grantex/mcp — adds 13 Grantex tools to any MCP-compatible client.'],
+      ['Connect to Claude Desktop', 'Add Grantex to your MCP config. Works with Claude Desktop, Cursor, and Windsurf.'],
+      ['Manage via natural language', 'Ask Claude to "register an agent", "create a grant", or "check the audit log".'],
+      ['Or add MCP Auth', 'Use @grantex/mcp-auth to add OAuth 2.1 + PKCE to your own MCP servers.'],
+      ['Full protocol access', 'All 13 Grantex operations available as MCP tools — agents, grants, tokens, audit, budgets.'],
+    ],
+    code: `// claude_desktop_config.json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "npx",
+      "args": ["@grantex/mcp"],
+      "env": {
+        "GRANTEX_API_KEY": "gx_live_..."
+      }
+    }
+  }
+}
+
+// Then in Claude Desktop:
+// "Register a new agent called travel-bot with flights:book scope"
+// "Create a grant for user alice on travel-bot"
+// "Show me the audit log for the last hour"`,
+    features: [
+      ['13 MCP Tools', 'Full Grantex protocol access: agents, grants, tokens, audit, budgets, verification — all as MCP tools.'],
+      ['Claude Desktop Ready', 'Works out of the box with Claude Desktop, Cursor, and Windsurf.'],
+      ['MCP Auth Server', 'Separate @grantex/mcp-auth package adds OAuth 2.1 + PKCE to any MCP server.'],
+      ['Natural Language Control', 'Manage authorization through conversation. "Revoke all grants for agent X."'],
+      ['Zero Code Setup', 'npx @grantex/mcp — no code required. Just add to your MCP config and go.'],
+      ['Enterprise Grade', 'Budget controls, policy engine, SCIM/SSO — all accessible via MCP tools.'],
+    ],
+    ctaFramework: 'MCP',
+    metaTitle: 'Grantex for MCP — Authorization for Model Context Protocol Servers',
+    metaDesc: 'Add OAuth 2.1 authorization to MCP servers. 13 tools for Claude Desktop, Cursor, and Windsurf. Scoped grants, audit trails, real-time revocation.',
+  },
+  express: {
+    name: 'Express.js',
+    badge: 'Express + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">Express.js</span>',
+    desc: 'Protect your Express.js APIs with Grantex grant tokens. Drop-in middleware that verifies JWTs, enforces scopes, and logs every request.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    install: 'npm install @grantex/express',
+    problemBad: 'Your Express APIs accept API keys or bearer tokens with no scope enforcement. Any valid token can access any endpoint. No agent identity tracking.',
+    problemGood: 'Grantex middleware verifies JWTs offline via JWKS, enforces scopes per route, and identifies the calling agent. Zero external network calls.',
+    howTitle: 'How Grantex Works with Express.js',
+    steps: [
+      ['Install the middleware', 'npm install @grantex/express — one package, zero external dependencies at runtime.'],
+      ['Add to your app', 'One line to protect your routes. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs are verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'req.grantex gives you the agent DID, scopes, principal, and grant ID.'],
+      ['Production ready', 'JWKS caching, key rotation, scope enforcement, and error handling built in.'],
+    ],
+    code: `import express from 'express';
+import { grantexMiddleware, requireScopes } from '@grantex/express';
+
+const app = express();
+
+// Verify Grantex JWTs on all /api routes
+app.use('/api', grantexMiddleware({
+  jwksUrl: 'https://grantex-auth-....a.run.app/.well-known/jwks.json',
+}));
+
+// Enforce specific scopes per route
+app.get('/api/emails', requireScopes(['email:read']), (req, res) => {
+  console.log(req.grantex.agent);  // agent DID
+  console.log(req.grantex.scopes); // ['email:read']
+  res.json({ emails: [] });
+});`,
+    features: [
+      ['Drop-In Middleware', 'One line to protect your Express routes. Works with any Express 4+ app.'],
+      ['Offline JWT Verification', 'JWKS-based verification. No network calls to Grantex on each request. Sub-millisecond overhead.'],
+      ['Per-Route Scopes', 'requireScopes() enforces specific permissions per endpoint. Returns 403 if scopes don\'t match.'],
+      ['Agent Identity', 'req.grantex provides agent DID, scopes, principal ID, grant ID on every request.'],
+      ['JWKS Caching', 'Automatic key caching and rotation. Handles key rollover transparently.'],
+      ['TypeScript Support', 'Full type definitions. req.grantex is fully typed.'],
+    ],
+    ctaFramework: 'Express.js',
+    metaTitle: 'Grantex for Express.js — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Drop-in Express.js middleware for Grantex JWT verification. Offline JWKS verification, per-route scope enforcement, and agent identity. Open source.',
+  },
+  fastapi: {
+    name: 'FastAPI',
+    badge: 'FastAPI + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">FastAPI</span>',
+    desc: 'Protect your FastAPI endpoints with Grantex grant tokens. Dependency-injection middleware that verifies JWTs, enforces scopes, and identifies agents.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    install: 'pip install grantex-fastapi',
+    problemBad: 'Your FastAPI endpoints accept bearer tokens with no scope enforcement. Any valid token accesses any route. No way to identify which AI agent made the request.',
+    problemGood: 'Grantex dependency verifies JWTs offline via JWKS, enforces scopes per route, and provides the agent identity. Pythonic, async, and type-safe.',
+    howTitle: 'How Grantex Works with FastAPI',
+    steps: [
+      ['Install the middleware', 'pip install grantex-fastapi — async-native, works with FastAPI\'s dependency injection.'],
+      ['Add the dependency', 'Use GrantexAuth as a FastAPI dependency. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'The dependency returns the full grant context: agent DID, scopes, principal, grant ID.'],
+      ['Production ready', 'Async JWKS fetching, key caching, automatic rotation, and proper error responses.'],
+    ],
+    code: `from fastapi import FastAPI, Depends
+from grantex_fastapi import GrantexAuth, GrantContext
+
+app = FastAPI()
+auth = GrantexAuth(
+    jwks_url="https://grantex-auth-....a.run.app/.well-known/jwks.json"
+)
+
+@app.get("/api/emails")
+async def list_emails(
+    grant: GrantContext = Depends(auth.require_scopes(["email:read"]))
+):
+    print(grant.agent)   # agent DID
+    print(grant.scopes)  # ["email:read"]
+    return {"emails": []}`,
+    features: [
+      ['FastAPI Dependency Injection', 'Works with FastAPI\'s Depends() pattern. Pythonic and type-safe.'],
+      ['Async Native', 'Fully async JWKS fetching and JWT verification. No blocking calls.'],
+      ['Per-Route Scopes', 'require_scopes() enforces specific permissions per endpoint. Returns 403 on mismatch.'],
+      ['Typed Grant Context', 'Full Pydantic model for grant context: agent DID, scopes, principal, grant ID.'],
+      ['JWKS Caching', 'Automatic async key caching and rotation. Handles key rollover transparently.'],
+      ['OpenAPI Integration', 'Scopes appear in your FastAPI OpenAPI docs automatically.'],
+    ],
+    ctaFramework: 'FastAPI',
+    metaTitle: 'Grantex for FastAPI — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.',
+  },
+  mpp: {
+    name: 'MPP (Machine Payments Protocol)',
+    badge: 'MPP + Grantex',
+    title: 'Agent Identity for <span class="highlight">Machine Payments</span>',
+    desc: 'MPP defines how AI agents pay for services. Grantex adds the missing identity layer — verifiable agent passports that let merchants know exactly who authorized every payment, with offline verification in under 50ms.',
+    docsUrl: 'https://docs.grantex.dev/features/mpp-agent-passport',
+    installUrl: 'https://docs.grantex.dev/guides/mpp-integration',
+    install: 'npm install @grantex/mpp @grantex/sdk',
+    problemBad: 'When an agent makes an MPP payment, the source is just a wallet address. No human name, no org, no authorization chain. For $0.10 API calls nobody cares. For $500 B2B procurement, it\'s a compliance blocker.',
+    problemGood: 'Every MPP payment carries an AgentPassportCredential — a W3C VC 2.0 credential with the human principal, org DID, spending limits, and allowed categories. Merchants verify in <50ms, offline.',
+    howTitle: 'How Grantex Works with MPP',
+    steps: [
+      ['Install the package', 'npm install @grantex/mpp — agent-side middleware + merchant-side verification in one package.'],
+      ['Issue an agent passport', 'Call grantex.passports.issue() with categories (inference, compute, data), spending limits, and expiry.'],
+      ['Attach to MPP requests', 'createMppPassportMiddleware() injects the X-Grantex-Passport header on every outgoing fetch.'],
+      ['Verify on the merchant side', 'requireAgentPassport() Express middleware — one line to verify identity, categories, and amounts.'],
+      ['Check the trust registry', 'lookupOrgTrust() returns verified org status (basic, verified, SOC 2) from the public registry.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createMppPassportMiddleware, requireAgentPassport } from '@grantex/mpp';
+
+// Agent side: issue passport and attach to requests
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const passport = await grantex.passports.issue({
+  agentId: 'ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  allowedMPPCategories: ['inference', 'compute'],
+  maxTransactionAmount: { amount: 50, currency: 'USDC' },
+  expiresIn: '24h',
+});
+
+const middleware = createMppPassportMiddleware({ passport });
+const enriched = await middleware(new Request(url));
+// X-Grantex-Passport header attached
+
+// Merchant side: one-line verification
+app.use('/api/inference', requireAgentPassport({
+  requiredCategories: ['inference'],
+  maxAmount: 10,
+}));
+// req.agentPassport → { humanDID, orgDID, categories, maxAmount, ... }`,
+    features: [
+      ['AgentPassportCredential', 'W3C VC 2.0 with agent DID, human principal, org, categories, spending limits, and delegation depth.'],
+      ['<50ms Verification', 'Offline verification using cached JWKS. No API roundtrip to Grantex servers needed.'],
+      ['9 MPP Categories', 'inference, compute, data, storage, search, media, delivery, browser, general — each maps to a Grantex scope.'],
+      ['StatusList2021 Revocation', 'Revoke any passport instantly. Bit-flip propagation, no polling required.'],
+      ['Trust Registry', 'Public org trust lookup by DID. DNS-TXT, manual, or SOC 2 verification levels.'],
+      ['Auto-Refresh', 'Middleware proactively refreshes passports before expiry via onRefresh callback.'],
+    ],
+    ctaFramework: 'MPP',
+    metaTitle: 'Grantex for MPP — Agent Identity for Machine Payments Protocol',
+    metaDesc: 'Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.',
+  },
+};
+
+// Determine framework from URL
+const path = window.location.pathname.replace(/\/$/, '');
+const slug = path.split('/').pop();
+const fw = frameworks[slug];
+
+if (!fw) {
+  // Redirect to homepage if unknown framework
+  window.location.href = '/';
+} else {
+  // Set meta tags
+  document.title = fw.metaTitle;
+  document.querySelector('meta[name="description"]').content = fw.metaDesc;
+  document.querySelector('link[rel="canonical"]').href = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[property="og:title"]').content = fw.metaTitle;
+  document.querySelector('meta[property="og:description"]').content = fw.metaDesc;
+  document.querySelector('meta[property="og:url"]').content = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[name="twitter:title"]').content = fw.metaTitle;
+  document.querySelector('meta[name="twitter:description"]').content = fw.metaDesc;
+
+  // Populate content
+  document.getElementById('badge').textContent = fw.badge;
+  document.getElementById('heroTitle').innerHTML = fw.title;
+  document.getElementById('heroDesc').textContent = fw.desc;
+  document.getElementById('ctaDocs').href = fw.docsUrl;
+  document.getElementById('ctaInstall').href = fw.installUrl;
+  document.getElementById('problemBad').textContent = fw.problemBad;
+  document.getElementById('problemGood').textContent = fw.problemGood;
+  document.getElementById('howTitle').textContent = fw.howTitle;
+  document.getElementById('installCmd').textContent = fw.install;
+  document.getElementById('codeExample').textContent = fw.code;
+  document.getElementById('ctaFramework').textContent = fw.ctaFramework;
+  document.getElementById('ctaDocsBottom').href = fw.docsUrl;
+  document.getElementById('featuresTitle').textContent = 'Why Grantex for ' + fw.name;
+
+  // Steps
+  const stepsEl = document.getElementById('steps');
+  fw.steps.forEach(([title, desc]) => {
+    stepsEl.innerHTML += `<div class="step"><div class="step-content"><h3>${title}</h3><p>${desc}</p></div></div>`;
+  });
+
+  // Features
+  const featuresEl = document.getElementById('features');
+  fw.features.forEach(([title, desc]) => {
+    featuresEl.innerHTML += `<div class="feature-card"><h3>${title}</h3><p>${desc}</p></div>`;
+  });
+
+  // Add JSON-LD structured data
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Grantex for " + fw.name,
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Any",
+    "url": "https://grantex.dev/for/" + slug,
+    "description": fw.metaDesc,
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  };
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.textContent = JSON.stringify(jsonLd);
+  document.head.appendChild(script);
+
+  // Track page view
+  gtag('event', 'page_view', { page_title: fw.metaTitle, page_location: window.location.href });
+}
+</script>
+</body>
+</html>

--- a/web/for/mcp/index.html
+++ b/web/for/mcp/index.html
@@ -1,0 +1,787 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
+  <!-- Dynamic meta tags set by JS below -->
+  <title>Grantex for MCP — Authorization for Model Context Protocol Servers</title>
+  <meta name="description" content="Add OAuth 2.1 authorization to MCP servers. 13 tools for Claude Desktop, Cursor, and Windsurf. Scoped grants, audit trails, real-time revocation.">
+  <link rel="canonical" href="https://grantex.dev/for/mcp/">
+  <meta property="og:title" content="Grantex for MCP — Authorization for Model Context Protocol Servers">
+  <meta property="og:description" content="Add OAuth 2.1 authorization to MCP servers. 13 tools for Claude Desktop, Cursor, and Windsurf. Scoped grants, audit trails, real-time revocation.">
+  <meta property="og:url" content="https://grantex.dev/for/mcp/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Grantex">
+  <meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grantex for MCP — Authorization for Model Context Protocol Servers">
+  <meta name="twitter:description" content="Add OAuth 2.1 authorization to MCP servers. 13 tools for Claude Desktop, Cursor, and Windsurf. Scoped grants, audit trails, real-time revocation.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
+  <style>
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --border:   #30363d;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --accent:   #3fb950;
+      --accent2:  #58a6ff;
+      --mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+      --sans:     'Inter', system-ui, -apple-system, sans-serif;
+      --radius:   8px;
+      --max-w:    900px;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: var(--sans); line-height: 1.6; }
+    a { color: var(--accent2); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { font-family: var(--mono); background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+    pre { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; overflow-x: auto; font-family: var(--mono); font-size: 0.875rem; line-height: 1.5; }
+    pre code { background: none; padding: 0; }
+
+    /* Nav */
+    .nav { display: flex; align-items: center; justify-content: space-between; max-width: var(--max-w); margin: 0 auto; padding: 1rem 1.5rem; }
+    .nav-logo { font-weight: 700; font-size: 1.25rem; color: var(--text); }
+    .nav-links { list-style: none; display: flex; gap: 1.5rem; }
+    .nav-links a { color: var(--muted); font-size: 0.9rem; }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+
+    /* Hero */
+    .hero { text-align: center; padding: 4rem 1.5rem 3rem; max-width: var(--max-w); margin: 0 auto; }
+    .hero-badge { display: inline-block; background: rgba(63,185,80,0.15); color: var(--accent); padding: 0.25rem 0.75rem; border-radius: 999px; font-size: 0.8rem; font-weight: 600; margin-bottom: 1rem; }
+    .hero h1 { font-size: 2.5rem; line-height: 1.2; margin-bottom: 1rem; }
+    .hero h1 .highlight { color: var(--accent); }
+    .hero p { color: var(--muted); font-size: 1.1rem; max-width: 650px; margin: 0 auto 2rem; }
+    .hero-ctas { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
+    .btn { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.65rem 1.25rem; border-radius: var(--radius); font-weight: 600; font-size: 0.9rem; text-decoration: none; transition: all 0.2s; }
+    .btn-primary { background: var(--accent); color: #0d1117; }
+    .btn-primary:hover { background: #2ea043; text-decoration: none; }
+    .btn-secondary { background: var(--surface); color: var(--text); border: 1px solid var(--border); }
+    .btn-secondary:hover { border-color: var(--muted); text-decoration: none; }
+
+    /* Sections */
+    .section { max-width: var(--max-w); margin: 0 auto; padding: 3rem 1.5rem; }
+    .section h2 { font-size: 1.75rem; margin-bottom: 1rem; }
+    .section h3 { font-size: 1.15rem; margin-bottom: 0.5rem; color: var(--accent); }
+    .section p, .section li { color: var(--muted); }
+    .section ul { padding-left: 1.25rem; }
+    .section li { margin-bottom: 0.5rem; }
+
+    /* Problem cards */
+    .problem-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; margin: 1.5rem 0; }
+    .problem-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .problem-card.bad { border-color: #f8514933; }
+    .problem-card.good { border-color: #3fb95033; }
+    .problem-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .problem-card.bad h3 { color: #f85149; }
+    .problem-card.good h3 { color: var(--accent); }
+
+    /* Steps */
+    .steps { counter-reset: step; margin: 1.5rem 0; }
+    .step { display: flex; gap: 1rem; margin-bottom: 1.5rem; }
+    .step::before { counter-increment: step; content: counter(step); display: flex; align-items: center; justify-content: center; min-width: 32px; height: 32px; background: rgba(63,185,80,0.15); color: var(--accent); border-radius: 50%; font-weight: 700; font-size: 0.85rem; }
+    .step-content h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.25rem; }
+    .step-content p { font-size: 0.9rem; }
+
+    /* Features */
+    .feature-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.25rem; margin: 1.5rem 0; }
+    .feature-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .feature-card h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; }
+
+    /* Install */
+    .install-box { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.25rem; display: flex; align-items: center; justify-content: space-between; margin: 1rem 0; font-family: var(--mono); font-size: 0.9rem; }
+    .install-box button { background: var(--accent); color: #0d1117; border: none; padding: 0.35rem 0.75rem; border-radius: 4px; font-weight: 600; cursor: pointer; font-size: 0.8rem; }
+
+    /* Footer */
+    .footer { max-width: var(--max-w); margin: 0 auto; padding: 2rem 1.5rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; }
+    .footer-links { list-style: none; display: flex; gap: 1.5rem; }
+    .footer-links a { color: var(--muted); font-size: 0.85rem; }
+
+    @media (max-width: 640px) {
+      .hero h1 { font-size: 1.75rem; }
+      .problem-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Grantex for Model Context Protocol","applicationCategory":"DeveloperApplication","operatingSystem":"Any","url":"https://grantex.dev/for/mcp/","description":"Add OAuth 2.1 authorization to MCP servers. 13 tools for Claude Desktop, Cursor, and Windsurf. Scoped grants, audit trails, real-time revocation.","license":"https://www.apache.org/licenses/LICENSE-2.0"}</script>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/" class="nav-logo">Grantex</a>
+  <ul class="nav-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="/playground">Playground</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+  </ul>
+</nav>
+
+<div id="app">
+  <section class="hero">
+    <span class="hero-badge" id="badge"></span>
+    <h1 id="heroTitle"></h1>
+    <p id="heroDesc"></p>
+    <div class="hero-ctas">
+      <a href="" id="ctaDocs" class="btn btn-primary">View Integration Docs</a>
+      <a href="" id="ctaInstall" class="btn btn-secondary">Get Started</a>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2>The Problem</h2>
+    <div class="problem-grid">
+      <div class="problem-card bad">
+        <h3>Without Grantex</h3>
+        <p id="problemBad"></p>
+      </div>
+      <div class="problem-card good">
+        <h3>With Grantex</h3>
+        <p id="problemGood"></p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2 id="howTitle">How It Works</h2>
+    <div class="steps" id="steps"></div>
+  </section>
+
+  <section class="section">
+    <h2>Quick Start</h2>
+    <div class="install-box">
+      <span id="installCmd"></span>
+      <button onclick="navigator.clipboard.writeText(document.getElementById('installCmd').textContent);this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)">Copy</button>
+    </div>
+    <pre><code id="codeExample"></code></pre>
+  </section>
+
+  <section class="section">
+    <h2 id="featuresTitle">Why Grantex</h2>
+    <div class="feature-grid" id="features"></div>
+  </section>
+
+  <section class="section" style="text-align:center">
+    <h2>Ready to secure your <span id="ctaFramework"></span> agents?</h2>
+    <p style="margin-bottom:1.5rem;color:var(--muted)">Get started in under 5 minutes. Open source, Apache 2.0.</p>
+    <div class="hero-ctas">
+      <a href="https://grantex.dev/dashboard/signup" class="btn btn-primary">Sign Up Free</a>
+      <a href="" id="ctaDocsBottom" class="btn btn-secondary">Read the Docs</a>
+    </div>
+  </section>
+</div>
+
+<footer class="footer">
+  <span style="color:var(--muted);font-size:0.85rem">Grantex — Open authorization for AI agents</span>
+  <ul class="footer-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+    <li><a href="/">Home</a></li>
+  </ul>
+</footer>
+
+<script>
+const frameworks = {
+  langchain: {
+    name: 'LangChain',
+    badge: 'LangChain + Grantex',
+    title: 'Authorization for <span class="highlight">LangChain</span> Agents',
+    desc: 'Add scoped, revocable permissions to your LangChain agents. Grantex integrates natively with LangChain tools — your agents get signed JWTs instead of raw API keys.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    install: 'npm install @grantex/langchain @grantex/sdk',
+    problemBad: 'Your LangChain agents use raw API keys with full access. No scoping, no audit trail, no way to revoke access if an agent goes rogue. One compromised key exposes everything.',
+    problemGood: 'Each LangChain agent gets a scoped, time-limited JWT. Tools verify permissions offline. You can revoke any agent instantly. Every action is audit-logged with a hash chain.',
+    howTitle: 'How Grantex Works with LangChain',
+    steps: [
+      ['Install the integration', 'npm install @grantex/langchain — wraps LangChain tools with automatic grant verification.'],
+      ['Register your agent', 'Create an agent identity with specific scopes like "email:send" or "calendar:read".'],
+      ['Get user consent', 'Redirect the user to a consent page. They approve exactly which permissions the agent gets.'],
+      ['Agent receives a JWT', 'The agent gets a signed token it presents to any service. Services verify offline via JWKS.'],
+      ['Audit & revoke', 'Every action is logged. Revoke access in under 1 second if something goes wrong.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexToolkit } from '@grantex/langchain';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap your LangChain tools with Grantex authorization
+const toolkit = new GrantexToolkit({
+  client: gx,
+  grantToken: token,  // JWT from the consent flow
+  tools: [searchTool, emailTool],
+});
+
+// Tools now automatically verify scopes before executing
+const agent = createToolCallingAgent({ llm, tools: toolkit.tools });`,
+    features: [
+      ['Native LangChain Integration', 'Drop-in toolkit that wraps your existing LangChain tools with automatic scope verification.'],
+      ['Scoped Permissions', 'Define exactly what each agent can do — "email:read" vs "email:send". No more all-or-nothing API keys.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS without calling Grantex. Zero latency overhead on your LangChain pipeline.'],
+      ['Multi-Agent Delegation', 'Parent agents delegate narrower scopes to sub-agents. Revoking the parent cascades to all children.'],
+      ['Hash-Chained Audit Trail', 'Every tool invocation is logged in an append-only, tamper-evident audit trail.'],
+      ['Real-Time Revocation', 'Kill a misbehaving agent\'s access in under 1 second. No waiting for token expiry.'],
+    ],
+    ctaFramework: 'LangChain',
+    metaTitle: 'Grantex for LangChain — Authorization for LangChain AI Agents',
+    metaDesc: 'Add scoped, revocable permissions to LangChain agents. Drop-in toolkit for authorization with signed JWTs, audit trails, and real-time revocation. Open source.',
+  },
+  crewai: {
+    name: 'CrewAI',
+    badge: 'CrewAI + Grantex',
+    title: 'Authorization for <span class="highlight">CrewAI</span> Agents',
+    desc: 'Secure your CrewAI crews with scoped, revocable permissions. Each crew member gets exactly the access it needs — nothing more.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    install: 'pip install grantex-crewai grantex',
+    problemBad: 'Your CrewAI agents share the same API keys. If one crew member is compromised, the entire crew\'s access is exposed. No way to scope or revoke individual agent access.',
+    problemGood: 'Each crew member gets its own scoped JWT. The researcher can only read, the writer can only draft, the publisher can only post. Revoke any member instantly.',
+    howTitle: 'How Grantex Works with CrewAI',
+    steps: [
+      ['Install the integration', 'pip install grantex-crewai — Python-native integration for CrewAI crews.'],
+      ['Register each crew member', 'Create agent identities with role-specific scopes for each crew member.'],
+      ['Authorize the crew', 'Users approve scoped permissions for each role in the crew.'],
+      ['Crew operates with scoped tokens', 'Each crew member presents its own JWT. Services verify independently.'],
+      ['Monitor & control', 'Audit every crew action. Revoke individual members without stopping the whole crew.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_crewai import GrantexCrewTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Each crew member gets scoped authorization
+researcher_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=researcher_token,  # scoped to "search:read"
+    tools=[search_tool],
+)
+
+writer_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=writer_token,  # scoped to "docs:write"
+    tools=[write_tool],
+)`,
+    features: [
+      ['Per-Agent Scoping', 'Each crew member gets exactly the permissions it needs. Researcher reads, writer writes, publisher posts.'],
+      ['Role-Based Access', 'Map CrewAI roles to Grantex scopes. Define authorization policies per role, not per API key.'],
+      ['Crew-Wide Audit Trail', 'See what every crew member did, when, and with what permissions. Hash-chained for tamper evidence.'],
+      ['Delegation Chains', 'A lead agent can delegate narrower permissions to sub-agents. Revoking the lead cascades to all.'],
+      ['Python Native', 'Pure Python integration. pip install and go — works with any CrewAI version.'],
+      ['Instant Revocation', 'Revoke any crew member\'s access in under 1 second without disrupting the rest of the crew.'],
+    ],
+    ctaFramework: 'CrewAI',
+    metaTitle: 'Grantex for CrewAI — Secure Multi-Agent Crew Permissions',
+    metaDesc: 'Scope and control permissions for CrewAI agents. Each crew member gets its own signed JWT with role-specific access. Audit trails, delegation, real-time revocation.',
+  },
+  'openai-agents': {
+    name: 'OpenAI Agents SDK',
+    badge: 'OpenAI Agents + Grantex',
+    title: 'Authorization for <span class="highlight">OpenAI Agents SDK</span>',
+    desc: 'Add enterprise-grade authorization to your OpenAI agents. Scoped permissions, audit trails, and instant revocation — built for the Agents SDK.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    install: 'pip install grantex-openai-agents grantex',
+    problemBad: 'Your OpenAI agents operate with full API access. No scoping, no audit trail, no revocation. You can\'t tell which agent did what or limit what it can do.',
+    problemGood: 'Each agent gets a scoped, time-limited JWT. Every tool call is authorized and logged. Revoke access instantly if an agent behaves unexpectedly.',
+    howTitle: 'How Grantex Works with OpenAI Agents SDK',
+    steps: [
+      ['Install the integration', 'pip install grantex-openai-agents — wraps OpenAI agent tools with authorization.'],
+      ['Register your agent', 'Create an agent identity with scopes matching its capabilities.'],
+      ['Get user approval', 'Users approve exactly which permissions the agent receives via a consent page.'],
+      ['Agent operates with JWT', 'The agent\'s tools automatically verify permissions before executing.'],
+      ['Full audit trail', 'Every tool invocation is logged with the agent identity, scopes used, and timestamp.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_openai_agents import GrantexTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap OpenAI agent tools with Grantex authorization
+tools = GrantexTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, email_tool],
+)
+
+# Tools automatically check scopes before execution
+agent = Agent(
+    name="assistant",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['OpenAI Agents SDK Integration', 'Drop-in wrapper for OpenAI agent tools. Add authorization without changing your agent logic.'],
+      ['Scoped Tool Access', 'Define which tools each agent can use and with what parameters. Enforced at the protocol level.'],
+      ['Enterprise Audit Trail', 'Every tool call logged with agent identity, scopes, and hash-chained integrity.'],
+      ['Multi-Agent Pipelines', 'Parent agents delegate narrower access to sub-agents. Full delegation chain tracking.'],
+      ['Budget Controls', 'Set spending limits per agent. Automatic cutoff when budget is exhausted.'],
+      ['Compliance Ready', 'SOC 2 compatible audit logging. SCIM/SSO for enterprise identity management.'],
+    ],
+    ctaFramework: 'OpenAI Agents',
+    metaTitle: 'Grantex for OpenAI Agents SDK — Enterprise Agent Authorization',
+    metaDesc: 'Add scoped permissions, audit trails, and real-time revocation to OpenAI Agents SDK. Enterprise-grade authorization for AI agents. Open source.',
+  },
+  anthropic: {
+    name: 'Anthropic SDK',
+    badge: 'Anthropic + Grantex',
+    title: 'Authorization for <span class="highlight">Anthropic SDK</span> Tool Use',
+    desc: 'Enforce scoped permissions on Claude tool calls. Offline JWT verification, automatic audit logging, and instant revocation for Anthropic SDK apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    installUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    install: 'npm install @grantex/anthropic @grantex/sdk',
+    problemBad: 'Your Claude-powered agents call tools with no authorization layer. Any tool can be invoked with full access. No scoping, no consent, no audit trail of what the agent did.',
+    problemGood: 'Grantex wraps each tool with scope enforcement. The agent\'s JWT is checked offline before execution. Every tool call is audit-logged. Revoke access in under 1 second.',
+    howTitle: 'How Grantex Works with the Anthropic SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/anthropic — wraps Anthropic tool definitions with authorization.'],
+      ['Create scoped tools', 'Use createGrantexTool() to define tools with required scopes and JSON Schema input.'],
+      ['Pass tools to Claude', 'tool.definition is type-compatible with client.messages.create({ tools }).'],
+      ['Dispatch tool_use blocks', 'Use GrantexToolRegistry or handleToolCall() to execute with automatic audit logging.'],
+      ['Monitor everything', 'Hash-chained audit trail of every tool call. Revoke access in under 1 second.'],
+    ],
+    code: `import Anthropic from '@anthropic-ai/sdk';
+import { createGrantexTool, GrantexToolRegistry } from '@grantex/anthropic';
+
+const client = new Anthropic();
+
+const readFile = createGrantexTool({
+  name: 'read_file',
+  description: 'Read a file from disk',
+  inputSchema: {
+    type: 'object',
+    properties: { path: { type: 'string' } },
+    required: ['path'],
+  },
+  grantToken,
+  requiredScope: 'file:read',
+  execute: async ({ path }) => fs.readFile(path, 'utf-8'),
+});
+
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  tools: [readFile.definition],
+  messages,
+});`,
+    features: [
+      ['Anthropic SDK Native', 'Type-compatible with client.messages.create(). tool.definition drops in directly.'],
+      ['Offline Scope Checks', 'JWT scp claim verified locally. No network call to Grantex during execution.'],
+      ['Tool Registry', 'GrantexToolRegistry manages multiple tools and dispatches tool_use blocks by name.'],
+      ['Audit Logging', 'withAuditLogging() and handleToolCall() log every success/failure automatically.'],
+      ['GrantexScopeError', 'Typed error with requiredScope and grantedScopes for clean error handling.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Anthropic SDK',
+    metaTitle: 'Grantex for Anthropic SDK — Secure Claude Tool Use Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Claude tool use. Offline JWT verification, tool registry, and instant revocation. Open source.',
+  },
+  'google-adk': {
+    name: 'Google ADK',
+    badge: 'Google ADK + Grantex',
+    title: 'Authorization for <span class="highlight">Google ADK</span> Agents',
+    desc: 'Secure your Google Agent Development Kit agents with scoped, human-approved permissions and full audit trails.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    install: 'pip install grantex-adk grantex',
+    problemBad: 'Your ADK agents access services with broad credentials. No fine-grained scoping, no delegation control, no tamper-proof audit log of agent actions.',
+    problemGood: 'Each ADK agent gets cryptographic identity and scoped JWTs. Delegation chains track multi-agent workflows. Every action is audit-logged.',
+    howTitle: 'How Grantex Works with Google ADK',
+    steps: [
+      ['Install the integration', 'pip install grantex-adk — Python-native integration for Google ADK.'],
+      ['Register your agent', 'Create an agent identity with specific scopes matching your ADK agent\'s capabilities.'],
+      ['Authorize via consent', 'Users approve scoped permissions through a consent flow.'],
+      ['Agent operates securely', 'ADK tools verify permissions via JWT before executing any action.'],
+      ['Monitor everything', 'Hash-chained audit trail of every action. Revoke access in under 1 second.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_adk import GrantexADKTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap ADK tools with Grantex authorization
+tools = GrantexADKTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, calendar_tool],
+)
+
+# Tools verify scopes automatically
+agent = Agent(
+    model="gemini-2.0-flash",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['Google ADK Native', 'Built for the Agent Development Kit. Wraps ADK tools with automatic authorization.'],
+      ['Scoped Permissions', 'Fine-grained scopes for each capability. "calendar:read" vs "calendar:write".'],
+      ['Delegation Chains', 'Multi-agent ADK pipelines with tracked delegation. Revoke parent to cascade.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS. No network calls to Grantex during execution.'],
+      ['Audit & Compliance', 'Tamper-proof audit trail. SOC 2 compatible. Enterprise compliance exports.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Google ADK',
+    metaTitle: 'Grantex for Google ADK — Secure Agent Development Kit Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Google ADK agents. Delegation chains, real-time revocation, and enterprise compliance. Open source.',
+  },
+  'vercel-ai': {
+    name: 'Vercel AI SDK',
+    badge: 'Vercel AI + Grantex',
+    title: 'Authorization for <span class="highlight">Vercel AI SDK</span>',
+    desc: 'Add scoped authorization to your Vercel AI SDK tools. Signed JWTs, audit trails, and instant revocation for AI-powered apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    install: 'npm install @grantex/vercel-ai @grantex/sdk',
+    problemBad: 'Your Vercel AI tools run with full access. Users can\'t see or control what the AI does on their behalf. No audit trail, no revocation.',
+    problemGood: 'Each AI tool call is authorized with a scoped JWT. Users approve permissions upfront. Every action is logged. Revoke instantly.',
+    howTitle: 'How Grantex Works with Vercel AI SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/vercel-ai — TypeScript-native integration for Vercel AI SDK.'],
+      ['Define authorized tools', 'Wrap your AI SDK tools with Grantex scope requirements.'],
+      ['User consents', 'Users approve specific scopes before the AI can act on their behalf.'],
+      ['Tools verify automatically', 'Each tool call checks the JWT scopes before execution.'],
+      ['Full observability', 'Audit trail of every tool invocation. Real-time event streaming.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createGrantexTools } from '@grantex/vercel-ai';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap Vercel AI SDK tools with authorization
+const tools = createGrantexTools({
+  client: gx,
+  grantToken: token,
+  tools: { search: searchTool, email: emailTool },
+});
+
+// Use with generateText or streamText
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prompt: 'Search for flights and send the results',
+});`,
+    features: [
+      ['Vercel AI SDK Native', 'Works with generateText, streamText, and all AI SDK tool patterns.'],
+      ['TypeScript First', 'Full type safety. Scopes are checked at compile time and runtime.'],
+      ['Edge Compatible', 'Works in Vercel Edge Functions. JWT verification is local — no external calls.'],
+      ['Streaming Support', 'Compatible with streaming responses. Authorization doesn\'t block the stream.'],
+      ['Multi-Step Flows', 'Authorize multi-step AI workflows where each step requires different scopes.'],
+      ['Next.js Ready', 'Drop into your Next.js app with zero configuration beyond the SDK.'],
+    ],
+    ctaFramework: 'Vercel AI',
+    metaTitle: 'Grantex for Vercel AI SDK — Authorization for AI-Powered Apps',
+    metaDesc: 'Add scoped permissions to Vercel AI SDK tools. TypeScript-native, Edge-compatible, with audit trails and real-time revocation. Open source.',
+  },
+  autogen: {
+    name: 'AutoGen',
+    badge: 'AutoGen + Grantex',
+    title: 'Authorization for <span class="highlight">AutoGen</span> Multi-Agent Systems',
+    desc: 'Secure your AutoGen conversations with per-agent permissions. Each agent in the group gets exactly the scopes it needs.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    install: 'npm install @grantex/autogen @grantex/sdk',
+    problemBad: 'AutoGen agents in a group chat share credentials. If one agent is compromised or hallucinates, it has access to everything the others can do.',
+    problemGood: 'Each AutoGen agent gets its own scoped JWT. The coder can only write code, the executor can only run tests. Isolated, audited, revocable.',
+    howTitle: 'How Grantex Works with AutoGen',
+    steps: [
+      ['Install the integration', 'npm install @grantex/autogen — wraps AutoGen function maps with authorization.'],
+      ['Register each agent', 'Create identities with role-specific scopes for each agent in the group.'],
+      ['Scope per conversation', 'Users approve what each agent can do before the conversation starts.'],
+      ['Agents operate independently', 'Each agent presents its own JWT. Function calls are scope-checked automatically.'],
+      ['Trace everything', 'Full audit trail across the multi-agent conversation. Attribute actions to specific agents.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexAutoGen } from '@grantex/autogen';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Each agent in the group gets scoped authorization
+const coderTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: coderToken,  // scoped to "code:write"
+  functionMap: { write_code: writeCodeFn },
+});
+
+const executorTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: executorToken,  // scoped to "code:execute"
+  functionMap: { run_code: runCodeFn },
+});`,
+    features: [
+      ['Per-Agent Authorization', 'Each agent in the AutoGen group gets its own scoped token and identity.'],
+      ['Group Chat Security', 'Prevent agents from accessing tools outside their role. Enforced at the protocol level.'],
+      ['Conversation Auditing', 'Track which agent called which function, with what scopes, across the entire conversation.'],
+      ['Delegation Support', 'Agents can delegate narrower scopes to spawned sub-agents with depth tracking.'],
+      ['Function Map Wrapping', 'Drop-in wrapper for AutoGen function maps. No changes to your agent logic.'],
+      ['Real-Time Control', 'Revoke any agent mid-conversation. Access is denied within 1 second.'],
+    ],
+    ctaFramework: 'AutoGen',
+    metaTitle: 'Grantex for AutoGen — Secure Multi-Agent Group Chat Authorization',
+    metaDesc: 'Per-agent scoped permissions for AutoGen multi-agent systems. Each agent gets its own JWT. Audit trails, delegation chains, instant revocation.',
+  },
+  mcp: {
+    name: 'Model Context Protocol',
+    badge: 'MCP + Grantex',
+    title: 'Authorization for <span class="highlight">MCP</span> Servers',
+    desc: 'Add enterprise-grade authorization to any MCP server. 13 built-in tools for managing agents, grants, and tokens from Claude Desktop, Cursor, or Windsurf.',
+    docsUrl: 'https://docs.grantex.dev/integrations/mcp',
+    installUrl: 'https://docs.grantex.dev/integrations/mcp',
+    install: 'npm install @grantex/mcp',
+    problemBad: 'MCP servers expose tools to AI assistants with no authorization layer. Any connected client can call any tool with full access. No scoping, no consent, no audit trail.',
+    problemGood: 'Grantex adds OAuth 2.1-style authorization to MCP. Users approve scoped access per tool. Every invocation is logged. Revoke access from the permission dashboard.',
+    howTitle: 'How Grantex Works with MCP',
+    steps: [
+      ['Install the MCP server', 'npm install @grantex/mcp — adds 13 Grantex tools to any MCP-compatible client.'],
+      ['Connect to Claude Desktop', 'Add Grantex to your MCP config. Works with Claude Desktop, Cursor, and Windsurf.'],
+      ['Manage via natural language', 'Ask Claude to "register an agent", "create a grant", or "check the audit log".'],
+      ['Or add MCP Auth', 'Use @grantex/mcp-auth to add OAuth 2.1 + PKCE to your own MCP servers.'],
+      ['Full protocol access', 'All 13 Grantex operations available as MCP tools — agents, grants, tokens, audit, budgets.'],
+    ],
+    code: `// claude_desktop_config.json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "npx",
+      "args": ["@grantex/mcp"],
+      "env": {
+        "GRANTEX_API_KEY": "gx_live_..."
+      }
+    }
+  }
+}
+
+// Then in Claude Desktop:
+// "Register a new agent called travel-bot with flights:book scope"
+// "Create a grant for user alice on travel-bot"
+// "Show me the audit log for the last hour"`,
+    features: [
+      ['13 MCP Tools', 'Full Grantex protocol access: agents, grants, tokens, audit, budgets, verification — all as MCP tools.'],
+      ['Claude Desktop Ready', 'Works out of the box with Claude Desktop, Cursor, and Windsurf.'],
+      ['MCP Auth Server', 'Separate @grantex/mcp-auth package adds OAuth 2.1 + PKCE to any MCP server.'],
+      ['Natural Language Control', 'Manage authorization through conversation. "Revoke all grants for agent X."'],
+      ['Zero Code Setup', 'npx @grantex/mcp — no code required. Just add to your MCP config and go.'],
+      ['Enterprise Grade', 'Budget controls, policy engine, SCIM/SSO — all accessible via MCP tools.'],
+    ],
+    ctaFramework: 'MCP',
+    metaTitle: 'Grantex for MCP — Authorization for Model Context Protocol Servers',
+    metaDesc: 'Add OAuth 2.1 authorization to MCP servers. 13 tools for Claude Desktop, Cursor, and Windsurf. Scoped grants, audit trails, real-time revocation.',
+  },
+  express: {
+    name: 'Express.js',
+    badge: 'Express + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">Express.js</span>',
+    desc: 'Protect your Express.js APIs with Grantex grant tokens. Drop-in middleware that verifies JWTs, enforces scopes, and logs every request.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    install: 'npm install @grantex/express',
+    problemBad: 'Your Express APIs accept API keys or bearer tokens with no scope enforcement. Any valid token can access any endpoint. No agent identity tracking.',
+    problemGood: 'Grantex middleware verifies JWTs offline via JWKS, enforces scopes per route, and identifies the calling agent. Zero external network calls.',
+    howTitle: 'How Grantex Works with Express.js',
+    steps: [
+      ['Install the middleware', 'npm install @grantex/express — one package, zero external dependencies at runtime.'],
+      ['Add to your app', 'One line to protect your routes. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs are verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'req.grantex gives you the agent DID, scopes, principal, and grant ID.'],
+      ['Production ready', 'JWKS caching, key rotation, scope enforcement, and error handling built in.'],
+    ],
+    code: `import express from 'express';
+import { grantexMiddleware, requireScopes } from '@grantex/express';
+
+const app = express();
+
+// Verify Grantex JWTs on all /api routes
+app.use('/api', grantexMiddleware({
+  jwksUrl: 'https://grantex-auth-....a.run.app/.well-known/jwks.json',
+}));
+
+// Enforce specific scopes per route
+app.get('/api/emails', requireScopes(['email:read']), (req, res) => {
+  console.log(req.grantex.agent);  // agent DID
+  console.log(req.grantex.scopes); // ['email:read']
+  res.json({ emails: [] });
+});`,
+    features: [
+      ['Drop-In Middleware', 'One line to protect your Express routes. Works with any Express 4+ app.'],
+      ['Offline JWT Verification', 'JWKS-based verification. No network calls to Grantex on each request. Sub-millisecond overhead.'],
+      ['Per-Route Scopes', 'requireScopes() enforces specific permissions per endpoint. Returns 403 if scopes don\'t match.'],
+      ['Agent Identity', 'req.grantex provides agent DID, scopes, principal ID, grant ID on every request.'],
+      ['JWKS Caching', 'Automatic key caching and rotation. Handles key rollover transparently.'],
+      ['TypeScript Support', 'Full type definitions. req.grantex is fully typed.'],
+    ],
+    ctaFramework: 'Express.js',
+    metaTitle: 'Grantex for Express.js — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Drop-in Express.js middleware for Grantex JWT verification. Offline JWKS verification, per-route scope enforcement, and agent identity. Open source.',
+  },
+  fastapi: {
+    name: 'FastAPI',
+    badge: 'FastAPI + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">FastAPI</span>',
+    desc: 'Protect your FastAPI endpoints with Grantex grant tokens. Dependency-injection middleware that verifies JWTs, enforces scopes, and identifies agents.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    install: 'pip install grantex-fastapi',
+    problemBad: 'Your FastAPI endpoints accept bearer tokens with no scope enforcement. Any valid token accesses any route. No way to identify which AI agent made the request.',
+    problemGood: 'Grantex dependency verifies JWTs offline via JWKS, enforces scopes per route, and provides the agent identity. Pythonic, async, and type-safe.',
+    howTitle: 'How Grantex Works with FastAPI',
+    steps: [
+      ['Install the middleware', 'pip install grantex-fastapi — async-native, works with FastAPI\'s dependency injection.'],
+      ['Add the dependency', 'Use GrantexAuth as a FastAPI dependency. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'The dependency returns the full grant context: agent DID, scopes, principal, grant ID.'],
+      ['Production ready', 'Async JWKS fetching, key caching, automatic rotation, and proper error responses.'],
+    ],
+    code: `from fastapi import FastAPI, Depends
+from grantex_fastapi import GrantexAuth, GrantContext
+
+app = FastAPI()
+auth = GrantexAuth(
+    jwks_url="https://grantex-auth-....a.run.app/.well-known/jwks.json"
+)
+
+@app.get("/api/emails")
+async def list_emails(
+    grant: GrantContext = Depends(auth.require_scopes(["email:read"]))
+):
+    print(grant.agent)   # agent DID
+    print(grant.scopes)  # ["email:read"]
+    return {"emails": []}`,
+    features: [
+      ['FastAPI Dependency Injection', 'Works with FastAPI\'s Depends() pattern. Pythonic and type-safe.'],
+      ['Async Native', 'Fully async JWKS fetching and JWT verification. No blocking calls.'],
+      ['Per-Route Scopes', 'require_scopes() enforces specific permissions per endpoint. Returns 403 on mismatch.'],
+      ['Typed Grant Context', 'Full Pydantic model for grant context: agent DID, scopes, principal, grant ID.'],
+      ['JWKS Caching', 'Automatic async key caching and rotation. Handles key rollover transparently.'],
+      ['OpenAPI Integration', 'Scopes appear in your FastAPI OpenAPI docs automatically.'],
+    ],
+    ctaFramework: 'FastAPI',
+    metaTitle: 'Grantex for FastAPI — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.',
+  },
+  mpp: {
+    name: 'MPP (Machine Payments Protocol)',
+    badge: 'MPP + Grantex',
+    title: 'Agent Identity for <span class="highlight">Machine Payments</span>',
+    desc: 'MPP defines how AI agents pay for services. Grantex adds the missing identity layer — verifiable agent passports that let merchants know exactly who authorized every payment, with offline verification in under 50ms.',
+    docsUrl: 'https://docs.grantex.dev/features/mpp-agent-passport',
+    installUrl: 'https://docs.grantex.dev/guides/mpp-integration',
+    install: 'npm install @grantex/mpp @grantex/sdk',
+    problemBad: 'When an agent makes an MPP payment, the source is just a wallet address. No human name, no org, no authorization chain. For $0.10 API calls nobody cares. For $500 B2B procurement, it\'s a compliance blocker.',
+    problemGood: 'Every MPP payment carries an AgentPassportCredential — a W3C VC 2.0 credential with the human principal, org DID, spending limits, and allowed categories. Merchants verify in <50ms, offline.',
+    howTitle: 'How Grantex Works with MPP',
+    steps: [
+      ['Install the package', 'npm install @grantex/mpp — agent-side middleware + merchant-side verification in one package.'],
+      ['Issue an agent passport', 'Call grantex.passports.issue() with categories (inference, compute, data), spending limits, and expiry.'],
+      ['Attach to MPP requests', 'createMppPassportMiddleware() injects the X-Grantex-Passport header on every outgoing fetch.'],
+      ['Verify on the merchant side', 'requireAgentPassport() Express middleware — one line to verify identity, categories, and amounts.'],
+      ['Check the trust registry', 'lookupOrgTrust() returns verified org status (basic, verified, SOC 2) from the public registry.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createMppPassportMiddleware, requireAgentPassport } from '@grantex/mpp';
+
+// Agent side: issue passport and attach to requests
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const passport = await grantex.passports.issue({
+  agentId: 'ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  allowedMPPCategories: ['inference', 'compute'],
+  maxTransactionAmount: { amount: 50, currency: 'USDC' },
+  expiresIn: '24h',
+});
+
+const middleware = createMppPassportMiddleware({ passport });
+const enriched = await middleware(new Request(url));
+// X-Grantex-Passport header attached
+
+// Merchant side: one-line verification
+app.use('/api/inference', requireAgentPassport({
+  requiredCategories: ['inference'],
+  maxAmount: 10,
+}));
+// req.agentPassport → { humanDID, orgDID, categories, maxAmount, ... }`,
+    features: [
+      ['AgentPassportCredential', 'W3C VC 2.0 with agent DID, human principal, org, categories, spending limits, and delegation depth.'],
+      ['<50ms Verification', 'Offline verification using cached JWKS. No API roundtrip to Grantex servers needed.'],
+      ['9 MPP Categories', 'inference, compute, data, storage, search, media, delivery, browser, general — each maps to a Grantex scope.'],
+      ['StatusList2021 Revocation', 'Revoke any passport instantly. Bit-flip propagation, no polling required.'],
+      ['Trust Registry', 'Public org trust lookup by DID. DNS-TXT, manual, or SOC 2 verification levels.'],
+      ['Auto-Refresh', 'Middleware proactively refreshes passports before expiry via onRefresh callback.'],
+    ],
+    ctaFramework: 'MPP',
+    metaTitle: 'Grantex for MPP — Agent Identity for Machine Payments Protocol',
+    metaDesc: 'Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.',
+  },
+};
+
+// Determine framework from URL
+const path = window.location.pathname.replace(/\/$/, '');
+const slug = path.split('/').pop();
+const fw = frameworks[slug];
+
+if (!fw) {
+  // Redirect to homepage if unknown framework
+  window.location.href = '/';
+} else {
+  // Set meta tags
+  document.title = fw.metaTitle;
+  document.querySelector('meta[name="description"]').content = fw.metaDesc;
+  document.querySelector('link[rel="canonical"]').href = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[property="og:title"]').content = fw.metaTitle;
+  document.querySelector('meta[property="og:description"]').content = fw.metaDesc;
+  document.querySelector('meta[property="og:url"]').content = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[name="twitter:title"]').content = fw.metaTitle;
+  document.querySelector('meta[name="twitter:description"]').content = fw.metaDesc;
+
+  // Populate content
+  document.getElementById('badge').textContent = fw.badge;
+  document.getElementById('heroTitle').innerHTML = fw.title;
+  document.getElementById('heroDesc').textContent = fw.desc;
+  document.getElementById('ctaDocs').href = fw.docsUrl;
+  document.getElementById('ctaInstall').href = fw.installUrl;
+  document.getElementById('problemBad').textContent = fw.problemBad;
+  document.getElementById('problemGood').textContent = fw.problemGood;
+  document.getElementById('howTitle').textContent = fw.howTitle;
+  document.getElementById('installCmd').textContent = fw.install;
+  document.getElementById('codeExample').textContent = fw.code;
+  document.getElementById('ctaFramework').textContent = fw.ctaFramework;
+  document.getElementById('ctaDocsBottom').href = fw.docsUrl;
+  document.getElementById('featuresTitle').textContent = 'Why Grantex for ' + fw.name;
+
+  // Steps
+  const stepsEl = document.getElementById('steps');
+  fw.steps.forEach(([title, desc]) => {
+    stepsEl.innerHTML += `<div class="step"><div class="step-content"><h3>${title}</h3><p>${desc}</p></div></div>`;
+  });
+
+  // Features
+  const featuresEl = document.getElementById('features');
+  fw.features.forEach(([title, desc]) => {
+    featuresEl.innerHTML += `<div class="feature-card"><h3>${title}</h3><p>${desc}</p></div>`;
+  });
+
+  // Add JSON-LD structured data
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Grantex for " + fw.name,
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Any",
+    "url": "https://grantex.dev/for/" + slug,
+    "description": fw.metaDesc,
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  };
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.textContent = JSON.stringify(jsonLd);
+  document.head.appendChild(script);
+
+  // Track page view
+  gtag('event', 'page_view', { page_title: fw.metaTitle, page_location: window.location.href });
+}
+</script>
+</body>
+</html>

--- a/web/for/mpp/index.html
+++ b/web/for/mpp/index.html
@@ -1,0 +1,787 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
+  <!-- Dynamic meta tags set by JS below -->
+  <title>Grantex for MPP — Agent Identity for Machine Payments Protocol</title>
+  <meta name="description" content="Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.">
+  <link rel="canonical" href="https://grantex.dev/for/mpp/">
+  <meta property="og:title" content="Grantex for MPP — Agent Identity for Machine Payments Protocol">
+  <meta property="og:description" content="Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.">
+  <meta property="og:url" content="https://grantex.dev/for/mpp/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Grantex">
+  <meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grantex for MPP — Agent Identity for Machine Payments Protocol">
+  <meta name="twitter:description" content="Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
+  <style>
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --border:   #30363d;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --accent:   #3fb950;
+      --accent2:  #58a6ff;
+      --mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+      --sans:     'Inter', system-ui, -apple-system, sans-serif;
+      --radius:   8px;
+      --max-w:    900px;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: var(--sans); line-height: 1.6; }
+    a { color: var(--accent2); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { font-family: var(--mono); background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+    pre { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; overflow-x: auto; font-family: var(--mono); font-size: 0.875rem; line-height: 1.5; }
+    pre code { background: none; padding: 0; }
+
+    /* Nav */
+    .nav { display: flex; align-items: center; justify-content: space-between; max-width: var(--max-w); margin: 0 auto; padding: 1rem 1.5rem; }
+    .nav-logo { font-weight: 700; font-size: 1.25rem; color: var(--text); }
+    .nav-links { list-style: none; display: flex; gap: 1.5rem; }
+    .nav-links a { color: var(--muted); font-size: 0.9rem; }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+
+    /* Hero */
+    .hero { text-align: center; padding: 4rem 1.5rem 3rem; max-width: var(--max-w); margin: 0 auto; }
+    .hero-badge { display: inline-block; background: rgba(63,185,80,0.15); color: var(--accent); padding: 0.25rem 0.75rem; border-radius: 999px; font-size: 0.8rem; font-weight: 600; margin-bottom: 1rem; }
+    .hero h1 { font-size: 2.5rem; line-height: 1.2; margin-bottom: 1rem; }
+    .hero h1 .highlight { color: var(--accent); }
+    .hero p { color: var(--muted); font-size: 1.1rem; max-width: 650px; margin: 0 auto 2rem; }
+    .hero-ctas { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
+    .btn { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.65rem 1.25rem; border-radius: var(--radius); font-weight: 600; font-size: 0.9rem; text-decoration: none; transition: all 0.2s; }
+    .btn-primary { background: var(--accent); color: #0d1117; }
+    .btn-primary:hover { background: #2ea043; text-decoration: none; }
+    .btn-secondary { background: var(--surface); color: var(--text); border: 1px solid var(--border); }
+    .btn-secondary:hover { border-color: var(--muted); text-decoration: none; }
+
+    /* Sections */
+    .section { max-width: var(--max-w); margin: 0 auto; padding: 3rem 1.5rem; }
+    .section h2 { font-size: 1.75rem; margin-bottom: 1rem; }
+    .section h3 { font-size: 1.15rem; margin-bottom: 0.5rem; color: var(--accent); }
+    .section p, .section li { color: var(--muted); }
+    .section ul { padding-left: 1.25rem; }
+    .section li { margin-bottom: 0.5rem; }
+
+    /* Problem cards */
+    .problem-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; margin: 1.5rem 0; }
+    .problem-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .problem-card.bad { border-color: #f8514933; }
+    .problem-card.good { border-color: #3fb95033; }
+    .problem-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .problem-card.bad h3 { color: #f85149; }
+    .problem-card.good h3 { color: var(--accent); }
+
+    /* Steps */
+    .steps { counter-reset: step; margin: 1.5rem 0; }
+    .step { display: flex; gap: 1rem; margin-bottom: 1.5rem; }
+    .step::before { counter-increment: step; content: counter(step); display: flex; align-items: center; justify-content: center; min-width: 32px; height: 32px; background: rgba(63,185,80,0.15); color: var(--accent); border-radius: 50%; font-weight: 700; font-size: 0.85rem; }
+    .step-content h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.25rem; }
+    .step-content p { font-size: 0.9rem; }
+
+    /* Features */
+    .feature-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.25rem; margin: 1.5rem 0; }
+    .feature-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .feature-card h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; }
+
+    /* Install */
+    .install-box { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.25rem; display: flex; align-items: center; justify-content: space-between; margin: 1rem 0; font-family: var(--mono); font-size: 0.9rem; }
+    .install-box button { background: var(--accent); color: #0d1117; border: none; padding: 0.35rem 0.75rem; border-radius: 4px; font-weight: 600; cursor: pointer; font-size: 0.8rem; }
+
+    /* Footer */
+    .footer { max-width: var(--max-w); margin: 0 auto; padding: 2rem 1.5rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; }
+    .footer-links { list-style: none; display: flex; gap: 1.5rem; }
+    .footer-links a { color: var(--muted); font-size: 0.85rem; }
+
+    @media (max-width: 640px) {
+      .hero h1 { font-size: 1.75rem; }
+      .problem-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Grantex for MPP (Machine Payments Protocol)","applicationCategory":"DeveloperApplication","operatingSystem":"Any","url":"https://grantex.dev/for/mpp/","description":"Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.","license":"https://www.apache.org/licenses/LICENSE-2.0"}</script>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/" class="nav-logo">Grantex</a>
+  <ul class="nav-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="/playground">Playground</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+  </ul>
+</nav>
+
+<div id="app">
+  <section class="hero">
+    <span class="hero-badge" id="badge"></span>
+    <h1 id="heroTitle"></h1>
+    <p id="heroDesc"></p>
+    <div class="hero-ctas">
+      <a href="" id="ctaDocs" class="btn btn-primary">View Integration Docs</a>
+      <a href="" id="ctaInstall" class="btn btn-secondary">Get Started</a>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2>The Problem</h2>
+    <div class="problem-grid">
+      <div class="problem-card bad">
+        <h3>Without Grantex</h3>
+        <p id="problemBad"></p>
+      </div>
+      <div class="problem-card good">
+        <h3>With Grantex</h3>
+        <p id="problemGood"></p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2 id="howTitle">How It Works</h2>
+    <div class="steps" id="steps"></div>
+  </section>
+
+  <section class="section">
+    <h2>Quick Start</h2>
+    <div class="install-box">
+      <span id="installCmd"></span>
+      <button onclick="navigator.clipboard.writeText(document.getElementById('installCmd').textContent);this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)">Copy</button>
+    </div>
+    <pre><code id="codeExample"></code></pre>
+  </section>
+
+  <section class="section">
+    <h2 id="featuresTitle">Why Grantex</h2>
+    <div class="feature-grid" id="features"></div>
+  </section>
+
+  <section class="section" style="text-align:center">
+    <h2>Ready to secure your <span id="ctaFramework"></span> agents?</h2>
+    <p style="margin-bottom:1.5rem;color:var(--muted)">Get started in under 5 minutes. Open source, Apache 2.0.</p>
+    <div class="hero-ctas">
+      <a href="https://grantex.dev/dashboard/signup" class="btn btn-primary">Sign Up Free</a>
+      <a href="" id="ctaDocsBottom" class="btn btn-secondary">Read the Docs</a>
+    </div>
+  </section>
+</div>
+
+<footer class="footer">
+  <span style="color:var(--muted);font-size:0.85rem">Grantex — Open authorization for AI agents</span>
+  <ul class="footer-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+    <li><a href="/">Home</a></li>
+  </ul>
+</footer>
+
+<script>
+const frameworks = {
+  langchain: {
+    name: 'LangChain',
+    badge: 'LangChain + Grantex',
+    title: 'Authorization for <span class="highlight">LangChain</span> Agents',
+    desc: 'Add scoped, revocable permissions to your LangChain agents. Grantex integrates natively with LangChain tools — your agents get signed JWTs instead of raw API keys.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    install: 'npm install @grantex/langchain @grantex/sdk',
+    problemBad: 'Your LangChain agents use raw API keys with full access. No scoping, no audit trail, no way to revoke access if an agent goes rogue. One compromised key exposes everything.',
+    problemGood: 'Each LangChain agent gets a scoped, time-limited JWT. Tools verify permissions offline. You can revoke any agent instantly. Every action is audit-logged with a hash chain.',
+    howTitle: 'How Grantex Works with LangChain',
+    steps: [
+      ['Install the integration', 'npm install @grantex/langchain — wraps LangChain tools with automatic grant verification.'],
+      ['Register your agent', 'Create an agent identity with specific scopes like "email:send" or "calendar:read".'],
+      ['Get user consent', 'Redirect the user to a consent page. They approve exactly which permissions the agent gets.'],
+      ['Agent receives a JWT', 'The agent gets a signed token it presents to any service. Services verify offline via JWKS.'],
+      ['Audit & revoke', 'Every action is logged. Revoke access in under 1 second if something goes wrong.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexToolkit } from '@grantex/langchain';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap your LangChain tools with Grantex authorization
+const toolkit = new GrantexToolkit({
+  client: gx,
+  grantToken: token,  // JWT from the consent flow
+  tools: [searchTool, emailTool],
+});
+
+// Tools now automatically verify scopes before executing
+const agent = createToolCallingAgent({ llm, tools: toolkit.tools });`,
+    features: [
+      ['Native LangChain Integration', 'Drop-in toolkit that wraps your existing LangChain tools with automatic scope verification.'],
+      ['Scoped Permissions', 'Define exactly what each agent can do — "email:read" vs "email:send". No more all-or-nothing API keys.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS without calling Grantex. Zero latency overhead on your LangChain pipeline.'],
+      ['Multi-Agent Delegation', 'Parent agents delegate narrower scopes to sub-agents. Revoking the parent cascades to all children.'],
+      ['Hash-Chained Audit Trail', 'Every tool invocation is logged in an append-only, tamper-evident audit trail.'],
+      ['Real-Time Revocation', 'Kill a misbehaving agent\'s access in under 1 second. No waiting for token expiry.'],
+    ],
+    ctaFramework: 'LangChain',
+    metaTitle: 'Grantex for LangChain — Authorization for LangChain AI Agents',
+    metaDesc: 'Add scoped, revocable permissions to LangChain agents. Drop-in toolkit for authorization with signed JWTs, audit trails, and real-time revocation. Open source.',
+  },
+  crewai: {
+    name: 'CrewAI',
+    badge: 'CrewAI + Grantex',
+    title: 'Authorization for <span class="highlight">CrewAI</span> Agents',
+    desc: 'Secure your CrewAI crews with scoped, revocable permissions. Each crew member gets exactly the access it needs — nothing more.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    install: 'pip install grantex-crewai grantex',
+    problemBad: 'Your CrewAI agents share the same API keys. If one crew member is compromised, the entire crew\'s access is exposed. No way to scope or revoke individual agent access.',
+    problemGood: 'Each crew member gets its own scoped JWT. The researcher can only read, the writer can only draft, the publisher can only post. Revoke any member instantly.',
+    howTitle: 'How Grantex Works with CrewAI',
+    steps: [
+      ['Install the integration', 'pip install grantex-crewai — Python-native integration for CrewAI crews.'],
+      ['Register each crew member', 'Create agent identities with role-specific scopes for each crew member.'],
+      ['Authorize the crew', 'Users approve scoped permissions for each role in the crew.'],
+      ['Crew operates with scoped tokens', 'Each crew member presents its own JWT. Services verify independently.'],
+      ['Monitor & control', 'Audit every crew action. Revoke individual members without stopping the whole crew.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_crewai import GrantexCrewTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Each crew member gets scoped authorization
+researcher_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=researcher_token,  # scoped to "search:read"
+    tools=[search_tool],
+)
+
+writer_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=writer_token,  # scoped to "docs:write"
+    tools=[write_tool],
+)`,
+    features: [
+      ['Per-Agent Scoping', 'Each crew member gets exactly the permissions it needs. Researcher reads, writer writes, publisher posts.'],
+      ['Role-Based Access', 'Map CrewAI roles to Grantex scopes. Define authorization policies per role, not per API key.'],
+      ['Crew-Wide Audit Trail', 'See what every crew member did, when, and with what permissions. Hash-chained for tamper evidence.'],
+      ['Delegation Chains', 'A lead agent can delegate narrower permissions to sub-agents. Revoking the lead cascades to all.'],
+      ['Python Native', 'Pure Python integration. pip install and go — works with any CrewAI version.'],
+      ['Instant Revocation', 'Revoke any crew member\'s access in under 1 second without disrupting the rest of the crew.'],
+    ],
+    ctaFramework: 'CrewAI',
+    metaTitle: 'Grantex for CrewAI — Secure Multi-Agent Crew Permissions',
+    metaDesc: 'Scope and control permissions for CrewAI agents. Each crew member gets its own signed JWT with role-specific access. Audit trails, delegation, real-time revocation.',
+  },
+  'openai-agents': {
+    name: 'OpenAI Agents SDK',
+    badge: 'OpenAI Agents + Grantex',
+    title: 'Authorization for <span class="highlight">OpenAI Agents SDK</span>',
+    desc: 'Add enterprise-grade authorization to your OpenAI agents. Scoped permissions, audit trails, and instant revocation — built for the Agents SDK.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    install: 'pip install grantex-openai-agents grantex',
+    problemBad: 'Your OpenAI agents operate with full API access. No scoping, no audit trail, no revocation. You can\'t tell which agent did what or limit what it can do.',
+    problemGood: 'Each agent gets a scoped, time-limited JWT. Every tool call is authorized and logged. Revoke access instantly if an agent behaves unexpectedly.',
+    howTitle: 'How Grantex Works with OpenAI Agents SDK',
+    steps: [
+      ['Install the integration', 'pip install grantex-openai-agents — wraps OpenAI agent tools with authorization.'],
+      ['Register your agent', 'Create an agent identity with scopes matching its capabilities.'],
+      ['Get user approval', 'Users approve exactly which permissions the agent receives via a consent page.'],
+      ['Agent operates with JWT', 'The agent\'s tools automatically verify permissions before executing.'],
+      ['Full audit trail', 'Every tool invocation is logged with the agent identity, scopes used, and timestamp.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_openai_agents import GrantexTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap OpenAI agent tools with Grantex authorization
+tools = GrantexTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, email_tool],
+)
+
+# Tools automatically check scopes before execution
+agent = Agent(
+    name="assistant",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['OpenAI Agents SDK Integration', 'Drop-in wrapper for OpenAI agent tools. Add authorization without changing your agent logic.'],
+      ['Scoped Tool Access', 'Define which tools each agent can use and with what parameters. Enforced at the protocol level.'],
+      ['Enterprise Audit Trail', 'Every tool call logged with agent identity, scopes, and hash-chained integrity.'],
+      ['Multi-Agent Pipelines', 'Parent agents delegate narrower access to sub-agents. Full delegation chain tracking.'],
+      ['Budget Controls', 'Set spending limits per agent. Automatic cutoff when budget is exhausted.'],
+      ['Compliance Ready', 'SOC 2 compatible audit logging. SCIM/SSO for enterprise identity management.'],
+    ],
+    ctaFramework: 'OpenAI Agents',
+    metaTitle: 'Grantex for OpenAI Agents SDK — Enterprise Agent Authorization',
+    metaDesc: 'Add scoped permissions, audit trails, and real-time revocation to OpenAI Agents SDK. Enterprise-grade authorization for AI agents. Open source.',
+  },
+  anthropic: {
+    name: 'Anthropic SDK',
+    badge: 'Anthropic + Grantex',
+    title: 'Authorization for <span class="highlight">Anthropic SDK</span> Tool Use',
+    desc: 'Enforce scoped permissions on Claude tool calls. Offline JWT verification, automatic audit logging, and instant revocation for Anthropic SDK apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    installUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    install: 'npm install @grantex/anthropic @grantex/sdk',
+    problemBad: 'Your Claude-powered agents call tools with no authorization layer. Any tool can be invoked with full access. No scoping, no consent, no audit trail of what the agent did.',
+    problemGood: 'Grantex wraps each tool with scope enforcement. The agent\'s JWT is checked offline before execution. Every tool call is audit-logged. Revoke access in under 1 second.',
+    howTitle: 'How Grantex Works with the Anthropic SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/anthropic — wraps Anthropic tool definitions with authorization.'],
+      ['Create scoped tools', 'Use createGrantexTool() to define tools with required scopes and JSON Schema input.'],
+      ['Pass tools to Claude', 'tool.definition is type-compatible with client.messages.create({ tools }).'],
+      ['Dispatch tool_use blocks', 'Use GrantexToolRegistry or handleToolCall() to execute with automatic audit logging.'],
+      ['Monitor everything', 'Hash-chained audit trail of every tool call. Revoke access in under 1 second.'],
+    ],
+    code: `import Anthropic from '@anthropic-ai/sdk';
+import { createGrantexTool, GrantexToolRegistry } from '@grantex/anthropic';
+
+const client = new Anthropic();
+
+const readFile = createGrantexTool({
+  name: 'read_file',
+  description: 'Read a file from disk',
+  inputSchema: {
+    type: 'object',
+    properties: { path: { type: 'string' } },
+    required: ['path'],
+  },
+  grantToken,
+  requiredScope: 'file:read',
+  execute: async ({ path }) => fs.readFile(path, 'utf-8'),
+});
+
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  tools: [readFile.definition],
+  messages,
+});`,
+    features: [
+      ['Anthropic SDK Native', 'Type-compatible with client.messages.create(). tool.definition drops in directly.'],
+      ['Offline Scope Checks', 'JWT scp claim verified locally. No network call to Grantex during execution.'],
+      ['Tool Registry', 'GrantexToolRegistry manages multiple tools and dispatches tool_use blocks by name.'],
+      ['Audit Logging', 'withAuditLogging() and handleToolCall() log every success/failure automatically.'],
+      ['GrantexScopeError', 'Typed error with requiredScope and grantedScopes for clean error handling.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Anthropic SDK',
+    metaTitle: 'Grantex for Anthropic SDK — Secure Claude Tool Use Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Claude tool use. Offline JWT verification, tool registry, and instant revocation. Open source.',
+  },
+  'google-adk': {
+    name: 'Google ADK',
+    badge: 'Google ADK + Grantex',
+    title: 'Authorization for <span class="highlight">Google ADK</span> Agents',
+    desc: 'Secure your Google Agent Development Kit agents with scoped, human-approved permissions and full audit trails.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    install: 'pip install grantex-adk grantex',
+    problemBad: 'Your ADK agents access services with broad credentials. No fine-grained scoping, no delegation control, no tamper-proof audit log of agent actions.',
+    problemGood: 'Each ADK agent gets cryptographic identity and scoped JWTs. Delegation chains track multi-agent workflows. Every action is audit-logged.',
+    howTitle: 'How Grantex Works with Google ADK',
+    steps: [
+      ['Install the integration', 'pip install grantex-adk — Python-native integration for Google ADK.'],
+      ['Register your agent', 'Create an agent identity with specific scopes matching your ADK agent\'s capabilities.'],
+      ['Authorize via consent', 'Users approve scoped permissions through a consent flow.'],
+      ['Agent operates securely', 'ADK tools verify permissions via JWT before executing any action.'],
+      ['Monitor everything', 'Hash-chained audit trail of every action. Revoke access in under 1 second.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_adk import GrantexADKTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap ADK tools with Grantex authorization
+tools = GrantexADKTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, calendar_tool],
+)
+
+# Tools verify scopes automatically
+agent = Agent(
+    model="gemini-2.0-flash",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['Google ADK Native', 'Built for the Agent Development Kit. Wraps ADK tools with automatic authorization.'],
+      ['Scoped Permissions', 'Fine-grained scopes for each capability. "calendar:read" vs "calendar:write".'],
+      ['Delegation Chains', 'Multi-agent ADK pipelines with tracked delegation. Revoke parent to cascade.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS. No network calls to Grantex during execution.'],
+      ['Audit & Compliance', 'Tamper-proof audit trail. SOC 2 compatible. Enterprise compliance exports.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Google ADK',
+    metaTitle: 'Grantex for Google ADK — Secure Agent Development Kit Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Google ADK agents. Delegation chains, real-time revocation, and enterprise compliance. Open source.',
+  },
+  'vercel-ai': {
+    name: 'Vercel AI SDK',
+    badge: 'Vercel AI + Grantex',
+    title: 'Authorization for <span class="highlight">Vercel AI SDK</span>',
+    desc: 'Add scoped authorization to your Vercel AI SDK tools. Signed JWTs, audit trails, and instant revocation for AI-powered apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    install: 'npm install @grantex/vercel-ai @grantex/sdk',
+    problemBad: 'Your Vercel AI tools run with full access. Users can\'t see or control what the AI does on their behalf. No audit trail, no revocation.',
+    problemGood: 'Each AI tool call is authorized with a scoped JWT. Users approve permissions upfront. Every action is logged. Revoke instantly.',
+    howTitle: 'How Grantex Works with Vercel AI SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/vercel-ai — TypeScript-native integration for Vercel AI SDK.'],
+      ['Define authorized tools', 'Wrap your AI SDK tools with Grantex scope requirements.'],
+      ['User consents', 'Users approve specific scopes before the AI can act on their behalf.'],
+      ['Tools verify automatically', 'Each tool call checks the JWT scopes before execution.'],
+      ['Full observability', 'Audit trail of every tool invocation. Real-time event streaming.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createGrantexTools } from '@grantex/vercel-ai';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap Vercel AI SDK tools with authorization
+const tools = createGrantexTools({
+  client: gx,
+  grantToken: token,
+  tools: { search: searchTool, email: emailTool },
+});
+
+// Use with generateText or streamText
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prompt: 'Search for flights and send the results',
+});`,
+    features: [
+      ['Vercel AI SDK Native', 'Works with generateText, streamText, and all AI SDK tool patterns.'],
+      ['TypeScript First', 'Full type safety. Scopes are checked at compile time and runtime.'],
+      ['Edge Compatible', 'Works in Vercel Edge Functions. JWT verification is local — no external calls.'],
+      ['Streaming Support', 'Compatible with streaming responses. Authorization doesn\'t block the stream.'],
+      ['Multi-Step Flows', 'Authorize multi-step AI workflows where each step requires different scopes.'],
+      ['Next.js Ready', 'Drop into your Next.js app with zero configuration beyond the SDK.'],
+    ],
+    ctaFramework: 'Vercel AI',
+    metaTitle: 'Grantex for Vercel AI SDK — Authorization for AI-Powered Apps',
+    metaDesc: 'Add scoped permissions to Vercel AI SDK tools. TypeScript-native, Edge-compatible, with audit trails and real-time revocation. Open source.',
+  },
+  autogen: {
+    name: 'AutoGen',
+    badge: 'AutoGen + Grantex',
+    title: 'Authorization for <span class="highlight">AutoGen</span> Multi-Agent Systems',
+    desc: 'Secure your AutoGen conversations with per-agent permissions. Each agent in the group gets exactly the scopes it needs.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    install: 'npm install @grantex/autogen @grantex/sdk',
+    problemBad: 'AutoGen agents in a group chat share credentials. If one agent is compromised or hallucinates, it has access to everything the others can do.',
+    problemGood: 'Each AutoGen agent gets its own scoped JWT. The coder can only write code, the executor can only run tests. Isolated, audited, revocable.',
+    howTitle: 'How Grantex Works with AutoGen',
+    steps: [
+      ['Install the integration', 'npm install @grantex/autogen — wraps AutoGen function maps with authorization.'],
+      ['Register each agent', 'Create identities with role-specific scopes for each agent in the group.'],
+      ['Scope per conversation', 'Users approve what each agent can do before the conversation starts.'],
+      ['Agents operate independently', 'Each agent presents its own JWT. Function calls are scope-checked automatically.'],
+      ['Trace everything', 'Full audit trail across the multi-agent conversation. Attribute actions to specific agents.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexAutoGen } from '@grantex/autogen';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Each agent in the group gets scoped authorization
+const coderTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: coderToken,  // scoped to "code:write"
+  functionMap: { write_code: writeCodeFn },
+});
+
+const executorTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: executorToken,  // scoped to "code:execute"
+  functionMap: { run_code: runCodeFn },
+});`,
+    features: [
+      ['Per-Agent Authorization', 'Each agent in the AutoGen group gets its own scoped token and identity.'],
+      ['Group Chat Security', 'Prevent agents from accessing tools outside their role. Enforced at the protocol level.'],
+      ['Conversation Auditing', 'Track which agent called which function, with what scopes, across the entire conversation.'],
+      ['Delegation Support', 'Agents can delegate narrower scopes to spawned sub-agents with depth tracking.'],
+      ['Function Map Wrapping', 'Drop-in wrapper for AutoGen function maps. No changes to your agent logic.'],
+      ['Real-Time Control', 'Revoke any agent mid-conversation. Access is denied within 1 second.'],
+    ],
+    ctaFramework: 'AutoGen',
+    metaTitle: 'Grantex for AutoGen — Secure Multi-Agent Group Chat Authorization',
+    metaDesc: 'Per-agent scoped permissions for AutoGen multi-agent systems. Each agent gets its own JWT. Audit trails, delegation chains, instant revocation.',
+  },
+  mcp: {
+    name: 'Model Context Protocol',
+    badge: 'MCP + Grantex',
+    title: 'Authorization for <span class="highlight">MCP</span> Servers',
+    desc: 'Add enterprise-grade authorization to any MCP server. 13 built-in tools for managing agents, grants, and tokens from Claude Desktop, Cursor, or Windsurf.',
+    docsUrl: 'https://docs.grantex.dev/integrations/mcp',
+    installUrl: 'https://docs.grantex.dev/integrations/mcp',
+    install: 'npm install @grantex/mcp',
+    problemBad: 'MCP servers expose tools to AI assistants with no authorization layer. Any connected client can call any tool with full access. No scoping, no consent, no audit trail.',
+    problemGood: 'Grantex adds OAuth 2.1-style authorization to MCP. Users approve scoped access per tool. Every invocation is logged. Revoke access from the permission dashboard.',
+    howTitle: 'How Grantex Works with MCP',
+    steps: [
+      ['Install the MCP server', 'npm install @grantex/mcp — adds 13 Grantex tools to any MCP-compatible client.'],
+      ['Connect to Claude Desktop', 'Add Grantex to your MCP config. Works with Claude Desktop, Cursor, and Windsurf.'],
+      ['Manage via natural language', 'Ask Claude to "register an agent", "create a grant", or "check the audit log".'],
+      ['Or add MCP Auth', 'Use @grantex/mcp-auth to add OAuth 2.1 + PKCE to your own MCP servers.'],
+      ['Full protocol access', 'All 13 Grantex operations available as MCP tools — agents, grants, tokens, audit, budgets.'],
+    ],
+    code: `// claude_desktop_config.json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "npx",
+      "args": ["@grantex/mcp"],
+      "env": {
+        "GRANTEX_API_KEY": "gx_live_..."
+      }
+    }
+  }
+}
+
+// Then in Claude Desktop:
+// "Register a new agent called travel-bot with flights:book scope"
+// "Create a grant for user alice on travel-bot"
+// "Show me the audit log for the last hour"`,
+    features: [
+      ['13 MCP Tools', 'Full Grantex protocol access: agents, grants, tokens, audit, budgets, verification — all as MCP tools.'],
+      ['Claude Desktop Ready', 'Works out of the box with Claude Desktop, Cursor, and Windsurf.'],
+      ['MCP Auth Server', 'Separate @grantex/mcp-auth package adds OAuth 2.1 + PKCE to any MCP server.'],
+      ['Natural Language Control', 'Manage authorization through conversation. "Revoke all grants for agent X."'],
+      ['Zero Code Setup', 'npx @grantex/mcp — no code required. Just add to your MCP config and go.'],
+      ['Enterprise Grade', 'Budget controls, policy engine, SCIM/SSO — all accessible via MCP tools.'],
+    ],
+    ctaFramework: 'MCP',
+    metaTitle: 'Grantex for MCP — Authorization for Model Context Protocol Servers',
+    metaDesc: 'Add OAuth 2.1 authorization to MCP servers. 13 tools for Claude Desktop, Cursor, and Windsurf. Scoped grants, audit trails, real-time revocation.',
+  },
+  express: {
+    name: 'Express.js',
+    badge: 'Express + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">Express.js</span>',
+    desc: 'Protect your Express.js APIs with Grantex grant tokens. Drop-in middleware that verifies JWTs, enforces scopes, and logs every request.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    install: 'npm install @grantex/express',
+    problemBad: 'Your Express APIs accept API keys or bearer tokens with no scope enforcement. Any valid token can access any endpoint. No agent identity tracking.',
+    problemGood: 'Grantex middleware verifies JWTs offline via JWKS, enforces scopes per route, and identifies the calling agent. Zero external network calls.',
+    howTitle: 'How Grantex Works with Express.js',
+    steps: [
+      ['Install the middleware', 'npm install @grantex/express — one package, zero external dependencies at runtime.'],
+      ['Add to your app', 'One line to protect your routes. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs are verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'req.grantex gives you the agent DID, scopes, principal, and grant ID.'],
+      ['Production ready', 'JWKS caching, key rotation, scope enforcement, and error handling built in.'],
+    ],
+    code: `import express from 'express';
+import { grantexMiddleware, requireScopes } from '@grantex/express';
+
+const app = express();
+
+// Verify Grantex JWTs on all /api routes
+app.use('/api', grantexMiddleware({
+  jwksUrl: 'https://grantex-auth-....a.run.app/.well-known/jwks.json',
+}));
+
+// Enforce specific scopes per route
+app.get('/api/emails', requireScopes(['email:read']), (req, res) => {
+  console.log(req.grantex.agent);  // agent DID
+  console.log(req.grantex.scopes); // ['email:read']
+  res.json({ emails: [] });
+});`,
+    features: [
+      ['Drop-In Middleware', 'One line to protect your Express routes. Works with any Express 4+ app.'],
+      ['Offline JWT Verification', 'JWKS-based verification. No network calls to Grantex on each request. Sub-millisecond overhead.'],
+      ['Per-Route Scopes', 'requireScopes() enforces specific permissions per endpoint. Returns 403 if scopes don\'t match.'],
+      ['Agent Identity', 'req.grantex provides agent DID, scopes, principal ID, grant ID on every request.'],
+      ['JWKS Caching', 'Automatic key caching and rotation. Handles key rollover transparently.'],
+      ['TypeScript Support', 'Full type definitions. req.grantex is fully typed.'],
+    ],
+    ctaFramework: 'Express.js',
+    metaTitle: 'Grantex for Express.js — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Drop-in Express.js middleware for Grantex JWT verification. Offline JWKS verification, per-route scope enforcement, and agent identity. Open source.',
+  },
+  fastapi: {
+    name: 'FastAPI',
+    badge: 'FastAPI + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">FastAPI</span>',
+    desc: 'Protect your FastAPI endpoints with Grantex grant tokens. Dependency-injection middleware that verifies JWTs, enforces scopes, and identifies agents.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    install: 'pip install grantex-fastapi',
+    problemBad: 'Your FastAPI endpoints accept bearer tokens with no scope enforcement. Any valid token accesses any route. No way to identify which AI agent made the request.',
+    problemGood: 'Grantex dependency verifies JWTs offline via JWKS, enforces scopes per route, and provides the agent identity. Pythonic, async, and type-safe.',
+    howTitle: 'How Grantex Works with FastAPI',
+    steps: [
+      ['Install the middleware', 'pip install grantex-fastapi — async-native, works with FastAPI\'s dependency injection.'],
+      ['Add the dependency', 'Use GrantexAuth as a FastAPI dependency. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'The dependency returns the full grant context: agent DID, scopes, principal, grant ID.'],
+      ['Production ready', 'Async JWKS fetching, key caching, automatic rotation, and proper error responses.'],
+    ],
+    code: `from fastapi import FastAPI, Depends
+from grantex_fastapi import GrantexAuth, GrantContext
+
+app = FastAPI()
+auth = GrantexAuth(
+    jwks_url="https://grantex-auth-....a.run.app/.well-known/jwks.json"
+)
+
+@app.get("/api/emails")
+async def list_emails(
+    grant: GrantContext = Depends(auth.require_scopes(["email:read"]))
+):
+    print(grant.agent)   # agent DID
+    print(grant.scopes)  # ["email:read"]
+    return {"emails": []}`,
+    features: [
+      ['FastAPI Dependency Injection', 'Works with FastAPI\'s Depends() pattern. Pythonic and type-safe.'],
+      ['Async Native', 'Fully async JWKS fetching and JWT verification. No blocking calls.'],
+      ['Per-Route Scopes', 'require_scopes() enforces specific permissions per endpoint. Returns 403 on mismatch.'],
+      ['Typed Grant Context', 'Full Pydantic model for grant context: agent DID, scopes, principal, grant ID.'],
+      ['JWKS Caching', 'Automatic async key caching and rotation. Handles key rollover transparently.'],
+      ['OpenAPI Integration', 'Scopes appear in your FastAPI OpenAPI docs automatically.'],
+    ],
+    ctaFramework: 'FastAPI',
+    metaTitle: 'Grantex for FastAPI — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.',
+  },
+  mpp: {
+    name: 'MPP (Machine Payments Protocol)',
+    badge: 'MPP + Grantex',
+    title: 'Agent Identity for <span class="highlight">Machine Payments</span>',
+    desc: 'MPP defines how AI agents pay for services. Grantex adds the missing identity layer — verifiable agent passports that let merchants know exactly who authorized every payment, with offline verification in under 50ms.',
+    docsUrl: 'https://docs.grantex.dev/features/mpp-agent-passport',
+    installUrl: 'https://docs.grantex.dev/guides/mpp-integration',
+    install: 'npm install @grantex/mpp @grantex/sdk',
+    problemBad: 'When an agent makes an MPP payment, the source is just a wallet address. No human name, no org, no authorization chain. For $0.10 API calls nobody cares. For $500 B2B procurement, it\'s a compliance blocker.',
+    problemGood: 'Every MPP payment carries an AgentPassportCredential — a W3C VC 2.0 credential with the human principal, org DID, spending limits, and allowed categories. Merchants verify in <50ms, offline.',
+    howTitle: 'How Grantex Works with MPP',
+    steps: [
+      ['Install the package', 'npm install @grantex/mpp — agent-side middleware + merchant-side verification in one package.'],
+      ['Issue an agent passport', 'Call grantex.passports.issue() with categories (inference, compute, data), spending limits, and expiry.'],
+      ['Attach to MPP requests', 'createMppPassportMiddleware() injects the X-Grantex-Passport header on every outgoing fetch.'],
+      ['Verify on the merchant side', 'requireAgentPassport() Express middleware — one line to verify identity, categories, and amounts.'],
+      ['Check the trust registry', 'lookupOrgTrust() returns verified org status (basic, verified, SOC 2) from the public registry.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createMppPassportMiddleware, requireAgentPassport } from '@grantex/mpp';
+
+// Agent side: issue passport and attach to requests
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const passport = await grantex.passports.issue({
+  agentId: 'ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  allowedMPPCategories: ['inference', 'compute'],
+  maxTransactionAmount: { amount: 50, currency: 'USDC' },
+  expiresIn: '24h',
+});
+
+const middleware = createMppPassportMiddleware({ passport });
+const enriched = await middleware(new Request(url));
+// X-Grantex-Passport header attached
+
+// Merchant side: one-line verification
+app.use('/api/inference', requireAgentPassport({
+  requiredCategories: ['inference'],
+  maxAmount: 10,
+}));
+// req.agentPassport → { humanDID, orgDID, categories, maxAmount, ... }`,
+    features: [
+      ['AgentPassportCredential', 'W3C VC 2.0 with agent DID, human principal, org, categories, spending limits, and delegation depth.'],
+      ['<50ms Verification', 'Offline verification using cached JWKS. No API roundtrip to Grantex servers needed.'],
+      ['9 MPP Categories', 'inference, compute, data, storage, search, media, delivery, browser, general — each maps to a Grantex scope.'],
+      ['StatusList2021 Revocation', 'Revoke any passport instantly. Bit-flip propagation, no polling required.'],
+      ['Trust Registry', 'Public org trust lookup by DID. DNS-TXT, manual, or SOC 2 verification levels.'],
+      ['Auto-Refresh', 'Middleware proactively refreshes passports before expiry via onRefresh callback.'],
+    ],
+    ctaFramework: 'MPP',
+    metaTitle: 'Grantex for MPP — Agent Identity for Machine Payments Protocol',
+    metaDesc: 'Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.',
+  },
+};
+
+// Determine framework from URL
+const path = window.location.pathname.replace(/\/$/, '');
+const slug = path.split('/').pop();
+const fw = frameworks[slug];
+
+if (!fw) {
+  // Redirect to homepage if unknown framework
+  window.location.href = '/';
+} else {
+  // Set meta tags
+  document.title = fw.metaTitle;
+  document.querySelector('meta[name="description"]').content = fw.metaDesc;
+  document.querySelector('link[rel="canonical"]').href = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[property="og:title"]').content = fw.metaTitle;
+  document.querySelector('meta[property="og:description"]').content = fw.metaDesc;
+  document.querySelector('meta[property="og:url"]').content = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[name="twitter:title"]').content = fw.metaTitle;
+  document.querySelector('meta[name="twitter:description"]').content = fw.metaDesc;
+
+  // Populate content
+  document.getElementById('badge').textContent = fw.badge;
+  document.getElementById('heroTitle').innerHTML = fw.title;
+  document.getElementById('heroDesc').textContent = fw.desc;
+  document.getElementById('ctaDocs').href = fw.docsUrl;
+  document.getElementById('ctaInstall').href = fw.installUrl;
+  document.getElementById('problemBad').textContent = fw.problemBad;
+  document.getElementById('problemGood').textContent = fw.problemGood;
+  document.getElementById('howTitle').textContent = fw.howTitle;
+  document.getElementById('installCmd').textContent = fw.install;
+  document.getElementById('codeExample').textContent = fw.code;
+  document.getElementById('ctaFramework').textContent = fw.ctaFramework;
+  document.getElementById('ctaDocsBottom').href = fw.docsUrl;
+  document.getElementById('featuresTitle').textContent = 'Why Grantex for ' + fw.name;
+
+  // Steps
+  const stepsEl = document.getElementById('steps');
+  fw.steps.forEach(([title, desc]) => {
+    stepsEl.innerHTML += `<div class="step"><div class="step-content"><h3>${title}</h3><p>${desc}</p></div></div>`;
+  });
+
+  // Features
+  const featuresEl = document.getElementById('features');
+  fw.features.forEach(([title, desc]) => {
+    featuresEl.innerHTML += `<div class="feature-card"><h3>${title}</h3><p>${desc}</p></div>`;
+  });
+
+  // Add JSON-LD structured data
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Grantex for " + fw.name,
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Any",
+    "url": "https://grantex.dev/for/" + slug,
+    "description": fw.metaDesc,
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  };
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.textContent = JSON.stringify(jsonLd);
+  document.head.appendChild(script);
+
+  // Track page view
+  gtag('event', 'page_view', { page_title: fw.metaTitle, page_location: window.location.href });
+}
+</script>
+</body>
+</html>

--- a/web/for/openai-agents/index.html
+++ b/web/for/openai-agents/index.html
@@ -1,0 +1,787 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
+  <!-- Dynamic meta tags set by JS below -->
+  <title>Grantex for OpenAI Agents SDK — Enterprise Agent Authorization</title>
+  <meta name="description" content="Add scoped permissions, audit trails, and real-time revocation to OpenAI Agents SDK. Enterprise-grade authorization for AI agents. Open source.">
+  <link rel="canonical" href="https://grantex.dev/for/openai-agents/">
+  <meta property="og:title" content="Grantex for OpenAI Agents SDK — Enterprise Agent Authorization">
+  <meta property="og:description" content="Add scoped permissions, audit trails, and real-time revocation to OpenAI Agents SDK. Enterprise-grade authorization for AI agents. Open source.">
+  <meta property="og:url" content="https://grantex.dev/for/openai-agents/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Grantex">
+  <meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grantex for OpenAI Agents SDK — Enterprise Agent Authorization">
+  <meta name="twitter:description" content="Add scoped permissions, audit trails, and real-time revocation to OpenAI Agents SDK. Enterprise-grade authorization for AI agents. Open source.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
+  <style>
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --border:   #30363d;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --accent:   #3fb950;
+      --accent2:  #58a6ff;
+      --mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+      --sans:     'Inter', system-ui, -apple-system, sans-serif;
+      --radius:   8px;
+      --max-w:    900px;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: var(--sans); line-height: 1.6; }
+    a { color: var(--accent2); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { font-family: var(--mono); background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+    pre { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; overflow-x: auto; font-family: var(--mono); font-size: 0.875rem; line-height: 1.5; }
+    pre code { background: none; padding: 0; }
+
+    /* Nav */
+    .nav { display: flex; align-items: center; justify-content: space-between; max-width: var(--max-w); margin: 0 auto; padding: 1rem 1.5rem; }
+    .nav-logo { font-weight: 700; font-size: 1.25rem; color: var(--text); }
+    .nav-links { list-style: none; display: flex; gap: 1.5rem; }
+    .nav-links a { color: var(--muted); font-size: 0.9rem; }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+
+    /* Hero */
+    .hero { text-align: center; padding: 4rem 1.5rem 3rem; max-width: var(--max-w); margin: 0 auto; }
+    .hero-badge { display: inline-block; background: rgba(63,185,80,0.15); color: var(--accent); padding: 0.25rem 0.75rem; border-radius: 999px; font-size: 0.8rem; font-weight: 600; margin-bottom: 1rem; }
+    .hero h1 { font-size: 2.5rem; line-height: 1.2; margin-bottom: 1rem; }
+    .hero h1 .highlight { color: var(--accent); }
+    .hero p { color: var(--muted); font-size: 1.1rem; max-width: 650px; margin: 0 auto 2rem; }
+    .hero-ctas { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
+    .btn { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.65rem 1.25rem; border-radius: var(--radius); font-weight: 600; font-size: 0.9rem; text-decoration: none; transition: all 0.2s; }
+    .btn-primary { background: var(--accent); color: #0d1117; }
+    .btn-primary:hover { background: #2ea043; text-decoration: none; }
+    .btn-secondary { background: var(--surface); color: var(--text); border: 1px solid var(--border); }
+    .btn-secondary:hover { border-color: var(--muted); text-decoration: none; }
+
+    /* Sections */
+    .section { max-width: var(--max-w); margin: 0 auto; padding: 3rem 1.5rem; }
+    .section h2 { font-size: 1.75rem; margin-bottom: 1rem; }
+    .section h3 { font-size: 1.15rem; margin-bottom: 0.5rem; color: var(--accent); }
+    .section p, .section li { color: var(--muted); }
+    .section ul { padding-left: 1.25rem; }
+    .section li { margin-bottom: 0.5rem; }
+
+    /* Problem cards */
+    .problem-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; margin: 1.5rem 0; }
+    .problem-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .problem-card.bad { border-color: #f8514933; }
+    .problem-card.good { border-color: #3fb95033; }
+    .problem-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .problem-card.bad h3 { color: #f85149; }
+    .problem-card.good h3 { color: var(--accent); }
+
+    /* Steps */
+    .steps { counter-reset: step; margin: 1.5rem 0; }
+    .step { display: flex; gap: 1rem; margin-bottom: 1.5rem; }
+    .step::before { counter-increment: step; content: counter(step); display: flex; align-items: center; justify-content: center; min-width: 32px; height: 32px; background: rgba(63,185,80,0.15); color: var(--accent); border-radius: 50%; font-weight: 700; font-size: 0.85rem; }
+    .step-content h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.25rem; }
+    .step-content p { font-size: 0.9rem; }
+
+    /* Features */
+    .feature-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.25rem; margin: 1.5rem 0; }
+    .feature-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .feature-card h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; }
+
+    /* Install */
+    .install-box { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.25rem; display: flex; align-items: center; justify-content: space-between; margin: 1rem 0; font-family: var(--mono); font-size: 0.9rem; }
+    .install-box button { background: var(--accent); color: #0d1117; border: none; padding: 0.35rem 0.75rem; border-radius: 4px; font-weight: 600; cursor: pointer; font-size: 0.8rem; }
+
+    /* Footer */
+    .footer { max-width: var(--max-w); margin: 0 auto; padding: 2rem 1.5rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; }
+    .footer-links { list-style: none; display: flex; gap: 1.5rem; }
+    .footer-links a { color: var(--muted); font-size: 0.85rem; }
+
+    @media (max-width: 640px) {
+      .hero h1 { font-size: 1.75rem; }
+      .problem-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Grantex for OpenAI Agents SDK","applicationCategory":"DeveloperApplication","operatingSystem":"Any","url":"https://grantex.dev/for/openai-agents/","description":"Add scoped permissions, audit trails, and real-time revocation to OpenAI Agents SDK. Enterprise-grade authorization for AI agents. Open source.","license":"https://www.apache.org/licenses/LICENSE-2.0"}</script>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/" class="nav-logo">Grantex</a>
+  <ul class="nav-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="/playground">Playground</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+  </ul>
+</nav>
+
+<div id="app">
+  <section class="hero">
+    <span class="hero-badge" id="badge"></span>
+    <h1 id="heroTitle"></h1>
+    <p id="heroDesc"></p>
+    <div class="hero-ctas">
+      <a href="" id="ctaDocs" class="btn btn-primary">View Integration Docs</a>
+      <a href="" id="ctaInstall" class="btn btn-secondary">Get Started</a>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2>The Problem</h2>
+    <div class="problem-grid">
+      <div class="problem-card bad">
+        <h3>Without Grantex</h3>
+        <p id="problemBad"></p>
+      </div>
+      <div class="problem-card good">
+        <h3>With Grantex</h3>
+        <p id="problemGood"></p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2 id="howTitle">How It Works</h2>
+    <div class="steps" id="steps"></div>
+  </section>
+
+  <section class="section">
+    <h2>Quick Start</h2>
+    <div class="install-box">
+      <span id="installCmd"></span>
+      <button onclick="navigator.clipboard.writeText(document.getElementById('installCmd').textContent);this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)">Copy</button>
+    </div>
+    <pre><code id="codeExample"></code></pre>
+  </section>
+
+  <section class="section">
+    <h2 id="featuresTitle">Why Grantex</h2>
+    <div class="feature-grid" id="features"></div>
+  </section>
+
+  <section class="section" style="text-align:center">
+    <h2>Ready to secure your <span id="ctaFramework"></span> agents?</h2>
+    <p style="margin-bottom:1.5rem;color:var(--muted)">Get started in under 5 minutes. Open source, Apache 2.0.</p>
+    <div class="hero-ctas">
+      <a href="https://grantex.dev/dashboard/signup" class="btn btn-primary">Sign Up Free</a>
+      <a href="" id="ctaDocsBottom" class="btn btn-secondary">Read the Docs</a>
+    </div>
+  </section>
+</div>
+
+<footer class="footer">
+  <span style="color:var(--muted);font-size:0.85rem">Grantex — Open authorization for AI agents</span>
+  <ul class="footer-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+    <li><a href="/">Home</a></li>
+  </ul>
+</footer>
+
+<script>
+const frameworks = {
+  langchain: {
+    name: 'LangChain',
+    badge: 'LangChain + Grantex',
+    title: 'Authorization for <span class="highlight">LangChain</span> Agents',
+    desc: 'Add scoped, revocable permissions to your LangChain agents. Grantex integrates natively with LangChain tools — your agents get signed JWTs instead of raw API keys.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    install: 'npm install @grantex/langchain @grantex/sdk',
+    problemBad: 'Your LangChain agents use raw API keys with full access. No scoping, no audit trail, no way to revoke access if an agent goes rogue. One compromised key exposes everything.',
+    problemGood: 'Each LangChain agent gets a scoped, time-limited JWT. Tools verify permissions offline. You can revoke any agent instantly. Every action is audit-logged with a hash chain.',
+    howTitle: 'How Grantex Works with LangChain',
+    steps: [
+      ['Install the integration', 'npm install @grantex/langchain — wraps LangChain tools with automatic grant verification.'],
+      ['Register your agent', 'Create an agent identity with specific scopes like "email:send" or "calendar:read".'],
+      ['Get user consent', 'Redirect the user to a consent page. They approve exactly which permissions the agent gets.'],
+      ['Agent receives a JWT', 'The agent gets a signed token it presents to any service. Services verify offline via JWKS.'],
+      ['Audit & revoke', 'Every action is logged. Revoke access in under 1 second if something goes wrong.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexToolkit } from '@grantex/langchain';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap your LangChain tools with Grantex authorization
+const toolkit = new GrantexToolkit({
+  client: gx,
+  grantToken: token,  // JWT from the consent flow
+  tools: [searchTool, emailTool],
+});
+
+// Tools now automatically verify scopes before executing
+const agent = createToolCallingAgent({ llm, tools: toolkit.tools });`,
+    features: [
+      ['Native LangChain Integration', 'Drop-in toolkit that wraps your existing LangChain tools with automatic scope verification.'],
+      ['Scoped Permissions', 'Define exactly what each agent can do — "email:read" vs "email:send". No more all-or-nothing API keys.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS without calling Grantex. Zero latency overhead on your LangChain pipeline.'],
+      ['Multi-Agent Delegation', 'Parent agents delegate narrower scopes to sub-agents. Revoking the parent cascades to all children.'],
+      ['Hash-Chained Audit Trail', 'Every tool invocation is logged in an append-only, tamper-evident audit trail.'],
+      ['Real-Time Revocation', 'Kill a misbehaving agent\'s access in under 1 second. No waiting for token expiry.'],
+    ],
+    ctaFramework: 'LangChain',
+    metaTitle: 'Grantex for LangChain — Authorization for LangChain AI Agents',
+    metaDesc: 'Add scoped, revocable permissions to LangChain agents. Drop-in toolkit for authorization with signed JWTs, audit trails, and real-time revocation. Open source.',
+  },
+  crewai: {
+    name: 'CrewAI',
+    badge: 'CrewAI + Grantex',
+    title: 'Authorization for <span class="highlight">CrewAI</span> Agents',
+    desc: 'Secure your CrewAI crews with scoped, revocable permissions. Each crew member gets exactly the access it needs — nothing more.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    install: 'pip install grantex-crewai grantex',
+    problemBad: 'Your CrewAI agents share the same API keys. If one crew member is compromised, the entire crew\'s access is exposed. No way to scope or revoke individual agent access.',
+    problemGood: 'Each crew member gets its own scoped JWT. The researcher can only read, the writer can only draft, the publisher can only post. Revoke any member instantly.',
+    howTitle: 'How Grantex Works with CrewAI',
+    steps: [
+      ['Install the integration', 'pip install grantex-crewai — Python-native integration for CrewAI crews.'],
+      ['Register each crew member', 'Create agent identities with role-specific scopes for each crew member.'],
+      ['Authorize the crew', 'Users approve scoped permissions for each role in the crew.'],
+      ['Crew operates with scoped tokens', 'Each crew member presents its own JWT. Services verify independently.'],
+      ['Monitor & control', 'Audit every crew action. Revoke individual members without stopping the whole crew.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_crewai import GrantexCrewTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Each crew member gets scoped authorization
+researcher_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=researcher_token,  # scoped to "search:read"
+    tools=[search_tool],
+)
+
+writer_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=writer_token,  # scoped to "docs:write"
+    tools=[write_tool],
+)`,
+    features: [
+      ['Per-Agent Scoping', 'Each crew member gets exactly the permissions it needs. Researcher reads, writer writes, publisher posts.'],
+      ['Role-Based Access', 'Map CrewAI roles to Grantex scopes. Define authorization policies per role, not per API key.'],
+      ['Crew-Wide Audit Trail', 'See what every crew member did, when, and with what permissions. Hash-chained for tamper evidence.'],
+      ['Delegation Chains', 'A lead agent can delegate narrower permissions to sub-agents. Revoking the lead cascades to all.'],
+      ['Python Native', 'Pure Python integration. pip install and go — works with any CrewAI version.'],
+      ['Instant Revocation', 'Revoke any crew member\'s access in under 1 second without disrupting the rest of the crew.'],
+    ],
+    ctaFramework: 'CrewAI',
+    metaTitle: 'Grantex for CrewAI — Secure Multi-Agent Crew Permissions',
+    metaDesc: 'Scope and control permissions for CrewAI agents. Each crew member gets its own signed JWT with role-specific access. Audit trails, delegation, real-time revocation.',
+  },
+  'openai-agents': {
+    name: 'OpenAI Agents SDK',
+    badge: 'OpenAI Agents + Grantex',
+    title: 'Authorization for <span class="highlight">OpenAI Agents SDK</span>',
+    desc: 'Add enterprise-grade authorization to your OpenAI agents. Scoped permissions, audit trails, and instant revocation — built for the Agents SDK.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    install: 'pip install grantex-openai-agents grantex',
+    problemBad: 'Your OpenAI agents operate with full API access. No scoping, no audit trail, no revocation. You can\'t tell which agent did what or limit what it can do.',
+    problemGood: 'Each agent gets a scoped, time-limited JWT. Every tool call is authorized and logged. Revoke access instantly if an agent behaves unexpectedly.',
+    howTitle: 'How Grantex Works with OpenAI Agents SDK',
+    steps: [
+      ['Install the integration', 'pip install grantex-openai-agents — wraps OpenAI agent tools with authorization.'],
+      ['Register your agent', 'Create an agent identity with scopes matching its capabilities.'],
+      ['Get user approval', 'Users approve exactly which permissions the agent receives via a consent page.'],
+      ['Agent operates with JWT', 'The agent\'s tools automatically verify permissions before executing.'],
+      ['Full audit trail', 'Every tool invocation is logged with the agent identity, scopes used, and timestamp.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_openai_agents import GrantexTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap OpenAI agent tools with Grantex authorization
+tools = GrantexTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, email_tool],
+)
+
+# Tools automatically check scopes before execution
+agent = Agent(
+    name="assistant",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['OpenAI Agents SDK Integration', 'Drop-in wrapper for OpenAI agent tools. Add authorization without changing your agent logic.'],
+      ['Scoped Tool Access', 'Define which tools each agent can use and with what parameters. Enforced at the protocol level.'],
+      ['Enterprise Audit Trail', 'Every tool call logged with agent identity, scopes, and hash-chained integrity.'],
+      ['Multi-Agent Pipelines', 'Parent agents delegate narrower access to sub-agents. Full delegation chain tracking.'],
+      ['Budget Controls', 'Set spending limits per agent. Automatic cutoff when budget is exhausted.'],
+      ['Compliance Ready', 'SOC 2 compatible audit logging. SCIM/SSO for enterprise identity management.'],
+    ],
+    ctaFramework: 'OpenAI Agents',
+    metaTitle: 'Grantex for OpenAI Agents SDK — Enterprise Agent Authorization',
+    metaDesc: 'Add scoped permissions, audit trails, and real-time revocation to OpenAI Agents SDK. Enterprise-grade authorization for AI agents. Open source.',
+  },
+  anthropic: {
+    name: 'Anthropic SDK',
+    badge: 'Anthropic + Grantex',
+    title: 'Authorization for <span class="highlight">Anthropic SDK</span> Tool Use',
+    desc: 'Enforce scoped permissions on Claude tool calls. Offline JWT verification, automatic audit logging, and instant revocation for Anthropic SDK apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    installUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    install: 'npm install @grantex/anthropic @grantex/sdk',
+    problemBad: 'Your Claude-powered agents call tools with no authorization layer. Any tool can be invoked with full access. No scoping, no consent, no audit trail of what the agent did.',
+    problemGood: 'Grantex wraps each tool with scope enforcement. The agent\'s JWT is checked offline before execution. Every tool call is audit-logged. Revoke access in under 1 second.',
+    howTitle: 'How Grantex Works with the Anthropic SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/anthropic — wraps Anthropic tool definitions with authorization.'],
+      ['Create scoped tools', 'Use createGrantexTool() to define tools with required scopes and JSON Schema input.'],
+      ['Pass tools to Claude', 'tool.definition is type-compatible with client.messages.create({ tools }).'],
+      ['Dispatch tool_use blocks', 'Use GrantexToolRegistry or handleToolCall() to execute with automatic audit logging.'],
+      ['Monitor everything', 'Hash-chained audit trail of every tool call. Revoke access in under 1 second.'],
+    ],
+    code: `import Anthropic from '@anthropic-ai/sdk';
+import { createGrantexTool, GrantexToolRegistry } from '@grantex/anthropic';
+
+const client = new Anthropic();
+
+const readFile = createGrantexTool({
+  name: 'read_file',
+  description: 'Read a file from disk',
+  inputSchema: {
+    type: 'object',
+    properties: { path: { type: 'string' } },
+    required: ['path'],
+  },
+  grantToken,
+  requiredScope: 'file:read',
+  execute: async ({ path }) => fs.readFile(path, 'utf-8'),
+});
+
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  tools: [readFile.definition],
+  messages,
+});`,
+    features: [
+      ['Anthropic SDK Native', 'Type-compatible with client.messages.create(). tool.definition drops in directly.'],
+      ['Offline Scope Checks', 'JWT scp claim verified locally. No network call to Grantex during execution.'],
+      ['Tool Registry', 'GrantexToolRegistry manages multiple tools and dispatches tool_use blocks by name.'],
+      ['Audit Logging', 'withAuditLogging() and handleToolCall() log every success/failure automatically.'],
+      ['GrantexScopeError', 'Typed error with requiredScope and grantedScopes for clean error handling.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Anthropic SDK',
+    metaTitle: 'Grantex for Anthropic SDK — Secure Claude Tool Use Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Claude tool use. Offline JWT verification, tool registry, and instant revocation. Open source.',
+  },
+  'google-adk': {
+    name: 'Google ADK',
+    badge: 'Google ADK + Grantex',
+    title: 'Authorization for <span class="highlight">Google ADK</span> Agents',
+    desc: 'Secure your Google Agent Development Kit agents with scoped, human-approved permissions and full audit trails.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    install: 'pip install grantex-adk grantex',
+    problemBad: 'Your ADK agents access services with broad credentials. No fine-grained scoping, no delegation control, no tamper-proof audit log of agent actions.',
+    problemGood: 'Each ADK agent gets cryptographic identity and scoped JWTs. Delegation chains track multi-agent workflows. Every action is audit-logged.',
+    howTitle: 'How Grantex Works with Google ADK',
+    steps: [
+      ['Install the integration', 'pip install grantex-adk — Python-native integration for Google ADK.'],
+      ['Register your agent', 'Create an agent identity with specific scopes matching your ADK agent\'s capabilities.'],
+      ['Authorize via consent', 'Users approve scoped permissions through a consent flow.'],
+      ['Agent operates securely', 'ADK tools verify permissions via JWT before executing any action.'],
+      ['Monitor everything', 'Hash-chained audit trail of every action. Revoke access in under 1 second.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_adk import GrantexADKTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap ADK tools with Grantex authorization
+tools = GrantexADKTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, calendar_tool],
+)
+
+# Tools verify scopes automatically
+agent = Agent(
+    model="gemini-2.0-flash",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['Google ADK Native', 'Built for the Agent Development Kit. Wraps ADK tools with automatic authorization.'],
+      ['Scoped Permissions', 'Fine-grained scopes for each capability. "calendar:read" vs "calendar:write".'],
+      ['Delegation Chains', 'Multi-agent ADK pipelines with tracked delegation. Revoke parent to cascade.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS. No network calls to Grantex during execution.'],
+      ['Audit & Compliance', 'Tamper-proof audit trail. SOC 2 compatible. Enterprise compliance exports.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Google ADK',
+    metaTitle: 'Grantex for Google ADK — Secure Agent Development Kit Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Google ADK agents. Delegation chains, real-time revocation, and enterprise compliance. Open source.',
+  },
+  'vercel-ai': {
+    name: 'Vercel AI SDK',
+    badge: 'Vercel AI + Grantex',
+    title: 'Authorization for <span class="highlight">Vercel AI SDK</span>',
+    desc: 'Add scoped authorization to your Vercel AI SDK tools. Signed JWTs, audit trails, and instant revocation for AI-powered apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    install: 'npm install @grantex/vercel-ai @grantex/sdk',
+    problemBad: 'Your Vercel AI tools run with full access. Users can\'t see or control what the AI does on their behalf. No audit trail, no revocation.',
+    problemGood: 'Each AI tool call is authorized with a scoped JWT. Users approve permissions upfront. Every action is logged. Revoke instantly.',
+    howTitle: 'How Grantex Works with Vercel AI SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/vercel-ai — TypeScript-native integration for Vercel AI SDK.'],
+      ['Define authorized tools', 'Wrap your AI SDK tools with Grantex scope requirements.'],
+      ['User consents', 'Users approve specific scopes before the AI can act on their behalf.'],
+      ['Tools verify automatically', 'Each tool call checks the JWT scopes before execution.'],
+      ['Full observability', 'Audit trail of every tool invocation. Real-time event streaming.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createGrantexTools } from '@grantex/vercel-ai';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap Vercel AI SDK tools with authorization
+const tools = createGrantexTools({
+  client: gx,
+  grantToken: token,
+  tools: { search: searchTool, email: emailTool },
+});
+
+// Use with generateText or streamText
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prompt: 'Search for flights and send the results',
+});`,
+    features: [
+      ['Vercel AI SDK Native', 'Works with generateText, streamText, and all AI SDK tool patterns.'],
+      ['TypeScript First', 'Full type safety. Scopes are checked at compile time and runtime.'],
+      ['Edge Compatible', 'Works in Vercel Edge Functions. JWT verification is local — no external calls.'],
+      ['Streaming Support', 'Compatible with streaming responses. Authorization doesn\'t block the stream.'],
+      ['Multi-Step Flows', 'Authorize multi-step AI workflows where each step requires different scopes.'],
+      ['Next.js Ready', 'Drop into your Next.js app with zero configuration beyond the SDK.'],
+    ],
+    ctaFramework: 'Vercel AI',
+    metaTitle: 'Grantex for Vercel AI SDK — Authorization for AI-Powered Apps',
+    metaDesc: 'Add scoped permissions to Vercel AI SDK tools. TypeScript-native, Edge-compatible, with audit trails and real-time revocation. Open source.',
+  },
+  autogen: {
+    name: 'AutoGen',
+    badge: 'AutoGen + Grantex',
+    title: 'Authorization for <span class="highlight">AutoGen</span> Multi-Agent Systems',
+    desc: 'Secure your AutoGen conversations with per-agent permissions. Each agent in the group gets exactly the scopes it needs.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    install: 'npm install @grantex/autogen @grantex/sdk',
+    problemBad: 'AutoGen agents in a group chat share credentials. If one agent is compromised or hallucinates, it has access to everything the others can do.',
+    problemGood: 'Each AutoGen agent gets its own scoped JWT. The coder can only write code, the executor can only run tests. Isolated, audited, revocable.',
+    howTitle: 'How Grantex Works with AutoGen',
+    steps: [
+      ['Install the integration', 'npm install @grantex/autogen — wraps AutoGen function maps with authorization.'],
+      ['Register each agent', 'Create identities with role-specific scopes for each agent in the group.'],
+      ['Scope per conversation', 'Users approve what each agent can do before the conversation starts.'],
+      ['Agents operate independently', 'Each agent presents its own JWT. Function calls are scope-checked automatically.'],
+      ['Trace everything', 'Full audit trail across the multi-agent conversation. Attribute actions to specific agents.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexAutoGen } from '@grantex/autogen';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Each agent in the group gets scoped authorization
+const coderTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: coderToken,  // scoped to "code:write"
+  functionMap: { write_code: writeCodeFn },
+});
+
+const executorTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: executorToken,  // scoped to "code:execute"
+  functionMap: { run_code: runCodeFn },
+});`,
+    features: [
+      ['Per-Agent Authorization', 'Each agent in the AutoGen group gets its own scoped token and identity.'],
+      ['Group Chat Security', 'Prevent agents from accessing tools outside their role. Enforced at the protocol level.'],
+      ['Conversation Auditing', 'Track which agent called which function, with what scopes, across the entire conversation.'],
+      ['Delegation Support', 'Agents can delegate narrower scopes to spawned sub-agents with depth tracking.'],
+      ['Function Map Wrapping', 'Drop-in wrapper for AutoGen function maps. No changes to your agent logic.'],
+      ['Real-Time Control', 'Revoke any agent mid-conversation. Access is denied within 1 second.'],
+    ],
+    ctaFramework: 'AutoGen',
+    metaTitle: 'Grantex for AutoGen — Secure Multi-Agent Group Chat Authorization',
+    metaDesc: 'Per-agent scoped permissions for AutoGen multi-agent systems. Each agent gets its own JWT. Audit trails, delegation chains, instant revocation.',
+  },
+  mcp: {
+    name: 'Model Context Protocol',
+    badge: 'MCP + Grantex',
+    title: 'Authorization for <span class="highlight">MCP</span> Servers',
+    desc: 'Add enterprise-grade authorization to any MCP server. 13 built-in tools for managing agents, grants, and tokens from Claude Desktop, Cursor, or Windsurf.',
+    docsUrl: 'https://docs.grantex.dev/integrations/mcp',
+    installUrl: 'https://docs.grantex.dev/integrations/mcp',
+    install: 'npm install @grantex/mcp',
+    problemBad: 'MCP servers expose tools to AI assistants with no authorization layer. Any connected client can call any tool with full access. No scoping, no consent, no audit trail.',
+    problemGood: 'Grantex adds OAuth 2.1-style authorization to MCP. Users approve scoped access per tool. Every invocation is logged. Revoke access from the permission dashboard.',
+    howTitle: 'How Grantex Works with MCP',
+    steps: [
+      ['Install the MCP server', 'npm install @grantex/mcp — adds 13 Grantex tools to any MCP-compatible client.'],
+      ['Connect to Claude Desktop', 'Add Grantex to your MCP config. Works with Claude Desktop, Cursor, and Windsurf.'],
+      ['Manage via natural language', 'Ask Claude to "register an agent", "create a grant", or "check the audit log".'],
+      ['Or add MCP Auth', 'Use @grantex/mcp-auth to add OAuth 2.1 + PKCE to your own MCP servers.'],
+      ['Full protocol access', 'All 13 Grantex operations available as MCP tools — agents, grants, tokens, audit, budgets.'],
+    ],
+    code: `// claude_desktop_config.json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "npx",
+      "args": ["@grantex/mcp"],
+      "env": {
+        "GRANTEX_API_KEY": "gx_live_..."
+      }
+    }
+  }
+}
+
+// Then in Claude Desktop:
+// "Register a new agent called travel-bot with flights:book scope"
+// "Create a grant for user alice on travel-bot"
+// "Show me the audit log for the last hour"`,
+    features: [
+      ['13 MCP Tools', 'Full Grantex protocol access: agents, grants, tokens, audit, budgets, verification — all as MCP tools.'],
+      ['Claude Desktop Ready', 'Works out of the box with Claude Desktop, Cursor, and Windsurf.'],
+      ['MCP Auth Server', 'Separate @grantex/mcp-auth package adds OAuth 2.1 + PKCE to any MCP server.'],
+      ['Natural Language Control', 'Manage authorization through conversation. "Revoke all grants for agent X."'],
+      ['Zero Code Setup', 'npx @grantex/mcp — no code required. Just add to your MCP config and go.'],
+      ['Enterprise Grade', 'Budget controls, policy engine, SCIM/SSO — all accessible via MCP tools.'],
+    ],
+    ctaFramework: 'MCP',
+    metaTitle: 'Grantex for MCP — Authorization for Model Context Protocol Servers',
+    metaDesc: 'Add OAuth 2.1 authorization to MCP servers. 13 tools for Claude Desktop, Cursor, and Windsurf. Scoped grants, audit trails, real-time revocation.',
+  },
+  express: {
+    name: 'Express.js',
+    badge: 'Express + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">Express.js</span>',
+    desc: 'Protect your Express.js APIs with Grantex grant tokens. Drop-in middleware that verifies JWTs, enforces scopes, and logs every request.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    install: 'npm install @grantex/express',
+    problemBad: 'Your Express APIs accept API keys or bearer tokens with no scope enforcement. Any valid token can access any endpoint. No agent identity tracking.',
+    problemGood: 'Grantex middleware verifies JWTs offline via JWKS, enforces scopes per route, and identifies the calling agent. Zero external network calls.',
+    howTitle: 'How Grantex Works with Express.js',
+    steps: [
+      ['Install the middleware', 'npm install @grantex/express — one package, zero external dependencies at runtime.'],
+      ['Add to your app', 'One line to protect your routes. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs are verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'req.grantex gives you the agent DID, scopes, principal, and grant ID.'],
+      ['Production ready', 'JWKS caching, key rotation, scope enforcement, and error handling built in.'],
+    ],
+    code: `import express from 'express';
+import { grantexMiddleware, requireScopes } from '@grantex/express';
+
+const app = express();
+
+// Verify Grantex JWTs on all /api routes
+app.use('/api', grantexMiddleware({
+  jwksUrl: 'https://grantex-auth-....a.run.app/.well-known/jwks.json',
+}));
+
+// Enforce specific scopes per route
+app.get('/api/emails', requireScopes(['email:read']), (req, res) => {
+  console.log(req.grantex.agent);  // agent DID
+  console.log(req.grantex.scopes); // ['email:read']
+  res.json({ emails: [] });
+});`,
+    features: [
+      ['Drop-In Middleware', 'One line to protect your Express routes. Works with any Express 4+ app.'],
+      ['Offline JWT Verification', 'JWKS-based verification. No network calls to Grantex on each request. Sub-millisecond overhead.'],
+      ['Per-Route Scopes', 'requireScopes() enforces specific permissions per endpoint. Returns 403 if scopes don\'t match.'],
+      ['Agent Identity', 'req.grantex provides agent DID, scopes, principal ID, grant ID on every request.'],
+      ['JWKS Caching', 'Automatic key caching and rotation. Handles key rollover transparently.'],
+      ['TypeScript Support', 'Full type definitions. req.grantex is fully typed.'],
+    ],
+    ctaFramework: 'Express.js',
+    metaTitle: 'Grantex for Express.js — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Drop-in Express.js middleware for Grantex JWT verification. Offline JWKS verification, per-route scope enforcement, and agent identity. Open source.',
+  },
+  fastapi: {
+    name: 'FastAPI',
+    badge: 'FastAPI + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">FastAPI</span>',
+    desc: 'Protect your FastAPI endpoints with Grantex grant tokens. Dependency-injection middleware that verifies JWTs, enforces scopes, and identifies agents.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    install: 'pip install grantex-fastapi',
+    problemBad: 'Your FastAPI endpoints accept bearer tokens with no scope enforcement. Any valid token accesses any route. No way to identify which AI agent made the request.',
+    problemGood: 'Grantex dependency verifies JWTs offline via JWKS, enforces scopes per route, and provides the agent identity. Pythonic, async, and type-safe.',
+    howTitle: 'How Grantex Works with FastAPI',
+    steps: [
+      ['Install the middleware', 'pip install grantex-fastapi — async-native, works with FastAPI\'s dependency injection.'],
+      ['Add the dependency', 'Use GrantexAuth as a FastAPI dependency. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'The dependency returns the full grant context: agent DID, scopes, principal, grant ID.'],
+      ['Production ready', 'Async JWKS fetching, key caching, automatic rotation, and proper error responses.'],
+    ],
+    code: `from fastapi import FastAPI, Depends
+from grantex_fastapi import GrantexAuth, GrantContext
+
+app = FastAPI()
+auth = GrantexAuth(
+    jwks_url="https://grantex-auth-....a.run.app/.well-known/jwks.json"
+)
+
+@app.get("/api/emails")
+async def list_emails(
+    grant: GrantContext = Depends(auth.require_scopes(["email:read"]))
+):
+    print(grant.agent)   # agent DID
+    print(grant.scopes)  # ["email:read"]
+    return {"emails": []}`,
+    features: [
+      ['FastAPI Dependency Injection', 'Works with FastAPI\'s Depends() pattern. Pythonic and type-safe.'],
+      ['Async Native', 'Fully async JWKS fetching and JWT verification. No blocking calls.'],
+      ['Per-Route Scopes', 'require_scopes() enforces specific permissions per endpoint. Returns 403 on mismatch.'],
+      ['Typed Grant Context', 'Full Pydantic model for grant context: agent DID, scopes, principal, grant ID.'],
+      ['JWKS Caching', 'Automatic async key caching and rotation. Handles key rollover transparently.'],
+      ['OpenAPI Integration', 'Scopes appear in your FastAPI OpenAPI docs automatically.'],
+    ],
+    ctaFramework: 'FastAPI',
+    metaTitle: 'Grantex for FastAPI — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.',
+  },
+  mpp: {
+    name: 'MPP (Machine Payments Protocol)',
+    badge: 'MPP + Grantex',
+    title: 'Agent Identity for <span class="highlight">Machine Payments</span>',
+    desc: 'MPP defines how AI agents pay for services. Grantex adds the missing identity layer — verifiable agent passports that let merchants know exactly who authorized every payment, with offline verification in under 50ms.',
+    docsUrl: 'https://docs.grantex.dev/features/mpp-agent-passport',
+    installUrl: 'https://docs.grantex.dev/guides/mpp-integration',
+    install: 'npm install @grantex/mpp @grantex/sdk',
+    problemBad: 'When an agent makes an MPP payment, the source is just a wallet address. No human name, no org, no authorization chain. For $0.10 API calls nobody cares. For $500 B2B procurement, it\'s a compliance blocker.',
+    problemGood: 'Every MPP payment carries an AgentPassportCredential — a W3C VC 2.0 credential with the human principal, org DID, spending limits, and allowed categories. Merchants verify in <50ms, offline.',
+    howTitle: 'How Grantex Works with MPP',
+    steps: [
+      ['Install the package', 'npm install @grantex/mpp — agent-side middleware + merchant-side verification in one package.'],
+      ['Issue an agent passport', 'Call grantex.passports.issue() with categories (inference, compute, data), spending limits, and expiry.'],
+      ['Attach to MPP requests', 'createMppPassportMiddleware() injects the X-Grantex-Passport header on every outgoing fetch.'],
+      ['Verify on the merchant side', 'requireAgentPassport() Express middleware — one line to verify identity, categories, and amounts.'],
+      ['Check the trust registry', 'lookupOrgTrust() returns verified org status (basic, verified, SOC 2) from the public registry.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createMppPassportMiddleware, requireAgentPassport } from '@grantex/mpp';
+
+// Agent side: issue passport and attach to requests
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const passport = await grantex.passports.issue({
+  agentId: 'ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  allowedMPPCategories: ['inference', 'compute'],
+  maxTransactionAmount: { amount: 50, currency: 'USDC' },
+  expiresIn: '24h',
+});
+
+const middleware = createMppPassportMiddleware({ passport });
+const enriched = await middleware(new Request(url));
+// X-Grantex-Passport header attached
+
+// Merchant side: one-line verification
+app.use('/api/inference', requireAgentPassport({
+  requiredCategories: ['inference'],
+  maxAmount: 10,
+}));
+// req.agentPassport → { humanDID, orgDID, categories, maxAmount, ... }`,
+    features: [
+      ['AgentPassportCredential', 'W3C VC 2.0 with agent DID, human principal, org, categories, spending limits, and delegation depth.'],
+      ['<50ms Verification', 'Offline verification using cached JWKS. No API roundtrip to Grantex servers needed.'],
+      ['9 MPP Categories', 'inference, compute, data, storage, search, media, delivery, browser, general — each maps to a Grantex scope.'],
+      ['StatusList2021 Revocation', 'Revoke any passport instantly. Bit-flip propagation, no polling required.'],
+      ['Trust Registry', 'Public org trust lookup by DID. DNS-TXT, manual, or SOC 2 verification levels.'],
+      ['Auto-Refresh', 'Middleware proactively refreshes passports before expiry via onRefresh callback.'],
+    ],
+    ctaFramework: 'MPP',
+    metaTitle: 'Grantex for MPP — Agent Identity for Machine Payments Protocol',
+    metaDesc: 'Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.',
+  },
+};
+
+// Determine framework from URL
+const path = window.location.pathname.replace(/\/$/, '');
+const slug = path.split('/').pop();
+const fw = frameworks[slug];
+
+if (!fw) {
+  // Redirect to homepage if unknown framework
+  window.location.href = '/';
+} else {
+  // Set meta tags
+  document.title = fw.metaTitle;
+  document.querySelector('meta[name="description"]').content = fw.metaDesc;
+  document.querySelector('link[rel="canonical"]').href = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[property="og:title"]').content = fw.metaTitle;
+  document.querySelector('meta[property="og:description"]').content = fw.metaDesc;
+  document.querySelector('meta[property="og:url"]').content = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[name="twitter:title"]').content = fw.metaTitle;
+  document.querySelector('meta[name="twitter:description"]').content = fw.metaDesc;
+
+  // Populate content
+  document.getElementById('badge').textContent = fw.badge;
+  document.getElementById('heroTitle').innerHTML = fw.title;
+  document.getElementById('heroDesc').textContent = fw.desc;
+  document.getElementById('ctaDocs').href = fw.docsUrl;
+  document.getElementById('ctaInstall').href = fw.installUrl;
+  document.getElementById('problemBad').textContent = fw.problemBad;
+  document.getElementById('problemGood').textContent = fw.problemGood;
+  document.getElementById('howTitle').textContent = fw.howTitle;
+  document.getElementById('installCmd').textContent = fw.install;
+  document.getElementById('codeExample').textContent = fw.code;
+  document.getElementById('ctaFramework').textContent = fw.ctaFramework;
+  document.getElementById('ctaDocsBottom').href = fw.docsUrl;
+  document.getElementById('featuresTitle').textContent = 'Why Grantex for ' + fw.name;
+
+  // Steps
+  const stepsEl = document.getElementById('steps');
+  fw.steps.forEach(([title, desc]) => {
+    stepsEl.innerHTML += `<div class="step"><div class="step-content"><h3>${title}</h3><p>${desc}</p></div></div>`;
+  });
+
+  // Features
+  const featuresEl = document.getElementById('features');
+  fw.features.forEach(([title, desc]) => {
+    featuresEl.innerHTML += `<div class="feature-card"><h3>${title}</h3><p>${desc}</p></div>`;
+  });
+
+  // Add JSON-LD structured data
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Grantex for " + fw.name,
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Any",
+    "url": "https://grantex.dev/for/" + slug,
+    "description": fw.metaDesc,
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  };
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.textContent = JSON.stringify(jsonLd);
+  document.head.appendChild(script);
+
+  // Track page view
+  gtag('event', 'page_view', { page_title: fw.metaTitle, page_location: window.location.href });
+}
+</script>
+</body>
+</html>

--- a/web/for/vercel-ai/index.html
+++ b/web/for/vercel-ai/index.html
@@ -1,0 +1,787 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
+  <!-- Dynamic meta tags set by JS below -->
+  <title>Grantex for Vercel AI SDK — Authorization for AI-Powered Apps</title>
+  <meta name="description" content="Add scoped permissions to Vercel AI SDK tools. TypeScript-native, Edge-compatible, with audit trails and real-time revocation. Open source.">
+  <link rel="canonical" href="https://grantex.dev/for/vercel-ai/">
+  <meta property="og:title" content="Grantex for Vercel AI SDK — Authorization for AI-Powered Apps">
+  <meta property="og:description" content="Add scoped permissions to Vercel AI SDK tools. TypeScript-native, Edge-compatible, with audit trails and real-time revocation. Open source.">
+  <meta property="og:url" content="https://grantex.dev/for/vercel-ai/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Grantex">
+  <meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grantex for Vercel AI SDK — Authorization for AI-Powered Apps">
+  <meta name="twitter:description" content="Add scoped permissions to Vercel AI SDK tools. TypeScript-native, Edge-compatible, with audit trails and real-time revocation. Open source.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
+  <style>
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --border:   #30363d;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --accent:   #3fb950;
+      --accent2:  #58a6ff;
+      --mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+      --sans:     'Inter', system-ui, -apple-system, sans-serif;
+      --radius:   8px;
+      --max-w:    900px;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: var(--sans); line-height: 1.6; }
+    a { color: var(--accent2); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { font-family: var(--mono); background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+    pre { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; overflow-x: auto; font-family: var(--mono); font-size: 0.875rem; line-height: 1.5; }
+    pre code { background: none; padding: 0; }
+
+    /* Nav */
+    .nav { display: flex; align-items: center; justify-content: space-between; max-width: var(--max-w); margin: 0 auto; padding: 1rem 1.5rem; }
+    .nav-logo { font-weight: 700; font-size: 1.25rem; color: var(--text); }
+    .nav-links { list-style: none; display: flex; gap: 1.5rem; }
+    .nav-links a { color: var(--muted); font-size: 0.9rem; }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+
+    /* Hero */
+    .hero { text-align: center; padding: 4rem 1.5rem 3rem; max-width: var(--max-w); margin: 0 auto; }
+    .hero-badge { display: inline-block; background: rgba(63,185,80,0.15); color: var(--accent); padding: 0.25rem 0.75rem; border-radius: 999px; font-size: 0.8rem; font-weight: 600; margin-bottom: 1rem; }
+    .hero h1 { font-size: 2.5rem; line-height: 1.2; margin-bottom: 1rem; }
+    .hero h1 .highlight { color: var(--accent); }
+    .hero p { color: var(--muted); font-size: 1.1rem; max-width: 650px; margin: 0 auto 2rem; }
+    .hero-ctas { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
+    .btn { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.65rem 1.25rem; border-radius: var(--radius); font-weight: 600; font-size: 0.9rem; text-decoration: none; transition: all 0.2s; }
+    .btn-primary { background: var(--accent); color: #0d1117; }
+    .btn-primary:hover { background: #2ea043; text-decoration: none; }
+    .btn-secondary { background: var(--surface); color: var(--text); border: 1px solid var(--border); }
+    .btn-secondary:hover { border-color: var(--muted); text-decoration: none; }
+
+    /* Sections */
+    .section { max-width: var(--max-w); margin: 0 auto; padding: 3rem 1.5rem; }
+    .section h2 { font-size: 1.75rem; margin-bottom: 1rem; }
+    .section h3 { font-size: 1.15rem; margin-bottom: 0.5rem; color: var(--accent); }
+    .section p, .section li { color: var(--muted); }
+    .section ul { padding-left: 1.25rem; }
+    .section li { margin-bottom: 0.5rem; }
+
+    /* Problem cards */
+    .problem-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; margin: 1.5rem 0; }
+    .problem-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .problem-card.bad { border-color: #f8514933; }
+    .problem-card.good { border-color: #3fb95033; }
+    .problem-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .problem-card.bad h3 { color: #f85149; }
+    .problem-card.good h3 { color: var(--accent); }
+
+    /* Steps */
+    .steps { counter-reset: step; margin: 1.5rem 0; }
+    .step { display: flex; gap: 1rem; margin-bottom: 1.5rem; }
+    .step::before { counter-increment: step; content: counter(step); display: flex; align-items: center; justify-content: center; min-width: 32px; height: 32px; background: rgba(63,185,80,0.15); color: var(--accent); border-radius: 50%; font-weight: 700; font-size: 0.85rem; }
+    .step-content h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.25rem; }
+    .step-content p { font-size: 0.9rem; }
+
+    /* Features */
+    .feature-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.25rem; margin: 1.5rem 0; }
+    .feature-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
+    .feature-card h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; }
+
+    /* Install */
+    .install-box { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.25rem; display: flex; align-items: center; justify-content: space-between; margin: 1rem 0; font-family: var(--mono); font-size: 0.9rem; }
+    .install-box button { background: var(--accent); color: #0d1117; border: none; padding: 0.35rem 0.75rem; border-radius: 4px; font-weight: 600; cursor: pointer; font-size: 0.8rem; }
+
+    /* Footer */
+    .footer { max-width: var(--max-w); margin: 0 auto; padding: 2rem 1.5rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; }
+    .footer-links { list-style: none; display: flex; gap: 1.5rem; }
+    .footer-links a { color: var(--muted); font-size: 0.85rem; }
+
+    @media (max-width: 640px) {
+      .hero h1 { font-size: 1.75rem; }
+      .problem-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Grantex for Vercel AI SDK","applicationCategory":"DeveloperApplication","operatingSystem":"Any","url":"https://grantex.dev/for/vercel-ai/","description":"Add scoped permissions to Vercel AI SDK tools. TypeScript-native, Edge-compatible, with audit trails and real-time revocation. Open source.","license":"https://www.apache.org/licenses/LICENSE-2.0"}</script>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/" class="nav-logo">Grantex</a>
+  <ul class="nav-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="/playground">Playground</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+  </ul>
+</nav>
+
+<div id="app">
+  <section class="hero">
+    <span class="hero-badge" id="badge"></span>
+    <h1 id="heroTitle"></h1>
+    <p id="heroDesc"></p>
+    <div class="hero-ctas">
+      <a href="" id="ctaDocs" class="btn btn-primary">View Integration Docs</a>
+      <a href="" id="ctaInstall" class="btn btn-secondary">Get Started</a>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2>The Problem</h2>
+    <div class="problem-grid">
+      <div class="problem-card bad">
+        <h3>Without Grantex</h3>
+        <p id="problemBad"></p>
+      </div>
+      <div class="problem-card good">
+        <h3>With Grantex</h3>
+        <p id="problemGood"></p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2 id="howTitle">How It Works</h2>
+    <div class="steps" id="steps"></div>
+  </section>
+
+  <section class="section">
+    <h2>Quick Start</h2>
+    <div class="install-box">
+      <span id="installCmd"></span>
+      <button onclick="navigator.clipboard.writeText(document.getElementById('installCmd').textContent);this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)">Copy</button>
+    </div>
+    <pre><code id="codeExample"></code></pre>
+  </section>
+
+  <section class="section">
+    <h2 id="featuresTitle">Why Grantex</h2>
+    <div class="feature-grid" id="features"></div>
+  </section>
+
+  <section class="section" style="text-align:center">
+    <h2>Ready to secure your <span id="ctaFramework"></span> agents?</h2>
+    <p style="margin-bottom:1.5rem;color:var(--muted)">Get started in under 5 minutes. Open source, Apache 2.0.</p>
+    <div class="hero-ctas">
+      <a href="https://grantex.dev/dashboard/signup" class="btn btn-primary">Sign Up Free</a>
+      <a href="" id="ctaDocsBottom" class="btn btn-secondary">Read the Docs</a>
+    </div>
+  </section>
+</div>
+
+<footer class="footer">
+  <span style="color:var(--muted);font-size:0.85rem">Grantex — Open authorization for AI agents</span>
+  <ul class="footer-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+    <li><a href="/">Home</a></li>
+  </ul>
+</footer>
+
+<script>
+const frameworks = {
+  langchain: {
+    name: 'LangChain',
+    badge: 'LangChain + Grantex',
+    title: 'Authorization for <span class="highlight">LangChain</span> Agents',
+    desc: 'Add scoped, revocable permissions to your LangChain agents. Grantex integrates natively with LangChain tools — your agents get signed JWTs instead of raw API keys.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/langchain',
+    install: 'npm install @grantex/langchain @grantex/sdk',
+    problemBad: 'Your LangChain agents use raw API keys with full access. No scoping, no audit trail, no way to revoke access if an agent goes rogue. One compromised key exposes everything.',
+    problemGood: 'Each LangChain agent gets a scoped, time-limited JWT. Tools verify permissions offline. You can revoke any agent instantly. Every action is audit-logged with a hash chain.',
+    howTitle: 'How Grantex Works with LangChain',
+    steps: [
+      ['Install the integration', 'npm install @grantex/langchain — wraps LangChain tools with automatic grant verification.'],
+      ['Register your agent', 'Create an agent identity with specific scopes like "email:send" or "calendar:read".'],
+      ['Get user consent', 'Redirect the user to a consent page. They approve exactly which permissions the agent gets.'],
+      ['Agent receives a JWT', 'The agent gets a signed token it presents to any service. Services verify offline via JWKS.'],
+      ['Audit & revoke', 'Every action is logged. Revoke access in under 1 second if something goes wrong.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexToolkit } from '@grantex/langchain';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap your LangChain tools with Grantex authorization
+const toolkit = new GrantexToolkit({
+  client: gx,
+  grantToken: token,  // JWT from the consent flow
+  tools: [searchTool, emailTool],
+});
+
+// Tools now automatically verify scopes before executing
+const agent = createToolCallingAgent({ llm, tools: toolkit.tools });`,
+    features: [
+      ['Native LangChain Integration', 'Drop-in toolkit that wraps your existing LangChain tools with automatic scope verification.'],
+      ['Scoped Permissions', 'Define exactly what each agent can do — "email:read" vs "email:send". No more all-or-nothing API keys.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS without calling Grantex. Zero latency overhead on your LangChain pipeline.'],
+      ['Multi-Agent Delegation', 'Parent agents delegate narrower scopes to sub-agents. Revoking the parent cascades to all children.'],
+      ['Hash-Chained Audit Trail', 'Every tool invocation is logged in an append-only, tamper-evident audit trail.'],
+      ['Real-Time Revocation', 'Kill a misbehaving agent\'s access in under 1 second. No waiting for token expiry.'],
+    ],
+    ctaFramework: 'LangChain',
+    metaTitle: 'Grantex for LangChain — Authorization for LangChain AI Agents',
+    metaDesc: 'Add scoped, revocable permissions to LangChain agents. Drop-in toolkit for authorization with signed JWTs, audit trails, and real-time revocation. Open source.',
+  },
+  crewai: {
+    name: 'CrewAI',
+    badge: 'CrewAI + Grantex',
+    title: 'Authorization for <span class="highlight">CrewAI</span> Agents',
+    desc: 'Secure your CrewAI crews with scoped, revocable permissions. Each crew member gets exactly the access it needs — nothing more.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/crewai',
+    install: 'pip install grantex-crewai grantex',
+    problemBad: 'Your CrewAI agents share the same API keys. If one crew member is compromised, the entire crew\'s access is exposed. No way to scope or revoke individual agent access.',
+    problemGood: 'Each crew member gets its own scoped JWT. The researcher can only read, the writer can only draft, the publisher can only post. Revoke any member instantly.',
+    howTitle: 'How Grantex Works with CrewAI',
+    steps: [
+      ['Install the integration', 'pip install grantex-crewai — Python-native integration for CrewAI crews.'],
+      ['Register each crew member', 'Create agent identities with role-specific scopes for each crew member.'],
+      ['Authorize the crew', 'Users approve scoped permissions for each role in the crew.'],
+      ['Crew operates with scoped tokens', 'Each crew member presents its own JWT. Services verify independently.'],
+      ['Monitor & control', 'Audit every crew action. Revoke individual members without stopping the whole crew.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_crewai import GrantexCrewTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Each crew member gets scoped authorization
+researcher_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=researcher_token,  # scoped to "search:read"
+    tools=[search_tool],
+)
+
+writer_tools = GrantexCrewTools(
+    client=gx,
+    grant_token=writer_token,  # scoped to "docs:write"
+    tools=[write_tool],
+)`,
+    features: [
+      ['Per-Agent Scoping', 'Each crew member gets exactly the permissions it needs. Researcher reads, writer writes, publisher posts.'],
+      ['Role-Based Access', 'Map CrewAI roles to Grantex scopes. Define authorization policies per role, not per API key.'],
+      ['Crew-Wide Audit Trail', 'See what every crew member did, when, and with what permissions. Hash-chained for tamper evidence.'],
+      ['Delegation Chains', 'A lead agent can delegate narrower permissions to sub-agents. Revoking the lead cascades to all.'],
+      ['Python Native', 'Pure Python integration. pip install and go — works with any CrewAI version.'],
+      ['Instant Revocation', 'Revoke any crew member\'s access in under 1 second without disrupting the rest of the crew.'],
+    ],
+    ctaFramework: 'CrewAI',
+    metaTitle: 'Grantex for CrewAI — Secure Multi-Agent Crew Permissions',
+    metaDesc: 'Scope and control permissions for CrewAI agents. Each crew member gets its own signed JWT with role-specific access. Audit trails, delegation, real-time revocation.',
+  },
+  'openai-agents': {
+    name: 'OpenAI Agents SDK',
+    badge: 'OpenAI Agents + Grantex',
+    title: 'Authorization for <span class="highlight">OpenAI Agents SDK</span>',
+    desc: 'Add enterprise-grade authorization to your OpenAI agents. Scoped permissions, audit trails, and instant revocation — built for the Agents SDK.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/openai-agents',
+    install: 'pip install grantex-openai-agents grantex',
+    problemBad: 'Your OpenAI agents operate with full API access. No scoping, no audit trail, no revocation. You can\'t tell which agent did what or limit what it can do.',
+    problemGood: 'Each agent gets a scoped, time-limited JWT. Every tool call is authorized and logged. Revoke access instantly if an agent behaves unexpectedly.',
+    howTitle: 'How Grantex Works with OpenAI Agents SDK',
+    steps: [
+      ['Install the integration', 'pip install grantex-openai-agents — wraps OpenAI agent tools with authorization.'],
+      ['Register your agent', 'Create an agent identity with scopes matching its capabilities.'],
+      ['Get user approval', 'Users approve exactly which permissions the agent receives via a consent page.'],
+      ['Agent operates with JWT', 'The agent\'s tools automatically verify permissions before executing.'],
+      ['Full audit trail', 'Every tool invocation is logged with the agent identity, scopes used, and timestamp.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_openai_agents import GrantexTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap OpenAI agent tools with Grantex authorization
+tools = GrantexTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, email_tool],
+)
+
+# Tools automatically check scopes before execution
+agent = Agent(
+    name="assistant",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['OpenAI Agents SDK Integration', 'Drop-in wrapper for OpenAI agent tools. Add authorization without changing your agent logic.'],
+      ['Scoped Tool Access', 'Define which tools each agent can use and with what parameters. Enforced at the protocol level.'],
+      ['Enterprise Audit Trail', 'Every tool call logged with agent identity, scopes, and hash-chained integrity.'],
+      ['Multi-Agent Pipelines', 'Parent agents delegate narrower access to sub-agents. Full delegation chain tracking.'],
+      ['Budget Controls', 'Set spending limits per agent. Automatic cutoff when budget is exhausted.'],
+      ['Compliance Ready', 'SOC 2 compatible audit logging. SCIM/SSO for enterprise identity management.'],
+    ],
+    ctaFramework: 'OpenAI Agents',
+    metaTitle: 'Grantex for OpenAI Agents SDK — Enterprise Agent Authorization',
+    metaDesc: 'Add scoped permissions, audit trails, and real-time revocation to OpenAI Agents SDK. Enterprise-grade authorization for AI agents. Open source.',
+  },
+  anthropic: {
+    name: 'Anthropic SDK',
+    badge: 'Anthropic + Grantex',
+    title: 'Authorization for <span class="highlight">Anthropic SDK</span> Tool Use',
+    desc: 'Enforce scoped permissions on Claude tool calls. Offline JWT verification, automatic audit logging, and instant revocation for Anthropic SDK apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    installUrl: 'https://docs.grantex.dev/integrations/anthropic',
+    install: 'npm install @grantex/anthropic @grantex/sdk',
+    problemBad: 'Your Claude-powered agents call tools with no authorization layer. Any tool can be invoked with full access. No scoping, no consent, no audit trail of what the agent did.',
+    problemGood: 'Grantex wraps each tool with scope enforcement. The agent\'s JWT is checked offline before execution. Every tool call is audit-logged. Revoke access in under 1 second.',
+    howTitle: 'How Grantex Works with the Anthropic SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/anthropic — wraps Anthropic tool definitions with authorization.'],
+      ['Create scoped tools', 'Use createGrantexTool() to define tools with required scopes and JSON Schema input.'],
+      ['Pass tools to Claude', 'tool.definition is type-compatible with client.messages.create({ tools }).'],
+      ['Dispatch tool_use blocks', 'Use GrantexToolRegistry or handleToolCall() to execute with automatic audit logging.'],
+      ['Monitor everything', 'Hash-chained audit trail of every tool call. Revoke access in under 1 second.'],
+    ],
+    code: `import Anthropic from '@anthropic-ai/sdk';
+import { createGrantexTool, GrantexToolRegistry } from '@grantex/anthropic';
+
+const client = new Anthropic();
+
+const readFile = createGrantexTool({
+  name: 'read_file',
+  description: 'Read a file from disk',
+  inputSchema: {
+    type: 'object',
+    properties: { path: { type: 'string' } },
+    required: ['path'],
+  },
+  grantToken,
+  requiredScope: 'file:read',
+  execute: async ({ path }) => fs.readFile(path, 'utf-8'),
+});
+
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  tools: [readFile.definition],
+  messages,
+});`,
+    features: [
+      ['Anthropic SDK Native', 'Type-compatible with client.messages.create(). tool.definition drops in directly.'],
+      ['Offline Scope Checks', 'JWT scp claim verified locally. No network call to Grantex during execution.'],
+      ['Tool Registry', 'GrantexToolRegistry manages multiple tools and dispatches tool_use blocks by name.'],
+      ['Audit Logging', 'withAuditLogging() and handleToolCall() log every success/failure automatically.'],
+      ['GrantexScopeError', 'Typed error with requiredScope and grantedScopes for clean error handling.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Anthropic SDK',
+    metaTitle: 'Grantex for Anthropic SDK — Secure Claude Tool Use Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Claude tool use. Offline JWT verification, tool registry, and instant revocation. Open source.',
+  },
+  'google-adk': {
+    name: 'Google ADK',
+    badge: 'Google ADK + Grantex',
+    title: 'Authorization for <span class="highlight">Google ADK</span> Agents',
+    desc: 'Secure your Google Agent Development Kit agents with scoped, human-approved permissions and full audit trails.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/google-adk',
+    install: 'pip install grantex-adk grantex',
+    problemBad: 'Your ADK agents access services with broad credentials. No fine-grained scoping, no delegation control, no tamper-proof audit log of agent actions.',
+    problemGood: 'Each ADK agent gets cryptographic identity and scoped JWTs. Delegation chains track multi-agent workflows. Every action is audit-logged.',
+    howTitle: 'How Grantex Works with Google ADK',
+    steps: [
+      ['Install the integration', 'pip install grantex-adk — Python-native integration for Google ADK.'],
+      ['Register your agent', 'Create an agent identity with specific scopes matching your ADK agent\'s capabilities.'],
+      ['Authorize via consent', 'Users approve scoped permissions through a consent flow.'],
+      ['Agent operates securely', 'ADK tools verify permissions via JWT before executing any action.'],
+      ['Monitor everything', 'Hash-chained audit trail of every action. Revoke access in under 1 second.'],
+    ],
+    code: `from grantex import Grantex
+from grantex_adk import GrantexADKTools
+
+gx = Grantex(api_key=os.environ["GRANTEX_API_KEY"])
+
+# Wrap ADK tools with Grantex authorization
+tools = GrantexADKTools(
+    client=gx,
+    grant_token=token,
+    tools=[search_tool, calendar_tool],
+)
+
+# Tools verify scopes automatically
+agent = Agent(
+    model="gemini-2.0-flash",
+    tools=tools.wrapped,
+)`,
+    features: [
+      ['Google ADK Native', 'Built for the Agent Development Kit. Wraps ADK tools with automatic authorization.'],
+      ['Scoped Permissions', 'Fine-grained scopes for each capability. "calendar:read" vs "calendar:write".'],
+      ['Delegation Chains', 'Multi-agent ADK pipelines with tracked delegation. Revoke parent to cascade.'],
+      ['Offline Verification', 'Services verify JWTs via JWKS. No network calls to Grantex during execution.'],
+      ['Audit & Compliance', 'Tamper-proof audit trail. SOC 2 compatible. Enterprise compliance exports.'],
+      ['Budget Controls', 'Per-agent spending limits with automatic cutoff at thresholds.'],
+    ],
+    ctaFramework: 'Google ADK',
+    metaTitle: 'Grantex for Google ADK — Secure Agent Development Kit Authorization',
+    metaDesc: 'Add scoped permissions and audit trails to Google ADK agents. Delegation chains, real-time revocation, and enterprise compliance. Open source.',
+  },
+  'vercel-ai': {
+    name: 'Vercel AI SDK',
+    badge: 'Vercel AI + Grantex',
+    title: 'Authorization for <span class="highlight">Vercel AI SDK</span>',
+    desc: 'Add scoped authorization to your Vercel AI SDK tools. Signed JWTs, audit trails, and instant revocation for AI-powered apps.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/vercel-ai',
+    install: 'npm install @grantex/vercel-ai @grantex/sdk',
+    problemBad: 'Your Vercel AI tools run with full access. Users can\'t see or control what the AI does on their behalf. No audit trail, no revocation.',
+    problemGood: 'Each AI tool call is authorized with a scoped JWT. Users approve permissions upfront. Every action is logged. Revoke instantly.',
+    howTitle: 'How Grantex Works with Vercel AI SDK',
+    steps: [
+      ['Install the integration', 'npm install @grantex/vercel-ai — TypeScript-native integration for Vercel AI SDK.'],
+      ['Define authorized tools', 'Wrap your AI SDK tools with Grantex scope requirements.'],
+      ['User consents', 'Users approve specific scopes before the AI can act on their behalf.'],
+      ['Tools verify automatically', 'Each tool call checks the JWT scopes before execution.'],
+      ['Full observability', 'Audit trail of every tool invocation. Real-time event streaming.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createGrantexTools } from '@grantex/vercel-ai';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Wrap Vercel AI SDK tools with authorization
+const tools = createGrantexTools({
+  client: gx,
+  grantToken: token,
+  tools: { search: searchTool, email: emailTool },
+});
+
+// Use with generateText or streamText
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prompt: 'Search for flights and send the results',
+});`,
+    features: [
+      ['Vercel AI SDK Native', 'Works with generateText, streamText, and all AI SDK tool patterns.'],
+      ['TypeScript First', 'Full type safety. Scopes are checked at compile time and runtime.'],
+      ['Edge Compatible', 'Works in Vercel Edge Functions. JWT verification is local — no external calls.'],
+      ['Streaming Support', 'Compatible with streaming responses. Authorization doesn\'t block the stream.'],
+      ['Multi-Step Flows', 'Authorize multi-step AI workflows where each step requires different scopes.'],
+      ['Next.js Ready', 'Drop into your Next.js app with zero configuration beyond the SDK.'],
+    ],
+    ctaFramework: 'Vercel AI',
+    metaTitle: 'Grantex for Vercel AI SDK — Authorization for AI-Powered Apps',
+    metaDesc: 'Add scoped permissions to Vercel AI SDK tools. TypeScript-native, Edge-compatible, with audit trails and real-time revocation. Open source.',
+  },
+  autogen: {
+    name: 'AutoGen',
+    badge: 'AutoGen + Grantex',
+    title: 'Authorization for <span class="highlight">AutoGen</span> Multi-Agent Systems',
+    desc: 'Secure your AutoGen conversations with per-agent permissions. Each agent in the group gets exactly the scopes it needs.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/autogen',
+    install: 'npm install @grantex/autogen @grantex/sdk',
+    problemBad: 'AutoGen agents in a group chat share credentials. If one agent is compromised or hallucinates, it has access to everything the others can do.',
+    problemGood: 'Each AutoGen agent gets its own scoped JWT. The coder can only write code, the executor can only run tests. Isolated, audited, revocable.',
+    howTitle: 'How Grantex Works with AutoGen',
+    steps: [
+      ['Install the integration', 'npm install @grantex/autogen — wraps AutoGen function maps with authorization.'],
+      ['Register each agent', 'Create identities with role-specific scopes for each agent in the group.'],
+      ['Scope per conversation', 'Users approve what each agent can do before the conversation starts.'],
+      ['Agents operate independently', 'Each agent presents its own JWT. Function calls are scope-checked automatically.'],
+      ['Trace everything', 'Full audit trail across the multi-agent conversation. Attribute actions to specific agents.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { GrantexAutoGen } from '@grantex/autogen';
+
+const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+
+// Each agent in the group gets scoped authorization
+const coderTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: coderToken,  // scoped to "code:write"
+  functionMap: { write_code: writeCodeFn },
+});
+
+const executorTools = new GrantexAutoGen({
+  client: gx,
+  grantToken: executorToken,  // scoped to "code:execute"
+  functionMap: { run_code: runCodeFn },
+});`,
+    features: [
+      ['Per-Agent Authorization', 'Each agent in the AutoGen group gets its own scoped token and identity.'],
+      ['Group Chat Security', 'Prevent agents from accessing tools outside their role. Enforced at the protocol level.'],
+      ['Conversation Auditing', 'Track which agent called which function, with what scopes, across the entire conversation.'],
+      ['Delegation Support', 'Agents can delegate narrower scopes to spawned sub-agents with depth tracking.'],
+      ['Function Map Wrapping', 'Drop-in wrapper for AutoGen function maps. No changes to your agent logic.'],
+      ['Real-Time Control', 'Revoke any agent mid-conversation. Access is denied within 1 second.'],
+    ],
+    ctaFramework: 'AutoGen',
+    metaTitle: 'Grantex for AutoGen — Secure Multi-Agent Group Chat Authorization',
+    metaDesc: 'Per-agent scoped permissions for AutoGen multi-agent systems. Each agent gets its own JWT. Audit trails, delegation chains, instant revocation.',
+  },
+  mcp: {
+    name: 'Model Context Protocol',
+    badge: 'MCP + Grantex',
+    title: 'Authorization for <span class="highlight">MCP</span> Servers',
+    desc: 'Add enterprise-grade authorization to any MCP server. 13 built-in tools for managing agents, grants, and tokens from Claude Desktop, Cursor, or Windsurf.',
+    docsUrl: 'https://docs.grantex.dev/integrations/mcp',
+    installUrl: 'https://docs.grantex.dev/integrations/mcp',
+    install: 'npm install @grantex/mcp',
+    problemBad: 'MCP servers expose tools to AI assistants with no authorization layer. Any connected client can call any tool with full access. No scoping, no consent, no audit trail.',
+    problemGood: 'Grantex adds OAuth 2.1-style authorization to MCP. Users approve scoped access per tool. Every invocation is logged. Revoke access from the permission dashboard.',
+    howTitle: 'How Grantex Works with MCP',
+    steps: [
+      ['Install the MCP server', 'npm install @grantex/mcp — adds 13 Grantex tools to any MCP-compatible client.'],
+      ['Connect to Claude Desktop', 'Add Grantex to your MCP config. Works with Claude Desktop, Cursor, and Windsurf.'],
+      ['Manage via natural language', 'Ask Claude to "register an agent", "create a grant", or "check the audit log".'],
+      ['Or add MCP Auth', 'Use @grantex/mcp-auth to add OAuth 2.1 + PKCE to your own MCP servers.'],
+      ['Full protocol access', 'All 13 Grantex operations available as MCP tools — agents, grants, tokens, audit, budgets.'],
+    ],
+    code: `// claude_desktop_config.json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "npx",
+      "args": ["@grantex/mcp"],
+      "env": {
+        "GRANTEX_API_KEY": "gx_live_..."
+      }
+    }
+  }
+}
+
+// Then in Claude Desktop:
+// "Register a new agent called travel-bot with flights:book scope"
+// "Create a grant for user alice on travel-bot"
+// "Show me the audit log for the last hour"`,
+    features: [
+      ['13 MCP Tools', 'Full Grantex protocol access: agents, grants, tokens, audit, budgets, verification — all as MCP tools.'],
+      ['Claude Desktop Ready', 'Works out of the box with Claude Desktop, Cursor, and Windsurf.'],
+      ['MCP Auth Server', 'Separate @grantex/mcp-auth package adds OAuth 2.1 + PKCE to any MCP server.'],
+      ['Natural Language Control', 'Manage authorization through conversation. "Revoke all grants for agent X."'],
+      ['Zero Code Setup', 'npx @grantex/mcp — no code required. Just add to your MCP config and go.'],
+      ['Enterprise Grade', 'Budget controls, policy engine, SCIM/SSO — all accessible via MCP tools.'],
+    ],
+    ctaFramework: 'MCP',
+    metaTitle: 'Grantex for MCP — Authorization for Model Context Protocol Servers',
+    metaDesc: 'Add OAuth 2.1 authorization to MCP servers. 13 tools for Claude Desktop, Cursor, and Windsurf. Scoped grants, audit trails, real-time revocation.',
+  },
+  express: {
+    name: 'Express.js',
+    badge: 'Express + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">Express.js</span>',
+    desc: 'Protect your Express.js APIs with Grantex grant tokens. Drop-in middleware that verifies JWTs, enforces scopes, and logs every request.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/express',
+    install: 'npm install @grantex/express',
+    problemBad: 'Your Express APIs accept API keys or bearer tokens with no scope enforcement. Any valid token can access any endpoint. No agent identity tracking.',
+    problemGood: 'Grantex middleware verifies JWTs offline via JWKS, enforces scopes per route, and identifies the calling agent. Zero external network calls.',
+    howTitle: 'How Grantex Works with Express.js',
+    steps: [
+      ['Install the middleware', 'npm install @grantex/express — one package, zero external dependencies at runtime.'],
+      ['Add to your app', 'One line to protect your routes. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs are verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'req.grantex gives you the agent DID, scopes, principal, and grant ID.'],
+      ['Production ready', 'JWKS caching, key rotation, scope enforcement, and error handling built in.'],
+    ],
+    code: `import express from 'express';
+import { grantexMiddleware, requireScopes } from '@grantex/express';
+
+const app = express();
+
+// Verify Grantex JWTs on all /api routes
+app.use('/api', grantexMiddleware({
+  jwksUrl: 'https://grantex-auth-....a.run.app/.well-known/jwks.json',
+}));
+
+// Enforce specific scopes per route
+app.get('/api/emails', requireScopes(['email:read']), (req, res) => {
+  console.log(req.grantex.agent);  // agent DID
+  console.log(req.grantex.scopes); // ['email:read']
+  res.json({ emails: [] });
+});`,
+    features: [
+      ['Drop-In Middleware', 'One line to protect your Express routes. Works with any Express 4+ app.'],
+      ['Offline JWT Verification', 'JWKS-based verification. No network calls to Grantex on each request. Sub-millisecond overhead.'],
+      ['Per-Route Scopes', 'requireScopes() enforces specific permissions per endpoint. Returns 403 if scopes don\'t match.'],
+      ['Agent Identity', 'req.grantex provides agent DID, scopes, principal ID, grant ID on every request.'],
+      ['JWKS Caching', 'Automatic key caching and rotation. Handles key rollover transparently.'],
+      ['TypeScript Support', 'Full type definitions. req.grantex is fully typed.'],
+    ],
+    ctaFramework: 'Express.js',
+    metaTitle: 'Grantex for Express.js — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Drop-in Express.js middleware for Grantex JWT verification. Offline JWKS verification, per-route scope enforcement, and agent identity. Open source.',
+  },
+  fastapi: {
+    name: 'FastAPI',
+    badge: 'FastAPI + Grantex',
+    title: 'Grantex Middleware for <span class="highlight">FastAPI</span>',
+    desc: 'Protect your FastAPI endpoints with Grantex grant tokens. Dependency-injection middleware that verifies JWTs, enforces scopes, and identifies agents.',
+    docsUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    installUrl: 'https://docs.grantex.dev/integrations/frameworks/fastapi',
+    install: 'pip install grantex-fastapi',
+    problemBad: 'Your FastAPI endpoints accept bearer tokens with no scope enforcement. Any valid token accesses any route. No way to identify which AI agent made the request.',
+    problemGood: 'Grantex dependency verifies JWTs offline via JWKS, enforces scopes per route, and provides the agent identity. Pythonic, async, and type-safe.',
+    howTitle: 'How Grantex Works with FastAPI',
+    steps: [
+      ['Install the middleware', 'pip install grantex-fastapi — async-native, works with FastAPI\'s dependency injection.'],
+      ['Add the dependency', 'Use GrantexAuth as a FastAPI dependency. Specify required scopes per endpoint.'],
+      ['Offline verification', 'JWTs verified locally via cached JWKS. No calls to Grantex servers on each request.'],
+      ['Access agent identity', 'The dependency returns the full grant context: agent DID, scopes, principal, grant ID.'],
+      ['Production ready', 'Async JWKS fetching, key caching, automatic rotation, and proper error responses.'],
+    ],
+    code: `from fastapi import FastAPI, Depends
+from grantex_fastapi import GrantexAuth, GrantContext
+
+app = FastAPI()
+auth = GrantexAuth(
+    jwks_url="https://grantex-auth-....a.run.app/.well-known/jwks.json"
+)
+
+@app.get("/api/emails")
+async def list_emails(
+    grant: GrantContext = Depends(auth.require_scopes(["email:read"]))
+):
+    print(grant.agent)   # agent DID
+    print(grant.scopes)  # ["email:read"]
+    return {"emails": []}`,
+    features: [
+      ['FastAPI Dependency Injection', 'Works with FastAPI\'s Depends() pattern. Pythonic and type-safe.'],
+      ['Async Native', 'Fully async JWKS fetching and JWT verification. No blocking calls.'],
+      ['Per-Route Scopes', 'require_scopes() enforces specific permissions per endpoint. Returns 403 on mismatch.'],
+      ['Typed Grant Context', 'Full Pydantic model for grant context: agent DID, scopes, principal, grant ID.'],
+      ['JWKS Caching', 'Automatic async key caching and rotation. Handles key rollover transparently.'],
+      ['OpenAPI Integration', 'Scopes appear in your FastAPI OpenAPI docs automatically.'],
+    ],
+    ctaFramework: 'FastAPI',
+    metaTitle: 'Grantex for FastAPI — JWT Middleware for AI Agent Authorization',
+    metaDesc: 'Async FastAPI middleware for Grantex JWT verification. Dependency-injection, per-route scopes, and agent identity. Type-safe, Pythonic. Open source.',
+  },
+  mpp: {
+    name: 'MPP (Machine Payments Protocol)',
+    badge: 'MPP + Grantex',
+    title: 'Agent Identity for <span class="highlight">Machine Payments</span>',
+    desc: 'MPP defines how AI agents pay for services. Grantex adds the missing identity layer — verifiable agent passports that let merchants know exactly who authorized every payment, with offline verification in under 50ms.',
+    docsUrl: 'https://docs.grantex.dev/features/mpp-agent-passport',
+    installUrl: 'https://docs.grantex.dev/guides/mpp-integration',
+    install: 'npm install @grantex/mpp @grantex/sdk',
+    problemBad: 'When an agent makes an MPP payment, the source is just a wallet address. No human name, no org, no authorization chain. For $0.10 API calls nobody cares. For $500 B2B procurement, it\'s a compliance blocker.',
+    problemGood: 'Every MPP payment carries an AgentPassportCredential — a W3C VC 2.0 credential with the human principal, org DID, spending limits, and allowed categories. Merchants verify in <50ms, offline.',
+    howTitle: 'How Grantex Works with MPP',
+    steps: [
+      ['Install the package', 'npm install @grantex/mpp — agent-side middleware + merchant-side verification in one package.'],
+      ['Issue an agent passport', 'Call grantex.passports.issue() with categories (inference, compute, data), spending limits, and expiry.'],
+      ['Attach to MPP requests', 'createMppPassportMiddleware() injects the X-Grantex-Passport header on every outgoing fetch.'],
+      ['Verify on the merchant side', 'requireAgentPassport() Express middleware — one line to verify identity, categories, and amounts.'],
+      ['Check the trust registry', 'lookupOrgTrust() returns verified org status (basic, verified, SOC 2) from the public registry.'],
+    ],
+    code: `import { Grantex } from '@grantex/sdk';
+import { createMppPassportMiddleware, requireAgentPassport } from '@grantex/mpp';
+
+// Agent side: issue passport and attach to requests
+const grantex = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
+const passport = await grantex.passports.issue({
+  agentId: 'ag_01HXYZ...',
+  grantId: 'grnt_01HXYZ...',
+  allowedMPPCategories: ['inference', 'compute'],
+  maxTransactionAmount: { amount: 50, currency: 'USDC' },
+  expiresIn: '24h',
+});
+
+const middleware = createMppPassportMiddleware({ passport });
+const enriched = await middleware(new Request(url));
+// X-Grantex-Passport header attached
+
+// Merchant side: one-line verification
+app.use('/api/inference', requireAgentPassport({
+  requiredCategories: ['inference'],
+  maxAmount: 10,
+}));
+// req.agentPassport → { humanDID, orgDID, categories, maxAmount, ... }`,
+    features: [
+      ['AgentPassportCredential', 'W3C VC 2.0 with agent DID, human principal, org, categories, spending limits, and delegation depth.'],
+      ['<50ms Verification', 'Offline verification using cached JWKS. No API roundtrip to Grantex servers needed.'],
+      ['9 MPP Categories', 'inference, compute, data, storage, search, media, delivery, browser, general — each maps to a Grantex scope.'],
+      ['StatusList2021 Revocation', 'Revoke any passport instantly. Bit-flip propagation, no polling required.'],
+      ['Trust Registry', 'Public org trust lookup by DID. DNS-TXT, manual, or SOC 2 verification levels.'],
+      ['Auto-Refresh', 'Middleware proactively refreshes passports before expiry via onRefresh callback.'],
+    ],
+    ctaFramework: 'MPP',
+    metaTitle: 'Grantex for MPP — Agent Identity for Machine Payments Protocol',
+    metaDesc: 'Add verifiable agent identity to MPP machine payments. AgentPassportCredential with spending limits, category restrictions, and offline merchant verification in under 50ms. Open source, W3C VC 2.0.',
+  },
+};
+
+// Determine framework from URL
+const path = window.location.pathname.replace(/\/$/, '');
+const slug = path.split('/').pop();
+const fw = frameworks[slug];
+
+if (!fw) {
+  // Redirect to homepage if unknown framework
+  window.location.href = '/';
+} else {
+  // Set meta tags
+  document.title = fw.metaTitle;
+  document.querySelector('meta[name="description"]').content = fw.metaDesc;
+  document.querySelector('link[rel="canonical"]').href = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[property="og:title"]').content = fw.metaTitle;
+  document.querySelector('meta[property="og:description"]').content = fw.metaDesc;
+  document.querySelector('meta[property="og:url"]').content = 'https://grantex.dev/for/' + slug;
+  document.querySelector('meta[name="twitter:title"]').content = fw.metaTitle;
+  document.querySelector('meta[name="twitter:description"]').content = fw.metaDesc;
+
+  // Populate content
+  document.getElementById('badge').textContent = fw.badge;
+  document.getElementById('heroTitle').innerHTML = fw.title;
+  document.getElementById('heroDesc').textContent = fw.desc;
+  document.getElementById('ctaDocs').href = fw.docsUrl;
+  document.getElementById('ctaInstall').href = fw.installUrl;
+  document.getElementById('problemBad').textContent = fw.problemBad;
+  document.getElementById('problemGood').textContent = fw.problemGood;
+  document.getElementById('howTitle').textContent = fw.howTitle;
+  document.getElementById('installCmd').textContent = fw.install;
+  document.getElementById('codeExample').textContent = fw.code;
+  document.getElementById('ctaFramework').textContent = fw.ctaFramework;
+  document.getElementById('ctaDocsBottom').href = fw.docsUrl;
+  document.getElementById('featuresTitle').textContent = 'Why Grantex for ' + fw.name;
+
+  // Steps
+  const stepsEl = document.getElementById('steps');
+  fw.steps.forEach(([title, desc]) => {
+    stepsEl.innerHTML += `<div class="step"><div class="step-content"><h3>${title}</h3><p>${desc}</p></div></div>`;
+  });
+
+  // Features
+  const featuresEl = document.getElementById('features');
+  fw.features.forEach(([title, desc]) => {
+    featuresEl.innerHTML += `<div class="feature-card"><h3>${title}</h3><p>${desc}</p></div>`;
+  });
+
+  // Add JSON-LD structured data
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Grantex for " + fw.name,
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Any",
+    "url": "https://grantex.dev/for/" + slug,
+    "description": fw.metaDesc,
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  };
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.textContent = JSON.stringify(jsonLd);
+  document.head.appendChild(script);
+
+  // Track page view
+  gtag('event', 'page_view', { page_title: fw.metaTitle, page_location: window.location.href });
+}
+</script>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -861,7 +861,7 @@
       border-radius: var(--radius);
       padding: 16px;
     }
-    .risk-q h4 {
+    .risk-q h3 {
       font-size: 14px;
       font-weight: 600;
       margin-bottom: 6px;
@@ -1205,7 +1205,7 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
       <span style="background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:4px 10px;font-size:12px;color:var(--muted);">Oracle</span>
       <span style="background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:4px 10px;font-size:12px;color:var(--muted);">Okta</span>
       <span style="background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:4px 10px;font-size:12px;color:var(--muted);">Zendesk</span>
-      <span style="background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:4px 10px;font-size:12px;color:var(--muted);">+41 more</span>
+      <span style="background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:4px 10px;font-size:12px;color:var(--muted);">+40 more</span>
     </div>
 
     <!-- CTA -->
@@ -1339,17 +1339,17 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
       </p>
       <div class="risk-questions">
         <div class="risk-q">
-          <h4>Who authorized it?</h4>
+          <h3>Who authorized it?</h3>
           <p>No consent record exists. The agent used your master key. You own the liability.</p>
           <span class="fix">Grantex fixes this &rarr;</span>
         </div>
         <div class="risk-q">
-          <h4>What did it access?</h4>
+          <h3>What did it access?</h3>
           <p>Full key = full access. No scope means no blast radius boundary.</p>
           <span class="fix">Grantex fixes this &rarr;</span>
         </div>
         <div class="risk-q">
-          <h4>Can you prove you tried?</h4>
+          <h3>Can you prove you tried?</h3>
           <p>No audit trail, no scoped token, no revocation log. The compliance gap is total.</p>
           <span class="fix">Grantex fixes this &rarr;</span>
         </div>
@@ -2043,6 +2043,18 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
         <span class="integration-icon">&#x1F4E1;</span>
         A2A Bridge (Py)
       </a>
+      <a href="https://www.npmjs.com/package/@grantex/cli" class="integration-pill" style="text-decoration:none;">
+        <span class="integration-icon" style="font-family:var(--mono);font-size:14px;font-weight:700;">&gt;_</span>
+        CLI
+      </a>
+      <a href="https://www.npmjs.com/package/@grantex/destinations" class="integration-pill" style="text-decoration:none;">
+        <span class="integration-icon">&#x1F4E8;</span>
+        Event Destinations
+      </a>
+      <a href="https://github.com/mishrasanjeev/grantex/tree/main/packages/terraform-provider-grantex" class="integration-pill" style="text-decoration:none;">
+        <span class="integration-icon" style="font-family:var(--mono);font-size:14px;font-weight:700;">TF</span>
+        Terraform Provider
+      </a>
     </div>
   </div>
 </section>
@@ -2147,6 +2159,143 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
         <div class="example-packages">
           <span class="example-pkg">grantex</span>
           <span class="example-pkg">grantex-adk</span>
+        </div>
+      </a>
+      <a href="https://github.com/mishrasanjeev/grantex/tree/main/examples/quickstart-go"
+         class="example-card" style="text-decoration:none;">
+        <div class="example-lang">Go</div>
+        <h3>Quickstart</h3>
+        <p>
+          Core authorization lifecycle in Go &mdash; register agent, authorize,
+          exchange code, verify token offline, log audit entry, revoke.
+        </p>
+        <div class="example-packages">
+          <span class="example-pkg">grantex-go</span>
+        </div>
+      </a>
+      <a href="https://github.com/mishrasanjeev/grantex/tree/main/examples/anthropic-tool-use"
+         class="example-card" style="text-decoration:none;">
+        <div class="example-lang">TypeScript</div>
+        <h3>Anthropic Tool Use</h3>
+        <p>
+          Anthropic SDK tool use with Grantex scope enforcement and audit logging.
+          Uses <code style="font-family:var(--mono);font-size:12px;">GrantexToolRegistry</code>
+          to manage tools and dispatch tool_use blocks.
+        </p>
+        <div class="example-packages">
+          <span class="example-pkg">@grantex/sdk</span>
+          <span class="example-pkg">@grantex/anthropic</span>
+        </div>
+      </a>
+      <a href="https://github.com/mishrasanjeev/grantex/tree/main/examples/nextjs-starter"
+         class="example-card" style="text-decoration:none;">
+        <div class="example-lang">TypeScript</div>
+        <h3>Next.js Starter</h3>
+        <p>
+          Interactive Next.js app with the full Grantex consent flow &mdash;
+          agent registration, consent UI, token exchange, and audit logging.
+        </p>
+        <div class="example-packages">
+          <span class="example-pkg">@grantex/sdk</span>
+          <span class="example-pkg">next</span>
+        </div>
+      </a>
+      <a href="https://github.com/mishrasanjeev/grantex/tree/main/examples/multi-agent-delegation"
+         class="example-card" style="text-decoration:none;">
+        <div class="example-lang">TypeScript</div>
+        <h3>Multi-Agent Delegation</h3>
+        <p>
+          Delegation chain pattern (SPEC &sect;9) &mdash; parent delegates scoped
+          subset to child agent with cascade revocation.
+        </p>
+        <div class="example-packages">
+          <span class="example-pkg">@grantex/sdk</span>
+        </div>
+      </a>
+      <a href="https://github.com/mishrasanjeev/grantex/tree/main/examples/multi-agent-email-flow"
+         class="example-card" style="text-decoration:none;">
+        <div class="example-lang">TypeScript</div>
+        <h3>Multi-Agent Email Flow</h3>
+        <p>
+          Agent-to-agent email automation with delegation, scope enforcement,
+          failure handling, cascade revocation, and audit trail inspection.
+        </p>
+        <div class="example-packages">
+          <span class="example-pkg">@grantex/sdk</span>
+        </div>
+      </a>
+      <a href="https://github.com/mishrasanjeev/grantex/tree/main/examples/gemma-raspberry-pi"
+         class="example-card" style="text-decoration:none;">
+        <div class="example-lang">Python</div>
+        <h3>Gemma on Raspberry Pi</h3>
+        <p>
+          Gemma 4 on-device agent with offline authorization via consent bundles.
+          Verifies every tool invocation locally &mdash; no internet required at runtime.
+        </p>
+        <div class="example-packages">
+          <span class="example-pkg">grantex-gemma</span>
+        </div>
+      </a>
+      <a href="https://github.com/mishrasanjeev/grantex/tree/main/examples/x402-agent-demo"
+         class="example-card" style="text-decoration:none;">
+        <div class="example-lang">TypeScript</div>
+        <h3>x402 Payment Protocol</h3>
+        <p>
+          AI agent uses a Grantex Delegation Token with x402 to fetch paid API
+          data &mdash; automatic 402 &rarr; pay &rarr; retry flow.
+        </p>
+        <div class="example-packages">
+          <span class="example-pkg">@grantex/x402</span>
+        </div>
+      </a>
+      <a href="https://github.com/mishrasanjeev/grantex/tree/main/examples/token-expiry-refresh"
+         class="example-card" style="text-decoration:none;">
+        <div class="example-lang">TypeScript</div>
+        <h3>Token Expiry &amp; Refresh</h3>
+        <p>
+          Time-bound grant tokens with automatic expiry detection, refresh token
+          rotation, and single-use refresh enforcement.
+        </p>
+        <div class="example-packages">
+          <span class="example-pkg">@grantex/sdk</span>
+        </div>
+      </a>
+      <a href="https://github.com/mishrasanjeev/grantex/tree/main/examples/audit-dashboard"
+         class="example-card" style="text-decoration:none;">
+        <div class="example-lang">TypeScript</div>
+        <h3>Audit Dashboard</h3>
+        <p>
+          Query, filter, and analyze the audit trail with metrics computation
+          and hash chain integrity verification.
+        </p>
+        <div class="example-packages">
+          <span class="example-pkg">@grantex/sdk</span>
+        </div>
+      </a>
+      <a href="https://github.com/mishrasanjeev/grantex/tree/main/examples/gateway-proxy"
+         class="example-card" style="text-decoration:none;">
+        <div class="example-lang">TypeScript</div>
+        <h3>Gateway Proxy</h3>
+        <p>
+          Grantex gateway as a reverse proxy with YAML config and scope enforcement.
+          Authorized requests pass through, unauthorized requests are rejected.
+        </p>
+        <div class="example-packages">
+          <span class="example-pkg">@grantex/sdk</span>
+          <span class="example-pkg">@grantex/gateway</span>
+        </div>
+      </a>
+      <a href="https://github.com/mishrasanjeev/grantex/tree/main/examples/adapter-google-calendar"
+         class="example-card" style="text-decoration:none;">
+        <div class="example-lang">TypeScript</div>
+        <h3>Google Calendar Adapter</h3>
+        <p>
+          GoogleCalendarAdapter with automatic grant token verification, scope
+          checking, and audit logging. Shows read-only vs read-write enforcement.
+        </p>
+        <div class="example-packages">
+          <span class="example-pkg">@grantex/sdk</span>
+          <span class="example-pkg">@grantex/adapters</span>
         </div>
       </a>
     </div>

--- a/web/llms.txt
+++ b/web/llms.txt
@@ -1,5 +1,7 @@
 # Grantex
 
+> Last updated: 2026-04-05
+
 > Delegated authorization protocol for AI agents. What OAuth 2.0 is to humans, Grantex is to agents.
 
 Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, human-approved, revocable permissions via signed JWTs. Any service can verify tokens offline using published JWKS — no runtime dependency on Grantex infrastructure.
@@ -77,7 +79,7 @@ Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, hum
 - SOC 2 Type I certified
 - Full compliance matrix: https://docs.grantex.dev/guides/compliance-matrix
 
-## Scope Enforcement (v0.3.1)
+## Scope Enforcement (v0.3.4)
 
 - `grantex.enforce(grant_token, connector, tool)` — verify JWT + check tool permission via manifest
 - `grantex.load_manifest(manifest)` / `load_manifests([...])` — load tool permission definitions

--- a/web/mpp-demo/index.html
+++ b/web/mpp-demo/index.html
@@ -11,7 +11,11 @@
   <meta property="og:description" content="Interactive demo: issue agent passports, simulate MPP payment flows, and verify passports as a merchant.">
   <meta property="og:url" content="https://grantex.dev/mpp-demo">
   <meta property="og:type" content="website">
-  <meta name="twitter:site" content="@grantex_dev">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+
+  <!-- JSON-LD -->
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebApplication","name":"Grantex MPP Demo","url":"https://grantex.dev/mpp-demo","description":"Interactive demo of agent identity and delegation for agentic commerce using the Machine Payments Protocol","applicationCategory":"DeveloperApplication","operatingSystem":"Web"}</script>
+
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Grantex × MPP Demo — Agent Identity for Machine Payments">
   <style>

--- a/web/playground.html
+++ b/web/playground.html
@@ -16,8 +16,10 @@
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Grantex">
 
+  <!-- JSON-LD -->
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebApplication","name":"Grantex Playground","url":"https://grantex.dev/playground","description":"Interactive authorization flow demo for the Grantex protocol","applicationCategory":"DeveloperApplication","operatingSystem":"Web"}</script>
+
   <!-- Twitter Card -->
-  <meta name="twitter:site" content="@grantex_dev">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Grantex Playground — Try AI Agent Authorization Live">
   <meta name="twitter:description" content="Create agents, issue scoped grants, and verify JWTs in your browser. No signup required.">

--- a/web/registry.html
+++ b/web/registry.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -20,7 +22,6 @@
   <meta property="og:site_name" content="Grantex">
 
   <!-- Twitter Card -->
-  <meta name="twitter:site" content="@grantex_dev">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Grantex Trust Registry — Verify AI Agent Identity">
   <meta name="twitter:description" content="The public directory of verified AI agent publishers. Look up any organization by DID. Get your agents certified. Build trust before authorization.">

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -2,265 +2,265 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://grantex.dev/</loc>
-    <lastmod>2026-03-28</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://grantex.dev/mpp-demo</loc>
-    <lastmod>2026-03-20</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/mpp</loc>
-    <lastmod>2026-03-20</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/playground</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/langchain</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/crewai</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/openai-agents</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/anthropic</loc>
-    <lastmod>2026-03-30</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/google-adk</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/vercel-ai</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/autogen</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/mcp</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/express</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://grantex.dev/for/fastapi</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://grantex.dev/vs/oauth</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/vs/api-keys</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/vs/mcp-auth</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/vs/securing-ai-agents</loc>
-    <lastmod>2026-03-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/report/state-of-agent-security-2026</loc>
-    <lastmod>2026-03-15</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
-  <url><loc>https://docs.grantex.dev/features/fido-webauthn</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://docs.grantex.dev/features/verifiable-credentials</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://docs.grantex.dev/features/sd-jwt</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://docs.grantex.dev/features/did-infrastructure</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://docs.grantex.dev/features/mpp-agent-passport</loc><lastmod>2026-03-20</lastmod><changefreq>weekly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://docs.grantex.dev/guides/mpp-integration</loc><lastmod>2026-03-20</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://docs.grantex.dev/features/fido-webauthn</loc><lastmod>2026-04-05</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://docs.grantex.dev/features/verifiable-credentials</loc><lastmod>2026-04-05</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://docs.grantex.dev/features/sd-jwt</loc><lastmod>2026-04-05</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://docs.grantex.dev/features/did-infrastructure</loc><lastmod>2026-04-05</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://docs.grantex.dev/features/mpp-agent-passport</loc><lastmod>2026-04-05</lastmod><changefreq>weekly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://docs.grantex.dev/guides/mpp-integration</loc><lastmod>2026-04-05</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url>
     <loc>https://grantex.dev/gemma</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/mcp</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/dpdp</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/registry</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://grantex.dev/anomaly</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/features/offline-authorization</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/features/mcp-auth-server</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/features/dpdp-compliance</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/features/trust-registry</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/features/anomaly-detection</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/compliance/dpdp-act-2023</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/compliance/eu-ai-act</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/blog/gemma-4-offline-agents-security</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/blog/dpdp-act-ai-agents</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://grantex.dev/llms.txt</loc>
-    <lastmod>2026-03-23</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://grantex.dev/llms-full.txt</loc>
-    <lastmod>2026-03-23</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://grantex.dev/x402</loc>
-    <lastmod>2026-03-23</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/blog/agent-security-breaches-2025-2026</loc>
-    <lastmod>2026-03-28</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/blog/owasp-agentic-top-10-compliance</loc>
-    <lastmod>2026-03-28</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/blog/from-copilot-to-autonomous-agents</loc>
-    <lastmod>2026-03-28</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/guides/compliance-matrix</loc>
-    <lastmod>2026-03-28</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/guides/scope-enforcement</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/concepts/tool-manifests</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://docs.grantex.dev/case-studies/agenticorg</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/web/vs/api-keys/index.html
+++ b/web/vs/api-keys/index.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <title>Grantex vs API Keys — Why API Keys Are Dangerous for AI Agents</title>
+  <meta name="description" content="API keys give AI agents unlimited access with no scoping, audit trail, or revocation. Learn how Grantex replaces all-or-nothing API keys with scoped, revocable JWTs.">
+  <link rel="canonical" href="https://grantex.dev/vs/api-keys/">
+  <meta property="og:title" content="Grantex vs API Keys — Why API Keys Are Dangerous for AI Agents">
+  <meta property="og:description" content="API keys give AI agents unlimited access with no scoping, audit trail, or revocation. Learn how Grantex replaces all-or-nothing API keys with scoped, revocable JWTs.">
+  <meta property="og:url" content="https://grantex.dev/vs/api-keys/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="Grantex">
+  <meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grantex vs API Keys — Why API Keys Are Dangerous for AI Agents">
+  <meta name="twitter:description" content="API keys give AI agents unlimited access with no scoping, audit trail, or revocation. Learn how Grantex replaces all-or-nothing API keys with scoped, revocable JWTs.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
+  <style>
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --text: #e6edf3; --muted: #8b949e; --accent: #3fb950; --accent2: #58a6ff;
+      --red: #f85149; --mono: 'JetBrains Mono','Fira Code',monospace;
+      --sans: 'Inter',system-ui,-apple-system,sans-serif; --radius: 8px; --max-w: 860px;
+    }
+    *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+    body{background:var(--bg);color:var(--text);font-family:var(--sans);line-height:1.7}
+    a{color:var(--accent2);text-decoration:none}a:hover{text-decoration:underline}
+    code{font-family:var(--mono);background:var(--surface);padding:2px 6px;border-radius:4px;font-size:.9em}
+    pre{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem;overflow-x:auto;font-family:var(--mono);font-size:.85rem;line-height:1.5;margin:1.5rem 0}
+    pre code{background:none;padding:0}
+
+    .nav{display:flex;align-items:center;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:1rem 1.5rem}
+    .nav-logo{font-weight:700;font-size:1.25rem;color:var(--text)}
+    .nav-links{list-style:none;display:flex;gap:1.5rem}
+    .nav-links a{color:var(--muted);font-size:.9rem}.nav-links a:hover{color:var(--text);text-decoration:none}
+
+    .article{max-width:var(--max-w);margin:0 auto;padding:2rem 1.5rem 4rem}
+    .article h1{font-size:2.25rem;line-height:1.2;margin-bottom:.5rem}
+    .article .subtitle{color:var(--muted);font-size:1.05rem;margin-bottom:2rem}
+    .article h2{font-size:1.5rem;margin:2.5rem 0 1rem;padding-top:1rem;border-top:1px solid var(--border)}
+    .article h3{font-size:1.15rem;margin:1.5rem 0 .5rem;color:var(--accent)}
+    .article p{color:var(--muted);margin-bottom:1rem}
+    .article ul,.article ol{color:var(--muted);padding-left:1.5rem;margin-bottom:1rem}
+    .article li{margin-bottom:.5rem}
+    .article strong{color:var(--text)}
+    .article blockquote{border-left:3px solid var(--accent);padding-left:1rem;margin:1.5rem 0;color:var(--muted);font-style:italic}
+
+    .comparison-table{width:100%;border-collapse:collapse;margin:1.5rem 0}
+    .comparison-table th,.comparison-table td{padding:.75rem 1rem;text-align:left;border:1px solid var(--border)}
+    .comparison-table th{background:var(--surface);color:var(--text);font-weight:600}
+    .comparison-table td{color:var(--muted)}
+    .comparison-table .yes{color:var(--accent)}
+    .comparison-table .no{color:var(--red)}
+
+    .cta-box{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:2rem;text-align:center;margin:2rem 0}
+    .cta-box h3{color:var(--text);margin-bottom:.5rem}
+    .cta-box p{margin-bottom:1rem}
+    .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.65rem 1.25rem;border-radius:var(--radius);font-weight:600;font-size:.9rem;text-decoration:none;transition:all .2s}
+    .btn-primary{background:var(--accent);color:#0d1117}.btn-primary:hover{background:#2ea043;text-decoration:none}
+    .btn-secondary{background:var(--surface);color:var(--text);border:1px solid var(--border)}.btn-secondary:hover{border-color:var(--muted);text-decoration:none}
+
+    .footer{max-width:var(--max-w);margin:0 auto;padding:2rem 1.5rem;border-top:1px solid var(--border);display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:1rem}
+    .footer-links{list-style:none;display:flex;gap:1.5rem}
+    .footer-links a{color:var(--muted);font-size:.85rem}
+
+    @media(max-width:640px){
+      .article h1{font-size:1.65rem}
+      .comparison-table{font-size:.85rem}
+      .comparison-table th,.comparison-table td{padding:.5rem}
+    }
+  </style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Grantex vs API Keys — Why API Keys Are Dangerous for AI Agents","description":"API keys give AI agents unlimited access with no scoping, audit trail, or revocation. Learn how Grantex replaces all-or-nothing API keys with scoped, revocable JWTs.","url":"https://grantex.dev/vs/api-keys/","author":{"@type":"Organization","name":"Grantex","url":"https://grantex.dev"},"publisher":{"@type":"Organization","name":"Grantex","url":"https://grantex.dev"}}</script>
+</head>
+<body>
+<nav class="nav">
+  <a href="/" class="nav-logo">Grantex</a>
+  <ul class="nav-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="/playground">Playground</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+  </ul>
+</nav>
+
+<article class="article" id="content"></article>
+
+<footer class="footer">
+  <span style="color:var(--muted);font-size:.85rem">Grantex — Open authorization for AI agents</span>
+  <ul class="footer-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+    <li><a href="/">Home</a></li>
+  </ul>
+</footer>
+
+<script>
+const pages = {
+  'oauth': {
+    metaTitle: 'Grantex vs OAuth 2.0 — How AI Agent Authorization Differs',
+    metaDesc: 'Comparing Grantex and OAuth 2.0 for AI agent authorization. Learn why OAuth falls short for agents and what Grantex adds: agent identity, delegation chains, audit trails.',
+    html: `
+      <h1>Grantex vs OAuth 2.0</h1>
+      <p class="subtitle">Why OAuth 2.0 doesn't work for AI agents — and what Grantex does differently</p>
+
+      <p>OAuth 2.0 is the gold standard for delegated authorization on the web. It's battle-tested, widely adopted, and well-understood. So why do AI agents need something different?</p>
+      <p>The short answer: <strong>OAuth was designed for human users granting access to applications. Agents aren't applications.</strong></p>
+
+      <h2>What OAuth 2.0 Gets Right</h2>
+      <p>Grantex builds on OAuth's proven patterns:</p>
+      <ul>
+        <li><strong>Consent flow</strong> — users explicitly approve access</li>
+        <li><strong>Scoped permissions</strong> — not all-or-nothing access</li>
+        <li><strong>Token-based</strong> — bearer tokens for API access</li>
+        <li><strong>Revocable</strong> — tokens can be invalidated</li>
+        <li><strong>PKCE</strong> — proof key for code exchange (S256)</li>
+      </ul>
+      <p>If you know OAuth, Grantex will feel familiar. The authorization code flow, token exchange, and scope model all work the same way.</p>
+
+      <h2>Where OAuth Falls Short for Agents</h2>
+
+      <h3>1. No Agent Identity</h3>
+      <p>In OAuth, the <em>application</em> (client) is the identity boundary. When you grant "Acme App" access to your calendar, the token represents your session with that app.</p>
+      <p>But agents aren't apps. A single application might spawn multiple agents — a travel planner, a flight booker, a hotel finder. In OAuth, they all share the same client credentials. You can't distinguish which agent performed an action.</p>
+      <p><strong>Grantex fix:</strong> Every agent gets a cryptographic DID (Decentralized Identifier). The agent's identity is embedded in the JWT (<code>agt</code> claim). You always know <em>which agent</em> performed an action.</p>
+
+      <h3>2. Flat Scopes</h3>
+      <p>OAuth scopes are flat — a user grants scopes to an app, end of story. But agents delegate work to sub-agents. A travel agent needs to give the flight booker <code>flights:book</code> but not <code>hotels:book</code>.</p>
+      <p><strong>Grantex fix:</strong> Delegation chains. A parent agent can delegate a <em>narrower subset</em> of its scopes to a child agent. The delegation depth is tracked in the JWT. Revoking the parent cascades to all children.</p>
+
+      <h3>3. No Audit Trail</h3>
+      <p>OAuth tokens are opaque to the authorization server after issuance. There's no standard for logging what actions were performed with a token.</p>
+      <p><strong>Grantex fix:</strong> Append-only, hash-chained audit log. Every action is recorded with the agent DID, scopes used, timestamp, and a SHA-256 hash linking to the previous entry. Tamper-evident by design.</p>
+
+      <h3>4. Slow Revocation</h3>
+      <p>OAuth revocation depends on token introspection or short expiry windows. If an agent goes rogue, you might have to wait for the token to expire.</p>
+      <p><strong>Grantex fix:</strong> Real-time revocation effective in under 1 second. Plus cascade revocation — revoke a parent to instantly kill all delegated sub-agent grants.</p>
+
+      <h2>Feature Comparison</h2>
+      <table class="comparison-table">
+        <tr><th>Feature</th><th>OAuth 2.0</th><th>Grantex</th></tr>
+        <tr><td>Consent flow</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>Scoped permissions</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>PKCE (S256)</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>Token refresh/rotation</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>Agent identity (DID)</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Delegation chains</td><td class="no">No</td><td class="yes">Yes (depth-tracked)</td></tr>
+        <tr><td>Cascade revocation</td><td class="no">No</td><td class="yes">Yes (&lt; 1s)</td></tr>
+        <tr><td>Hash-chained audit trail</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Offline verification (JWKS)</td><td>Varies</td><td class="yes">Yes (always)</td></tr>
+        <tr><td>Budget controls</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Multi-agent delegation</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Anomaly detection</td><td class="no">No</td><td class="yes">Yes</td></tr>
+      </table>
+
+      <h2>When to Use What</h2>
+      <p><strong>Use OAuth 2.0</strong> when you're building a traditional web/mobile app where humans interact directly with services. OAuth is mature, universally supported, and the right tool for human-to-app authorization.</p>
+      <p><strong>Use Grantex</strong> when AI agents act on behalf of users — especially when agents spawn sub-agents, operate autonomously, or access sensitive services. Grantex gives you the agent-specific primitives that OAuth lacks.</p>
+
+      <h2>Can I Use Both?</h2>
+      <p>Yes. Many teams use OAuth for their user-facing app and Grantex for the agent layer. Grantex's <a href="https://grantex.dev/for/express">Express middleware</a> and <a href="https://grantex.dev/for/fastapi">FastAPI middleware</a> can run alongside existing OAuth middleware.</p>
+
+      <div class="cta-box">
+        <h3>Ready to add agent authorization?</h3>
+        <p>Get started in under 5 minutes. Open source, Apache 2.0.</p>
+        <a href="https://docs.grantex.dev/getting-started/quickstart" class="btn btn-primary" style="margin-right:.5rem">Get Started</a>
+        <a href="/" class="btn btn-secondary">Learn More</a>
+      </div>
+    `
+  },
+
+  'api-keys': {
+    metaTitle: 'Grantex vs API Keys — Why API Keys Are Dangerous for AI Agents',
+    metaDesc: 'API keys give AI agents unlimited access with no scoping, audit trail, or revocation. Learn how Grantex replaces all-or-nothing API keys with scoped, revocable JWTs.',
+    html: `
+      <h1>Grantex vs API Keys</h1>
+      <p class="subtitle">Why all-or-nothing API keys are dangerous for AI agents</p>
+
+      <p>Most AI agents today run on raw API keys. This is the simplest approach — and the most dangerous.</p>
+
+      <h2>The Problem with API Keys for Agents</h2>
+
+      <h3>1. No Scoping</h3>
+      <p>An API key typically grants full access to a service. Your LangChain agent has a Stripe API key? It can read transactions, create charges, issue refunds, and delete customers. There's no way to say "this agent can only <em>read</em> transactions."</p>
+
+      <h3>2. No Audit Trail</h3>
+      <p>API keys don't identify <em>which agent</em> made a request. If you have 5 agents sharing a Stripe key, your logs show "API key sk_live_... made a charge" — not "the travel-booking agent made a charge on behalf of user Alice."</p>
+
+      <h3>3. No Revocation (Without Breaking Everything)</h3>
+      <p>Revoking an API key kills <em>all</em> agents using it. If one agent misbehaves, you can't revoke just that agent's access. You have to rotate the key and update every agent.</p>
+
+      <h3>4. No User Consent</h3>
+      <p>API keys are developer-level credentials. End users never approve what an agent can do on their behalf. This is a compliance and trust problem.</p>
+
+      <h3>5. No Delegation Control</h3>
+      <p>If a parent agent gives its API key to a sub-agent, the sub-agent has the same full access. There's no narrowing, no depth tracking, no cascade revocation.</p>
+
+      <h2>How Grantex Replaces API Keys</h2>
+
+      <table class="comparison-table">
+        <tr><th>Aspect</th><th>API Keys</th><th>Grantex</th></tr>
+        <tr><td>Access scope</td><td class="no">Full access</td><td class="yes">Per-grant scoping</td></tr>
+        <tr><td>User consent</td><td class="no">None</td><td class="yes">Explicit consent flow</td></tr>
+        <tr><td>Agent identity</td><td class="no">Shared key</td><td class="yes">Cryptographic DID per agent</td></tr>
+        <tr><td>Audit trail</td><td class="no">Key-level only</td><td class="yes">Per-agent, hash-chained</td></tr>
+        <tr><td>Revocation</td><td class="no">Kills all agents</td><td class="yes">Per-agent, &lt; 1 second</td></tr>
+        <tr><td>Delegation</td><td class="no">Copy the key</td><td class="yes">Scoped, depth-tracked</td></tr>
+        <tr><td>Expiration</td><td class="no">Usually never</td><td class="yes">Time-limited JWTs</td></tr>
+        <tr><td>Budget limits</td><td class="no">No</td><td class="yes">Per-grant budgets</td></tr>
+        <tr><td>Verification</td><td>API call required</td><td class="yes">Offline via JWKS</td></tr>
+      </table>
+
+      <h2>Migration Path</h2>
+      <p>You don't have to replace all your API keys at once. The typical migration:</p>
+      <ol>
+        <li><strong>Add Grantex to your agent layer</strong> — agents get scoped JWTs for user-facing actions</li>
+        <li><strong>Keep API keys for internal services</strong> — machine-to-machine calls that don't involve user data</li>
+        <li><strong>Add verification middleware</strong> — Express.js or FastAPI middleware checks Grantex JWTs on your endpoints</li>
+        <li><strong>Phase out agent API keys</strong> — as you add Grantex coverage, remove direct API key access from agents</li>
+      </ol>
+
+      <h2>Code Comparison</h2>
+
+      <h3>Before: Agent with API Key</h3>
+      <pre><code>// Agent has FULL Stripe access
+const stripe = new Stripe(process.env.STRIPE_API_KEY);
+await stripe.charges.create({ amount: 5000, currency: 'usd' });
+// Who authorized this? Which agent? What scopes? No idea.</code></pre>
+
+      <h3>After: Agent with Grantex JWT</h3>
+      <pre><code>// Agent has scoped access: "payments:read" only
+const toolkit = new GrantexToolkit({
+  client: gx,
+  grantToken: token,  // JWT with scopes: ["payments:read"]
+  tools: [stripeReadTool],
+});
+// Agent CAN read charges but CANNOT create them.
+// Every action logged with agent DID, user ID, timestamp.</code></pre>
+
+      <div class="cta-box">
+        <h3>Replace API keys with scoped grants</h3>
+        <p>10 lines of code. Open source. Apache 2.0.</p>
+        <a href="https://docs.grantex.dev/getting-started/quickstart" class="btn btn-primary" style="margin-right:.5rem">Get Started</a>
+        <a href="/playground" class="btn btn-secondary">Try in Playground</a>
+      </div>
+    `
+  },
+
+  'mcp-auth': {
+    metaTitle: 'How to Add Authentication to MCP Servers — Grantex MCP Auth',
+    metaDesc: 'Add OAuth 2.1 + PKCE authentication to any MCP server. Grantex MCP Auth provides scoped authorization for Claude Desktop, Cursor, and Windsurf tools.',
+    html: `
+      <h1>How to Add Auth to MCP Servers</h1>
+      <p class="subtitle">OAuth 2.1 + PKCE authorization for Model Context Protocol servers</p>
+
+      <p>MCP (Model Context Protocol) lets AI assistants like Claude Desktop, Cursor, and Windsurf call external tools. But out of the box, <strong>MCP servers have no authorization layer</strong>. Any connected client can call any tool with full access.</p>
+
+      <h2>The Problem</h2>
+      <p>When you build an MCP server that accesses real services — databases, APIs, file systems — you need to control who can call what. Without auth:</p>
+      <ul>
+        <li>Any MCP client can invoke any tool</li>
+        <li>No way to scope access per user or per session</li>
+        <li>No audit trail of tool invocations</li>
+        <li>No consent flow for sensitive operations</li>
+      </ul>
+
+      <h2>Two Grantex Solutions for MCP</h2>
+
+      <h3>1. @grantex/mcp — Grantex as an MCP Server</h3>
+      <p>13 tools for managing agent authorization directly from Claude Desktop or Cursor:</p>
+      <pre><code>// claude_desktop_config.json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "npx",
+      "args": ["@grantex/mcp"],
+      "env": { "GRANTEX_API_KEY": "gx_live_..." }
+    }
+  }
+}
+
+// Then ask Claude:
+// "Register an agent called data-bot with db:read scope"
+// "Create a grant for user alice on data-bot"
+// "Show me the audit log for the last hour"</code></pre>
+
+      <h3>2. @grantex/mcp-auth — Add Auth to YOUR MCP Server</h3>
+      <p>OAuth 2.1 + PKCE authorization for any MCP server you build:</p>
+      <pre><code>import { GrantexMCPAuth } from '@grantex/mcp-auth';
+
+const auth = new GrantexMCPAuth({
+  jwksUrl: 'https://your-auth/.well-known/jwks.json',
+});
+
+// Wrap your MCP tool handlers with authorization
+server.tool('query_database', auth.requireScopes(['db:read']), async (params) => {
+  // Only executes if the caller has db:read scope
+  return await db.query(params.sql);
+});</code></pre>
+
+      <h2>Feature Comparison</h2>
+      <table class="comparison-table">
+        <tr><th>Feature</th><th>MCP (default)</th><th>MCP + Grantex</th></tr>
+        <tr><td>Tool access control</td><td class="no">None</td><td class="yes">Per-tool scopes</td></tr>
+        <tr><td>User consent</td><td class="no">No</td><td class="yes">OAuth 2.1 consent flow</td></tr>
+        <tr><td>PKCE</td><td class="no">No</td><td class="yes">S256</td></tr>
+        <tr><td>Audit trail</td><td class="no">No</td><td class="yes">Hash-chained</td></tr>
+        <tr><td>Token revocation</td><td class="no">N/A</td><td class="yes">&lt; 1 second</td></tr>
+        <tr><td>Multi-user</td><td class="no">No</td><td class="yes">Per-user grants</td></tr>
+      </table>
+
+      <div class="cta-box">
+        <h3>Secure your MCP server in 5 minutes</h3>
+        <p>Works with Claude Desktop, Cursor, and Windsurf.</p>
+        <a href="https://docs.grantex.dev/integrations/mcp" class="btn btn-primary" style="margin-right:.5rem">Read the Docs</a>
+        <a href="https://www.npmjs.com/package/@grantex/mcp-auth" class="btn btn-secondary">npm install</a>
+      </div>
+    `
+  },
+
+  'securing-ai-agents': {
+    metaTitle: 'How to Secure AI Agents — Authorization, Scoping, and Audit Trails',
+    metaDesc: 'A practical guide to securing AI agents in production. Scoped permissions, cryptographic identity, audit trails, delegation control, and real-time revocation.',
+    html: `
+      <h1>How to Secure AI Agents in Production</h1>
+      <p class="subtitle">A practical guide to authorization, scoping, and audit trails for AI agents</p>
+
+      <p>Your AI agent books flights, reads emails, and processes payments. How do you make sure it only does what it's supposed to?</p>
+      <p>This guide covers the key security primitives you need for production AI agents, and how to implement them.</p>
+
+      <h2>1. Scoped Permissions</h2>
+      <p>The #1 rule: <strong>never give an agent more access than it needs.</strong></p>
+      <p>Instead of a full API key, give each agent a token with specific scopes:</p>
+      <pre><code>// Agent can read emails but NOT send them
+const auth = await gx.authorize({
+  agentId: agent.id,
+  userId: 'user_alice',
+  scopes: ['email:read'],  // not 'email:*'
+});</code></pre>
+      <p>With Grantex, scopes are enforced at the protocol level. If an agent tries to call a tool requiring <code>email:send</code> but only has <code>email:read</code>, the request is denied.</p>
+
+      <h2>2. Agent Identity</h2>
+      <p>Every agent needs its own cryptographic identity — not shared credentials.</p>
+      <p>Grantex assigns each agent a DID (Decentralized Identifier) embedded in its JWT. This means you can always answer: <em>"Which agent performed this action?"</em></p>
+
+      <h2>3. User Consent</h2>
+      <p>Before an agent acts on a user's behalf, the user should explicitly approve:</p>
+      <ul>
+        <li>What scopes the agent gets</li>
+        <li>How long the access lasts</li>
+        <li>What services the agent can access</li>
+      </ul>
+      <p>Grantex provides a consent URL that users visit to approve or deny the request. This is the same pattern as OAuth — familiar to users.</p>
+
+      <h2>4. Audit Trail</h2>
+      <p>You need to know what your agents did, not just what they were authorized to do.</p>
+      <p>Grantex provides an append-only, hash-chained audit log. Each entry includes:</p>
+      <ul>
+        <li>Agent DID and grant ID</li>
+        <li>Action performed and scopes used</li>
+        <li>Timestamp</li>
+        <li>SHA-256 hash linking to the previous entry (tamper-evident)</li>
+      </ul>
+
+      <h2>5. Delegation Control</h2>
+      <p>When a parent agent spawns sub-agents, the sub-agents should get <em>narrower</em> permissions, not the same or broader.</p>
+      <pre><code>// Parent has: ["flights:book", "hotels:book"]
+// Delegate only flights to the sub-agent:
+const delegated = await gx.grants.delegate({
+  parentGrantToken: parentToken,
+  childAgentId: flightBooker.id,
+  scopes: ['flights:book'],  // subset only
+});</code></pre>
+      <p>The delegation depth is tracked in the JWT. Revoking the parent cascades to all children.</p>
+
+      <h2>6. Real-Time Revocation</h2>
+      <p>If an agent behaves unexpectedly, you need to kill its access immediately — not wait for a token to expire.</p>
+      <p>Grantex revocation takes effect in under 1 second. Cascade revocation kills all delegated sub-agent grants simultaneously.</p>
+
+      <h2>7. Budget Controls</h2>
+      <p>For agents that spend money (API calls, compute, purchases), set spending limits:</p>
+      <pre><code>await gx.budgets.allocate({
+  grantId: grant.id,
+  amount: 100.00,  // max $100
+  currency: 'USD',
+});
+// Agent is automatically cut off at the limit</code></pre>
+
+      <h2>Getting Started</h2>
+      <p>Grantex provides all of these primitives as an open protocol (Apache 2.0) with SDKs for <a href="https://docs.grantex.dev/sdks/typescript/overview">TypeScript</a>, <a href="https://docs.grantex.dev/sdks/python/overview">Python</a>, and <a href="https://docs.grantex.dev/sdks/go/overview">Go</a>.</p>
+
+      <div class="cta-box">
+        <h3>Secure your agents in under 5 minutes</h3>
+        <p>Open source. 14 framework integrations. 174 pages of docs.</p>
+        <a href="https://docs.grantex.dev/getting-started/quickstart" class="btn btn-primary" style="margin-right:.5rem">Quickstart Guide</a>
+        <a href="/playground" class="btn btn-secondary">Try in Playground</a>
+      </div>
+    `
+  }
+};
+
+const slug = window.location.pathname.replace(/\/$/, '').split('/').pop();
+const page = pages[slug];
+
+if (!page) {
+  window.location.href = '/';
+} else {
+  document.title = page.metaTitle;
+  document.querySelector('meta[name="description"]').content = page.metaDesc;
+  document.querySelector('link[rel="canonical"]').href = 'https://grantex.dev/vs/' + slug;
+  document.querySelector('meta[property="og:title"]').content = page.metaTitle;
+  document.querySelector('meta[property="og:description"]').content = page.metaDesc;
+  document.querySelector('meta[property="og:url"]').content = 'https://grantex.dev/vs/' + slug;
+  document.querySelector('meta[name="twitter:title"]').content = page.metaTitle;
+  document.querySelector('meta[name="twitter:description"]').content = page.metaDesc;
+  document.getElementById('content').innerHTML = page.html;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": page.metaTitle,
+    "description": page.metaDesc,
+    "url": "https://grantex.dev/vs/" + slug,
+    "author": { "@type": "Organization", "name": "Grantex", "url": "https://grantex.dev" },
+    "publisher": { "@type": "Organization", "name": "Grantex", "url": "https://grantex.dev" }
+  };
+  const s = document.createElement('script');
+  s.type = 'application/ld+json';
+  s.textContent = JSON.stringify(jsonLd);
+  document.head.appendChild(s);
+
+  gtag('event', 'page_view', { page_title: page.metaTitle, page_location: window.location.href });
+}
+</script>
+</body>
+</html>

--- a/web/vs/mcp-auth/index.html
+++ b/web/vs/mcp-auth/index.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <title>How to Add Authentication to MCP Servers — Grantex MCP Auth</title>
+  <meta name="description" content="Add OAuth 2.1 + PKCE authentication to any MCP server. Grantex MCP Auth provides scoped authorization for Claude Desktop, Cursor, and Windsurf tools.">
+  <link rel="canonical" href="https://grantex.dev/vs/mcp-auth/">
+  <meta property="og:title" content="How to Add Authentication to MCP Servers — Grantex MCP Auth">
+  <meta property="og:description" content="Add OAuth 2.1 + PKCE authentication to any MCP server. Grantex MCP Auth provides scoped authorization for Claude Desktop, Cursor, and Windsurf tools.">
+  <meta property="og:url" content="https://grantex.dev/vs/mcp-auth/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="Grantex">
+  <meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="How to Add Authentication to MCP Servers — Grantex MCP Auth">
+  <meta name="twitter:description" content="Add OAuth 2.1 + PKCE authentication to any MCP server. Grantex MCP Auth provides scoped authorization for Claude Desktop, Cursor, and Windsurf tools.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
+  <style>
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --text: #e6edf3; --muted: #8b949e; --accent: #3fb950; --accent2: #58a6ff;
+      --red: #f85149; --mono: 'JetBrains Mono','Fira Code',monospace;
+      --sans: 'Inter',system-ui,-apple-system,sans-serif; --radius: 8px; --max-w: 860px;
+    }
+    *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+    body{background:var(--bg);color:var(--text);font-family:var(--sans);line-height:1.7}
+    a{color:var(--accent2);text-decoration:none}a:hover{text-decoration:underline}
+    code{font-family:var(--mono);background:var(--surface);padding:2px 6px;border-radius:4px;font-size:.9em}
+    pre{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem;overflow-x:auto;font-family:var(--mono);font-size:.85rem;line-height:1.5;margin:1.5rem 0}
+    pre code{background:none;padding:0}
+
+    .nav{display:flex;align-items:center;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:1rem 1.5rem}
+    .nav-logo{font-weight:700;font-size:1.25rem;color:var(--text)}
+    .nav-links{list-style:none;display:flex;gap:1.5rem}
+    .nav-links a{color:var(--muted);font-size:.9rem}.nav-links a:hover{color:var(--text);text-decoration:none}
+
+    .article{max-width:var(--max-w);margin:0 auto;padding:2rem 1.5rem 4rem}
+    .article h1{font-size:2.25rem;line-height:1.2;margin-bottom:.5rem}
+    .article .subtitle{color:var(--muted);font-size:1.05rem;margin-bottom:2rem}
+    .article h2{font-size:1.5rem;margin:2.5rem 0 1rem;padding-top:1rem;border-top:1px solid var(--border)}
+    .article h3{font-size:1.15rem;margin:1.5rem 0 .5rem;color:var(--accent)}
+    .article p{color:var(--muted);margin-bottom:1rem}
+    .article ul,.article ol{color:var(--muted);padding-left:1.5rem;margin-bottom:1rem}
+    .article li{margin-bottom:.5rem}
+    .article strong{color:var(--text)}
+    .article blockquote{border-left:3px solid var(--accent);padding-left:1rem;margin:1.5rem 0;color:var(--muted);font-style:italic}
+
+    .comparison-table{width:100%;border-collapse:collapse;margin:1.5rem 0}
+    .comparison-table th,.comparison-table td{padding:.75rem 1rem;text-align:left;border:1px solid var(--border)}
+    .comparison-table th{background:var(--surface);color:var(--text);font-weight:600}
+    .comparison-table td{color:var(--muted)}
+    .comparison-table .yes{color:var(--accent)}
+    .comparison-table .no{color:var(--red)}
+
+    .cta-box{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:2rem;text-align:center;margin:2rem 0}
+    .cta-box h3{color:var(--text);margin-bottom:.5rem}
+    .cta-box p{margin-bottom:1rem}
+    .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.65rem 1.25rem;border-radius:var(--radius);font-weight:600;font-size:.9rem;text-decoration:none;transition:all .2s}
+    .btn-primary{background:var(--accent);color:#0d1117}.btn-primary:hover{background:#2ea043;text-decoration:none}
+    .btn-secondary{background:var(--surface);color:var(--text);border:1px solid var(--border)}.btn-secondary:hover{border-color:var(--muted);text-decoration:none}
+
+    .footer{max-width:var(--max-w);margin:0 auto;padding:2rem 1.5rem;border-top:1px solid var(--border);display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:1rem}
+    .footer-links{list-style:none;display:flex;gap:1.5rem}
+    .footer-links a{color:var(--muted);font-size:.85rem}
+
+    @media(max-width:640px){
+      .article h1{font-size:1.65rem}
+      .comparison-table{font-size:.85rem}
+      .comparison-table th,.comparison-table td{padding:.5rem}
+    }
+  </style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Add Authentication to MCP Servers — Grantex MCP Auth","description":"Add OAuth 2.1 + PKCE authentication to any MCP server. Grantex MCP Auth provides scoped authorization for Claude Desktop, Cursor, and Windsurf tools.","url":"https://grantex.dev/vs/mcp-auth/","author":{"@type":"Organization","name":"Grantex","url":"https://grantex.dev"},"publisher":{"@type":"Organization","name":"Grantex","url":"https://grantex.dev"}}</script>
+</head>
+<body>
+<nav class="nav">
+  <a href="/" class="nav-logo">Grantex</a>
+  <ul class="nav-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="/playground">Playground</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+  </ul>
+</nav>
+
+<article class="article" id="content"></article>
+
+<footer class="footer">
+  <span style="color:var(--muted);font-size:.85rem">Grantex — Open authorization for AI agents</span>
+  <ul class="footer-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+    <li><a href="/">Home</a></li>
+  </ul>
+</footer>
+
+<script>
+const pages = {
+  'oauth': {
+    metaTitle: 'Grantex vs OAuth 2.0 — How AI Agent Authorization Differs',
+    metaDesc: 'Comparing Grantex and OAuth 2.0 for AI agent authorization. Learn why OAuth falls short for agents and what Grantex adds: agent identity, delegation chains, audit trails.',
+    html: `
+      <h1>Grantex vs OAuth 2.0</h1>
+      <p class="subtitle">Why OAuth 2.0 doesn't work for AI agents — and what Grantex does differently</p>
+
+      <p>OAuth 2.0 is the gold standard for delegated authorization on the web. It's battle-tested, widely adopted, and well-understood. So why do AI agents need something different?</p>
+      <p>The short answer: <strong>OAuth was designed for human users granting access to applications. Agents aren't applications.</strong></p>
+
+      <h2>What OAuth 2.0 Gets Right</h2>
+      <p>Grantex builds on OAuth's proven patterns:</p>
+      <ul>
+        <li><strong>Consent flow</strong> — users explicitly approve access</li>
+        <li><strong>Scoped permissions</strong> — not all-or-nothing access</li>
+        <li><strong>Token-based</strong> — bearer tokens for API access</li>
+        <li><strong>Revocable</strong> — tokens can be invalidated</li>
+        <li><strong>PKCE</strong> — proof key for code exchange (S256)</li>
+      </ul>
+      <p>If you know OAuth, Grantex will feel familiar. The authorization code flow, token exchange, and scope model all work the same way.</p>
+
+      <h2>Where OAuth Falls Short for Agents</h2>
+
+      <h3>1. No Agent Identity</h3>
+      <p>In OAuth, the <em>application</em> (client) is the identity boundary. When you grant "Acme App" access to your calendar, the token represents your session with that app.</p>
+      <p>But agents aren't apps. A single application might spawn multiple agents — a travel planner, a flight booker, a hotel finder. In OAuth, they all share the same client credentials. You can't distinguish which agent performed an action.</p>
+      <p><strong>Grantex fix:</strong> Every agent gets a cryptographic DID (Decentralized Identifier). The agent's identity is embedded in the JWT (<code>agt</code> claim). You always know <em>which agent</em> performed an action.</p>
+
+      <h3>2. Flat Scopes</h3>
+      <p>OAuth scopes are flat — a user grants scopes to an app, end of story. But agents delegate work to sub-agents. A travel agent needs to give the flight booker <code>flights:book</code> but not <code>hotels:book</code>.</p>
+      <p><strong>Grantex fix:</strong> Delegation chains. A parent agent can delegate a <em>narrower subset</em> of its scopes to a child agent. The delegation depth is tracked in the JWT. Revoking the parent cascades to all children.</p>
+
+      <h3>3. No Audit Trail</h3>
+      <p>OAuth tokens are opaque to the authorization server after issuance. There's no standard for logging what actions were performed with a token.</p>
+      <p><strong>Grantex fix:</strong> Append-only, hash-chained audit log. Every action is recorded with the agent DID, scopes used, timestamp, and a SHA-256 hash linking to the previous entry. Tamper-evident by design.</p>
+
+      <h3>4. Slow Revocation</h3>
+      <p>OAuth revocation depends on token introspection or short expiry windows. If an agent goes rogue, you might have to wait for the token to expire.</p>
+      <p><strong>Grantex fix:</strong> Real-time revocation effective in under 1 second. Plus cascade revocation — revoke a parent to instantly kill all delegated sub-agent grants.</p>
+
+      <h2>Feature Comparison</h2>
+      <table class="comparison-table">
+        <tr><th>Feature</th><th>OAuth 2.0</th><th>Grantex</th></tr>
+        <tr><td>Consent flow</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>Scoped permissions</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>PKCE (S256)</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>Token refresh/rotation</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>Agent identity (DID)</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Delegation chains</td><td class="no">No</td><td class="yes">Yes (depth-tracked)</td></tr>
+        <tr><td>Cascade revocation</td><td class="no">No</td><td class="yes">Yes (&lt; 1s)</td></tr>
+        <tr><td>Hash-chained audit trail</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Offline verification (JWKS)</td><td>Varies</td><td class="yes">Yes (always)</td></tr>
+        <tr><td>Budget controls</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Multi-agent delegation</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Anomaly detection</td><td class="no">No</td><td class="yes">Yes</td></tr>
+      </table>
+
+      <h2>When to Use What</h2>
+      <p><strong>Use OAuth 2.0</strong> when you're building a traditional web/mobile app where humans interact directly with services. OAuth is mature, universally supported, and the right tool for human-to-app authorization.</p>
+      <p><strong>Use Grantex</strong> when AI agents act on behalf of users — especially when agents spawn sub-agents, operate autonomously, or access sensitive services. Grantex gives you the agent-specific primitives that OAuth lacks.</p>
+
+      <h2>Can I Use Both?</h2>
+      <p>Yes. Many teams use OAuth for their user-facing app and Grantex for the agent layer. Grantex's <a href="https://grantex.dev/for/express">Express middleware</a> and <a href="https://grantex.dev/for/fastapi">FastAPI middleware</a> can run alongside existing OAuth middleware.</p>
+
+      <div class="cta-box">
+        <h3>Ready to add agent authorization?</h3>
+        <p>Get started in under 5 minutes. Open source, Apache 2.0.</p>
+        <a href="https://docs.grantex.dev/getting-started/quickstart" class="btn btn-primary" style="margin-right:.5rem">Get Started</a>
+        <a href="/" class="btn btn-secondary">Learn More</a>
+      </div>
+    `
+  },
+
+  'api-keys': {
+    metaTitle: 'Grantex vs API Keys — Why API Keys Are Dangerous for AI Agents',
+    metaDesc: 'API keys give AI agents unlimited access with no scoping, audit trail, or revocation. Learn how Grantex replaces all-or-nothing API keys with scoped, revocable JWTs.',
+    html: `
+      <h1>Grantex vs API Keys</h1>
+      <p class="subtitle">Why all-or-nothing API keys are dangerous for AI agents</p>
+
+      <p>Most AI agents today run on raw API keys. This is the simplest approach — and the most dangerous.</p>
+
+      <h2>The Problem with API Keys for Agents</h2>
+
+      <h3>1. No Scoping</h3>
+      <p>An API key typically grants full access to a service. Your LangChain agent has a Stripe API key? It can read transactions, create charges, issue refunds, and delete customers. There's no way to say "this agent can only <em>read</em> transactions."</p>
+
+      <h3>2. No Audit Trail</h3>
+      <p>API keys don't identify <em>which agent</em> made a request. If you have 5 agents sharing a Stripe key, your logs show "API key sk_live_... made a charge" — not "the travel-booking agent made a charge on behalf of user Alice."</p>
+
+      <h3>3. No Revocation (Without Breaking Everything)</h3>
+      <p>Revoking an API key kills <em>all</em> agents using it. If one agent misbehaves, you can't revoke just that agent's access. You have to rotate the key and update every agent.</p>
+
+      <h3>4. No User Consent</h3>
+      <p>API keys are developer-level credentials. End users never approve what an agent can do on their behalf. This is a compliance and trust problem.</p>
+
+      <h3>5. No Delegation Control</h3>
+      <p>If a parent agent gives its API key to a sub-agent, the sub-agent has the same full access. There's no narrowing, no depth tracking, no cascade revocation.</p>
+
+      <h2>How Grantex Replaces API Keys</h2>
+
+      <table class="comparison-table">
+        <tr><th>Aspect</th><th>API Keys</th><th>Grantex</th></tr>
+        <tr><td>Access scope</td><td class="no">Full access</td><td class="yes">Per-grant scoping</td></tr>
+        <tr><td>User consent</td><td class="no">None</td><td class="yes">Explicit consent flow</td></tr>
+        <tr><td>Agent identity</td><td class="no">Shared key</td><td class="yes">Cryptographic DID per agent</td></tr>
+        <tr><td>Audit trail</td><td class="no">Key-level only</td><td class="yes">Per-agent, hash-chained</td></tr>
+        <tr><td>Revocation</td><td class="no">Kills all agents</td><td class="yes">Per-agent, &lt; 1 second</td></tr>
+        <tr><td>Delegation</td><td class="no">Copy the key</td><td class="yes">Scoped, depth-tracked</td></tr>
+        <tr><td>Expiration</td><td class="no">Usually never</td><td class="yes">Time-limited JWTs</td></tr>
+        <tr><td>Budget limits</td><td class="no">No</td><td class="yes">Per-grant budgets</td></tr>
+        <tr><td>Verification</td><td>API call required</td><td class="yes">Offline via JWKS</td></tr>
+      </table>
+
+      <h2>Migration Path</h2>
+      <p>You don't have to replace all your API keys at once. The typical migration:</p>
+      <ol>
+        <li><strong>Add Grantex to your agent layer</strong> — agents get scoped JWTs for user-facing actions</li>
+        <li><strong>Keep API keys for internal services</strong> — machine-to-machine calls that don't involve user data</li>
+        <li><strong>Add verification middleware</strong> — Express.js or FastAPI middleware checks Grantex JWTs on your endpoints</li>
+        <li><strong>Phase out agent API keys</strong> — as you add Grantex coverage, remove direct API key access from agents</li>
+      </ol>
+
+      <h2>Code Comparison</h2>
+
+      <h3>Before: Agent with API Key</h3>
+      <pre><code>// Agent has FULL Stripe access
+const stripe = new Stripe(process.env.STRIPE_API_KEY);
+await stripe.charges.create({ amount: 5000, currency: 'usd' });
+// Who authorized this? Which agent? What scopes? No idea.</code></pre>
+
+      <h3>After: Agent with Grantex JWT</h3>
+      <pre><code>// Agent has scoped access: "payments:read" only
+const toolkit = new GrantexToolkit({
+  client: gx,
+  grantToken: token,  // JWT with scopes: ["payments:read"]
+  tools: [stripeReadTool],
+});
+// Agent CAN read charges but CANNOT create them.
+// Every action logged with agent DID, user ID, timestamp.</code></pre>
+
+      <div class="cta-box">
+        <h3>Replace API keys with scoped grants</h3>
+        <p>10 lines of code. Open source. Apache 2.0.</p>
+        <a href="https://docs.grantex.dev/getting-started/quickstart" class="btn btn-primary" style="margin-right:.5rem">Get Started</a>
+        <a href="/playground" class="btn btn-secondary">Try in Playground</a>
+      </div>
+    `
+  },
+
+  'mcp-auth': {
+    metaTitle: 'How to Add Authentication to MCP Servers — Grantex MCP Auth',
+    metaDesc: 'Add OAuth 2.1 + PKCE authentication to any MCP server. Grantex MCP Auth provides scoped authorization for Claude Desktop, Cursor, and Windsurf tools.',
+    html: `
+      <h1>How to Add Auth to MCP Servers</h1>
+      <p class="subtitle">OAuth 2.1 + PKCE authorization for Model Context Protocol servers</p>
+
+      <p>MCP (Model Context Protocol) lets AI assistants like Claude Desktop, Cursor, and Windsurf call external tools. But out of the box, <strong>MCP servers have no authorization layer</strong>. Any connected client can call any tool with full access.</p>
+
+      <h2>The Problem</h2>
+      <p>When you build an MCP server that accesses real services — databases, APIs, file systems — you need to control who can call what. Without auth:</p>
+      <ul>
+        <li>Any MCP client can invoke any tool</li>
+        <li>No way to scope access per user or per session</li>
+        <li>No audit trail of tool invocations</li>
+        <li>No consent flow for sensitive operations</li>
+      </ul>
+
+      <h2>Two Grantex Solutions for MCP</h2>
+
+      <h3>1. @grantex/mcp — Grantex as an MCP Server</h3>
+      <p>13 tools for managing agent authorization directly from Claude Desktop or Cursor:</p>
+      <pre><code>// claude_desktop_config.json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "npx",
+      "args": ["@grantex/mcp"],
+      "env": { "GRANTEX_API_KEY": "gx_live_..." }
+    }
+  }
+}
+
+// Then ask Claude:
+// "Register an agent called data-bot with db:read scope"
+// "Create a grant for user alice on data-bot"
+// "Show me the audit log for the last hour"</code></pre>
+
+      <h3>2. @grantex/mcp-auth — Add Auth to YOUR MCP Server</h3>
+      <p>OAuth 2.1 + PKCE authorization for any MCP server you build:</p>
+      <pre><code>import { GrantexMCPAuth } from '@grantex/mcp-auth';
+
+const auth = new GrantexMCPAuth({
+  jwksUrl: 'https://your-auth/.well-known/jwks.json',
+});
+
+// Wrap your MCP tool handlers with authorization
+server.tool('query_database', auth.requireScopes(['db:read']), async (params) => {
+  // Only executes if the caller has db:read scope
+  return await db.query(params.sql);
+});</code></pre>
+
+      <h2>Feature Comparison</h2>
+      <table class="comparison-table">
+        <tr><th>Feature</th><th>MCP (default)</th><th>MCP + Grantex</th></tr>
+        <tr><td>Tool access control</td><td class="no">None</td><td class="yes">Per-tool scopes</td></tr>
+        <tr><td>User consent</td><td class="no">No</td><td class="yes">OAuth 2.1 consent flow</td></tr>
+        <tr><td>PKCE</td><td class="no">No</td><td class="yes">S256</td></tr>
+        <tr><td>Audit trail</td><td class="no">No</td><td class="yes">Hash-chained</td></tr>
+        <tr><td>Token revocation</td><td class="no">N/A</td><td class="yes">&lt; 1 second</td></tr>
+        <tr><td>Multi-user</td><td class="no">No</td><td class="yes">Per-user grants</td></tr>
+      </table>
+
+      <div class="cta-box">
+        <h3>Secure your MCP server in 5 minutes</h3>
+        <p>Works with Claude Desktop, Cursor, and Windsurf.</p>
+        <a href="https://docs.grantex.dev/integrations/mcp" class="btn btn-primary" style="margin-right:.5rem">Read the Docs</a>
+        <a href="https://www.npmjs.com/package/@grantex/mcp-auth" class="btn btn-secondary">npm install</a>
+      </div>
+    `
+  },
+
+  'securing-ai-agents': {
+    metaTitle: 'How to Secure AI Agents — Authorization, Scoping, and Audit Trails',
+    metaDesc: 'A practical guide to securing AI agents in production. Scoped permissions, cryptographic identity, audit trails, delegation control, and real-time revocation.',
+    html: `
+      <h1>How to Secure AI Agents in Production</h1>
+      <p class="subtitle">A practical guide to authorization, scoping, and audit trails for AI agents</p>
+
+      <p>Your AI agent books flights, reads emails, and processes payments. How do you make sure it only does what it's supposed to?</p>
+      <p>This guide covers the key security primitives you need for production AI agents, and how to implement them.</p>
+
+      <h2>1. Scoped Permissions</h2>
+      <p>The #1 rule: <strong>never give an agent more access than it needs.</strong></p>
+      <p>Instead of a full API key, give each agent a token with specific scopes:</p>
+      <pre><code>// Agent can read emails but NOT send them
+const auth = await gx.authorize({
+  agentId: agent.id,
+  userId: 'user_alice',
+  scopes: ['email:read'],  // not 'email:*'
+});</code></pre>
+      <p>With Grantex, scopes are enforced at the protocol level. If an agent tries to call a tool requiring <code>email:send</code> but only has <code>email:read</code>, the request is denied.</p>
+
+      <h2>2. Agent Identity</h2>
+      <p>Every agent needs its own cryptographic identity — not shared credentials.</p>
+      <p>Grantex assigns each agent a DID (Decentralized Identifier) embedded in its JWT. This means you can always answer: <em>"Which agent performed this action?"</em></p>
+
+      <h2>3. User Consent</h2>
+      <p>Before an agent acts on a user's behalf, the user should explicitly approve:</p>
+      <ul>
+        <li>What scopes the agent gets</li>
+        <li>How long the access lasts</li>
+        <li>What services the agent can access</li>
+      </ul>
+      <p>Grantex provides a consent URL that users visit to approve or deny the request. This is the same pattern as OAuth — familiar to users.</p>
+
+      <h2>4. Audit Trail</h2>
+      <p>You need to know what your agents did, not just what they were authorized to do.</p>
+      <p>Grantex provides an append-only, hash-chained audit log. Each entry includes:</p>
+      <ul>
+        <li>Agent DID and grant ID</li>
+        <li>Action performed and scopes used</li>
+        <li>Timestamp</li>
+        <li>SHA-256 hash linking to the previous entry (tamper-evident)</li>
+      </ul>
+
+      <h2>5. Delegation Control</h2>
+      <p>When a parent agent spawns sub-agents, the sub-agents should get <em>narrower</em> permissions, not the same or broader.</p>
+      <pre><code>// Parent has: ["flights:book", "hotels:book"]
+// Delegate only flights to the sub-agent:
+const delegated = await gx.grants.delegate({
+  parentGrantToken: parentToken,
+  childAgentId: flightBooker.id,
+  scopes: ['flights:book'],  // subset only
+});</code></pre>
+      <p>The delegation depth is tracked in the JWT. Revoking the parent cascades to all children.</p>
+
+      <h2>6. Real-Time Revocation</h2>
+      <p>If an agent behaves unexpectedly, you need to kill its access immediately — not wait for a token to expire.</p>
+      <p>Grantex revocation takes effect in under 1 second. Cascade revocation kills all delegated sub-agent grants simultaneously.</p>
+
+      <h2>7. Budget Controls</h2>
+      <p>For agents that spend money (API calls, compute, purchases), set spending limits:</p>
+      <pre><code>await gx.budgets.allocate({
+  grantId: grant.id,
+  amount: 100.00,  // max $100
+  currency: 'USD',
+});
+// Agent is automatically cut off at the limit</code></pre>
+
+      <h2>Getting Started</h2>
+      <p>Grantex provides all of these primitives as an open protocol (Apache 2.0) with SDKs for <a href="https://docs.grantex.dev/sdks/typescript/overview">TypeScript</a>, <a href="https://docs.grantex.dev/sdks/python/overview">Python</a>, and <a href="https://docs.grantex.dev/sdks/go/overview">Go</a>.</p>
+
+      <div class="cta-box">
+        <h3>Secure your agents in under 5 minutes</h3>
+        <p>Open source. 14 framework integrations. 174 pages of docs.</p>
+        <a href="https://docs.grantex.dev/getting-started/quickstart" class="btn btn-primary" style="margin-right:.5rem">Quickstart Guide</a>
+        <a href="/playground" class="btn btn-secondary">Try in Playground</a>
+      </div>
+    `
+  }
+};
+
+const slug = window.location.pathname.replace(/\/$/, '').split('/').pop();
+const page = pages[slug];
+
+if (!page) {
+  window.location.href = '/';
+} else {
+  document.title = page.metaTitle;
+  document.querySelector('meta[name="description"]').content = page.metaDesc;
+  document.querySelector('link[rel="canonical"]').href = 'https://grantex.dev/vs/' + slug;
+  document.querySelector('meta[property="og:title"]').content = page.metaTitle;
+  document.querySelector('meta[property="og:description"]').content = page.metaDesc;
+  document.querySelector('meta[property="og:url"]').content = 'https://grantex.dev/vs/' + slug;
+  document.querySelector('meta[name="twitter:title"]').content = page.metaTitle;
+  document.querySelector('meta[name="twitter:description"]').content = page.metaDesc;
+  document.getElementById('content').innerHTML = page.html;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": page.metaTitle,
+    "description": page.metaDesc,
+    "url": "https://grantex.dev/vs/" + slug,
+    "author": { "@type": "Organization", "name": "Grantex", "url": "https://grantex.dev" },
+    "publisher": { "@type": "Organization", "name": "Grantex", "url": "https://grantex.dev" }
+  };
+  const s = document.createElement('script');
+  s.type = 'application/ld+json';
+  s.textContent = JSON.stringify(jsonLd);
+  document.head.appendChild(s);
+
+  gtag('event', 'page_view', { page_title: page.metaTitle, page_location: window.location.href });
+}
+</script>
+</body>
+</html>

--- a/web/vs/oauth/index.html
+++ b/web/vs/oauth/index.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <title>Grantex vs OAuth 2.0 — How AI Agent Authorization Differs</title>
+  <meta name="description" content="Comparing Grantex and OAuth 2.0 for AI agent authorization. Learn why OAuth falls short for agents and what Grantex adds: agent identity, delegation chains, audit trails.">
+  <link rel="canonical" href="https://grantex.dev/vs/oauth/">
+  <meta property="og:title" content="Grantex vs OAuth 2.0 — How AI Agent Authorization Differs">
+  <meta property="og:description" content="Comparing Grantex and OAuth 2.0 for AI agent authorization. Learn why OAuth falls short for agents and what Grantex adds: agent identity, delegation chains, audit trails.">
+  <meta property="og:url" content="https://grantex.dev/vs/oauth/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="Grantex">
+  <meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grantex vs OAuth 2.0 — How AI Agent Authorization Differs">
+  <meta name="twitter:description" content="Comparing Grantex and OAuth 2.0 for AI agent authorization. Learn why OAuth falls short for agents and what Grantex adds: agent identity, delegation chains, audit trails.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
+  <style>
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --text: #e6edf3; --muted: #8b949e; --accent: #3fb950; --accent2: #58a6ff;
+      --red: #f85149; --mono: 'JetBrains Mono','Fira Code',monospace;
+      --sans: 'Inter',system-ui,-apple-system,sans-serif; --radius: 8px; --max-w: 860px;
+    }
+    *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+    body{background:var(--bg);color:var(--text);font-family:var(--sans);line-height:1.7}
+    a{color:var(--accent2);text-decoration:none}a:hover{text-decoration:underline}
+    code{font-family:var(--mono);background:var(--surface);padding:2px 6px;border-radius:4px;font-size:.9em}
+    pre{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem;overflow-x:auto;font-family:var(--mono);font-size:.85rem;line-height:1.5;margin:1.5rem 0}
+    pre code{background:none;padding:0}
+
+    .nav{display:flex;align-items:center;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:1rem 1.5rem}
+    .nav-logo{font-weight:700;font-size:1.25rem;color:var(--text)}
+    .nav-links{list-style:none;display:flex;gap:1.5rem}
+    .nav-links a{color:var(--muted);font-size:.9rem}.nav-links a:hover{color:var(--text);text-decoration:none}
+
+    .article{max-width:var(--max-w);margin:0 auto;padding:2rem 1.5rem 4rem}
+    .article h1{font-size:2.25rem;line-height:1.2;margin-bottom:.5rem}
+    .article .subtitle{color:var(--muted);font-size:1.05rem;margin-bottom:2rem}
+    .article h2{font-size:1.5rem;margin:2.5rem 0 1rem;padding-top:1rem;border-top:1px solid var(--border)}
+    .article h3{font-size:1.15rem;margin:1.5rem 0 .5rem;color:var(--accent)}
+    .article p{color:var(--muted);margin-bottom:1rem}
+    .article ul,.article ol{color:var(--muted);padding-left:1.5rem;margin-bottom:1rem}
+    .article li{margin-bottom:.5rem}
+    .article strong{color:var(--text)}
+    .article blockquote{border-left:3px solid var(--accent);padding-left:1rem;margin:1.5rem 0;color:var(--muted);font-style:italic}
+
+    .comparison-table{width:100%;border-collapse:collapse;margin:1.5rem 0}
+    .comparison-table th,.comparison-table td{padding:.75rem 1rem;text-align:left;border:1px solid var(--border)}
+    .comparison-table th{background:var(--surface);color:var(--text);font-weight:600}
+    .comparison-table td{color:var(--muted)}
+    .comparison-table .yes{color:var(--accent)}
+    .comparison-table .no{color:var(--red)}
+
+    .cta-box{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:2rem;text-align:center;margin:2rem 0}
+    .cta-box h3{color:var(--text);margin-bottom:.5rem}
+    .cta-box p{margin-bottom:1rem}
+    .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.65rem 1.25rem;border-radius:var(--radius);font-weight:600;font-size:.9rem;text-decoration:none;transition:all .2s}
+    .btn-primary{background:var(--accent);color:#0d1117}.btn-primary:hover{background:#2ea043;text-decoration:none}
+    .btn-secondary{background:var(--surface);color:var(--text);border:1px solid var(--border)}.btn-secondary:hover{border-color:var(--muted);text-decoration:none}
+
+    .footer{max-width:var(--max-w);margin:0 auto;padding:2rem 1.5rem;border-top:1px solid var(--border);display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:1rem}
+    .footer-links{list-style:none;display:flex;gap:1.5rem}
+    .footer-links a{color:var(--muted);font-size:.85rem}
+
+    @media(max-width:640px){
+      .article h1{font-size:1.65rem}
+      .comparison-table{font-size:.85rem}
+      .comparison-table th,.comparison-table td{padding:.5rem}
+    }
+  </style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Grantex vs OAuth 2.0 — How AI Agent Authorization Differs","description":"Comparing Grantex and OAuth 2.0 for AI agent authorization. Learn why OAuth falls short for agents and what Grantex adds: agent identity, delegation chains, audit trails.","url":"https://grantex.dev/vs/oauth/","author":{"@type":"Organization","name":"Grantex","url":"https://grantex.dev"},"publisher":{"@type":"Organization","name":"Grantex","url":"https://grantex.dev"}}</script>
+</head>
+<body>
+<nav class="nav">
+  <a href="/" class="nav-logo">Grantex</a>
+  <ul class="nav-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="/playground">Playground</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+  </ul>
+</nav>
+
+<article class="article" id="content"></article>
+
+<footer class="footer">
+  <span style="color:var(--muted);font-size:.85rem">Grantex — Open authorization for AI agents</span>
+  <ul class="footer-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+    <li><a href="/">Home</a></li>
+  </ul>
+</footer>
+
+<script>
+const pages = {
+  'oauth': {
+    metaTitle: 'Grantex vs OAuth 2.0 — How AI Agent Authorization Differs',
+    metaDesc: 'Comparing Grantex and OAuth 2.0 for AI agent authorization. Learn why OAuth falls short for agents and what Grantex adds: agent identity, delegation chains, audit trails.',
+    html: `
+      <h1>Grantex vs OAuth 2.0</h1>
+      <p class="subtitle">Why OAuth 2.0 doesn't work for AI agents — and what Grantex does differently</p>
+
+      <p>OAuth 2.0 is the gold standard for delegated authorization on the web. It's battle-tested, widely adopted, and well-understood. So why do AI agents need something different?</p>
+      <p>The short answer: <strong>OAuth was designed for human users granting access to applications. Agents aren't applications.</strong></p>
+
+      <h2>What OAuth 2.0 Gets Right</h2>
+      <p>Grantex builds on OAuth's proven patterns:</p>
+      <ul>
+        <li><strong>Consent flow</strong> — users explicitly approve access</li>
+        <li><strong>Scoped permissions</strong> — not all-or-nothing access</li>
+        <li><strong>Token-based</strong> — bearer tokens for API access</li>
+        <li><strong>Revocable</strong> — tokens can be invalidated</li>
+        <li><strong>PKCE</strong> — proof key for code exchange (S256)</li>
+      </ul>
+      <p>If you know OAuth, Grantex will feel familiar. The authorization code flow, token exchange, and scope model all work the same way.</p>
+
+      <h2>Where OAuth Falls Short for Agents</h2>
+
+      <h3>1. No Agent Identity</h3>
+      <p>In OAuth, the <em>application</em> (client) is the identity boundary. When you grant "Acme App" access to your calendar, the token represents your session with that app.</p>
+      <p>But agents aren't apps. A single application might spawn multiple agents — a travel planner, a flight booker, a hotel finder. In OAuth, they all share the same client credentials. You can't distinguish which agent performed an action.</p>
+      <p><strong>Grantex fix:</strong> Every agent gets a cryptographic DID (Decentralized Identifier). The agent's identity is embedded in the JWT (<code>agt</code> claim). You always know <em>which agent</em> performed an action.</p>
+
+      <h3>2. Flat Scopes</h3>
+      <p>OAuth scopes are flat — a user grants scopes to an app, end of story. But agents delegate work to sub-agents. A travel agent needs to give the flight booker <code>flights:book</code> but not <code>hotels:book</code>.</p>
+      <p><strong>Grantex fix:</strong> Delegation chains. A parent agent can delegate a <em>narrower subset</em> of its scopes to a child agent. The delegation depth is tracked in the JWT. Revoking the parent cascades to all children.</p>
+
+      <h3>3. No Audit Trail</h3>
+      <p>OAuth tokens are opaque to the authorization server after issuance. There's no standard for logging what actions were performed with a token.</p>
+      <p><strong>Grantex fix:</strong> Append-only, hash-chained audit log. Every action is recorded with the agent DID, scopes used, timestamp, and a SHA-256 hash linking to the previous entry. Tamper-evident by design.</p>
+
+      <h3>4. Slow Revocation</h3>
+      <p>OAuth revocation depends on token introspection or short expiry windows. If an agent goes rogue, you might have to wait for the token to expire.</p>
+      <p><strong>Grantex fix:</strong> Real-time revocation effective in under 1 second. Plus cascade revocation — revoke a parent to instantly kill all delegated sub-agent grants.</p>
+
+      <h2>Feature Comparison</h2>
+      <table class="comparison-table">
+        <tr><th>Feature</th><th>OAuth 2.0</th><th>Grantex</th></tr>
+        <tr><td>Consent flow</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>Scoped permissions</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>PKCE (S256)</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>Token refresh/rotation</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>Agent identity (DID)</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Delegation chains</td><td class="no">No</td><td class="yes">Yes (depth-tracked)</td></tr>
+        <tr><td>Cascade revocation</td><td class="no">No</td><td class="yes">Yes (&lt; 1s)</td></tr>
+        <tr><td>Hash-chained audit trail</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Offline verification (JWKS)</td><td>Varies</td><td class="yes">Yes (always)</td></tr>
+        <tr><td>Budget controls</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Multi-agent delegation</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Anomaly detection</td><td class="no">No</td><td class="yes">Yes</td></tr>
+      </table>
+
+      <h2>When to Use What</h2>
+      <p><strong>Use OAuth 2.0</strong> when you're building a traditional web/mobile app where humans interact directly with services. OAuth is mature, universally supported, and the right tool for human-to-app authorization.</p>
+      <p><strong>Use Grantex</strong> when AI agents act on behalf of users — especially when agents spawn sub-agents, operate autonomously, or access sensitive services. Grantex gives you the agent-specific primitives that OAuth lacks.</p>
+
+      <h2>Can I Use Both?</h2>
+      <p>Yes. Many teams use OAuth for their user-facing app and Grantex for the agent layer. Grantex's <a href="https://grantex.dev/for/express">Express middleware</a> and <a href="https://grantex.dev/for/fastapi">FastAPI middleware</a> can run alongside existing OAuth middleware.</p>
+
+      <div class="cta-box">
+        <h3>Ready to add agent authorization?</h3>
+        <p>Get started in under 5 minutes. Open source, Apache 2.0.</p>
+        <a href="https://docs.grantex.dev/getting-started/quickstart" class="btn btn-primary" style="margin-right:.5rem">Get Started</a>
+        <a href="/" class="btn btn-secondary">Learn More</a>
+      </div>
+    `
+  },
+
+  'api-keys': {
+    metaTitle: 'Grantex vs API Keys — Why API Keys Are Dangerous for AI Agents',
+    metaDesc: 'API keys give AI agents unlimited access with no scoping, audit trail, or revocation. Learn how Grantex replaces all-or-nothing API keys with scoped, revocable JWTs.',
+    html: `
+      <h1>Grantex vs API Keys</h1>
+      <p class="subtitle">Why all-or-nothing API keys are dangerous for AI agents</p>
+
+      <p>Most AI agents today run on raw API keys. This is the simplest approach — and the most dangerous.</p>
+
+      <h2>The Problem with API Keys for Agents</h2>
+
+      <h3>1. No Scoping</h3>
+      <p>An API key typically grants full access to a service. Your LangChain agent has a Stripe API key? It can read transactions, create charges, issue refunds, and delete customers. There's no way to say "this agent can only <em>read</em> transactions."</p>
+
+      <h3>2. No Audit Trail</h3>
+      <p>API keys don't identify <em>which agent</em> made a request. If you have 5 agents sharing a Stripe key, your logs show "API key sk_live_... made a charge" — not "the travel-booking agent made a charge on behalf of user Alice."</p>
+
+      <h3>3. No Revocation (Without Breaking Everything)</h3>
+      <p>Revoking an API key kills <em>all</em> agents using it. If one agent misbehaves, you can't revoke just that agent's access. You have to rotate the key and update every agent.</p>
+
+      <h3>4. No User Consent</h3>
+      <p>API keys are developer-level credentials. End users never approve what an agent can do on their behalf. This is a compliance and trust problem.</p>
+
+      <h3>5. No Delegation Control</h3>
+      <p>If a parent agent gives its API key to a sub-agent, the sub-agent has the same full access. There's no narrowing, no depth tracking, no cascade revocation.</p>
+
+      <h2>How Grantex Replaces API Keys</h2>
+
+      <table class="comparison-table">
+        <tr><th>Aspect</th><th>API Keys</th><th>Grantex</th></tr>
+        <tr><td>Access scope</td><td class="no">Full access</td><td class="yes">Per-grant scoping</td></tr>
+        <tr><td>User consent</td><td class="no">None</td><td class="yes">Explicit consent flow</td></tr>
+        <tr><td>Agent identity</td><td class="no">Shared key</td><td class="yes">Cryptographic DID per agent</td></tr>
+        <tr><td>Audit trail</td><td class="no">Key-level only</td><td class="yes">Per-agent, hash-chained</td></tr>
+        <tr><td>Revocation</td><td class="no">Kills all agents</td><td class="yes">Per-agent, &lt; 1 second</td></tr>
+        <tr><td>Delegation</td><td class="no">Copy the key</td><td class="yes">Scoped, depth-tracked</td></tr>
+        <tr><td>Expiration</td><td class="no">Usually never</td><td class="yes">Time-limited JWTs</td></tr>
+        <tr><td>Budget limits</td><td class="no">No</td><td class="yes">Per-grant budgets</td></tr>
+        <tr><td>Verification</td><td>API call required</td><td class="yes">Offline via JWKS</td></tr>
+      </table>
+
+      <h2>Migration Path</h2>
+      <p>You don't have to replace all your API keys at once. The typical migration:</p>
+      <ol>
+        <li><strong>Add Grantex to your agent layer</strong> — agents get scoped JWTs for user-facing actions</li>
+        <li><strong>Keep API keys for internal services</strong> — machine-to-machine calls that don't involve user data</li>
+        <li><strong>Add verification middleware</strong> — Express.js or FastAPI middleware checks Grantex JWTs on your endpoints</li>
+        <li><strong>Phase out agent API keys</strong> — as you add Grantex coverage, remove direct API key access from agents</li>
+      </ol>
+
+      <h2>Code Comparison</h2>
+
+      <h3>Before: Agent with API Key</h3>
+      <pre><code>// Agent has FULL Stripe access
+const stripe = new Stripe(process.env.STRIPE_API_KEY);
+await stripe.charges.create({ amount: 5000, currency: 'usd' });
+// Who authorized this? Which agent? What scopes? No idea.</code></pre>
+
+      <h3>After: Agent with Grantex JWT</h3>
+      <pre><code>// Agent has scoped access: "payments:read" only
+const toolkit = new GrantexToolkit({
+  client: gx,
+  grantToken: token,  // JWT with scopes: ["payments:read"]
+  tools: [stripeReadTool],
+});
+// Agent CAN read charges but CANNOT create them.
+// Every action logged with agent DID, user ID, timestamp.</code></pre>
+
+      <div class="cta-box">
+        <h3>Replace API keys with scoped grants</h3>
+        <p>10 lines of code. Open source. Apache 2.0.</p>
+        <a href="https://docs.grantex.dev/getting-started/quickstart" class="btn btn-primary" style="margin-right:.5rem">Get Started</a>
+        <a href="/playground" class="btn btn-secondary">Try in Playground</a>
+      </div>
+    `
+  },
+
+  'mcp-auth': {
+    metaTitle: 'How to Add Authentication to MCP Servers — Grantex MCP Auth',
+    metaDesc: 'Add OAuth 2.1 + PKCE authentication to any MCP server. Grantex MCP Auth provides scoped authorization for Claude Desktop, Cursor, and Windsurf tools.',
+    html: `
+      <h1>How to Add Auth to MCP Servers</h1>
+      <p class="subtitle">OAuth 2.1 + PKCE authorization for Model Context Protocol servers</p>
+
+      <p>MCP (Model Context Protocol) lets AI assistants like Claude Desktop, Cursor, and Windsurf call external tools. But out of the box, <strong>MCP servers have no authorization layer</strong>. Any connected client can call any tool with full access.</p>
+
+      <h2>The Problem</h2>
+      <p>When you build an MCP server that accesses real services — databases, APIs, file systems — you need to control who can call what. Without auth:</p>
+      <ul>
+        <li>Any MCP client can invoke any tool</li>
+        <li>No way to scope access per user or per session</li>
+        <li>No audit trail of tool invocations</li>
+        <li>No consent flow for sensitive operations</li>
+      </ul>
+
+      <h2>Two Grantex Solutions for MCP</h2>
+
+      <h3>1. @grantex/mcp — Grantex as an MCP Server</h3>
+      <p>13 tools for managing agent authorization directly from Claude Desktop or Cursor:</p>
+      <pre><code>// claude_desktop_config.json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "npx",
+      "args": ["@grantex/mcp"],
+      "env": { "GRANTEX_API_KEY": "gx_live_..." }
+    }
+  }
+}
+
+// Then ask Claude:
+// "Register an agent called data-bot with db:read scope"
+// "Create a grant for user alice on data-bot"
+// "Show me the audit log for the last hour"</code></pre>
+
+      <h3>2. @grantex/mcp-auth — Add Auth to YOUR MCP Server</h3>
+      <p>OAuth 2.1 + PKCE authorization for any MCP server you build:</p>
+      <pre><code>import { GrantexMCPAuth } from '@grantex/mcp-auth';
+
+const auth = new GrantexMCPAuth({
+  jwksUrl: 'https://your-auth/.well-known/jwks.json',
+});
+
+// Wrap your MCP tool handlers with authorization
+server.tool('query_database', auth.requireScopes(['db:read']), async (params) => {
+  // Only executes if the caller has db:read scope
+  return await db.query(params.sql);
+});</code></pre>
+
+      <h2>Feature Comparison</h2>
+      <table class="comparison-table">
+        <tr><th>Feature</th><th>MCP (default)</th><th>MCP + Grantex</th></tr>
+        <tr><td>Tool access control</td><td class="no">None</td><td class="yes">Per-tool scopes</td></tr>
+        <tr><td>User consent</td><td class="no">No</td><td class="yes">OAuth 2.1 consent flow</td></tr>
+        <tr><td>PKCE</td><td class="no">No</td><td class="yes">S256</td></tr>
+        <tr><td>Audit trail</td><td class="no">No</td><td class="yes">Hash-chained</td></tr>
+        <tr><td>Token revocation</td><td class="no">N/A</td><td class="yes">&lt; 1 second</td></tr>
+        <tr><td>Multi-user</td><td class="no">No</td><td class="yes">Per-user grants</td></tr>
+      </table>
+
+      <div class="cta-box">
+        <h3>Secure your MCP server in 5 minutes</h3>
+        <p>Works with Claude Desktop, Cursor, and Windsurf.</p>
+        <a href="https://docs.grantex.dev/integrations/mcp" class="btn btn-primary" style="margin-right:.5rem">Read the Docs</a>
+        <a href="https://www.npmjs.com/package/@grantex/mcp-auth" class="btn btn-secondary">npm install</a>
+      </div>
+    `
+  },
+
+  'securing-ai-agents': {
+    metaTitle: 'How to Secure AI Agents — Authorization, Scoping, and Audit Trails',
+    metaDesc: 'A practical guide to securing AI agents in production. Scoped permissions, cryptographic identity, audit trails, delegation control, and real-time revocation.',
+    html: `
+      <h1>How to Secure AI Agents in Production</h1>
+      <p class="subtitle">A practical guide to authorization, scoping, and audit trails for AI agents</p>
+
+      <p>Your AI agent books flights, reads emails, and processes payments. How do you make sure it only does what it's supposed to?</p>
+      <p>This guide covers the key security primitives you need for production AI agents, and how to implement them.</p>
+
+      <h2>1. Scoped Permissions</h2>
+      <p>The #1 rule: <strong>never give an agent more access than it needs.</strong></p>
+      <p>Instead of a full API key, give each agent a token with specific scopes:</p>
+      <pre><code>// Agent can read emails but NOT send them
+const auth = await gx.authorize({
+  agentId: agent.id,
+  userId: 'user_alice',
+  scopes: ['email:read'],  // not 'email:*'
+});</code></pre>
+      <p>With Grantex, scopes are enforced at the protocol level. If an agent tries to call a tool requiring <code>email:send</code> but only has <code>email:read</code>, the request is denied.</p>
+
+      <h2>2. Agent Identity</h2>
+      <p>Every agent needs its own cryptographic identity — not shared credentials.</p>
+      <p>Grantex assigns each agent a DID (Decentralized Identifier) embedded in its JWT. This means you can always answer: <em>"Which agent performed this action?"</em></p>
+
+      <h2>3. User Consent</h2>
+      <p>Before an agent acts on a user's behalf, the user should explicitly approve:</p>
+      <ul>
+        <li>What scopes the agent gets</li>
+        <li>How long the access lasts</li>
+        <li>What services the agent can access</li>
+      </ul>
+      <p>Grantex provides a consent URL that users visit to approve or deny the request. This is the same pattern as OAuth — familiar to users.</p>
+
+      <h2>4. Audit Trail</h2>
+      <p>You need to know what your agents did, not just what they were authorized to do.</p>
+      <p>Grantex provides an append-only, hash-chained audit log. Each entry includes:</p>
+      <ul>
+        <li>Agent DID and grant ID</li>
+        <li>Action performed and scopes used</li>
+        <li>Timestamp</li>
+        <li>SHA-256 hash linking to the previous entry (tamper-evident)</li>
+      </ul>
+
+      <h2>5. Delegation Control</h2>
+      <p>When a parent agent spawns sub-agents, the sub-agents should get <em>narrower</em> permissions, not the same or broader.</p>
+      <pre><code>// Parent has: ["flights:book", "hotels:book"]
+// Delegate only flights to the sub-agent:
+const delegated = await gx.grants.delegate({
+  parentGrantToken: parentToken,
+  childAgentId: flightBooker.id,
+  scopes: ['flights:book'],  // subset only
+});</code></pre>
+      <p>The delegation depth is tracked in the JWT. Revoking the parent cascades to all children.</p>
+
+      <h2>6. Real-Time Revocation</h2>
+      <p>If an agent behaves unexpectedly, you need to kill its access immediately — not wait for a token to expire.</p>
+      <p>Grantex revocation takes effect in under 1 second. Cascade revocation kills all delegated sub-agent grants simultaneously.</p>
+
+      <h2>7. Budget Controls</h2>
+      <p>For agents that spend money (API calls, compute, purchases), set spending limits:</p>
+      <pre><code>await gx.budgets.allocate({
+  grantId: grant.id,
+  amount: 100.00,  // max $100
+  currency: 'USD',
+});
+// Agent is automatically cut off at the limit</code></pre>
+
+      <h2>Getting Started</h2>
+      <p>Grantex provides all of these primitives as an open protocol (Apache 2.0) with SDKs for <a href="https://docs.grantex.dev/sdks/typescript/overview">TypeScript</a>, <a href="https://docs.grantex.dev/sdks/python/overview">Python</a>, and <a href="https://docs.grantex.dev/sdks/go/overview">Go</a>.</p>
+
+      <div class="cta-box">
+        <h3>Secure your agents in under 5 minutes</h3>
+        <p>Open source. 14 framework integrations. 174 pages of docs.</p>
+        <a href="https://docs.grantex.dev/getting-started/quickstart" class="btn btn-primary" style="margin-right:.5rem">Quickstart Guide</a>
+        <a href="/playground" class="btn btn-secondary">Try in Playground</a>
+      </div>
+    `
+  }
+};
+
+const slug = window.location.pathname.replace(/\/$/, '').split('/').pop();
+const page = pages[slug];
+
+if (!page) {
+  window.location.href = '/';
+} else {
+  document.title = page.metaTitle;
+  document.querySelector('meta[name="description"]').content = page.metaDesc;
+  document.querySelector('link[rel="canonical"]').href = 'https://grantex.dev/vs/' + slug;
+  document.querySelector('meta[property="og:title"]').content = page.metaTitle;
+  document.querySelector('meta[property="og:description"]').content = page.metaDesc;
+  document.querySelector('meta[property="og:url"]').content = 'https://grantex.dev/vs/' + slug;
+  document.querySelector('meta[name="twitter:title"]').content = page.metaTitle;
+  document.querySelector('meta[name="twitter:description"]').content = page.metaDesc;
+  document.getElementById('content').innerHTML = page.html;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": page.metaTitle,
+    "description": page.metaDesc,
+    "url": "https://grantex.dev/vs/" + slug,
+    "author": { "@type": "Organization", "name": "Grantex", "url": "https://grantex.dev" },
+    "publisher": { "@type": "Organization", "name": "Grantex", "url": "https://grantex.dev" }
+  };
+  const s = document.createElement('script');
+  s.type = 'application/ld+json';
+  s.textContent = JSON.stringify(jsonLd);
+  document.head.appendChild(s);
+
+  gtag('event', 'page_view', { page_title: page.metaTitle, page_location: window.location.href });
+}
+</script>
+</body>
+</html>

--- a/web/vs/securing-ai-agents/index.html
+++ b/web/vs/securing-ai-agents/index.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <title>How to Secure AI Agents — Authorization, Scoping, and Audit Trails</title>
+  <meta name="description" content="A practical guide to securing AI agents in production. Scoped permissions, cryptographic identity, audit trails, delegation control, and real-time revocation.">
+  <link rel="canonical" href="https://grantex.dev/vs/securing-ai-agents/">
+  <meta property="og:title" content="How to Secure AI Agents — Authorization, Scoping, and Audit Trails">
+  <meta property="og:description" content="A practical guide to securing AI agents in production. Scoped permissions, cryptographic identity, audit trails, delegation control, and real-time revocation.">
+  <meta property="og:url" content="https://grantex.dev/vs/securing-ai-agents/">
+  <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="Grantex">
+  <meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="How to Secure AI Agents — Authorization, Scoping, and Audit Trails">
+  <meta name="twitter:description" content="A practical guide to securing AI agents in production. Scoped permissions, cryptographic identity, audit trails, delegation control, and real-time revocation.">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
+  <style>
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --text: #e6edf3; --muted: #8b949e; --accent: #3fb950; --accent2: #58a6ff;
+      --red: #f85149; --mono: 'JetBrains Mono','Fira Code',monospace;
+      --sans: 'Inter',system-ui,-apple-system,sans-serif; --radius: 8px; --max-w: 860px;
+    }
+    *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+    body{background:var(--bg);color:var(--text);font-family:var(--sans);line-height:1.7}
+    a{color:var(--accent2);text-decoration:none}a:hover{text-decoration:underline}
+    code{font-family:var(--mono);background:var(--surface);padding:2px 6px;border-radius:4px;font-size:.9em}
+    pre{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem;overflow-x:auto;font-family:var(--mono);font-size:.85rem;line-height:1.5;margin:1.5rem 0}
+    pre code{background:none;padding:0}
+
+    .nav{display:flex;align-items:center;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:1rem 1.5rem}
+    .nav-logo{font-weight:700;font-size:1.25rem;color:var(--text)}
+    .nav-links{list-style:none;display:flex;gap:1.5rem}
+    .nav-links a{color:var(--muted);font-size:.9rem}.nav-links a:hover{color:var(--text);text-decoration:none}
+
+    .article{max-width:var(--max-w);margin:0 auto;padding:2rem 1.5rem 4rem}
+    .article h1{font-size:2.25rem;line-height:1.2;margin-bottom:.5rem}
+    .article .subtitle{color:var(--muted);font-size:1.05rem;margin-bottom:2rem}
+    .article h2{font-size:1.5rem;margin:2.5rem 0 1rem;padding-top:1rem;border-top:1px solid var(--border)}
+    .article h3{font-size:1.15rem;margin:1.5rem 0 .5rem;color:var(--accent)}
+    .article p{color:var(--muted);margin-bottom:1rem}
+    .article ul,.article ol{color:var(--muted);padding-left:1.5rem;margin-bottom:1rem}
+    .article li{margin-bottom:.5rem}
+    .article strong{color:var(--text)}
+    .article blockquote{border-left:3px solid var(--accent);padding-left:1rem;margin:1.5rem 0;color:var(--muted);font-style:italic}
+
+    .comparison-table{width:100%;border-collapse:collapse;margin:1.5rem 0}
+    .comparison-table th,.comparison-table td{padding:.75rem 1rem;text-align:left;border:1px solid var(--border)}
+    .comparison-table th{background:var(--surface);color:var(--text);font-weight:600}
+    .comparison-table td{color:var(--muted)}
+    .comparison-table .yes{color:var(--accent)}
+    .comparison-table .no{color:var(--red)}
+
+    .cta-box{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:2rem;text-align:center;margin:2rem 0}
+    .cta-box h3{color:var(--text);margin-bottom:.5rem}
+    .cta-box p{margin-bottom:1rem}
+    .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.65rem 1.25rem;border-radius:var(--radius);font-weight:600;font-size:.9rem;text-decoration:none;transition:all .2s}
+    .btn-primary{background:var(--accent);color:#0d1117}.btn-primary:hover{background:#2ea043;text-decoration:none}
+    .btn-secondary{background:var(--surface);color:var(--text);border:1px solid var(--border)}.btn-secondary:hover{border-color:var(--muted);text-decoration:none}
+
+    .footer{max-width:var(--max-w);margin:0 auto;padding:2rem 1.5rem;border-top:1px solid var(--border);display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:1rem}
+    .footer-links{list-style:none;display:flex;gap:1.5rem}
+    .footer-links a{color:var(--muted);font-size:.85rem}
+
+    @media(max-width:640px){
+      .article h1{font-size:1.65rem}
+      .comparison-table{font-size:.85rem}
+      .comparison-table th,.comparison-table td{padding:.5rem}
+    }
+  </style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Secure AI Agents — Authorization, Scoping, and Audit Trails","description":"A practical guide to securing AI agents in production. Scoped permissions, cryptographic identity, audit trails, delegation control, and real-time revocation.","url":"https://grantex.dev/vs/securing-ai-agents/","author":{"@type":"Organization","name":"Grantex","url":"https://grantex.dev"},"publisher":{"@type":"Organization","name":"Grantex","url":"https://grantex.dev"}}</script>
+</head>
+<body>
+<nav class="nav">
+  <a href="/" class="nav-logo">Grantex</a>
+  <ul class="nav-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="/playground">Playground</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+  </ul>
+</nav>
+
+<article class="article" id="content"></article>
+
+<footer class="footer">
+  <span style="color:var(--muted);font-size:.85rem">Grantex — Open authorization for AI agents</span>
+  <ul class="footer-links">
+    <li><a href="https://docs.grantex.dev">Docs</a></li>
+    <li><a href="https://github.com/mishrasanjeev/grantex">GitHub</a></li>
+    <li><a href="/">Home</a></li>
+  </ul>
+</footer>
+
+<script>
+const pages = {
+  'oauth': {
+    metaTitle: 'Grantex vs OAuth 2.0 — How AI Agent Authorization Differs',
+    metaDesc: 'Comparing Grantex and OAuth 2.0 for AI agent authorization. Learn why OAuth falls short for agents and what Grantex adds: agent identity, delegation chains, audit trails.',
+    html: `
+      <h1>Grantex vs OAuth 2.0</h1>
+      <p class="subtitle">Why OAuth 2.0 doesn't work for AI agents — and what Grantex does differently</p>
+
+      <p>OAuth 2.0 is the gold standard for delegated authorization on the web. It's battle-tested, widely adopted, and well-understood. So why do AI agents need something different?</p>
+      <p>The short answer: <strong>OAuth was designed for human users granting access to applications. Agents aren't applications.</strong></p>
+
+      <h2>What OAuth 2.0 Gets Right</h2>
+      <p>Grantex builds on OAuth's proven patterns:</p>
+      <ul>
+        <li><strong>Consent flow</strong> — users explicitly approve access</li>
+        <li><strong>Scoped permissions</strong> — not all-or-nothing access</li>
+        <li><strong>Token-based</strong> — bearer tokens for API access</li>
+        <li><strong>Revocable</strong> — tokens can be invalidated</li>
+        <li><strong>PKCE</strong> — proof key for code exchange (S256)</li>
+      </ul>
+      <p>If you know OAuth, Grantex will feel familiar. The authorization code flow, token exchange, and scope model all work the same way.</p>
+
+      <h2>Where OAuth Falls Short for Agents</h2>
+
+      <h3>1. No Agent Identity</h3>
+      <p>In OAuth, the <em>application</em> (client) is the identity boundary. When you grant "Acme App" access to your calendar, the token represents your session with that app.</p>
+      <p>But agents aren't apps. A single application might spawn multiple agents — a travel planner, a flight booker, a hotel finder. In OAuth, they all share the same client credentials. You can't distinguish which agent performed an action.</p>
+      <p><strong>Grantex fix:</strong> Every agent gets a cryptographic DID (Decentralized Identifier). The agent's identity is embedded in the JWT (<code>agt</code> claim). You always know <em>which agent</em> performed an action.</p>
+
+      <h3>2. Flat Scopes</h3>
+      <p>OAuth scopes are flat — a user grants scopes to an app, end of story. But agents delegate work to sub-agents. A travel agent needs to give the flight booker <code>flights:book</code> but not <code>hotels:book</code>.</p>
+      <p><strong>Grantex fix:</strong> Delegation chains. A parent agent can delegate a <em>narrower subset</em> of its scopes to a child agent. The delegation depth is tracked in the JWT. Revoking the parent cascades to all children.</p>
+
+      <h3>3. No Audit Trail</h3>
+      <p>OAuth tokens are opaque to the authorization server after issuance. There's no standard for logging what actions were performed with a token.</p>
+      <p><strong>Grantex fix:</strong> Append-only, hash-chained audit log. Every action is recorded with the agent DID, scopes used, timestamp, and a SHA-256 hash linking to the previous entry. Tamper-evident by design.</p>
+
+      <h3>4. Slow Revocation</h3>
+      <p>OAuth revocation depends on token introspection or short expiry windows. If an agent goes rogue, you might have to wait for the token to expire.</p>
+      <p><strong>Grantex fix:</strong> Real-time revocation effective in under 1 second. Plus cascade revocation — revoke a parent to instantly kill all delegated sub-agent grants.</p>
+
+      <h2>Feature Comparison</h2>
+      <table class="comparison-table">
+        <tr><th>Feature</th><th>OAuth 2.0</th><th>Grantex</th></tr>
+        <tr><td>Consent flow</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>Scoped permissions</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>PKCE (S256)</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>Token refresh/rotation</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>Agent identity (DID)</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Delegation chains</td><td class="no">No</td><td class="yes">Yes (depth-tracked)</td></tr>
+        <tr><td>Cascade revocation</td><td class="no">No</td><td class="yes">Yes (&lt; 1s)</td></tr>
+        <tr><td>Hash-chained audit trail</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Offline verification (JWKS)</td><td>Varies</td><td class="yes">Yes (always)</td></tr>
+        <tr><td>Budget controls</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Multi-agent delegation</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>Anomaly detection</td><td class="no">No</td><td class="yes">Yes</td></tr>
+      </table>
+
+      <h2>When to Use What</h2>
+      <p><strong>Use OAuth 2.0</strong> when you're building a traditional web/mobile app where humans interact directly with services. OAuth is mature, universally supported, and the right tool for human-to-app authorization.</p>
+      <p><strong>Use Grantex</strong> when AI agents act on behalf of users — especially when agents spawn sub-agents, operate autonomously, or access sensitive services. Grantex gives you the agent-specific primitives that OAuth lacks.</p>
+
+      <h2>Can I Use Both?</h2>
+      <p>Yes. Many teams use OAuth for their user-facing app and Grantex for the agent layer. Grantex's <a href="https://grantex.dev/for/express">Express middleware</a> and <a href="https://grantex.dev/for/fastapi">FastAPI middleware</a> can run alongside existing OAuth middleware.</p>
+
+      <div class="cta-box">
+        <h3>Ready to add agent authorization?</h3>
+        <p>Get started in under 5 minutes. Open source, Apache 2.0.</p>
+        <a href="https://docs.grantex.dev/getting-started/quickstart" class="btn btn-primary" style="margin-right:.5rem">Get Started</a>
+        <a href="/" class="btn btn-secondary">Learn More</a>
+      </div>
+    `
+  },
+
+  'api-keys': {
+    metaTitle: 'Grantex vs API Keys — Why API Keys Are Dangerous for AI Agents',
+    metaDesc: 'API keys give AI agents unlimited access with no scoping, audit trail, or revocation. Learn how Grantex replaces all-or-nothing API keys with scoped, revocable JWTs.',
+    html: `
+      <h1>Grantex vs API Keys</h1>
+      <p class="subtitle">Why all-or-nothing API keys are dangerous for AI agents</p>
+
+      <p>Most AI agents today run on raw API keys. This is the simplest approach — and the most dangerous.</p>
+
+      <h2>The Problem with API Keys for Agents</h2>
+
+      <h3>1. No Scoping</h3>
+      <p>An API key typically grants full access to a service. Your LangChain agent has a Stripe API key? It can read transactions, create charges, issue refunds, and delete customers. There's no way to say "this agent can only <em>read</em> transactions."</p>
+
+      <h3>2. No Audit Trail</h3>
+      <p>API keys don't identify <em>which agent</em> made a request. If you have 5 agents sharing a Stripe key, your logs show "API key sk_live_... made a charge" — not "the travel-booking agent made a charge on behalf of user Alice."</p>
+
+      <h3>3. No Revocation (Without Breaking Everything)</h3>
+      <p>Revoking an API key kills <em>all</em> agents using it. If one agent misbehaves, you can't revoke just that agent's access. You have to rotate the key and update every agent.</p>
+
+      <h3>4. No User Consent</h3>
+      <p>API keys are developer-level credentials. End users never approve what an agent can do on their behalf. This is a compliance and trust problem.</p>
+
+      <h3>5. No Delegation Control</h3>
+      <p>If a parent agent gives its API key to a sub-agent, the sub-agent has the same full access. There's no narrowing, no depth tracking, no cascade revocation.</p>
+
+      <h2>How Grantex Replaces API Keys</h2>
+
+      <table class="comparison-table">
+        <tr><th>Aspect</th><th>API Keys</th><th>Grantex</th></tr>
+        <tr><td>Access scope</td><td class="no">Full access</td><td class="yes">Per-grant scoping</td></tr>
+        <tr><td>User consent</td><td class="no">None</td><td class="yes">Explicit consent flow</td></tr>
+        <tr><td>Agent identity</td><td class="no">Shared key</td><td class="yes">Cryptographic DID per agent</td></tr>
+        <tr><td>Audit trail</td><td class="no">Key-level only</td><td class="yes">Per-agent, hash-chained</td></tr>
+        <tr><td>Revocation</td><td class="no">Kills all agents</td><td class="yes">Per-agent, &lt; 1 second</td></tr>
+        <tr><td>Delegation</td><td class="no">Copy the key</td><td class="yes">Scoped, depth-tracked</td></tr>
+        <tr><td>Expiration</td><td class="no">Usually never</td><td class="yes">Time-limited JWTs</td></tr>
+        <tr><td>Budget limits</td><td class="no">No</td><td class="yes">Per-grant budgets</td></tr>
+        <tr><td>Verification</td><td>API call required</td><td class="yes">Offline via JWKS</td></tr>
+      </table>
+
+      <h2>Migration Path</h2>
+      <p>You don't have to replace all your API keys at once. The typical migration:</p>
+      <ol>
+        <li><strong>Add Grantex to your agent layer</strong> — agents get scoped JWTs for user-facing actions</li>
+        <li><strong>Keep API keys for internal services</strong> — machine-to-machine calls that don't involve user data</li>
+        <li><strong>Add verification middleware</strong> — Express.js or FastAPI middleware checks Grantex JWTs on your endpoints</li>
+        <li><strong>Phase out agent API keys</strong> — as you add Grantex coverage, remove direct API key access from agents</li>
+      </ol>
+
+      <h2>Code Comparison</h2>
+
+      <h3>Before: Agent with API Key</h3>
+      <pre><code>// Agent has FULL Stripe access
+const stripe = new Stripe(process.env.STRIPE_API_KEY);
+await stripe.charges.create({ amount: 5000, currency: 'usd' });
+// Who authorized this? Which agent? What scopes? No idea.</code></pre>
+
+      <h3>After: Agent with Grantex JWT</h3>
+      <pre><code>// Agent has scoped access: "payments:read" only
+const toolkit = new GrantexToolkit({
+  client: gx,
+  grantToken: token,  // JWT with scopes: ["payments:read"]
+  tools: [stripeReadTool],
+});
+// Agent CAN read charges but CANNOT create them.
+// Every action logged with agent DID, user ID, timestamp.</code></pre>
+
+      <div class="cta-box">
+        <h3>Replace API keys with scoped grants</h3>
+        <p>10 lines of code. Open source. Apache 2.0.</p>
+        <a href="https://docs.grantex.dev/getting-started/quickstart" class="btn btn-primary" style="margin-right:.5rem">Get Started</a>
+        <a href="/playground" class="btn btn-secondary">Try in Playground</a>
+      </div>
+    `
+  },
+
+  'mcp-auth': {
+    metaTitle: 'How to Add Authentication to MCP Servers — Grantex MCP Auth',
+    metaDesc: 'Add OAuth 2.1 + PKCE authentication to any MCP server. Grantex MCP Auth provides scoped authorization for Claude Desktop, Cursor, and Windsurf tools.',
+    html: `
+      <h1>How to Add Auth to MCP Servers</h1>
+      <p class="subtitle">OAuth 2.1 + PKCE authorization for Model Context Protocol servers</p>
+
+      <p>MCP (Model Context Protocol) lets AI assistants like Claude Desktop, Cursor, and Windsurf call external tools. But out of the box, <strong>MCP servers have no authorization layer</strong>. Any connected client can call any tool with full access.</p>
+
+      <h2>The Problem</h2>
+      <p>When you build an MCP server that accesses real services — databases, APIs, file systems — you need to control who can call what. Without auth:</p>
+      <ul>
+        <li>Any MCP client can invoke any tool</li>
+        <li>No way to scope access per user or per session</li>
+        <li>No audit trail of tool invocations</li>
+        <li>No consent flow for sensitive operations</li>
+      </ul>
+
+      <h2>Two Grantex Solutions for MCP</h2>
+
+      <h3>1. @grantex/mcp — Grantex as an MCP Server</h3>
+      <p>13 tools for managing agent authorization directly from Claude Desktop or Cursor:</p>
+      <pre><code>// claude_desktop_config.json
+{
+  "mcpServers": {
+    "grantex": {
+      "command": "npx",
+      "args": ["@grantex/mcp"],
+      "env": { "GRANTEX_API_KEY": "gx_live_..." }
+    }
+  }
+}
+
+// Then ask Claude:
+// "Register an agent called data-bot with db:read scope"
+// "Create a grant for user alice on data-bot"
+// "Show me the audit log for the last hour"</code></pre>
+
+      <h3>2. @grantex/mcp-auth — Add Auth to YOUR MCP Server</h3>
+      <p>OAuth 2.1 + PKCE authorization for any MCP server you build:</p>
+      <pre><code>import { GrantexMCPAuth } from '@grantex/mcp-auth';
+
+const auth = new GrantexMCPAuth({
+  jwksUrl: 'https://your-auth/.well-known/jwks.json',
+});
+
+// Wrap your MCP tool handlers with authorization
+server.tool('query_database', auth.requireScopes(['db:read']), async (params) => {
+  // Only executes if the caller has db:read scope
+  return await db.query(params.sql);
+});</code></pre>
+
+      <h2>Feature Comparison</h2>
+      <table class="comparison-table">
+        <tr><th>Feature</th><th>MCP (default)</th><th>MCP + Grantex</th></tr>
+        <tr><td>Tool access control</td><td class="no">None</td><td class="yes">Per-tool scopes</td></tr>
+        <tr><td>User consent</td><td class="no">No</td><td class="yes">OAuth 2.1 consent flow</td></tr>
+        <tr><td>PKCE</td><td class="no">No</td><td class="yes">S256</td></tr>
+        <tr><td>Audit trail</td><td class="no">No</td><td class="yes">Hash-chained</td></tr>
+        <tr><td>Token revocation</td><td class="no">N/A</td><td class="yes">&lt; 1 second</td></tr>
+        <tr><td>Multi-user</td><td class="no">No</td><td class="yes">Per-user grants</td></tr>
+      </table>
+
+      <div class="cta-box">
+        <h3>Secure your MCP server in 5 minutes</h3>
+        <p>Works with Claude Desktop, Cursor, and Windsurf.</p>
+        <a href="https://docs.grantex.dev/integrations/mcp" class="btn btn-primary" style="margin-right:.5rem">Read the Docs</a>
+        <a href="https://www.npmjs.com/package/@grantex/mcp-auth" class="btn btn-secondary">npm install</a>
+      </div>
+    `
+  },
+
+  'securing-ai-agents': {
+    metaTitle: 'How to Secure AI Agents — Authorization, Scoping, and Audit Trails',
+    metaDesc: 'A practical guide to securing AI agents in production. Scoped permissions, cryptographic identity, audit trails, delegation control, and real-time revocation.',
+    html: `
+      <h1>How to Secure AI Agents in Production</h1>
+      <p class="subtitle">A practical guide to authorization, scoping, and audit trails for AI agents</p>
+
+      <p>Your AI agent books flights, reads emails, and processes payments. How do you make sure it only does what it's supposed to?</p>
+      <p>This guide covers the key security primitives you need for production AI agents, and how to implement them.</p>
+
+      <h2>1. Scoped Permissions</h2>
+      <p>The #1 rule: <strong>never give an agent more access than it needs.</strong></p>
+      <p>Instead of a full API key, give each agent a token with specific scopes:</p>
+      <pre><code>// Agent can read emails but NOT send them
+const auth = await gx.authorize({
+  agentId: agent.id,
+  userId: 'user_alice',
+  scopes: ['email:read'],  // not 'email:*'
+});</code></pre>
+      <p>With Grantex, scopes are enforced at the protocol level. If an agent tries to call a tool requiring <code>email:send</code> but only has <code>email:read</code>, the request is denied.</p>
+
+      <h2>2. Agent Identity</h2>
+      <p>Every agent needs its own cryptographic identity — not shared credentials.</p>
+      <p>Grantex assigns each agent a DID (Decentralized Identifier) embedded in its JWT. This means you can always answer: <em>"Which agent performed this action?"</em></p>
+
+      <h2>3. User Consent</h2>
+      <p>Before an agent acts on a user's behalf, the user should explicitly approve:</p>
+      <ul>
+        <li>What scopes the agent gets</li>
+        <li>How long the access lasts</li>
+        <li>What services the agent can access</li>
+      </ul>
+      <p>Grantex provides a consent URL that users visit to approve or deny the request. This is the same pattern as OAuth — familiar to users.</p>
+
+      <h2>4. Audit Trail</h2>
+      <p>You need to know what your agents did, not just what they were authorized to do.</p>
+      <p>Grantex provides an append-only, hash-chained audit log. Each entry includes:</p>
+      <ul>
+        <li>Agent DID and grant ID</li>
+        <li>Action performed and scopes used</li>
+        <li>Timestamp</li>
+        <li>SHA-256 hash linking to the previous entry (tamper-evident)</li>
+      </ul>
+
+      <h2>5. Delegation Control</h2>
+      <p>When a parent agent spawns sub-agents, the sub-agents should get <em>narrower</em> permissions, not the same or broader.</p>
+      <pre><code>// Parent has: ["flights:book", "hotels:book"]
+// Delegate only flights to the sub-agent:
+const delegated = await gx.grants.delegate({
+  parentGrantToken: parentToken,
+  childAgentId: flightBooker.id,
+  scopes: ['flights:book'],  // subset only
+});</code></pre>
+      <p>The delegation depth is tracked in the JWT. Revoking the parent cascades to all children.</p>
+
+      <h2>6. Real-Time Revocation</h2>
+      <p>If an agent behaves unexpectedly, you need to kill its access immediately — not wait for a token to expire.</p>
+      <p>Grantex revocation takes effect in under 1 second. Cascade revocation kills all delegated sub-agent grants simultaneously.</p>
+
+      <h2>7. Budget Controls</h2>
+      <p>For agents that spend money (API calls, compute, purchases), set spending limits:</p>
+      <pre><code>await gx.budgets.allocate({
+  grantId: grant.id,
+  amount: 100.00,  // max $100
+  currency: 'USD',
+});
+// Agent is automatically cut off at the limit</code></pre>
+
+      <h2>Getting Started</h2>
+      <p>Grantex provides all of these primitives as an open protocol (Apache 2.0) with SDKs for <a href="https://docs.grantex.dev/sdks/typescript/overview">TypeScript</a>, <a href="https://docs.grantex.dev/sdks/python/overview">Python</a>, and <a href="https://docs.grantex.dev/sdks/go/overview">Go</a>.</p>
+
+      <div class="cta-box">
+        <h3>Secure your agents in under 5 minutes</h3>
+        <p>Open source. 14 framework integrations. 174 pages of docs.</p>
+        <a href="https://docs.grantex.dev/getting-started/quickstart" class="btn btn-primary" style="margin-right:.5rem">Quickstart Guide</a>
+        <a href="/playground" class="btn btn-secondary">Try in Playground</a>
+      </div>
+    `
+  }
+};
+
+const slug = window.location.pathname.replace(/\/$/, '').split('/').pop();
+const page = pages[slug];
+
+if (!page) {
+  window.location.href = '/';
+} else {
+  document.title = page.metaTitle;
+  document.querySelector('meta[name="description"]').content = page.metaDesc;
+  document.querySelector('link[rel="canonical"]').href = 'https://grantex.dev/vs/' + slug;
+  document.querySelector('meta[property="og:title"]').content = page.metaTitle;
+  document.querySelector('meta[property="og:description"]').content = page.metaDesc;
+  document.querySelector('meta[property="og:url"]').content = 'https://grantex.dev/vs/' + slug;
+  document.querySelector('meta[name="twitter:title"]').content = page.metaTitle;
+  document.querySelector('meta[name="twitter:description"]').content = page.metaDesc;
+  document.getElementById('content').innerHTML = page.html;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": page.metaTitle,
+    "description": page.metaDesc,
+    "url": "https://grantex.dev/vs/" + slug,
+    "author": { "@type": "Organization", "name": "Grantex", "url": "https://grantex.dev" },
+    "publisher": { "@type": "Organization", "name": "Grantex", "url": "https://grantex.dev" }
+  };
+  const s = document.createElement('script');
+  s.type = 'application/ld+json';
+  s.textContent = JSON.stringify(jsonLd);
+  document.head.appendChild(s);
+
+  gtag('event', 'page_view', { page_title: page.metaTitle, page_location: window.location.href });
+}
+</script>
+</body>
+</html>

--- a/web/x402-playground/index.html
+++ b/web/x402-playground/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Grantex x402 Playground</title>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebApplication","name":"Grantex x402 Playground","url":"https://grantex.dev/x402-playground","description":"Interactive demo of agent spend authorization for x402 payment flows","applicationCategory":"DeveloperApplication","operatingSystem":"Web"}</script>
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
 :root{--bg:#0a0f1a;--surface:#111827;--border:#1f2937;--text:#f9fafb;--text-dim:#9ca3af;--indigo:#6366f1;--emerald:#10b981;--amber:#f59e0b;--red:#ef4444;--code-bg:#1e1e2e;--mono:'Menlo','Monaco','Cascadia Code','Consolas',monospace}

--- a/web/x402/index.html
+++ b/web/x402/index.html
@@ -5,6 +5,43 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Grantex x402 — Agent Spend Authorization for HTTP 402 Payment Flows</title>
 <meta name="description" content="Add authorization to x402 payment flows. Grantex Delegation Tokens prove which agent was authorized to spend, with scope, limits, and audit trails.">
+<link rel="canonical" href="https://grantex.dev/x402/">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
+<!-- OpenGraph -->
+<meta property="og:title" content="Grantex x402 — Agent Spend Authorization for HTTP 402 Payment Flows">
+<meta property="og:description" content="Add authorization to x402 payment flows. Grantex Delegation Tokens prove which agent was authorized to spend, with scope, limits, and audit trails.">
+<meta property="og:url" content="https://grantex.dev/x402/">
+<meta property="og:image" content="https://grantex.dev/og-image.png">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Grantex">
+
+<!-- Twitter Card -->
+<meta name="twitter:site" content="@grantex_dev">
+  <meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Grantex x402 — Agent Spend Authorization for HTTP 402 Payment Flows">
+<meta name="twitter:description" content="Add authorization to x402 payment flows. Grantex Delegation Tokens prove which agent was authorized to spend, with scope, limits, and audit trails.">
+<meta name="twitter:image" content="https://grantex.dev/og-image.png">
+
+<!-- JSON-LD -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "Grantex x402",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Any",
+  "url": "https://grantex.dev/x402/",
+  "description": "Add authorization to x402 payment flows. Grantex Delegation Tokens prove which agent was authorized to spend, with scope, limits, and audit trails.",
+  "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  "author": { "@type": "Organization", "name": "Grantex", "url": "https://grantex.dev" }
+}
+</script>
+
+<!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-DNXYVLS5NY"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','G-DNXYVLS5NY');</script>
+
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
 :root{--bg:#0a0f1a;--surface:#111827;--border:#1f2937;--text:#f9fafb;--text-dim:#9ca3af;--indigo:#6366f1;--emerald:#10b981;--amber:#f59e0b;--code-bg:#1e1e2e;--mono:'Menlo','Monaco','Cascadia Code','Consolas',monospace}


### PR DESCRIPTION
## Summary
Complete landing page and SEO audit fix.

### Landing page content
- Examples: 7 → 18 cards (Go, Anthropic, Next.js, multi-agent, Gemma, x402, gateway, adapter)
- Connector count: +41 → +40 more (53 total, was implying 54)
- Integrations grid: 19 → 22 pills (added CLI, Destinations, Terraform)
- Heading hierarchy: H4 → H3 in business risk section

### Critical SEO
- **15 pre-rendered static pages** for /for/* (11 frameworks) and /vs/* (4 comparisons) — meta tags now server-side, visible to Googlebot
- x402 page: canonical, OG, Twitter, JSON-LD, GA4 (was missing ALL SEO)
- GA4 added to 4 pages (registry, playground, mpp-demo, x402-playground)
- twitter:site @grantex_dev on all 27 pages

### Medium SEO
- Sitemap: all 49 lastmod dates → 2026-04-05
- JSON-LD on playground, mpp-demo, x402-playground
- og:image on mpp-demo
- llms.txt → v0.3.4 + last updated date

**23 files changed, 15 new static pages**

## Test plan
- [ ] Landing page renders correctly
- [ ] /for/langchain loads with proper meta tags
- [ ] /vs/oauth loads with proper meta tags
- [ ] GA4 fires on registry page