### PR TITLE
fix(hosting): route all client-reachable paths from grantex.dev to Cloud Run; split config

### DIFF
--- a/.github/workflows/deploy-portal.yml
+++ b/.github/workflows/deploy-portal.yml
@@ -53,3 +53,33 @@ jobs:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
           projectId: grantex-prod
           channelId: live
+
+      - name: Smoke test Firebase -> Cloud Run rewrites
+        run: |
+          set -e
+          BASE=https://grantex.dev
+
+          # Give Firebase CDN a moment to pick up the new config.
+          sleep 15
+
+          check() {
+            local path="$1"
+            local expect_substr="$2"
+            local url="$BASE$path"
+            echo "--- GET $url"
+            local body
+            body=$(curl -sS -L --fail --max-time 20 "$url")
+            if ! grep -q "$expect_substr" <<<"$body"; then
+              echo "FAIL: $url did not contain '$expect_substr'"
+              echo "---- response head ----"
+              head -c 500 <<<"$body"
+              exit 1
+            fi
+            echo "OK"
+          }
+
+          # /consent always returns HTML regardless of req param — the page JS
+          # handles not-found cases after loading.
+          check "/consent?req=smoke-test" "Authorization Request"
+          check "/.well-known/jwks.json" "\"keys\""
+          check "/.well-known/did.json" "\"id\""

--- a/apps/auth-service/src/config.ts
+++ b/apps/auth-service/src/config.ts
@@ -18,6 +18,13 @@ export const config = {
   rsaPrivateKey: process.env['RSA_PRIVATE_KEY'] ?? null,
   autoGenerateKeys: process.env['AUTO_GENERATE_KEYS'] === 'true',
   jwtIssuer: optional('JWT_ISSUER', 'https://grantex.dev'),
+  // Base URL for client-facing pages and endpoints embedded in responses
+  // (consent page, VC status lists, offline-sync endpoint, email links).
+  // Defaults to JWT_ISSUER for back-compat, but is conceptually distinct:
+  // jwtIssuer is the JWT `iss` claim string, publicBaseUrl is the
+  // browser-reachable base URL. They differ when the issuer URL is fronted
+  // by a static host (Firebase) that proxies only some paths to the API.
+  publicBaseUrl: optional('PUBLIC_BASE_URL', process.env['JWT_ISSUER'] ?? 'https://grantex.dev'),
   seedApiKey: process.env['SEED_API_KEY'] ?? null,
   seedSandboxKey: process.env['SEED_SANDBOX_KEY'] ?? null,
   // Stripe billing (optional — billing endpoints return 503 when not configured)

--- a/apps/auth-service/src/lib/vc.ts
+++ b/apps/auth-service/src/lib/vc.ts
@@ -163,11 +163,11 @@ export async function issueAgentGrantVC(params: IssueVCParams): Promise<{
   };
 
   const credentialStatus = {
-    id: `${config.jwtIssuer}/v1/credentials/status/${statusList.id}#${statusListIdx}`,
+    id: `${config.publicBaseUrl}/v1/credentials/status/${statusList.id}#${statusListIdx}`,
     type: 'StatusList2021Entry',
     statusPurpose: 'revocation',
     statusListIndex: String(statusListIdx),
-    statusListCredential: `${config.jwtIssuer}/v1/credentials/status/${statusList.id}`,
+    statusListCredential: `${config.publicBaseUrl}/v1/credentials/status/${statusList.id}`,
   };
 
   const evidence: Record<string, unknown>[] = [];
@@ -364,12 +364,12 @@ export async function buildStatusListCredential(
       'https://www.w3.org/ns/credentials/v2',
       'https://w3id.org/vc/status-list/2021/v1',
     ],
-    id: `${config.jwtIssuer}/v1/credentials/status/${list['id'] as string}`,
+    id: `${config.publicBaseUrl}/v1/credentials/status/${list['id'] as string}`,
     type: ['VerifiableCredential', 'StatusList2021Credential'],
     issuer: issuerDid,
     issued: (list['updated_at'] as Date).toISOString(),
     credentialSubject: {
-      id: `${config.jwtIssuer}/v1/credentials/status/${list['id'] as string}#list`,
+      id: `${config.publicBaseUrl}/v1/credentials/status/${list['id'] as string}#list`,
       type: 'StatusList2021',
       statusPurpose: list['purpose'] as string,
       encodedList: list['encoded_list'] as string,

--- a/apps/auth-service/src/routes/authorize.ts
+++ b/apps/auth-service/src/routes/authorize.ts
@@ -135,7 +135,7 @@ export async function authorizeRoutes(app: FastifyInstance): Promise<void> {
       )
     `;
 
-    const consentUrl = `${config.jwtIssuer}/consent?req=${id}`;
+    const consentUrl = `${config.publicBaseUrl}/consent?req=${id}`;
 
     const responseBody: Record<string, unknown> = {
       authRequestId: id,

--- a/apps/auth-service/src/routes/consent-bundles.ts
+++ b/apps/auth-service/src/routes/consent-bundles.ts
@@ -170,7 +170,7 @@ export async function consentBundlesRoutes(app: FastifyInstance): Promise<void> 
           jwksSnapshot,
           offlineAuditKey,
           checkpointAt,
-          syncEndpoint: `${config.jwtIssuer}/v1/audit/offline-sync`,
+          syncEndpoint: `${config.publicBaseUrl}/v1/audit/offline-sync`,
           offlineExpiresAt: offlineExpiresAt.toISOString(),
         },
       });
@@ -431,7 +431,7 @@ export async function consentBundlesRoutes(app: FastifyInstance): Promise<void> 
         jwksSnapshot,
         offlineExpiresAt: offlineExpiresAt.toISOString(),
         checkpointAt: Math.floor(Date.now() / 1000),
-        syncEndpoint: `${config.jwtIssuer}/v1/audit/offline-sync`,
+        syncEndpoint: `${config.publicBaseUrl}/v1/audit/offline-sync`,
       });
     },
   );

--- a/apps/auth-service/src/routes/passport.ts
+++ b/apps/auth-service/src/routes/passport.ts
@@ -187,11 +187,11 @@ export async function passportRoutes(app: FastifyInstance): Promise<void> {
       `;
 
       const credentialStatus = {
-        id: `${config.jwtIssuer}/v1/credentials/status/${statusList.id}#${statusListIdx}`,
+        id: `${config.publicBaseUrl}/v1/credentials/status/${statusList.id}#${statusListIdx}`,
         type: 'StatusList2021Entry',
         statusPurpose: 'revocation',
         statusListIndex: String(statusListIdx),
-        statusListCredential: `${config.jwtIssuer}/v1/credentials/status/${statusList.id}`,
+        statusListCredential: `${config.publicBaseUrl}/v1/credentials/status/${statusList.id}`,
       };
 
       const credentialSubject: Record<string, unknown> = {

--- a/apps/auth-service/src/routes/verify-email.ts
+++ b/apps/auth-service/src/routes/verify-email.ts
@@ -34,7 +34,7 @@ export async function verifyEmailRoutes(app: FastifyInstance): Promise<void> {
       await sendEmail({
         to: email,
         subject: 'Verify your Grantex email',
-        html: verificationEmailHtml(token, config.jwtIssuer),
+        html: verificationEmailHtml(token, config.publicBaseUrl),
       });
     } catch {
       // Email send failure is non-fatal

--- a/firebase.json
+++ b/firebase.json
@@ -11,6 +11,11 @@
     "rewrites": [
       { "source": "/consent", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
       { "source": "/v1/consent/**", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
+      { "source": "/.well-known/jwks.json", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
+      { "source": "/.well-known/did.json", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
+      { "source": "/v1/audit/offline-sync", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
+      { "source": "/v1/credentials/status/**", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
+      { "source": "/v1/signup/verify/**", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
       { "source": "/dashboard/**", "destination": "/dashboard/index.html" },
       { "source": "/playground", "destination": "/playground.html" },
       { "source": "/for/:framework", "destination": "/for/index.html" },

--- a/firebase.json
+++ b/firebase.json
@@ -9,6 +9,8 @@
       { "source": "/docs/:path*", "destination": "https://docs.grantex.dev/:path*", "type": 301 }
     ],
     "rewrites": [
+      { "source": "/consent", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
+      { "source": "/v1/consent/**", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
       { "source": "/dashboard/**", "destination": "/dashboard/index.html" },
       { "source": "/playground", "destination": "/playground.html" },
       { "source": "/for/:framework", "destination": "/for/index.html" },


### PR DESCRIPTION
## Summary

Audit of every client-reachable URL the auth service embeds in API responses found **7 paths** built off `config.jwtIssuer` (which defaults to `https://grantex.dev`), but Firebase Hosting had no rewrite for any of them — so every one returned a 404 on grantex.dev in production:

| Path | Used by | Consequence in prod today |
|---|---|---|
| `/consent` | Principal consent page (live-mode grant flow) | **Live authorize flow 404s** (the reported bug — `areq_01KPQKXAA4KRHWBXGZNA1X9F42`) |
| `/v1/consent/**` | Fetch/approve/deny endpoints the consent page calls | Page can't load request details or submit approval |
| `/.well-known/jwks.json` | Offline JWT verification (RFC 8414 discovery) | Standard JWKS discovery from `iss` fails; SDKs must hardcode Cloud Run URL |
| `/.well-known/did.json` | DID resolution for `did:web:grantex.dev` | Wallets/verifiers can't resolve the issuer DID |
| `/v1/audit/offline-sync` | `syncEndpoint` in consent bundles | Offline clients can't sync audit logs |
| `/v1/credentials/status/**` | `credentialStatus.statusListCredential` in issued VCs | Verifiers can't check VC revocation |
| `/v1/signup/verify/**` | Email verification link | Users can't complete signup from the email |

Verified current prod state before the fix — all 7 return 404 HTML from Firebase; all 7 serve 200/JSON correctly on the Cloud Run URL. Rewrites will make them reachable.

## Changes

1. **`firebase.json`** — add same-project Cloud Run rewrites for all 7 paths (`grantex-prod` / `us-central1` / `grantex-auth`).

2. **`apps/auth-service/src/config.ts`** — split conceptually-distinct URLs that were conflated in `jwtIssuer`:
   - `jwtIssuer` — JWT `iss` claim string only (used in `lib/crypto.ts` sign/verify).
   - `publicBaseUrl` — browser-reachable base URL for pages and endpoints embedded in API responses. Defaults to `JWT_ISSUER` for back-compat.
   
   RFC 8414 JWKS discovery still works: `iss = https://grantex.dev` → JWKS fetched at `https://grantex.dev/.well-known/jwks.json` via the new rewrite.

3. **URL builders switched to `publicBaseUrl`** — `routes/authorize.ts`, `routes/consent-bundles.ts`, `routes/passport.ts`, `routes/verify-email.ts`, `lib/vc.ts`. JWT signing/verification in `lib/crypto.ts` keeps `jwtIssuer`.

4. **`.github/workflows/deploy-portal.yml`** — post-deploy smoke test that curls `https://grantex.dev/consent?req=...`, `/.well-known/jwks.json`, and `/.well-known/did.json` after every Firebase deploy. Fails the workflow if the rewrites stop working. **This is the specific check that would have caught the original bug.**

## Why this wasn't caught before

- Unit tests hit Fastify in-process — never cross Firebase boundary.
- E2E (`.github/workflows/e2e.yml`) sets `E2E_BASE_URL=https://grantex-auth-...run.app` — talks to Cloud Run directly, so the Firebase ↔ Cloud Run split was untested.
- E2E tests auto-create **sandbox** accounts (`Grantex.signup({ mode: 'sandbox' })`), and sandbox short-circuits `consentUrl` by returning `code` inline — masking any break in the live-mode consent flow.

## Test plan
- [x] `npm run typecheck` in apps/auth-service — clean
- [x] `npm test` in apps/auth-service — 1002/1002 pass
- [x] Probed all 7 paths on Cloud Run directly — each serves correct content
- [x] Probed all 7 paths on grantex.dev today — each returns 404 HTML (confirming what the rewrites fix)
- [ ] After merge + deploy-portal runs: smoke test passes (would block broken rewrites)
- [ ] Manual: run a real live-mode authorize via SDK, open returned `consentUrl`, confirm approve/deny round-trips
- [ ] Reproduce original case with a fresh `areq_...` ID to confirm live-mode is unblocked

## Follow-up suggestions
- Add a live-mode variant of the e2e suite (not just sandbox) so future Firebase↔Cloud Run regressions fail in CI, not prod.
- Audit other embedded URLs in API responses for similar assumptions (beyond jwtIssuer).