### PR TITLE
fix(go-sdk): align endpoint paths with auth-service contract

### DIFF
--- a/packages/go-sdk/grantex.go
+++ b/packages/go-sdk/grantex.go
@@ -119,7 +119,7 @@ func Signup(ctx context.Context, params SignupParams, opts ...Option) (*SignupRe
 		maxRetriesSet: cfg.maxRetriesSet,
 	}
 
-	return unmarshal[SignupResponse](h.post(ctx, "/v1/developers/signup", params))
+	return unmarshal[SignupResponse](h.post(ctx, "/v1/signup", params))
 }
 
 // LastRateLimit returns the rate limit metadata from the most recent API response, or nil if unavailable.
@@ -134,5 +134,5 @@ func (c *Client) Authorize(ctx context.Context, params AuthorizeParams) (*Author
 
 // RotateKey rotates the developer API key.
 func (c *Client) RotateKey(ctx context.Context) (*RotateKeyResponse, error) {
-	return unmarshal[RotateKeyResponse](c.http.post(ctx, "/v1/developers/rotate-key", nil))
+	return unmarshal[RotateKeyResponse](c.http.post(ctx, "/v1/keys/rotate", nil))
 }

--- a/packages/go-sdk/grantex_test.go
+++ b/packages/go-sdk/grantex_test.go
@@ -105,8 +105,8 @@ func TestAuthorize(t *testing.T) {
 
 func TestRotateKey(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/developers/rotate-key" {
-			t.Errorf("expected /v1/developers/rotate-key, got %s", r.URL.Path)
+		if r.URL.Path != "/v1/keys/rotate" {
+			t.Errorf("expected /v1/keys/rotate, got %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(RotateKeyResponse{
@@ -128,8 +128,8 @@ func TestRotateKey(t *testing.T) {
 
 func TestSignup(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/developers/signup" {
-			t.Errorf("expected /v1/developers/signup, got %s", r.URL.Path)
+		if r.URL.Path != "/v1/signup" {
+			t.Errorf("expected /v1/signup, got %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(SignupResponse{

--- a/packages/go-sdk/scim.go
+++ b/packages/go-sdk/scim.go
@@ -29,7 +29,7 @@ func (s *SCIMService) RevokeToken(ctx context.Context, tokenID string) error {
 
 // ListUsers retrieves SCIM users with optional pagination.
 func (s *SCIMService) ListUsers(ctx context.Context, params *ListScimUsersParams) (*ScimListResponse, error) {
-	path := "/v1/scim/v2/Users"
+	path := "/scim/v2/Users"
 	if params != nil {
 		q := make(map[string]string)
 		if params.StartIndex > 0 {
@@ -45,17 +45,17 @@ func (s *SCIMService) ListUsers(ctx context.Context, params *ListScimUsersParams
 
 // GetUser retrieves a SCIM user by ID.
 func (s *SCIMService) GetUser(ctx context.Context, userID string) (*ScimUser, error) {
-	return unmarshal[ScimUser](s.http.get(ctx, "/v1/scim/v2/Users/"+userID))
+	return unmarshal[ScimUser](s.http.get(ctx, "/scim/v2/Users/"+userID))
 }
 
 // CreateUser creates a new SCIM user.
 func (s *SCIMService) CreateUser(ctx context.Context, params CreateScimUserParams) (*ScimUser, error) {
-	return unmarshal[ScimUser](s.http.post(ctx, "/v1/scim/v2/Users", params))
+	return unmarshal[ScimUser](s.http.post(ctx, "/scim/v2/Users", params))
 }
 
 // ReplaceUser replaces a SCIM user (PUT).
 func (s *SCIMService) ReplaceUser(ctx context.Context, userID string, params CreateScimUserParams) (*ScimUser, error) {
-	return unmarshal[ScimUser](s.http.put(ctx, "/v1/scim/v2/Users/"+userID, params))
+	return unmarshal[ScimUser](s.http.put(ctx, "/scim/v2/Users/"+userID, params))
 }
 
 // UpdateUser performs a SCIM PATCH operation on a user.
@@ -63,11 +63,11 @@ func (s *SCIMService) UpdateUser(ctx context.Context, userID string, ops []ScimO
 	body := map[string]interface{}{
 		"Operations": ops,
 	}
-	return unmarshal[ScimUser](s.http.patch(ctx, "/v1/scim/v2/Users/"+userID, body))
+	return unmarshal[ScimUser](s.http.patch(ctx, "/scim/v2/Users/"+userID, body))
 }
 
 // DeleteUser removes a SCIM user.
 func (s *SCIMService) DeleteUser(ctx context.Context, userID string) error {
-	_, err := s.http.del(ctx, "/v1/scim/v2/Users/"+userID)
+	_, err := s.http.del(ctx, "/scim/v2/Users/"+userID)
 	return err
 }

--- a/packages/go-sdk/scim_test.go
+++ b/packages/go-sdk/scim_test.go
@@ -75,7 +75,7 @@ func TestSCIMRevokeToken(t *testing.T) {
 
 func TestSCIMListUsers(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/scim/v2/Users" || r.Method != http.MethodGet {
+		if r.URL.Path != "/scim/v2/Users" || r.Method != http.MethodGet {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -100,7 +100,7 @@ func TestSCIMListUsers(t *testing.T) {
 
 func TestSCIMGetUser(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/scim/v2/Users/user-1" {
+		if r.URL.Path != "/scim/v2/Users/user-1" {
 			t.Errorf("unexpected path %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -120,7 +120,7 @@ func TestSCIMGetUser(t *testing.T) {
 
 func TestSCIMCreateUser(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/scim/v2/Users" || r.Method != http.MethodPost {
+		if r.URL.Path != "/scim/v2/Users" || r.Method != http.MethodPost {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -142,7 +142,7 @@ func TestSCIMCreateUser(t *testing.T) {
 
 func TestSCIMReplaceUser(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/scim/v2/Users/user-1" || r.Method != http.MethodPut {
+		if r.URL.Path != "/scim/v2/Users/user-1" || r.Method != http.MethodPut {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -164,7 +164,7 @@ func TestSCIMReplaceUser(t *testing.T) {
 
 func TestSCIMUpdateUser(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/scim/v2/Users/user-1" || r.Method != http.MethodPatch {
+		if r.URL.Path != "/scim/v2/Users/user-1" || r.Method != http.MethodPatch {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -186,7 +186,7 @@ func TestSCIMUpdateUser(t *testing.T) {
 
 func TestSCIMDeleteUser(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/scim/v2/Users/user-1" || r.Method != http.MethodDelete {
+		if r.URL.Path != "/scim/v2/Users/user-1" || r.Method != http.MethodDelete {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
 		w.WriteHeader(http.StatusNoContent)

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.3.8"
+version = "0.3.9"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -159,7 +159,7 @@ from ._webhook import verify_webhook_signature
 from .manifest import ToolManifest, Permission, EnforceResult
 from ._fastapi import GrantexEnforcer
 
-__version__ = "0.1.6"
+__version__ = "0.3.9"
 
 __all__ = [
     # Main client

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "homepage": "https://grantex.dev",
   "bugs": {


### PR DESCRIPTION
## Summary

The Go SDK called three endpoint paths that don't exist on the server. The Go test suite asserted the same wrong paths against `httptest` mocks, so the drift never surfaced in CI.

| Method | Go SDK called | Server actually exposes |
|---|---|---|
| `Signup` | `/v1/developers/signup` | `/v1/signup` |
| `RotateKey` | `/v1/developers/rotate-key` | `/v1/keys/rotate` |
| `SCIM Users` (list/get/create/replace/update/delete) | `/v1/scim/v2/Users[...]` | `/scim/v2/Users[...]` (no `/v1` prefix) |

Server paths verified against `apps/auth-service/src/routes/signup.ts` and `apps/auth-service/src/routes/scim.ts`. SCIM path also matches `docs/openapi.yaml` (which uses `/scim/v2/Users`, no `/v1` prefix — SCIM 2.0 has its own URL space).

## Test plan

- [x] `go test ./...` passes in `packages/go-sdk` (35s, all green)
- [ ] After merge, cut a Go SDK patch release from the standalone `grantex-go` repo so consumers pick up the fix

## Note

The expert review (finding #4) flagged this. The other findings (grant lifecycle / refresh expiry / budget tie-in) are coupled and will land in a separate PR.