### PR TITLE
fix(authorize): re-key per-route rate limit on developer.id (Option A)

### DIFF
--- a/apps/auth-service/src/lib/rate-limit.ts
+++ b/apps/auth-service/src/lib/rate-limit.ts
@@ -1,0 +1,43 @@
+import { getRedis } from '../redis/client.js';
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  resetSeconds: number;
+}
+
+/**
+ * Post-auth rate limit keyed on an identifier the caller controls — typically
+ * a developer id resolved by the auth plugin. The fastify/rate-limit plugin
+ * registered in server.ts runs `onRequest` (before auth), so it cannot see
+ * the authenticated developer and has to key on IP. Call this from a route
+ * handler once `request.developer` is known to apply a per-developer cap.
+ *
+ * Fixed-window counter in Redis: one key per (identifier, window), TTL set
+ * on first increment so expired keys self-clean.
+ */
+export async function checkRateLimit(
+  identifier: string,
+  max: number,
+  windowSeconds: number,
+): Promise<RateLimitResult> {
+  const redis = getRedis();
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const windowIndex = Math.floor(nowSeconds / windowSeconds);
+  const key = `ratelimit:${identifier}:${windowIndex}`;
+
+  const count = await redis.incr(key);
+  if (count === 1) {
+    await redis.expire(key, windowSeconds);
+  }
+
+  // Reset is the time until the current window ends; derived from the window
+  // index rather than a second Redis TTL call, so this stays to one round-trip.
+  const resetSeconds = Math.max(1, (windowIndex + 1) * windowSeconds - nowSeconds);
+
+  return {
+    allowed: count <= max,
+    remaining: Math.max(0, max - count),
+    resetSeconds,
+  };
+}

--- a/apps/auth-service/src/routes/authorize.ts
+++ b/apps/auth-service/src/routes/authorize.ts
@@ -8,6 +8,10 @@ import { isPlanName, PLAN_LIMITS } from '../lib/plans.js';
 import { authorizeTotal, authorizeDuration } from '../lib/metrics.js';
 import { incrementUsage } from '../lib/usage.js';
 import { parseExpiresIn } from '../lib/crypto.js';
+import { checkRateLimit } from '../lib/rate-limit.js';
+
+const AUTHORIZE_MAX_PER_MINUTE = 10;
+const AUTHORIZE_WINDOW_SECONDS = 60;
 
 interface AuthorizeBody {
   agentId: string;
@@ -22,10 +26,31 @@ interface AuthorizeBody {
 }
 
 export async function authorizeRoutes(app: FastifyInstance): Promise<void> {
-  // POST /v1/authorize — stricter rate limit: 10/min
-  app.post<{ Body: AuthorizeBody }>('/v1/authorize', { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } }, async (request, reply) => {
+  // POST /v1/authorize — per-developer rate limit of 10/min.
+  // Keyed on developer.id (post-auth) instead of IP so that multiple developers
+  // sharing a NAT'd egress IP — and our own CI running many suites from one
+  // runner IP — don't share a bucket. The global IP-keyed limit in server.ts
+  // still caps unauthenticated abuse.
+  app.post<{ Body: AuthorizeBody }>('/v1/authorize', async (request, reply) => {
     const endTimer = authorizeDuration.startTimer();
     const { agentId, principalId, scopes, redirectUri, state, expiresIn = '24h', audience, codeChallenge, codeChallengeMethod } = request.body;
+
+    const rl = await checkRateLimit(
+      `authorize:${request.developer.id}`,
+      AUTHORIZE_MAX_PER_MINUTE,
+      AUTHORIZE_WINDOW_SECONDS,
+    );
+    if (!rl.allowed) {
+      reply.header('retry-after', String(rl.resetSeconds));
+      reply.header('x-ratelimit-limit', String(AUTHORIZE_MAX_PER_MINUTE));
+      reply.header('x-ratelimit-remaining', '0');
+      reply.header('x-ratelimit-reset', String(rl.resetSeconds));
+      return reply.status(429).send({
+        message: `Rate limit exceeded, retry in ${rl.resetSeconds} seconds`,
+        code: 'RATE_LIMITED',
+        requestId: request.id,
+      });
+    }
 
     if (!agentId || !principalId || !scopes?.length) {
       return reply.status(400).send({


### PR DESCRIPTION
## Summary

Option A from the cross-feature investigation: re-key `/v1/authorize`'s per-route `10/min` rate limit on the authenticated `developer.id` instead of `req.ip`. Keeps the limit numerically identical, just changes the bucket. Matches the documented pattern in `server.ts:103-108` ("per-developer plan-based throughput is the responsibility of a post-auth limiter").

## Why

Prior behavior: `@fastify/rate-limit` runs `onRequest` (before auth), so the per-route config on `/v1/authorize` inherited the global IP-based `keyGenerator`. That meant:
- Multiple developers behind a shared NAT egress competed for one 10/min bucket.
- Our e2e suite fires ~23 authorize calls across 18 test files **from a single GH runner IP**. `cross-feature.test.ts`'s last test alone bursts 8 authorize calls in ~50 s. Once the IP's 10/min is drained by earlier suites, that test gets 429 + `retry-after: 19`, the SDK's retry budget runs out (`RETRY_MAX_DELAY_MS = 10 s` × 3 retries < the 19 s window), and the test fails.

The bug that #302 papered over with `testTimeout: 120_000` was this — not slow prod APIs. This PR fixes the root cause.

## Change

1. New `apps/auth-service/src/lib/rate-limit.ts` — Redis-backed fixed-window counter (`INCR` + one `EXPIRE` on first hit; reset seconds derived from window index, one round-trip).
2. `routes/authorize.ts` — drop the `config: { rateLimit: {...} }` override; after `request.developer` is populated, call `checkRateLimit('authorize:\${developer.id}', 10, 60)`. Same 429 shape, `retry-after` + `x-ratelimit-*` headers.
3. Global `100/min` IP limit in `server.ts` is untouched — unauthenticated abuse still capped there.

## Security note

Keying on `developer.id` is only safe **after** auth passes — which this change guarantees by calling `checkRateLimit` inside the handler body, not in a pre-auth hook. An attacker cannot mint fresh buckets by varying an `Authorization` header; a bogus token never reaches the handler (auth plugin rejects at preHandler). This satisfies the correctness pattern at `server.ts:103-108`.

## Tests

- `npm run typecheck` — clean
- `npm test` — 1002/1002 pass in the auth-service
- `security-rate-limiting.test.ts` still passes (covers the 429 shape via `/v1/trust-registry/verify-dns`; no change to that path)

## Post-merge

- Dispatch `e2e.yml`. `cross-feature > Budget + Delegation` should pass cleanly — each suite's fresh `Grantex.signup` developer gets its own 10/min bucket, uncontested.
- If that's green, the `testTimeout: 120_000` bump from #302 is no longer load-bearing. I'd leave it; it's a reasonable default for e2e against a prod API.