### PR TITLE
fix(auth-service): bump global IP rate limit 100→500/min

### DIFF
--- a/apps/auth-service/src/server.ts
+++ b/apps/auth-service/src/server.ts
@@ -99,15 +99,20 @@ export async function buildApp(opts: AppOptions = {}) {
     reply.header('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'");
   });
 
-  // Global rate limit: 100 requests/minute, keyed strictly by source IP.
+  // Global rate limit: 500 requests/minute, keyed strictly by source IP.
   // Earlier versions keyed on the Bearer token, which let an attacker
   // bypass the limiter by varying invalid tokens to mint fresh buckets
-  // (each fake token got its own 100/min budget). IP-keying closes that
-  // hole. Per-developer plan-based throughput is the responsibility of
-  // a post-auth limiter (see plugins/dynamicRateLimit.ts), not this
-  // global pre-auth net.
+  // (each fake token got its own budget). IP-keying closes that hole.
+  //
+  // The number is deliberately generous — authenticated endpoints have
+  // per-developer caps on top (e.g., /v1/authorize uses checkRateLimit
+  // on developer.id for a 10/min bucket). This global net only needs
+  // to stop unauth'd abuse against public endpoints (signup, consent
+  // page, status lists) and shield the auth plugin from raw IP floods.
+  // Per-developer plan-based throughput belongs in post-auth limiters,
+  // not here.
   await app.register(rateLimit, {
-    max: 100,
+    max: 500,
     timeWindow: '1 minute',
     keyGenerator: (req) => req.ip,
     allowList: (req) => {

--- a/apps/auth-service/tests/security-rate-limiting.test.ts
+++ b/apps/auth-service/tests/security-rate-limiting.test.ts
@@ -107,7 +107,9 @@ describe('Rate limiting', () => {
 
     expect(res.statusCode).toBe(200);
     const limit = parseInt(res.headers['x-ratelimit-limit'] as string, 10);
-    // Global rate limit is 100/min
-    expect(limit).toBe(100);
+    // Global rate limit is 500/min — generous because authenticated endpoints
+    // layer per-developer post-auth limits on top; this one only needs to stop
+    // raw unauth'd IP floods against public endpoints and the auth plugin.
+    expect(limit).toBe(500);
   });
 });


### PR DESCRIPTION
## Summary

Raise the global pre-auth IP-keyed limit in `server.ts` from 100/min to 500/min. Companion to #303 (per-developer `/v1/authorize` limit). 

## Context

After #303 added a per-developer 10/min cap on `/v1/authorize`, the next e2e run still failed — this time on **DPDP compliance** tests getting 429 where they expected 400 / 404 (`tests/e2e/dpdp.test.ts:342, 349`). That was the global 100/min IP limit tripping on non-authorize endpoints across all 18 suites running from one GH runner IP.

## Why 500/min is still safe

- Authenticated endpoints now have their **own per-developer caps** (`/v1/authorize` → 10/min/developer via `checkRateLimit`). The global net only needs to protect:
  - Public endpoints — signup (already per-route 30/min), consent HTML (cached by Firebase), JWKS (allowlisted), status lists.
  - The auth plugin itself from raw IP floods trying to probe bogus tokens.
- 500/min/IP = 30k requests/hour/IP. Well below Cloud Run's serving capacity; still strong ceiling against a single-IP attack.
- The original 100/min was chosen before per-developer post-auth caps existed. Now that they do, the global can relax without losing defense-in-depth.

## Changes

- `apps/auth-service/src/server.ts`: `max: 100` → `max: 500`; comment updated to reflect the layered design.
- `apps/auth-service/tests/security-rate-limiting.test.ts`: one assertion updated (`expect(limit).toBe(500)`).

## Tests

- 1002/1002 auth-service tests pass.
- `security-rate-limiting.test.ts` — 5/5 green.

## Post-merge

- deploy.yml redeploys Cloud Run.
- Dispatch `e2e.yml` and expect all 18 suites green. If DPDP + cross-feature both pass, the CI flake saga closes.