### PR TITLE
docs: scope custom-domains messaging on landing page + SDK docs

### DIFF
--- a/docs/api-reference/domains/create.mdx
+++ b/docs/api-reference/domains/create.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Register Custom Domain"
 sidebarTitle: "Register Domain"
-description: "Register a custom domain for your Grantex deployment. Requires Enterprise plan."
+description: "Register a custom domain on your Grantex account. Returns a token to add as a DNS TXT record. Requires Enterprise plan. Runtime traffic routing on your domain is on the roadmap; today endpoints still resolve under *.grantex.dev."
 ---
 
 ## Endpoint

--- a/docs/sdks/go/domains.mdx
+++ b/docs/sdks/go/domains.mdx
@@ -1,11 +1,15 @@
 ---
 title: "Domains"
-description: "Register custom domains with DNS TXT verification for your Grantex API endpoints"
+description: "Register and verify custom domains for your Grantex account via DNS TXT records."
 ---
 
 ## Overview
 
-The `Domains` service manages custom domains for your Grantex API endpoints. Register a domain, verify ownership via DNS TXT records, list all registered domains, and remove them.
+The `Domains` service manages the registration and ownership-verification lifecycle for custom domains on your Grantex account. Register a domain, verify ownership via a DNS TXT record, list registered domains, and remove them.
+
+<Note>
+Today the API covers registration, DNS verification, listing, and deletion. Runtime traffic routing — having Grantex consent UI and API endpoints actually served from your verified domain — is on the roadmap; both still resolve under `*.grantex.dev`.
+</Note>
 
 ## Create
 

--- a/docs/sdks/python/domains.mdx
+++ b/docs/sdks/python/domains.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Domains"
 sidebarTitle: "Domains"
-description: "Register custom domains with DNS TXT verification for your Grantex API endpoints."
+description: "Register and verify custom domains for your Grantex account via DNS TXT records."
 ---
 
 ## Overview
 
-The `domains` client manages custom domains for your Grantex API endpoints. Register a domain, verify ownership via DNS TXT records, list all registered domains, and remove them.
+The `domains` client manages the registration and ownership-verification lifecycle for custom domains on your Grantex account. Register a domain, verify ownership via a DNS TXT record, list registered domains, and remove them.
+
+<Note>
+Today the API covers registration, DNS verification, listing, and deletion. Runtime traffic routing — having Grantex consent UI and API endpoints actually served from your verified domain — is on the roadmap; both still resolve under `*.grantex.dev`.
+</Note>
 
 Access the domains client via `client.domains`.
 

--- a/docs/sdks/typescript/domains.mdx
+++ b/docs/sdks/typescript/domains.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Domains"
 sidebarTitle: "Domains"
-description: "Register custom domains with DNS TXT verification for your Grantex API endpoints."
+description: "Register and verify custom domains for your Grantex account via DNS TXT records."
 ---
 
 ## Overview
 
-The `domains` sub-client manages custom domains for your Grantex API endpoints. Register a domain, verify ownership via DNS TXT records, list all registered domains, and remove them.
+The `domains` sub-client manages the registration and ownership-verification lifecycle for custom domains on your Grantex account. Register a domain, verify ownership via a DNS TXT record, list registered domains, and remove them.
+
+<Note>
+Today the API covers registration, DNS verification, listing, and deletion. Runtime traffic routing — having Grantex consent UI and API endpoints actually served from your verified domain — is on the roadmap; both still resolve under `*.grantex.dev`.
+</Note>
 
 ```typescript
 const domain = await grantex.domains.create({ domain: 'auth.example.com' });

--- a/web/index.html
+++ b/web/index.html
@@ -2523,7 +2523,7 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
             <span class="check">&#x2713;</span>
             <div>
               <h4><a href="https://docs.grantex.dev/guides/custom-domains" style="color:inherit;text-decoration:none;">Custom Domains</a></h4>
-              <p>Use your own domain for API endpoints with DNS TXT record verification.</p>
+              <p>Register and verify your domain via DNS TXT records. Runtime traffic routing on your domain is on the roadmap.</p>
             </div>
           </div>
           <div class="enterprise-feature">


### PR DESCRIPTION
## Summary

Follow-up to #285. That PR scoped \`README.md\` and \`docs/guides/custom-domains.mdx\` to match what custom domains actually do today (registration + DNS verification, no runtime routing). I missed these other surfaces:

- \`web/index.html\` — landing-page enterprise feature card overstated *"Use your own domain for API endpoints"*
- \`docs/sdks/typescript/domains.mdx\`
- \`docs/sdks/python/domains.mdx\`
- \`docs/sdks/go/domains.mdx\`
- \`docs/api-reference/domains/create.mdx\`

All now describe what's built and flag runtime traffic routing as on the roadmap. The other api-reference pages (verify, list, delete) describe specific actions accurately and are unchanged.

## Test plan

- [x] No code changed; docs-only and one HTML change
- [x] Manual eyeball of each updated file
- [ ] Mintlify auto-deploys docs; Firebase deploys landing page on merge