### PR TITLE
[codex] Harden grant verification and session flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ const session = await grantex.principalSessions.create({
   expiresIn: '2h',
 });
 // Send session.dashboardUrl to the user via email, in-app notification, etc.
+// The short-lived session token is carried in the URL fragment, not the query string.
 ```
 
 ---

--- a/apps/auth-service/src/lib/active-grant-token.ts
+++ b/apps/auth-service/src/lib/active-grant-token.ts
@@ -1,0 +1,75 @@
+import { getSql } from '../db/client.js';
+import { getRedis } from '../redis/client.js';
+import {
+  verifyGrantToken,
+  type VerifiedGrantTokenClaims,
+} from './crypto.js';
+
+export type ActiveGrantTokenCheckResult =
+  | { ok: true; claims: VerifiedGrantTokenClaims }
+  | {
+      ok: false;
+      reason:
+        | 'invalid'
+        | 'invalid_claims'
+        | 'wrong_developer'
+        | 'revoked'
+        | 'expired'
+        | 'not_found';
+    };
+
+export async function checkActiveGrantToken(
+  token: string,
+  options: { expectedDeveloperId?: string } = {},
+): Promise<ActiveGrantTokenCheckResult> {
+  let claims: VerifiedGrantTokenClaims;
+  try {
+    claims = await verifyGrantToken(token);
+  } catch (err) {
+    if (err instanceof Error && err.message === 'Missing required grant token claims') {
+      return { ok: false, reason: 'invalid_claims' };
+    }
+    return { ok: false, reason: 'invalid' };
+  }
+
+  if (
+    options.expectedDeveloperId !== undefined
+    && claims.dev !== options.expectedDeveloperId
+  ) {
+    return { ok: false, reason: 'wrong_developer' };
+  }
+
+  const redis = getRedis();
+  const [tokenRevoked, grantRevoked] = await Promise.all([
+    redis.get(`revoked:tok:${claims.jti}`),
+    redis.get(`revoked:grant:${claims.grnt}`),
+  ]);
+
+  if (tokenRevoked || grantRevoked) {
+    return { ok: false, reason: 'revoked' };
+  }
+
+  const sql = getSql();
+  const rows = await sql`
+    SELECT gt.is_revoked, gt.expires_at, g.status AS grant_status
+    FROM grant_tokens gt
+    JOIN grants g ON g.id = gt.grant_id
+    WHERE gt.jti = ${claims.jti}
+      AND (${options.expectedDeveloperId ?? null}::text IS NULL OR g.developer_id = ${options.expectedDeveloperId ?? null})
+  `;
+
+  const row = rows[0];
+  if (!row) {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  if ((row['is_revoked'] as boolean) || row['grant_status'] !== 'active') {
+    return { ok: false, reason: 'revoked' };
+  }
+
+  if (new Date(row['expires_at'] as string) < new Date()) {
+    return { ok: false, reason: 'expired' };
+  }
+
+  return { ok: true, claims };
+}

--- a/apps/auth-service/src/lib/crypto.ts
+++ b/apps/auth-service/src/lib/crypto.ts
@@ -31,6 +31,23 @@ export interface GrantTokenPayload {
   bdg?: number;
 }
 
+export interface VerifiedGrantTokenClaims {
+  sub: string;
+  agt: string;
+  dev: string;
+  scp: string[];
+  jti: string;
+  grnt: string;
+  iat: number;
+  exp: number;
+  aud?: string | string[];
+  iss?: string;
+  parentAgt?: string;
+  parentGrnt?: string;
+  delegationDepth?: number;
+  bdg?: number;
+}
+
 let _keyPair: KeyPair | null = null;
 
 function buildKid(): string {
@@ -110,7 +127,7 @@ export async function signGrantToken(
 
 export async function verifyGrantToken(
   token: string,
-): Promise<{ sub: string; dev: string; scp: string[] }> {
+): Promise<VerifiedGrantTokenClaims> {
   const { publicKey } = getKeyPair();
   const { payload } = await jwtVerify(token, publicKey, {
     issuer: config.jwtIssuer,
@@ -118,13 +135,32 @@ export async function verifyGrantToken(
   });
 
   const sub = payload.sub;
+  const agt = payload['agt'] as string | undefined;
   const dev = payload['dev'] as string | undefined;
   const scp = payload['scp'] as string[] | undefined;
-  if (!sub || !dev || !scp) {
+  const jti = payload.jti;
+  const iat = payload.iat;
+  const exp = payload.exp;
+  if (!sub || !agt || !dev || !scp || !jti || typeof iat !== 'number' || typeof exp !== 'number') {
     throw new Error('Missing required grant token claims');
   }
 
-  return { sub, dev, scp };
+  return {
+    sub,
+    agt,
+    dev,
+    scp,
+    jti,
+    grnt: typeof payload['grnt'] === 'string' ? payload['grnt'] : jti,
+    iat,
+    exp,
+    ...(payload.aud !== undefined ? { aud: payload.aud as string | string[] } : {}),
+    ...(payload.iss !== undefined ? { iss: payload.iss } : {}),
+    ...(payload['parentAgt'] !== undefined ? { parentAgt: payload['parentAgt'] as string } : {}),
+    ...(payload['parentGrnt'] !== undefined ? { parentGrnt: payload['parentGrnt'] as string } : {}),
+    ...(payload['delegationDepth'] !== undefined ? { delegationDepth: payload['delegationDepth'] as number } : {}),
+    ...(payload['bdg'] !== undefined ? { bdg: payload['bdg'] as number } : {}),
+  };
 }
 
 // ─── Ed25519 key support (optional — for VC Data Integrity proofs) ────────────

--- a/apps/auth-service/src/routes/authorize.ts
+++ b/apps/auth-service/src/routes/authorize.ts
@@ -7,6 +7,7 @@ import { getPolicyBackend } from '../lib/policy-backend.js';
 import { isPlanName, PLAN_LIMITS } from '../lib/plans.js';
 import { authorizeTotal, authorizeDuration } from '../lib/metrics.js';
 import { incrementUsage } from '../lib/usage.js';
+import { parseExpiresIn } from '../lib/crypto.js';
 
 interface AuthorizeBody {
   agentId: string;
@@ -99,8 +100,16 @@ export async function authorizeRoutes(app: FastifyInstance): Promise<void> {
       });
     }
 
-    // Parse expiresIn to compute expires_at
-    const expiresSeconds = parseExpiresIn(expiresIn);
+    let expiresSeconds: number;
+    try {
+      expiresSeconds = parseExpiresIn(expiresIn);
+    } catch {
+      return reply.status(400).send({
+        message: 'Invalid expiresIn format. Use e.g. "1h", "30m", "24h".',
+        code: 'BAD_REQUEST',
+        requestId: request.id,
+      });
+    }
     const expiresAt = new Date(Date.now() + expiresSeconds * 1000);
 
     const id = newAuthRequestId();
@@ -192,18 +201,4 @@ export async function authorizeRoutes(app: FastifyInstance): Promise<void> {
 
     return reply.send({ requestId: row['id'], status: row['status'] });
   });
-}
-
-function parseExpiresIn(expiresIn: string): number {
-  const match = /^(\d+)([smhd])$/.exec(expiresIn);
-  if (!match) return 86400; // default 24h
-  const [, amount, unit] = match;
-  const n = parseInt(amount!, 10);
-  switch (unit) {
-    case 's': return n;
-    case 'm': return n * 60;
-    case 'h': return n * 3600;
-    case 'd': return n * 86400;
-    default: return 86400;
-  }
 }

--- a/apps/auth-service/src/routes/consent.ts
+++ b/apps/auth-service/src/routes/consent.ts
@@ -52,8 +52,17 @@ const CONSENT_HTML = `<!DOCTYPE html>
   const reqId = params.get('req');
   const el = document.getElementById('content');
 
+  function esc(value) {
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
   function showError(msg) {
-    el.innerHTML = '<div class="error-msg">' + msg + '</div>';
+    el.innerHTML = '<div class="error-msg">' + esc(msg) + '</div>';
   }
 
   function formatExpiry(isoStr) {
@@ -81,15 +90,15 @@ const CONSENT_HTML = `<!DOCTYPE html>
 
   const expiry = formatExpiry(data.expiresAt);
   const scopeItems = (data.scopeDescriptions || []).map(function(d) {
-    return '<li>' + d + '</li>';
+    return '<li>' + esc(d) + '</li>';
   }).join('');
 
   el.innerHTML =
     '<div class="header"><div class="icon">&#128274;</div><h1>Authorization Request</h1></div>' +
     '<div class="agent-box">' +
-      '<div class="agent-name">' + data.agentName + ' wants permission:</div>' +
-      (data.agentDescription ? '<div class="agent-desc">' + data.agentDescription + '</div>' : '') +
-      '<div class="agent-did">' + data.agentDid + '</div>' +
+      '<div class="agent-name">' + esc(data.agentName) + ' wants permission:</div>' +
+      (data.agentDescription ? '<div class="agent-desc">' + esc(data.agentDescription) + '</div>' : '') +
+      '<div class="agent-did">' + esc(data.agentDid) + '</div>' +
     '</div>' +
     '<div class="scopes-label">Requested permissions</div>' +
     '<ul class="scope-list">' + scopeItems + '</ul>' +

--- a/apps/auth-service/src/routes/delegate.ts
+++ b/apps/auth-service/src/routes/delegate.ts
@@ -1,10 +1,10 @@
 import type { FastifyInstance } from 'fastify';
 import { getSql } from '../db/client.js';
-import { getRedis } from '../redis/client.js';
 import { newGrantId, newTokenId, newRefreshTokenId } from '../lib/ids.js';
-import { decodeTokenClaims, signGrantToken, parseExpiresIn } from '../lib/crypto.js';
+import { signGrantToken, parseExpiresIn } from '../lib/crypto.js';
 import { emitEvent } from '../lib/events.js';
 import { issueAgentGrantVC } from '../lib/vc.js';
+import { checkActiveGrantToken } from '../lib/active-grant-token.js';
 
 interface DelegateBody {
   parentGrantToken: string;
@@ -27,35 +27,39 @@ export async function delegateRoutes(app: FastifyInstance): Promise<void> {
       });
     }
 
-    // Decode parent token
-    let parentClaims: Record<string, unknown>;
-    try {
-      parentClaims = decodeTokenClaims(parentGrantToken);
-    } catch {
-      return reply.status(400).send({ message: 'Invalid parentGrantToken', code: 'BAD_REQUEST', requestId: request.id });
+    const parentCheck = await checkActiveGrantToken(parentGrantToken, {
+      expectedDeveloperId: request.developer.id,
+    });
+
+    if (!parentCheck.ok) {
+      if (parentCheck.reason === 'invalid') {
+        return reply.status(400).send({ message: 'Invalid parentGrantToken', code: 'BAD_REQUEST', requestId: request.id });
+      }
+      if (parentCheck.reason === 'invalid_claims') {
+        return reply.status(400).send({ message: 'Invalid parentGrantToken claims', code: 'BAD_REQUEST', requestId: request.id });
+      }
+      if (parentCheck.reason === 'wrong_developer') {
+        return reply.status(403).send({ message: 'Parent grant belongs to a different developer', code: 'FORBIDDEN', requestId: request.id });
+      }
+      if (parentCheck.reason === 'not_found') {
+        return reply.status(400).send({ message: 'Invalid parentGrantToken claims', code: 'BAD_REQUEST', requestId: request.id });
+      }
+      if (parentCheck.reason === 'revoked') {
+        return reply.status(400).send({ message: 'Parent grant has been revoked', code: 'BAD_REQUEST', requestId: request.id });
+      }
+      return reply.status(400).send({ message: 'Parent grant has expired', code: 'BAD_REQUEST', requestId: request.id });
     }
 
-    const parentJti = parentClaims['jti'] as string | undefined;
-    const parentGrnt = (parentClaims['grnt'] ?? parentClaims['jti']) as string | undefined;
-    const parentAgt = parentClaims['agt'] as string | undefined;
-    const parentScp = parentClaims['scp'] as string[] | undefined;
-    const parentExp = parentClaims['exp'] as number | undefined;
-    const parentDepth = (parentClaims['delegationDepth'] as number | undefined) ?? 0;
-
-    if (!parentJti || !parentGrnt || !parentScp || !parentExp) {
+    const parentClaims = parentCheck.claims;
+    if (!parentClaims.jti || !parentClaims.grnt || !parentClaims.scp || !parentClaims.exp) {
       return reply.status(400).send({ message: 'Invalid parentGrantToken claims', code: 'BAD_REQUEST', requestId: request.id });
     }
 
-    // Check parent not revoked in Redis
-    const redis = getRedis();
-    const [parentTokenRevoked, parentGrantRevoked] = await Promise.all([
-      redis.get(`revoked:tok:${parentJti}`),
-      redis.get(`revoked:grant:${parentGrnt}`),
-    ]);
-
-    if (parentTokenRevoked || parentGrantRevoked) {
-      return reply.status(400).send({ message: 'Parent grant has been revoked', code: 'BAD_REQUEST', requestId: request.id });
-    }
+    const parentGrnt = parentClaims.grnt;
+    const parentAgt = parentClaims.agt;
+    const parentScp = parentClaims.scp;
+    const parentExp = parentClaims.exp;
+    const parentDepth = parentClaims.delegationDepth ?? 0;
 
     // Validate scopes ⊆ parent scopes
     const invalidScopes = scopes.filter((s) => !parentScp.includes(s));
@@ -98,7 +102,7 @@ export async function delegateRoutes(app: FastifyInstance): Promise<void> {
       VALUES (
         ${grantId},
         ${subAgentId},
-        ${parentClaims['sub'] as string},
+        ${parentClaims.sub},
         ${developerId},
         ${scopes},
         ${expiresAt},
@@ -142,7 +146,7 @@ export async function delegateRoutes(app: FastifyInstance): Promise<void> {
         const vcResult = await issueAgentGrantVC({
           grantId,
           agentDid: subAgent['did'] as string,
-          principalId: parentClaims['sub'] as string,
+          principalId: parentClaims.sub,
           developerId,
           scopes,
           expiresAt,
@@ -159,7 +163,7 @@ export async function delegateRoutes(app: FastifyInstance): Promise<void> {
     emitEvent(developerId, 'grant.created', {
       grantId,
       agentId: subAgentId,
-      principalId: parentClaims['sub'] as string,
+      principalId: parentClaims.sub,
       scopes,
       expiresAt: expiresAt.toISOString(),
       delegationDepth,
@@ -169,7 +173,7 @@ export async function delegateRoutes(app: FastifyInstance): Promise<void> {
       tokenId: jti,
       grantId,
       agentId: subAgentId,
-      principalId: parentClaims['sub'] as string,
+      principalId: parentClaims.sub,
       scopes,
       expiresAt: expiresAt.toISOString(),
     }).catch(() => {});

--- a/apps/auth-service/src/routes/grants.ts
+++ b/apps/auth-service/src/routes/grants.ts
@@ -1,8 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { getSql } from '../db/client.js';
-import { getRedis } from '../redis/client.js';
-import { decodeTokenClaims } from '../lib/crypto.js';
 import { revokeGrantCascade } from '../lib/revoke.js';
+import { checkActiveGrantToken } from '../lib/active-grant-token.js';
 
 export async function grantsRoutes(app: FastifyInstance): Promise<void> {
   // GET /v1/grants
@@ -61,53 +60,18 @@ export async function grantsRoutes(app: FastifyInstance): Promise<void> {
       return reply.status(400).send({ message: 'token is required', code: 'BAD_REQUEST', requestId: request.id });
     }
 
-    let claims: Record<string, unknown>;
-    try {
-      claims = decodeTokenClaims(token);
-    } catch {
-      return reply.status(400).send({ message: 'Invalid token', code: 'BAD_REQUEST', requestId: request.id });
+    const result = await checkActiveGrantToken(token, {
+      expectedDeveloperId: request.developer.id,
+    });
+
+    if (!result.ok) {
+      if (result.reason === 'invalid' || result.reason === 'invalid_claims') {
+        return reply.status(400).send({ message: 'Invalid token', code: 'BAD_REQUEST', requestId: request.id });
+      }
+      return reply.send({ active: false, reason: result.reason });
     }
 
-    const jti = claims['jti'] as string;
-    const gid = (claims['grnt'] ?? claims['jti']) as string;
-
-    // Check Redis first
-    const redis = getRedis();
-    const [tokenRevoked, grantRevoked] = await Promise.all([
-      redis.get(`revoked:tok:${jti}`),
-      redis.get(`revoked:grant:${gid}`),
-    ]);
-
-    if (tokenRevoked || grantRevoked) {
-      return reply.send({ active: false, reason: 'revoked' });
-    }
-
-    // Check DB
-    const sql = getSql();
-    const tokenRows = await sql`
-      SELECT gt.is_revoked, gt.expires_at, g.status AS grant_status
-      FROM grant_tokens gt
-      JOIN grants g ON g.id = gt.grant_id
-      WHERE gt.jti = ${jti} AND g.developer_id = ${request.developer.id}
-    `;
-
-    const row = tokenRows[0];
-    if (!row) {
-      return reply.send({ active: false, reason: 'not_found' });
-    }
-    if (row['is_revoked'] || row['grant_status'] !== 'active') {
-      return reply.send({ active: false, reason: 'revoked' });
-    }
-    if (new Date(row['expires_at'] as string) < new Date()) {
-      return reply.send({ active: false, reason: 'expired' });
-    }
-
-    const exp = claims['exp'] as number | undefined;
-    if (exp && Math.floor(Date.now() / 1000) > exp) {
-      return reply.send({ active: false, reason: 'expired' });
-    }
-
-    return reply.send({ active: true, claims });
+    return reply.send({ active: true, claims: result.claims });
   });
 }
 

--- a/apps/auth-service/src/routes/principal.ts
+++ b/apps/auth-service/src/routes/principal.ts
@@ -87,7 +87,7 @@ export async function principalRoutes(app: FastifyInstance): Promise<void> {
 
       return reply.status(201).send({
         sessionToken,
-        dashboardUrl: `${request.protocol}://${request.hostname}/permissions?session=${sessionToken}`,
+        dashboardUrl: `${request.protocol}://${request.hostname}/permissions#session=${encodeURIComponent(sessionToken)}`,
         expiresAt,
       });
     },
@@ -303,7 +303,17 @@ function permissionsPageHtml(): string {
 </div>
 
 <script>
-  var sessionToken = new URLSearchParams(window.location.search).get('session');
+  function getSessionToken() {
+    var hash = window.location.hash || '';
+    if (hash.startsWith('#')) {
+      var hashParams = new URLSearchParams(hash.slice(1));
+      var hashToken = hashParams.get('session');
+      if (hashToken) return hashToken;
+    }
+    return new URLSearchParams(window.location.search).get('session');
+  }
+
+  var sessionToken = getSessionToken();
 
   if (!sessionToken) {
     document.getElementById('loading').style.display = 'none';

--- a/apps/auth-service/src/routes/token.ts
+++ b/apps/auth-service/src/routes/token.ts
@@ -23,6 +23,24 @@ interface RefreshBody {
   agentId: string;
 }
 
+interface RouteError {
+  statusCode: number;
+  message: string;
+  code: string;
+}
+
+function routeError(statusCode: number, message: string, code = 'BAD_REQUEST'): never {
+  throw { statusCode, message, code } satisfies RouteError;
+}
+
+function isRouteError(err: unknown): err is RouteError {
+  return typeof err === 'object'
+    && err !== null
+    && 'statusCode' in err
+    && 'message' in err
+    && 'code' in err;
+}
+
 export async function tokenRoutes(app: FastifyInstance): Promise<void> {
   // POST /v1/token — stricter rate limit: 20/min
   app.post<{ Body: TokenBody }>('/v1/token', { config: { rateLimit: { max: 20, timeWindow: '1 minute' } } }, async (request, reply) => {
@@ -40,83 +58,90 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
     const sql = getSql();
     const developerId = request.developer.id;
 
-    // Validate code + agentId
-    const authRows = await sql`
-      SELECT ar.id, ar.agent_id, ar.principal_id, ar.developer_id,
-             ar.scopes, ar.expires_in, ar.expires_at, ar.status,
-             ar.audience, ar.code_challenge, a.did AS agent_did
-      FROM auth_requests ar
-      JOIN agents a ON a.id = ar.agent_id
-      WHERE ar.code = ${code}
-        AND ar.agent_id = ${agentId}
-        AND ar.developer_id = ${developerId}
-    `;
-
-    const authReq = authRows[0];
-    if (!authReq) {
-      return reply.status(400).send({ message: 'Invalid code', code: 'BAD_REQUEST', requestId: request.id });
-    }
-
-    if (authReq['status'] !== 'approved') {
-      return reply.status(400).send({ message: 'Auth request not approved', code: 'BAD_REQUEST', requestId: request.id });
-    }
-
-    if (new Date(authReq['expires_at'] as string) < new Date()) {
-      return reply.status(400).send({ message: 'Auth request expired', code: 'BAD_REQUEST', requestId: request.id });
-    }
-
-    // PKCE verification
-    const storedChallenge = authReq['code_challenge'] as string | null;
-    if (storedChallenge) {
-      if (!codeVerifier) {
-        return reply.status(400).send({ message: 'codeVerifier is required for PKCE', code: 'BAD_REQUEST', requestId: request.id });
-      }
-      if (!verifyPkceChallenge(codeVerifier, storedChallenge)) {
-        return reply.status(400).send({ message: 'Invalid codeVerifier', code: 'BAD_REQUEST', requestId: request.id });
-      }
-    }
-
-    // Parse expiry
-    const expiresInStr = authReq['expires_in'] as string;
-    const expiresSeconds = parseExpiresIn(expiresInStr);
-    const now = Date.now();
-    const expiresAt = new Date(now + expiresSeconds * 1000);
-    const expTimestamp = Math.floor(expiresAt.getTime() / 1000);
-
+    let authReq!: Record<string, unknown>;
+    let expiresAt!: Date;
+    let expTimestamp!: number;
     const grantId = newGrantId();
     const jti = newTokenId();
     const refreshId = newRefreshTokenId();
 
-    // Atomically create grant, token, refresh token, and consume auth request
-    const refreshExpiresAt = new Date(now + 30 * 86400 * 1000); // 30 days
-    await sql.begin(async (_tx) => {
-      const tx = _tx as unknown as TxSql;
-      await tx`
-        INSERT INTO grants (id, agent_id, principal_id, developer_id, scopes, expires_at)
-        VALUES (
-          ${grantId},
-          ${authReq['agent_id'] as string},
-          ${authReq['principal_id'] as string},
-          ${authReq['developer_id'] as string},
-          ${authReq['scopes'] as string[]},
-          ${expiresAt}
-        )
-      `;
+    try {
+      await sql.begin(async (_tx) => {
+        const tx = _tx as unknown as TxSql;
+        const authRows = await tx`
+          SELECT ar.id, ar.agent_id, ar.principal_id, ar.developer_id,
+                 ar.scopes, ar.expires_in, ar.expires_at, ar.status,
+                 ar.audience, ar.code_challenge, a.did AS agent_did
+          FROM auth_requests ar
+          JOIN agents a ON a.id = ar.agent_id
+          WHERE ar.code = ${code}
+            AND ar.agent_id = ${agentId}
+            AND ar.developer_id = ${developerId}
+          FOR UPDATE
+        `;
 
-      await tx`
-        INSERT INTO grant_tokens (jti, grant_id, expires_at)
-        VALUES (${jti}, ${grantId}, ${expiresAt})
-      `;
+        authReq = authRows[0] ?? routeError(400, 'Invalid code');
+        if (authReq['status'] !== 'approved') {
+          routeError(400, 'Auth request not approved');
+        }
+        if (new Date(authReq['expires_at'] as string) < new Date()) {
+          routeError(400, 'Auth request expired');
+        }
 
-      await tx`
-        INSERT INTO refresh_tokens (id, grant_id, expires_at)
-        VALUES (${refreshId}, ${grantId}, ${refreshExpiresAt})
-      `;
+        const storedChallenge = authReq['code_challenge'] as string | null;
+        if (storedChallenge) {
+          if (!codeVerifier) {
+            routeError(400, 'codeVerifier is required for PKCE');
+          }
+          if (!verifyPkceChallenge(codeVerifier, storedChallenge)) {
+            routeError(400, 'Invalid codeVerifier');
+          }
+        }
 
-      await tx`
-        UPDATE auth_requests SET status = 'consumed' WHERE id = ${authReq['id'] as string}
-      `;
-    });
+        const expiresSeconds = parseExpiresIn(authReq['expires_in'] as string);
+        const now = Date.now();
+        expiresAt = new Date(now + expiresSeconds * 1000);
+        expTimestamp = Math.floor(expiresAt.getTime() / 1000);
+        const refreshExpiresAt = new Date(now + 30 * 86400 * 1000);
+
+        await tx`
+          INSERT INTO grants (id, agent_id, principal_id, developer_id, scopes, expires_at)
+          VALUES (
+            ${grantId},
+            ${authReq['agent_id'] as string},
+            ${authReq['principal_id'] as string},
+            ${authReq['developer_id'] as string},
+            ${authReq['scopes'] as string[]},
+            ${expiresAt}
+          )
+        `;
+
+        await tx`
+          INSERT INTO grant_tokens (jti, grant_id, expires_at)
+          VALUES (${jti}, ${grantId}, ${expiresAt})
+        `;
+
+        await tx`
+          INSERT INTO refresh_tokens (id, grant_id, expires_at)
+          VALUES (${refreshId}, ${grantId}, ${refreshExpiresAt})
+        `;
+
+        await tx`
+          UPDATE auth_requests
+          SET status = 'consumed'
+          WHERE id = ${authReq['id'] as string}
+        `;
+      });
+    } catch (err) {
+      if (isRouteError(err)) {
+        return reply.status(err.statusCode).send({
+          message: err.message,
+          code: err.code,
+          requestId: request.id,
+        });
+      }
+      throw err;
+    }
 
     // Check for budget allocation
     const budgetRows = await sql<{ remaining_budget: string }[]>`
@@ -240,69 +265,83 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
     const sql = getSql();
     const developerId = request.developer.id;
 
-    // Look up refresh token, joining grants and agents
-    const rows = await sql`
-      SELECT rt.id AS refresh_id, rt.grant_id, rt.is_used, rt.expires_at AS refresh_expires_at,
-             g.agent_id, g.principal_id, g.developer_id, g.scopes, g.status AS grant_status,
-             g.expires_at AS grant_expires_at,
-             a.did AS agent_did
-      FROM refresh_tokens rt
-      JOIN grants g ON g.id = rt.grant_id
-      JOIN agents a ON a.id = g.agent_id
-      WHERE rt.id = ${refreshToken}
-        AND g.developer_id = ${developerId}
-    `;
-
-    const row = rows[0];
-    if (!row) {
-      return reply.status(400).send({ message: 'Invalid refresh token', code: 'BAD_REQUEST', requestId: request.id });
-    }
-
-    if (row['agent_id'] !== agentId) {
-      return reply.status(400).send({ message: 'Agent mismatch', code: 'BAD_REQUEST', requestId: request.id });
-    }
-
-    if (row['is_used']) {
-      return reply.status(400).send({ message: 'Refresh token already used', code: 'BAD_REQUEST', requestId: request.id });
-    }
-
-    if (new Date(row['refresh_expires_at'] as string) < new Date()) {
-      return reply.status(400).send({ message: 'Refresh token expired', code: 'BAD_REQUEST', requestId: request.id });
-    }
-
-    if (row['grant_status'] === 'revoked') {
-      return reply.status(400).send({ message: 'Grant has been revoked', code: 'BAD_REQUEST', requestId: request.id });
-    }
-
-    const grantId = row['grant_id'] as string;
-    const scopes = row['scopes'] as string[];
-    const now = Date.now();
-
-    // Use remaining grant expiry window for the new token
-    const grantExpiresAt = new Date(row['grant_expires_at'] as string);
-    const expTimestamp = Math.floor(grantExpiresAt.getTime() / 1000);
-
+    let row!: Record<string, unknown>;
+    let grantId!: string;
+    let scopes!: string[];
+    let grantExpiresAt!: Date;
     const jti = newTokenId();
     const newRefreshId = newRefreshTokenId();
 
-    // Atomically rotate: mark old refresh token used, create new token + refresh token
-    const refreshExpiresAt = new Date(now + 30 * 86400 * 1000);
-    await sql.begin(async (_tx) => {
-      const tx = _tx as unknown as TxSql;
-      await tx`UPDATE refresh_tokens SET is_used = true WHERE id = ${row['refresh_id'] as string}`;
+    try {
+      await sql.begin(async (_tx) => {
+        const tx = _tx as unknown as TxSql;
+        const rows = await tx`
+          SELECT rt.id AS refresh_id, rt.grant_id, rt.is_used, rt.expires_at AS refresh_expires_at,
+                 g.agent_id, g.principal_id, g.developer_id, g.scopes, g.status AS grant_status,
+                 g.expires_at AS grant_expires_at,
+                 a.did AS agent_did
+          FROM refresh_tokens rt
+          JOIN grants g ON g.id = rt.grant_id
+          JOIN agents a ON a.id = g.agent_id
+          WHERE rt.id = ${refreshToken}
+            AND g.developer_id = ${developerId}
+          FOR UPDATE
+        `;
 
-      await tx`
-        INSERT INTO grant_tokens (jti, grant_id, expires_at)
-        VALUES (${jti}, ${grantId}, ${grantExpiresAt})
-      `;
+        row = rows[0] ?? routeError(400, 'Invalid refresh token');
+        if (row['agent_id'] !== agentId) {
+          routeError(400, 'Agent mismatch');
+        }
+        if (row['is_used']) {
+          routeError(400, 'Refresh token already used');
+        }
+        if (new Date(row['refresh_expires_at'] as string) < new Date()) {
+          routeError(400, 'Refresh token expired');
+        }
+        if (row['grant_status'] === 'revoked') {
+          routeError(400, 'Grant has been revoked');
+        }
 
-      await tx`
-        INSERT INTO refresh_tokens (id, grant_id, expires_at)
-        VALUES (${newRefreshId}, ${grantId}, ${refreshExpiresAt})
-      `;
-    });
+        grantId = row['grant_id'] as string;
+        scopes = row['scopes'] as string[];
+        grantExpiresAt = new Date(row['grant_expires_at'] as string);
+        const now = Date.now();
+        const refreshExpiresAt = new Date(now + 30 * 86400 * 1000);
+
+        const updated = await tx`
+          UPDATE refresh_tokens
+          SET is_used = true
+          WHERE id = ${row['refresh_id'] as string}
+            AND is_used = false
+          RETURNING id
+        `;
+        if (!updated[0]) {
+          routeError(400, 'Refresh token already used');
+        }
+
+        await tx`
+          INSERT INTO grant_tokens (jti, grant_id, expires_at)
+          VALUES (${jti}, ${grantId}, ${grantExpiresAt})
+        `;
+
+        await tx`
+          INSERT INTO refresh_tokens (id, grant_id, expires_at)
+          VALUES (${newRefreshId}, ${grantId}, ${refreshExpiresAt})
+        `;
+      });
+    } catch (err) {
+      if (isRouteError(err)) {
+        return reply.status(err.statusCode).send({
+          message: err.message,
+          code: err.code,
+          requestId: request.id,
+        });
+      }
+      throw err;
+    }
 
     // Sign JWT with same grant claims
+    const expTimestamp = Math.floor(grantExpiresAt.getTime() / 1000);
     const jwt = await signGrantToken({
       sub: row['principal_id'] as string,
       agt: row['agent_did'] as string,

--- a/apps/auth-service/src/routes/tokens.ts
+++ b/apps/auth-service/src/routes/tokens.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify';
-import { getSql } from '../db/client.js';
 import { getRedis } from '../redis/client.js';
-import { decodeTokenClaims } from '../lib/crypto.js';
+import { checkActiveGrantToken } from '../lib/active-grant-token.js';
+import { getSql } from '../db/client.js';
 
 export async function tokensRoutes(app: FastifyInstance): Promise<void> {
   // POST /v1/tokens/verify
@@ -11,61 +11,23 @@ export async function tokensRoutes(app: FastifyInstance): Promise<void> {
       return reply.status(400).send({ message: 'token is required', code: 'BAD_REQUEST', requestId: request.id });
     }
 
-    let claims: Record<string, unknown>;
-    try {
-      claims = decodeTokenClaims(token);
-    } catch {
+    const result = await checkActiveGrantToken(token, {
+      expectedDeveloperId: request.developer.id,
+    });
+
+    if (!result.ok) {
       return reply.send({ valid: false });
     }
 
-    const jti = claims['jti'] as string | undefined;
-    const gid = (claims['grnt'] ?? claims['jti']) as string | undefined;
-
-    if (!jti) return reply.send({ valid: false });
-
-    // Redis check first
-    const redis = getRedis();
-    const [tokenRevoked, grantRevoked] = await Promise.all([
-      redis.get(`revoked:tok:${jti}`),
-      gid ? redis.get(`revoked:grant:${gid}`) : Promise.resolve(null),
-    ]);
-
-    if (tokenRevoked || grantRevoked) {
-      return reply.send({ valid: false });
-    }
-
-    // DB check
-    const sql = getSql();
-    const rows = await sql`
-      SELECT gt.is_revoked, gt.expires_at, g.status AS grant_status
-      FROM grant_tokens gt
-      JOIN grants g ON g.id = gt.grant_id
-      WHERE gt.jti = ${jti}
-    `;
-
-    const row = rows[0];
-    if (!row) return reply.send({ valid: false });
-
-    if (row['is_revoked'] as boolean) {
-      // Write-back to Redis
-      const expiresAt = new Date(row['expires_at'] as string);
-      const ttl = Math.max(1, Math.floor((expiresAt.getTime() - Date.now()) / 1000));
-      await redis.set(`revoked:tok:${jti}`, '1', 'EX', ttl);
-      return reply.send({ valid: false });
-    }
-
-    if (row['grant_status'] !== 'active') return reply.send({ valid: false });
-
-    const expiresAt = new Date(row['expires_at'] as string);
-    if (expiresAt < new Date()) return reply.send({ valid: false });
+    const { claims } = result;
 
     return reply.send({
       valid: true,
-      grantId: gid,
-      scopes: claims['scp'],
-      principal: claims['sub'],
-      agent: claims['agt'],
-      expiresAt: new Date((claims['exp'] as number) * 1000).toISOString(),
+      grantId: claims.grnt,
+      scopes: claims.scp,
+      principal: claims.sub,
+      agent: claims.agt,
+      expiresAt: new Date(claims.exp * 1000).toISOString(),
     });
   });
 

--- a/apps/auth-service/src/routes/vault.ts
+++ b/apps/auth-service/src/routes/vault.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { getSql } from '../db/client.js';
 import { newVaultCredentialId } from '../lib/ids.js';
 import { encrypt, decrypt } from '../lib/vault-crypto.js';
-import { verifyGrantToken } from '../lib/crypto.js';
+import { checkActiveGrantToken } from '../lib/active-grant-token.js';
 
 interface StoreCredentialBody {
   principalId: string;
@@ -51,7 +51,7 @@ export async function vaultRoutes(app: FastifyInstance): Promise<void> {
     const encryptedAccess = encrypt(accessToken);
     const encryptedRefresh = refreshToken ? encrypt(refreshToken) : null;
 
-    await sql`
+    const rows = await sql`
       INSERT INTO vault_credentials (id, developer_id, principal_id, service, credential_type, access_token, refresh_token, token_expires_at, metadata)
       VALUES (
         ${id}, ${developerId}, ${principalId}, ${service},
@@ -65,14 +65,17 @@ export async function vaultRoutes(app: FastifyInstance): Promise<void> {
         token_expires_at = ${tokenExpiresAt ?? null},
         metadata = ${JSON.stringify(metadata ?? {})},
         updated_at = NOW()
+      RETURNING id, principal_id, service, credential_type, created_at
     `;
 
+    const row = rows[0]!;
+
     return reply.status(201).send({
-      id,
-      principalId,
-      service,
-      credentialType: credentialType ?? 'oauth2',
-      createdAt: new Date().toISOString(),
+      id: row['id'],
+      principalId: row['principal_id'],
+      service: row['service'],
+      credentialType: row['credential_type'],
+      createdAt: row['created_at'],
     });
   });
 
@@ -149,16 +152,15 @@ export async function vaultRoutes(app: FastifyInstance): Promise<void> {
       }
 
       const grantToken = auth.slice(7);
-      let claims: { sub: string; dev: string; scp: string[] };
-      try {
-        claims = await verifyGrantToken(grantToken);
-      } catch {
+      const result = await checkActiveGrantToken(grantToken);
+      if (!result.ok) {
         return reply.status(401).send({
           message: 'Invalid or expired grant token',
           code: 'UNAUTHORIZED',
           requestId: request.id,
         });
       }
+      const { claims } = result;
 
       const { service } = request.body;
       if (!service) {

--- a/apps/auth-service/tests/authorize.test.ts
+++ b/apps/auth-service/tests/authorize.test.ts
@@ -52,6 +52,29 @@ describe('POST /v1/authorize', () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it('returns 400 for invalid expiresIn format', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);                  // subscription lookup → free plan
+    sqlMock.mockResolvedValueOnce([{ count: '0' }]);    // grant count → 0
+    sqlMock.mockResolvedValueOnce([{ id: TEST_AGENT.id }]);
+    sqlMock.mockResolvedValueOnce([]);                  // policy lookup
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/authorize',
+      headers: authHeader(),
+      payload: {
+        agentId: TEST_AGENT.id,
+        principalId: 'user_123',
+        scopes: ['read'],
+        expiresIn: 'tomorrow-ish',
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ code: string }>().code).toBe('BAD_REQUEST');
+  });
+
   it('returns 402 when plan grant limit is reached', async () => {
     seedAuth();
     sqlMock.mockResolvedValueOnce([{ plan: 'free' }]);  // subscription → free plan

--- a/apps/auth-service/tests/consent.test.ts
+++ b/apps/auth-service/tests/consent.test.ts
@@ -39,6 +39,13 @@ describe('GET /consent', () => {
     const res = await app.inject({ method: 'GET', url: '/consent' });
     expect(res.statusCode).toBe(200);
   });
+
+  it('includes client-side escaping helpers for developer-controlled content', async () => {
+    const res = await app.inject({ method: 'GET', url: '/consent' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('function esc(value)');
+    expect(res.body).toContain("replace(/</g, '&lt;')");
+  });
 });
 
 describe('GET /v1/consent/:id', () => {

--- a/apps/auth-service/tests/delegate.test.ts
+++ b/apps/auth-service/tests/delegate.test.ts
@@ -7,6 +7,12 @@ import { decodeJwt } from 'jose';
 let app: FastifyInstance;
 let parentToken: string;
 
+const ACTIVE_PARENT_ROW = {
+  is_revoked: false,
+  expires_at: new Date(Date.now() + 3600_000).toISOString(),
+  grant_status: 'active',
+};
+
 const SUB_AGENT = {
   id: 'ag_SUBAGENT01',
   did: 'did:grantex:ag_SUBAGENT01',
@@ -36,6 +42,8 @@ describe('POST /v1/grants/delegate', () => {
     seedAuth();
     // Redis: parent token not revoked
     mockRedis.get.mockResolvedValue(null);
+    // Parent token DB check
+    sqlMock.mockResolvedValueOnce([ACTIVE_PARENT_ROW]);
     // Sub-agent lookup
     sqlMock.mockResolvedValueOnce([SUB_AGENT]);
     // INSERT grants
@@ -79,6 +87,7 @@ describe('POST /v1/grants/delegate', () => {
   it('returns 400 when requested scopes exceed parent scopes', async () => {
     seedAuth();
     mockRedis.get.mockResolvedValue(null);
+    sqlMock.mockResolvedValueOnce([ACTIVE_PARENT_ROW]);
 
     const res = await app.inject({
       method: 'POST',
@@ -120,6 +129,7 @@ describe('POST /v1/grants/delegate', () => {
   it('returns 404 when sub-agent is not found', async () => {
     seedAuth();
     mockRedis.get.mockResolvedValue(null);
+    sqlMock.mockResolvedValueOnce([ACTIVE_PARENT_ROW]);
     // Sub-agent lookup returns empty
     sqlMock.mockResolvedValueOnce([]);
 
@@ -160,12 +170,21 @@ describe('POST /v1/grants/delegate', () => {
   it('returns 400 when parentGrantToken is missing required claims (jti)', async () => {
     seedAuth();
 
-    // Create a JWT without jti (and without grnt, scp, exp)
+    // Create a JWT that passes signature/issuer validation but omits jti.
     const { SignJWT: JoseSignJWT } = await import('jose');
     const { getKeyPair } = await import('../src/lib/crypto.js');
+    const { config } = await import('../src/config.js');
     const { privateKey } = getKeyPair();
-    const invalidToken = await new JoseSignJWT({ sub: 'user_123', agt: 'did:test:agent' })
+    const invalidToken = await new JoseSignJWT({
+      agt: TEST_AGENT.did,
+      dev: TEST_DEVELOPER.id,
+      scp: ['read'],
+    })
       .setProtectedHeader({ alg: 'RS256' })
+      .setIssuer(config.jwtIssuer)
+      .setSubject('user_123')
+      .setIssuedAt()
+      .setExpirationTime(Math.floor(Date.now() / 1000) + 3600)
       .sign(privateKey);
 
     const res = await app.inject({
@@ -201,6 +220,7 @@ describe('POST /v1/grants/delegate', () => {
   it('includes verifiableCredential when credentialFormat is vc-jwt', async () => {
     seedAuth();
     mockRedis.get.mockResolvedValue(null);
+    sqlMock.mockResolvedValueOnce([ACTIVE_PARENT_ROW]);
     // Sub-agent lookup
     sqlMock.mockResolvedValueOnce([SUB_AGENT]);
     // INSERT grants
@@ -255,6 +275,7 @@ describe('POST /v1/grants/delegate', () => {
   it('includes verifiableCredential when credentialFormat is both', async () => {
     seedAuth();
     mockRedis.get.mockResolvedValue(null);
+    sqlMock.mockResolvedValueOnce([ACTIVE_PARENT_ROW]);
     // Sub-agent lookup
     sqlMock.mockResolvedValueOnce([SUB_AGENT]);
     // INSERT grants
@@ -309,6 +330,7 @@ describe('POST /v1/grants/delegate', () => {
   it('succeeds without verifiableCredential when VC issuance fails (best-effort)', async () => {
     seedAuth();
     mockRedis.get.mockResolvedValue(null);
+    sqlMock.mockResolvedValueOnce([ACTIVE_PARENT_ROW]);
     // Sub-agent lookup
     sqlMock.mockResolvedValueOnce([SUB_AGENT]);
     // INSERT grants

--- a/apps/auth-service/tests/grants.test.ts
+++ b/apps/auth-service/tests/grants.test.ts
@@ -254,8 +254,36 @@ describe('POST /v1/grants/verify', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    const body = res.json<{ active: boolean }>();
+    const body = res.json<{ active: boolean; claims?: { iat?: number; jti?: string } }>();
     expect(body.active).toBe(true);
+    expect(typeof body.claims?.iat).toBe('number');
+    expect(body.claims?.jti).toBe('tok_valid');
+  });
+
+  it('returns active:false when the token belongs to a different developer', async () => {
+    seedAuth();
+    const { signGrantToken } = await import('../src/lib/crypto.js');
+    const token = await signGrantToken({
+      sub: 'user_123',
+      agt: TEST_GRANT.agent_id,
+      dev: 'dev_OTHER',
+      scp: TEST_GRANT.scopes,
+      jti: 'tok_other_dev',
+      grnt: TEST_GRANT.id,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/grants/verify',
+      headers: authHeader(),
+      payload: { token },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ active: boolean; reason?: string }>();
+    expect(body.active).toBe(false);
+    expect(body.reason).toBe('wrong_developer');
   });
 
   it('returns active:false reason not_found when token not in DB', async () => {

--- a/apps/auth-service/tests/metrics.test.ts
+++ b/apps/auth-service/tests/metrics.test.ts
@@ -148,7 +148,7 @@ describe('metrics instrumentation', () => {
       grant_expires_at: new Date(Date.now() + 86400_000).toISOString(),
     }]);
     // mark old used
-    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([{ id: 'ref_1' }]);
     // insert new token
     sqlMock.mockResolvedValueOnce([]);
     // insert new refresh

--- a/apps/auth-service/tests/principal.test.ts
+++ b/apps/auth-service/tests/principal.test.ts
@@ -44,7 +44,8 @@ describe('POST /v1/principal-sessions', () => {
     expect(res.statusCode).toBe(201);
     const body = res.json<{ sessionToken: string; dashboardUrl: string; expiresAt: string }>();
     expect(body.sessionToken).toBeTruthy();
-    expect(body.dashboardUrl).toContain('/permissions?session=');
+    expect(body.dashboardUrl).toContain('/permissions#session=');
+    expect(body.dashboardUrl).not.toContain('/permissions?session=');
     expect(body.expiresAt).toBeTruthy();
   });
 

--- a/apps/auth-service/tests/security-escalation.test.ts
+++ b/apps/auth-service/tests/security-escalation.test.ts
@@ -22,6 +22,12 @@ import { signGrantToken } from '../src/lib/crypto.js';
 
 let app: FastifyInstance;
 
+const ACTIVE_PARENT_ROW = {
+  is_revoked: false,
+  expires_at: new Date(Date.now() + 3600_000).toISOString(),
+  grant_status: 'active',
+};
+
 beforeAll(async () => {
   app = await buildTestApp();
 });
@@ -129,6 +135,7 @@ describe('Authorization escalation prevention', () => {
 
     seedAuth();
     mockRedis.get.mockResolvedValue(null); // not revoked
+    sqlMock.mockResolvedValueOnce([ACTIVE_PARENT_ROW]);
 
     const res = await app.inject({
       method: 'POST',

--- a/apps/auth-service/tests/security-multi-tenancy.test.ts
+++ b/apps/auth-service/tests/security-multi-tenancy.test.ts
@@ -177,12 +177,6 @@ describe('Multi-tenancy isolation', () => {
       exp: Math.floor(Date.now() / 1000) + 3600,
     });
 
-    // Redis check: not revoked
-    mockRedis.get.mockResolvedValue(null);
-    // DB check: the join includes `g.developer_id = ${request.developer.id}`,
-    // so it returns empty because the token belongs to developer B
-    sqlMock.mockResolvedValueOnce([]);
-
     const res = await app.inject({
       method: 'POST',
       url: '/v1/grants/verify',
@@ -192,7 +186,7 @@ describe('Multi-tenancy isolation', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json().active).toBe(false);
-    expect(res.json().reason).toBe('not_found');
+    expect(res.json().reason).toBe('wrong_developer');
   });
 
   // ── Vault credentials ──────────────────────────────────────────────────

--- a/apps/auth-service/tests/security.test.ts
+++ b/apps/auth-service/tests/security.test.ts
@@ -12,6 +12,12 @@ import { gzipSync } from 'node:zlib';
 
 let app: FastifyInstance;
 
+const ACTIVE_PARENT_ROW = {
+  is_revoked: false,
+  expires_at: new Date(Date.now() + 3600_000).toISOString(),
+  grant_status: 'active',
+};
+
 beforeAll(async () => {
   app = await buildTestApp();
 });
@@ -456,6 +462,7 @@ describe('Token Security', () => {
 
     seedAuth();
     mockRedis.get.mockResolvedValue(null);
+    sqlMock.mockResolvedValueOnce([ACTIVE_PARENT_ROW]);
 
     const res = await app.inject({
       method: 'POST',

--- a/apps/auth-service/tests/token-refresh.test.ts
+++ b/apps/auth-service/tests/token-refresh.test.ts
@@ -29,7 +29,7 @@ describe('POST /v1/token/refresh', () => {
     // Refresh token lookup (JOIN grants + agents)
     sqlMock.mockResolvedValueOnce([validRefreshRow]);
     // UPDATE refresh_tokens SET is_used = true
-    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([{ id: 'ref_EXISTING' }]);
     // INSERT grant_tokens
     sqlMock.mockResolvedValueOnce([]);
     // INSERT refresh_tokens (new)
@@ -64,6 +64,22 @@ describe('POST /v1/token/refresh', () => {
     expect(claims['dev']).toBe(TEST_DEVELOPER.id);
     expect(claims['scp']).toEqual(['read', 'write']);
     expect(claims['grnt']).toBe('grnt_EXISTING');
+  });
+
+  it('returns 400 when the refresh token was consumed concurrently', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([validRefreshRow]);
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token/refresh',
+      headers: authHeader(),
+      payload: { refreshToken: 'ref_EXISTING', agentId: TEST_AGENT.id },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toBe('Refresh token already used');
   });
 
   it('returns 400 for already-used refresh token', async () => {

--- a/apps/auth-service/tests/tokens.test.ts
+++ b/apps/auth-service/tests/tokens.test.ts
@@ -107,6 +107,30 @@ describe('POST /v1/tokens/verify', () => {
     expect(body.valid).toBe(false);
   });
 
+  it('returns valid:false when the token belongs to a different developer', async () => {
+    seedAuth();
+    const { signGrantToken } = await import('../src/lib/crypto.js');
+    const otherDevToken = await signGrantToken({
+      sub: 'user_123',
+      agt: TEST_GRANT.agent_id,
+      dev: 'dev_OTHER',
+      scp: TEST_GRANT.scopes,
+      jti: 'tok_OTHER_DEV',
+      grnt: TEST_GRANT.id,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/tokens/verify',
+      headers: authHeader(),
+      payload: { token: otherDevToken },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ valid: boolean }>().valid).toBe(false);
+  });
+
   it('returns 400 when token field is missing', async () => {
     seedAuth();
     const res = await app.inject({

--- a/apps/auth-service/tests/vault.test.ts
+++ b/apps/auth-service/tests/vault.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, vi } from 'vitest';
-import { buildTestApp, authHeader, seedAuth, sqlMock } from './helpers.js';
+import { buildTestApp, authHeader, seedAuth, sqlMock, mockRedis } from './helpers.js';
 import type { FastifyInstance } from 'fastify';
 
 // Mock vault-crypto module
@@ -18,7 +18,13 @@ describe('POST /v1/vault/credentials', () => {
   it('stores a credential and returns metadata', async () => {
     seedAuth();
     // INSERT ... ON CONFLICT
-    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([{
+      id: 'vault_1',
+      principal_id: 'user_123',
+      service: 'google',
+      credential_type: 'oauth2',
+      created_at: '2026-03-01T00:00:00Z',
+    }]);
 
     const res = await app.inject({
       method: 'POST',
@@ -54,6 +60,31 @@ describe('POST /v1/vault/credentials', () => {
 
     expect(res.statusCode).toBe(400);
     expect(res.json().code).toBe('BAD_REQUEST');
+  });
+
+  it('returns the persisted credential id on upsert', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{
+      id: 'vault_existing',
+      principal_id: 'user_123',
+      service: 'google',
+      credential_type: 'oauth2',
+      created_at: '2026-03-01T00:00:00Z',
+    }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/vault/credentials',
+      headers: authHeader(),
+      payload: {
+        principalId: 'user_123',
+        service: 'google',
+        accessToken: 'ya29.updated',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json().id).toBe('vault_existing');
   });
 });
 
@@ -189,6 +220,13 @@ describe('POST /v1/vault/credentials/exchange', () => {
 
     sqlMock.mockResolvedValueOnce([
       {
+        is_revoked: false,
+        expires_at: new Date(Date.now() + 3600_000).toISOString(),
+        grant_status: 'active',
+      },
+    ]);
+    sqlMock.mockResolvedValueOnce([
+      {
         id: 'vault_1',
         access_token: 'encrypted:ya29.real_token',
         refresh_token: null,
@@ -233,6 +271,14 @@ describe('POST /v1/vault/credentials/exchange', () => {
       exp: Math.floor(Date.now() / 1000) + 3600,
     });
 
+    sqlMock.mockResolvedValueOnce([
+      {
+        is_revoked: false,
+        expires_at: new Date(Date.now() + 3600_000).toISOString(),
+        grant_status: 'active',
+      },
+    ]);
+
     const res = await app.inject({
       method: 'POST',
       url: '/v1/vault/credentials/exchange',
@@ -255,6 +301,13 @@ describe('POST /v1/vault/credentials/exchange', () => {
       exp: Math.floor(Date.now() / 1000) + 3600,
     });
 
+    sqlMock.mockResolvedValueOnce([
+      {
+        is_revoked: false,
+        expires_at: new Date(Date.now() + 3600_000).toISOString(),
+        grant_status: 'active',
+      },
+    ]);
     sqlMock.mockResolvedValueOnce([]);
 
     const res = await app.inject({
@@ -272,6 +325,31 @@ describe('POST /v1/vault/credentials/exchange', () => {
       method: 'POST',
       url: '/v1/vault/credentials/exchange',
       headers: { authorization: 'Bearer invalid.jwt.token' },
+      payload: { service: 'google' },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 401 when grant token is revoked', async () => {
+    const { signGrantToken } = await import('../src/lib/crypto.js');
+    const token = await signGrantToken({
+      sub: 'user_123',
+      agt: 'did:grantex:ag_01',
+      dev: 'dev_TEST',
+      scp: ['google:read'],
+      jti: 'tok_VAULT04',
+      grnt: 'grnt_VAULT04',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    mockRedis.get.mockResolvedValueOnce('1');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/vault/credentials/exchange',
+      headers: { authorization: `Bearer ${token}` },
       payload: { service: 'google' },
     });
 

--- a/packages/conformance/src/suites/principal-sessions.ts
+++ b/packages/conformance/src/suites/principal-sessions.ts
@@ -36,9 +36,9 @@ export const principalSessionsSuite: SuiteDefinition = {
           expectString(res.body.dashboardUrl, 'dashboardUrl');
           expectString(res.body.expiresAt, 'expiresAt');
 
-          if (!res.body.dashboardUrl.includes('/permissions?session=')) {
+          if (!res.body.dashboardUrl.includes('/permissions#session=')) {
             throw new Error(
-              `Expected dashboardUrl to contain /permissions?session=, got: ${res.body.dashboardUrl}`,
+              `Expected dashboardUrl to contain /permissions#session=, got: ${res.body.dashboardUrl}`,
             );
           }
         },

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -233,6 +233,8 @@ console.log(verified.principalId);
 console.log(verified.scopes);
 ```
 
+Throws `GrantexTokenError` when the token is inactive, revoked, expired, or otherwise unusable.
+
 ---
 
 ### Tokens

--- a/packages/sdk-ts/src/resources/grants.ts
+++ b/packages/sdk-ts/src/resources/grants.ts
@@ -1,11 +1,13 @@
 import type { HttpClient } from '../http.js';
-import { mapOnlineVerifyToVerifiedGrant } from '../verify.js';
+import { claimsToVerifiedGrant } from '../verify.js';
+import { GrantexTokenError } from '../errors.js';
 import type {
   Grant,
   ListGrantsParams,
   ListGrantsResponse,
   VerifiedGrant,
   DelegateParams,
+  GrantTokenPayload,
 } from '../types.js';
 
 export class GrantsClient {
@@ -38,17 +40,22 @@ export class GrantsClient {
 
   /**
    * Verify a grant token via the API (online verification).
-   * Returns a clean VerifiedGrant shape by decoding the raw token returned
-   * from the server to fill fields the summary response may omit.
    */
   async verify(token: string): Promise<VerifiedGrant> {
-    const response = await this.#http.post<{ token: string } & Partial<VerifiedGrant>>(
+    const response = await this.#http.post<{
+      active?: boolean;
+      reason?: string;
+      claims?: GrantTokenPayload;
+    }>(
       '/v1/grants/verify',
       { token },
     );
-    // The API may echo back the raw token; decode it to guarantee all fields.
-    const rawToken: string = response.token ?? token;
-    return mapOnlineVerifyToVerifiedGrant(rawToken);
+    if (!response.active || !response.claims) {
+      throw new GrantexTokenError(
+        `Grant token is not active${response.reason ? `: ${response.reason}` : ''}`,
+      );
+    }
+    return claimsToVerifiedGrant(response.claims);
   }
 }
 

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -285,6 +285,8 @@ export interface VerifyGrantTokenOptions {
   jwksUri: string;
   requiredScopes?: string[];
   audience?: string;
+  /** Expected issuer URL. Defaults to the issuer derived from issuerDid or jwksUri. */
+  issuer?: string;
   /** Resolve a did:web DID to derive the JWKS URL instead of using jwksUri directly */
   issuerDid?: string;
   /** @internal override clock for testing */

--- a/packages/sdk-ts/src/verify.ts
+++ b/packages/sdk-ts/src/verify.ts
@@ -13,9 +13,17 @@ export async function verifyGrantToken(
   options: VerifyGrantTokenOptions,
 ): Promise<VerifiedGrant> {
   let jwksUri = options.jwksUri;
+  let expectedIssuer = options.issuer;
   if (options.issuerDid?.startsWith('did:web:')) {
     const domain = options.issuerDid.replace('did:web:', '').replaceAll(':', '/');
     jwksUri = `https://${domain}/.well-known/jwks.json`;
+    expectedIssuer ??= `https://${domain}`;
+  }
+  if (expectedIssuer === undefined) {
+    const jwksUrl = new URL(jwksUri);
+    expectedIssuer = jwksUrl.pathname.endsWith('/.well-known/jwks.json')
+      ? `${jwksUrl.origin}${jwksUrl.pathname.slice(0, -'/.well-known/jwks.json'.length)}`
+      : `${jwksUrl.origin}${jwksUrl.pathname.replace(/\/$/, '')}`;
   }
   const jwks = createRemoteJWKSet(new URL(jwksUri));
 
@@ -23,6 +31,7 @@ export async function verifyGrantToken(
   try {
     const jwtOptions = {
       algorithms: ['RS256'] as string[],
+      issuer: expectedIssuer,
       ...(options.clockTolerance !== undefined
         ? { clockTolerance: options.clockTolerance }
         : {}),
@@ -66,10 +75,10 @@ export function mapOnlineVerifyToVerifiedGrant(token: string): VerifiedGrant {
     const message = err instanceof Error ? err.message : String(err);
     throw new GrantexTokenError(`Failed to decode grant token: ${message}`);
   }
-  return payloadToVerifiedGrant(payload);
+  return claimsToVerifiedGrant(payload);
 }
 
-function payloadToVerifiedGrant(payload: GrantTokenPayload): VerifiedGrant {
+export function claimsToVerifiedGrant(payload: GrantTokenPayload): VerifiedGrant {
   if (
     typeof payload.jti !== 'string' ||
     typeof payload.sub !== 'string' ||
@@ -94,7 +103,11 @@ function payloadToVerifiedGrant(payload: GrantTokenPayload): VerifiedGrant {
     issuedAt: payload.iat,
     expiresAt: payload.exp,
     ...(payload.parentAgt !== undefined ? { parentAgentDid: payload.parentAgt } : {}),
-    ...(payload.parentGrnt !== undefined ? { parentGrantId: payload.parentGrnt } : {}),
-    ...(payload.delegationDepth !== undefined ? { delegationDepth: payload.delegationDepth } : {}),
+      ...(payload.parentGrnt !== undefined ? { parentGrantId: payload.parentGrnt } : {}),
+      ...(payload.delegationDepth !== undefined ? { delegationDepth: payload.delegationDepth } : {}),
   };
+}
+
+function payloadToVerifiedGrant(payload: GrantTokenPayload): VerifiedGrant {
+  return claimsToVerifiedGrant(payload);
 }

--- a/packages/sdk-ts/tests/grants.test.ts
+++ b/packages/sdk-ts/tests/grants.test.ts
@@ -1,14 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Grantex } from '../src/client.js';
-
-// Mock jose so verify.ts doesn't try to fetch JWKS
-vi.mock('jose', () => ({
-  jwtVerify: vi.fn(),
-  decodeJwt: vi.fn(),
-  createRemoteJWKSet: vi.fn(() => 'mock-jwks'),
-}));
-
-import * as jose from 'jose';
+import { GrantexTokenError } from '../src/errors.js';
 
 const MOCK_GRANT = {
   id: 'grant_01',
@@ -94,10 +86,12 @@ describe('GrantsClient', () => {
     expect(init.method).toBe('DELETE');
   });
 
-  it('verify() returns VerifiedGrant using decoded token', async () => {
-    const serverResponse = { token: 'fake.jwt.token' };
+  it('verify() returns VerifiedGrant from verified server claims', async () => {
+    const serverResponse = {
+      active: true,
+      claims: MOCK_PAYLOAD,
+    };
     vi.stubGlobal('fetch', makeFetch(200, serverResponse));
-    vi.mocked(jose.decodeJwt).mockReturnValue(MOCK_PAYLOAD as never);
 
     const grantex = new Grantex({ apiKey: 'test_key' });
     const result = await grantex.grants.verify('fake.jwt.token');
@@ -107,18 +101,17 @@ describe('GrantsClient', () => {
     expect(result.grantId).toBe('grant_01');
   });
 
-  it('verify() uses fallback token when API response has no token property', async () => {
+  it('verify() throws when server reports the token is inactive', async () => {
     // Response without a `token` field — the code falls back to the original token
-    const serverResponse = { valid: true, grantId: 'grant_01' };
+    const serverResponse = { active: false, reason: 'revoked' };
     vi.stubGlobal('fetch', makeFetch(200, serverResponse));
-    vi.mocked(jose.decodeJwt).mockReturnValue(MOCK_PAYLOAD as never);
-
     const grantex = new Grantex({ apiKey: 'test_key' });
-    const result = await grantex.grants.verify('original.jwt.token');
-
-    // mapOnlineVerifyToVerifiedGrant should be called with the fallback (original) token
-    expect(jose.decodeJwt).toHaveBeenCalledWith('original.jwt.token');
-    expect(result.principalId).toBe('user_abc');
+    await expect(grantex.grants.verify('original.jwt.token')).rejects.toBeInstanceOf(
+      GrantexTokenError,
+    );
+    await expect(grantex.grants.verify('original.jwt.token')).rejects.toThrow(
+      'Grant token is not active: revoked',
+    );
   });
 
   it('list() filters out undefined/null query param values', async () => {

--- a/packages/sdk-ts/tests/principal-sessions.test.ts
+++ b/packages/sdk-ts/tests/principal-sessions.test.ts
@@ -19,7 +19,7 @@ describe('PrincipalSessionsClient', () => {
   it('create() POSTs to /v1/principal-sessions', async () => {
     const mockResponse = {
       sessionToken: 'eyJ...',
-      dashboardUrl: 'https://api.grantex.dev/permissions?session=eyJ...',
+      dashboardUrl: 'https://api.grantex.dev/permissions#session=eyJ...',
       expiresAt: '2026-03-01T00:00:00.000Z',
     };
     const mockFetch = makeFetch(201, mockResponse);
@@ -32,7 +32,7 @@ describe('PrincipalSessionsClient', () => {
     });
 
     expect(result.sessionToken).toBe('eyJ...');
-    expect(result.dashboardUrl).toContain('/permissions?session=');
+    expect(result.dashboardUrl).toContain('/permissions#session=');
     expect(result.expiresAt).toBeTruthy();
 
     const [url, init] = mockFetch.mock.calls[0]!;

--- a/packages/sdk-ts/tests/verify.test.ts
+++ b/packages/sdk-ts/tests/verify.test.ts
@@ -55,6 +55,23 @@ describe('verifyGrantToken', () => {
     expect(result.expiresAt).toBe(1700086400);
   });
 
+  it('passes a derived issuer to jwtVerify when using jwksUri', async () => {
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: VALID_PAYLOAD,
+      protectedHeader: { alg: 'RS256' },
+    } as never);
+
+    await verifyGrantToken('fake.token.here', {
+      jwksUri: 'https://grantex.dev/.well-known/jwks.json',
+    });
+
+    expect(jose.jwtVerify).toHaveBeenCalledWith(
+      'fake.token.here',
+      'mock-jwks',
+      expect.objectContaining({ issuer: 'https://grantex.dev' }),
+    );
+  });
+
   it('throws GrantexTokenError when jose throws', async () => {
     vi.mocked(jose.jwtVerify).mockRejectedValue(
       new Error('JWTExpired: token has expired'),
@@ -172,6 +189,11 @@ describe('verifyGrantToken', () => {
     expect(jose.createRemoteJWKSet).toHaveBeenCalledWith(
       new URL('https://grantex.dev/.well-known/jwks.json'),
     );
+    expect(jose.jwtVerify).toHaveBeenCalledWith(
+      'fake.token.here',
+      'mock-jwks',
+      expect.objectContaining({ issuer: 'https://grantex.dev' }),
+    );
     expect(result.grantId).toBe('grant_01');
   });
 
@@ -189,6 +211,29 @@ describe('verifyGrantToken', () => {
     // Colons after the method-specific-id prefix become path separators
     expect(jose.createRemoteJWKSet).toHaveBeenCalledWith(
       new URL('https://example.com/api/v1/.well-known/jwks.json'),
+    );
+    expect(jose.jwtVerify).toHaveBeenCalledWith(
+      'fake.token.here',
+      'mock-jwks',
+      expect.objectContaining({ issuer: 'https://example.com/api/v1' }),
+    );
+  });
+
+  it('passes an explicit issuer override to jwtVerify', async () => {
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: VALID_PAYLOAD,
+      protectedHeader: { alg: 'RS256' },
+    } as never);
+
+    await verifyGrantToken('fake.token.here', {
+      jwksUri: 'https://keys.example.com/grantex/jwks.json',
+      issuer: 'https://issuer.example.com',
+    });
+
+    expect(jose.jwtVerify).toHaveBeenCalledWith(
+      'fake.token.here',
+      'mock-jwks',
+      expect.objectContaining({ issuer: 'https://issuer.example.com' }),
     );
   });
 });

--- a/skills/expert-code-review/SKILL.md
+++ b/skills/expert-code-review/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: expert-code-review
+description: Expert review guidelines for auditing repositories, pull requests, and system designs. Use when performing code review to find functional gaps, security risks, correctness bugs, maintainability problems, missing tests, and architectural weaknesses without making direct code changes.
+---
+
+# Expert Code Review
+
+Behavioral guidelines for high-signal engineering reviews. The goal is to identify the most important problems first, prove them with concrete evidence, and distinguish real defects from stylistic preference.
+
+**Tradeoff:** These guidelines bias toward rigor over speed. For trivial diffs, use judgment.
+
+## 1. Review for Behavior First
+
+**Start from what can break for users, operators, or integrators.**
+
+- Check correctness before style.
+- Look for security, data loss, privilege escalation, race conditions, and broken API contracts first.
+- Prefer end-to-end reasoning over isolated line comments.
+- Ask: "What bad outcome becomes possible because of this code?"
+
+## 2. Prove Every Claim
+
+**Do not speculate silently. Build findings from evidence.**
+
+- Read the code path far enough to understand inputs, state transitions, and outputs.
+- Cite exact files and lines for each finding.
+- Explain the failure mode, not just the suspicious code.
+- If a concern depends on an assumption, state that assumption explicitly.
+
+## 3. Separate Severity from Preference
+
+**Not every imperfection is a bug.**
+
+- Treat user-visible regressions, security flaws, and integrity issues as high severity.
+- Treat maintainability issues as findings only when they create real delivery or reliability risk.
+- Do not file style-only comments as defects.
+- If something is merely a tradeoff, label it as such.
+
+## 4. Hunt for Functional Gaps
+
+**Review what the system claims to support against what the code actually implements.**
+
+- Compare README, API surface, routes, SDK methods, and tests.
+- Look for missing validation, partial implementations, unsupported edge cases, and inconsistent behavior across SDKs or adapters.
+- Check whether auth, pagination, filtering, retry, revocation, idempotency, and observability are handled consistently.
+- Treat "documented but not enforced" as a real gap.
+
+## 5. Audit Code Quality Through Risk
+
+**Code quality matters when it increases the chance of defects.**
+
+- Flag duplication when it creates drift risk.
+- Flag weak typing when it hides unsafe behavior.
+- Flag oversized files or mixed responsibilities when they block safe change.
+- Flag tests that only prove happy paths while critical failure modes remain uncovered.
+
+## 6. Be Surgical in Output
+
+**Deliver the shortest review that still changes engineering decisions.**
+
+- Lead with findings, ordered by severity.
+- For each finding, include: impact, evidence, and why it matters.
+- Keep summaries brief.
+- If no defects are found, say so explicitly and note residual risk areas or test gaps.
+
+## Review Checklist
+
+Use this checklist to guide the pass:
+
+1. Public contract: Does implementation match documented behavior?
+2. Auth and trust: Are identity, authorization, and secret boundaries enforced correctly?
+3. Data integrity: Can bad state be created, persisted, or returned?
+4. Failure handling: Do retries, timeouts, and partial failures behave safely?
+5. Concurrency: Can workers, background jobs, or duplicate requests race?
+6. SDK parity: Do TypeScript, Python, Go, CLI, and adapters behave consistently where expected?
+7. Test coverage: Are high-risk branches and regressions actually exercised?
+
+## Output Shape
+
+For substantial reviews, use:
+
+1. Findings
+2. Open questions or assumptions
+3. Residual risks or testing gaps
+
+Do not propose code changes unless asked. Focus on surfacing the most important gaps with defensible reasoning.

--- a/tests/e2e/principal-sessions.test.ts
+++ b/tests/e2e/principal-sessions.test.ts
@@ -115,5 +115,7 @@ describe('E2E: Principal Session Creation', () => {
     // Dashboard URL should be a valid URL
     const url = new URL(session.dashboardUrl);
     expect(url.protocol).toMatch(/^https?:$/);
+    expect(url.hash).toMatch(/^#session=/);
+    expect(url.search).toBe('');
   });
 });


### PR DESCRIPTION
## What changed

This PR remediates the highest-risk review findings across `auth-service` and `@grantex/sdk` without changing product scope.

- added a shared active grant-token verifier that validates signature, developer ownership, Redis revocation state, and persisted DB state before online verification or vault exchange succeeds
- hardened `/v1/tokens/verify`, `/v1/grants/verify`, `/v1/grants/delegate`, and `/v1/vault/credentials/exchange` to use that verifier instead of trusting unverified decoded claims
- fixed `@grantex/sdk` online grant verification to consume server-verified claims instead of decoding the caller-supplied JWT locally
- made auth-code exchange and refresh-token rotation transaction-safe with row locking and atomic single-use enforcement
- escaped consent-page developer-controlled content before injecting it into HTML
- moved principal-session tokens from the permissions page query string to the URL fragment
- made `/v1/authorize` reject invalid `expiresIn` values instead of silently defaulting
- fixed vault credential upserts to return the persisted row id
- added the requested repo-local expert review skill file under `skills/expert-code-review/SKILL.md`

## Why it changed

The review surfaced several places where revoked or forged tokens could still influence verification flows, where single-use credentials could be raced, and where browser-facing pages leaked or rendered sensitive values unsafely.

## Root cause

The main issues came from split verification logic:

- some routes used signature verification, others trusted `decodeJwt` output first
- online verification and vault exchange did not share the same active-token checks
- single-use semantics were enforced in application code but not under transaction locks
- UI routes interpolated developer-controlled strings directly into `innerHTML`

## Impact

- revoked or cross-developer grant tokens are rejected consistently across online verification, delegation, and vault exchange
- SDK `grants.verify()` now matches the documented real-time verification behavior
- principal-session links no longer place bearer tokens in query strings
- invalid authorization TTLs now fail fast instead of being silently normalized
- refresh-token rotation and auth-code exchange reject contested single-use flows predictably

## Validation

- `apps/auth-service`: `npm test -- tests/authorize.test.ts tests/consent.test.ts tests/delegate.test.ts tests/grants.test.ts tests/principal.test.ts tests/token.test.ts tests/token-refresh.test.ts tests/tokens.test.ts tests/vault.test.ts`
- `packages/sdk-ts`: `npm test -- tests/grants.test.ts tests/principal-sessions.test.ts tests/verify.test.ts`
- `apps/auth-service`: `npm run typecheck`
- `packages/sdk-ts`: `npm run typecheck`
- `packages/conformance`: `npm run typecheck`

## Follow-up not included here

These review items are still open and should land in follow-up PRs:

- event-stream connection counting / TTL drift
- broader issuer-validation ergonomics outside the standard JWKS layout path
- any deeper E2E coverage for the transaction race cases under concurrent load
