### PR TITLE
fix(portal): repair MCP dashboard — match server response shape

### DIFF
--- a/apps/auth-service/src/routes/mcp-servers.ts
+++ b/apps/auth-service/src/routes/mcp-servers.ts
@@ -93,9 +93,13 @@ export async function mcpServersRoutes(app: FastifyInstance): Promise<void> {
         certified: r['certified'] as boolean,
         ...(r['certified_at'] ? { certifiedAt: (r['certified_at'] as Date).toISOString() } : {}),
         ...(r['certification_level'] ? { certificationLevel: r['certification_level'] as string } : {}),
-        ...(r['npm_package'] ? { npmPackage: r['npm_package'] as string } : {}),
+        serverUrl: (r['server_url'] as string | null) ?? null,
+        authEndpoint: (r['auth_endpoint'] as string | null) ?? null,
+        npmPackage: (r['npm_package'] as string | null) ?? null,
         weeklyActiveAgents: r['weekly_active_agents'] as number,
         stars: r['stars'] as number,
+        status: 'active' as const,
+        createdAt: (r['created_at'] as Date).toISOString(),
       }));
 
       const nextCursor = rows.length === limit ? (rows[rows.length - 1]!['id'] as string) : undefined;
@@ -138,7 +142,7 @@ export async function mcpServersRoutes(app: FastifyInstance): Promise<void> {
       const sql = getSql();
       const scopeList = scopes ?? [];
 
-      await sql`
+      const inserted = await sql<{ created_at: Date }[]>`
         INSERT INTO mcp_servers (
           id, developer_id, name, description, server_url, auth_endpoint,
           npm_package, category, scopes
@@ -148,6 +152,7 @@ export async function mcpServersRoutes(app: FastifyInstance): Promise<void> {
           ${serverUrl ?? null}, ${authEndpoint ?? null},
           ${npmPackage ?? null}, ${category}, ${scopeList}
         )
+        RETURNING created_at
       `;
 
       return reply.status(201).send({
@@ -163,6 +168,7 @@ export async function mcpServersRoutes(app: FastifyInstance): Promise<void> {
         weeklyActiveAgents: 0,
         stars: 0,
         status: 'active',
+        createdAt: inserted[0]!.created_at.toISOString(),
       });
     },
   );

--- a/apps/auth-service/tests/mcp-servers.test.ts
+++ b/apps/auth-service/tests/mcp-servers.test.ts
@@ -139,8 +139,8 @@ describe('GET /v1/mcp/servers', () => {
 describe('POST /v1/mcp/servers', () => {
   it('creates server (201)', async () => {
     seedAuth();
-    // Insert
-    sqlMock.mockResolvedValueOnce([]);
+    // Insert returns created_at
+    sqlMock.mockResolvedValueOnce([{ created_at: new Date('2026-04-14T00:00:00Z') }]);
 
     const res = await app.inject({
       method: 'POST',
@@ -162,6 +162,8 @@ describe('POST /v1/mcp/servers', () => {
     expect(body.category).toBe('productivity');
     expect(body.certified).toBe(false);
     expect(body.scopes).toEqual(['calendar:read']);
+    expect(body.status).toBe('active');
+    expect(body.createdAt).toBe('2026-04-14T00:00:00.000Z');
   });
 
   it('rejects missing name (400)', async () => {

--- a/apps/portal/src/api/__tests__/mcp.test.ts
+++ b/apps/portal/src/api/__tests__/mcp.test.ts
@@ -27,32 +27,32 @@ describe('mcp', () => {
   // ── listMcpServers ────────────────────────────────────────────────────
 
   it('listMcpServers without params sends GET /v1/mcp/servers', async () => {
-    ok({ servers: [{ id: 's1', name: 'Server 1' }] });
+    ok({ data: [{ serverId: 's1', name: 'Server 1' }], meta: { total: 1 } });
     const result = await listMcpServers();
     expect(result).toEqual([{ id: 's1', name: 'Server 1' }]);
     expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/mcp/servers', expect.objectContaining({ method: 'GET' }));
   });
 
   it('listMcpServers with category param', async () => {
-    ok({ servers: [] });
+    ok({ data: [], meta: { total: 0 } });
     await listMcpServers({ category: 'data' });
     expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/mcp/servers?category=data');
   });
 
   it('listMcpServers with certified param (true)', async () => {
-    ok({ servers: [] });
+    ok({ data: [], meta: { total: 0 } });
     await listMcpServers({ certified: true });
     expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/mcp/servers?certified=true');
   });
 
   it('listMcpServers with certified param (false)', async () => {
-    ok({ servers: [] });
+    ok({ data: [], meta: { total: 0 } });
     await listMcpServers({ certified: false });
     expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/mcp/servers?certified=false');
   });
 
   it('listMcpServers with both params', async () => {
-    ok({ servers: [] });
+    ok({ data: [], meta: { total: 0 } });
     await listMcpServers({ category: 'auth', certified: true });
     const url = mockFetch.mock.calls[0]![0];
     expect(url).toContain('category=auth');
@@ -67,14 +67,14 @@ describe('mcp', () => {
   // ── getMcpServer ──────────────────────────────────────────────────────
 
   it('getMcpServer sends GET /v1/mcp/servers/:id', async () => {
-    ok({ id: 's1', name: 'Server 1' });
+    ok({ serverId: 's1', name: 'Server 1' });
     const result = await getMcpServer('s1');
     expect(result).toEqual({ id: 's1', name: 'Server 1' });
     expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/v1/mcp/servers/s1', expect.objectContaining({ method: 'GET' }));
   });
 
   it('getMcpServer encodes id', async () => {
-    ok({ id: 's/1' });
+    ok({ serverId: 's/1' });
     await getMcpServer('s/1');
     expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:3000/v1/mcp/servers/s%2F1');
   });
@@ -88,7 +88,7 @@ describe('mcp', () => {
 
   it('createMcpServer sends POST /v1/mcp/servers with params', async () => {
     const params = { name: 'New Server', category: 'data', scopes: ['read'] };
-    ok({ id: 's2', ...params });
+    ok({ serverId: 's2', ...params });
     const result = await createMcpServer(params);
     expect(result).toEqual({ id: 's2', ...params });
     const [url, opts] = mockFetch.mock.calls[0]!;

--- a/apps/portal/src/api/mcp.ts
+++ b/apps/portal/src/api/mcp.ts
@@ -43,21 +43,36 @@ export interface ListMcpServersParams {
   certified?: boolean;
 }
 
+// Server returns { data: [{ serverId, ... }], meta: { total, cursor? } } —
+// normalize to the portal's { id, ... } shape.
+interface McpServerWire extends Omit<McpServer, 'id'> {
+  serverId: string;
+}
+
+function normalizeServer(w: McpServerWire): McpServer {
+  const { serverId, ...rest } = w;
+  return { id: serverId, ...rest };
+}
+
 export async function listMcpServers(params?: ListMcpServersParams): Promise<McpServer[]> {
   const query = new URLSearchParams();
   if (params?.category) query.set('category', params.category);
   if (params?.certified !== undefined) query.set('certified', String(params.certified));
   const qs = query.toString();
-  const res = await api.get<{ servers: McpServer[] }>(`/v1/mcp/servers${qs ? `?${qs}` : ''}`);
-  return res.servers;
+  const res = await api.get<{ data: McpServerWire[]; meta: { total: number; cursor?: string } }>(
+    `/v1/mcp/servers${qs ? `?${qs}` : ''}`,
+  );
+  return (res.data ?? []).map(normalizeServer);
 }
 
-export function getMcpServer(id: string): Promise<McpServer> {
-  return api.get<McpServer>(`/v1/mcp/servers/${encodeURIComponent(id)}`);
+export async function getMcpServer(id: string): Promise<McpServer> {
+  const res = await api.get<McpServerWire>(`/v1/mcp/servers/${encodeURIComponent(id)}`);
+  return normalizeServer(res);
 }
 
-export function createMcpServer(params: CreateMcpServerParams): Promise<McpServer> {
-  return api.post<McpServer>('/v1/mcp/servers', params);
+export async function createMcpServer(params: CreateMcpServerParams): Promise<McpServer> {
+  const res = await api.post<McpServerWire>('/v1/mcp/servers', params);
+  return normalizeServer(res);
 }
 
 export function applyForCertification(serverId: string, level: string): Promise<McpCertification> {


### PR DESCRIPTION
## Symptom

\`grantex.dev/dashboard/mcp\` crashed with:

> Something went wrong  
> Cannot read properties of undefined (reading 'length')

## Root cause

\`listMcpServers()\` in \`apps/portal/src/api/mcp.ts\` did:

\`\`\`ts
const res = await api.get<{ servers: McpServer[] }>('/v1/mcp/servers');
return res.servers;  // undefined — server returns { data, meta }, not { servers }
\`\`\`

The list page then did \`servers.length === 0\` on undefined → crash.

Contract drift beyond that single field:

| Portal expected | Server returned |
|---|---|
| \`{ servers: [] }\` | \`{ data: [], meta: { total, cursor? } }\` |
| \`id\` | \`serverId\` |
| \`status\`, \`createdAt\` on list items | missing |
| \`createdAt\` on POST response | missing |

## Fix

Portal adapts to the server shape rather than the other way round, because the server has explicit tests pinning \`{ data, meta }\` and \`serverId\`.

**Portal** (\`apps/portal/src/api/mcp.ts\`)
- \`listMcpServers\` unwraps \`{ data, meta }\` and maps \`serverId → id\`
- \`getMcpServer\` / \`createMcpServer\` route through the same normalizer
- Public \`McpServer\` type unchanged (still uses \`id\`); internal \`McpServerWire\` captures the on-the-wire shape

**Server** (\`apps/auth-service/src/routes/mcp-servers.ts\`)
- List item mapping now includes \`serverUrl\`, \`authEndpoint\`, \`npmPackage\`, \`status: 'active'\`, and \`createdAt\` — fields the list page renders but the handler wasn't sending
- \`POST /v1/mcp/servers\` now \`RETURNING created_at\` and returns it in the body

## Test plan

- [x] auth-service: \`npm test\` — **1002/1002 pass**
- [x] auth-service: \`npm run typecheck\` clean
- [x] portal: \`npx tsc --noEmit\` clean
- [x] portal: \`npm run build\` clean
- [x] portal: MCP API test suite **16/16 pass** (tests updated for new shape)
- [ ] After merge + deploy: \`/dashboard/mcp\` renders without error

## Note

Two tests in \`McpServerDetail.test.tsx\` (\"shows stats row\", \"shows Active Clients table\") fail on \`main\` today — \"Found multiple elements with the text: Active Clients\". Pre-existing, unrelated to this PR, left alone.