### PR TITLE
chore(release): sdk-ts 0.3.8, sdk-py 0.3.9 (security hardening)

### DIFF
--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.3.8"
+version = "0.3.9"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -159,7 +159,7 @@ from ._webhook import verify_webhook_signature
 from .manifest import ToolManifest, Permission, EnforceResult
 from ._fastapi import GrantexEnforcer
 
-__version__ = "0.1.6"
+__version__ = "0.3.9"
 
 __all__ = [
     # Main client

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev",
   "bugs": {


### PR DESCRIPTION
## Summary
Ship the security fixes from PRs #275, #280, and #281 to SDK consumers.

- `@grantex/sdk` 0.3.7 → 0.3.8 — `grants.verify()` consumes server-verified claims (#275)
- `grantex` (Python) 0.3.8 → 0.3.9 — `grants.verify()` server claims (#280) + `verify_grant_token()` issuer binding (#281). Also corrects `__version__` in `grantex/__init__.py` which had drifted to 0.1.6.

## Publish status
- **PyPI**: `grantex 0.3.9` already published — https://pypi.org/project/grantex/0.3.9/
- **npm**: awaiting user's PowerShell `npm publish` with OTP.

## Test plan
- [ ] CI green
- [ ] `pip install grantex==0.3.9` resolves
- [ ] After npm publish: `npm view @grantex/sdk@0.3.8 version`