### PR TITLE
chore(ci): restore e2e.yml with workflow_dispatch only (no schedule)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,125 @@
+name: E2E Integration Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    name: E2E Smoke Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      E2E_ISSUER: https://grantex.dev
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            packages/sdk-ts/package-lock.json
+
+      - name: Install and build SDK
+        run: cd packages/sdk-ts && npm ci && npm run build
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Core auth flow
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/e2e.test.ts
+
+      - name: Live-mode consent flow (via grantex.dev Firebase rewrites)
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+          E2E_PUBLIC_BASE_URL: https://grantex.dev
+        run: npx vitest run --testTimeout=120000 tests/e2e/live-mode.test.ts
+
+      - name: Portal features (full API surface)
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/portal-features.test.ts
+
+      - name: Scope enforcement
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/enforce-integration.test.ts
+
+      - name: Budgets
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/budget.test.ts
+
+      - name: DPDP compliance
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/dpdp.test.ts
+
+      - name: Policies
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/policies.test.ts
+
+      - name: Webhooks
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/webhooks.test.ts
+
+      - name: Usage
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/usage.test.ts
+
+      - name: Domains
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/domains.test.ts
+
+      - name: Vault
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/vault.test.ts
+
+      - name: Compliance
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/compliance.test.ts
+
+      - name: Credentials
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/credentials.test.ts
+
+      - name: Events
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/events.test.ts
+
+      - name: Principal sessions
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/principal-sessions.test.ts
+
+      - name: SCIM
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/scim.test.ts
+
+      - name: SSO
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/sso.test.ts
+
+      - name: MPP Passports
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/mpp-passport.test.ts
+
+      - name: Cross-feature
+        env:
+          E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+        run: npx vitest run --testTimeout=120000 tests/e2e/cross-feature.test.ts


### PR DESCRIPTION
## Summary
- Restores `.github/workflows/e2e.yml` (deleted in #305) but **without** the daily `cron` schedule.
- Only `workflow_dispatch` is kept, so the full non-MPP E2E suite (consent, policies, webhooks, SSO, principal sessions, credentials, vault, budgets, etc.) can still be manually launched from the Actions tab for incident triage or pre-release verification.
- Addresses Codex P2 feedback on #305 (deletion removed the only manual entry point for these flows — `e2e-mpp.yml` covers MPP passport lifecycle only).
- Zero ongoing cost: workflow only runs when manually dispatched.

## Test plan
- [ ] Merge, then navigate to Actions → "E2E Integration Tests" → "Run workflow" to confirm it can still be dispatched
- [ ] Confirm no scheduled runs appear (no `schedule:` block)