### PR TITLE
fix(e2e): pass explicit issuer for offline token verification

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,8 @@ jobs:
     name: E2E Smoke Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      E2E_ISSUER: https://grantex.dev
 
     steps:
       - uses: actions/checkout@v6

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -58,6 +58,8 @@ await grantex.tokens.revoke(grant.tokenId);
 const grantex = new Grantex({
   apiKey: 'gx_....',              // or set GRANTEX_API_KEY env var
   baseUrl: 'https://api.grantex.dev', // default
+  issuer: 'https://grantex.dev',  // optional when token issuer differs from API host
+  jwksUri: 'https://api.grantex.dev/.well-known/jwks.json', // optional JWKS override
   timeout: 30000,                 // request timeout in ms (default: 30s)
 });
 ```
@@ -66,6 +68,8 @@ const grantex = new Grantex({
 |--------|------|---------|-------------|
 | `apiKey` | `string` | `process.env.GRANTEX_API_KEY` | API key for authentication |
 | `baseUrl` | `string` | `https://api.grantex.dev` | Base URL of the Grantex API |
+| `issuer` | `string` | derived from `jwksUri` | Expected JWT issuer for offline verification |
+| `jwksUri` | `string` | `${baseUrl}/.well-known/jwks.json` | JWKS URL used for offline verification |
 | `timeout` | `number` | `30000` | Request timeout in milliseconds |
 
 ## PKCE Support
@@ -304,10 +308,13 @@ import { verifyGrantToken } from '@grantex/sdk';
 
 const grant = await verifyGrantToken('eyJhbG...', {
   jwksUri: 'https://api.grantex.dev/.well-known/jwks.json',
+  issuer: 'https://grantex.dev',   // optional when issuer differs from JWKS host
   requiredScopes: ['files:read'],   // optional — rejects if missing
   audience: 'https://myapp.com',    // optional — validates aud claim
 });
 ```
+
+If you call a deployment through a raw Cloud Run URL or another internal host, but the service signs tokens for a canonical public domain, pass `issuer` explicitly. Otherwise offline verification will reject a valid token because the JWT `iss` claim will not match the transport host.
 
 **Returns**: `VerifiedGrant`
 

--- a/packages/sdk-ts/src/client.ts
+++ b/packages/sdk-ts/src/client.ts
@@ -41,6 +41,7 @@ export class Grantex {
   readonly #http: HttpClient;
   readonly #manifests: Map<string, ToolManifest> = new Map();
   #jwksUri: string;
+  #issuer: string | undefined;
   #enforceMode: 'strict' | 'permissive';
 
   readonly agents: AgentsClient;
@@ -72,6 +73,8 @@ export class Grantex {
   constructor(options: GrantexClientOptions = {}) {
     const apiKey =
       options.apiKey ?? process.env['GRANTEX_API_KEY'] ?? '';
+    const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+    const normalizedBaseUrl = baseUrl.replace(/\/$/, '');
 
     if (!apiKey) {
       throw new Error(
@@ -80,7 +83,7 @@ export class Grantex {
     }
 
     this.#http = new HttpClient({
-      baseUrl: options.baseUrl ?? DEFAULT_BASE_URL,
+      baseUrl,
       apiKey,
       ...(options.timeout !== undefined ? { timeout: options.timeout } : {}),
       ...(options.maxRetries !== undefined ? { maxRetries: options.maxRetries } : {}),
@@ -98,7 +101,7 @@ export class Grantex {
     this.scim = new ScimClient(this.#http);
     this.sso = new SsoClient(this.#http);
     this.principalSessions = new PrincipalSessionsClient(this.#http);
-    this.vault = new VaultClient(this.#http, options.baseUrl ?? DEFAULT_BASE_URL);
+    this.vault = new VaultClient(this.#http, baseUrl);
     this.budgets = new BudgetsClient(this.#http);
     this.events = new EventsClient(this.#http);
     this.usage = new UsageClient(this.#http);
@@ -107,7 +110,8 @@ export class Grantex {
     this.credentials = new CredentialsClient(this.#http);
     this.passports = new PassportsClient(this.#http);
     this.dpdp = new DpdpClient(this.#http);
-    this.#jwksUri = `${(options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '')}/.well-known/jwks.json`;
+    this.#jwksUri = options.jwksUri ?? `${normalizedBaseUrl}/.well-known/jwks.json`;
+    this.#issuer = options.issuer;
     this.#enforceMode = (options as Record<string, unknown>)['enforceMode'] as 'strict' | 'permissive' ?? 'strict';
   }
 
@@ -232,7 +236,10 @@ export class Grantex {
     // 1. Verify the token offline via JWKS
     let grant: VerifiedGrant;
     try {
-      grant = await verifyGrantToken(grantToken, { jwksUri: this.#jwksUri });
+      grant = await verifyGrantToken(grantToken, {
+        jwksUri: this.#jwksUri,
+        ...(this.#issuer !== undefined ? { issuer: this.#issuer } : {}),
+      });
     } catch (err) {
       return this.#applyEnforceMode({
         ...base,

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -14,6 +14,10 @@ export interface GrantexClientOptions {
   apiKey?: string;
   /** Base URL for the Grantex API. Defaults to https://api.grantex.dev */
   baseUrl?: string;
+  /** Override the JWKS URL used for offline token verification. Defaults to `${baseUrl}/.well-known/jwks.json`. */
+  jwksUri?: string;
+  /** Expected JWT issuer for offline token verification. Set this when tokens are issued for a canonical domain different from `baseUrl`. */
+  issuer?: string;
   /** Request timeout in milliseconds. Defaults to 30000. */
   timeout?: number;
   /** Maximum number of retries for transient failures (429, 502, 503, 504). Defaults to 3. Set to 0 to disable. */

--- a/packages/sdk-ts/tests/enforce.test.ts
+++ b/packages/sdk-ts/tests/enforce.test.ts
@@ -83,6 +83,32 @@ describe('enforce()', () => {
     expect(result.permission).toBe(Permission.WRITE);
   });
 
+  it('passes explicit issuer and jwksUri overrides to offline verification', async () => {
+    vi.mocked(verifyGrantToken).mockResolvedValue(
+      makeGrant({ scopes: ['tool:salesforce:write'] }),
+    );
+    vi.stubGlobal('fetch', makeFetch(200, {}));
+
+    const grantex = new Grantex({
+      apiKey: 'test_key',
+      baseUrl: 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app',
+      jwksUri: 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app/.well-known/jwks.json',
+      issuer: 'https://grantex.dev',
+    });
+    grantex.loadManifest(salesforceManifest);
+
+    await grantex.enforce({
+      grantToken: 'fake.token',
+      connector: 'salesforce',
+      tool: 'create_lead',
+    });
+
+    expect(verifyGrantToken).toHaveBeenCalledWith('fake.token', {
+      jwksUri: 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app/.well-known/jwks.json',
+      issuer: 'https://grantex.dev',
+    });
+  });
+
   it('returns denied when scope is insufficient (read scope, write tool)', async () => {
     vi.mocked(verifyGrantToken).mockResolvedValue(
       makeGrant({ scopes: ['tool:salesforce:read'] }),

--- a/tests/e2e/cross-feature.test.ts
+++ b/tests/e2e/cross-feature.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { Grantex, verifyGrantToken } from '@grantex/sdk';
 
 const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+const ISSUER = process.env.E2E_ISSUER ?? 'https://grantex.dev';
 const JWKS_URI = `${BASE_URL}/.well-known/jwks.json`;
 
 let grantex: Grantex;
@@ -142,7 +143,7 @@ describe('E2E: Revocation Cascade', () => {
     expect(childVerifyBefore.valid).toBe(true);
 
     // Verify delegation claims in the child token
-    const childGrant = await verifyGrantToken(delegated.grantToken, { jwksUri: JWKS_URI });
+    const childGrant = await verifyGrantToken(delegated.grantToken, { jwksUri: JWKS_URI, issuer: ISSUER });
     expect(childGrant.parentGrantId).toBeDefined();
     expect(childGrant.delegationDepth).toBeGreaterThanOrEqual(1);
 

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { Grantex, verifyGrantToken } from '@grantex/sdk';
 
 const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+const ISSUER = process.env.E2E_ISSUER ?? 'https://grantex.dev';
 const JWKS_URI = `${BASE_URL}/.well-known/jwks.json`;
 
 let grantex: Grantex;
@@ -117,7 +118,7 @@ describe('E2E: Full Auth Flow', () => {
   });
 
   it('should verify the grant token offline (JWKS)', async () => {
-    const grant = await verifyGrantToken(grantToken, { jwksUri: JWKS_URI });
+    const grant = await verifyGrantToken(grantToken, { jwksUri: JWKS_URI, issuer: ISSUER });
 
     expect(grant.grantId).toBe(grantId);
     expect(grant.scopes).toEqual(expect.arrayContaining(['calendar:read', 'email:send']));
@@ -147,7 +148,7 @@ describe('E2E: Full Auth Flow', () => {
 
   it('should revoke the grant token', async () => {
     // Get the current token's ID (after refresh, tokenId points to old token)
-    const currentGrant = await verifyGrantToken(grantToken, { jwksUri: JWKS_URI });
+    const currentGrant = await verifyGrantToken(grantToken, { jwksUri: JWKS_URI, issuer: ISSUER });
     await grantex.tokens.revoke(currentGrant.tokenId);
 
     const result = await grantex.tokens.verify(grantToken);
@@ -235,7 +236,7 @@ describe('E2E: Grant Delegation', () => {
       scopes: ['calendar:read'],
     });
 
-    const grant = await verifyGrantToken(delegation.grantToken, { jwksUri: JWKS_URI });
+    const grant = await verifyGrantToken(delegation.grantToken, { jwksUri: JWKS_URI, issuer: ISSUER });
 
     expect(grant.parentGrantId).toBeDefined();
     expect(grant.delegationDepth).toBeGreaterThanOrEqual(1);

--- a/tests/e2e/enforce-integration.test.ts
+++ b/tests/e2e/enforce-integration.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { Grantex, ToolManifest, Permission } from '@grantex/sdk';
 
 const BASE_URL = process.env.E2E_BASE_URL ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
+const ISSUER = process.env.E2E_ISSUER ?? 'https://grantex.dev';
 
 let grantex: Grantex;
 let apiKey: string;
@@ -13,7 +14,7 @@ let apiKey: string;
 beforeAll(async () => {
   const account = await Grantex.signup({ name: `e2e-enforce-${Date.now()}`, mode: 'sandbox' }, { baseUrl: BASE_URL });
   apiKey = account.apiKey;
-  grantex = new Grantex({ apiKey, baseUrl: BASE_URL });
+  grantex = new Grantex({ apiKey, baseUrl: BASE_URL, issuer: ISSUER });
 
   // Load manifest
   grantex.loadManifest(new ToolManifest({


### PR DESCRIPTION
## Summary
- Nightly E2E smoke tests have been failing for 4 consecutive nights (runs 24433521818 → 24594942627) with `unexpected "iss" claim value`. Root cause: JWKS is served from the Cloud Run URL (`https://grantex-auth-dd4mtrt2gq-uc.a.run.app`) but tokens are signed with `iss: https://grantex.dev`. When only `jwksUri` is supplied, `verifyGrantToken` derives the expected issuer from the JWKS host, which never matches.
- Add `issuer` and `jwksUri` options to `GrantexClientOptions` and thread `issuer` through `enforce()`'s offline verification path.
- Pass `issuer: https://grantex.dev` (overridable via `E2E_ISSUER`) from the three E2E test files, and set `E2E_ISSUER` at the workflow job level.

## Test plan
- [x] `npm test` in `packages/sdk-ts` — 403/403 pass (new test added for the overrides)
- [x] `E2E_ISSUER=https://grantex.dev npx vitest run tests/e2e/e2e.test.ts` — 12/12 pass against production
- [x] `E2E_ISSUER=https://grantex.dev npx vitest run tests/e2e/cross-feature.test.ts tests/e2e/enforce-integration.test.ts` — 16/16 pass
- [ ] Nightly scheduled run on `main` after merge goes green


@codex please review
