### PR TITLE
fix(auth): Codex follow-ups + remaining expert-review findings (#5–#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,11 +1005,11 @@ for entry in history.entries:
 </details>
 
 <details>
-<summary><strong>Custom Domains</strong> — white-label consent UI and API endpoints</summary>
+<summary><strong>Custom Domains</strong> — register & verify domains for white-labeling</summary>
 
 ## Custom Domains
 
-Grantex supports custom domains for white-labeling the consent UI and API endpoints. Register your domain, verify ownership via DNS TXT record, and all Grantex-hosted consent pages will be served under your brand.
+Grantex provides domain registration and DNS-based ownership verification so your account is provisioned and ready to host Grantex on your own domain. Today the API covers registration, verification, listing, and deletion; runtime traffic routing through verified domains (consent UI / API endpoints served from your domain) is on the roadmap and currently still served from `*.grantex.dev`. Track progress in [issues](https://github.com/mishrasanjeev/grantex/issues).
 
 ```typescript
 // Register a custom domain

--- a/apps/auth-service/src/lib/budget.ts
+++ b/apps/auth-service/src/lib/budget.ts
@@ -32,14 +32,32 @@ export async function createBudgetAllocation(
 ): Promise<BudgetAllocation> {
   const id = newBudgetAllocationId();
 
+  // Single statement: insert only if the grant is currently active and not
+  // expired. Closes the race where a concurrent revoke between a separate
+  // pre-check and the insert would still allow allocation against a dead grant.
   const rows = await sql`
     INSERT INTO budget_allocations (id, grant_id, developer_id, initial_budget, remaining_budget, currency)
-    VALUES (${id}, ${grantId}, ${developerId}, ${initialBudget}, ${initialBudget}, ${currency})
+    SELECT ${id}, g.id, g.developer_id, ${initialBudget}, ${initialBudget}, ${currency}
+    FROM grants g
+    WHERE g.id = ${grantId}
+      AND g.developer_id = ${developerId}
+      AND g.status = 'active'
+      AND g.expires_at > NOW()
     RETURNING id, grant_id, developer_id, initial_budget, remaining_budget, currency, created_at, updated_at
   `;
 
-  const row = rows[0]!;
-  return mapAllocationRow(row);
+  if (rows.length === 0) {
+    // Disambiguate: missing entirely vs. revoked/expired.
+    const grantCheck = await sql<{ status: string; expires_at: Date }[]>`
+      SELECT status, expires_at FROM grants
+      WHERE id = ${grantId} AND developer_id = ${developerId}
+    `;
+    const g = grantCheck[0];
+    if (!g) throw new GrantNotFoundError(grantId);
+    throw new GrantInactiveError(grantId);
+  }
+
+  return mapAllocationRow(rows[0]!);
 }
 
 export async function debitBudget(
@@ -68,13 +86,16 @@ export async function debitBudget(
   `;
 
   if (rows.length === 0) {
-    // Disambiguate: is the grant still live, or just out of funds?
+    // Disambiguate: missing entirely, dead, or just out of funds?
     const grantCheck = await sql<{ status: string; expires_at: Date }[]>`
       SELECT status, expires_at FROM grants
       WHERE id = ${grantId} AND developer_id = ${developerId}
     `;
     const g = grantCheck[0];
-    if (!g || g.status !== 'active' || new Date(g.expires_at) <= new Date()) {
+    if (!g) {
+      throw new GrantNotFoundError(grantId);
+    }
+    if (g.status !== 'active' || new Date(g.expires_at) <= new Date()) {
       throw new GrantInactiveError(grantId);
     }
     throw new InsufficientBudgetError(grantId);
@@ -196,5 +217,12 @@ export class GrantInactiveError extends Error {
   constructor(grantId: string) {
     super(`Grant ${grantId} is not active (revoked or expired)`);
     this.name = 'GrantInactiveError';
+  }
+}
+
+export class GrantNotFoundError extends Error {
+  constructor(grantId: string) {
+    super(`Grant ${grantId} not found`);
+    this.name = 'GrantNotFoundError';
   }
 }

--- a/apps/auth-service/src/routes/budget.ts
+++ b/apps/auth-service/src/routes/budget.ts
@@ -8,6 +8,7 @@ import {
   listBudgetTransactions,
   InsufficientBudgetError,
   GrantInactiveError,
+  GrantNotFoundError,
 } from '../lib/budget.js';
 
 interface AllocateBody {
@@ -46,27 +47,20 @@ export async function budgetRoutes(app: FastifyInstance): Promise<void> {
     const sql = getSql();
     const developerId = request.developer.id;
 
-    // Verify grant belongs to developer and is still live
-    const grantRows = await sql<{ id: string; status: string; expires_at: Date }[]>`
-      SELECT id, status, expires_at FROM grants
-      WHERE id = ${grantId} AND developer_id = ${developerId}
-    `;
-    const grant = grantRows[0];
-    if (!grant) {
-      return reply.status(404).send({ message: 'Grant not found', code: 'NOT_FOUND', requestId: request.id });
-    }
-    if (grant.status !== 'active' || new Date(grant.expires_at) <= new Date()) {
-      return reply.status(409).send({
-        message: 'Grant is not active (revoked or expired)',
-        code: 'GRANT_INACTIVE',
-        requestId: request.id,
-      });
-    }
-
     try {
       const allocation = await createBudgetAllocation(sql, grantId, developerId, initialBudget, currency);
       return reply.status(201).send(allocation);
     } catch (err) {
+      if (err instanceof GrantNotFoundError) {
+        return reply.status(404).send({ message: 'Grant not found', code: 'NOT_FOUND', requestId: request.id });
+      }
+      if (err instanceof GrantInactiveError) {
+        return reply.status(409).send({
+          message: 'Grant is not active (revoked or expired)',
+          code: 'GRANT_INACTIVE',
+          requestId: request.id,
+        });
+      }
       if (err instanceof Error && err.message.includes('unique')) {
         return reply.status(409).send({
           message: 'Budget allocation already exists for this grant',
@@ -105,6 +99,13 @@ export async function budgetRoutes(app: FastifyInstance): Promise<void> {
         return reply.status(402).send({
           message: err.message,
           code: 'INSUFFICIENT_BUDGET',
+          requestId: request.id,
+        });
+      }
+      if (err instanceof GrantNotFoundError) {
+        return reply.status(404).send({
+          message: err.message,
+          code: 'NOT_FOUND',
           requestId: request.id,
         });
       }

--- a/apps/auth-service/src/routes/grants.ts
+++ b/apps/auth-service/src/routes/grants.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { getSql } from '../db/client.js';
 import { revokeGrantCascade } from '../lib/revoke.js';
 import { checkActiveGrantToken } from '../lib/active-grant-token.js';
+import { incrementUsage } from '../lib/usage.js';
 
 export async function grantsRoutes(app: FastifyInstance): Promise<void> {
   // GET /v1/grants
@@ -63,6 +64,8 @@ export async function grantsRoutes(app: FastifyInstance): Promise<void> {
     const result = await checkActiveGrantToken(token, {
       expectedDeveloperId: request.developer.id,
     });
+
+    incrementUsage(request.developer.id, 'verifications').catch(() => {});
 
     if (!result.ok) {
       if (result.reason === 'invalid' || result.reason === 'invalid_claims') {

--- a/apps/auth-service/src/routes/tokens.ts
+++ b/apps/auth-service/src/routes/tokens.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { getRedis } from '../redis/client.js';
 import { checkActiveGrantToken } from '../lib/active-grant-token.js';
 import { getSql } from '../db/client.js';
+import { incrementUsage } from '../lib/usage.js';
 
 export async function tokensRoutes(app: FastifyInstance): Promise<void> {
   // POST /v1/tokens/verify
@@ -14,6 +15,8 @@ export async function tokensRoutes(app: FastifyInstance): Promise<void> {
     const result = await checkActiveGrantToken(token, {
       expectedDeveloperId: request.developer.id,
     });
+
+    incrementUsage(request.developer.id, 'verifications').catch(() => {});
 
     if (!result.ok) {
       return reply.send({ valid: false });

--- a/apps/auth-service/src/routes/verify-email.ts
+++ b/apps/auth-service/src/routes/verify-email.ts
@@ -80,14 +80,40 @@ export async function verifyEmailRoutes(app: FastifyInstance): Promise<void> {
       });
     }
 
-    // Mark verified
+    // Bind the verified address onto the developer record so developers.email
+    // is always the address that was actually proven. Without this, a developer
+    // could verify any mailbox while the canonical email field stayed unset or
+    // pointed to a different address.
+    const verifiedEmail = row['email'] as string;
+    const developerId = row['developer_id'] as string;
+
+    // Reject if another verified developer already owns this address — keeps
+    // the application-level uniqueness invariant from signup intact.
+    const conflicts = await sql`
+      SELECT id FROM developers
+      WHERE email = ${verifiedEmail}
+        AND id != ${developerId}
+        AND email_verified = TRUE
+      LIMIT 1
+    `;
+    if (conflicts.length > 0) {
+      return reply.status(409).send({
+        message: 'This email is already verified by another account',
+        code: 'EMAIL_TAKEN',
+        requestId: request.id,
+      });
+    }
+
     await sql`
       UPDATE email_verifications SET verified_at = NOW() WHERE id = ${row['id'] as string}
     `;
     await sql`
-      UPDATE developers SET email_verified = TRUE WHERE id = ${row['developer_id'] as string}
+      UPDATE developers
+      SET email_verified = TRUE,
+          email = ${verifiedEmail}
+      WHERE id = ${developerId}
     `;
 
-    return reply.send({ message: 'Email verified successfully' });
+    return reply.send({ message: 'Email verified successfully', email: verifiedEmail });
   });
 }

--- a/apps/auth-service/src/server.ts
+++ b/apps/auth-service/src/server.ts
@@ -78,20 +78,17 @@ export async function buildApp(opts: AppOptions = {}) {
     reply.header('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'");
   });
 
-  // Global rate limit: 100 requests/minute, keyed by developer API key
-  // when authenticated, falling back to IP for unauthenticated requests.
-  // Per-developer keying prevents shared-IP scenarios (CI runners, NAT)
-  // from cross-contaminating rate limit buckets.
+  // Global rate limit: 100 requests/minute, keyed strictly by source IP.
+  // Earlier versions keyed on the Bearer token, which let an attacker
+  // bypass the limiter by varying invalid tokens to mint fresh buckets
+  // (each fake token got its own 100/min budget). IP-keying closes that
+  // hole. Per-developer plan-based throughput is the responsibility of
+  // a post-auth limiter (see plugins/dynamicRateLimit.ts), not this
+  // global pre-auth net.
   await app.register(rateLimit, {
     max: 100,
     timeWindow: '1 minute',
-    keyGenerator: (req) => {
-      const auth = req.headers.authorization;
-      if (auth?.startsWith('Bearer ')) {
-        return `bearer:${auth.slice(7)}`;
-      }
-      return req.ip;
-    },
+    keyGenerator: (req) => req.ip,
     allowList: (req) => {
       // Skip rate limiting for JWKS (public key distribution must never be throttled)
       return req.url.startsWith('/.well-known/');

--- a/apps/auth-service/tests/budget.test.ts
+++ b/apps/auth-service/tests/budget.test.ts
@@ -11,9 +11,7 @@ beforeAll(async () => {
 describe('POST /v1/budget/allocate', () => {
   it('creates a budget allocation', async () => {
     seedAuth();
-    // Grant exists, active, not expired
-    sqlMock.mockResolvedValueOnce([{ id: 'grnt_1', status: 'active', expires_at: new Date(Date.now() + 3600_000) }]);
-    // Insert allocation
+    // INSERT...SELECT FROM grants — atomic insert returns the new row
     sqlMock.mockResolvedValueOnce([{
       id: 'bdg_1',
       grant_id: 'grnt_1',
@@ -52,7 +50,8 @@ describe('POST /v1/budget/allocate', () => {
 
   it('returns 404 when grant not found', async () => {
     seedAuth();
-    sqlMock.mockResolvedValueOnce([]); // No grant
+    sqlMock.mockResolvedValueOnce([]); // INSERT...SELECT: no row inserted (no matching grant)
+    sqlMock.mockResolvedValueOnce([]); // disambiguation SELECT: grant truly missing
 
     const res = await app.inject({
       method: 'POST',
@@ -62,11 +61,13 @@ describe('POST /v1/budget/allocate', () => {
     });
 
     expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('NOT_FOUND');
   });
 
   it('returns 409 GRANT_INACTIVE when allocating against a revoked grant', async () => {
     seedAuth();
-    sqlMock.mockResolvedValueOnce([{ id: 'grnt_revoked', status: 'revoked', expires_at: new Date(Date.now() + 3600_000) }]);
+    sqlMock.mockResolvedValueOnce([]); // INSERT...SELECT: zero rows (grant revoked)
+    sqlMock.mockResolvedValueOnce([{ status: 'revoked', expires_at: new Date(Date.now() + 3600_000) }]);
 
     const res = await app.inject({
       method: 'POST',
@@ -81,7 +82,8 @@ describe('POST /v1/budget/allocate', () => {
 
   it('returns 409 GRANT_INACTIVE when allocating against an expired grant', async () => {
     seedAuth();
-    sqlMock.mockResolvedValueOnce([{ id: 'grnt_exp', status: 'active', expires_at: new Date(Date.now() - 1000) }]);
+    sqlMock.mockResolvedValueOnce([]); // INSERT...SELECT: zero rows (expires_at past)
+    sqlMock.mockResolvedValueOnce([{ status: 'active', expires_at: new Date(Date.now() - 1000) }]);
 
     const res = await app.inject({
       method: 'POST',
@@ -106,9 +108,7 @@ describe('POST /v1/budget/allocate', () => {
 
   it('returns 409 for duplicate budget allocation', async () => {
     seedAuth();
-    // Grant exists, active, not expired
-    sqlMock.mockResolvedValueOnce([{ id: 'grnt_1', status: 'active', expires_at: new Date(Date.now() + 3600_000) }]);
-    // Insert fails with unique constraint
+    // INSERT...SELECT fails with unique constraint
     sqlMock.mockRejectedValueOnce(Object.assign(new Error('unique constraint violated'), { code: '23505' }));
 
     const res = await app.inject({
@@ -124,9 +124,7 @@ describe('POST /v1/budget/allocate', () => {
 
   it('re-throws unknown errors from allocation', async () => {
     seedAuth();
-    // Grant exists, active, not expired
-    sqlMock.mockResolvedValueOnce([{ id: 'grnt_1', status: 'active', expires_at: new Date(Date.now() + 3600_000) }]);
-    // Insert fails with non-unique error
+    // INSERT...SELECT fails with non-unique error
     sqlMock.mockRejectedValueOnce(new Error('connection lost'));
 
     const res = await app.inject({
@@ -175,6 +173,23 @@ describe('POST /v1/budget/debit', () => {
 
     expect(res.statusCode).toBe(402);
     expect(res.json().code).toBe('INSUFFICIENT_BUDGET');
+  });
+
+  it('returns 404 NOT_FOUND when debiting an unknown grant id', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]); // UPDATE: no matching row
+    // Disambiguation SELECT — grant truly missing
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/budget/debit',
+      headers: authHeader(),
+      payload: { grantId: 'grnt_typo', amount: 10 },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('NOT_FOUND');
   });
 
   it('returns 409 GRANT_INACTIVE when debiting against a revoked grant', async () => {

--- a/apps/auth-service/tests/verify-email.test.ts
+++ b/apps/auth-service/tests/verify-email.test.ts
@@ -80,9 +80,11 @@ describe('GET /v1/signup/verify/:token', () => {
       expires_at: new Date(Date.now() + 86400_000).toISOString(),
       verified_at: null,
     }]);
+    // Conflict check — no other developer owns this email
+    sqlMock.mockResolvedValueOnce([]);
     // Update verification
     sqlMock.mockResolvedValueOnce([]);
-    // Update developer
+    // Update developer (sets email_verified=TRUE and email=verifiedEmail)
     sqlMock.mockResolvedValueOnce([]);
 
     const res = await app.inject({
@@ -92,6 +94,27 @@ describe('GET /v1/signup/verify/:token', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json().message).toContain('verified');
+    expect(res.json().email).toBe('test@example.com');
+  });
+
+  it('returns 409 EMAIL_TAKEN when another developer already verified the same address', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      id: 'emv_1',
+      developer_id: 'dev_TEST',
+      email: 'shared@example.com',
+      expires_at: new Date(Date.now() + 86400_000).toISOString(),
+      verified_at: null,
+    }]);
+    // Conflict check — another developer already owns this verified email
+    sqlMock.mockResolvedValueOnce([{ id: 'dev_OTHER' }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/signup/verify/conflict-token',
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('EMAIL_TAKEN');
   });
 
   it('returns 404 for invalid token', async () => {
@@ -149,6 +172,8 @@ describe('GET /v1/signup/verify/:token', () => {
       expires_at: new Date(Date.now() + 86400_000).toISOString(),
       verified_at: null,
     }]);
+    // Conflict check, then two updates
+    sqlMock.mockResolvedValueOnce([]);
     sqlMock.mockResolvedValueOnce([]);
     sqlMock.mockResolvedValueOnce([]);
 

--- a/docs/guides/custom-domains.mdx
+++ b/docs/guides/custom-domains.mdx
@@ -5,7 +5,7 @@ description: "Use your own domain for Grantex API endpoints (Enterprise)"
 
 ## Overview
 
-Enterprise plan customers can configure custom domains for their Grantex API endpoints. Domain ownership is verified via DNS TXT records.
+Enterprise plan customers can register a custom domain and prove ownership via DNS TXT records. The current release covers the registration and verification lifecycle — runtime traffic routing through verified domains (consent UI and API endpoints actually served from your domain) is on the roadmap; today both still resolve under `*.grantex.dev`.
 
 ## Setup
 


### PR DESCRIPTION
## Summary

Bundles the two P2 Codex comments left on #284 with the four deferred findings (#5–#8) from the original expert review.

### Codex P2 #1 — atomic budget allocation
\`createBudgetAllocation\` is now a single \`INSERT...SELECT FROM grants\` with the active+not-expired predicate inline. The route's separate pre-check is gone, closing the race where a concurrent revoke between the check and the insert would still allow allocation against a dead grant. On zero rows, a follow-up SELECT disambiguates not-found vs inactive.

### Codex P2 #2 — preserve not-found distinction in debit
\`debitBudget\`'s disambiguation branch now throws a dedicated \`GrantNotFoundError\` when the follow-up SELECT yields no row. Unknown / typo grant IDs return **404 NOT_FOUND** instead of being conflated with revoked/expired (\`409 GRANT_INACTIVE\`).

### #6 — Rate-limit bypass via varying Bearer tokens
The pre-auth global limiter previously keyed on the raw Bearer token, so an attacker could mint a fresh 100/min bucket per made-up token, completely bypassing the per-IP cap. \`keyGenerator\` now returns \`req.ip\` only. Per-developer plan throughput remains the responsibility of the post-auth limiter.

### #7 — Email verification rebinding
The verify step now sets \`developers.email = verifiedEmail\` alongside \`email_verified = TRUE\`, so the canonical address is always the one that was actually proven. Adds an \`EMAIL_TAKEN\` (409) precheck so a developer can't claim an address another verified developer owns, preserving the application-level uniqueness invariant from signup.

### #8 — Verifications counter
Both \`/v1/grants/verify\` and \`/v1/tokens/verify\` now call \`incrementUsage(developerId, 'verifications')\`. The metric reported by \`/v1/usage\` will actually move.

### #5 — Custom-domains docs honesty
\`README.md\` and \`docs/guides/custom-domains.mdx\` no longer promise white-labeled consent UI / API endpoints. They describe what the current API actually does (registration + DNS verification) and flag runtime traffic routing through verified domains as on the roadmap. Implementing actual Cloud Run domain-mapping + per-tenant URL routing is a separate, larger change.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm test\` — **998/998 pass** (75 files)
- [x] New tests:
  - budget allocate: 404 NOT_FOUND when grant missing (was conflated with INACTIVE before Codex fix)
  - budget debit: 404 NOT_FOUND for unknown grant ID
  - verify-email: 409 EMAIL_TAKEN when another verified developer owns the address
  - verify-email: response now returns the verified \`email\` field
- [ ] Manual smoke after merge