### PR TITLE
ci: ignore ZAP rule 90005 (Sec-Fetch-Dest missing)

### DIFF
--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -3,3 +3,4 @@
 10049	IGNORE	(Storable and Cacheable Content)
 10021	IGNORE	(X-Content-Type-Options Header Missing)
 40025	IGNORE	(Proxy Disclosure - Cloud Run infrastructure)
+90005	IGNORE	(Sec-Fetch-Dest Header Missing - API service, not browser-fronted)


### PR DESCRIPTION
## Summary
- The baseline scan flags ZAP rule 90005 on every request because ZAP itself does not send Fetch Metadata headers.
- The rule advises servers to enforce Fetch Metadata as a CSRF mitigation — which does not apply to this API. Grantex is consumed by SDKs and curl over Bearer auth (not browsers), so enforcing `Sec-Fetch-*` would break legitimate clients without adding security.
- Ignoring the rule takes baseline results to 0 WARN / 0 FAIL against a running auth-service.

## Test plan
- [ ] Security Scan workflow passes with no WARN-NEW entries