### PR TITLE
test(portal): fix 17 pre-existing test failures

### DIFF
--- a/apps/portal/src/pages/__tests__/AlertDetail.test.tsx
+++ b/apps/portal/src/pages/__tests__/AlertDetail.test.tsx
@@ -65,7 +65,12 @@ describe('AlertDetail', () => {
 
   it('acknowledges alert on button click', async () => {
     mockAcknowledgeAlert.mockResolvedValueOnce(undefined);
-    mockGetAlert.mockResolvedValue({ ...alert, status: 'acknowledged', acknowledgedAt: new Date().toISOString() });
+    // Initial fetch: open (so the Acknowledge button renders). Post-ack refresh:
+    // acknowledged. Previously this used mockResolvedValue with the final state,
+    // which hid the button at mount time.
+    mockGetAlert
+      .mockResolvedValueOnce(alert)
+      .mockResolvedValueOnce({ ...alert, status: 'acknowledged', acknowledgedAt: new Date().toISOString() });
     const user = userEvent.setup();
     r();
     await waitFor(() => expect(screen.getByRole('button', { name: 'Acknowledge' })).toBeInTheDocument());

--- a/apps/portal/src/pages/__tests__/BundleDetail.test.tsx
+++ b/apps/portal/src/pages/__tests__/BundleDetail.test.tsx
@@ -111,11 +111,13 @@ describe('BundleDetail', () => {
     r();
     await waitFor(() => expect(screen.getByText('Revoke Bundle')).toBeInTheDocument());
     await user.click(screen.getByText('Revoke Bundle'));
+    // Dialog message is "Are you sure you want to revoke this bundle? The
+    // device will lose offline authorization on its next sync." — so the
+    // exact-match lookup on just the question fails. Use a regex.
     await waitFor(() => {
-      const dialog = screen.getByText('Are you sure you want to revoke this bundle?').closest('div[class*="fixed"]')!;
-      expect(dialog).toBeInTheDocument();
+      expect(screen.getByText(/Are you sure you want to revoke this bundle\?/)).toBeInTheDocument();
     });
-    const dialog = screen.getByText('Are you sure you want to revoke this bundle?').closest('div[class*="fixed"]')!;
+    const dialog = screen.getByText(/Are you sure you want to revoke this bundle\?/).closest('div[class*="fixed"]')!;
     const btns = within(dialog as HTMLElement).getAllByRole('button', { name: 'Revoke' });
     await user.click(btns[btns.length - 1]!);
     await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Bundle revoked', 'success'));

--- a/apps/portal/src/pages/__tests__/ConsentRecordDetail.test.tsx
+++ b/apps/portal/src/pages/__tests__/ConsentRecordDetail.test.tsx
@@ -41,6 +41,9 @@ describe('ConsentRecordDetail', () => {
 
   it('has back navigation link', async () => {
     r();
-    await waitFor(() => expect(screen.getByText('Consent Records')).toBeInTheDocument());
+    // Link text is "← Consent Records" in one node, so exact match fails.
+    // Regex matches the label; also check by href to prove it's a real link.
+    await waitFor(() => expect(screen.getAllByText(/Consent Records/).length).toBeGreaterThan(0));
+    expect(document.querySelector('a[href="/dashboard/dpdp/records"]')).toBeTruthy();
   });
 });

--- a/apps/portal/src/pages/__tests__/ExportPage.test.tsx
+++ b/apps/portal/src/pages/__tests__/ExportPage.test.tsx
@@ -24,7 +24,9 @@ describe('ExportPage', () => {
 
   it('shows Generate Export form', () => {
     r();
-    expect(screen.getByText('Generate Export')).toBeInTheDocument();
+    // Appears as a section heading AND as the submit button label.
+    expect(screen.getByRole('heading', { name: 'Generate Export' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Generate Export' })).toBeInTheDocument();
   });
 
   it('shows export type options', () => {

--- a/apps/portal/src/pages/__tests__/GrievanceList.test.tsx
+++ b/apps/portal/src/pages/__tests__/GrievanceList.test.tsx
@@ -31,20 +31,21 @@ describe('GrievanceList', () => {
 
   it('has File Grievance button', () => {
     r();
-    expect(screen.getByText('File Grievance')).toBeInTheDocument();
+    // Header toggle + empty-state CTA both render "File Grievance" — both expected.
+    expect(screen.getAllByRole('button', { name: 'File Grievance' }).length).toBeGreaterThan(0);
   });
 
   it('opens file form on button click', async () => {
     const user = userEvent.setup();
     r();
-    await user.click(screen.getByText('File Grievance'));
+    await user.click(screen.getAllByRole('button', { name: 'File Grievance' })[0]!);
     await waitFor(() => expect(screen.getByText('File New Grievance')).toBeInTheDocument());
   });
 
   it('shows grievance form fields', async () => {
     const user = userEvent.setup();
     r();
-    await user.click(screen.getByText('File Grievance'));
+    await user.click(screen.getAllByRole('button', { name: 'File Grievance' })[0]!);
     await waitFor(() => expect(screen.getByText('Data Principal ID *')).toBeInTheDocument());
     expect(screen.getByText('Type *')).toBeInTheDocument();
     expect(screen.getByText('Description *')).toBeInTheDocument();
@@ -58,11 +59,12 @@ describe('GrievanceList', () => {
     });
     const user = userEvent.setup();
     r();
-    await user.click(screen.getByText('File Grievance'));
+    await user.click(screen.getAllByRole('button', { name: 'File Grievance' })[0]!);
     await waitFor(() => expect(screen.getByText('File New Grievance')).toBeInTheDocument());
     await user.type(screen.getByPlaceholderText('e.g. user_123'), 'user-1');
     await user.type(screen.getByPlaceholderText('Describe the grievance...'), 'Request data erasure');
-    await user.click(screen.getAllByText('File Grievance').find(el => el.tagName === 'BUTTON' && el.getAttribute('type') === 'submit')!);
+    const submit = screen.getAllByRole('button', { name: 'File Grievance' }).find((b) => (b as HTMLButtonElement).type === 'submit')!;
+    await user.click(submit);
     await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Grievance filed: REF-001', 'success'));
   });
 
@@ -70,11 +72,12 @@ describe('GrievanceList', () => {
     mockFileGrievance.mockRejectedValueOnce(new Error('fail'));
     const user = userEvent.setup();
     r();
-    await user.click(screen.getByText('File Grievance'));
+    await user.click(screen.getAllByRole('button', { name: 'File Grievance' })[0]!);
     await waitFor(() => expect(screen.getByText('File New Grievance')).toBeInTheDocument());
     await user.type(screen.getByPlaceholderText('e.g. user_123'), 'user-1');
     await user.type(screen.getByPlaceholderText('Describe the grievance...'), 'Test');
-    await user.click(screen.getAllByText('File Grievance').find(el => el.tagName === 'BUTTON' && el.getAttribute('type') === 'submit')!);
+    const submit = screen.getAllByRole('button', { name: 'File Grievance' }).find((b) => (b as HTMLButtonElement).type === 'submit')!;
+    await user.click(submit);
     await waitFor(() => expect(mockShow).toHaveBeenCalledWith('Failed to file grievance', 'error'));
   });
 
@@ -115,7 +118,7 @@ describe('GrievanceList', () => {
   it('shows grievance type dropdown', async () => {
     const user = userEvent.setup();
     r();
-    await user.click(screen.getByText('File Grievance'));
+    await user.click(screen.getAllByRole('button', { name: 'File Grievance' })[0]!);
     await waitFor(() => expect(screen.getByText('Type *')).toBeInTheDocument());
   });
 });

--- a/apps/portal/src/pages/__tests__/McpServerDetail.test.tsx
+++ b/apps/portal/src/pages/__tests__/McpServerDetail.test.tsx
@@ -73,8 +73,10 @@ describe('McpServerDetail', () => {
     r();
     await waitFor(() => expect(screen.getByText('Weekly Agents')).toBeInTheDocument());
     expect(screen.getByText('Stars')).toBeInTheDocument();
-    expect(screen.getByText('142')).toBeInTheDocument();
-    expect(screen.getByText('87')).toBeInTheDocument();
+    // 142 (weekly agents) is also listed in the Active Clients sample table,
+    // so the numeric text can appear multiple times by design.
+    expect(screen.getAllByText('142').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('87').length).toBeGreaterThan(0);
   });
 
   it('shows certification section', async () => {
@@ -118,7 +120,8 @@ describe('McpServerDetail', () => {
 
   it('shows Active Clients table', async () => {
     r();
-    await waitFor(() => expect(screen.getByText('Active Clients')).toBeInTheDocument());
+    // "Active Clients" appears as both a stat label and a section heading.
+    await waitFor(() => expect(screen.getAllByText('Active Clients').length).toBeGreaterThan(0));
     expect(screen.getByText('data-pipeline-agent')).toBeInTheDocument();
   });
 });

--- a/apps/portal/src/pages/__tests__/PolicyForm.test.tsx
+++ b/apps/portal/src/pages/__tests__/PolicyForm.test.tsx
@@ -42,7 +42,8 @@ describe('PolicyForm', () => {
 
   it('renders Create Policy mode', () => {
     renderCreate();
-    expect(screen.getByText('Create Policy')).toBeInTheDocument();
+    // "Create Policy" appears as both the page heading and the submit button.
+    expect(screen.getByRole('heading', { name: 'Create Policy' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create Policy' })).toBeInTheDocument();
   });
 

--- a/apps/portal/src/pages/__tests__/WebhookDeliveries.test.tsx
+++ b/apps/portal/src/pages/__tests__/WebhookDeliveries.test.tsx
@@ -38,9 +38,10 @@ describe('WebhookDeliveries', () => {
 
   it('shows delivery status badges', async () => {
     r();
-    await waitFor(() => expect(screen.getByText('delivered')).toBeInTheDocument());
-    expect(screen.getByText('failed')).toBeInTheDocument();
-    expect(screen.getByText('pending')).toBeInTheDocument();
+    // 'delivered' appears as both a filter button and row badge — both are expected.
+    await waitFor(() => expect(screen.getAllByText('delivered').length).toBeGreaterThan(0));
+    expect(screen.getAllByText('failed').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('pending').length).toBeGreaterThan(0);
   });
 
   it('shows event types', async () => {
@@ -57,7 +58,8 @@ describe('WebhookDeliveries', () => {
 
   it('shows attempt counts', async () => {
     r();
-    await waitFor(() => expect(screen.getByText('1/3')).toBeInTheDocument());
+    // Two deliveries both show "1/3" so the row renders duplicates by design.
+    await waitFor(() => expect(screen.getAllByText('1/3').length).toBeGreaterThanOrEqual(1));
     expect(screen.getByText('3/3')).toBeInTheDocument();
   });
 
@@ -75,10 +77,10 @@ describe('WebhookDeliveries', () => {
 
   it('has status filter buttons', async () => {
     r();
-    await waitFor(() => expect(screen.getByText('All')).toBeInTheDocument());
-    expect(screen.getByText('delivered')).toBeInTheDocument();
-    expect(screen.getByText('pending')).toBeInTheDocument();
-    expect(screen.getByText('failed')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'delivered' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'pending' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'failed' })).toBeInTheDocument();
   });
 
   it('has back link to webhooks', async () => {

--- a/apps/portal/src/store/__tests__/auth.test.tsx
+++ b/apps/portal/src/store/__tests__/auth.test.tsx
@@ -34,7 +34,9 @@ function AuthTestHarness() {
       <div data-testid="api-key">{apiKey ?? 'null'}</div>
       <div data-testid="developer-name">{developer?.name ?? 'null'}</div>
       <div data-testid="loading">{loading ? 'true' : 'false'}</div>
-      <button onClick={() => login('gx_live_test123')}>Login</button>
+      {/* Swallow the rejection in the harness — individual tests that care
+          about the failure path assert via mocks, not via a thrown promise. */}
+      <button onClick={() => { login('gx_live_test123').catch(() => {}); }}>Login</button>
       <button onClick={logout}>Logout</button>
     </div>
   );


### PR DESCRIPTION
## Summary

Cleans up 17 pre-existing portal test failures across 9 files. **Test-only changes** — application code is untouched. All failures were present on \`main\` before this PR.

## Root causes

### Bucket A — "Found multiple elements with text X" (11 failures)

The UI legitimately renders the same label in multiple spots (page heading + button, filter + row badge, toggle + empty-state CTA). Tests used \`getByText\` which throws on duplicates. Fixes:
- \`getByRole('button' | 'heading', { name })\` when the role disambiguates
- \`getAllByText(...).length > 0\` when duplication is by design

Files: \`WebhookDeliveries\` (3), \`GrievanceList\` (6), \`ExportPage\` (1), \`PolicyForm\` (1), \`McpServerDetail\` (2)

### Bucket B — "Unable to find element with text X" (3 failures)

- \`ConsentRecordDetail "has back navigation link"\`: link text is \`"← Consent Records"\` in one node, exact match fails. Regex + href assertion.
- \`BundleDetail "revokes bundle on confirm"\`: dialog message is the full sentence (\"Are you sure... The device will lose offline authorization on its next sync.\"), not just the question. Regex.

### Bucket C — test mock-chain bug (1 failure)

\`AlertDetail "acknowledges alert on button click"\` used \`mockResolvedValue\` (sticky) with \`status: 'acknowledged'\`. That applied to the initial fetch too, so the Acknowledge button never rendered (only shown when \`status === 'open'\`). Switched to \`mockResolvedValueOnce\` chain: open at mount, acknowledged on refresh.

### Bonus — unhandled-rejection warning

\`auth.test.tsx\`'s harness Login button called \`login()\` without a catch. In the propagates-error test, the rejection bubbled to vitest as an unhandled rejection. Swallowed in the harness.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [x] \`npm test\` — **887/887 tests pass, 94/94 files, 0 errors** (was: 17 failing + 1 error on main)