### PR TITLE
fix(auth): tie grant lifecycle to active checks, refresh, and budget

### DIFF
--- a/apps/auth-service/src/lib/budget.ts
+++ b/apps/auth-service/src/lib/budget.ts
@@ -50,18 +50,33 @@ export async function debitBudget(
   description?: string,
   metadata?: Record<string, unknown>,
 ): Promise<{ remaining: string; transactionId: string }> {
-  // Atomic debit — race-condition safe via WHERE clause
+  // Atomic debit — race-condition safe via WHERE clause.
+  // Joins grants so a revoked or expired grant cannot be debited even
+  // if a budget_allocations row still exists.
   const rows = await sql`
-    UPDATE budget_allocations
+    UPDATE budget_allocations ba
     SET remaining_budget = remaining_budget - ${amount},
         updated_at = NOW()
-    WHERE grant_id = ${grantId}
-      AND developer_id = ${developerId}
-      AND remaining_budget >= ${amount}
-    RETURNING id, initial_budget, remaining_budget
+    FROM grants g
+    WHERE ba.grant_id = ${grantId}
+      AND ba.developer_id = ${developerId}
+      AND ba.remaining_budget >= ${amount}
+      AND g.id = ba.grant_id
+      AND g.status = 'active'
+      AND g.expires_at > NOW()
+    RETURNING ba.id, ba.initial_budget, ba.remaining_budget
   `;
 
   if (rows.length === 0) {
+    // Disambiguate: is the grant still live, or just out of funds?
+    const grantCheck = await sql<{ status: string; expires_at: Date }[]>`
+      SELECT status, expires_at FROM grants
+      WHERE id = ${grantId} AND developer_id = ${developerId}
+    `;
+    const g = grantCheck[0];
+    if (!g || g.status !== 'active' || new Date(g.expires_at) <= new Date()) {
+      throw new GrantInactiveError(grantId);
+    }
     throw new InsufficientBudgetError(grantId);
   }
 
@@ -174,5 +189,12 @@ export class InsufficientBudgetError extends Error {
   constructor(grantId: string) {
     super(`Insufficient budget for grant ${grantId}`);
     this.name = 'InsufficientBudgetError';
+  }
+}
+
+export class GrantInactiveError extends Error {
+  constructor(grantId: string) {
+    super(`Grant ${grantId} is not active (revoked or expired)`);
+    this.name = 'GrantInactiveError';
   }
 }

--- a/apps/auth-service/src/routes/anomalies.ts
+++ b/apps/auth-service/src/routes/anomalies.ts
@@ -222,7 +222,10 @@ export async function anomaliesRoutes(app: FastifyInstance): Promise<void> {
       if ((a.severity === 'critical' || a.severity === 'high') && a.agent_id) {
         const activeGrants = await sql`
           SELECT id FROM grants
-          WHERE agent_id = ${a.agent_id} AND developer_id = ${developerId} AND status = 'active'
+          WHERE agent_id = ${a.agent_id}
+            AND developer_id = ${developerId}
+            AND status = 'active'
+            AND expires_at > NOW()
         `;
         for (const g of activeGrants as Array<Record<string, unknown>>) {
           const grantId = g['id'] as string;

--- a/apps/auth-service/src/routes/authorize.ts
+++ b/apps/auth-service/src/routes/authorize.ts
@@ -63,7 +63,10 @@ export async function authorizeRoutes(app: FastifyInstance): Promise<void> {
     const grantLimit = PLAN_LIMITS[plan].grants;
 
     const countRows = await sql<{ count: string }[]>`
-      SELECT COUNT(*) AS count FROM grants WHERE developer_id = ${developerId} AND status = 'active'
+      SELECT COUNT(*) AS count FROM grants
+      WHERE developer_id = ${developerId}
+        AND status = 'active'
+        AND expires_at > NOW()
     `;
     const grantCount = parseInt(countRows[0]?.count ?? '0', 10);
 

--- a/apps/auth-service/src/routes/budget.ts
+++ b/apps/auth-service/src/routes/budget.ts
@@ -7,6 +7,7 @@ import {
   listBudgetAllocations,
   listBudgetTransactions,
   InsufficientBudgetError,
+  GrantInactiveError,
 } from '../lib/budget.js';
 
 interface AllocateBody {
@@ -45,12 +46,21 @@ export async function budgetRoutes(app: FastifyInstance): Promise<void> {
     const sql = getSql();
     const developerId = request.developer.id;
 
-    // Verify grant belongs to developer
-    const grantRows = await sql`
-      SELECT id FROM grants WHERE id = ${grantId} AND developer_id = ${developerId}
+    // Verify grant belongs to developer and is still live
+    const grantRows = await sql<{ id: string; status: string; expires_at: Date }[]>`
+      SELECT id, status, expires_at FROM grants
+      WHERE id = ${grantId} AND developer_id = ${developerId}
     `;
-    if (!grantRows[0]) {
+    const grant = grantRows[0];
+    if (!grant) {
       return reply.status(404).send({ message: 'Grant not found', code: 'NOT_FOUND', requestId: request.id });
+    }
+    if (grant.status !== 'active' || new Date(grant.expires_at) <= new Date()) {
+      return reply.status(409).send({
+        message: 'Grant is not active (revoked or expired)',
+        code: 'GRANT_INACTIVE',
+        requestId: request.id,
+      });
     }
 
     try {
@@ -95,6 +105,13 @@ export async function budgetRoutes(app: FastifyInstance): Promise<void> {
         return reply.status(402).send({
           message: err.message,
           code: 'INSUFFICIENT_BUDGET',
+          requestId: request.id,
+        });
+      }
+      if (err instanceof GrantInactiveError) {
+        return reply.status(409).send({
+          message: err.message,
+          code: 'GRANT_INACTIVE',
           requestId: request.id,
         });
       }

--- a/apps/auth-service/src/routes/compliance.ts
+++ b/apps/auth-service/src/routes/compliance.ts
@@ -37,10 +37,10 @@ export async function complianceRoutes(app: FastifyInstance): Promise<void> {
       `,
       sql`
         SELECT
-          COUNT(*)                                       AS total,
-          COUNT(*) FILTER (WHERE status = 'active')     AS active,
-          COUNT(*) FILTER (WHERE status = 'revoked')    AS revoked,
-          COUNT(*) FILTER (WHERE status = 'expired')    AS expired
+          COUNT(*)                                                                       AS total,
+          COUNT(*) FILTER (WHERE status = 'active' AND expires_at > NOW())              AS active,
+          COUNT(*) FILTER (WHERE status = 'revoked')                                    AS revoked,
+          COUNT(*) FILTER (WHERE status = 'expired' OR (status = 'active' AND expires_at <= NOW())) AS expired
         FROM grants WHERE developer_id = ${developerId}
           AND (${since}::timestamptz IS NULL OR issued_at >= ${since}::timestamptz)
           AND (${until}::timestamptz IS NULL OR issued_at <= ${until}::timestamptz)
@@ -162,10 +162,10 @@ export async function complianceRoutes(app: FastifyInstance): Promise<void> {
       `,
       sql`
         SELECT
-          COUNT(*)                                       AS total,
-          COUNT(*) FILTER (WHERE status = 'active')     AS active,
-          COUNT(*) FILTER (WHERE status = 'revoked')    AS revoked,
-          COUNT(*) FILTER (WHERE status = 'expired')    AS expired
+          COUNT(*)                                                                       AS total,
+          COUNT(*) FILTER (WHERE status = 'active' AND expires_at > NOW())              AS active,
+          COUNT(*) FILTER (WHERE status = 'revoked')                                    AS revoked,
+          COUNT(*) FILTER (WHERE status = 'expired' OR (status = 'active' AND expires_at <= NOW())) AS expired
         FROM grants WHERE developer_id = ${developerId}
           AND (${since}::timestamptz IS NULL OR issued_at >= ${since}::timestamptz)
           AND (${until}::timestamptz IS NULL OR issued_at <= ${until}::timestamptz)

--- a/apps/auth-service/src/routes/delegate.ts
+++ b/apps/auth-service/src/routes/delegate.ts
@@ -117,8 +117,8 @@ export async function delegateRoutes(app: FastifyInstance): Promise<void> {
       VALUES (${jti}, ${grantId}, ${expiresAt})
     `;
 
-    // Insert refresh token
-    const refreshExpiresAt = new Date(now + 30 * 86400 * 1000);
+    // Insert refresh token — cannot outlive the underlying grant.
+    const refreshExpiresAt = new Date(Math.min(now + 30 * 86400 * 1000, expiresAt.getTime()));
     await sql`
       INSERT INTO refresh_tokens (id, grant_id, expires_at)
       VALUES (${refreshId}, ${grantId}, ${refreshExpiresAt})

--- a/apps/auth-service/src/routes/principal.ts
+++ b/apps/auth-service/src/routes/principal.ts
@@ -67,6 +67,7 @@ export async function principalRoutes(app: FastifyInstance): Promise<void> {
         WHERE developer_id = ${request.developer.id}
           AND principal_id = ${principalId}
           AND status = 'active'
+          AND expires_at > NOW()
         LIMIT 1
       `;
 

--- a/apps/auth-service/src/routes/token.ts
+++ b/apps/auth-service/src/routes/token.ts
@@ -102,7 +102,8 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
         const now = Date.now();
         expiresAt = new Date(now + expiresSeconds * 1000);
         expTimestamp = Math.floor(expiresAt.getTime() / 1000);
-        const refreshExpiresAt = new Date(now + 30 * 86400 * 1000);
+        // Refresh tokens cannot outlive the underlying grant.
+        const refreshExpiresAt = new Date(Math.min(now + 30 * 86400 * 1000, expiresAt.getTime()));
 
         await tx`
           INSERT INTO grants (id, agent_id, principal_id, developer_id, scopes, expires_at)
@@ -301,12 +302,16 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
         if (row['grant_status'] === 'revoked') {
           routeError(400, 'Grant has been revoked');
         }
+        if (new Date(row['grant_expires_at'] as string) <= new Date()) {
+          routeError(400, 'Grant has expired');
+        }
 
         grantId = row['grant_id'] as string;
         scopes = row['scopes'] as string[];
         grantExpiresAt = new Date(row['grant_expires_at'] as string);
         const now = Date.now();
-        const refreshExpiresAt = new Date(now + 30 * 86400 * 1000);
+        // Refresh tokens cannot outlive the underlying grant.
+        const refreshExpiresAt = new Date(Math.min(now + 30 * 86400 * 1000, grantExpiresAt.getTime()));
 
         const updated = await tx`
           UPDATE refresh_tokens

--- a/apps/auth-service/tests/budget.test.ts
+++ b/apps/auth-service/tests/budget.test.ts
@@ -11,8 +11,8 @@ beforeAll(async () => {
 describe('POST /v1/budget/allocate', () => {
   it('creates a budget allocation', async () => {
     seedAuth();
-    // Grant exists
-    sqlMock.mockResolvedValueOnce([{ id: 'grnt_1' }]);
+    // Grant exists, active, not expired
+    sqlMock.mockResolvedValueOnce([{ id: 'grnt_1', status: 'active', expires_at: new Date(Date.now() + 3600_000) }]);
     // Insert allocation
     sqlMock.mockResolvedValueOnce([{
       id: 'bdg_1',
@@ -64,6 +64,36 @@ describe('POST /v1/budget/allocate', () => {
     expect(res.statusCode).toBe(404);
   });
 
+  it('returns 409 GRANT_INACTIVE when allocating against a revoked grant', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ id: 'grnt_revoked', status: 'revoked', expires_at: new Date(Date.now() + 3600_000) }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/budget/allocate',
+      headers: authHeader(),
+      payload: { grantId: 'grnt_revoked', initialBudget: 50 },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('GRANT_INACTIVE');
+  });
+
+  it('returns 409 GRANT_INACTIVE when allocating against an expired grant', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{ id: 'grnt_exp', status: 'active', expires_at: new Date(Date.now() - 1000) }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/budget/allocate',
+      headers: authHeader(),
+      payload: { grantId: 'grnt_exp', initialBudget: 50 },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('GRANT_INACTIVE');
+  });
+
   it('requires authentication', async () => {
     const res = await app.inject({
       method: 'POST',
@@ -76,8 +106,8 @@ describe('POST /v1/budget/allocate', () => {
 
   it('returns 409 for duplicate budget allocation', async () => {
     seedAuth();
-    // Grant exists
-    sqlMock.mockResolvedValueOnce([{ id: 'grnt_1' }]);
+    // Grant exists, active, not expired
+    sqlMock.mockResolvedValueOnce([{ id: 'grnt_1', status: 'active', expires_at: new Date(Date.now() + 3600_000) }]);
     // Insert fails with unique constraint
     sqlMock.mockRejectedValueOnce(Object.assign(new Error('unique constraint violated'), { code: '23505' }));
 
@@ -94,8 +124,8 @@ describe('POST /v1/budget/allocate', () => {
 
   it('re-throws unknown errors from allocation', async () => {
     seedAuth();
-    // Grant exists
-    sqlMock.mockResolvedValueOnce([{ id: 'grnt_1' }]);
+    // Grant exists, active, not expired
+    sqlMock.mockResolvedValueOnce([{ id: 'grnt_1', status: 'active', expires_at: new Date(Date.now() + 3600_000) }]);
     // Insert fails with non-unique error
     sqlMock.mockRejectedValueOnce(new Error('connection lost'));
 
@@ -132,7 +162,9 @@ describe('POST /v1/budget/debit', () => {
 
   it('returns 402 when insufficient budget', async () => {
     seedAuth();
-    sqlMock.mockResolvedValueOnce([]); // No matching row (insufficient)
+    sqlMock.mockResolvedValueOnce([]); // UPDATE: no matching row
+    // Disambiguation SELECT — grant is still live → INSUFFICIENT_BUDGET (not GRANT_INACTIVE)
+    sqlMock.mockResolvedValueOnce([{ status: 'active', expires_at: new Date(Date.now() + 3600_000) }]);
 
     const res = await app.inject({
       method: 'POST',
@@ -143,6 +175,40 @@ describe('POST /v1/budget/debit', () => {
 
     expect(res.statusCode).toBe(402);
     expect(res.json().code).toBe('INSUFFICIENT_BUDGET');
+  });
+
+  it('returns 409 GRANT_INACTIVE when debiting against a revoked grant', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]); // UPDATE: no matching row (grant blocked the join)
+    // Disambiguation SELECT — grant exists but is revoked
+    sqlMock.mockResolvedValueOnce([{ status: 'revoked', expires_at: new Date(Date.now() + 3600_000) }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/budget/debit',
+      headers: authHeader(),
+      payload: { grantId: 'grnt_revoked', amount: 10 },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('GRANT_INACTIVE');
+  });
+
+  it('returns 409 GRANT_INACTIVE when debiting against an expired grant', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]); // UPDATE: no matching row
+    // Disambiguation SELECT — grant exists, status active, but expires_at is past
+    sqlMock.mockResolvedValueOnce([{ status: 'active', expires_at: new Date(Date.now() - 1000) }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/budget/debit',
+      headers: authHeader(),
+      payload: { grantId: 'grnt_expired', amount: 10 },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('GRANT_INACTIVE');
   });
 
   it('returns 400 for missing fields', async () => {

--- a/apps/auth-service/tests/token-refresh.test.ts
+++ b/apps/auth-service/tests/token-refresh.test.ts
@@ -130,6 +130,25 @@ describe('POST /v1/token/refresh', () => {
     expect(res.json().message).toBe('Grant has been revoked');
   });
 
+  it('returns 400 when the underlying grant has expired', async () => {
+    seedAuth();
+    // Refresh token itself is fresh, but grant_expires_at is in the past
+    sqlMock.mockResolvedValueOnce([{
+      ...validRefreshRow,
+      grant_expires_at: new Date(Date.now() - 1000).toISOString(),
+    }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token/refresh',
+      headers: authHeader(),
+      payload: { refreshToken: 'ref_GRANTEXPIRED', agentId: TEST_AGENT.id },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toBe('Grant has expired');
+  });
+
   it('returns 400 when agent does not match', async () => {
     seedAuth();
     sqlMock.mockResolvedValueOnce([{ ...validRefreshRow, agent_id: 'ag_DIFFERENT' }]);


### PR DESCRIPTION
## Summary

Bundles three coupled findings from the recent expert review (#1, #2, #3). All three trace back to the same root: grants whose \`expires_at\` had passed never transitioned out of \`status='active'\`, so several control-plane checks treated dead grants as live forever.

### #1 — Liveness checks now require \`status='active' AND expires_at > NOW()\`

| Site | Before | After |
|---|---|---|
| Plan-limit grant count (\`authorize.ts\`) | counted expired grants against quota | only live grants count |
| Principal-session issuance (\`principal.ts\`) | issued sessions for principals whose grants had all expired | requires at least one truly live grant |
| Anomaly auto-revoke (\`anomalies.ts\`) | revoked already-expired grants for no effect | targets only live grants |
| Compliance dashboard counters (\`compliance.ts\`) | \`expired\` was always 0; expired grants inflated \`active\` | counters split correctly |

### #2 — Refresh + delegate refresh expiry

- \`/v1/token/refresh\` now rejects with 400 \`Grant has expired\` when \`grant_expires_at <= NOW()\`, even if the refresh token itself is fresh.
- New refresh tokens are capped at \`min(now+30d, grantExpiresAt)\` on both \`/v1/token\` (initial exchange), \`/v1/token/refresh\`, and \`/v1/grants/delegate\` — a refresh token can no longer outlive its grant.

### #3 — Budget tied to grant lifecycle

- \`POST /v1/budget/allocate\` returns **409 GRANT_INACTIVE** if the target grant is revoked or expired.
- \`debitBudget\` now \`UPDATE ... FROM grants\` with the active+not-expired predicate atomically. On a zero-row result, a follow-up SELECT disambiguates so callers still receive \`INSUFFICIENT_BUDGET\` (402) when funds are the issue and \`GRANT_INACTIVE\` (409) when the grant is dead. New \`GrantInactiveError\` exported from \`lib/budget.ts\`.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm test\` — 996/996 pass (75 files)
- [x] New tests:
  - token-refresh: rejects refresh when grant has expired
  - budget allocate: rejects revoked and expired grants
  - budget debit: rejects revoked and expired grants; preserves \`INSUFFICIENT_BUDGET\` path
- [ ] Manual smoke against live auth-service after merge

## Related

Independent of #283 (Go SDK endpoint paths). The fourth review finding (custom-domain runtime), the rate-limit bypass (#6), and email-verify rebinding (#7), plus the verifications-counter (#8), will be follow-up PRs.