### PR TITLE
fix(auth): enable CORS for the developer dashboard

### DIFF
--- a/apps/auth-service/src/config.ts
+++ b/apps/auth-service/src/config.ts
@@ -50,6 +50,15 @@ export const config = {
   fidoOrigin: optional('FIDO_ORIGIN', 'https://grantex.dev'),
   // SSO state HMAC key (optional — derived from RSA_PRIVATE_KEY if not set)
   ssoStateSecret: process.env['SSO_STATE_SECRET'] ?? null,
+  // CORS: comma-separated list of browser origins allowed to call the API
+  // (developer dashboard, docs, etc.). Empty string disables CORS.
+  corsAllowedOrigins: optional(
+    'CORS_ALLOWED_ORIGINS',
+    'https://grantex.dev,https://portal.grantex.dev,http://localhost:5173',
+  )
+    .split(',')
+    .map((o) => o.trim())
+    .filter((o) => o.length > 0),
 } as const;
 
 if (!config.rsaPrivateKey && !config.autoGenerateKeys) {

--- a/apps/auth-service/src/server.ts
+++ b/apps/auth-service/src/server.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import Fastify from 'fastify';
 import cors from '@fastify/cors';
+import { config } from './config.js';
 import rateLimit from '@fastify/rate-limit';
 import { errorsPlugin } from './plugins/errors.js';
 import { authPlugin } from './plugins/auth.js';
@@ -63,7 +64,27 @@ export async function buildApp(opts: AppOptions = {}) {
     genReqId: () => randomUUID(),
   });
 
-  await app.register(cors, { origin: false });
+  // Browser clients (developer dashboard at grantex.dev/dashboard, local
+  // Vite during development) need to call the API cross-origin. Fastify-cors
+  // intercepts OPTIONS preflight before the auth preHandler runs, so allowed
+  // origins get proper Access-Control-Allow-Origin headers while unknown
+  // origins still fail the browser's CORS check.
+  const allowedOrigins = new Set(config.corsAllowedOrigins);
+  await app.register(cors, {
+    origin: (origin, cb) => {
+      // Same-origin and non-browser callers have no Origin header — allow.
+      if (!origin) return cb(null, true);
+      if (allowedOrigins.has(origin)) return cb(null, true);
+      // Unknown origin: reflect back "false" so the browser blocks the
+      // response but we don't throw a 5xx on the server.
+      return cb(null, false);
+    },
+    credentials: true,
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'Idempotency-Key'],
+    exposedHeaders: ['X-RateLimit-Limit', 'X-RateLimit-Remaining', 'X-RateLimit-Reset'],
+    maxAge: 600,
+  });
   await app.register(websocket);
 
   // HTTP security headers

--- a/apps/auth-service/tests/cors.test.ts
+++ b/apps/auth-service/tests/cors.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { buildTestApp } from './helpers.js';
+import type { FastifyInstance } from 'fastify';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+describe('CORS', () => {
+  it('allows preflight from https://grantex.dev and skips auth', async () => {
+    const res = await app.inject({
+      method: 'OPTIONS',
+      url: '/v1/signup',
+      headers: {
+        origin: 'https://grantex.dev',
+        'access-control-request-method': 'POST',
+        'access-control-request-headers': 'content-type',
+      },
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(res.headers['access-control-allow-origin']).toBe('https://grantex.dev');
+    expect(res.headers['access-control-allow-methods']).toContain('POST');
+  });
+
+  it('allows preflight from http://localhost:5173 (dev)', async () => {
+    const res = await app.inject({
+      method: 'OPTIONS',
+      url: '/v1/signup',
+      headers: {
+        origin: 'http://localhost:5173',
+        'access-control-request-method': 'POST',
+      },
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(res.headers['access-control-allow-origin']).toBe('http://localhost:5173');
+  });
+
+  it('does not reflect unknown origins', async () => {
+    const res = await app.inject({
+      method: 'OPTIONS',
+      url: '/v1/signup',
+      headers: {
+        origin: 'https://evil.example.com',
+        'access-control-request-method': 'POST',
+      },
+    });
+
+    // Fastify-cors returns 204 but does NOT set Allow-Origin for unknown
+    // origins, so the browser blocks the response.
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('actual POST from allowed origin returns Allow-Origin header', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/signup',
+      headers: {
+        origin: 'https://grantex.dev',
+        'content-type': 'application/json',
+      },
+      payload: {}, // empty body → 400, but CORS headers still land
+    });
+
+    expect(res.headers['access-control-allow-origin']).toBe('https://grantex.dev');
+  });
+});


### PR DESCRIPTION
## Symptom

Both \`grantex.dev/dashboard/signup\` and \`grantex.dev/dashboard/admin\` failed with \"Failed to fetch\". Admin page showed \"No developers found\" because the list call was blocked by the browser.

## Root cause

\`apps/auth-service/src/server.ts\` registered \`@fastify/cors\` with \`origin: false\`, which **disables CORS entirely** — no \`Access-Control-Allow-Origin\` header is returned. OPTIONS preflight then fell through to the auth \`preHandler\` and got 401.

\`\`\`
$ curl -I -X OPTIONS https://grantex-auth-dd4mtrt2gq-uc.a.run.app/v1/signup \
    -H 'Origin: https://grantex.dev' \
    -H 'Access-Control-Request-Method: POST'
HTTP/1.1 401 Unauthorized
(no access-control-allow-origin)
\`\`\`

Every cross-origin call from the portal → auth-service was blocked.

## Fix

Register \`@fastify/cors\` with a real allowlist (new \`CORS_ALLOWED_ORIGINS\` env var). Default: \`https://grantex.dev,https://portal.grantex.dev,http://localhost:5173\`. Fastify-cors intercepts OPTIONS before the auth hook, so allowed origins get proper preflight responses and unknown origins still fail the browser's CORS check (no \`Allow-Origin\` reflected — no server error either).

Also sets:
- \`credentials: true\`
- \`allowedHeaders\`: \`Content-Type\`, \`Authorization\`, \`Idempotency-Key\`
- \`exposedHeaders\`: rate-limit headers
- \`maxAge: 600\` (10-min preflight cache)

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — **1002/1002 pass** (76 files, new \`tests/cors.test.ts\`)
- [x] New tests cover: preflight from grantex.dev, preflight from localhost dev, unknown origin not reflected, actual POST from allowed origin returns Allow-Origin
- [ ] After merge: probe \`curl -I -X OPTIONS ...\` returns 204 with \`access-control-allow-origin: https://grantex.dev\`
- [ ] After merge: signup and admin pages work end-to-end in browser

## Follow-ups (separate PRs)

The original review also flagged that \`SEED_API_KEY\`, \`SEED_SANDBOX_KEY\`, \`ADMIN_API_KEY\`, and \`VAULT_ENCRYPTION_KEY\` are in plaintext Cloud Run env vars instead of Secret Manager. Should be moved + rotated in a follow-up.