### PR TITLE
fix(sdk-py): grants.verify server-claims parity + post-ship docs + ship-verification skill

### DIFF
--- a/docs/sdks/python/errors.mdx
+++ b/docs/sdks/python/errors.mdx
@@ -90,7 +90,7 @@ with Grantex(api_key="gx_invalid_key") as client:
 
 ## GrantexTokenError
 
-Raised when JWT verification or decoding fails. This occurs when using `verify_grant_token()` for offline verification or when `grants.verify()` cannot decode the returned token.
+Raised when JWT verification fails. This occurs when using `verify_grant_token()` for offline verification or when `grants.verify()` receives an `active: false` response (revoked, expired, or unknown token) from the Grantex API.
 
 ```python
 from grantex import verify_grant_token, VerifyGrantTokenOptions, GrantexTokenError

--- a/docs/sdks/python/grants.mdx
+++ b/docs/sdks/python/grants.mdx
@@ -110,7 +110,7 @@ All parameters are keyword-only.
 
 ## Verify
 
-Verify a grant token online and decode its claims. This calls the Grantex API for server-side validation, then decodes the token locally:
+Verify a grant token online against the Grantex API. The SDK uses the server-verified claims returned by `POST /v1/grants/verify` — it does not decode the caller-supplied token locally, so forged or tampered tokens are always rejected by the server before any claim is surfaced. Raises `GrantexTokenError` if the server reports the token as inactive (revoked, expired, or unknown):
 
 ```python
 from grantex import Grantex

--- a/docs/sdks/python/principal-sessions.mdx
+++ b/docs/sdks/python/principal-sessions.mdx
@@ -60,7 +60,7 @@ print(session.expires_at)      # '2026-03-01T14:00:00.000Z'
 </ResponseField>
 
 <ResponseField name="dashboard_url" type="str">
-  Full URL the user can open in their browser to view and revoke permissions.
+  Full URL the user can open in their browser to view and revoke permissions. The session token is carried in the URL **fragment** (`#session=...`), not the query string, so it is never transmitted to the server or captured in `Referer` headers or access logs.
 </ResponseField>
 
 <ResponseField name="expires_at" type="str">

--- a/docs/sdks/typescript/grants.mdx
+++ b/docs/sdks/typescript/grants.mdx
@@ -222,7 +222,7 @@ console.log(delegated.expiresAt);  // '2026-02-28T13:00:00Z'
 
 ## grants.verify()
 
-Verify a grant token online and return a `VerifiedGrant` with full claim details. The SDK decodes the token returned by the API to populate all fields.
+Verify a grant token online and return a `VerifiedGrant` with full claim details. The SDK uses the server-verified claims returned by `POST /v1/grants/verify` — it does not decode the caller-supplied token locally, so forged or tampered tokens are always rejected by the server before any claim is surfaced.
 
 ```typescript
 const verified = await grantex.grants.verify(grantToken);

--- a/docs/sdks/typescript/principal-sessions.mdx
+++ b/docs/sdks/typescript/principal-sessions.mdx
@@ -52,7 +52,7 @@ console.log(session.expiresAt);     // '2026-03-01T14:00:00.000Z'
 </ResponseField>
 
 <ResponseField name="dashboardUrl" type="string">
-  Full URL the user can open in their browser to view and revoke permissions.
+  Full URL the user can open in their browser to view and revoke permissions. The session token is carried in the URL **fragment** (`#session=...`), not the query string, so it is never transmitted to the server or captured in `Referer` headers or access logs.
 </ResponseField>
 
 <ResponseField name="expiresAt" type="string">

--- a/packages/sdk-py/src/grantex/_verify.py
+++ b/packages/sdk-py/src/grantex/_verify.py
@@ -75,25 +75,6 @@ def verify_grant_token(
     return _payload_to_verified_grant(payload)
 
 
-def _map_online_verify_to_verified_grant(token: str) -> VerifiedGrant:
-    """Decode a grant token without re-verifying the signature.
-
-    Used by GrantsClient.verify() after the server has already validated.
-    """
-    try:
-        payload_data: dict[str, Any] = jwt.decode(
-            token,
-            options={"verify_signature": False, "verify_aud": False},
-            algorithms=["RS256"],
-        )
-    except jwt.PyJWTError as exc:
-        raise GrantexTokenError(
-            f"Failed to decode grant token: {exc}"
-        ) from exc
-
-    return _payload_to_verified_grant(_build_payload(payload_data))
-
-
 def _fetch_signing_key(jwks_uri: str, kid: str | None) -> Any:
     """Fetch the JWKS and return the matching RSA public key."""
     try:

--- a/packages/sdk-py/src/grantex/resources/_grants.py
+++ b/packages/sdk-py/src/grantex/resources/_grants.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from typing import Any, List
 from urllib.parse import urlencode
 
+from .._errors import GrantexTokenError
 from .._http import HttpClient
 from .._types import Grant, ListGrantsParams, ListGrantsResponse, VerifiedGrant, DelegateParams
-from .._verify import _map_online_verify_to_verified_grant
+from .._verify import _build_payload, _payload_to_verified_grant
 
 
 class GrantsClient:
@@ -43,8 +44,12 @@ class GrantsClient:
 
     def verify(self, token: str) -> VerifiedGrant:
         response = self._http.post("/v1/grants/verify", {"token": token})
-        raw_token: str = response.get("token", token) if isinstance(response, dict) else token
-        return _map_online_verify_to_verified_grant(raw_token)
+        if not isinstance(response, dict) or not response.get("active") or not response.get("claims"):
+            reason = response.get("reason") if isinstance(response, dict) else None
+            suffix = f": {reason}" if reason else ""
+            raise GrantexTokenError(f"Grant token is not active{suffix}")
+        claims: dict[str, Any] = response["claims"]
+        return _payload_to_verified_grant(_build_payload(claims))
 
 
 def _build_query(params: dict[str, object]) -> str:

--- a/packages/sdk-py/tests/test_grants.py
+++ b/packages/sdk-py/tests/test_grants.py
@@ -76,20 +76,37 @@ def test_revoke_delete(client: Grantex) -> None:
 
 
 @respx.mock
-def test_verify_returns_verified_grant(
-    client: Grantex, mocker: pytest.FixtureRequest
-) -> None:
-    fake_token = _make_fake_jwt(MOCK_JWT_PAYLOAD)
+def test_verify_returns_verified_grant(client: Grantex) -> None:
+    server_claims = {
+        "iss": "https://api.grantex.dev",
+        "sub": "user_abc123",
+        "agt": "did:grantex:ag_01HXYZ123abc",
+        "dev": "org_test",
+        "scp": ["calendar:read"],
+        "iat": 1709000000,
+        "exp": 9999999999,
+        "jti": "tok_01HXYZ987xyz",
+        "grnt": "grant_01HXYZ",
+    }
     respx.post("https://api.grantex.dev/v1/grants/verify").mock(
-        return_value=httpx.Response(200, json={"token": fake_token})
+        return_value=httpx.Response(200, json={"active": True, "claims": server_claims})
     )
-    mocker.patch(  # type: ignore[attr-defined]
-        "grantex._verify._map_online_verify_to_verified_grant",
-        return_value=_build_verified_grant(),
-    )
-    grant = client.grants.verify(fake_token)
+    grant = client.grants.verify("any.caller.supplied.token")
     assert grant.token_id == "tok_01HXYZ987xyz"
     assert grant.grant_id == "grant_01HXYZ"
+    assert grant.principal_id == "user_abc123"
+    assert grant.scopes == ("calendar:read",)
+
+
+@respx.mock
+def test_verify_raises_when_inactive(client: Grantex) -> None:
+    from grantex import GrantexTokenError
+
+    respx.post("https://api.grantex.dev/v1/grants/verify").mock(
+        return_value=httpx.Response(200, json={"active": False, "reason": "revoked"})
+    )
+    with pytest.raises(GrantexTokenError, match="revoked"):
+        client.grants.verify("any.caller.supplied.token")
 
 
 def _build_verified_grant():

--- a/packages/sdk-py/tests/test_principal_sessions.py
+++ b/packages/sdk-py/tests/test_principal_sessions.py
@@ -19,7 +19,7 @@ def client() -> Grantex:
 def test_create_principal_session(client: Grantex) -> None:
     payload = {
         "sessionToken": "eyJ...",
-        "dashboardUrl": "https://api.grantex.dev/permissions?session=eyJ...",
+        "dashboardUrl": "https://api.grantex.dev/permissions#session=eyJ...",
         "expiresAt": "2026-03-01T00:00:00Z",
     }
     route = respx.post("https://api.grantex.dev/v1/principal-sessions").mock(
@@ -31,7 +31,7 @@ def test_create_principal_session(client: Grantex) -> None:
     )
 
     assert response.session_token == "eyJ..."
-    assert response.dashboard_url.endswith("/permissions?session=eyJ...")
+    assert response.dashboard_url.endswith("/permissions#session=eyJ...")
     assert response.expires_at == "2026-03-01T00:00:00Z"
 
     body = json.loads(route.calls[0].request.content)

--- a/packages/sdk-py/tests/test_verify.py
+++ b/packages/sdk-py/tests/test_verify.py
@@ -1,4 +1,4 @@
-"""Tests for verify_grant_token and _map_online_verify_to_verified_grant."""
+"""Tests for verify_grant_token."""
 from __future__ import annotations
 
 import base64
@@ -8,7 +8,6 @@ import pytest
 
 from grantex import verify_grant_token, GrantexTokenError
 from grantex._types import VerifyGrantTokenOptions, VerifiedGrant
-from grantex._verify import _map_online_verify_to_verified_grant
 from tests.conftest import MOCK_JWT_PAYLOAD
 
 
@@ -151,25 +150,3 @@ def test_no_matching_kid_raises_token_error(mocker: pytest.FixtureRequest) -> No
         verify_grant_token(token, options)
 
 
-# ─── _map_online_verify_to_verified_grant ────────────────────────────────────
-
-
-def test_decode_without_verify_path(mocker: pytest.FixtureRequest) -> None:
-    token = _fake_jwt(MOCK_JWT_PAYLOAD)
-    mocker.patch(  # type: ignore[attr-defined]
-        "jwt.decode", return_value=MOCK_JWT_PAYLOAD
-    )
-    result = _map_online_verify_to_verified_grant(token)
-    assert result.token_id == MOCK_JWT_PAYLOAD["jti"]
-    assert result.grant_id == MOCK_JWT_PAYLOAD["grnt"]
-
-
-def test_decode_error_raises_token_error(mocker: pytest.FixtureRequest) -> None:
-    import jwt as pyjwt
-
-    token = _fake_jwt(MOCK_JWT_PAYLOAD)
-    mocker.patch(  # type: ignore[attr-defined]
-        "jwt.decode", side_effect=pyjwt.DecodeError("invalid token")
-    )
-    with pytest.raises(GrantexTokenError, match="decode"):
-        _map_online_verify_to_verified_grant(token)

--- a/skills/ship-verification/SKILL.md
+++ b/skills/ship-verification/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: ship-verification
+description: Post-merge verification pass for Grantex. After any PR merges to main or ships to prod, run this pass without being asked — verify README, Mintlify docs, landing page, SDK READMEs (TS, Python, Go), integration docs, and SEO surfaces are consistent with what just shipped. Use this skill whenever a PR merges, a release goes out, or a feature ships.
+---
+
+# Ship Verification
+
+Behavioral guideline for keeping Grantex's public surfaces honest after every merge. The goal is to catch drift between what the code does and what the docs claim — before a user runs into it.
+
+**Trigger**: run this pass automatically after any merge to `main` or any prod deploy. Do not wait to be reminded. If the diff is trivial (dependabot version bump, CI-only change, internal refactor with no public contract change), say so and skip.
+
+**Tradeoff**: biases toward catching drift over speed. For a pure CI / dependabot / internal refactor PR, a one-sentence "no public surface touched, skipping" is the right output.
+
+## 1. Scope the diff first
+
+Before touching any doc, identify what actually shipped:
+
+- What routes, SDK methods, response shapes, or CLI commands changed?
+- Did any behavior change silently — e.g. a request that used to succeed now 400s, or a value now appears in a different place?
+- If the answer to both is "no" (CI, deps, tests, security-internal hardening with no contract change), skip the rest and report that.
+
+Do not fabricate updates. A security fix that tightens verification without changing the API contract usually needs no doc change.
+
+## 2. Surfaces to check
+
+Walk these in order. Stop when the diff doesn't touch a surface.
+
+1. **`README.md`** (repo root) — quickstart code, feature matrix, example table, package versions.
+2. **Mintlify docs (`docs/`)** — concept pages, SDK reference pages (TS + Python), guides, integration pages. Check `docs/sdks/typescript/` and `docs/sdks/python/` mirror each other when a feature exists in both.
+3. **SDK READMEs** — `packages/sdk-ts/README.md`, `packages/sdk-py/README.md`, `packages/go-sdk/README.md`. Each has its own quickstart that can drift from the root.
+4. **Landing page** — `web/index.html`. Only update for new capabilities that change the value proposition. Security-internal changes do not belong here.
+5. **Integrations index** — `docs/integrations/overview.mdx` if a new integration shipped.
+6. **SDK test fixtures** — mocked response shapes in `packages/sdk-*/tests/*` that encode server behavior. These are technically tests, but they document the shape; keep them honest.
+7. **SEO** — only when keywords or messaging change. Never touch for internal fixes. Use the keywords from `seo-system` memory, not generic SEO audit advice.
+
+## 3. What counts as a real gap
+
+A finding is real when:
+
+- A code example would fail if copy-pasted.
+- A response field or URL format in docs no longer matches what the server returns.
+- A parameter's documented behavior (defaults, validation, errors) diverges from the implementation.
+- A feature shipped but is not mentioned anywhere a user would discover it.
+
+A finding is not real when:
+
+- Docs use a synonym or different phrasing for the same thing.
+- A test mock uses a stale value that is not user-visible and does not affect production (flag it, but it's not a release blocker).
+- A page could be restructured for clarity but is not wrong.
+
+## 4. Output shape
+
+Keep reports tight. For each surface:
+
+- `README.md` — OK / needs X
+- `docs/` — OK / list files needing updates with one-line reason each
+- SDK READMEs — OK / which package and why
+- Landing page — OK / out of scope for this change
+- SEO — OK / out of scope
+
+If changes are needed, batch them in a single PR named `docs/<topic>-followup` unless the diff naturally splits. Do not open a PR per file.
+
+## 5. When to skip
+
+Skip the pass entirely when:
+
+- PR is a dependabot bump that did not touch source.
+- PR only touches `.github/workflows/`, `skills/`, or `scripts/`.
+- PR is an internal refactor with no change to exported symbols, route shapes, or response bodies.
+- PR is a test-only change.
+
+Always report what you skipped and why, in one line. Silence is not the right signal.
+
+## 6. Order of operations in a session
+
+When multiple PRs merge in a session:
+
+1. Batch the doc audit at the end of the session, not after each merge.
+2. Group updates from related PRs into one follow-up PR.
+3. If a single PR is large enough that its doc impact is nontrivial (e.g. a new SDK method), audit and fix as part of the same PR if still open; otherwise follow-up immediately.
+
+## Checklist
+
+Use this before declaring done:
+
+1. Did I scope the diff to what actually shipped, not speculate?
+2. For each affected surface, did I read the current doc and compare it to the code?
+3. Did I avoid editing surfaces the change did not touch?
+4. Is there a single clean PR for the follow-up, or a clear statement that none was needed?


### PR DESCRIPTION
## Summary
Audit of PR #275's security hardening surfaced a real parity gap: the Python SDK's `grants.verify()` still decoded the caller-supplied JWT locally with `verify_signature=False`, so forged or tampered tokens could surface attacker-controlled claims even when the server correctly marked the grant inactive. TS SDK was fixed in #275 but Python was missed.

## Changes
### sdk-py security parity (new, load-bearing)
- `GrantsClient.verify()` now checks `response['active']` and builds the `VerifiedGrant` from `response['claims']` — same pattern as TS SDK.
- Raises `GrantexTokenError` with the server's `reason` when `active=false`.
- Removes `_map_online_verify_to_verified_grant` and its tests — the insecure path should not exist in the codebase.
- Tests updated to exercise the server-claims path and the inactive-response error path. All 574 Python SDK tests pass locally.

### Doc fallout from #275
- `docs/sdks/typescript/grants.mdx`: online verify described as consuming server-verified claims.
- `docs/sdks/python/grants.mdx`: same correction.
- `docs/sdks/python/errors.mdx`: `GrantexTokenError` is raised on `active=false`, not decode failure.
- `docs/sdks/typescript/principal-sessions.mdx` + `docs/sdks/python/principal-sessions.mdx`: document that `dashboardUrl` carries the token in the URL fragment.
- `packages/sdk-py/tests/test_principal_sessions.py`: mock fixture aligned with fragment URL.

### Ship-verification skill (new)
- `skills/ship-verification/SKILL.md` — post-merge audit rules (README / Mintlify / SDK READMEs / landing / SEO) so this pass runs automatically on every ship.

## Audit outcome for this session's shipped work
- `README.md` — OK (already updated in #275).
- `docs/` — fixes applied above.
- SDK READMEs (TS, Py, Go) — no drift.
- `web/index.html` landing page — out of scope for security-internal change.
- `docs/integrations/overview.mdx` — no change.
- SEO — out of scope, no keyword impact.

## Test plan
- [x] `python -m pytest` in `packages/sdk-py` — 574 passed
- [ ] CI green (Python SDK + TS SDK jobs)
- [ ] Mintlify preview renders updated copy