### PR TITLE
test(e2e): bump testTimeout to 120s; fix cross-feature retry-storm timeout

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,95 +33,95 @@ jobs:
       - name: Core auth flow
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/e2e.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/e2e.test.ts
 
       - name: Live-mode consent flow (via grantex.dev Firebase rewrites)
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
           E2E_PUBLIC_BASE_URL: https://grantex.dev
-        run: npx vitest run tests/e2e/live-mode.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/live-mode.test.ts
 
       - name: Portal features (full API surface)
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/portal-features.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/portal-features.test.ts
 
       - name: Scope enforcement
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/enforce-integration.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/enforce-integration.test.ts
 
       - name: Budgets
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/budget.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/budget.test.ts
 
       - name: DPDP compliance
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/dpdp.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/dpdp.test.ts
 
       - name: Policies
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/policies.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/policies.test.ts
 
       - name: Webhooks
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/webhooks.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/webhooks.test.ts
 
       - name: Usage
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/usage.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/usage.test.ts
 
       - name: Domains
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/domains.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/domains.test.ts
 
       - name: Vault
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/vault.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/vault.test.ts
 
       - name: Compliance
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/compliance.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/compliance.test.ts
 
       - name: Credentials
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/credentials.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/credentials.test.ts
 
       - name: Events
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/events.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/events.test.ts
 
       - name: Principal sessions
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/principal-sessions.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/principal-sessions.test.ts
 
       - name: SCIM
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/scim.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/scim.test.ts
 
       - name: SSO
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/sso.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/sso.test.ts
 
       - name: MPP Passports
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/mpp-passport.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/mpp-passport.test.ts
 
       - name: Cross-feature
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
-        run: npx vitest run tests/e2e/cross-feature.test.ts
+        run: npx vitest run --testTimeout=120000 tests/e2e/cross-feature.test.ts


### PR DESCRIPTION
## Summary

Fixes the deterministic `cross-feature > Budget + Delegation > allocates budget on parent and delegates without affecting budget` timeout in CI (reproduced in runs 24725285000 and 24725592055). The test is not broken — the SDK's retry backoff + a shared-IP rate-limit bucket blow past vitest's 30 s default.

## Investigation

1. `apps/auth-service/src/server.ts:109` — global rate limit is `100 req/min` keyed on `req.ip`.
2. `packages/sdk-ts/src/http.ts:99–189` — SDK retries 429 with exponential backoff, each attempt capped at `RETRY_MAX_DELAY_MS = 10_000 ms`. Worst case = 3 × 10 s = **30 s of backoff per call**.
3. The e2e workflow runs 18 suites sequentially from a single GH runner IP, so the IP's 100/min bucket is routinely saturated by the time later suites run. Tests that chain many calls (`cross-feature`'s last test fires 8+ sequential SDK calls) predictably exceed the default 30 s `testTimeout`.

**Local evidence** — with `--testTimeout=120000`, the same test passes in 2.8 s on my machine (single fresh IP, no bucket pressure).

## Fix

`.github/workflows/e2e.yml`: add `--testTimeout=120000` to every `npx vitest run` step (19 places). Gives the SDK's retry budget headroom without touching prod.

## Real fix (out of scope, tracked as follow-up)

Re-key the global rate limit on `developer.id` when authenticated, falling back to `req.ip` for unauth'd requests. The IP-level 100/min then only matters for public endpoints (signup, consent page, JWKS) — which is the actual DDoS threat model. Per-developer limits can stay in the per-route `rateLimit` configs.

This is a real change to plugin ordering (`@fastify/rate-limit` runs `onRequest`, before auth sets `request.developer`). Would need either preHandler ordering or a post-auth secondary limiter. Worth doing, but not in scope of this CI unblocker.

## Test plan
- [ ] Merge, dispatch `e2e.yml`, confirm all 18 suites green
- [ ] (Optional) Open follow-up PR to re-key the global rate limit so CI isn't papering over a real architectural quirk