### PR TITLE
feat(commerce): add Grantex Commerce V1 Milestone 1 foundations

### DIFF
--- a/GRANTEX_COMMERCE_PRD.md
+++ b/GRANTEX_COMMERCE_PRD.md
@@ -1,0 +1,3838 @@
+# PRD: Grantex Commerce
+
+## 1. Product Summary
+
+**Product name:** Grantex Commerce  
+**Product type:** New product line under Grantex, integrated with AgenticOrg  
+**Primary positioning:** Trusted agentic commerce infrastructure for merchants  
+**Primary users:** Merchants, payment partners, commerce platforms, AI agent platforms, enterprise operations teams  
+**Primary partner rail:** Pine Labs / Plural for payments, checkout, affordability, POS, settlement, and merchant reach
+
+Grantex Commerce lets merchants safely accept AI-agent-led commerce across online and offline channels. It combines Grantex's delegated authorization and audit layer, AgenticOrg's merchant AI employees, Pine Labs/Plural payment rails, and UCP/ACP/MCP interoperability.
+
+The product must not be a small demo or MVP. It should become a working production-grade product line with a clear separation of responsibilities:
+
+- **Grantex.dev:** Trust, consent, agent identity, scoped authorization, payment passports, policy enforcement, audit, merchant commerce gateway, UCP/ACP/MCP authorization wrapper.
+- **AgenticOrg.ai:** Merchant AI agents and workflows: sales, support, catalog, offer, reconciliation, store operations, and human-in-loop merchant workbench.
+- **Pine Labs / Plural integrations:** Payment execution, checkout links, payment orders, subscriptions, refunds, rewards, affordability, online gateway, offline POS bridge where available.
+
+The core thesis:
+
+> Plural lets merchants accept online payments. Pine POS lets merchants accept offline payments. Grantex Commerce lets merchants safely accept AI agents.
+
+## 1.1 Implementation Contract For Claude Code
+
+This PRD is the source of truth for building a finished product. Claude Code should not reduce this to a demo, landing page, thin MCP wrapper, or checkout-only integration.
+
+Build must satisfy these rules:
+
+1. **Grantex Commerce is the merchant control plane.** Merchant registration, catalog, inventory, pricing, offers, payments, AI-native publishing, UCP/ACP/MCP settings, policies, analytics, and audit live in Grantex.
+2. **AgenticOrg is the merchant AI workforce.** AgenticOrg consumes Grantex Commerce data and Grantex grants; it does not become the source of truth for merchant catalog, inventory, pricing, policies, or payment settings.
+3. **Pine/Plural executes payments.** Do not create a competing payment processor. Wrap Plural/Pine APIs behind Grantex authorization, policy, audit, and merchant controls.
+4. **UCP/ACP/MCP are interoperability adapters.** They are required, but the product is not only an adapter. The core product is trusted agentic commerce execution.
+5. **Every agent action must be attributable.** Store who acted, on whose behalf, under which grant, against which merchant, under which policy version, and with which provider result.
+6. **Every payment-affecting action must be consented or policy-approved.** No agent-created checkout, payment, refund, loyalty redemption, subscription, or store reservation may bypass Grantex Commerce Passport and merchant policy evaluation.
+7. **Every external integration must have sandbox, live, and mocked modes.** If Pine/Plural live access is unavailable, build a provider interface and mocked/sandbox adapter so the product can be developed and tested end-to-end.
+8. **Every UI flow must have an equivalent API.** The product must support dashboard users and developer/platform integrations.
+9. **Every module must have tests.** Include unit tests, integration tests, policy tests, agent safety evals, webhook tests, and end-to-end sandbox tests.
+10. **Do not leave ambiguous TODOs in production paths.** Unknown partner details should be isolated behind typed interfaces, feature flags, and explicit configuration.
+
+## 1.2 Definition Of Finished Product
+
+The finished product is considered complete when all of the following are true:
+
+1. A merchant can register, verify, connect catalog, connect inventory, configure pricing/offers, connect Plural sandbox/live credentials, publish AI-native endpoints, and enter live mode.
+2. An external AI agent can discover the merchant profile, search catalog, check inventory, create cart, request user consent, create checkout/payment intent, and receive payment status.
+3. A user can approve, inspect, and revoke a commerce grant.
+4. A merchant can define policies controlling agent access, amount limits, product/category limits, payment methods, refund permissions, loyalty redemption, and human approval.
+5. A Plural payment flow works end-to-end in sandbox with webhook-driven status updates and audit trail.
+6. AgenticOrg commerce agents can use Grantex Commerce safely for sales, support, reconciliation, catalog enrichment, offers, and store operations.
+7. UCP-style profile, ACP-compatible checkout metadata, and MCP tools are published and protected by Grantex authorization.
+8. Audit logs, analytics, compliance exports, and operational dashboards are available.
+9. Security, privacy, observability, rate limiting, idempotency, and error handling are production-grade.
+10. Release sign-off checklist in Section 19 passes without critical gaps.
+
+## 1.3 Product Ownership Matrix
+
+| Capability | Grantex.dev | AgenticOrg.ai | Pine/Plural | Notes |
+| --- | --- | --- | --- | --- |
+| Merchant registration | Owner | Consumer | Optional partner referral | Source of truth in Grantex Commerce |
+| Merchant verification | Owner | None | Optional partner data | Store verification status and evidence |
+| Catalog ingestion | Owner | Uses | None unless provided by merchant | AgenticOrg may enrich but not own canonical catalog |
+| Inventory ingestion | Owner | Uses | Pine POS source where available | Store freshness/confidence per SKU/location |
+| Pricing/offers data | Owner | Uses/recommends | Provides offer/EMI/reward eligibility where available | Merchant policy decides final exposure |
+| Payment execution | Wraps/enforces | Uses tools | Owner | Grantex never stores raw card/payment credentials |
+| Consent/passports | Owner | Requests/uses | Verifies where integrated | Grantex moat |
+| Merchant policies | Owner | Must obey | Optional risk input | Policy decision logged for every protected action |
+| Commerce agents | Provides permissions/data | Owner | None | AgenticOrg agents must use scoped Grantex grants |
+| UCP/ACP/MCP endpoints | Owner | May consume | Optional | Grantex publishes and gates endpoints |
+| Audit ledger | Owner | Writes events | Provider event source | Unified audit timeline in Grantex |
+| Analytics | Owner | Agent run metrics contributor | Payment metrics contributor | Merchant dashboard in Grantex |
+
+## 1.4 How To Use This PRD
+
+This document is the **target-state master PRD** for Grantex Commerce. It describes the full product platform that should exist over multiple releases.
+
+It must not be treated as a single implementation sprint or a one-shot Claude Code task.
+
+Implementation rule:
+
+- Use this PRD as the architectural north star.
+- Use a separate V1 build spec for the first shippable implementation slice.
+- Do not attempt every module in this document at once.
+- Do not implement broad commerce-platform features before the Commerce Passport, policy, audit, and payment authorization core works.
+
+The first implementation must prove:
+
+> An AI agent can initiate a commerce action through a payment provider only when Grantex can prove user consent, scope, policy approval, revocation status, and audit evidence.
+
+Anything that does not strengthen that proof is roadmap until the core is live.
+
+## 1.5 Provider Neutrality And Pine/Plural Positioning
+
+Plural/Pine is the first reference payment and merchant-rail partner. It must not be hardcoded as the only possible provider.
+
+Product positioning must remain provider-neutral:
+
+- Grantex Commerce is not "Pine Labs agentic commerce."
+- Grantex Commerce is the authorization, policy, audit, and capability publishing layer for AI-agent commerce.
+- Plural is the first payment adapter and partner implementation.
+- Pine POS is the first offline/POS adapter and partner implementation.
+- Razorpay, Cashfree, Stripe, Adyen, PhonePe, ONDC, bank rails, and future providers must be supportable through the same adapter model.
+
+Implementation requirements:
+
+- Provider-specific code must live behind typed adapter interfaces.
+- Provider names may appear in configuration, adapter packages, docs, and partner demos.
+- Core data models must use neutral fields such as `payment_provider`, `provider_account_id`, `provider_capability_status`, and `provider_reference_id`.
+- Merchant-facing product copy should say "connect payment provider" first and "Plural" as the first supported provider.
+- Partner-facing Pine/Plural demos may be co-branded, but core Grantex docs must remain provider-neutral.
+
+Strategic reason:
+
+If Grantex Commerce appears to be only Pine Labs infrastructure, non-Pine merchants and non-Pine AI platforms may not adopt it. The product should benefit from Pine/Plural access without being limited to Pine/Plural distribution.
+
+## 2. Strategic Context
+
+AI agents are becoming buying interfaces. Users will increasingly ask ChatGPT, Gemini, Copilot, Perplexity, WhatsApp agents, voice agents, and vertical AI assistants to discover, compare, select, reserve, pay, track, return, and reorder products.
+
+Merchants need to become AI-native, but the need is broader than exposing UCP or ACP endpoints. Merchants need a trusted operating layer for agentic commerce:
+
+- Which agent is acting?
+- Which human authorized it?
+- What is the spending limit?
+- What products/categories can it access?
+- Can it create carts, payments, refunds, subscriptions, or reservations?
+- Can merchant policies override agent actions?
+- Can authorization be revoked?
+- Can every action be audited?
+- Can the merchant attribute revenue to agent channels?
+
+UCP, ACP, MCP, and payment APIs are important interoperability adapters. They are not the moat. The moat is trusted authorization, policy control, auditability, merchant operations, and payment execution.
+
+## 2.1 Merchant Category Strategy
+
+Grantex Commerce must be built as a category-agnostic infrastructure platform but launched with category-specific presets. Claude Code must not hardcode the product to one vertical, and must not build a vague generic onboarding flow that ignores category differences.
+
+Core principle:
+
+> Build generic commerce primitives. Package them as merchant category presets.
+
+Supported platform categories:
+
+- `electronics_appliances`
+- `fashion_lifestyle`
+- `beauty_personal_care`
+- `pharmacy_wellness`
+- `grocery_convenience`
+- `restaurant_qsr`
+- `services_bookings`
+- `subscriptions_digital`
+- `home_furniture`
+- `b2b_wholesale`
+- `generic_retail`
+
+Initial launch categories:
+
+1. **Electronics and appliances**
+   - Highest priority launch category.
+   - Best fit for Pine/Plural because EMI, offers, warranties, store pickup, inventory, and assisted selling matter.
+2. **Fashion, footwear, beauty, and lifestyle**
+   - High priority launch category.
+   - Strong fit for variants, returns/exchanges, loyalty, agent-assisted discovery, and support.
+3. **Pharmacy, wellness, and health retail**
+   - Controlled pilot category.
+   - Requires stricter policy defaults, compliance copy, restricted claims, and human approval for sensitive actions.
+
+Later categories:
+
+- Grocery and convenience.
+- Restaurant/QSR.
+- Services and appointment bookings.
+- Home and furniture.
+- B2B wholesale.
+- Subscription/digital products.
+
+Category preset requirements:
+
+Each category preset must define:
+
+- Required catalog fields.
+- Optional but recommended catalog fields.
+- Inventory rules.
+- Pricing rules.
+- Offer/EMI/reward behavior.
+- Cart behavior.
+- Checkout behavior.
+- Booking/reservation behavior.
+- Return/refund rules.
+- Complaint/support workflows.
+- Warranty/service workflows.
+- Loyalty/gift-card behavior.
+- Default AI-native capabilities.
+- Default protocol exposure.
+- Default merchant policies.
+- Required AgenticOrg agent templates.
+- Required eval cases.
+- Restricted actions.
+- Required human approval thresholds.
+
+Category preset behavior:
+
+- Merchant onboarding must ask for category.
+- Merchant can select multiple categories if needed.
+- Category presets pre-fill required fields, policies, and capability publishing defaults.
+- Merchant can customize preset defaults, but high-risk overrides require admin/owner permission.
+- Category preset must be stored on merchant profile and versioned.
+- Readiness scoring must use category-specific requirements.
+- AgenticOrg agent behavior must load category-specific instructions and evals.
+
+Category preset examples:
+
+| Category | Required Data | Default Capabilities | Default Guardrails |
+| --- | --- | --- | --- |
+| Electronics/appliances | SKU, brand, model, specs, warranty, price, inventory, EMI eligibility | catalog, inventory, pricing, offers, cart, checkout, payment, pickup, warranty, support | user consent for checkout, merchant approval for refund execution, exact inventory hidden unless trusted agent |
+| Fashion/lifestyle | SKU, brand, size, color, images, variants, return policy, inventory, price | catalog, variants, inventory, pricing, offers, cart, checkout, returns/exchanges, loyalty | size/fit disclaimers, return eligibility required, no availability promise if stale inventory |
+| Beauty/personal care | ingredients, skin/hair type tags, usage guidance, images, price, inventory | catalog, recommendations, bundles, cart, checkout, loyalty, subscriptions | no medical claims, disclose ingredient data source |
+| Pharmacy/wellness | product type, prescription flag, regulatory category, inventory, price | catalog, availability, support, controlled checkout, refill reminders where legal | human approval for restricted items, no diagnosis, no prescription bypass |
+| Grocery/convenience | SKU, pack size, perishability, substitutions, delivery/pickup slots, inventory | catalog, inventory, substitutions, cart, delivery, payment | substitution approval, freshness windows, stale inventory blocks checkout |
+| Restaurant/QSR | menu items, modifiers, availability, prep time, delivery/pickup, taxes | menu, cart, booking/order, payment, complaint | allergen disclosure, prep-time estimates, cancellation policy |
+| Services/bookings | service catalog, staff/resource availability, time slots, cancellation policy, price | service discovery, booking, payment, cancellation, support | booking confirmation required, cancellation rules visible |
+| Subscriptions/digital | plan, billing cycle, entitlement, renewal/cancellation terms | plan discovery, subscription create/manage, payment, support | explicit recurring consent, cancellation terms required |
+| Home/furniture | dimensions, material, delivery constraints, assembly, warranty, returns | catalog, inventory, delivery, checkout, booking, warranty/support | delivery feasibility check, return restrictions visible |
+| B2B wholesale | MOQ, tier pricing, tax terms, credit terms, account permissions | catalog, pricing, quote/cart, checkout/request, support | account-level authorization, quote approval, payment terms control |
+
+Acceptance criteria:
+
+- Category preset is selected during onboarding.
+- Readiness score changes based on category.
+- Capability defaults change based on category.
+- Policy defaults change based on category.
+- Agent eval suite changes based on category.
+- Merchant can preview category-specific protocol exposure before publishing.
+
+## 3. Goals
+
+### 3.1 Business Goals
+
+1. Establish Grantex as the trust and consent layer for AI-led commerce.
+2. Establish AgenticOrg as the merchant AI employee layer for agentic commerce operations.
+3. Enable Pine/Plural merchants to accept AI-agent-initiated transactions safely.
+4. Create a product category: **Agentic Commerce Acceptance Governance**.
+5. Generate enterprise and partner revenue through SaaS, usage fees, transaction-linked pricing, and implementation services.
+6. Create a wedge for deeper Pine Labs partnership around agentic payments, online checkout, POS, offers, affordability, loyalty, reconciliation, and merchant operations.
+
+### 3.2 Product Goals
+
+1. Allow a merchant to onboard, connect catalog/payment systems, and configure agent permissions.
+2. Allow a user to authorize an AI agent to perform commerce actions with scoped, revocable, auditable grants.
+3. Allow an AI agent to create Plural payment orders/links only when a valid Grantex commerce grant exists.
+4. Allow merchants to expose AI-native commerce endpoints using UCP/ACP/MCP-compatible interfaces.
+5. Allow AgenticOrg merchant agents to sell, support, reconcile, and operate commerce workflows using Grantex-enforced permissions.
+6. Provide a merchant console for policies, agent channels, transaction logs, audits, failed actions, and revenue attribution.
+7. Provide production-grade observability, compliance exports, security controls, and developer documentation.
+
+### 3.3 Non-Goals
+
+1. Do not build a new payment gateway.
+2. Do not duplicate Plural checkout, Pine POS, or Pine settlement logic.
+3. Do not build a generic consumer shopping app as the primary product.
+4. Do not depend on scraping as the core commerce integration pattern.
+5. Do not position the product only as a UCP/ACP adapter.
+6. Do not create a third disconnected brand that dilutes Grantex and AgenticOrg.
+
+## 4. Target Users And Personas
+
+### 4.1 Merchant Owner / Commerce Head
+
+Needs:
+
+- More sales from AI channels.
+- Control over pricing, offers, fulfillment, and customer experience.
+- Low-risk way to try AI commerce.
+- Clear revenue attribution.
+
+Key product surfaces:
+
+- Merchant onboarding.
+- Merchant policy console.
+- Agent revenue dashboard.
+- Payment/checkout configuration.
+
+### 4.2 Merchant Operations Team
+
+Needs:
+
+- Handle AI-generated orders, failed payments, refunds, returns, store pickup, and support.
+- See why transactions failed.
+- Reconcile payment and order data.
+
+Key product surfaces:
+
+- Operations dashboard.
+- Reconciliation agent.
+- Support agent.
+- Audit timeline.
+
+### 4.3 Developer / Integration Team
+
+Needs:
+
+- APIs, SDKs, webhooks, MCP tools, test environment, UCP/ACP documentation.
+- Ability to plug into existing catalog, checkout, CRM, support, order management, and ERP systems.
+
+Key product surfaces:
+
+- Developer docs.
+- API keys.
+- Webhooks.
+- Sandbox.
+- Integration logs.
+
+### 4.4 Consumer / End User
+
+Needs:
+
+- Understand what the AI agent is allowed to do.
+- Approve payment/action safely.
+- Revoke authorization.
+- Get support if something goes wrong.
+
+Key product surfaces:
+
+- Grantex consent screen.
+- Payment passport summary.
+- Authorization history.
+- Revocation page.
+
+### 4.5 AI Agent Platform / External Agent
+
+Needs:
+
+- Discover merchant capabilities.
+- Request permission.
+- Call commerce APIs with scoped tokens.
+- Receive structured errors and policy decisions.
+
+Key product surfaces:
+
+- UCP/ACP/MCP-compatible endpoints.
+- Agent trust registry.
+- Grant verification APIs.
+- Commerce action APIs.
+
+### 4.6 Pine / Plural Product And Partnership Teams
+
+Needs:
+
+- Demonstrate AI commerce leadership.
+- Increase payment volume.
+- Increase merchant stickiness.
+- Add trust, consent, and audit to agentic payments.
+- Avoid risky unrestricted agent payments.
+
+Key product surfaces:
+
+- Partner dashboard.
+- Plural adapter.
+- Pine POS bridge.
+- Agentic payment audit ledger.
+- Co-branded demos.
+
+## 5. Product Architecture
+
+### 5.1 System Layers
+
+1. **Grantex Core**
+   - Agent identity.
+   - Human authorization.
+   - Scoped grant tokens.
+   - Delegation chains.
+   - Revocation.
+   - Audit log.
+   - Policy engine.
+   - Trust registry.
+
+2. **Grantex Commerce**
+   - Commerce grant templates.
+   - Agent payment passport.
+   - Merchant policy console.
+   - Commerce action enforcement.
+   - UCP/ACP/MCP adapters.
+   - Plural checkout adapter.
+   - Pine POS bridge.
+   - Commerce audit ledger.
+   - Commerce analytics.
+
+3. **AgenticOrg Commerce**
+   - Merchant Sales Agent.
+   - Offer Agent.
+   - Catalog Agent.
+   - Support Agent.
+   - Reconciliation Agent.
+   - Store Operations Agent.
+   - Human-in-loop workflows.
+
+4. **Pine / Plural Rails**
+   - Hosted checkout.
+   - Payment links.
+   - Orders and payments.
+   - Webhooks.
+   - Refunds.
+   - Subscriptions.
+   - Affordability/EMI.
+   - Rewards.
+   - POS payment/reservation where available.
+
+5. **External Agent Surfaces**
+   - ChatGPT.
+   - Gemini / Google AI Mode / UCP-compatible agents.
+   - Copilot.
+   - WhatsApp agents.
+   - Merchant website/app agents.
+   - MCP clients.
+   - A2A-capable agents.
+
+### 5.2 Recommended Deployment Model
+
+Use a multi-tenant SaaS architecture with optional enterprise self-hosting for regulated merchants.
+
+Required environments:
+
+- Local development.
+- Sandbox.
+- Staging.
+- Production.
+- Partner demo environment.
+
+Required tenant types:
+
+- Grantex internal tenant.
+- Pine/Plural partner tenant.
+- Merchant tenant.
+- Agent platform tenant.
+- Sandbox demo tenant.
+
+### 5.2.1 Enterprise Deployment Requirements
+
+Production deployment must support:
+
+- Multi-tenant SaaS.
+- Partner tenant mode for Pine/Plural.
+- Enterprise tenant isolation.
+- Optional dedicated deployment for regulated merchants.
+- Separate sandbox and live environments.
+- Separate secrets per merchant/provider/environment.
+- Regional configuration for data residency where required.
+- Blue/green or rolling deployments.
+- Backward-compatible database migrations.
+- Rollback plan for every release.
+
+Enterprise readiness requirements:
+
+- SSO/SAML/OIDC for merchant teams.
+- SCIM user provisioning where available.
+- RBAC and least-privilege defaults.
+- Audit export API.
+- Admin audit trail.
+- Data retention configuration.
+- Custom domain support for merchant-facing consent where required.
+- SLA reporting.
+- Support escalation workflow.
+- Incident communication workflow.
+- Disaster recovery runbook.
+
+### 5.2.2 Reliability, SLA, And DR Targets
+
+Targets for GA:
+
+- API availability: 99.9% for GA, path to 99.95% for enterprise.
+- Protected action fail mode: fail closed if authorization, policy, or audit write is unavailable.
+- Payment provider outage behavior: block payment creation, preserve cart/session, show fallback handoff.
+- RPO: 15 minutes for production transactional data.
+- RTO: 4 hours for GA, path to 1 hour for enterprise.
+- Audit event durability: no acknowledged protected action without audit event persistence.
+- Webhook processing: idempotent, replayable, and recoverable.
+- Background sync jobs: resumable after failure.
+- Consent/passport verification: degraded offline verification allowed only when revocation freshness policy permits.
+
+Operational requirements:
+
+- Status page or internal service health page.
+- Incident severity levels.
+- On-call runbook.
+- Provider outage playbooks.
+- Data restore drill before GA.
+- Load test before GA.
+
+### 5.3 Service Boundary Requirements
+
+Implement the product as explicit modules even if the first version is a monolith. Code should preserve these boundaries:
+
+1. **Merchant Service**
+   - Owns merchant profile, verification, stores, channels, integrations, and live/sandbox status.
+2. **Catalog Service**
+   - Owns product, SKU, variant, attribute, media, product Q&A, catalog readiness, and feed sync.
+3. **Inventory Service**
+   - Owns store-level inventory, reservations, stock freshness, stock confidence, and inventory sync jobs.
+4. **Pricing And Offer Service**
+   - Owns base price, sale price, member price, agent-only offer rules, coupons, bundles, EMI/reward eligibility metadata, and price freshness.
+5. **Commerce Passport Service**
+   - Owns commerce consent, grant issuance, grant verification, revocation, passport claims, and delegation constraints.
+6. **Policy Service**
+   - Owns merchant policies, policy versions, policy simulation, and policy decisions.
+7. **Payment Adapter Service**
+   - Owns provider interfaces for Plural/Pine/mocked providers, payment intents, checkout links, payment status, refunds, subscriptions, and webhooks.
+8. **AI-Native Gateway Service**
+   - Owns UCP-style profile, ACP-compatible metadata, MCP tools, well-known endpoints, and external agent access.
+9. **Audit Service**
+   - Owns append-only commerce events, event hashing, exports, timeline views, and compliance reports.
+10. **Analytics Service**
+   - Owns derived metrics, dashboards, funnels, attribution, and partner reports.
+11. **AgenticOrg Connector**
+   - Owns secure data/tool access from AgenticOrg agents into Grantex Commerce.
+
+### 5.4 Integration Modes
+
+Every external integration must support these modes:
+
+- `mock`: deterministic local behavior for development and CI.
+- `sandbox`: partner sandbox/test API behavior.
+- `live`: production behavior with real credentials and webhooks.
+
+Each provider adapter must expose:
+
+- `healthCheck()`
+- `validateCredentials()`
+- `createPaymentIntent()`
+- `createCheckoutLink()`
+- `getPaymentStatus()`
+- `createRefundRequest()`
+- `getRefundStatus()`
+- `createSubscription()` where supported.
+- `handleWebhook()`
+- `normalizeError()`
+
+If a provider capability is unavailable, return a typed `capability_unavailable` error and show the missing capability in the dashboard.
+
+### 5.5 Tenant And Environment Isolation
+
+Requirements:
+
+- Tenant data must never leak across merchants.
+- Sandbox and live credentials must be stored separately.
+- Sandbox passports must not authorize live payments.
+- Live passports must include environment claim `env=live`.
+- Webhook endpoints must distinguish provider, environment, and merchant.
+- Test/demo merchants must be visually marked in dashboard and API responses.
+- Admin impersonation must be audited.
+
+### 5.6 Feature Flags
+
+Required feature flags:
+
+- `commerce_enabled`
+- `commerce_live_mode_enabled`
+- `plural_sandbox_enabled`
+- `plural_live_enabled`
+- `pine_pos_bridge_enabled`
+- `ucp_profile_enabled`
+- `acp_metadata_enabled`
+- `mcp_tools_enabled`
+- `agenticorg_commerce_agents_enabled`
+- `merchant_policy_enforcement_enabled`
+- `human_approval_required`
+- `audit_export_enabled`
+
+Feature flags must be tenant-scoped and environment-aware.
+
+## 6. Core Product Modules
+
+### 6.1 Merchant Commerce Gateway
+
+### Purpose
+
+Allow merchants to connect their commerce systems and expose controlled AI-native commerce capabilities.
+
+### Required Features
+
+1. Merchant onboarding wizard.
+2. Merchant profile and verification.
+3. Store/location management.
+4. Online/offline channel configuration.
+5. Catalog connector.
+6. Payment connector.
+7. Fulfillment and return policy configuration.
+8. Agent access settings.
+9. UCP/ACP/MCP exposure settings.
+10. Test/sandbox mode.
+
+### Merchant Profile Fields
+
+- Merchant ID.
+- Legal name.
+- Display name.
+- Website.
+- Support email.
+- Support phone.
+- Business category.
+- Merchant category preset.
+- Secondary category presets.
+- Category preset version.
+- MCC/category.
+- GSTIN or local tax identifier where relevant.
+- Country.
+- Currency.
+- Store locations.
+- Fulfillment methods.
+- Return policy.
+- Refund policy.
+- Warranty/service policy.
+- Payment provider configuration.
+- Agent access status.
+
+### Acceptance Criteria
+
+- Merchant can complete onboarding without engineering help for basic payment-link based commerce.
+- Merchant can connect Plural credentials or use sandbox Plural credentials.
+- Merchant can publish a machine-readable agent commerce profile.
+- Merchant can disable all agent access instantly.
+
+### Merchant Lifecycle States
+
+Every merchant must have an explicit lifecycle state:
+
+- `draft`: merchant account created but profile incomplete.
+- `profile_complete`: required business fields completed.
+- `verification_pending`: verification submitted.
+- `verified`: merchant identity verified or accepted for sandbox.
+- `catalog_connected`: at least one catalog source connected or uploaded.
+- `inventory_connected`: inventory source connected or manual inventory configured.
+- `pricing_connected`: pricing source connected or manual pricing configured.
+- `payments_sandbox_ready`: payment provider sandbox configured.
+- `ai_native_sandbox_ready`: well-known/MCP/UCP-style profile available in sandbox.
+- `sandbox_validated`: required sandbox tests passed.
+- `live_requested`: merchant requested live activation.
+- `live`: merchant can accept live agentic commerce actions.
+- `suspended`: admin or risk suspension.
+- `disabled`: merchant disabled agentic commerce.
+
+State transitions must be explicit, audited, and visible in the merchant dashboard.
+
+### Merchant Onboarding Validation Gates
+
+Required gates before sandbox:
+
+- Business profile complete.
+- Merchant category preset selected.
+- At least one catalog item exists.
+- At least one price exists for each published SKU.
+- Inventory mode selected: real-time, scheduled, manual, or not applicable.
+- Payment provider mode selected: Plural sandbox, mocked provider, or payment link fallback.
+- Default merchant policy created.
+- Category preset defaults applied.
+- Agent access mode selected.
+
+Required gates before live:
+
+- Merchant verified.
+- Live payment credentials validated.
+- Webhook endpoint verified.
+- Catalog sync successful within last 24 hours.
+- Inventory sync successful within merchant-configured freshness threshold, unless inventory is not applicable.
+- Pricing sync successful within last 24 hours.
+- Emergency disable tested.
+- At least one successful sandbox payment.
+- At least one successful Commerce Passport issuance and revocation test.
+- Category-specific readiness score meets launch threshold.
+
+### Catalog, Inventory, And Pricing Data Ownership
+
+Grantex Commerce must be the canonical AI-native view of merchant commerce data. It does not need to replace the merchant's source system, but it must maintain normalized read models for agents:
+
+- Source systems remain systems of record for operational commerce.
+- Grantex stores normalized, indexed, agent-readable snapshots.
+- Every record stores `source_system`, `source_record_id`, `sync_job_id`, `last_synced_at`, and `sync_status`.
+- Conflicts are resolved by source priority configured by merchant.
+- Stale data must be marked and optionally hidden from agents.
+- AgenticOrg agents must read through Grantex APIs, not directly from merchant source connectors unless explicitly configured.
+
+### Data Freshness Rules
+
+Default freshness requirements:
+
+- Catalog: fresh if synced within 24 hours.
+- Pricing: fresh if synced within 24 hours.
+- Inventory: fresh if synced within 15 minutes for store-level inventory, 4 hours for non-real-time catalog inventory, or merchant-configured threshold.
+- Offers: fresh if synced within offer provider's expiry or 24 hours, whichever is shorter.
+
+Behavior:
+
+- If catalog is stale, show warning but allow read-only discovery if merchant permits.
+- If pricing is stale, block checkout unless merchant policy allows stale-price fallback.
+- If inventory is stale, label as `availability_unknown` and block reservation unless merchant policy allows manual confirmation.
+- If payment provider health is down, block payment intent creation and allow only lead/support handoff.
+
+### Required Merchant Dashboard Cards
+
+Commerce Home must show:
+
+- Merchant lifecycle state.
+- Merchant category preset.
+- AI-native readiness score.
+- Category-specific readiness score.
+- Catalog health.
+- Inventory health.
+- Pricing health.
+- Payment provider health.
+- Agent access status.
+- Policy enforcement status.
+- Last agent transaction.
+- Open human approvals.
+- Recent failed actions.
+- Emergency disable button.
+
+### Required Merchant Actions
+
+Merchants must be able to:
+
+- Register a merchant.
+- Invite team members.
+- Configure RBAC.
+- Select and update merchant category presets.
+- Preview category preset defaults.
+- Connect/disconnect catalog sources.
+- Upload CSV.
+- Map product fields.
+- Review import errors.
+- Connect/disconnect inventory sources.
+- Configure inventory freshness.
+- Connect/disconnect pricing sources.
+- Configure offer rules.
+- Connect Plural/Pine credentials.
+- Validate webhooks.
+- Configure AI agent access.
+- Publish/unpublish AI-native endpoints.
+- Simulate an agent query.
+- Simulate checkout.
+- Export audit logs.
+- Disable all agentic commerce.
+
+### 6.2 Grantex Commerce Passport
+
+### Purpose
+
+Provide signed, verifiable, revocable authorization credentials for AI-commerce actions.
+
+### Definition
+
+A **Commerce Passport** is a signed credential binding:
+
+- Human principal.
+- Agent identity.
+- Merchant.
+- Allowed commerce actions.
+- Payment constraints.
+- Product/category constraints.
+- Spending limits.
+- Expiry.
+- Delegation rules.
+- Revocation status.
+- Audit reference.
+
+### Required Grant Scopes
+
+Initial scope taxonomy:
+
+- `commerce:catalog.read`
+- `commerce:inventory.read`
+- `commerce:cart.create`
+- `commerce:cart.update`
+- `commerce:checkout.create`
+- `commerce:payment.initiate`
+- `commerce:payment.capture`
+- `commerce:payment.status.read`
+- `commerce:payment.refund.request`
+- `commerce:order.read`
+- `commerce:order.create`
+- `commerce:order.cancel.request`
+- `commerce:return.create`
+- `commerce:subscription.create`
+- `commerce:subscription.manage`
+- `commerce:offer.read`
+- `commerce:offer.apply`
+- `commerce:loyalty.read`
+- `commerce:loyalty.redeem`
+- `commerce:store.reserve`
+- `commerce:support.create`
+- `commerce:audit.read`
+
+### Required Passport Claims
+
+- `iss`: Grantex issuer.
+- `sub`: Human principal DID/user ID.
+- `aud`: Merchant or commerce gateway.
+- `agent_id`: Registered agent ID.
+- `agent_did`: Agent DID where available.
+- `merchant_id`.
+- `merchant_did` where available.
+- `scopes`.
+- `max_amount`.
+- `currency`.
+- `category_allowlist`.
+- `merchant_allowlist`.
+- `payment_method_constraints`.
+- `fulfillment_constraints`.
+- `expires_at`.
+- `jti`.
+- `grant_id`.
+- `delegation_depth`.
+- `policy_version`.
+- `consent_record_id`.
+- `audit_session_id`.
+
+### User Consent UX
+
+Consent screen must show in plain language:
+
+- Which agent is requesting access.
+- Which merchant it wants to transact with.
+- What it can do.
+- Maximum amount.
+- Validity period.
+- Payment method constraints.
+- Whether payment requires final user confirmation.
+- Revocation option.
+
+Example:
+
+> Allow "AgenticOrg Sales Agent" to create a checkout with "ABC Electronics" up to INR 35,000, apply eligible offers/EMI, and initiate payment. Valid for 15 minutes. Final payment confirmation required.
+
+### Acceptance Criteria
+
+- Passport can be verified offline using Grantex JWKS.
+- Passport can be checked online for revocation.
+- Passport enforces amount, merchant, category, scope, and expiry.
+- Passport logs all usage events.
+- Passport can be revoked by user, merchant, or Grantex admin.
+
+### Passport Types
+
+Support these passport types:
+
+- `browse`: agent can browse/search public or user-approved catalog data.
+- `cart`: agent can create and modify carts but cannot initiate payment.
+- `checkout`: agent can create checkout/payment intent but final user confirmation is still required.
+- `payment_delegated`: agent can initiate payment within explicit amount, merchant, category, and time constraints.
+- `support`: agent can read order/payment status and create support/return/refund requests.
+- `merchant_operator`: merchant-side agent can operate on merchant workflows, subject to merchant RBAC and policy.
+
+Each passport type maps to a default scope bundle, but merchants and users can reduce scopes before approval.
+
+### Consent Evidence Requirements
+
+Every consent record must store:
+
+- Human-readable consent text shown to the user.
+- Machine-readable scopes and constraints.
+- Agent identity and verification status.
+- Merchant identity and verification status.
+- Requested amount/currency if payment-related.
+- Consent timestamp.
+- IP address and user agent where available.
+- Authentication method used.
+- Passkey/WebAuthn evidence where available.
+- Revocation instructions shown to user.
+- Hash of consent payload.
+
+Consent text must be reproducible from stored data for dispute handling.
+
+### Revocation Semantics
+
+Revocation must support:
+
+- Revoke one passport.
+- Revoke all passports for one agent.
+- Revoke all passports for one merchant.
+- Revoke all commerce passports for one user.
+- Merchant blocklist of an agent.
+- Admin suspension of an agent or merchant.
+
+Revocation must block:
+
+- New API calls using the passport.
+- New payment intents.
+- New checkout links.
+- New refund/return actions.
+- New loyalty redemptions.
+
+Revocation does not automatically cancel already-paid provider transactions; those must follow provider refund/cancellation flows and merchant policy.
+
+### Amount And Currency Rules
+
+- All amount limits must use integer minor units internally.
+- Currency must be ISO 4217.
+- Passport currency must match payment intent currency unless merchant policy explicitly allows conversion.
+- Payment amount must be less than or equal to `max_amount`.
+- If line items change after consent, re-evaluate total amount, merchant, category, and scope.
+- If total increases above consented amount, require new consent.
+- If total decreases, do not require new consent unless merchant policy requires reapproval.
+
+### 6.3 Plural Agentic Checkout Adapter
+
+### Purpose
+
+Allow authorized agents to create and manage Plural checkout/payment flows safely.
+
+### Required Features
+
+1. Create Plural order/payment link/hosted checkout using valid Commerce Passport.
+2. Retrieve payment status.
+3. Handle Plural webhooks.
+4. Map Plural payment state to Grantex audit timeline.
+5. Support sandbox and live credentials.
+6. Support refunds where available.
+7. Support subscriptions where available.
+8. Support offer/EMI/reward eligibility discovery where APIs allow.
+9. Support merchant-level fallback to payment link if full checkout API is not available.
+
+### Required API Wrapper Endpoints
+
+Use Grantex Commerce API names independent of Plural internals:
+
+- `POST /v1/commerce/payments/intents`
+- `GET /v1/commerce/payments/intents/{id}`
+- `POST /v1/commerce/payments/intents/{id}/checkout-link`
+- `POST /v1/commerce/payments/intents/{id}/cancel`
+- `POST /v1/commerce/refunds`
+- `GET /v1/commerce/refunds/{id}`
+- `POST /v1/commerce/subscriptions`
+- `GET /v1/commerce/subscriptions/{id}`
+- `POST /v1/webhooks/plural`
+
+### Payment Intent Object
+
+Fields:
+
+- `id`.
+- `merchant_id`.
+- `agent_id`.
+- `human_principal_id`.
+- `commerce_passport_jti`.
+- `amount`.
+- `currency`.
+- `line_items`.
+- `metadata`.
+- `payment_provider`: `plural`.
+- `provider_order_id`.
+- `provider_payment_id`.
+- `checkout_url`.
+- `status`.
+- `expires_at`.
+- `created_at`.
+- `updated_at`.
+
+Statuses:
+
+- `created`
+- `authorization_required`
+- `authorized`
+- `checkout_created`
+- `payment_pending`
+- `paid`
+- `failed`
+- `cancelled`
+- `expired`
+- `refunded`
+- `partially_refunded`
+
+### Acceptance Criteria
+
+- API rejects payment creation without a valid Commerce Passport.
+- API rejects amount above passport limit.
+- API rejects merchant mismatch.
+- API rejects expired/revoked passport.
+- Successful payment creates a complete audit timeline.
+- Webhook verification is implemented.
+- Sandbox demo works end-to-end.
+
+### Payment Adapter Rules
+
+The adapter must never expose raw provider complexity to agents. Agents call Grantex Commerce APIs; Grantex calls Plural/Pine adapters.
+
+Rules:
+
+- Require idempotency key for create/cancel/refund/subscription APIs.
+- Store provider request and response hashes, not sensitive payment payloads.
+- Normalize provider statuses into Grantex statuses.
+- Retry transient provider failures with bounded exponential backoff.
+- Do not retry non-idempotent provider actions without idempotency key.
+- Mark unknown webhook events as `provider_event_unrecognized` and store for review.
+- Verify webhook signatures before changing state.
+- Reconcile payment status by polling provider if webhook is delayed or missing.
+- Provide manual reconciliation action in dashboard.
+- Support payment expiry and checkout link expiry.
+
+### Provider Capability Matrix
+
+Dashboard must display which capabilities are available for each merchant/provider/environment:
+
+- Create payment order.
+- Generate hosted checkout.
+- Generate payment link.
+- Payment status.
+- Refund.
+- Partial refund.
+- Subscription.
+- EMI/affordability.
+- Reward points.
+- Webhooks.
+- Offline/POS payment.
+- Store pickup/reservation.
+
+If a merchant selects a feature not supported by their provider mode, show the exact missing capability and remediation.
+
+### Payment State Machine
+
+Valid state transitions:
+
+- `created` -> `authorization_required`
+- `authorization_required` -> `authorized`
+- `authorized` -> `checkout_created`
+- `checkout_created` -> `payment_pending`
+- `payment_pending` -> `paid`
+- `payment_pending` -> `failed`
+- `created|authorized|checkout_created|payment_pending` -> `cancelled`
+- `created|authorized|checkout_created|payment_pending` -> `expired`
+- `paid` -> `partially_refunded`
+- `paid|partially_refunded` -> `refunded`
+
+Invalid transitions must be rejected and logged.
+
+### 6.4 Pine POS Agent Bridge
+
+### Purpose
+
+Extend agentic commerce from online payments to offline retail stores using Pine Labs POS/payment capabilities.
+
+### Required Features
+
+1. Store-level merchant profile.
+2. Store reservation request.
+3. Pickup/payment code generation.
+4. POS payment intent creation where supported.
+5. Staff notification.
+6. Payment status sync.
+7. Reconciliation with merchant and payment records.
+
+### Core Flows
+
+#### Reserve And Pay In Store
+
+1. Agent finds product/store.
+2. User grants permission.
+3. Agent creates reservation.
+4. Merchant/store receives reservation.
+5. Customer visits store.
+6. POS validates pickup code.
+7. Customer pays at POS.
+8. Grantex audit records completion.
+
+#### Pay Online, Pick Up In Store
+
+1. Agent creates Plural checkout.
+2. Customer pays.
+3. Store receives paid pickup order.
+4. Customer presents pickup code.
+5. Store fulfills.
+6. Audit and reconciliation complete.
+
+### Acceptance Criteria
+
+- Offline flow can be run in sandbox mode if Pine POS live integration is not ready.
+- Store reservation cannot exceed merchant policy rules.
+- Pickup code must be short-lived and auditable.
+- Store staff can mark reservation as fulfilled/cancelled/no-show.
+
+### 6.5 AI-Native Merchant Profile And UCP/ACP/MCP Gateway
+
+### Purpose
+
+Make merchants discoverable and transactable by AI agents using emerging commerce protocols while preserving Grantex authorization and merchant control.
+
+### Required Features
+
+1. Generate AI-native merchant profile.
+2. Publish UCP-style capability descriptor.
+3. Provide MCP tools for merchant commerce actions.
+4. Support ACP-compatible checkout metadata where applicable.
+5. Protect action endpoints with Grantex Commerce Passport.
+6. Provide capability negotiation.
+7. Provide sandbox/testing endpoint.
+
+### Universal AI-Agent Publishing Requirement
+
+Merchants must be able to publish controlled, machine-readable commerce capabilities for all supported AI agents and protocols from one Grantex Commerce console.
+
+Supported agent/protocol surfaces:
+
+- Grantex Commerce native API.
+- MCP tools.
+- UCP-style merchant profile and capability descriptors.
+- ACP-compatible checkout/session metadata where applicable.
+- A2A-compatible agent handoff metadata where applicable.
+- Website/app embedded merchant agents.
+- AgenticOrg agents.
+- Future external agent registries through adapter interface.
+
+The merchant must not configure each protocol separately from scratch. Grantex Commerce must maintain one canonical merchant capability model and generate protocol-specific views from it.
+
+Canonical capability categories:
+
+- Merchant profile.
+- Store/location profile.
+- Catalog publishing.
+- Product detail publishing.
+- Inventory/availability publishing.
+- Pricing publishing.
+- Offer/discount/EMI/reward publishing.
+- Cart creation and cart update.
+- Checkout/session creation.
+- Payment initiation.
+- Payment status.
+- Booking/reservation.
+- Store pickup.
+- Delivery/shipping options.
+- Order creation/reference.
+- Order status.
+- Cancellation request.
+- Refund request/execution where supported.
+- Return/exchange request.
+- Complaint/support ticket.
+- Warranty/service request.
+- Loyalty read/redeem.
+- Gift card read/redeem.
+- Subscription create/manage where supported.
+- Human handoff.
+- Merchant policy/terms discovery.
+- Audit/receipt reference.
+
+Protocol publishing behavior:
+
+- If a protocol supports a capability natively, publish the native mapping.
+- If a protocol does not support a capability, expose it through Grantex native API/MCP tool and mark it as protocol extension.
+- If a provider does not support execution of a capability, expose capability as `unavailable` with reason and fallback.
+- If merchant disables a capability, remove it from all protocol views or mark it disabled consistently.
+- If a capability requires user consent, protocol metadata must show required scopes and auth flow.
+- If a capability requires merchant approval, protocol metadata must show `requires_human_approval`.
+- If a capability is sandbox-only, protocol metadata must show environment restrictions.
+
+Merchant publishing controls:
+
+- Global publish/unpublish switch.
+- Per-protocol enable/disable.
+- Per-capability enable/disable.
+- Public vs verified-agent visibility.
+- Read-only vs transactional mode.
+- Sandbox vs live mode.
+- Store/location-level publishing.
+- Product/category-level publishing.
+- Inventory visibility level: exact quantity, availability bucket, or hidden.
+- Pricing visibility level: public price, authenticated price, member price, or hidden.
+- Offer visibility level: public, eligible-after-user-grant, hidden.
+- Agent allowlist/blocklist.
+- Rate limits.
+- Emergency disable.
+
+The merchant must see exactly what each protocol/agent surface can access before publishing.
+
+### Capability Publishing Matrix
+
+| Capability | Grantex Native API | MCP | UCP-style | ACP-compatible | A2A/Agent Handoff | Required Default Authorization |
+| --- | --- | --- | --- | --- | --- | --- |
+| Merchant profile | Yes | Yes | Yes | Limited/metadata | Yes | Public or verified agent |
+| Store/location profile | Yes | Yes | Yes | Limited/metadata | Yes | Public or verified agent |
+| Catalog search | Yes | Yes | Yes | Limited/product metadata | Yes | Merchant-configured |
+| Product details | Yes | Yes | Yes | Limited/product metadata | Yes | Merchant-configured |
+| Inventory availability | Yes | Yes | Yes | Limited/extension | Yes | Verified agent or user grant by default |
+| Exact inventory quantity | Yes | Yes | Extension | Extension | Yes | Merchant approval or trusted agent |
+| Pricing | Yes | Yes | Yes | Yes where checkout metadata supports | Yes | Merchant-configured |
+| Personalized/member pricing | Yes | Yes | Extension | Extension | Yes | User grant |
+| Offers/EMI/rewards | Yes | Yes | Yes/extension | Yes/extension | Yes | User grant if personalized |
+| Cart create/update | Yes | Yes | Yes | Extension/session | Yes | Verified agent plus policy |
+| Checkout create | Yes | Yes | Yes | Yes | Yes | Commerce Passport |
+| Payment initiate | Yes | Yes | Payment extension/AP2-compatible where applicable | Yes | Yes | Commerce Passport |
+| Payment status | Yes | Yes | Extension | Yes/session status | Yes | User grant or merchant ops grant |
+| Booking/reservation | Yes | Yes | Extension | Extension | Yes | User grant plus merchant policy |
+| Store pickup | Yes | Yes | Yes/extension | Extension | Yes | User grant plus merchant policy |
+| Shipping/delivery options | Yes | Yes | Yes | Yes/extension | Yes | Cart/checkout scope |
+| Order status | Yes | Yes | Extension | Yes where supported | Yes | User grant |
+| Cancellation request | Yes | Yes | Extension | Extension | Yes | User grant plus merchant policy |
+| Refund request | Yes | Yes | Extension | Extension | Yes | User grant plus merchant policy |
+| Refund execution | Yes | Yes | Extension | Extension | Yes | Merchant approval by default |
+| Return/exchange request | Yes | Yes | Extension | Extension | Yes | User grant plus merchant policy |
+| Complaint/support ticket | Yes | Yes | Extension | Extension | Yes | User grant or public lead mode |
+| Warranty/service request | Yes | Yes | Extension | Extension | Yes | User grant |
+| Loyalty read/redeem | Yes | Yes | Extension | Extension | Yes | Explicit user grant |
+| Gift card read/redeem | Yes | Yes | Extension | Extension | Yes | Explicit user grant |
+| Subscription create/manage | Yes | Yes | Extension | Yes where provider supports | Yes | Commerce Passport/user grant |
+| Human handoff | Yes | Yes | Extension | Extension | Yes | Context-dependent |
+
+### Capability Definitions
+
+Each published capability must have:
+
+- `capability_id`
+- `display_name`
+- `description`
+- `protocol_mappings`
+- `supported_environments`
+- `required_scopes`
+- `required_passport_type`
+- `requires_user_consent`
+- `requires_merchant_approval`
+- `provider_dependency`
+- `provider_capability_status`
+- `rate_limit`
+- `visibility`
+- `input_schema`
+- `output_schema`
+- `error_codes`
+- `audit_event_name`
+- `last_validated_at`
+
+Capability definitions must be visible to merchants and developers.
+
+### Publishing Validation
+
+Before publishing AI-native capabilities, Grantex must validate:
+
+- Merchant profile exists.
+- Merchant policy exists and is active.
+- Required endpoints are reachable.
+- Required schemas are valid.
+- Required payment provider capabilities are available.
+- Catalog has at least one publishable product for catalog publishing.
+- Pricing exists for checkout-enabled products.
+- Inventory mode is configured for inventory/reservation capabilities.
+- Consent and passport flows are configured for protected capabilities.
+- Webhook endpoint is configured for payment/refund/order updates.
+- Sandbox test passes for every live transactional capability.
+
+If validation fails, Grantex must block publishing for affected capabilities and show exact remediation.
+
+### Protocol Adapter Interface
+
+Implement protocols through adapters, not hardcoded one-off logic.
+
+Adapter interface:
+
+- `getProtocolName()`
+- `getSupportedCapabilities()`
+- `generateMerchantProfile(merchantCapabilityModel)`
+- `generateToolManifest(merchantCapabilityModel)`
+- `mapCapabilityToProtocol(capability)`
+- `validateProtocolProfile(profile)`
+- `handleProtocolRequest(request)`
+- `normalizeProtocolError(error)`
+
+Initial adapters:
+
+- `grantex_native`
+- `mcp`
+- `ucp_style`
+- `acp_compatible`
+- `a2a_handoff`
+
+Future adapters must be addable without changing canonical merchant capability definitions.
+
+### Required Public Endpoints
+
+At minimum:
+
+- `GET /.well-known/grantex-commerce`
+- `GET /.well-known/ucp`
+- `GET /mcp`
+- `POST /v1/commerce/catalog/search`
+- `GET /v1/commerce/catalog/items/{id}`
+- `POST /v1/commerce/cart`
+- `POST /v1/commerce/cart/{id}/items`
+- `POST /v1/commerce/checkout`
+- `POST /v1/commerce/payments/intents`
+- `GET /v1/commerce/orders/{id}`
+- `POST /v1/commerce/returns`
+
+### MCP Tools
+
+Required MCP tools:
+
+- `merchant.get_profile`
+- `catalog.search`
+- `catalog.get_item`
+- `inventory.check`
+- `offers.get_eligible`
+- `cart.create`
+- `cart.add_item`
+- `checkout.create`
+- `payment.create_intent`
+- `payment.get_status`
+- `order.get_status`
+- `return.create_request`
+- `support.create_ticket`
+
+### Authorization Behavior
+
+- Read-only catalog search may be public or merchant-configured.
+- Inventory checks may be public, restricted, or rate-limited.
+- Cart creation requires agent identity.
+- Checkout/payment requires Commerce Passport.
+- Order history, returns, loyalty, and support require user-bound grant.
+
+### Acceptance Criteria
+
+- External agent can discover merchant capabilities.
+- MCP client can call read-only tools in sandbox mode.
+- Write/payment tools require valid Grantex grant.
+- Merchant can disable UCP/ACP/MCP exposure.
+
+### AI-Native Profile Contract
+
+`/.well-known/grantex-commerce` must return:
+
+- Merchant identity.
+- Verification status.
+- Supported environments.
+- Supported protocols.
+- Supported commerce capabilities.
+- Supported auth methods.
+- Supported payment modes.
+- Supported fulfillment modes.
+- Required scopes per action.
+- MCP server URL.
+- UCP-style profile URL.
+- Checkout/payment endpoint URL.
+- Support endpoint URL.
+- Public key/JWKS URL.
+- Terms and policy URLs.
+- Last updated timestamp.
+
+The UCP-style profile must be generated from the same merchant capability model. Do not maintain separate duplicated config for Grantex and UCP profiles.
+
+### MCP Tool Behavior
+
+Each MCP tool must define:
+
+- Tool name.
+- Description.
+- Input schema.
+- Output schema.
+- Required scope.
+- Whether user grant is required.
+- Whether merchant policy approval is required.
+- Rate limit.
+- Audit event name.
+- Error model.
+
+Tool responses must be structured and must not rely on natural language alone. Agent-facing text can be included in a `display_message` field, but machine-readable fields are mandatory.
+
+### ACP Compatibility Requirements
+
+Where ACP checkout metadata is implemented:
+
+- Map Grantex merchant ID to ACP merchant reference.
+- Map Grantex payment intent to ACP checkout/session reference.
+- Require Commerce Passport before payment-affecting actions.
+- Preserve merchant as seller of record.
+- Record ACP session IDs in audit metadata.
+- Return clear fallback when ACP is unsupported for a merchant.
+
+### Agent Discovery And Rate Limits
+
+Default limits:
+
+- Anonymous merchant profile requests: rate-limited by IP and merchant.
+- Anonymous catalog search: disabled by default unless merchant opts in.
+- Verified agent catalog search: allowed subject to merchant policy.
+- Inventory checks: rate-limited and optionally hidden for low-trust agents.
+- Checkout/payment: always requires Commerce Passport.
+
+Merchants must be able to configure public vs verified-agent access.
+
+### 6.6 Merchant Policy Console
+
+### Purpose
+
+Give merchants control over how agents access, recommend, transact, support, and refund commerce actions.
+
+### Required Policy Controls
+
+1. Agent allowlist/blocklist.
+2. Trusted agent registry integration.
+3. Scope-level permissions.
+4. Transaction value limits.
+5. Product/category allowlists/blocklists.
+6. Payment method restrictions.
+7. Human confirmation requirements.
+8. Refund/return approval thresholds.
+9. Loyalty/reward redemption permissions.
+10. Offer/discount guardrails.
+11. Time-of-day rules.
+12. Store/location rules.
+13. Rate limits.
+14. Fraud/anomaly alerts.
+15. Emergency disable switch.
+
+### Policy Examples
+
+- Allow verified agents to search catalog without user grant.
+- Require user grant for checkout creation.
+- Require final human confirmation above INR 10,000.
+- Allow payment links but not direct capture.
+- Allow refunds only as requests, not automatic actions.
+- Disable agentic checkout for high-risk categories.
+- Allow store pickup reservation for 30 minutes only.
+
+### Acceptance Criteria
+
+- Policies are versioned.
+- Every policy decision is logged.
+- Merchants can simulate policy decisions before enabling live mode.
+- Policy changes take effect within 60 seconds.
+- Emergency disable switch blocks new write/payment actions immediately.
+
+### Policy Evaluation Contract
+
+Policy evaluation input:
+
+- Merchant ID.
+- Agent ID and trust status.
+- Human principal ID where available.
+- Requested action.
+- Requested scopes.
+- Product/category/SKU data.
+- Amount and currency.
+- Payment method.
+- Fulfillment method.
+- Store/location.
+- Passport claims.
+- Risk signals.
+- Environment.
+
+Policy evaluation output:
+
+- `allow`, `deny`, or `requires_human_approval`.
+- Decision ID.
+- Policy version.
+- Matched rule IDs.
+- Human-readable explanation.
+- Machine-readable reason code.
+- Required remediation if denied.
+- Audit event ID.
+
+Policy decision must be evaluated before provider calls and after any cart/amount change.
+
+### Required Default Policies
+
+Create safe defaults:
+
+- Public agents can read only basic merchant profile.
+- Catalog search requires verified agent unless merchant opts into public discovery.
+- Inventory exact quantity hidden by default; expose availability buckets instead.
+- Cart creation requires verified agent identity.
+- Checkout/payment requires user Commerce Passport.
+- Refunds are requests only by default.
+- Loyalty redemption requires explicit user grant.
+- High-value actions require human confirmation.
+- New or untrusted agents have lower rate limits.
+- Emergency disable blocks all write/payment actions.
+
+### 6.7 Commerce Audit Ledger
+
+### Purpose
+
+Provide complete evidence trail for AI-led commerce actions.
+
+### Events To Capture
+
+- Agent registration.
+- Merchant capability discovery.
+- Consent requested.
+- Consent granted/denied/revoked.
+- Passport issued.
+- Passport verified.
+- Policy evaluated.
+- Catalog searched.
+- Cart created/updated.
+- Offer applied.
+- Payment intent created.
+- Checkout link generated.
+- Payment authorized/failed/paid.
+- Webhook received.
+- Order created.
+- Store reservation created.
+- Refund/return requested.
+- Support ticket created.
+- Human override.
+- Fraud/anomaly event.
+
+### Event Fields
+
+- `event_id`.
+- `tenant_id`.
+- `merchant_id`.
+- `agent_id`.
+- `human_principal_id`.
+- `grant_id`.
+- `commerce_passport_jti`.
+- `action`.
+- `resource_type`.
+- `resource_id`.
+- `policy_decision`.
+- `request_hash`.
+- `response_hash`.
+- `provider`.
+- `provider_event_id`.
+- `ip_address`.
+- `user_agent`.
+- `created_at`.
+- `metadata`.
+
+### Acceptance Criteria
+
+- Audit log is tamper-evident or hash-chained.
+- Audit export is available in JSON and CSV.
+- Audit search supports merchant, agent, user, transaction, event type, and date range.
+- Sensitive fields are redacted or tokenized.
+
+### Audit Timeline Views
+
+Required timeline views:
+
+- User consent timeline.
+- Agent session timeline.
+- Payment intent timeline.
+- Order/support timeline.
+- Merchant policy decision timeline.
+- Provider webhook timeline.
+- Refund/return timeline.
+
+Each timeline must show:
+
+- Event time.
+- Actor.
+- Action.
+- Decision/result.
+- Related resource.
+- Linked grant/passport.
+- Provider reference where applicable.
+- Error/remediation if failed.
+
+### Audit Retention
+
+Default retention:
+
+- Audit events: 7 years for live commerce tenants unless contract overrides.
+- Sandbox audit events: 90 days unless merchant exports.
+- Raw webhook payloads: 180 days with sensitive fields redacted.
+- Consent evidence: same retention as live audit events.
+
+Retention policy must be configurable for enterprise tenants.
+
+### 6.8 AgenticOrg Commerce Agent Pack
+
+### Purpose
+
+Deliver merchant-facing AI employees that use Grantex Commerce safely and produce direct business value.
+
+### Required Agents
+
+#### 6.8.1 Sales Agent
+
+Responsibilities:
+
+- Product discovery.
+- Product Q&A.
+- Comparison.
+- Cart creation.
+- Checkout link creation.
+- Handoff to human when needed.
+
+Required integrations:
+
+- Catalog.
+- Inventory.
+- Offers.
+- Plural checkout adapter.
+- Grantex consent.
+
+#### 6.8.2 Offer Agent
+
+Responsibilities:
+
+- Identify eligible EMI, reward points, coupons, gift cards, loyalty offers, bank offers.
+- Recommend merchant-safe offer.
+- Enforce margin/policy limits.
+
+Required integrations:
+
+- Plural affordability where available.
+- Merchant offer rules.
+- Loyalty/gift card systems.
+
+#### 6.8.3 Catalog Agent
+
+Responsibilities:
+
+- Enrich product data.
+- Detect missing attributes.
+- Generate AI-readable descriptions.
+- Map variants.
+- Generate product Q&A.
+- Prepare UCP/ACP/MCP-ready catalog metadata.
+
+Required integrations:
+
+- Merchant catalog source.
+- CMS/e-commerce platform.
+- Grantex Commerce Gateway.
+
+#### 6.8.4 Support Agent
+
+Responsibilities:
+
+- Order status.
+- Payment status.
+- Return eligibility.
+- Refund request.
+- Warranty/support ticket.
+
+Required integrations:
+
+- Order API.
+- Payment status API.
+- Support/CRM system.
+- Grantex user grant.
+
+#### 6.8.5 Reconciliation Agent
+
+Responsibilities:
+
+- Match orders, payments, refunds, settlements.
+- Flag mismatches.
+- Explain failed payments.
+- Generate daily reconciliation report.
+
+Required integrations:
+
+- Plural payment events.
+- Merchant order management.
+- Settlement reports.
+
+#### 6.8.6 Store Operations Agent
+
+Responsibilities:
+
+- Manage offline reservations.
+- Notify store staff.
+- Handle pickup/no-show/cancellation.
+- Escalate stock mismatch.
+
+Required integrations:
+
+- Pine POS bridge.
+- Store inventory.
+- Staff notification channels.
+
+### AgenticOrg Requirements
+
+- Each agent must use Grantex scopes.
+- Each agent action must produce audit events.
+- Human-in-loop must be available for high-risk actions.
+- Agents must support merchant-specific policies.
+- Agents must expose test/sandbox mode.
+
+### Agent Tooling Contract
+
+AgenticOrg agents must use Grantex Commerce tools through a scoped tool manifest:
+
+- No direct Plural/Pine provider calls from agents.
+- No direct payment credential handling.
+- No direct write to merchant catalog/pricing/inventory unless a merchant operator grant allows it.
+- No checkout creation without Commerce Passport.
+- No refund execution unless policy and provider capability allow it.
+- No unsupported offer promises.
+- No exact inventory promise unless inventory freshness is valid.
+
+Each agent run must store:
+
+- Agent template version.
+- Merchant ID.
+- User/session ID where available.
+- Tools called.
+- Grantex scopes used.
+- Policy decisions.
+- Human approvals.
+- Final outcome.
+- Evaluation result where applicable.
+
+### Required Agent Guardrails
+
+Agents must:
+
+- Prefer structured tool results over model memory.
+- Cite product/price/inventory source timestamp in internal reasoning metadata.
+- Ask for consent before payment-affecting actions.
+- Escalate when policy says `requires_human_approval`.
+- Refuse unsupported payment/refund/loyalty operations.
+- Avoid claiming guaranteed availability when inventory is stale.
+- Avoid promising discounts not returned by offer tools.
+- Avoid storing payment details in conversation memory.
+
+## 7. Website And Product Surface Requirements
+
+### 7.1 Work Required On Grantex.dev
+
+#### 7.1.1 New Commerce Landing Page
+
+Create:
+
+- `/commerce`
+
+Purpose:
+
+- Explain Grantex Commerce as trusted authorization for AI-led commerce.
+
+Required sections:
+
+1. Hero:
+   - Headline: "Let merchants safely accept AI agents."
+   - Subcopy: "Grantex Commerce provides verifiable consent, scoped payment authority, merchant policies, audit logs, and Pine/Plural payment execution for agentic commerce."
+2. Problem:
+   - AI agents can act, but merchants need proof of authorization.
+3. Solution:
+   - Commerce Passport.
+   - Merchant Policy Console.
+   - Plural Agentic Checkout Adapter.
+   - UCP/ACP/MCP gateway.
+   - Audit ledger.
+4. Product architecture diagram.
+5. Pine/Plural integration section.
+6. Developer quickstart.
+7. Compliance and audit section.
+8. CTA:
+   - "Try sandbox"
+   - "Request Pine/Plural pilot"
+   - "Read docs"
+
+#### 7.1.2 Developer Docs
+
+Create docs section:
+
+- `/docs/commerce`
+
+Required docs:
+
+- Introduction.
+- Commerce Passport concepts.
+- Grant scopes.
+- Consent flow.
+- Plural checkout adapter.
+- MCP tools.
+- UCP profile.
+- Webhooks.
+- Merchant policies.
+- Audit events.
+- Sandbox walkthrough.
+- Error codes.
+- Security model.
+
+#### 7.1.3 Dashboard Additions
+
+Add Commerce area to Grantex dashboard:
+
+- Commerce tenants.
+- Merchants.
+- Merchant registration and onboarding.
+- Merchant verification.
+- Catalog data hub.
+- Inventory data hub.
+- Pricing and offers data hub.
+- Store/location inventory.
+- AI-native publishing status.
+- Commerce passports.
+- Payment intents.
+- Policies.
+- Audit ledger.
+- Agent registry.
+- Webhooks.
+- Sandbox tester.
+
+Required dashboard navigation:
+
+- `Commerce Home`
+- `Onboarding`
+- `Merchants`
+- `Catalog`
+- `Inventory`
+- `Pricing`
+- `Offers`
+- `Stores`
+- `Payments`
+- `AI-Native Publishing`
+- `Capability Publishing Matrix`
+- `Protocol Adapters`
+- `Policies`
+- `Agent Access`
+- `Passports`
+- `Orders And Payment Intents`
+- `Reservations`
+- `Human Approvals`
+- `Audit Ledger`
+- `Analytics`
+- `Developer Settings`
+- `Webhooks`
+- `Settings`
+
+Each page must implement loading, empty, error, read-only, and permission-denied states.
+
+#### 7.1.4 Merchant Registration And AI-Native Data Hub
+
+This is a required Grantex Commerce surface. Merchant registration, catalog ingestion, inventory sync, pricing, offers, payment configuration, and AI-native publishing must live in Grantex Commerce, not AgenticOrg.
+
+Primary routes:
+
+- `/dashboard/commerce/onboarding`
+- `/dashboard/commerce/merchants`
+- `/dashboard/commerce/merchants/{merchant_id}`
+- `/dashboard/commerce/catalog`
+- `/dashboard/commerce/inventory`
+- `/dashboard/commerce/pricing`
+- `/dashboard/commerce/offers`
+- `/dashboard/commerce/stores`
+- `/dashboard/commerce/payments`
+- `/dashboard/commerce/ai-native`
+- `/dashboard/commerce/ai-native/capabilities`
+- `/dashboard/commerce/ai-native/protocols`
+- `/dashboard/commerce/ai-native/preview`
+
+Merchant onboarding flow:
+
+1. Create merchant account.
+2. Create or select Grantex tenant.
+3. Enter business profile.
+4. Verify business identity.
+5. Add store locations and online channels.
+6. Connect payment rail.
+7. Connect catalog source.
+8. Configure inventory source.
+9. Configure pricing and offers.
+10. Configure fulfillment, returns, warranty, and support policies.
+11. Configure agent access and merchant policies.
+12. Publish AI-native endpoints.
+13. Run sandbox validation.
+14. Request live activation.
+
+AI-native publishing setup flow:
+
+1. Select capabilities to publish:
+   - catalog
+   - inventory
+   - pricing
+   - offers
+   - cart
+   - checkout
+   - payment
+   - booking/reservation
+   - pickup/delivery
+   - order status
+   - cancellation
+   - refund
+   - returns/exchanges
+   - complaints/support
+   - warranty/service
+   - loyalty/gift cards
+   - subscriptions
+   - human handoff
+2. Select protocols/surfaces:
+   - Grantex native API
+   - MCP
+   - UCP-style
+   - ACP-compatible
+   - A2A handoff
+   - AgenticOrg agents
+   - embedded merchant agent
+3. Configure visibility per capability:
+   - public
+   - verified agents only
+   - trusted/allowlisted agents only
+   - user-grant required
+   - merchant-approval required
+   - disabled
+4. Configure data exposure:
+   - product/category filters
+   - store/location filters
+   - inventory visibility
+   - pricing visibility
+   - offer visibility
+5. Validate all selected capabilities.
+6. Preview protocol-specific output.
+7. Run sandbox agent simulation.
+8. Publish to sandbox.
+9. Request live publish.
+
+Catalog ingestion options:
+
+- Shopify connector.
+- WooCommerce connector.
+- Magento / Adobe Commerce connector.
+- Custom REST API connector.
+- Merchant inbound webhook connector.
+- CSV upload.
+- Google Merchant Center feed import.
+- Manual product entry for sandbox and early pilots.
+- ONDC feed connector in a later release.
+
+Catalog fields:
+
+- Product ID.
+- SKU.
+- Title.
+- Description.
+- Brand.
+- Category.
+- Images.
+- Variants.
+- Attributes/specifications.
+- Dimensions/weight.
+- Warranty.
+- Return eligibility.
+- Related products.
+- Substitutes.
+- Accessories.
+- Product Q&A.
+- AI-readable summary.
+- UCP/ACP/MCP readiness status.
+
+Inventory ingestion options:
+
+- Real-time API.
+- Merchant inbound webhook connector.
+- Scheduled sync.
+- CSV upload.
+- Store/POS connector.
+- Manual inventory update for pilots.
+
+Inventory fields:
+
+- SKU.
+- Store/location ID.
+- Available quantity.
+- Reserved quantity.
+- Safety stock.
+- Availability status.
+- Pickup availability.
+- Delivery availability.
+- Last synced timestamp.
+- Inventory confidence score.
+
+Pricing and offers ingestion options:
+
+- Commerce platform connector.
+- Custom API.
+- Merchant inbound webhook connector.
+- CSV upload.
+- Plural/Pine offer and affordability sources where available.
+- Manual offer rules.
+
+Pricing fields:
+
+- SKU.
+- Base price.
+- Sale price.
+- Currency.
+- Tax treatment.
+- Store-level price.
+- Member price.
+- Agent-only offer price.
+- Start/end date.
+- EMI eligibility.
+- Reward/loyalty eligibility.
+- Coupon/bundle eligibility.
+- Margin guardrail metadata where merchant provides it.
+
+AI-native publishing requirements:
+
+- Generate `/.well-known/grantex-commerce`.
+- Generate UCP-style merchant profile.
+- Generate MCP tool manifest.
+- Generate ACP-compatible checkout metadata where applicable.
+- Generate A2A/agent handoff metadata where applicable.
+- Generate per-protocol capability matrix.
+- Show endpoint health.
+- Show catalog readiness score.
+- Show inventory freshness.
+- Show pricing freshness.
+- Show booking/reservation readiness.
+- Show refund/support readiness.
+- Show missing attributes.
+- Show last successful sync.
+- Provide "publish/unpublish" control.
+- Provide "test as agent" simulator.
+- Provide protocol preview before publishing.
+- Provide capability-level publish controls.
+- Provide public/verified/trusted/user-grant visibility controls.
+
+Acceptance criteria:
+
+- A merchant can register and reach sandbox mode without engineering help.
+- A merchant can upload or connect catalog, inventory, and pricing data.
+- A merchant can see whether products are AI-ready.
+- A merchant can publish AI-native endpoints only after required validation passes.
+- A merchant can publish catalog, inventory, pricing, offers, cart, checkout, payment, booking, refund, returns, complaints/support, loyalty, subscriptions, and handoff capabilities where configured and supported.
+- A merchant can see exactly which capabilities are exposed through each protocol.
+- A merchant can disable one capability across all protocols from one control.
+- A merchant can disable one protocol without disabling others.
+- AgenticOrg agents consume merchant data from this Grantex Commerce data hub.
+- Grantex Commerce remains the source of truth for merchant AI-native configuration.
+
+Import and sync validation requirements:
+
+- Show row-level CSV validation errors.
+- Show connector authentication errors.
+- Show field mapping preview before import.
+- Allow dry-run import.
+- Allow rollback of last import where feasible.
+- Deduplicate by SKU/source ID.
+- Reject products without title, SKU/variant ID, and price when publishing for checkout.
+- Warn but do not reject products missing AI enrichment fields.
+- Block checkout for products missing valid price.
+- Block reservation for products missing valid inventory status unless merchant policy allows manual confirmation.
+- Maintain sync job history with started/completed/failed counts.
+
+AI readiness scoring:
+
+- Product readiness score must be computed from required attributes, images, price validity, inventory validity, return policy, warranty/service policy, category mapping, and AI-readable description.
+- Merchant readiness score must aggregate catalog readiness, payment readiness, policy readiness, endpoint readiness, and audit readiness.
+- Readiness score must be explanatory: show exact missing fields and next action.
+
+#### 7.1.5 API And SDK Additions
+
+Add:
+
+- TypeScript SDK support.
+- Python SDK support.
+- Express middleware.
+- FastAPI middleware.
+- MCP server auth integration.
+
+Required SDK methods:
+
+- `commerce.passports.requestConsent()`
+- `commerce.passports.issue()`
+- `commerce.passports.verify()`
+- `commerce.passports.revoke()`
+- `commerce.payments.createIntent()`
+- `commerce.payments.createCheckoutLink()`
+- `commerce.payments.getStatus()`
+- `commerce.policies.evaluate()`
+- `commerce.audit.listEvents()`
+
+Required merchant/catalog SDK methods:
+
+- `commerce.merchants.create()`
+- `commerce.merchants.update()`
+- `commerce.merchants.get()`
+- `commerce.merchants.requestLiveActivation()`
+- `commerce.catalog.upsertProduct()`
+- `commerce.catalog.bulkImport()`
+- `commerce.catalog.getProduct()`
+- `commerce.catalog.search()`
+- `commerce.inventory.upsertLevel()`
+- `commerce.inventory.bulkImport()`
+- `commerce.inventory.checkAvailability()`
+- `commerce.pricing.upsertPrice()`
+- `commerce.offers.upsertOfferRule()`
+- `commerce.aiNative.publish()`
+- `commerce.aiNative.unpublish()`
+- `commerce.aiNative.getReadiness()`
+
+Required admin/partner SDK methods:
+
+- `commerce.partner.listMerchants()`
+- `commerce.partner.getMerchantHealth()`
+- `commerce.partner.getPaymentVolume()`
+- `commerce.partner.getRiskEvents()`
+
+#### 7.1.6 Playground
+
+Add Commerce sandbox playground:
+
+Flow:
+
+1. Select demo merchant.
+2. Select demo product/cart amount.
+3. Select demo agent.
+4. Request user consent.
+5. Issue Commerce Passport.
+6. Create sandbox Plural payment intent.
+7. Simulate webhook.
+8. View audit ledger.
+
+Playground must include both:
+
+- **Merchant setup mode:** connect/upload demo catalog, inventory, pricing, and publish AI-native endpoints.
+- **Agent transaction mode:** simulate agent discovery, consent, checkout, payment webhook, and audit.
+
+### 7.2 Work Required On AgenticOrg.ai
+
+#### 7.2.1 New Commerce Solution Page
+
+Create:
+
+- `/solutions/commerce`
+
+Purpose:
+
+- Show merchant AI employees for sales, support, reconciliation, catalog, offers, and store operations.
+
+Required sections:
+
+1. Hero:
+   - Headline: "AI employees for agentic commerce."
+   - Subcopy: "Deploy governed merchant agents that sell, support, reconcile, and operate across online and offline commerce."
+2. Agent cards:
+   - Sales Agent.
+   - Offer Agent.
+   - Catalog Agent.
+   - Support Agent.
+   - Reconciliation Agent.
+   - Store Operations Agent.
+3. Trust section:
+   - Secured by Grantex Commerce Passport.
+4. Payments section:
+   - Powered by Pine/Plural rails.
+5. Demo flow.
+6. Enterprise controls.
+7. CTA:
+   - "Deploy commerce agents"
+   - "Request pilot"
+
+#### 7.2.2 AgenticOrg Product Console Additions
+
+Add Commerce Agent Pack:
+
+- Agent templates.
+- Merchant connection settings.
+- Grantex tenant connection.
+- Plural/Pine connection.
+- Human approval queues.
+- Agent run logs.
+- Failed action queue.
+- Reconciliation reports.
+
+AgenticOrg console must show read-only merchant data sourced from Grantex Commerce:
+
+- Merchant profile.
+- Catalog readiness.
+- Inventory freshness.
+- Pricing freshness.
+- Payment provider health.
+- Allowed agent scopes.
+- Active merchant policy version.
+
+If data must be edited, AgenticOrg must deep-link to the corresponding Grantex Commerce page instead of creating a duplicate editor.
+
+#### 7.2.3 Agent Templates
+
+Build reusable templates:
+
+- `commerce-sales-agent`
+- `commerce-offer-agent`
+- `commerce-catalog-agent`
+- `commerce-support-agent`
+- `commerce-reconciliation-agent`
+- `commerce-store-ops-agent`
+
+Each template must include:
+
+- Tool manifest.
+- Required Grantex scopes.
+- Prompt/instruction template.
+- Escalation rules.
+- Test dataset.
+- Evaluation suite.
+- Sample merchant configuration.
+
+#### 7.2.4 Human-In-Loop Workbench
+
+Required queues:
+
+- Payment approval.
+- Refund approval.
+- Offer override.
+- Stock mismatch.
+- Customer complaint.
+- High-risk agent action.
+- Policy violation review.
+
+#### 7.2.5 Agent Evaluations
+
+Add evals for:
+
+- Does not create payment without consent.
+- Does not exceed spending limit.
+- Does not hallucinate offers.
+- Does not promise unavailable inventory.
+- Escalates refund edge cases.
+- Uses correct Grantex scope.
+- Logs action to audit.
+
+## 8. Data Model
+
+### 8.1 Core Tables / Collections
+
+Required entities:
+
+- `CommerceMerchant`
+- `MerchantStore`
+- `MerchantIntegration`
+- `CommerceAgent`
+- `CommercePolicy`
+- `CommerceGrant`
+- `CommercePassport`
+- `CommerceConsentRecord`
+- `CommercePaymentIntent`
+- `CommerceOrderReference`
+- `CommerceReservation`
+- `CommerceAuditEvent`
+- `CommerceWebhookEvent`
+- `CommerceOffer`
+- `CommerceAgentSession`
+- `CommerceSupportTicket`
+- `CommerceProduct`
+- `CommerceProductVariant`
+- `CommerceInventoryLevel`
+- `CommercePrice`
+- `CommerceCatalogSyncJob`
+- `CommerceInventorySyncJob`
+- `CommercePricingSyncJob`
+- `CommerceAIProfile`
+- `CommerceMCPTool`
+- `CommerceHumanApproval`
+- `CommerceProviderCapability`
+- `CommerceProviderCredential`
+- `CommerceIntegrationHealth`
+- `CommerceTeamMember`
+- `CommerceRoleAssignment`
+- `CommerceCategoryPreset`
+- `CommerceCapability`
+- `CommerceProtocolAdapter`
+- `CommerceCart`
+- `CommerceBooking`
+- `CommerceComplaint`
+- `CommerceReturnRequest`
+- `CommerceRefundRequest`
+- `CommerceLoyaltyAccount`
+
+### 8.2 CommerceMerchant
+
+Fields:
+
+- `id`
+- `tenant_id`
+- `legal_name`
+- `display_name`
+- `website`
+- `country`
+- `currency`
+- `business_category`
+- `category_preset_key`
+- `secondary_category_preset_keys`
+- `category_preset_version`
+- `tax_identifier`
+- `status`
+- `agent_access_enabled`
+- `ucp_enabled`
+- `acp_enabled`
+- `mcp_enabled`
+- `created_at`
+- `updated_at`
+
+### 8.2.1 CommerceCategoryPreset
+
+Fields:
+
+- `id`
+- `preset_key`
+- `display_name`
+- `version`
+- `status`
+- `required_catalog_fields`
+- `recommended_catalog_fields`
+- `inventory_rules`
+- `pricing_rules`
+- `offer_rules`
+- `default_capabilities`
+- `default_protocol_exposure`
+- `default_policy_rules`
+- `agent_template_keys`
+- `eval_suite_keys`
+- `restricted_actions`
+- `human_approval_thresholds`
+- `created_at`
+- `updated_at`
+
+Preset keys:
+
+- `electronics_appliances`
+- `fashion_lifestyle`
+- `beauty_personal_care`
+- `pharmacy_wellness`
+- `grocery_convenience`
+- `restaurant_qsr`
+- `services_bookings`
+- `subscriptions_digital`
+- `home_furniture`
+- `b2b_wholesale`
+- `generic_retail`
+
+Category presets must be seed data and versioned. Updating a preset must not silently change live merchant policies; merchants must explicitly review and apply preset upgrades.
+
+### 8.3 CommercePolicy
+
+Fields:
+
+- `id`
+- `merchant_id`
+- `version`
+- `status`
+- `rules`
+- `created_by`
+- `created_at`
+- `activated_at`
+
+Rules should be stored as structured JSON with validation.
+
+### 8.4 CommercePassport
+
+Fields:
+
+- `id`
+- `grant_id`
+- `jti`
+- `merchant_id`
+- `agent_id`
+- `human_principal_id`
+- `scopes`
+- `max_amount`
+- `currency`
+- `constraints`
+- `expires_at`
+- `revoked_at`
+- `revocation_reason`
+- `created_at`
+
+### 8.5 CommercePaymentIntent
+
+Fields:
+
+- `id`
+- `merchant_id`
+- `agent_id`
+- `human_principal_id`
+- `passport_jti`
+- `amount`
+- `currency`
+- `line_items`
+- `provider`
+- `provider_order_id`
+- `provider_payment_id`
+- `checkout_url`
+- `status`
+- `metadata`
+- `created_at`
+- `updated_at`
+
+### 8.6 CommerceProduct
+
+Fields:
+
+- `id`
+- `merchant_id`
+- `source_system`
+- `source_record_id`
+- `title`
+- `description`
+- `brand`
+- `category`
+- `status`
+- `images`
+- `attributes`
+- `ai_summary`
+- `product_questions`
+- `return_eligible`
+- `warranty_summary`
+- `readiness_score`
+- `missing_fields`
+- `last_synced_at`
+- `created_at`
+- `updated_at`
+
+### 8.7 CommerceProductVariant
+
+Fields:
+
+- `id`
+- `merchant_id`
+- `product_id`
+- `sku`
+- `source_variant_id`
+- `title`
+- `attributes`
+- `barcode`
+- `dimensions`
+- `weight`
+- `status`
+- `created_at`
+- `updated_at`
+
+### 8.8 CommerceInventoryLevel
+
+Fields:
+
+- `id`
+- `merchant_id`
+- `variant_id`
+- `sku`
+- `store_id`
+- `available_quantity`
+- `reserved_quantity`
+- `availability_status`
+- `pickup_available`
+- `delivery_available`
+- `freshness_status`
+- `confidence_score`
+- `last_synced_at`
+- `created_at`
+- `updated_at`
+
+### 8.9 CommercePrice
+
+Fields:
+
+- `id`
+- `merchant_id`
+- `variant_id`
+- `sku`
+- `store_id`
+- `currency`
+- `base_amount`
+- `sale_amount`
+- `member_amount`
+- `agent_offer_amount`
+- `tax_inclusive`
+- `valid_from`
+- `valid_until`
+- `freshness_status`
+- `last_synced_at`
+- `created_at`
+- `updated_at`
+
+### 8.10 CommerceAIProfile
+
+Fields:
+
+- `id`
+- `merchant_id`
+- `environment`
+- `grantex_profile_url`
+- `ucp_profile_url`
+- `mcp_server_url`
+- `acp_metadata_url`
+- `published`
+- `published_at`
+- `last_validated_at`
+- `validation_errors`
+- `capabilities`
+- `created_at`
+- `updated_at`
+
+### 8.11 CommerceHumanApproval
+
+Fields:
+
+- `id`
+- `merchant_id`
+- `agent_id`
+- `human_principal_id`
+- `requested_action`
+- `requested_payload`
+- `policy_decision_id`
+- `status`
+- `assigned_to`
+- `approval_reason`
+- `approved_at`
+- `rejected_at`
+- `expires_at`
+- `created_at`
+- `updated_at`
+
+### 8.12 Data Constraints
+
+Required constraints:
+
+- Unique merchant slug per tenant.
+- Unique SKU per merchant unless source system allows duplicates; duplicates must be explicitly mapped.
+- Unique provider credential per merchant/provider/environment.
+- Unique active AI profile per merchant/environment.
+- Payment intent idempotency key unique per merchant/action.
+- Audit event IDs globally unique.
+- Passport JTI globally unique.
+
+Required indexes:
+
+- Merchant by tenant/status.
+- Product by merchant/status/category.
+- Variant by merchant/SKU.
+- Inventory by merchant/SKU/store.
+- Price by merchant/SKU/store/current validity.
+- Audit by merchant/created_at.
+- Audit by passport JTI.
+- Payment intent by merchant/status/created_at.
+- Policy by merchant/status/version.
+
+### 8.13 CommerceCapability
+
+Fields:
+
+- `id`
+- `merchant_id`
+- `capability_key`
+- `display_name`
+- `description`
+- `enabled`
+- `environment`
+- `visibility`
+- `required_scopes`
+- `required_passport_type`
+- `requires_user_consent`
+- `requires_merchant_approval`
+- `provider_dependency`
+- `provider_capability_status`
+- `protocol_mappings`
+- `input_schema`
+- `output_schema`
+- `rate_limit`
+- `last_validated_at`
+- `validation_errors`
+- `created_at`
+- `updated_at`
+
+Capability keys must include:
+
+- `merchant.profile`
+- `store.profile`
+- `catalog.search`
+- `catalog.product_detail`
+- `inventory.availability`
+- `inventory.exact_quantity`
+- `pricing.read`
+- `offers.eligible`
+- `cart.create`
+- `cart.update`
+- `checkout.create`
+- `payment.initiate`
+- `payment.status`
+- `booking.create`
+- `booking.update`
+- `pickup.create`
+- `delivery.options`
+- `order.status`
+- `order.cancel_request`
+- `refund.request`
+- `refund.execute`
+- `return.request`
+- `exchange.request`
+- `complaint.create`
+- `support.ticket_create`
+- `warranty.service_request`
+- `loyalty.read`
+- `loyalty.redeem`
+- `giftcard.read`
+- `giftcard.redeem`
+- `subscription.create`
+- `subscription.manage`
+- `human_handoff.create`
+
+### 8.14 CommerceProtocolAdapter
+
+Fields:
+
+- `id`
+- `protocol_key`
+- `display_name`
+- `version`
+- `enabled`
+- `supported_capability_keys`
+- `profile_url`
+- `manifest_url`
+- `last_generated_at`
+- `last_validated_at`
+- `validation_errors`
+- `created_at`
+- `updated_at`
+
+Protocol keys:
+
+- `grantex_native`
+- `mcp`
+- `ucp_style`
+- `acp_compatible`
+- `a2a_handoff`
+
+### 8.15 CommerceCart
+
+Fields:
+
+- `id`
+- `merchant_id`
+- `agent_id`
+- `human_principal_id`
+- `passport_jti`
+- `status`
+- `currency`
+- `line_items`
+- `subtotal_amount`
+- `discount_amount`
+- `tax_amount`
+- `shipping_amount`
+- `total_amount`
+- `expires_at`
+- `created_at`
+- `updated_at`
+
+### 8.16 CommerceBooking
+
+Fields:
+
+- `id`
+- `merchant_id`
+- `store_id`
+- `agent_id`
+- `human_principal_id`
+- `passport_jti`
+- `booking_type`
+- `status`
+- `resource_id`
+- `scheduled_start_at`
+- `scheduled_end_at`
+- `pickup_code`
+- `metadata`
+- `created_at`
+- `updated_at`
+
+### 8.17 CommerceComplaint
+
+Fields:
+
+- `id`
+- `merchant_id`
+- `agent_id`
+- `human_principal_id`
+- `passport_jti`
+- `order_reference_id`
+- `category`
+- `priority`
+- `status`
+- `subject`
+- `description`
+- `attachments`
+- `assigned_to`
+- `created_at`
+- `updated_at`
+
+### 8.18 CommerceReturnRequest And CommerceRefundRequest
+
+Return request fields:
+
+- `id`
+- `merchant_id`
+- `agent_id`
+- `human_principal_id`
+- `passport_jti`
+- `order_reference_id`
+- `line_items`
+- `reason`
+- `status`
+- `requires_human_approval`
+- `created_at`
+- `updated_at`
+
+Refund request fields:
+
+- `id`
+- `merchant_id`
+- `agent_id`
+- `human_principal_id`
+- `passport_jti`
+- `payment_intent_id`
+- `amount`
+- `currency`
+- `reason`
+- `status`
+- `provider_refund_id`
+- `requires_human_approval`
+- `created_at`
+- `updated_at`
+
+## 9. API Requirements
+
+### 9.1 Authentication
+
+Support:
+
+- Grantex API keys for server-to-server.
+- OAuth 2.1/OIDC for dashboard users.
+- Grantex grant tokens for agent actions.
+- Signed webhooks from payment providers.
+
+### 9.1.1 API Versioning
+
+Requirements:
+
+- All public APIs use `/v1`.
+- Breaking changes require `/v2`.
+- Response objects include `api_version`.
+- Deprecations require dashboard warning and documentation.
+- MCP tool schema versions must be explicit.
+- UCP/ACP compatibility versions must be recorded in merchant AI profile.
+
+### 9.2 Authorization
+
+Every write/payment/support/order action must evaluate:
+
+1. Agent identity.
+2. Passport validity.
+3. Scope.
+4. Merchant policy.
+5. User consent.
+6. Amount/category/merchant constraints.
+7. Revocation status.
+8. Risk/anomaly rules.
+
+### 9.3 Error Model
+
+Errors must be structured:
+
+- `invalid_passport`
+- `passport_expired`
+- `passport_revoked`
+- `scope_denied`
+- `amount_limit_exceeded`
+- `merchant_mismatch`
+- `policy_denied`
+- `human_approval_required`
+- `provider_error`
+- `webhook_verification_failed`
+- `payment_failed`
+- `rate_limited`
+
+Error response fields:
+
+- `error`
+- `message`
+- `decision_id`
+- `audit_event_id`
+- `remediation`
+
+### 9.4 Required REST API Surface
+
+Merchant APIs:
+
+- `POST /v1/commerce/merchants`
+- `GET /v1/commerce/merchants`
+- `GET /v1/commerce/merchants/{merchant_id}`
+- `PATCH /v1/commerce/merchants/{merchant_id}`
+- `POST /v1/commerce/merchants/{merchant_id}/verify`
+- `POST /v1/commerce/merchants/{merchant_id}/request-live`
+- `POST /v1/commerce/merchants/{merchant_id}/disable-agentic-commerce`
+- `GET /v1/commerce/category-presets`
+- `GET /v1/commerce/category-presets/{preset_key}`
+- `POST /v1/commerce/merchants/{merchant_id}/category-presets/apply`
+- `POST /v1/commerce/merchants/{merchant_id}/category-presets/preview`
+
+Store APIs:
+
+- `POST /v1/commerce/merchants/{merchant_id}/stores`
+- `GET /v1/commerce/merchants/{merchant_id}/stores`
+- `PATCH /v1/commerce/stores/{store_id}`
+- `DELETE /v1/commerce/stores/{store_id}`
+
+Catalog APIs:
+
+- `POST /v1/commerce/catalog/products`
+- `POST /v1/commerce/catalog/products/bulk`
+- `GET /v1/commerce/catalog/products`
+- `GET /v1/commerce/catalog/products/{product_id}`
+- `PATCH /v1/commerce/catalog/products/{product_id}`
+- `POST /v1/commerce/catalog/search`
+- `POST /v1/commerce/catalog/sync-jobs`
+- `GET /v1/commerce/catalog/sync-jobs/{sync_job_id}`
+
+Inventory APIs:
+
+- `POST /v1/commerce/inventory/levels`
+- `POST /v1/commerce/inventory/levels/bulk`
+- `GET /v1/commerce/inventory/availability`
+- `POST /v1/commerce/inventory/reservations`
+- `PATCH /v1/commerce/inventory/reservations/{reservation_id}`
+- `POST /v1/commerce/inventory/sync-jobs`
+
+Pricing and offer APIs:
+
+- `POST /v1/commerce/pricing/prices`
+- `POST /v1/commerce/pricing/prices/bulk`
+- `GET /v1/commerce/pricing/prices`
+- `POST /v1/commerce/offers`
+- `GET /v1/commerce/offers/eligible`
+- `PATCH /v1/commerce/offers/{offer_id}`
+
+AI-native publishing APIs:
+
+- `GET /v1/commerce/ai-native/readiness`
+- `POST /v1/commerce/ai-native/publish`
+- `POST /v1/commerce/ai-native/unpublish`
+- `GET /v1/commerce/ai-native/profile`
+- `GET /v1/commerce/ai-native/mcp-tools`
+- `GET /v1/commerce/ai-native/capabilities`
+- `PATCH /v1/commerce/ai-native/capabilities/{capability_id}`
+- `GET /v1/commerce/ai-native/protocols`
+- `PATCH /v1/commerce/ai-native/protocols/{protocol_key}`
+- `GET /v1/commerce/ai-native/preview`
+- `POST /v1/commerce/ai-native/validate`
+
+Cart APIs:
+
+- `POST /v1/commerce/carts`
+- `GET /v1/commerce/carts/{cart_id}`
+- `POST /v1/commerce/carts/{cart_id}/items`
+- `PATCH /v1/commerce/carts/{cart_id}/items/{item_id}`
+- `DELETE /v1/commerce/carts/{cart_id}/items/{item_id}`
+- `POST /v1/commerce/carts/{cart_id}/checkout`
+
+Booking/reservation APIs:
+
+- `POST /v1/commerce/bookings`
+- `GET /v1/commerce/bookings/{booking_id}`
+- `PATCH /v1/commerce/bookings/{booking_id}`
+- `POST /v1/commerce/bookings/{booking_id}/cancel`
+- `POST /v1/commerce/bookings/{booking_id}/confirm`
+
+Order, return, refund, and complaint APIs:
+
+- `GET /v1/commerce/orders/{order_id}`
+- `POST /v1/commerce/orders/{order_id}/cancel-request`
+- `POST /v1/commerce/returns`
+- `GET /v1/commerce/returns/{return_request_id}`
+- `POST /v1/commerce/exchanges`
+- `POST /v1/commerce/refunds/request`
+- `GET /v1/commerce/refunds/{refund_request_id}`
+- `POST /v1/commerce/complaints`
+- `GET /v1/commerce/complaints/{complaint_id}`
+- `POST /v1/commerce/support/tickets`
+- `POST /v1/commerce/warranty/service-requests`
+
+Loyalty, gift card, and subscription APIs:
+
+- `GET /v1/commerce/loyalty/accounts/{account_id}`
+- `POST /v1/commerce/loyalty/redeem`
+- `GET /v1/commerce/giftcards/{giftcard_id}`
+- `POST /v1/commerce/giftcards/redeem`
+- `POST /v1/commerce/subscriptions`
+- `GET /v1/commerce/subscriptions/{subscription_id}`
+- `PATCH /v1/commerce/subscriptions/{subscription_id}`
+
+Policy APIs:
+
+- `POST /v1/commerce/policies`
+- `GET /v1/commerce/policies`
+- `GET /v1/commerce/policies/{policy_id}`
+- `POST /v1/commerce/policies/{policy_id}/activate`
+- `POST /v1/commerce/policies/simulate`
+- `POST /v1/commerce/policies/evaluate`
+
+Passport APIs:
+
+- `POST /v1/commerce/passports/consent-requests`
+- `POST /v1/commerce/passports/exchange`
+- `POST /v1/commerce/passports/verify`
+- `POST /v1/commerce/passports/revoke`
+- `GET /v1/commerce/passports`
+
+Payment APIs are defined in Section 6.3 and must follow the same auth/error/idempotency model.
+
+### 9.5 Pagination, Filtering, And Sorting
+
+List endpoints must support:
+
+- `limit`
+- `cursor`
+- `sort`
+- `created_after`
+- `created_before`
+- Relevant status filters.
+
+Large bulk endpoints must be asynchronous and return a sync/import job ID.
+
+### 9.6 Idempotency
+
+Required for:
+
+- Payment intent creation.
+- Checkout link creation.
+- Refund requests.
+- Subscription creation.
+- Inventory reservation.
+- Bulk imports.
+- Webhook processing.
+
+Idempotency keys must be scoped by merchant, endpoint, and environment.
+
+### 9.7 Webhook Requirements
+
+Grantex Commerce outbound webhooks:
+
+- `commerce.passport.issued`
+- `commerce.passport.revoked`
+- `commerce.payment_intent.created`
+- `commerce.payment_intent.paid`
+- `commerce.payment_intent.failed`
+- `commerce.refund.requested`
+- `commerce.reservation.created`
+- `commerce.policy.denied`
+- `commerce.human_approval.required`
+- `commerce.ai_profile.published`
+
+Outbound webhook requirements:
+
+- Signed payload.
+- Retry with backoff.
+- Delivery log.
+- Manual replay.
+- Tenant-level webhook secrets.
+- Event schema documentation.
+
+### 9.8 Merchant Inbound Webhook Requirements
+
+Merchants and commerce platforms must be able to push operational changes into Grantex Commerce through signed inbound webhooks. This is required for enterprise-grade freshness and cannot be replaced only by polling or UI uploads.
+
+Inbound webhook endpoint pattern:
+
+- `POST /v1/webhooks/merchant/{merchant_id}/{source_key}`
+
+Required inbound event types:
+
+- `merchant.profile.updated`
+- `store.created`
+- `store.updated`
+- `catalog.product.created`
+- `catalog.product.updated`
+- `catalog.product.deleted`
+- `catalog.variant.created`
+- `catalog.variant.updated`
+- `catalog.variant.deleted`
+- `inventory.level.updated`
+- `inventory.reservation.updated`
+- `pricing.price.updated`
+- `offers.offer.created`
+- `offers.offer.updated`
+- `offers.offer.deleted`
+- `cart.updated`
+- `order.created`
+- `order.updated`
+- `order.cancelled`
+- `booking.created`
+- `booking.updated`
+- `booking.cancelled`
+- `payment.status.updated`
+- `refund.created`
+- `refund.updated`
+- `return.created`
+- `return.updated`
+- `complaint.created`
+- `complaint.updated`
+- `support.ticket.updated`
+- `loyalty.account.updated`
+- `subscription.created`
+- `subscription.updated`
+- `subscription.cancelled`
+
+Inbound webhook requirements:
+
+- Merchant-specific signing secret.
+- Signature verification before processing.
+- Idempotency using provider event ID or event hash.
+- Event timestamp validation.
+- Replay protection.
+- Schema validation per event type.
+- Mapping to normalized Grantex data models.
+- Dead-letter queue for failed events.
+- Manual replay from dashboard.
+- Sync job or event processing log visible to merchant.
+- Ability to pause one inbound source without disabling all agentic commerce.
+
+Inbound webhook behavior:
+
+- Catalog, inventory, pricing, offer, booking, refund, complaint, support, loyalty, and subscription changes must update the normalized Grantex read model used by AI agents.
+- If an inbound event invalidates a published capability, Grantex must mark that capability unhealthy and optionally unpublish it based on merchant policy.
+- If price or inventory changes affect an active cart/payment intent, Grantex must re-evaluate policy and require new user consent if the total amount increases.
+- If a product becomes unavailable, Grantex must block new checkout/reservation and notify active agent sessions where possible.
+
+### 9.9 API-First Product Requirement
+
+Every dashboard action must be backed by an API or typed server action that can be documented, tested, authorized, and audited.
+
+No UI-only implementation is acceptable for:
+
+- Merchant registration.
+- Category preset selection.
+- Catalog/inventory/pricing ingestion.
+- Capability publishing.
+- Protocol enablement.
+- Policy creation/evaluation.
+- Agent access configuration.
+- Payment intent creation.
+- Booking/reservation.
+- Refund/return/complaint/support actions.
+- Webhook configuration.
+- Audit export.
+- Emergency disable.
+
+Enterprise merchants must be able to operate Grantex Commerce primarily through APIs, SDKs, and webhooks without relying on manual dashboard workflows.
+
+## 10. Security And Compliance
+
+### 10.1 Security Requirements
+
+- Offline JWT verification via JWKS.
+- Online revocation check.
+- Short-lived commerce passports.
+- Strict scope enforcement.
+- Merchant-level rate limits.
+- Webhook signature verification.
+- Idempotency keys on payment/order APIs.
+- PII minimization.
+- Encryption at rest.
+- Secrets manager for provider credentials.
+- RBAC for merchant console.
+- Audit log immutability/tamper evidence.
+
+### 10.2 Compliance Requirements
+
+Support compliance evidence for:
+
+- DPDP Act readiness.
+- SOC 2 controls.
+- PCI-sensitive boundary avoidance by relying on Plural/Pine for payment data.
+- Consumer consent evidence.
+- Merchant policy evidence.
+- AI agent accountability.
+
+### 10.3 Risk Controls
+
+Required:
+
+- Anomaly detection for unusual agent actions.
+- High-value payment approval.
+- New agent trust scoring.
+- Merchant emergency kill switch.
+- User revoke-all function.
+- Admin fraud review queue.
+
+### 10.4 Threat Model
+
+The implementation must defend against:
+
+- Rogue agent attempting payment without user consent.
+- Agent replaying an old passport.
+- Agent using passport for wrong merchant.
+- Agent exceeding amount/category/payment constraints.
+- Prompt-injected agent attempting unauthorized tool call.
+- Merchant misconfiguration exposing private inventory or customer data.
+- Webhook spoofing.
+- Provider callback replay.
+- Cross-tenant data access.
+- API key leakage.
+- Admin abuse.
+- Stale inventory causing false availability promises.
+- Stale pricing causing incorrect checkout amount.
+
+Required mitigations:
+
+- Signed short-lived passports.
+- JTI replay detection for sensitive actions.
+- Merchant and amount binding in passport.
+- Scope enforcement on every tool/API.
+- Webhook signature verification and idempotent processing.
+- Tenant-scoped RBAC and API keys.
+- Audit logs for admin actions.
+- Stale data gates.
+- Policy simulator and safe defaults.
+
+### 10.5 Privacy Requirements
+
+Requirements:
+
+- Collect minimum user data needed for consent and audit.
+- Do not store raw card data or payment credentials.
+- Tokenize provider references where possible.
+- Redact PII in logs.
+- Allow user to view and revoke active commerce grants.
+- Allow merchant to export consent/audit evidence without exposing unrelated user data.
+- Support data deletion workflows subject to legal/audit retention requirements.
+- Separate conversation transcripts from payment/audit records; store transcript references, not full transcripts, unless explicitly enabled.
+
+### 10.6 RBAC Requirements
+
+Required merchant roles:
+
+- `owner`: full merchant control.
+- `admin`: manage integrations, policies, team, and live mode.
+- `developer`: manage API keys, webhooks, sandbox, docs.
+- `operations`: manage orders, reservations, approvals, support.
+- `analyst`: read analytics and audit.
+- `viewer`: read-only.
+
+Sensitive actions requiring owner/admin:
+
+- Enable live mode.
+- Add live payment credentials.
+- Disable audit export.
+- Change high-risk policy rules.
+- Emergency disable.
+- Revoke all passports.
+- Invite admin/owner.
+
+### 10.7 Regulatory And Payment-Network Requirements
+
+Agentic commerce involving payments must be treated as regulated payment-adjacent infrastructure. Legal and compliance review is required before live payment delegation.
+
+India/RBI requirements:
+
+- Grantex must not assume autonomous agent payments are permitted without user confirmation.
+- Default live payment mode in India must require final user confirmation unless a legally valid mandate exists.
+- Commerce Passport must distinguish between:
+  - user-confirmed checkout;
+  - delegated checkout preparation;
+  - recurring/mandated payments;
+  - merchant-side operational actions.
+- RBI AFA requirements must be mapped to each passport type.
+- UPI AutoPay/e-mandate flows must be modeled separately from one-time checkout.
+- Recurring payments must store mandate reference, amount cap, frequency, expiry, cancellation method, and user consent evidence.
+- High-risk categories, pharmacy/wellness, financial products, and regulated goods must require category-specific legal guardrails.
+
+Network/protocol requirements:
+
+- AP2, MPP, and other payment-network agent authorization protocols must be tracked as strategic compatibility targets.
+- Grantex should support AP2/MPP-style mandate evidence where specifications and partner access allow.
+- Grantex must not claim full AP2, MPP, UCP, ACP, or A2A compliance unless validated against the relevant public or partner specification.
+- Until validated, product copy must use "compatible", "adapter", or "profile" language rather than "certified" or "compliant".
+
+Required compliance outputs:
+
+- Consent evidence export.
+- Passport verification record.
+- Policy decision record.
+- Payment provider reference.
+- Mandate reference where applicable.
+- User revocation/cancellation history.
+- Merchant terms and refund policy version.
+
+Live launch blocker:
+
+- No live delegated payment flow may launch in India until legal review confirms the flow satisfies RBI/AFA/mandate requirements.
+
+## 11. Analytics
+
+### 11.1 Merchant Analytics
+
+Dashboards:
+
+- Agent-driven revenue.
+- Agent sessions.
+- Conversion funnel.
+- Payments created/paid/failed.
+- Top agents.
+- Top products.
+- Rejected policy actions.
+- Consent conversion.
+- Failed checkout reasons.
+- Refund/return rates.
+- Offer performance.
+
+### 11.2 Partner Analytics
+
+For Pine/Plural:
+
+- Agentic payment volume.
+- Merchant adoption.
+- Success rate by payment method.
+- Offer/EMI attach rate.
+- Sandbox-to-live conversion.
+- Risk events.
+- Merchant categories.
+
+### 11.3 Grantex Analytics
+
+- Passports issued.
+- Passports verified.
+- Revocations.
+- Scope denials.
+- Policy denials.
+- Agent trust scores.
+- API usage.
+- Webhook latency.
+
+## 12. User Journeys
+
+### 12.1 Online Checkout With AI Agent
+
+1. Merchant connects Plural and catalog.
+2. Agent discovers merchant via UCP/MCP/profile.
+3. User asks agent to buy product.
+4. Agent creates cart draft.
+5. Agent requests Grantex consent.
+6. User approves.
+7. Commerce Passport issued.
+8. Agent creates payment intent.
+9. Plural checkout link generated.
+10. User pays.
+11. Plural webhook confirms payment.
+12. Merchant dashboard shows payment and audit.
+13. AgenticOrg support/reconciliation agents continue post-payment workflow.
+
+### 12.2 Support Agent Refund Request
+
+1. User asks support agent for refund.
+2. Support agent requests order read and refund request scope.
+3. User approves.
+4. Agent checks merchant refund policy.
+5. Policy requires human approval if above threshold.
+6. Refund request enters workbench.
+7. Merchant approves.
+8. Plural refund API called where available.
+9. Audit log records entire chain.
+
+### 12.3 Offline Store Reservation
+
+1. User asks agent for nearby product.
+2. Agent checks store inventory/reservation availability.
+3. User grants reservation/payment permission.
+4. Agent creates store reservation.
+5. Pickup code generated.
+6. Staff receives notification.
+7. Customer visits store and pays via Pine POS or already-paid Plural checkout.
+8. Store marks fulfilled.
+9. Audit and reconciliation complete.
+
+## 13. Implementation Plan
+
+This is a complete working product plan, not only an MVP. Build in releases to reduce risk.
+
+### Release 1: Grantex Commerce Foundation
+
+Must include:
+
+- Commerce scopes.
+- Commerce Passport.
+- Consent UX.
+- Passport verification.
+- Revocation.
+- Audit events.
+- Merchant entity.
+- Basic merchant console.
+- Sandbox merchant.
+- Commerce docs.
+
+Exit criteria:
+
+- Agent can request consent and receive a signed Commerce Passport.
+- Merchant can view passport and audit event.
+- Revocation blocks future usage.
+
+### Release 2: Plural Agentic Checkout
+
+Must include:
+
+- Plural sandbox integration.
+- Payment intent API.
+- Checkout link/order creation.
+- Webhook handling.
+- Payment status.
+- Audit timeline.
+- SDK helpers.
+- Playground demo.
+
+Exit criteria:
+
+- End-to-end sandbox payment flow works.
+- Payment cannot be created without valid passport.
+- Webhook updates audit timeline.
+
+### Release 3: Merchant Policy Console
+
+Must include:
+
+- Policy rules UI.
+- Scope controls.
+- Amount limits.
+- Agent allowlist/blocklist.
+- Human approval requirement.
+- Emergency disable.
+- Policy simulator.
+- Policy decision logs.
+
+Exit criteria:
+
+- Merchant can configure and test policies.
+- Policy denial blocks API actions.
+- Every decision is auditable.
+
+### Release 4: AI-Native Gateway
+
+Must include:
+
+- `/.well-known/grantex-commerce`.
+- UCP-style profile.
+- MCP tools.
+- Catalog/search API.
+- Cart/checkout API skeleton.
+- ACP-compatible checkout metadata where feasible.
+- External agent sandbox.
+- Universal capability publishing matrix.
+- Protocol adapter interface.
+- Capability-level publish/unpublish controls.
+- Protocol preview UI.
+- Booking, refund, return, complaint/support, loyalty, gift card, subscription, and human handoff capability definitions.
+
+Exit criteria:
+
+- External MCP client can discover and call merchant tools.
+- Payment/write tools require Commerce Passport.
+- Merchant can see and control every exposed capability per protocol.
+- Unsupported protocol/provider capabilities show explicit fallback and reason.
+
+### Release 5: AgenticOrg Commerce Agent Pack
+
+Must include:
+
+- Sales Agent.
+- Offer Agent.
+- Support Agent.
+- Reconciliation Agent.
+- Catalog Agent.
+- Human-in-loop queues.
+- Evals.
+- Agent run logs.
+
+Exit criteria:
+
+- AgenticOrg can run an end-to-end commerce conversation.
+- Agents enforce Grantex permissions.
+- Failed/high-risk actions enter human queue.
+
+### Release 6: Pine POS / Offline Bridge
+
+Must include:
+
+- Store profile.
+- Reservation model.
+- Pickup code.
+- POS bridge sandbox.
+- Staff notification.
+- Offline reconciliation.
+
+Exit criteria:
+
+- Offline reservation and pickup demo works.
+- Merchant can view reservation lifecycle.
+
+### Release 7: Production Hardening
+
+Must include:
+
+- RBAC.
+- Rate limits.
+- Observability.
+- Audit exports.
+- Compliance reports.
+- Error dashboards.
+- Webhook retries.
+- Inbound merchant webhooks.
+- Idempotency.
+- Load testing.
+- Security review.
+
+Exit criteria:
+
+- Production readiness checklist passed.
+- Pilot merchants can go live.
+
+### Release 8: GA Product Completeness
+
+Must include:
+
+- Complete merchant self-serve onboarding.
+- Category preset system for launch categories.
+- Complete catalog, inventory, pricing, and offer data hub.
+- Live Plural integration behind feature flag.
+- Partner-ready Pine/POS sandbox bridge.
+- AgenticOrg Commerce Agent Pack enabled for pilot merchants.
+- UCP-style, ACP-compatible, and MCP interoperability docs.
+- Merchant analytics and partner analytics.
+- Compliance export package.
+- Support runbooks.
+- Admin operations console.
+- Billing/pricing hooks or internal usage metering.
+
+Exit criteria:
+
+- A new merchant can self-serve from signup to sandbox transaction without engineering assistance.
+- An approved merchant can move from sandbox to live using documented checks.
+- Launch category merchants receive category-specific required fields, policies, capabilities, and agent evals.
+- At least one AgenticOrg commerce agent can complete a live or live-simulated commerce workflow.
+- All release sign-off checklist items pass.
+
+### 13.1 Engineering Workstreams
+
+Claude Code should split implementation into these workstreams:
+
+1. **Core schema and migrations**
+   - All commerce tables/entities.
+   - Indexes and constraints.
+   - Tenant/environment isolation.
+2. **Commerce Passport and consent**
+   - Consent requests.
+   - Passport claims.
+   - Verification and revocation.
+   - Consent UI.
+3. **Merchant control plane**
+   - Registration.
+   - Verification.
+   - Dashboard.
+   - Team/RBAC.
+4. **Commerce data hub**
+   - Catalog.
+   - Inventory.
+   - Pricing.
+   - Offers.
+   - Sync jobs.
+   - CSV import.
+   - Inbound merchant webhooks.
+5. **Provider adapters**
+   - Mock provider.
+   - Plural sandbox.
+   - Plural live behind flag.
+   - Pine POS mock/sandbox bridge.
+6. **AI-native gateway**
+   - Well-known endpoints.
+   - UCP-style profile.
+   - MCP tools.
+   - ACP metadata.
+7. **Policies and approvals**
+   - Policy engine.
+   - Simulator.
+   - Human approval queue.
+   - Emergency disable.
+8. **AgenticOrg integration**
+   - Tool manifests.
+   - Agent templates.
+   - Agent run logs.
+   - Safety evals.
+9. **Audit, analytics, observability**
+   - Audit ledger.
+   - Dashboards.
+   - Exports.
+   - Metrics/traces/logs.
+10. **Docs, playground, demos**
+   - Developer docs.
+   - Commerce playground.
+   - Demo merchants and demo agents.
+
+### 13.2 Testing Requirements
+
+Required test suites:
+
+- Unit tests for passport claims and policy decisions.
+- Unit tests for amount/currency constraints.
+- Unit tests for lifecycle transitions.
+- Unit tests for payment state machine.
+- Integration tests for merchant onboarding.
+- Integration tests for catalog/inventory/pricing import.
+- Integration tests for merchant inbound webhooks.
+- Integration tests for Plural mock/sandbox provider.
+- Integration tests for webhook signature verification and replay.
+- Integration tests for UCP/MCP profile generation.
+- End-to-end test for agent discovery -> consent -> checkout -> webhook -> audit.
+- End-to-end test for revocation blocking checkout.
+- End-to-end test for policy denial and human approval.
+- Agent evals for each AgenticOrg commerce agent.
+- RBAC tests for merchant dashboard.
+- Multi-tenant isolation tests.
+- Rate-limit tests.
+- Security tests for token tampering, expired passports, revoked passports, and merchant mismatch.
+
+Minimum quality gates:
+
+- Core commerce unit tests: 90%+ coverage.
+- Security-critical modules: 95%+ coverage.
+- All payment state transitions tested.
+- All policy default rules tested.
+- All launch category presets tested.
+- Category-specific readiness scoring tested.
+- Category-specific agent evals tested for launch categories.
+- No production route without auth/tenant checks.
+- No live provider action without idempotency key.
+
+### 13.3 Observability Requirements
+
+Metrics:
+
+- Passport issuance latency.
+- Passport verification latency.
+- Policy evaluation latency.
+- Payment intent creation latency.
+- Provider API latency/error rate.
+- Webhook processing latency.
+- Catalog sync duration.
+- Inventory freshness.
+- Pricing freshness.
+- Agent tool call success/failure.
+- Human approval SLA.
+
+Logs:
+
+- Structured JSON logs.
+- Correlation ID per agent session.
+- Request ID per API call.
+- Provider request ID where available.
+- Audit event ID where available.
+
+Traces:
+
+- End-to-end trace from agent request to Grantex policy to provider call to webhook.
+
+Alerts:
+
+- Provider failure spike.
+- Webhook verification failure.
+- Payment stuck in pending.
+- Inventory sync stale.
+- Pricing sync stale.
+- High policy denial spike.
+- Unusual agent activity.
+- Audit write failure.
+
+### 13.4 Admin Operations Requirements
+
+Internal admins must be able to:
+
+- Search merchants.
+- View merchant health.
+- Suspend merchant.
+- Suspend agent.
+- Revoke passports.
+- Replay webhooks.
+- Retry sync jobs.
+- Inspect provider capabilities.
+- Export audit evidence.
+- View failed policy decisions.
+- View system alerts.
+- Toggle tenant feature flags.
+
+All admin actions must be audited.
+
+## 14. Demo Requirements
+
+Build a polished demo that shows:
+
+> A user asks an AI agent to find a product, approve a bounded payment, create a Plural checkout, complete payment, and view audit trail.
+
+Required demo scenario:
+
+- Merchant: ABC Electronics.
+- Product: washing machine or smartphone.
+- Amount: INR 35,000 or lower.
+- Offer: EMI or reward option if available.
+- Agent: AgenticOrg Sales Agent.
+- Consent: Grantex Commerce Passport.
+- Payment: Plural sandbox checkout/payment link.
+- Audit: full event timeline.
+
+The demo must be repeatable from:
+
+- Grantex playground.
+- AgenticOrg commerce agent page.
+- API/SDK quickstart.
+
+## 15. Success Metrics
+
+### Product Metrics
+
+- Time to onboard merchant.
+- Time to create first agentic payment.
+- Consent completion rate.
+- Payment success rate.
+- Policy denial correctness.
+- Audit completeness.
+- Agent action failure rate.
+
+### Business Metrics
+
+- Number of live merchants.
+- Agentic GMV.
+- Plural/Pine payment volume influenced.
+- Agent-driven conversion.
+- Merchant retention.
+- Revenue per merchant.
+- Number of partner integrations.
+
+### Trust Metrics
+
+- Revocation latency.
+- Passport verification latency.
+- Policy evaluation latency.
+- Audit event completeness.
+- Fraud/anomaly detection rate.
+- Human approval SLA.
+
+### 15.4 GA Readiness Targets
+
+Target thresholds before GA:
+
+- Merchant self-serve sandbox onboarding: under 30 minutes for CSV/manual setup.
+- Commerce Passport verification latency: p95 under 100 ms online, under 10 ms offline where cached JWKS is available.
+- Policy evaluation latency: p95 under 150 ms.
+- Payment intent creation latency excluding provider time: p95 under 500 ms.
+- Webhook processing latency: p95 under 2 seconds.
+- Audit event write success: 99.99% or fail-closed for protected actions.
+- Catalog import success for valid CSV: 99%+.
+- Payment state reconciliation: pending payments reconciled within 15 minutes.
+- Revocation effectiveness: new protected calls blocked within 60 seconds, immediate for online verification.
+- Agent eval pass rate: 95%+ on required commerce safety evals before pilot.
+
+### 15.5 North Star Metric
+
+Primary north star:
+
+- **Trusted agentic GMV:** total successful payment volume initiated by AI agents with valid Grantex Commerce Passport and complete audit trail.
+
+Supporting metrics:
+
+- AI-native merchants live.
+- Agentic payment success rate.
+- Consent-to-payment conversion.
+- Agent-driven revenue per merchant.
+- Policy-safe action completion rate.
+- Merchant retained after 90 days.
+
+## 16. Pricing Direction
+
+Recommended pricing:
+
+1. Platform fee per merchant/month.
+2. Usage fee per Commerce Passport issued or verified.
+3. Usage fee per agentic payment intent.
+4. Premium fee for AgenticOrg Commerce Agent Pack.
+5. Enterprise fee for custom policies, self-hosting, compliance exports, and partner analytics.
+6. Potential transaction revenue share with Pine/Plural where contractually possible.
+
+Do not price only as a percentage of payment volume. The product creates value through trust, consent, compliance, and operations, not only transaction processing.
+
+## 17. Open Questions
+
+1. Which Plural APIs are available in partner sandbox for order/payment/refund/subscription/offer flows?
+2. What Pine POS APIs can be used for reservation/payment intent/offline pickup?
+3. Does Pine want co-branded product packaging or white-label integration?
+4. Should UCP profile be generated per merchant domain or hosted under Grantex Commerce?
+5. Which commerce platforms should be first connectors: Shopify, WooCommerce, Magento, custom API?
+6. What legal language is required for agentic payment consent in India?
+7. What merchant categories should be excluded from first launch?
+8. Should Grantex Trust Registry include external commerce agents from day one?
+9. What data can Pine/Plural share for partner analytics?
+10. What is the exact division of support responsibility among merchant, Pine/Plural, Grantex, and AgenticOrg?
+
+## 18. Recommended Build Order For Claude Code
+
+When implementing in codebases, proceed in this order:
+
+1. Add Grantex Commerce feature flags, tenant/environment boundaries, and RBAC primitives.
+2. Add Grantex Commerce data models, migrations, indexes, and constraints.
+3. Add commerce scopes and tool/action manifest.
+4. Add Commerce Passport consent request, issuance, verification, revocation, and consent evidence.
+5. Add audit event taxonomy, append-only event writer, and timeline APIs.
+6. Add merchant registration, merchant lifecycle states, and merchant dashboard shell.
+7. Add category presets for launch categories and wire presets into onboarding, readiness, policies, capabilities, and evals.
+8. Add catalog, inventory, pricing, offers, stores, sync jobs, CSV import, validation, and readiness scoring.
+9. Add mocked payment provider adapter and payment state machine.
+10. Add Plural sandbox adapter, payment intent APIs, checkout link creation, webhooks, and reconciliation.
+11. Add Merchant Policy Console, policy defaults, simulator, evaluation API, and human approval queue.
+12. Add AI-native publishing: `/.well-known/grantex-commerce`, UCP-style profile, MCP tools, ACP metadata.
+13. Add Commerce playground with merchant setup mode and agent transaction mode.
+14. Add `/commerce` landing page and `/docs/commerce` documentation.
+15. Add AgenticOrg Commerce Agent Pack, tool manifests, guardrails, run logs, and evals.
+16. Add AgenticOrg console pages that consume Grantex merchant data and deep-link edits to Grantex.
+17. Add Pine POS bridge mocked/sandbox flow for reservations and pickup.
+18. Add merchant, partner, Grantex, and admin analytics.
+19. Add observability, alerts, runbooks, operational admin console, compliance exports, and security hardening.
+20. Run full test suite, E2E sandbox flow, threat model tests, and release sign-off checklist.
+
+## 19. Release Sign-Off Checklist
+
+Before production launch:
+
+- Commerce Passport verified offline and online.
+- Revocation tested.
+- Scope enforcement tested.
+- Amount/category/merchant constraints tested.
+- Plural sandbox and live test complete.
+- Webhook signature verification complete.
+- Idempotency complete.
+- Merchant emergency disable tested.
+- Audit exports tested.
+- AgenticOrg agents pass safety evals.
+- Payment cannot be created without consent.
+- Refund cannot be executed without proper scope and merchant policy.
+- Sensitive payment data is not stored by Grantex.
+- Security review complete.
+- Developer docs complete.
+- Demo works reliably.
+
+### 19.1 Merchant Control Plane Sign-Off
+
+- Merchant can register.
+- Merchant can verify or enter sandbox verification.
+- Merchant can select category preset.
+- Merchant category preset applies required fields.
+- Merchant category preset applies default policies.
+- Merchant category preset applies default capability publishing settings.
+- Category-specific readiness score works.
+- Merchant can connect catalog.
+- Merchant can import CSV catalog.
+- Merchant can connect or upload inventory.
+- Merchant can connect or upload pricing.
+- Merchant can configure offers.
+- Merchant can connect Plural sandbox.
+- Merchant can validate provider credentials.
+- Merchant can validate webhooks.
+- Merchant can publish AI-native profile.
+- Merchant can unpublish AI-native profile.
+- Merchant can disable all agentic commerce.
+- Merchant can invite team members and assign roles.
+
+### 19.2 AI-Native Gateway Sign-Off
+
+- `/.well-known/grantex-commerce` works.
+- UCP-style profile works.
+- MCP server/tools work.
+- ACP-compatible metadata works or returns explicit unsupported state.
+- A2A/agent handoff metadata works or returns explicit unsupported state.
+- External agent discovery works.
+- Read-only and protected tools enforce correct auth mode.
+- Rate limits work.
+- Tool schemas are documented.
+- Capability Publishing Matrix is visible and accurate.
+- Merchant can publish/unpublish each capability.
+- Merchant can enable/disable each protocol independently.
+- Catalog publishing works.
+- Inventory publishing works.
+- Pricing publishing works.
+- Offer publishing works.
+- Cart publishing works.
+- Checkout/payment publishing works.
+- Booking/reservation publishing works.
+- Order status publishing works.
+- Refund/return publishing works.
+- Complaint/support publishing works.
+- Loyalty/gift card publishing works or returns explicit unsupported state.
+- Subscription publishing works or returns explicit unsupported state.
+- Human handoff publishing works.
+
+### 19.3 Payment And Provider Sign-Off
+
+- Mock provider E2E passes.
+- Plural sandbox E2E passes.
+- Payment intent state machine rejects invalid transitions.
+- Checkout link expiry works.
+- Provider errors normalize correctly.
+- Webhook replay is idempotent.
+- Payment reconciliation job works.
+- Refund request flow works in supported mode or returns explicit capability error.
+- Subscription flow works in supported mode or returns explicit capability error.
+
+### 19.4 AgenticOrg Sign-Off
+
+- Sales Agent passes evals.
+- Offer Agent passes evals.
+- Catalog Agent passes evals.
+- Support Agent passes evals.
+- Reconciliation Agent passes evals.
+- Store Operations Agent passes evals or is feature-flagged off.
+- Agents cannot bypass Grantex tools.
+- Agents cannot create checkout without consent.
+- Agents cannot hallucinate offers in eval suite.
+- Agents escalate human approvals correctly.
+
+### 19.5 Security And Compliance Sign-Off
+
+- Tenant isolation tests pass.
+- RBAC tests pass.
+- Passport tampering tests pass.
+- Expired/revoked passport tests pass.
+- Webhook spoofing tests pass.
+- Merchant inbound webhook signature, replay, and schema tests pass.
+- Audit write failure handling works.
+- PII redaction verified.
+- Secrets are stored only in approved secret storage.
+- Admin actions are audited.
+- Compliance export generated.
+
+### 19.6 Operational Sign-Off
+
+- Metrics dashboards live.
+- Alerts configured.
+- Runbooks written.
+- Support escalation path documented.
+- Feature flags configured.
+- Backup and restore tested for critical data.
+- Load test completed for expected pilot traffic.
+- Rollback plan documented.
+- Pilot merchant onboarding guide complete.
+
+## 20. Final Product Statement
+
+Grantex Commerce is a new product line that makes merchants safely usable by AI agents. It is not merely UCP, ACP, MCP, or checkout integration. It is the trust and control layer where agents get permission, merchants set policy, payments execute through Pine/Plural, AgenticOrg agents perform commerce work, and every action is auditable.
+
+The product should make this sentence true:
+
+> Any merchant using Pine/Plural can safely accept AI-agent-led commerce with verifiable consent, scoped payment authority, merchant policy controls, UCP/ACP/MCP interoperability, AgenticOrg merchant agents, and complete auditability.

--- a/GRANTEX_COMMERCE_V1_BUILD_SPEC.md
+++ b/GRANTEX_COMMERCE_V1_BUILD_SPEC.md
@@ -1,0 +1,1769 @@
+# Grantex Commerce V1 Build Spec
+
+## 1. Purpose
+
+This is the first shippable implementation slice for Grantex Commerce.
+
+The master PRD (`GRANTEX_COMMERCE_PRD.md`) describes the long-term platform. This V1 spec defines what engineering should build first so the product is real, focused, and pilot-production-grade in a narrow lane.
+
+V1 objective:
+
+> Prove that an AI agent can initiate a commerce checkout through a payment provider only when Grantex can verify user consent, scope, merchant policy, revocation status, and audit evidence.
+
+V1 positioning:
+
+> Authorization-as-a-service for agent-initiated commerce actions.
+
+V1 should not attempt to become a full merchant commerce platform.
+
+## 2. Brutal Scope Boundary
+
+V1 includes:
+
+- Commerce Passport.
+- Commerce Agent identity and registration.
+- Consent request and approval.
+- Passport issuance, verification, and revocation.
+- Basic merchant registration.
+- One launch category preset: `electronics_appliances`.
+- One payment provider adapter: Plural sandbox, with live behind feature flag.
+- One protocol/tool surface: Grantex native REST API plus MCP.
+- Basic policy engine.
+- Append-only audit ledger.
+- One AgenticOrg agent: Sales Agent.
+- Minimal merchant dashboard.
+- OpenAPI docs and sandbox playground.
+- Metering events for future billing.
+
+V1 excludes:
+
+- Pine POS bridge.
+- UCP full implementation.
+- ACP full implementation.
+- A2A handoff.
+- Multi-category launch.
+- Full catalog/PIM system.
+- Full inventory hub.
+- Full pricing/offers hub.
+- Refund execution.
+- Refund request platform.
+- Subscriptions.
+- Loyalty/gift cards.
+- Complaints/support platform.
+- Six-agent AgenticOrg pack.
+- SSO/SAML/SCIM.
+- Dedicated deployments.
+- Partner analytics.
+- Hash-chained audit.
+- SDKs.
+- Public marketing site beyond a simple product page.
+
+Deferred items are not rejected. They remain in the master PRD roadmap.
+
+## 3. V1 Personas
+
+### 3.1 Merchant Developer / Operator
+
+Uses Grantex to:
+
+- register a merchant;
+- connect Plural sandbox credentials;
+- configure basic policy;
+- publish MCP/native API capabilities;
+- view payment attempts and audit events.
+
+### 3.2 AI Agent Platform / AgenticOrg Integrator
+
+Uses Grantex to:
+
+- request user consent;
+- obtain Commerce Passport;
+- call checkout/payment APIs;
+- verify payment status;
+- read audit-safe outcomes.
+
+### 3.3 End User
+
+Uses Grantex to:
+
+- approve agent action;
+- see spending limit, merchant, agent, and expiry;
+- revoke the grant.
+
+## 4. Provider Neutrality
+
+Plural is the first adapter, not the product boundary.
+
+V1 must implement a neutral payment provider interface:
+
+- `MockPaymentProvider`
+- `PluralPaymentProvider`
+
+Provider interface:
+
+- `healthCheck()`
+- `validateCredentials()`
+- `createPaymentIntent()`
+- `createCheckoutLink()`
+- `getPaymentStatus()`
+- `handleWebhook()`
+- `normalizeError()`
+
+Provider interface contract:
+
+```ts
+type ProviderKey = "mock" | "plural";
+type CommerceEnvironment = "sandbox" | "live";
+type Money = { amount_minor_units: number; currency: "INR" | string };
+
+type ProviderErrorCode =
+  | "provider_unavailable"
+  | "invalid_provider_credentials"
+  | "provider_validation_failed"
+  | "provider_rate_limited"
+  | "provider_timeout"
+  | "payment_declined"
+  | "payment_expired"
+  | "webhook_signature_invalid"
+  | "webhook_replay_detected"
+  | "unsupported_provider_event"
+  | "unknown_provider_error";
+
+type NormalizedProviderError = {
+  code: ProviderErrorCode;
+  message: string;
+  retryable: boolean;
+  provider_key: ProviderKey;
+  provider_error_code?: string;
+  provider_request_id?: string;
+  safe_metadata?: Record<string, unknown>;
+};
+
+interface PaymentProvider {
+  healthCheck(input: {
+    tenant_id: string;
+    merchant_id: string;
+    environment: CommerceEnvironment;
+  }): Promise<{ ok: boolean; status: "healthy" | "degraded" | "down"; checked_at: string; details?: Record<string, unknown> }>;
+
+  validateCredentials(input: {
+    tenant_id: string;
+    merchant_id: string;
+    environment: CommerceEnvironment;
+    credential_ref: string;
+  }): Promise<{ valid: boolean; merchant_account_ref?: string; capabilities: string[]; checked_at: string; error?: NormalizedProviderError }>;
+
+  createPaymentIntent(input: {
+    tenant_id: string;
+    merchant_id: string;
+    agent_id: string;
+    payment_intent_id: string;
+    cart_id: string;
+    passport_jti: string;
+    amount: Money;
+    line_items_snapshot: unknown[];
+    idempotency_key: string;
+    environment: CommerceEnvironment;
+    metadata: Record<string, string>;
+  }): Promise<{ provider_payment_id: string; provider_order_id?: string; status: "created" | "authorized" | "payment_pending"; raw_status: string; provider_metadata?: Record<string, unknown> }>;
+
+  createCheckoutLink(input: {
+    tenant_id: string;
+    merchant_id: string;
+    payment_intent_id: string;
+    provider_payment_id: string;
+    amount: Money;
+    success_url: string;
+    cancel_url: string;
+    expires_at: string;
+    idempotency_key: string;
+  }): Promise<{ checkout_url: string; expires_at: string; raw_status: string; provider_metadata?: Record<string, unknown> }>;
+
+  getPaymentStatus(input: {
+    tenant_id: string;
+    merchant_id: string;
+    payment_intent_id: string;
+    provider_payment_id: string;
+  }): Promise<{ status: "payment_pending" | "paid" | "failed" | "expired" | "cancelled"; raw_status: string; provider_metadata?: Record<string, unknown> }>;
+
+  handleWebhook(input: {
+    provider_key: ProviderKey;
+    headers: Record<string, string>;
+    raw_body: string;
+    received_at: string;
+  }): Promise<{ event_id: string; event_type: string; merchant_ref?: string; provider_payment_id?: string; status?: string; signature_valid: boolean; replay: boolean; provider_metadata?: Record<string, unknown> }>;
+
+  normalizeError(error: unknown): NormalizedProviderError;
+}
+```
+
+All provider methods are asynchronous. Provider adapters must never throw raw provider errors outside the adapter boundary; callers receive `NormalizedProviderError`. Transient provider/network failures may be retried by the service layer with bounded backoff. Validation, auth, policy, consent, tenant, and amount-cap failures must not be retried.
+
+Do not put Plural-specific fields into core tables unless they are namespaced under provider metadata.
+
+## 5. V1 Merchant Category
+
+Only one preset ships in V1:
+
+- `electronics_appliances`
+
+Required product fields:
+
+- SKU.
+- Parent SKU for variants where applicable.
+- Title.
+- Brand.
+- Model or variant.
+- Price.
+- Currency.
+- Tax-inclusive flag.
+- GST slab or tax rate.
+- HSN code where applicable.
+- Warranty summary.
+- Return policy.
+- Variant-level availability status: `in_stock`, `out_of_stock`, `pre_order`, `back_order`, or `unknown`.
+
+V1 does not need full inventory quantity tracking. Variant-level availability bucket is enough because two variants of the same product may have different availability.
+
+V1 must support variants. Implement `CommerceProduct` for the product family and `CommerceProductVariant` for purchasable SKUs. A product may have one variant if the merchant does not use variant groupings.
+
+V1 default capabilities:
+
+- merchant profile;
+- catalog product detail;
+- basic catalog search;
+- price read;
+- availability read;
+- cart draft;
+- checkout create;
+- payment initiate;
+- payment status.
+
+V1 default guardrails:
+
+- checkout requires Commerce Passport;
+- payment amount cannot exceed passport limit;
+- exact inventory quantity is not exposed;
+- refund execution is disabled;
+- emergency disable blocks all protected actions;
+- stale price blocks checkout;
+- unknown inventory requires user-facing warning.
+- `pre_order` and `back_order` require clear user-facing availability copy before checkout.
+
+Freshness rule:
+
+- Price and availability are stale when `last_synced_at` is older than 24 hours, unless the merchant's source marks the product as manually maintained.
+- Stale price blocks checkout/payment creation.
+- Stale availability may allow browse/search but must show user-facing warning and cannot be represented as guaranteed inventory.
+
+## 6. Commerce Passport V1
+
+V1 passport types:
+
+- `browse`
+- `checkout`
+
+Defer:
+
+- `payment_delegated`
+- `merchant_operator`
+- `cart`
+- `support`
+
+V1 scopes:
+
+- `commerce:catalog.read`
+- `commerce:inventory.read`
+- `commerce:checkout.create`
+- `commerce:payment.initiate`
+- `commerce:payment.status.read`
+
+Default passport scope bundles:
+
+- `browse`: `commerce:catalog.read`, `commerce:inventory.read`
+- `checkout`: `commerce:catalog.read`, `commerce:inventory.read`, `commerce:checkout.create`, `commerce:payment.initiate`, `commerce:payment.status.read`
+
+Agents may request a subset of the default bundle. Agents may not request scopes outside the selected passport type's maximum bundle.
+
+Default passport expiry:
+
+- `browse`: 60 minutes.
+- `checkout`: 10 minutes.
+
+The issuer may shorten expiry. Merchant policy may cap maximum expiry. Checkout passports should remain short-lived because they authorize payment-affecting actions.
+
+Cart draft authorization:
+
+- Creating a pre-consent cart draft is allowed for a registered `CommerceAgent` using agent authentication and merchant policy.
+- Creating checkout/payment from a cart requires a `checkout` Commerce Passport.
+- Cart draft creation must be audited but does not require a user-bound Commerce Passport.
+
+Required claims:
+
+- `iss`
+- `sub`
+- `aud`
+- `tenant_id`
+- `agent_id`
+- `merchant_id`
+- `scopes`
+- `max_amount`
+- `currency`
+- `iat`
+- `exp`
+- `nbf`
+- `jti`
+- `grant_id`
+- `consent_record_id`
+- `policy_version`
+- `env`
+- `ver`
+
+`max_amount` is always the tax-inclusive maximum total in minor currency units.
+
+Agent identity requirement:
+
+- `agent_id` must reference a registered `CommerceAgent`.
+- Commerce Passport issuance must fail for unknown, disabled, or untrusted agents.
+- Agent public key or DID metadata must be stored before the agent can request commerce passports.
+- `CommerceAgent.trust_status` enum: `pending`, `trusted`, `suspended`, `disabled`.
+- Only `trusted` agents may receive passports or call protected checkout/payment tools.
+
+Agent authentication:
+
+- Agent API calls must authenticate as a registered `CommerceAgent`.
+- Preferred V1 agent auth is signed JWT bearer assertion in `Authorization: Bearer <agent_assertion_jwt>`, verified against `CommerceAgent.public_key_jwk`.
+- Agent API keys may be supported as a secondary server-to-server mode using `Authorization: Bearer grtx_agent_<secret>`, stored only as a hash.
+- Agent assertion must include `iss=agent_id`, `sub=agent_id`, `aud=grantex-commerce`, `tenant_id`, `iat`, `exp`, `jti`, and optional `session_id`.
+- Agent assertion max lifetime is 5 minutes. Replay `jti` must be rejected during the assertion lifetime.
+- The auth method used must be recorded on consent, passport, cart, and payment audit events.
+- Agent authentication is not a substitute for user consent; checkout/payment still requires a valid `checkout` Commerce Passport.
+
+API caller authentication:
+
+- Merchant/operator dashboard uses the existing Grantex user auth if present; otherwise V1 fallback is email/password plus TOTP MFA with secure HTTP-only session cookie.
+- Merchant server-to-server APIs use `Authorization: Bearer grtx_sk_<environment>_<secret>` API keys. Store only salted hashes. Resolve `tenant_id` and allowed merchants from the API key record.
+- Agent APIs use agent JWT assertion or agent API key as above. Resolve `tenant_id` from the registered agent and validate it matches the request path/body.
+- Internal background jobs use service identity with least-privilege scopes and explicit tenant/merchant parameters.
+- Authentication failure returns `401`; authenticated caller without tenant, merchant, scope, or policy permission returns `403`.
+
+V1 verification:
+
+- Commerce Passport JWT signing algorithm is ES256 for V1.
+- Verifiers must pin ES256 and reject `alg=none`, unexpected algorithms, missing `kid`, and unknown `kid`.
+- JWKS endpoint: `GET /.well-known/jwks.json`.
+- JWKS keys use `kid` format `commerce-passport-<yyyyMMdd>-<random_suffix>`.
+- Key rotation keeps previous public keys available for at least 24 hours after the last passport signed with that key can expire.
+- Clock skew tolerance for `iat`, `nbf`, and `exp` is 30 seconds.
+- Offline JWT verification uses JWKS for non-payment reads.
+- Online revocation check for payment-affecting actions.
+- Merchant match is an always-on invariant: the passport `merchant_id` must belong to the `tenant_id` resolved from caller auth.
+- A passport for tenant A's merchant must never authorize an action by a caller authenticated under tenant B.
+- Protected actions fail closed if revocation service is unavailable.
+
+V1 revocation:
+
+- revoke passport;
+- revoke all passports for user;
+- revoke all passports for merchant.
+
+## 7. Policy Engine V1
+
+V1 policies:
+
+1. Amount cap.
+2. Scope allowlist.
+3. Emergency disable.
+
+Always-on invariants, not merchant-configurable policy toggles:
+
+- tenant match;
+- merchant match;
+- agent status/trust check;
+- passport expiry;
+- passport revocation;
+- sandbox/live environment match.
+
+`CommercePolicy.rules` V1 schema:
+
+```json
+{
+  "amount_cap": {
+    "max_amount_minor_units": 50000000,
+    "currency": "INR"
+  },
+  "scope_allowlist": [
+    "commerce:catalog.read",
+    "commerce:inventory.read",
+    "commerce:checkout.create",
+    "commerce:payment.initiate",
+    "commerce:payment.status.read"
+  ],
+  "emergency_disable": false,
+  "checkout_passport_max_ttl_seconds": 600,
+  "browse_passport_max_ttl_seconds": 3600,
+  "stale_price_max_age_seconds": 86400,
+  "allow_unknown_inventory_checkout": false
+}
+```
+
+Unknown rule keys must be rejected in V1. Policy activation must validate the schema and currency consistency. Amount cap uses tax-inclusive totals in minor currency units.
+
+Policy output:
+
+- `allow`
+- `deny`
+- `requires_user_consent`
+
+Defer:
+
+- complex category policies;
+- agent trust scores;
+- product/category allowlists;
+- loyalty/refund/subscription policies;
+- human approval workbench.
+
+Emergency disable must take effect immediately for new protected actions. Do not rely only on a 60-second cache TTL.
+
+Policy activation:
+
+- Creating a policy does not automatically activate it.
+- A policy becomes active only through `POST /v1/commerce/policies/{policy_id}/activate`.
+- Policy activation must emit `policy.activated`.
+- Every protected action must record the active policy version used for evaluation.
+
+## 8. Payment V1
+
+Provider:
+
+- Mock provider for tests and local development.
+- Plural sandbox for integration.
+- Plural live behind feature flag only after legal and partner review.
+
+V1 payment flow:
+
+1. Agent creates cart draft.
+2. Agent requests user consent.
+3. Grantex issues Commerce Passport.
+4. Agent calls Grantex payment intent API.
+5. Grantex verifies passport and policy.
+6. Grantex creates Plural checkout/payment link.
+7. User completes payment.
+8. Plural webhook updates payment status.
+9. Audit timeline shows the full chain.
+
+V1 payment statuses:
+
+- `created`
+- `authorized`
+- `checkout_created`
+- `payment_pending`
+- `paid`
+- `failed`
+- `cancelled`
+- `expired`
+
+Valid payment state transitions:
+
+- `created` -> `authorized`
+- `authorized` -> `checkout_created`
+- `checkout_created` -> `payment_pending`
+- `payment_pending` -> `paid`
+- `payment_pending` -> `failed`
+- `payment_pending` -> `expired`
+- `created|authorized|checkout_created|payment_pending` -> `cancelled`
+
+Invalid payment state transitions must be rejected and audited.
+
+AFA/OTP behavior:
+
+- Plural hosted checkout owns the bank OTP/3DS/AFA step.
+- Grantex tracks the payment as `payment_pending` while the user is on the hosted checkout or bank authorization step.
+- Default pending timeout is 15 minutes.
+- Successful AFA/OTP completion transitions to `paid` through webhook or reconciliation.
+- User abandonment transitions to `expired` after timeout and reconciliation.
+- Repeated AFA/OTP failure transitions to `failed` when provider reports failure.
+
+Webhook reconciliation:
+
+- Run automated reconciliation every 5 minutes.
+- Reconcile `payment_pending` intents older than 2 minutes by calling provider `getPaymentStatus()`.
+- Provide a manual "reconcile now" dashboard action for stuck payment intents.
+- Reconciliation must be idempotent and audited.
+
+Idempotency contract:
+
+- `POST /v1/commerce/payments/intents` requires `Idempotency-Key`.
+- `POST /v1/commerce/payments/intents/{id}/checkout-link` requires `Idempotency-Key`.
+- `POST /v1/commerce/carts` requires `Idempotency-Key`.
+- Keys are scoped by merchant, endpoint, and environment.
+- Repeated request with same key and same body returns the original response.
+- Repeated request with same key and different body returns HTTP `409`.
+- Keys persist for at least 24 hours.
+
+Defer:
+
+- refunds as execution;
+- subscriptions;
+- EMI optimization;
+- rewards;
+- Pine POS.
+
+Refund in V1:
+
+- Refund execution is out of scope.
+- Refund request API is out of scope.
+- Merchant must process refunds in existing provider/merchant systems during V1.
+- V1 may display provider payment status and audit references needed for manual refund handling.
+
+## 9. Protocol Surface V1
+
+V1 includes:
+
+- Grantex native REST API.
+- MCP server/tools.
+- `/.well-known/grantex-commerce`.
+
+V1 excludes:
+
+- full UCP;
+- full ACP;
+- A2A.
+
+The V1 docs may say:
+
+- "designed for future UCP/ACP/AP2 compatibility";
+- "MCP supported";
+- "native Grantex Commerce API supported".
+
+Do not claim certified compliance with ACP, UCP, AP2, MPP, or A2A.
+
+AP2/MPP positioning:
+
+- Grantex Commerce V1 is a delegated authorization and audit layer.
+- Payment-network protocols such as AP2/MPP are treated as future compatibility targets for payment-network mandate evidence.
+- V1 should not present itself as a replacement for AP2/MPP.
+- V1 should state that Grantex can provide consent, scope, revocation, and audit evidence that payment-network protocols may consume in later integrations.
+
+V1 MCP tools:
+
+- `merchant.get_profile`
+- `catalog.search`
+- `catalog.get_item`
+- `inventory.check`
+- `cart.create`
+- `checkout.create`
+- `payment.create_intent`
+- `payment.get_status`
+
+MCP tool contract:
+
+| Tool | Required auth | Required scope/passport | Input schema summary | Output schema summary | Audit |
+| --- | --- | --- | --- | --- | --- |
+| `merchant.get_profile` | Agent or public if merchant published public browse | none or `commerce:catalog.read` for private profile | `{merchant_id}` | merchant display/legal name, category preset, environment, capability list, verified status | no audit for public reads; `passport.verified` if passport used |
+| `catalog.search` | Agent/API key/public per merchant setting | `commerce:catalog.read` for private catalog | `{merchant_id, query, filters?, limit?, cursor?}` | `{items:[{product_id,title,brand,variants_summary}], next_cursor?}` | no audit for public reads; read audit optional |
+| `catalog.get_item` | Agent/API key/public per merchant setting | `commerce:catalog.read` for private catalog | `{merchant_id, product_id}` | product plus variant fields, price, tax, warranty, return summary, availability, freshness | read audit optional |
+| `inventory.check` | Agent/API key | `commerce:inventory.read` | `{merchant_id, variant_ids:[...]}` | `{items:[{variant_id, availability_status, last_synced_at, stale}]}` | read audit optional |
+| `cart.create` | Registered `CommerceAgent` | agent auth; checkout passport not required for pre-consent draft | `{merchant_id, line_items:[{variant_id, quantity}], currency}` | `{cart_id,status,total_amount,currency,expires_at,line_items_snapshot}` | `cart.created` |
+| `checkout.create` | Registered `CommerceAgent` | `checkout` passport with `commerce:checkout.create` | `{merchant_id, cart_id, passport_jti}` | `{payment_intent_id,status,requires_payment_link:true}` | `policy.evaluated` if deny/consent; action audit |
+| `payment.create_intent` | Registered `CommerceAgent` | `checkout` passport with `commerce:payment.initiate` | `{merchant_id, cart_id, passport_jti, idempotency_key}` | `{payment_intent_id,status,amount,currency}` | `payment_intent.created` |
+| `payment.get_status` | Registered `CommerceAgent` or merchant API key | `commerce:payment.status.read` or merchant API permission | `{merchant_id, payment_intent_id}` | `{payment_intent_id,status,provider_status?,updated_at,audit_event_ids}` | no status-read audit required unless denied |
+
+Every MCP tool must expose JSON Schema `inputSchema`. V1 should expose output schemas in tool metadata or documentation even if the runtime only requires input schemas. MCP errors use the same standard error envelope as REST where possible.
+
+V1 MCP client requirement:
+
+- Build a demo MCP client in the Grantex playground so the MCP server can be tested without relying on an external directory listing.
+- Start external connector/listing conversations separately; connector listing is not a V1 launch dependency.
+
+Outbound webhook policy:
+
+- V1 emits no outbound webhooks.
+- Agents poll `payment.get_status` for state changes.
+- Merchants observe status through the dashboard or `GET /v1/commerce/payments/intents/{id}`.
+- Outbound Grantex webhooks are deferred to V2.
+
+## 10. Audit V1
+
+Use append-only Postgres audit table.
+
+Audit events:
+
+- merchant.created
+- merchant.disabled
+- merchant.credentials.updated
+- merchant.feature_flag.updated
+- merchant.provider_credentials.validated
+- merchant.webhook_source.created
+- merchant.webhook_source.secret_rotated
+- policy.created
+- policy.activated
+- consent.requested
+- consent.granted
+- consent.denied
+- passport.issued
+- passport.verified
+- passport.revoked
+- passport.expired
+- policy.evaluated
+- cart.created
+- payment_intent.created
+- payment_intent.cancelled
+- payment_intent.expired
+- checkout_link.created
+- provider.webhook.received
+- provider.webhook.signature_failed
+- payment_intent.paid
+- payment_intent.failed
+- protected_action.denied
+- idempotency.conflict
+- rate_limit.exceeded
+- meter.passport_issued
+- meter.payment_intent_created
+
+Every protected action must have an audit event.
+
+Policy audit semantics:
+
+- Audit `policy.evaluated` when the decision is `deny` or `requires_user_consent`.
+- For `allow` decisions, the resulting action event must include `policy_version` and policy decision reference instead of emitting a separate `policy.evaluated` row.
+- This avoids unnecessary audit write amplification while preserving forensic traceability.
+
+V1 does not need hash chaining.
+
+Audit append-only enforcement:
+
+- The application database role must have only `INSERT` and `SELECT` on `commerce_audit_events`.
+- `UPDATE` and `DELETE` must be revoked at the database level.
+- Audit corrections must be new compensating events, never row edits.
+- Admin users must not have dashboard controls that mutate audit rows.
+
+Metering:
+
+- Emit a metering event for every `passport.issued`.
+- Emit a metering event for every `payment_intent.created`.
+- Metering is not billing in V1, but it prevents historical usage gaps when billing is added later.
+
+## 11. Merchant Data V1
+
+V1 should avoid building a full PIM/inventory/pricing system.
+
+Supported input methods:
+
+- manual entry in dashboard;
+- CSV upload;
+- simple REST upsert APIs;
+- merchant inbound webhook for one complete-state event:
+  - `catalog.product.updated`
+
+V1 product model:
+
+- merchant_id;
+- product_id;
+- title;
+- brand;
+- description;
+- image_url;
+- variants.
+
+V1 product variant model:
+
+- variant_id;
+- sku;
+- parent_sku;
+- model;
+- variant_title;
+- attributes;
+- price_amount;
+- currency;
+- tax_inclusive;
+- gst_slab or tax_rate;
+- hsn_code;
+- availability_status;
+- warranty_summary;
+- return_policy_summary;
+- source_system;
+- last_synced_at.
+
+Inbound webhook behavior:
+
+- `catalog.product.updated` payload must include full product plus variant price and availability state.
+- Envelope:
+  - `event_id`: unique per merchant/source;
+  - `event_type`: `catalog.product.updated`;
+  - `occurred_at`: ISO-8601 timestamp;
+  - `payload_version`: `2026-05-01`;
+  - `source_key`: configured source key;
+  - `data`: full product payload.
+- Signature header: `Grantex-Signature: t=<unix_timestamp>,v1=<hex_hmac_sha256>`.
+- Signature payload is `<timestamp>.<raw_body>`.
+- Signature secret is merchant/source-specific and rotated through the webhook source APIs.
+- Partial price-only or inventory-only webhooks are out of scope for V1.
+- If an inbound product update changes price for an active payment intent, the existing payment intent must not be silently updated.
+- If the new price exceeds the passport `max_amount`, creating a new checkout link must require fresh consent.
+- Multiple webhook sources per merchant are allowed in V1 so a merchant can separate manual back-office, ERP, POS, and test feeds even though only one event type is accepted.
+
+V1 does not sync Shopify, WooCommerce, Magento, Google Merchant Center, or ONDC unless an existing connector already exists in the codebase.
+
+## 12. Merchant Dashboard V1
+
+Routes:
+
+- `/dashboard/commerce/onboarding`
+- `/dashboard/commerce/passports`
+- `/dashboard/commerce/payments`
+- `/dashboard/commerce/audit`
+- `/dashboard/commerce/settings`
+- `/dashboard/commerce/playground`
+
+V1 dashboard features:
+
+- create merchant;
+- select electronics category preset;
+- configure Plural sandbox credentials;
+- validate Plural sandbox credentials;
+- configure inbound webhook sources and rotate source secrets;
+- add/upload product;
+- configure amount cap and emergency disable;
+- view passports;
+- view payment attempts;
+- view audit timeline;
+- manually reconcile a stuck payment intent;
+- run sandbox demo.
+
+Dashboard authentication:
+
+- Use existing Grantex dashboard authentication if present.
+- If no operator auth exists, V1 fallback is email/password plus TOTP MFA.
+- Merchant operator sessions use secure HTTP-only cookies, CSRF protection, idle timeout, and audit on privileged actions.
+- SSO/SAML/SCIM are out of scope for V1 but must not be blocked architecturally.
+
+No 22-route dashboard in V1.
+
+## 13. AgenticOrg V1
+
+Only one agent:
+
+- `commerce-sales-agent`
+
+Responsibilities:
+
+- product discovery;
+- product Q&A from tool data;
+- cart draft;
+- consent request;
+- checkout/payment intent creation through Grantex tools.
+
+Guardrails:
+
+- no checkout without consent;
+- no amount above passport limit;
+- no unsupported offers;
+- no guaranteed inventory when status is `unknown`;
+- Agent's tool surface is Grantex tools only; provider orchestration happens in Grantex services, not in agent code;
+- no direct payment credential handling.
+
+V1 evals:
+
+- refuses checkout without consent;
+- respects amount cap;
+- respects emergency disable;
+- uses tool data for price;
+- does not hallucinate EMI/discount;
+- logs audit events.
+
+## 14. Regulatory V1
+
+India live payment mode:
+
+- user-confirmed checkout only by default.
+- no autonomous delegated payment without legal approval.
+- no recurring mandates in V1.
+- no UPI AutoPay/e-mandate in V1 unless separately approved.
+
+RBI payment data localization:
+
+- Live deployment region for India payment mode must be India-resident before Plural live mode opens.
+- Live deployment must store payment-related data in India-resident infrastructure.
+- Payment-related data includes payment intents, provider payment IDs, provider order IDs, checkout references, webhook payloads or payload hashes, audit events containing payment references, and consent records tied to payment actions.
+- Sandbox may operate outside India if no real payment data is present.
+- Live mode must not store payment-related data outside India unless legal review explicitly approves the architecture.
+- Data residency requirements apply before Plural live mode is enabled.
+
+V1 consent screen must show:
+
+- merchant;
+- agent;
+- amount cap;
+- currency;
+- expiry;
+- action being authorized;
+- final payment confirmation requirement;
+- revocation path.
+
+Consent UX/security requirements:
+
+- Consent page should be hosted on a Grantex-controlled domain such as `consent.grantex.dev` for V1.
+- Consent approval and denial must be single-use actions tied to a consent request ID.
+- Consent request ID must be UUID v4 or at least 128 bits of CSPRNG entropy.
+- Consent request must expire; default expiry is 10 minutes.
+- Consent request details must be immutable after presentation to the user.
+- Use frame-busting headers: `X-Frame-Options: DENY` and appropriate `Content-Security-Policy`.
+- Minimum CSP: `default-src 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; connect-src 'self'`.
+- Do not use third-party iframes on the V1 consent page.
+- Use CSRF protection for approval/deny actions.
+- Show amount in tax-inclusive total and local currency formatting.
+- Show merchant legal/display name and verified status.
+- Show agent display name and trust status.
+- Show expiry and revocation path before approval.
+- High-value consent must be compatible with step-up authentication such as passkey/WebAuthn later, but passkey is not required in V1 unless already available.
+- Page must be mobile responsive.
+- Page must be accessible to screen readers.
+- English copy is required in V1; Hindi/localization is recommended before broader India launch.
+
+V1 payment requirement:
+
+- Every V1 live payment requires final user confirmation.
+- No autonomous delegated payment is allowed in V1.
+
+Live launch blocker:
+
+- legal review for RBI AFA/payment consent language.
+
+## 15. V1 Data Model
+
+Required entities:
+
+- `CommerceMerchant`
+- `CommerceCategoryPreset`
+- `CommerceAgent`
+- `CommerceProduct`
+- `CommerceProductVariant`
+- `CommerceConsentRecord`
+- `CommercePassport`
+- `CommercePolicy`
+- `CommerceCart`
+- `CommercePaymentIntent`
+- `CommerceAuditEvent`
+- `CommerceProviderCredential`
+- `CommerceWebhookEvent`
+- `CommerceAgentSession`
+- `CommerceMeterEvent`
+
+Database:
+
+- V1 persistence target is Postgres.
+- Use the codebase's existing migration tool if one exists.
+- Migrations must be forward-only and backward-compatible enough to deploy before code that depends on them.
+- Prefer Postgres row-level security for tenant-owned commerce tables if it fits the existing auth model.
+
+V1 tenant model:
+
+- One tenant represents one Grantex customer organization.
+- A tenant may own one or more merchants, agents, provider credentials, policies, passports, carts, payment intents, and audit events.
+- The Pine/Plural partner uses a dedicated partner tenant.
+- AgenticOrg may have its own tenant for agent platform integration, but merchant commerce records remain owned by the merchant tenant.
+- Every authenticated request resolves exactly one `tenant_id` from dashboard session, API key, agent identity, or service identity.
+
+Minimum `CommerceMerchant` fields:
+
+- `id`
+- `tenant_id`
+- `legal_name`
+- `display_name`
+- `category_preset`
+- `verification_status`: `unverified`, `pending`, `verified`, `rejected`
+- `environment`: `sandbox`, `live`
+- `agentic_commerce_enabled`
+- `default_currency`
+- `country_code`
+- `support_email`
+- `provider_account_refs`
+- `metadata`
+- `created_at`
+- `updated_at`
+- `disabled_at`
+
+Minimum `CommerceCategoryPreset` fields:
+
+- `id`
+- `preset_key`
+- `display_name`
+- `version`
+- `required_fields`
+- `default_policy_rules`
+- `default_capabilities`
+- `created_at`
+- `updated_at`
+
+Minimum `CommerceAgent` fields:
+
+- `id`
+- `tenant_id`
+- `display_name`
+- `agent_type`
+- `public_key_jwk`
+- `api_key_hash`
+- `trust_status`: `pending`, `trusted`, `suspended`, `disabled`
+- `disabled_at`
+- `created_at`
+- `updated_at`
+
+Minimum `CommerceProduct` fields:
+
+- `id`
+- `tenant_id`
+- `merchant_id`
+- `product_id`
+- `title`
+- `brand`
+- `description`
+- `image_url`
+- `category_preset`
+- `source_system`
+- `manually_maintained`
+- `archived_at`
+- `created_at`
+- `updated_at`
+
+Minimum `CommerceProductVariant` fields:
+
+- `id`
+- `tenant_id`
+- `merchant_id`
+- `product_id`
+- `sku`
+- `parent_sku`
+- `model`
+- `variant_title`
+- `attributes`
+- `price_amount`
+- `currency`
+- `tax_inclusive`
+- `gst_slab` or `tax_rate`
+- `hsn_code`
+- `availability_status`
+- `warranty_summary`
+- `return_policy_summary`
+- `source_system`
+- `last_synced_at`
+- `archived_at`
+
+Minimum `CommerceConsentRecord` fields:
+
+- `id`
+- `tenant_id`
+- `merchant_id`
+- `agent_id`
+- `user_principal_id`
+- `consent_request_id`
+- `passport_type`
+- `requested_scopes`
+- `approved_scopes`
+- `max_amount`
+- `currency`
+- `consent_text_version`
+- `presented_payload_hash`
+- `status`: `requested`, `granted`, `denied`, `expired`
+- `auth_method`
+- `ip_hash`
+- `user_agent_hash`
+- `expires_at`
+- `approved_at`
+- `denied_at`
+- `created_at`
+- `updated_at`
+
+Minimum `CommercePassport` fields:
+
+- `id`
+- `tenant_id`
+- `merchant_id`
+- `agent_id`
+- `consent_record_id`
+- `passport_type`
+- `jti`
+- `kid`
+- `subject`
+- `scopes`
+- `max_amount`
+- `currency`
+- `policy_version`
+- `environment`
+- `issued_at`
+- `not_before`
+- `expires_at`
+- `revoked_at`
+- `revocation_reason`
+- `created_at`
+
+Minimum `CommercePolicy` fields:
+
+- `id`
+- `tenant_id`
+- `merchant_id`
+- `version`
+- `rules`
+- `status`: `draft`, `active`, `archived`
+- `created_by`
+- `activated_by`
+- `activated_at`
+- `created_at`
+- `updated_at`
+
+Minimum `CommerceCart` fields:
+
+- `id`
+- `tenant_id`
+- `merchant_id`
+- `agent_id`
+- `passport_jti`
+- `line_items`
+- `currency`
+- `subtotal_amount`
+- `tax_amount`
+- `total_amount`
+- `status`
+- `expires_at`
+- `line_items_snapshot_hash`
+- `created_at`
+- `updated_at`
+
+`passport_jti` is nullable while the cart is a pre-consent draft. It becomes required when creating checkout/payment from the cart.
+
+V1 carts are immutable after creation except for status transitions. To change line items, create a new cart. This keeps idempotency, consent, and amount-cap checks simple for V1.
+
+Minimum `CommercePaymentIntent` fields:
+
+- `id`
+- `tenant_id`
+- `merchant_id`
+- `agent_id`
+- `cart_id`
+- `passport_jti`
+- `amount`
+- `currency`
+- `provider`
+- `provider_environment`
+- `provider_payment_id`
+- `provider_order_id`
+- `checkout_url`
+- `status`
+- `line_items_snapshot`
+- `idempotency_key_hash`
+- `provider_metadata`
+- `created_at`
+- `updated_at`
+- `expires_at`
+
+`CommercePaymentIntent` must either reference `cart_id` or carry an immutable `line_items_snapshot`; V1 requires both for debuggability. The snapshot must not be silently changed after payment intent creation.
+
+Minimum `CommerceAuditEvent` fields:
+
+- `id`
+- `tenant_id`
+- `merchant_id`
+- `agent_id`
+- `user_principal_id`
+- `event_type`
+- `resource_type`
+- `resource_id`
+- `passport_jti`
+- `policy_version`
+- `decision_id`
+- `idempotency_key_hash`
+- `request_id`
+- `occurred_at`
+- `metadata`
+
+Minimum `CommerceProviderCredential` fields:
+
+- `id`
+- `tenant_id`
+- `merchant_id`
+- `provider_key`
+- `environment`
+- `credential_ref`
+- `encrypted_secret_blob`
+- `secret_version`
+- `status`: `pending`, `valid`, `invalid`, `disabled`
+- `last_validated_at`
+- `last_validation_error`
+- `capabilities`
+- `created_at`
+- `updated_at`
+- `rotated_at`
+
+Provider credential storage:
+
+- Store provider credentials encrypted at rest using the platform KMS/secrets manager available in the codebase.
+- If no secrets manager exists, use envelope encryption with a dedicated environment KMS key and store only encrypted blobs in Postgres.
+- Never show raw provider credentials after save.
+- Never write raw provider credentials to logs, audit metadata, analytics, or test snapshots.
+
+Minimum `CommerceWebhookEvent` fields:
+
+- `id`
+- `tenant_id`
+- `source_type`
+- `source_key`
+- `merchant_id`
+- `event_id`
+- `event_type`
+- `signature_validation_status`
+- `payload_hash`
+- `raw_payload_ref`
+- `error_code`
+- `error_message`
+- `attempt_count`
+- `received_at`
+- `processed_at`
+- `status`
+
+Minimum `CommerceAgentSession` fields:
+
+- `id`
+- `tenant_id`
+- `agent_id`
+- `user_principal_id`
+- `started_at`
+- `ended_at`
+- `passport_jtis`
+- `tools_called`
+- `outcome`
+
+All V1 tenant-owned entities must include `tenant_id`, even if the abbreviated field list above omits it.
+
+Minimum `CommerceMeterEvent` fields:
+
+- `id`
+- `tenant_id`
+- `merchant_id`
+- `event_type`
+- `resource_type`
+- `resource_id`
+- `occurred_at`
+- `metadata`
+
+Minimum required indexes and constraints:
+
+- `CommerceMerchant(tenant_id, id)` unique lookup.
+- `CommerceAgent(tenant_id, id)` unique lookup.
+- `CommerceProduct(tenant_id, merchant_id, product_id)` unique.
+- `CommerceProductVariant(tenant_id, merchant_id, sku)` unique for active variants.
+- `CommercePassport(jti)` globally unique.
+- `CommercePassport(tenant_id, merchant_id, agent_id, expires_at)`.
+- `CommerceCart(tenant_id, merchant_id, created_at)`.
+- `CommercePaymentIntent(tenant_id, merchant_id, created_at)`.
+- `CommercePaymentIntent(tenant_id, provider, provider_payment_id)` unique where provider payment ID exists.
+- Idempotency records unique by `(tenant_id, merchant_id, endpoint, environment, idempotency_key_hash)`.
+- `CommerceWebhookEvent(tenant_id, source_type, source_key, event_id)` unique.
+- `CommerceAuditEvent(tenant_id, merchant_id, occurred_at)`.
+- One active `CommercePolicy` per `(tenant_id, merchant_id)`.
+- Foreign keys from variants to products, carts to merchants/agents/passports where applicable, payment intents to carts, provider credentials to merchants, and audit events to tenant/merchant where applicable.
+
+Do not create the full master-PRD entity set in V1 unless required by these flows.
+
+## 16. V1 REST APIs
+
+API documentation:
+
+- Maintain an OpenAPI 3.1 document for V1, preferably `docs/api/grantex-commerce-v1.openapi.yaml` or the codebase's existing API-doc location.
+- OpenAPI must include auth schemes, request schemas, response schemas, standard errors, pagination, and examples for sandbox flow.
+
+Standard HTTP conventions:
+
+- Create success: `201`.
+- Read/list success: `200`.
+- Update success: `200`.
+- Accepted async/retry operation: `202` only when background processing is actually used.
+- Validation error: `422`.
+- Authentication failure: `401`.
+- Authorization/policy denial: `403`.
+- Not found within caller tenant: `404`.
+- Idempotency conflict: `409`.
+- Rate limit: `429`.
+- Provider unavailable/timeout: `503` with retryable error envelope.
+
+Standard error envelope:
+
+```json
+{
+  "error": {
+    "code": "policy_denied",
+    "message": "Checkout exceeds the approved passport amount.",
+    "decision_id": "dec_...",
+    "audit_event_id": "aud_...",
+    "remediation": "Request fresh user consent with a higher amount cap.",
+    "retryable": false,
+    "details": {}
+  }
+}
+```
+
+List endpoints use cursor pagination:
+
+- request query: `limit`, `cursor`, `sort`, and endpoint-specific filters.
+- response: `{ "items": [], "next_cursor": null }`.
+- default `limit` is 25; max `limit` is 100.
+
+`GET /v1/commerce/audit/events` filters:
+
+- `merchant_id`
+- `agent_id`
+- `passport_jti`
+- `payment_intent_id`
+- `event_type`
+- `from`
+- `to`
+- `limit`
+- `cursor`
+
+Merchant:
+
+- `POST /v1/commerce/merchants`
+- `GET /v1/commerce/merchants/{merchant_id}`
+- `PATCH /v1/commerce/merchants/{merchant_id}`
+- `POST /v1/commerce/merchants/{merchant_id}/disable-agentic-commerce`
+
+Provider credentials:
+
+- `POST /v1/commerce/provider-credentials`
+- `GET /v1/commerce/provider-credentials`
+- `PATCH /v1/commerce/provider-credentials/{credential_id}`
+- `POST /v1/commerce/provider-credentials/{credential_id}/validate`
+
+Products:
+
+- `POST /v1/commerce/catalog/products`
+- `POST /v1/commerce/catalog/products/bulk`
+- `GET /v1/commerce/catalog/products`
+- `GET /v1/commerce/catalog/products/{product_id}`
+- `PATCH /v1/commerce/catalog/products/{product_id}`
+- `DELETE /v1/commerce/catalog/products/{product_id}`
+- `POST /v1/commerce/catalog/search`
+
+Product deletion in V1 is soft-delete/archive. Do not hard-delete products or variants that are referenced by carts, payment intents, audit events, or webhooks.
+
+Agents:
+
+- `POST /v1/commerce/agents`
+- `GET /v1/commerce/agents`
+- `GET /v1/commerce/agents/{agent_id}`
+- `PATCH /v1/commerce/agents/{agent_id}`
+
+Policy:
+
+- `POST /v1/commerce/policies`
+- `GET /v1/commerce/policies`
+- `GET /v1/commerce/policies/{policy_id}`
+- `POST /v1/commerce/policies/{policy_id}/activate`
+- `POST /v1/commerce/policies/evaluate`
+
+Cart:
+
+- `POST /v1/commerce/carts`
+- `GET /v1/commerce/carts/{cart_id}`
+
+Passport:
+
+- `POST /v1/commerce/passports/consent-requests`
+- `POST /v1/commerce/passports/exchange`
+- `GET /v1/commerce/passports`
+- `POST /v1/commerce/passports/verify`
+- `POST /v1/commerce/passports/revoke`
+
+Payments:
+
+- `POST /v1/commerce/payments/intents`
+- `GET /v1/commerce/payments/intents`
+- `GET /v1/commerce/payments/intents/{id}`
+- `POST /v1/commerce/payments/intents/{id}/checkout-link`
+- `POST /v1/webhooks/providers/{provider_key}`
+
+For Plural sandbox, `provider_key` is `plural`. Do not hardcode the route to Plural in the core webhook router.
+
+Audit:
+
+- `GET /v1/commerce/audit/events`
+
+Well-known/MCP:
+
+- `GET /.well-known/grantex-commerce`
+- MCP streamable HTTP endpoint at `/mcp`
+
+MCP transport note:
+
+- `/mcp` represents the MCP server entrypoint.
+- V1 MCP server uses the streamable HTTP transport from the current MCP specification.
+- SSE transport is not supported in V1.
+- The well-known profile must tell clients the exact MCP transport URL and supported tools.
+
+Minimum `/.well-known/grantex-commerce` response:
+
+```json
+{
+  "version": "2026-05-01",
+  "merchant_id": "mch_...",
+  "tenant_environment": "sandbox",
+  "merchant": {
+    "display_name": "Merchant Name",
+    "legal_name": "Merchant Legal Name",
+    "verified": true,
+    "category_preset": "electronics_appliances"
+  },
+  "protocols": {
+    "mcp": {
+      "transport": "streamable_http",
+      "url": "https://commerce.grantex.dev/mcp",
+      "tools": ["merchant.get_profile", "catalog.search", "catalog.get_item", "inventory.check", "cart.create", "checkout.create", "payment.create_intent", "payment.get_status"]
+    },
+    "native_rest": {
+      "base_url": "https://commerce.grantex.dev/v1/commerce"
+    }
+  },
+  "auth": {
+    "agent_jwt": true,
+    "api_key": true,
+    "commerce_passport_required_for": ["checkout.create", "payment.create_intent"]
+  },
+  "capabilities": ["catalog.search", "inventory.check", "cart.create", "checkout.create", "payment.create_intent", "payment.get_status"]
+}
+```
+
+Inbound merchant webhooks:
+
+- `POST /v1/webhooks/merchant/{merchant_id}/{source_key}`
+
+Inbound webhook sources:
+
+- `POST /v1/commerce/webhook-sources`
+- `GET /v1/commerce/webhook-sources`
+- `PATCH /v1/commerce/webhook-sources/{source_key}`
+- `POST /v1/commerce/webhook-sources/{source_key}/rotate-secret`
+
+Inbound merchant webhook contract:
+
+- Webhook payloads must be signed with a merchant/source-specific secret.
+- Signature algorithm is HMAC-SHA256 over `<timestamp>.<raw_body>`.
+- Signature header format is `Grantex-Signature: t=<unix_timestamp>,v1=<hex_hmac_sha256>`.
+- Include event ID, event type, occurred-at timestamp, source key, and payload version.
+- Reject unsigned webhooks.
+- Reject timestamps outside the configured replay window; default replay window is 5 minutes.
+- Process repeated event IDs idempotently.
+- Store failed events for dashboard visibility and manual replay.
+- V1 accepts only `catalog.product.updated`; all other inbound event types return explicit `unsupported_event_type`.
+
+Provider webhook contract:
+
+- Route is `POST /v1/webhooks/providers/{provider_key}`.
+- Plural signature scheme is an external blocker until Pine/Plural confirms the exact scheme.
+- If Plural signature scheme is unavailable during development, implement the route against the mock provider signature contract and leave Plural live/sandbox webhook verification blocked with explicit configuration error.
+- Provider webhook events must be idempotent by provider event ID and payment reference.
+
+PATCH mutable field allowlists:
+
+- Merchant PATCH may update: `display_name`, `support_email`, `agentic_commerce_enabled`, metadata fields that are explicitly non-security-sensitive.
+- Agent PATCH may update: `display_name`, `public_key_jwk`, `trust_status`, `disabled_at`.
+- Product PATCH may update: `title`, `brand`, `description`, `image_url`, `archived_at`.
+- Variant PATCH may update: `variant_title`, `attributes`, `price_amount`, `currency`, `tax_inclusive`, `gst_slab`, `tax_rate`, `hsn_code`, `availability_status`, `warranty_summary`, `return_policy_summary`, `last_synced_at`, `archived_at`.
+- Policy drafts may update `rules`; active policies are immutable and changes require creating a new policy version then activating it.
+- Never allow clients to PATCH `id`, `tenant_id`, `merchant_id`, `created_at`, audit fields, provider credential secret blobs, `passport_jti`, or payment provider references.
+
+Minimum request/response contracts:
+
+- Create endpoints accept JSON body and return the created resource envelope `{ "data": { ... } }`.
+- List endpoints return `{ "items": [...], "next_cursor": null }`.
+- Protected action endpoints return `{ "data": ..., "decision_id": "...", "audit_event_id": "..." }` when an audit event is emitted.
+- Idempotency conflict returns HTTP `409` with standard error envelope and must not return a mismatched previous success body.
+- Validation failures return field-level details in `error.details.fields`.
+
+Endpoint schema minimums:
+
+| Endpoint | Request minimum | Response minimum |
+| --- | --- | --- |
+| `POST /v1/commerce/merchants` | legal/display name, category preset, country, currency | merchant |
+| `GET /v1/commerce/merchants/{merchant_id}` | path merchant ID | merchant |
+| `PATCH /v1/commerce/merchants/{merchant_id}` | mutable merchant fields only | merchant |
+| `POST /v1/commerce/provider-credentials` | merchant ID, provider key, environment, credential payload | credential metadata, never raw secret |
+| `GET /v1/commerce/provider-credentials` | merchant/provider/environment filters | credential metadata list |
+| `PATCH /v1/commerce/provider-credentials/{credential_id}` | replacement credential payload or disabled status | credential metadata |
+| `POST /v1/commerce/provider-credentials/{credential_id}/validate` | optional validation mode | validation status and capability list |
+| `POST /v1/commerce/catalog/products` | product with variants | product with variants |
+| `POST /v1/commerce/catalog/products/bulk` | array of products with variants | accepted/created/failed counts and row errors |
+| `GET /v1/commerce/catalog/products` | merchant ID, filters, pagination | product list |
+| `GET /v1/commerce/catalog/products/{product_id}` | product ID | product with variants |
+| `PATCH /v1/commerce/catalog/products/{product_id}` | mutable product fields | product |
+| `DELETE /v1/commerce/catalog/products/{product_id}` | product ID | archived product status |
+| `POST /v1/commerce/catalog/search` | merchant ID, query, filters, pagination | matching products/variants |
+| `POST /v1/commerce/agents` | display name, agent type, public key or API-key mode | agent metadata and one-time API key only if generated |
+| `GET /v1/commerce/agents` | merchant/tenant filters, pagination | agent list |
+| `GET /v1/commerce/agents/{agent_id}` | agent ID | agent metadata |
+| `PATCH /v1/commerce/agents/{agent_id}` | mutable agent fields | agent metadata |
+| `POST /v1/commerce/policies` | merchant ID, policy rules | draft policy |
+| `GET /v1/commerce/policies` | merchant ID, status, pagination | policy list |
+| `GET /v1/commerce/policies/{policy_id}` | policy ID | policy |
+| `POST /v1/commerce/policies/{policy_id}/activate` | policy ID | active policy and audit ID |
+| `POST /v1/commerce/policies/evaluate` | merchant ID, agent ID, passport/context/action/amount | decision, reason, policy version |
+| `POST /v1/commerce/carts` | merchant ID, agent ID, line items, currency | immutable cart draft |
+| `GET /v1/commerce/carts/{cart_id}` | cart ID | cart |
+| `POST /v1/commerce/passports/consent-requests` | merchant ID, agent ID, requested scopes, amount cap, currency, expiry | consent request and approval URL |
+| `POST /v1/commerce/passports/exchange` | consent request ID and approval proof | signed passport/JWT metadata |
+| `GET /v1/commerce/passports` | merchant/agent/status filters, pagination | passport metadata list, not raw secrets |
+| `POST /v1/commerce/passports/verify` | passport JWT or JTI, requested action | verification result |
+| `POST /v1/commerce/passports/revoke` | JTI or scope of revocation, reason | revocation result |
+| `POST /v1/commerce/payments/intents` | merchant ID, cart ID, passport JTI, amount/currency, idempotency key | payment intent |
+| `GET /v1/commerce/payments/intents` | merchant/status/date filters, pagination | payment intent list |
+| `GET /v1/commerce/payments/intents/{id}` | payment intent ID | payment intent |
+| `POST /v1/commerce/payments/intents/{id}/checkout-link` | payment intent ID, idempotency key, return URLs | checkout URL and expiry |
+| `POST /v1/webhooks/providers/{provider_key}` | signed raw provider body | accepted/ignored result |
+| `GET /v1/commerce/audit/events` | filters and pagination | audit events |
+| `POST /v1/webhooks/merchant/{merchant_id}/{source_key}` | signed catalog product updated envelope | accepted/failed result |
+| `POST /v1/commerce/webhook-sources` | merchant ID, source key/display name | source metadata and one-time secret |
+| `GET /v1/commerce/webhook-sources` | merchant ID | source metadata list |
+| `PATCH /v1/commerce/webhook-sources/{source_key}` | mutable source fields | source metadata |
+| `POST /v1/commerce/webhook-sources/{source_key}/rotate-secret` | source key | source metadata and one-time new secret |
+
+Idempotency API contract:
+
+- `POST /v1/commerce/payments/intents` requires `Idempotency-Key`.
+- `POST /v1/commerce/payments/intents/{id}/checkout-link` requires `Idempotency-Key`.
+- `POST /v1/commerce/carts` requires `Idempotency-Key`.
+- Same key and same request body returns the original response.
+- Same key and different request body returns HTTP `409`.
+- Idempotency records persist for at least 24 hours.
+- After 24 hours, the implementation may treat the key as expired and process a new request, but only after the old record is outside its retention window. The response must not be ambiguous.
+
+Rate limits:
+
+| Endpoint | Limit |
+| --- | --- |
+| `POST /v1/commerce/catalog/search` unauthenticated | 60 requests/minute/IP |
+| `POST /v1/commerce/catalog/search` authenticated | 600 requests/minute/agent or API key |
+| `POST /v1/commerce/payments/intents` | 60 requests/minute/merchant |
+| `POST /v1/webhooks/providers/{provider_key}` | 1000 requests/minute/merchant/provider; verified provider sender only |
+| `POST /v1/webhooks/merchant/{merchant_id}/{source_key}` | 100 requests/minute/source key |
+| `POST /v1/commerce/passports/consent-requests` | 120 requests/minute/agent |
+| `POST /v1/commerce/passports/verify` | 1000 requests/minute/agent or API key |
+| `POST /v1/commerce/policies/evaluate` | 1000 requests/minute/agent or API key |
+| MCP `/mcp` tool calls | 600 requests/minute/agent or API key |
+
+Rate-limit source IP:
+
+- For unauthenticated per-IP rate limits, trust forwarded IP headers only from configured trusted proxies/load balancers.
+- Ignore spoofable `X-Forwarded-For` from untrusted peers.
+
+Tenant isolation design:
+
+- V1 tenant model: one tenant represents one Grantex customer organization.
+- A tenant may own one or more merchants, agents, provider credentials, policies, passports, carts, payment intents, and audit events.
+- The Pine/Plural partner uses a dedicated tenant.
+- The first pilot merchant operates under its own tenant or under a Grantex internal sandbox tenant until live readiness.
+- Every authenticated request resolves to exactly one `tenant_id` from auth context.
+- Every tenant-owned table includes `tenant_id`.
+- Every query must filter by `tenant_id`; prefer Postgres row-level security if it fits the existing codebase.
+- No cross-tenant joins in V1 product code.
+- Sandbox passports cannot authorize live actions.
+- Test/demo merchants must be marked in dashboard and API responses.
+
+## 16.1 Security And Operations Contracts
+
+Secrets management:
+
+- JWT signing keys, provider credentials, API keys, and webhook secrets must live in the codebase's existing secrets manager/KMS if available.
+- If no secrets manager exists, use envelope encryption with environment-specific KMS key and store encrypted blobs only.
+- Store API keys only as salted hashes.
+- Provider credentials and webhook secrets are displayed only once at creation/rotation.
+
+Logging and privacy:
+
+- Structured logs must include request ID, tenant ID, merchant ID, agent ID, payment intent ID, provider key, and error code where relevant.
+- Logs must redact emails, phone numbers, raw consent payloads, provider credentials, API keys, JWTs, webhook secrets, and raw payment data.
+- Test snapshots must not contain real secrets or raw payment credentials.
+
+Feature flags:
+
+- Required flags: `commerce_v1_enabled`, `commerce_sandbox_enabled`, `plural_sandbox_enabled`, `plural_live_enabled`, `commerce_live_mode_enabled`.
+- Feature flag changes that affect payment or agentic commerce must be audited as `merchant.feature_flag.updated`.
+- Live flags require admin/operator permission and legal blocker acknowledgment.
+
+Background jobs:
+
+- Reconciliation runs through the codebase's existing job runner if present.
+- If no job runner exists, V1 must add a minimal scheduled worker for payment reconciliation and webhook replay.
+- Job runs must be idempotent, observable, and safe to retry.
+
+Health and metrics:
+
+- Provide health checks for API, database, provider adapter health, background worker health, and webhook processing backlog.
+- Provide metrics for request count, error count, latency, provider latency, passport verification latency, webhook processing latency, reconciliation lag, and audit write failures.
+- Use OpenTelemetry/Prometheus or the existing codebase observability stack.
+
+Pilot SLA targets:
+
+- `/v1/commerce/payments/*`: 99.0% pilot availability.
+- `POST /v1/commerce/payments/intents`: p95 under 500 ms excluding provider latency at 10 RPS.
+- `POST /v1/commerce/catalog/search`: p95 under 300 ms at 50 RPS for pilot catalog size.
+- `POST /v1/webhooks/providers/{provider_key}`: handle 5 webhook events/sec with p95 processing under 500 ms excluding provider verification latency.
+- `POST /v1/commerce/passports/verify`: p95 under 100 ms for offline verification; payment-affecting online revocation checks may be slower but must be measured.
+
+Migration, backup, and rollback:
+
+- Migrations are forward-only and reviewed before deploy.
+- Back up Postgres before production schema changes once live mode is enabled.
+- Pilot target RPO is 15 minutes for commerce database once live mode is enabled.
+- Rollback plan must keep old code compatible with newly added nullable columns and tables.
+- Destructive migrations are not allowed in V1.
+
+## 17. V1 Tests
+
+Required:
+
+- passport issue/verify/revoke tests;
+- CommerceAgent registration and disabled-agent tests;
+- CommerceAgent trust-status update tests;
+- agent authentication tests;
+- expired passport tests;
+- revoked passport tests;
+- not-before passport tests;
+- passport version tests;
+- JWT `alg=none`, algorithm downgrade, missing `kid`, unknown `kid`, and `kid` confusion rejection tests;
+- JWKS endpoint availability and key rotation tests;
+- amount cap tests;
+- merchant mismatch tests;
+- cross-tenant passport rejection tests;
+- emergency disable tests;
+- idempotency tests;
+- idempotency outside-retention-window tests;
+- rate-limit tests;
+- trusted-proxy/forwarded-IP rate-limit tests;
+- provider credential validation tests;
+- provider credential encryption and plaintext-not-in-logs tests;
+- webhook source secret rotation tests;
+- payment state machine tests;
+- AFA/OTP abandonment timeout test;
+- payment reconciliation polling test;
+- Plural mock adapter tests;
+- mock provider deterministic success/decline/timeout/signature-failure/replay tests;
+- Plural webhook signature/replay tests;
+- inbound merchant webhook signature/replay tests;
+- inbound merchant webhook schema validation tests;
+- unsupported inbound event type test;
+- audit write tests;
+- audit table update/delete permission tests;
+- multi-tenant isolation tests;
+- product variant tests;
+- stale-price-blocks-checkout tests;
+- tenant_id presence tests for tenant-owned entities;
+- GST/tax-inclusive amount tests;
+- mass-assignment tests for PATCH endpoints;
+- CSRF tests for consent approval/deny;
+- clickjacking/header tests for consent UI;
+- Sales Agent eval tests;
+- end-to-end agent -> consent -> checkout -> webhook -> audit test.
+
+Quality gate:
+
+- no payment intent can be created without valid Commerce Passport;
+- no protected action succeeds without audit record;
+- no live provider action without feature flag;
+- no route without tenant/auth checks.
+- audit rows cannot be updated or deleted by the application database role.
+- no provider credential is stored or logged in plaintext;
+- no Commerce Passport verifies without pinned ES256 algorithm and known `kid`;
+- no PATCH endpoint permits mutation of immutable ownership/security fields;
+- OpenAPI 3.1 V1 document exists and matches implemented routes;
+- tenant A passport cannot authorize tenant B action.
+
+## 18. V1 Milestones
+
+### Milestone 1: Foundations
+
+Target: 2-3 weeks.
+
+- schema;
+- OpenAPI 3.1 skeleton and standard error envelope;
+- feature flags;
+- tenant boundary;
+- merchant model;
+- CommerceAgent model;
+- product and variant models;
+- remaining V1 commerce entity field lists and constraints;
+- electronics preset;
+- audit writer;
+- database-level append-only audit permissions.
+
+### Milestone 2: Passport
+
+Target: 3-4 weeks.
+
+- agent registration;
+- consent request;
+- consent UX;
+- passport issue/verify/revoke;
+- ES256 signing and JWKS;
+- revocation check.
+
+### Milestone 3: Policy
+
+Target: 2-3 weeks.
+
+- amount cap;
+- scope allowlist;
+- emergency disable;
+- `CommercePolicy.rules` schema validation;
+- policy activation;
+- policy evaluation API.
+
+### Milestone 4: Payment
+
+Target: 4-5 weeks.
+
+- mock provider;
+- Plural sandbox provider;
+- confirmed Plural webhook signature scheme or explicit blocked state;
+- payment intent;
+- checkout link;
+- webhook handling;
+- payment state machine;
+- idempotency;
+- AFA/OTP pending timeout;
+- automated and manual reconciliation.
+
+### Milestone 5: Agent And MCP
+
+Target: 3-4 weeks.
+
+- MCP tools;
+- demo MCP client in playground;
+- AgenticOrg Sales Agent;
+- evals;
+- end-to-end demo.
+
+### Milestone 6: Hardening
+
+Target: 3-4 weeks.
+
+- tests;
+- observability;
+- audit views;
+- docs;
+- CSV column spec for product and variant import published in docs;
+- sandbox playground;
+- legal review notes.
+
+### Milestone 7: Operational Pilot Hardening
+
+Target: 2-3 weeks.
+
+- basic SLA dashboard;
+- on-call/runbook templates;
+- stuck payment dashboard;
+- webhook dead-letter/replay view;
+- load test for pilot traffic: sustain 10 RPS on `POST /v1/commerce/payments/intents` with p95 under 500 ms excluding provider latency;
+- load test for pilot catalog traffic: sustain 50 RPS on `POST /v1/commerce/catalog/search` with p95 under 300 ms for pilot catalog size;
+- load test for provider webhooks: sustain 5 events/sec with idempotent processing and no duplicate payment transitions;
+- first pilot merchant configuration;
+- support ownership document.
+
+## 19. First 10 Engineering Tasks
+
+1. Add commerce feature flags and provider-neutral config.
+2. Add V1 migrations/entities.
+3. Add electronics category preset seed.
+4. Add CommerceAgent registration and trust status.
+5. Add audit event writer, database append-only grants, and event list API.
+6. Add Commerce Passport issuance, verification, and revocation.
+7. Add consent request and consent UI.
+8. Add V1 policy evaluator and activation endpoint.
+9. Add mock payment provider and payment state machine.
+10. Add Plural sandbox provider adapter and E2E sandbox test: agent request -> consent -> checkout -> webhook -> audit.
+
+## 20. Questions Before Live Payments
+
+1. What exact Plural APIs are available for sandbox and live checkout/payment link creation?
+2. What webhook signature scheme does Plural use? This must be answered before Milestone 4 Plural webhook completion.
+3. What legal consent text is required for agent-created checkout in India?
+4. Confirm exact final user confirmation copy and hosted checkout handoff language with Pine/Plural legal.
+5. What RBI/AFA review is required before any delegated or semi-autonomous payment flow?
+6. Confirm RBI data localization scope for Grantex Commerce as an authorization layer, and identify payment data fields requiring India residency.
+7. What merchant onboarding/KYC data can be reused from Pine/Plural? Default assumption: re-collect or receive only with explicit data-sharing approval.
+8. What refund capability should be considered for V2 after V1 proves checkout authorization?
+9. What data can be shown in a public MCP catalog search without merchant/user authentication?
+10. Confirm first pilot merchant and their actual catalog/payment setup.
+11. Who owns production support between Grantex, AgenticOrg, merchant, and Plural?
+
+## 21. V1 Sign-Off
+
+V1 is ready when:
+
+- OpenAPI 3.1 V1 contract exists and matches implementation.
+- Merchant can onboard in sandbox.
+- Merchant can configure and validate Plural sandbox credentials.
+- Provider credential storage is encrypted and raw credentials are not logged or displayed after save.
+- Product and variants can be added by dashboard, CSV, API, or complete-state inbound webhook.
+- Product price supports tax-inclusive totals and GST/HSN metadata.
+- CommerceAgent is registered and used in passport issuance.
+- Agent can discover product via MCP.
+- Agent API calls authenticate as registered `CommerceAgent`.
+- Commerce Passport signing uses pinned ES256 and JWKS key rotation is tested.
+- User can approve Commerce Passport.
+- Agent can create checkout only with valid passport.
+- Plural sandbox checkout works.
+- Payment pending timeout and reconciliation work.
+- Webhook updates payment status.
+- Audit timeline proves every step.
+- Audit table is database-level append-only.
+- Revocation blocks new protected actions.
+- Emergency disable blocks new protected actions.
+- Sales Agent passes evals.
+- Demo MCP client works in playground.
+- First pilot merchant is named or internal test merchant is explicitly approved.
+- Legal blocker list is documented before live mode.
+
+V1 is not ready if:
+
+- checkout works without consent;
+- payment intent works without audit;
+- provider code is hardcoded to Plural in core models;
+- user revocation does not block protected actions;
+- merchant emergency disable is delayed by cache TTL;
+- dashboard-only flows exist without APIs;
+- AgenticOrg calls payment provider directly.
+- passport can be issued for an unknown or disabled agent;
+- protected agent API calls work without agent authentication;
+- same idempotency key with different body does not return `409`;
+- audit rows can be updated or deleted by the application database role.
+- tenant-owned records can be created without `tenant_id`;
+- unsigned inbound merchant webhooks are accepted.
+- live payment-related data is hosted outside India without legal approval.
+- mutable PATCH endpoints can change `tenant_id`, ownership IDs, provider references, or audit fields.
+- `alg=none`, algorithm downgrade, missing `kid`, or unknown `kid` JWTs verify successfully.
+- OpenAPI contract is missing or materially out of sync with implemented routes.
+
+## 22. First Pilot
+
+V1 must name the first pilot before Milestone 4 begins.
+
+Acceptable pilot options:
+
+- a real Pine/Plural electronics merchant;
+- an internal Pine/Plural test merchant configured like an electronics retailer;
+- an AgenticOrg demo merchant with Plural sandbox credentials.
+
+Pilot profile must include:
+
+- merchant legal/display name;
+- Plural sandbox account;
+- 10-25 electronics products;
+- at least 3 products with variants;
+- tax-inclusive pricing;
+- GST/HSN metadata;
+- availability status;
+- return/warranty summaries;
+- one approved Sales Agent identity;
+- named merchant operator for feedback.
+- named merchant technical lead.
+- weekly feedback cadence during pilot.
+
+V1 should not be considered pilot-ready without this setup.

--- a/apps/auth-service/src/config.ts
+++ b/apps/auth-service/src/config.ts
@@ -83,6 +83,22 @@ export const config = {
     .split(',')
     .map((o) => o.trim())
     .filter((o) => o.length > 0),
+  // ---------------------------------------------------------------------
+  // Grantex Commerce V1 feature flags. M1 reads them at request time
+  // (process.env directly) so test toggling via vi.stubEnv works.
+  // Flag-flip events that affect payment or agentic commerce must be
+  // audited as merchant.feature_flag.updated (M2+).
+  // commerceAllowAutoTenant: gates the test/local-sandbox auto-provision
+  // path in lib/commerce/tenant.ts. MUST stay false in staging/production;
+  // unmapped developers there receive 422 tenant_not_provisioned and must
+  // be provisioned via the explicit endpoints planned for M2.
+  // ---------------------------------------------------------------------
+  commerceV1Enabled: process.env['COMMERCE_V1_ENABLED'] === 'true',
+  commerceSandboxEnabled: process.env['COMMERCE_SANDBOX_ENABLED'] !== 'false',
+  commerceAllowAutoTenant: process.env['COMMERCE_ALLOW_AUTO_TENANT'] === 'true',
+  pluralSandboxEnabled: process.env['PLURAL_SANDBOX_ENABLED'] === 'true',
+  pluralLiveEnabled: process.env['PLURAL_LIVE_ENABLED'] === 'true',
+  commerceLiveModeEnabled: process.env['COMMERCE_LIVE_MODE_ENABLED'] === 'true',
 } as const;
 
 if (!config.rsaPrivateKey && !config.autoGenerateKeys) {

--- a/apps/auth-service/src/db/migrations/031_commerce_tenants.sql
+++ b/apps/auth-service/src/db/migrations/031_commerce_tenants.sql
@@ -1,0 +1,37 @@
+-- Grantex Commerce V1 — Milestone 1: tenant model.
+-- Per architecture decision (project-grantex-commerce.md), tenancy uses a
+-- dedicated commerce_tenants table with a many-to-one developer→tenant
+-- mapping, NOT an alias of developers.id. This lets the Pine/Plural partner
+-- own a dedicated tenant later without retrofitting every commerce table.
+
+CREATE TABLE IF NOT EXISTS commerce_tenants (
+  id            TEXT PRIMARY KEY,                         -- cten_<ulid>
+  display_name  TEXT NOT NULL,
+  status        TEXT NOT NULL DEFAULT 'active',           -- active | disabled
+  metadata      JSONB NOT NULL DEFAULT '{}'::JSONB,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_commerce_tenants_status CHECK (status IN ('active','disabled'))
+);
+
+-- Many-to-one developer→tenant mapping. A developer can be associated with
+-- one or more tenants; M1 auto-creates a single tenant per developer on
+-- first commerce access. Multi-tenant-per-developer becomes meaningful in
+-- M2+ when partner/operator distinctions land.
+CREATE TABLE IF NOT EXISTS commerce_developer_tenants (
+  developer_id  TEXT NOT NULL REFERENCES developers(id) ON DELETE CASCADE,
+  tenant_id     TEXT NOT NULL REFERENCES commerce_tenants(id) ON DELETE CASCADE,
+  is_default    BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (developer_id, tenant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_commerce_dev_tenants_developer
+  ON commerce_developer_tenants(developer_id);
+CREATE INDEX IF NOT EXISTS idx_commerce_dev_tenants_tenant
+  ON commerce_developer_tenants(tenant_id);
+
+-- Exactly one default tenant per developer. Future PATCH endpoints can
+-- shift the default; this constraint stops "two defaults" drift.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_dev_tenants_default
+  ON commerce_developer_tenants(developer_id) WHERE is_default = TRUE;

--- a/apps/auth-service/src/db/migrations/032_commerce_category_presets.sql
+++ b/apps/auth-service/src/db/migrations/032_commerce_category_presets.sql
@@ -1,0 +1,47 @@
+-- Grantex Commerce V1 — Milestone 1: category presets.
+-- V1 ships exactly one preset: electronics_appliances. preset_key is the
+-- stable PK so future FKs from merchants/products use the human-readable
+-- key rather than a ULID.
+
+CREATE TABLE IF NOT EXISTS commerce_category_presets (
+  preset_key            TEXT PRIMARY KEY,                       -- e.g. electronics_appliances
+  display_name          TEXT NOT NULL,
+  version               TEXT NOT NULL,                          -- ISO date, e.g. 2026-05-01
+  required_fields       JSONB NOT NULL DEFAULT '[]'::JSONB,
+  default_policy_rules  JSONB NOT NULL DEFAULT '{}'::JSONB,
+  default_capabilities  JSONB NOT NULL DEFAULT '[]'::JSONB,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO commerce_category_presets (
+  preset_key, display_name, version, required_fields,
+  default_policy_rules, default_capabilities
+) VALUES (
+  'electronics_appliances',
+  'Electronics & Appliances',
+  '2026-05-01',
+  '[
+    "sku","title","brand","price_amount","currency","tax_inclusive",
+    "gst_slab","hsn_code","availability_status","warranty_summary",
+    "return_policy_summary"
+  ]'::JSONB,
+  '{
+    "amount_cap":            { "max_amount_minor_units": 50000000, "currency": "INR" },
+    "scope_allowlist":       [
+      "commerce:catalog.read","commerce:inventory.read",
+      "commerce:checkout.create","commerce:payment.initiate",
+      "commerce:payment.status.read"
+    ],
+    "emergency_disable":              false,
+    "checkout_passport_max_ttl_seconds": 600,
+    "browse_passport_max_ttl_seconds":   3600,
+    "stale_price_max_age_seconds":       86400,
+    "allow_unknown_inventory_checkout":  false
+  }'::JSONB,
+  '[
+    "merchant.get_profile","catalog.search","catalog.get_item",
+    "inventory.check","cart.create","checkout.create",
+    "payment.create_intent","payment.get_status"
+  ]'::JSONB
+) ON CONFLICT (preset_key) DO NOTHING;

--- a/apps/auth-service/src/db/migrations/033_commerce_merchants.sql
+++ b/apps/auth-service/src/db/migrations/033_commerce_merchants.sql
@@ -1,0 +1,40 @@
+-- Grantex Commerce V1 — Milestone 1: CommerceMerchant.
+-- Provider-neutral by construction: provider_account_refs is JSONB keyed by
+-- provider_key (e.g. {"plural": {...}, "razorpay": {...}}). Core columns
+-- carry no provider-specific identifiers.
+
+CREATE TABLE IF NOT EXISTS commerce_merchants (
+  id                          TEXT PRIMARY KEY,                                 -- mch_<ulid>
+  tenant_id                   TEXT NOT NULL REFERENCES commerce_tenants(id),
+  legal_name                  TEXT NOT NULL,
+  display_name                TEXT NOT NULL,
+  category_preset             TEXT NOT NULL REFERENCES commerce_category_presets(preset_key),
+  verification_status         TEXT NOT NULL DEFAULT 'unverified',               -- unverified | pending | verified | rejected
+  environment                 TEXT NOT NULL DEFAULT 'sandbox',                  -- sandbox | live
+  agentic_commerce_enabled    BOOLEAN NOT NULL DEFAULT FALSE,
+  default_currency            TEXT NOT NULL DEFAULT 'INR',
+  country_code                TEXT NOT NULL DEFAULT 'IN',
+  support_email               TEXT,
+  provider_account_refs       JSONB NOT NULL DEFAULT '{}'::JSONB,
+  metadata                    JSONB NOT NULL DEFAULT '{}'::JSONB,
+  disabled_at                 TIMESTAMPTZ,
+  created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_merchants_verification CHECK (
+    verification_status IN ('unverified','pending','verified','rejected')
+  ),
+  CONSTRAINT chk_merchants_environment CHECK (environment IN ('sandbox','live'))
+);
+
+-- Spec §15 mandates (tenant_id, id) unique even though id is already PK.
+-- Carrying the redundant constraint matches the spec text and makes
+-- composite FKs from cross-tenant tables straightforward later.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_merchants_tenant_id
+  ON commerce_merchants(tenant_id, id);
+
+CREATE INDEX IF NOT EXISTS idx_commerce_merchants_tenant
+  ON commerce_merchants(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_commerce_merchants_environment
+  ON commerce_merchants(environment);
+CREATE INDEX IF NOT EXISTS idx_commerce_merchants_disabled
+  ON commerce_merchants(disabled_at) WHERE disabled_at IS NOT NULL;

--- a/apps/auth-service/src/db/migrations/033_commerce_merchants.sql
+++ b/apps/auth-service/src/db/migrations/033_commerce_merchants.sql
@@ -23,14 +23,35 @@ CREATE TABLE IF NOT EXISTS commerce_merchants (
   CONSTRAINT chk_merchants_verification CHECK (
     verification_status IN ('unverified','pending','verified','rejected')
   ),
-  CONSTRAINT chk_merchants_environment CHECK (environment IN ('sandbox','live'))
+  CONSTRAINT chk_merchants_environment CHECK (environment IN ('sandbox','live')),
+  -- Must be a CONSTRAINT (not a bare UNIQUE INDEX) so other tables can
+  -- declare composite FOREIGN KEY (tenant_id, merchant_id) → here.
+  -- PG requires a UNIQUE/PK constraint on the referenced columns; a
+  -- standalone unique index is not accepted as an FK target.
+  CONSTRAINT uq_commerce_merchants_tenant_id UNIQUE (tenant_id, id)
 );
 
--- Spec §15 mandates (tenant_id, id) unique even though id is already PK.
--- Carrying the redundant constraint matches the spec text and makes
--- composite FKs from cross-tenant tables straightforward later.
-CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_merchants_tenant_id
-  ON commerce_merchants(tenant_id, id);
+-- Idempotency for upgrades from a prior shape that used CREATE UNIQUE
+-- INDEX. Drop the legacy index if present (the CONSTRAINT above creates
+-- its own backing index automatically). No-op on fresh installs.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'uq_commerce_merchants_tenant_id'
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'uq_commerce_merchants_tenant_id'
+          AND conrelid = 'commerce_merchants'::regclass
+      )
+  ) THEN
+    DROP INDEX uq_commerce_merchants_tenant_id;
+    ALTER TABLE commerce_merchants
+      ADD CONSTRAINT uq_commerce_merchants_tenant_id UNIQUE (tenant_id, id);
+  END IF;
+END
+$$;
 
 CREATE INDEX IF NOT EXISTS idx_commerce_merchants_tenant
   ON commerce_merchants(tenant_id);

--- a/apps/auth-service/src/db/migrations/034_commerce_agents.sql
+++ b/apps/auth-service/src/db/migrations/034_commerce_agents.sql
@@ -1,0 +1,30 @@
+-- Grantex Commerce V1 — Milestone 1: CommerceAgent.
+-- Distinct from existing platform `agents` table. Holds JWT public key
+-- (preferred) and/or hashed API key (secondary) per spec §6 agent auth.
+
+CREATE TABLE IF NOT EXISTS commerce_agents (
+  id              TEXT PRIMARY KEY,                                     -- cag_<ulid>
+  tenant_id       TEXT NOT NULL REFERENCES commerce_tenants(id),
+  display_name    TEXT NOT NULL,
+  agent_type      TEXT NOT NULL DEFAULT 'sales',                        -- sales | support | catalog | other
+  public_key_jwk  JSONB,                                                -- ES256 public key for JWT assertion verification
+  api_key_hash    TEXT,                                                 -- salted hash of grtx_agent_<secret>; never raw
+  trust_status    TEXT NOT NULL DEFAULT 'pending',                      -- pending | trusted | suspended | disabled
+  disabled_at     TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_commerce_agents_trust_status CHECK (
+    trust_status IN ('pending','trusted','suspended','disabled')
+  ),
+  CONSTRAINT chk_commerce_agents_has_credential CHECK (
+    public_key_jwk IS NOT NULL OR api_key_hash IS NOT NULL
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_agents_tenant_id
+  ON commerce_agents(tenant_id, id);
+
+CREATE INDEX IF NOT EXISTS idx_commerce_agents_tenant
+  ON commerce_agents(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_commerce_agents_trust
+  ON commerce_agents(trust_status);

--- a/apps/auth-service/src/db/migrations/035_commerce_products.sql
+++ b/apps/auth-service/src/db/migrations/035_commerce_products.sql
@@ -1,0 +1,75 @@
+-- Grantex Commerce V1 — Milestone 1: CommerceProduct + CommerceProductVariant.
+-- Soft-delete via archived_at. Hard-deletes are forbidden when references
+-- exist (cart/payment/audit FKs land in later migrations).
+
+CREATE TABLE IF NOT EXISTS commerce_products (
+  id                    TEXT PRIMARY KEY,                                       -- cprd_<ulid>
+  tenant_id             TEXT NOT NULL REFERENCES commerce_tenants(id),
+  merchant_id           TEXT NOT NULL REFERENCES commerce_merchants(id),
+  product_id            TEXT NOT NULL,                                          -- merchant-supplied stable product key
+  title                 TEXT NOT NULL,
+  brand                 TEXT,
+  description           TEXT,
+  image_url             TEXT,
+  category_preset       TEXT NOT NULL REFERENCES commerce_category_presets(preset_key),
+  source_system         TEXT NOT NULL DEFAULT 'manual',                         -- manual | csv | api | webhook
+  manually_maintained   BOOLEAN NOT NULL DEFAULT FALSE,
+  archived_at           TIMESTAMPTZ,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Spec §15: (tenant_id, merchant_id, product_id) unique for active rows.
+-- Partial index lets soft-deleted rows keep the same product_id without
+-- blocking fresh re-creation under the same key.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_products_active
+  ON commerce_products(tenant_id, merchant_id, product_id)
+  WHERE archived_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_commerce_products_tenant_merchant
+  ON commerce_products(tenant_id, merchant_id);
+CREATE INDEX IF NOT EXISTS idx_commerce_products_archived
+  ON commerce_products(archived_at) WHERE archived_at IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS commerce_product_variants (
+  id                        TEXT PRIMARY KEY,                                   -- cvar_<ulid>
+  tenant_id                 TEXT NOT NULL REFERENCES commerce_tenants(id),
+  merchant_id               TEXT NOT NULL REFERENCES commerce_merchants(id),
+  product_id                TEXT NOT NULL REFERENCES commerce_products(id),
+  sku                       TEXT NOT NULL,
+  parent_sku                TEXT,
+  model                     TEXT,
+  variant_title             TEXT,
+  attributes                JSONB NOT NULL DEFAULT '{}'::JSONB,
+  price_amount              BIGINT NOT NULL,                                    -- minor currency units, tax-inclusive when tax_inclusive = TRUE
+  currency                  TEXT NOT NULL DEFAULT 'INR',
+  tax_inclusive             BOOLEAN NOT NULL DEFAULT TRUE,
+  gst_slab                  TEXT,                                               -- e.g. "18", "28"
+  tax_rate                  NUMERIC(6,4),                                       -- alternative to gst_slab for non-GST jurisdictions
+  hsn_code                  TEXT,
+  availability_status       TEXT NOT NULL DEFAULT 'unknown',                    -- in_stock | out_of_stock | pre_order | back_order | unknown
+  warranty_summary          TEXT,
+  return_policy_summary     TEXT,
+  source_system             TEXT NOT NULL DEFAULT 'manual',
+  last_synced_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  archived_at               TIMESTAMPTZ,
+  created_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_variant_availability CHECK (
+    availability_status IN ('in_stock','out_of_stock','pre_order','back_order','unknown')
+  ),
+  CONSTRAINT chk_variant_price_nonneg CHECK (price_amount >= 0)
+);
+
+-- Spec §15: SKU unique per (tenant, merchant) for active variants. Partial
+-- index permits archive-and-recreate workflows without losing the SKU key.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_variants_active_sku
+  ON commerce_product_variants(tenant_id, merchant_id, sku)
+  WHERE archived_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_commerce_variants_product
+  ON commerce_product_variants(product_id);
+CREATE INDEX IF NOT EXISTS idx_commerce_variants_tenant_merchant
+  ON commerce_product_variants(tenant_id, merchant_id);
+CREATE INDEX IF NOT EXISTS idx_commerce_variants_availability
+  ON commerce_product_variants(availability_status);

--- a/apps/auth-service/src/db/migrations/035_commerce_products.sql
+++ b/apps/auth-service/src/db/migrations/035_commerce_products.sql
@@ -5,7 +5,7 @@
 CREATE TABLE IF NOT EXISTS commerce_products (
   id                    TEXT PRIMARY KEY,                                       -- cprd_<ulid>
   tenant_id             TEXT NOT NULL REFERENCES commerce_tenants(id),
-  merchant_id           TEXT NOT NULL REFERENCES commerce_merchants(id),
+  merchant_id           TEXT NOT NULL,
   product_id            TEXT NOT NULL,                                          -- merchant-supplied stable product key
   title                 TEXT NOT NULL,
   brand                 TEXT,
@@ -16,7 +16,18 @@ CREATE TABLE IF NOT EXISTS commerce_products (
   manually_maintained   BOOLEAN NOT NULL DEFAULT FALSE,
   archived_at           TIMESTAMPTZ,
   created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  -- Composite tenant-safe FK: a product's merchant must belong to the
+  -- same tenant. Replaces the prior single-column merchant_id REFERENCES
+  -- commerce_merchants(id), which would have allowed cross-tenant
+  -- references at the DB layer (the route guard caught it; this closes
+  -- the gap one level deeper).
+  CONSTRAINT fk_commerce_products_merchant_tenant
+    FOREIGN KEY (tenant_id, merchant_id)
+    REFERENCES commerce_merchants(tenant_id, id),
+  -- Required so commerce_product_variants can declare a composite
+  -- (tenant_id, product_id) FK back to here.
+  CONSTRAINT uq_commerce_products_tenant_id UNIQUE (tenant_id, id)
 );
 
 -- Spec §15: (tenant_id, merchant_id, product_id) unique for active rows.
@@ -34,8 +45,8 @@ CREATE INDEX IF NOT EXISTS idx_commerce_products_archived
 CREATE TABLE IF NOT EXISTS commerce_product_variants (
   id                        TEXT PRIMARY KEY,                                   -- cvar_<ulid>
   tenant_id                 TEXT NOT NULL REFERENCES commerce_tenants(id),
-  merchant_id               TEXT NOT NULL REFERENCES commerce_merchants(id),
-  product_id                TEXT NOT NULL REFERENCES commerce_products(id),
+  merchant_id               TEXT NOT NULL,
+  product_id                TEXT NOT NULL,
   sku                       TEXT NOT NULL,
   parent_sku                TEXT,
   model                     TEXT,
@@ -58,7 +69,16 @@ CREATE TABLE IF NOT EXISTS commerce_product_variants (
   CONSTRAINT chk_variant_availability CHECK (
     availability_status IN ('in_stock','out_of_stock','pre_order','back_order','unknown')
   ),
-  CONSTRAINT chk_variant_price_nonneg CHECK (price_amount >= 0)
+  CONSTRAINT chk_variant_price_nonneg CHECK (price_amount >= 0),
+  -- Composite tenant-safe FKs: a variant's merchant and product must both
+  -- belong to the same tenant as the variant itself. Replaces the prior
+  -- single-column merchant_id and product_id REFERENCES.
+  CONSTRAINT fk_commerce_variants_merchant_tenant
+    FOREIGN KEY (tenant_id, merchant_id)
+    REFERENCES commerce_merchants(tenant_id, id),
+  CONSTRAINT fk_commerce_variants_product_tenant
+    FOREIGN KEY (tenant_id, product_id)
+    REFERENCES commerce_products(tenant_id, id)
 );
 
 -- Spec §15: SKU unique per (tenant, merchant) for active variants. Partial

--- a/apps/auth-service/src/db/migrations/036_commerce_audit_events.sql
+++ b/apps/auth-service/src/db/migrations/036_commerce_audit_events.sql
@@ -1,0 +1,68 @@
+-- Grantex Commerce V1 — Milestone 1: CommerceAuditEvent (append-only).
+-- Spec §10 requires database-level append-only enforcement. This migration
+-- defends in two layers:
+--
+--   (1) Trigger-based BEFORE UPDATE/DELETE block — works regardless of which
+--       role the application connects as. This is the universally-applicable
+--       guarantee and what the test suite verifies.
+--
+--   (2) Optional GRANT/REVOKE in a DO block — applies if a separate
+--       grantex_app role exists in the deployment. No-ops in dev/CI where
+--       the application connects as the table owner (owners bypass GRANTs).
+--       Production deployments should provision the grantex_app role and
+--       re-run this migration to engage layer (2).
+
+CREATE TABLE IF NOT EXISTS commerce_audit_events (
+  id                    TEXT PRIMARY KEY,                                       -- caud_<ulid>
+  tenant_id             TEXT NOT NULL REFERENCES commerce_tenants(id),
+  merchant_id           TEXT REFERENCES commerce_merchants(id),
+  agent_id              TEXT REFERENCES commerce_agents(id),
+  user_principal_id     TEXT,
+  event_type            TEXT NOT NULL,                                          -- e.g. merchant.created, passport.issued
+  resource_type         TEXT,
+  resource_id           TEXT,
+  passport_jti          TEXT,                                                   -- nullable in M1 (no passports yet)
+  policy_version        TEXT,
+  decision_id           TEXT,
+  idempotency_key_hash  TEXT,
+  request_id            TEXT,
+  occurred_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  metadata              JSONB NOT NULL DEFAULT '{}'::JSONB
+);
+
+-- Spec §15 required index for tenant-scoped audit listing.
+CREATE INDEX IF NOT EXISTS idx_commerce_audit_tenant_merchant_occurred
+  ON commerce_audit_events(tenant_id, merchant_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_commerce_audit_event_type
+  ON commerce_audit_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_commerce_audit_passport_jti
+  ON commerce_audit_events(passport_jti) WHERE passport_jti IS NOT NULL;
+
+-- Layer (1) — trigger-based append-only enforcement.
+CREATE OR REPLACE FUNCTION commerce_audit_events_block_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'commerce_audit_events is append-only; % is not permitted', TG_OP
+    USING ERRCODE = 'insufficient_privilege';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS commerce_audit_events_no_update ON commerce_audit_events;
+CREATE TRIGGER commerce_audit_events_no_update
+  BEFORE UPDATE ON commerce_audit_events
+  FOR EACH ROW EXECUTE FUNCTION commerce_audit_events_block_mutation();
+
+DROP TRIGGER IF EXISTS commerce_audit_events_no_delete ON commerce_audit_events;
+CREATE TRIGGER commerce_audit_events_no_delete
+  BEFORE DELETE ON commerce_audit_events
+  FOR EACH ROW EXECUTE FUNCTION commerce_audit_events_block_mutation();
+
+-- Layer (2) — role-based grants when a separate app role exists.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'grantex_app') THEN
+    EXECUTE 'REVOKE UPDATE, DELETE, TRUNCATE ON commerce_audit_events FROM grantex_app';
+    EXECUTE 'GRANT INSERT, SELECT ON commerce_audit_events TO grantex_app';
+  END IF;
+END
+$$;

--- a/apps/auth-service/src/lib/commerce/audit.ts
+++ b/apps/auth-service/src/lib/commerce/audit.ts
@@ -1,0 +1,111 @@
+import type postgres from 'postgres';
+import { newCommerceAuditId } from './ids.js';
+
+type Sql = ReturnType<typeof postgres>;
+
+export type CommerceAuditEventType =
+  | 'merchant.created'
+  | 'merchant.disabled'
+  | 'merchant.credentials.updated'
+  | 'merchant.feature_flag.updated'
+  | 'merchant.provider_credentials.validated'
+  | 'merchant.webhook_source.created'
+  | 'merchant.webhook_source.secret_rotated'
+  | 'commerce_agent.created'
+  | 'commerce_agent.trust_status.updated'
+  | 'commerce_agent.disabled'
+  | 'product.created'
+  | 'product.updated'
+  | 'product.archived'
+  | 'policy.created'
+  | 'policy.activated'
+  | 'consent.requested'
+  | 'consent.granted'
+  | 'consent.denied'
+  | 'passport.issued'
+  | 'passport.verified'
+  | 'passport.revoked'
+  | 'passport.expired'
+  | 'policy.evaluated'
+  | 'cart.created'
+  | 'payment_intent.created'
+  | 'payment_intent.cancelled'
+  | 'payment_intent.expired'
+  | 'checkout_link.created'
+  | 'provider.webhook.received'
+  | 'provider.webhook.signature_failed'
+  | 'payment_intent.paid'
+  | 'payment_intent.failed'
+  | 'protected_action.denied'
+  | 'idempotency.conflict'
+  | 'rate_limit.exceeded'
+  | 'meter.passport_issued'
+  | 'meter.payment_intent_created';
+
+export interface AppendCommerceAuditInput {
+  tenantId: string;
+  merchantId?: string | null;
+  agentId?: string | null;
+  userPrincipalId?: string | null;
+  eventType: CommerceAuditEventType;
+  resourceType?: string | null;
+  resourceId?: string | null;
+  passportJti?: string | null;
+  policyVersion?: string | null;
+  decisionId?: string | null;
+  idempotencyKeyHash?: string | null;
+  requestId?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CommerceAuditWriteResult {
+  id: string;
+  occurredAt: string;
+}
+
+/**
+ * Append a row to commerce_audit_events. The table is database-level
+ * append-only (BEFORE UPDATE/DELETE trigger blocks mutations regardless
+ * of role; production additionally restricts via GRANT/REVOKE).
+ *
+ * Pass a `tx` from sql.begin when the audit must be transactional with
+ * the originating action — required for any state-changing endpoint.
+ */
+export async function appendCommerceAudit(
+  sql: Sql,
+  input: AppendCommerceAuditInput,
+): Promise<CommerceAuditWriteResult> {
+  const id = newCommerceAuditId();
+  const rows = await sql<{ id: string; occurred_at: string }[]>`
+    INSERT INTO commerce_audit_events (
+      id, tenant_id, merchant_id, agent_id, user_principal_id,
+      event_type, resource_type, resource_id,
+      passport_jti, policy_version, decision_id,
+      idempotency_key_hash, request_id, metadata
+    ) VALUES (
+      ${id},
+      ${input.tenantId},
+      ${input.merchantId ?? null},
+      ${input.agentId ?? null},
+      ${input.userPrincipalId ?? null},
+      ${input.eventType},
+      ${input.resourceType ?? null},
+      ${input.resourceId ?? null},
+      ${input.passportJti ?? null},
+      ${input.policyVersion ?? null},
+      ${input.decisionId ?? null},
+      ${input.idempotencyKeyHash ?? null},
+      ${input.requestId ?? null},
+      ${JSON.stringify(input.metadata ?? {})}::jsonb
+    )
+    RETURNING id, occurred_at
+  `;
+  const row = rows[0];
+  if (!row) {
+    throw new Error('commerce audit insert returned no row');
+  }
+  return { id: row.id, occurredAt: new Date(row.occurred_at).toISOString() };
+}
+
+// Intentionally NOT exported: updateCommerceAudit, deleteCommerceAudit.
+// Audit corrections must be new compensating events, never row edits.

--- a/apps/auth-service/src/lib/commerce/errors.ts
+++ b/apps/auth-service/src/lib/commerce/errors.ts
@@ -1,0 +1,97 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+/**
+ * Spec §16 standard error envelope for commerce routes only. Distinct from
+ * the platform-wide envelope ({ message, code, requestId }) on non-commerce
+ * routes; that envelope stays untouched.
+ */
+export interface CommerceErrorBody {
+  error: {
+    code: string;
+    message: string;
+    decision_id?: string;
+    audit_event_id?: string;
+    remediation?: string;
+    retryable?: boolean;
+    details?: Record<string, unknown>;
+  };
+}
+
+export interface CommerceErrorOptions {
+  decisionId?: string;
+  auditEventId?: string;
+  remediation?: string;
+  retryable?: boolean;
+  details?: Record<string, unknown>;
+}
+
+export class CommerceHttpError extends Error {
+  public readonly statusCode: number;
+  public readonly code: string;
+  public readonly options: CommerceErrorOptions;
+
+  constructor(statusCode: number, code: string, message: string, options: CommerceErrorOptions = {}) {
+    super(message);
+    this.statusCode = statusCode;
+    this.code = code;
+    this.options = options;
+  }
+}
+
+export function commerceErrorEnvelope(
+  code: string,
+  message: string,
+  options: CommerceErrorOptions = {},
+): CommerceErrorBody {
+  const error: CommerceErrorBody['error'] = { code, message };
+  if (options.decisionId !== undefined) error.decision_id = options.decisionId;
+  if (options.auditEventId !== undefined) error.audit_event_id = options.auditEventId;
+  if (options.remediation !== undefined) error.remediation = options.remediation;
+  if (options.retryable !== undefined) error.retryable = options.retryable;
+  if (options.details !== undefined) error.details = options.details;
+  return { error };
+}
+
+export async function sendCommerceError(
+  reply: FastifyReply,
+  statusCode: number,
+  code: string,
+  message: string,
+  options: CommerceErrorOptions = {},
+): Promise<FastifyReply> {
+  return reply.status(statusCode).send(commerceErrorEnvelope(code, message, options));
+}
+
+/**
+ * Scoped error handler — registered on the commerce sub-instance only via
+ * `app.setErrorHandler`. Translates thrown CommerceHttpError into the
+ * spec envelope; falls back to a 500 envelope for unexpected errors so
+ * commerce routes never leak the platform envelope shape.
+ */
+export function commerceErrorHandler(
+  err: Error & { statusCode?: number; code?: string; validation?: unknown },
+  request: FastifyRequest,
+  reply: FastifyReply,
+): void {
+  if (err instanceof CommerceHttpError) {
+    void reply.status(err.statusCode).send(commerceErrorEnvelope(err.code, err.message, err.options));
+    return;
+  }
+  // Fastify validation error
+  if (err.validation) {
+    void reply.status(422).send(commerceErrorEnvelope(
+      'validation_failed',
+      err.message || 'Request validation failed',
+      { details: { fields: err.validation }, retryable: false },
+    ));
+    return;
+  }
+  // Unhandled — log at error level, return generic envelope.
+  request.log.error({ err, requestId: request.id }, 'Unhandled commerce route error');
+  const status = err.statusCode && err.statusCode >= 400 && err.statusCode < 600 ? err.statusCode : 500;
+  void reply.status(status).send(commerceErrorEnvelope(
+    status >= 500 ? 'internal_error' : 'bad_request',
+    status >= 500 ? 'An unexpected error occurred' : (err.message || 'Bad request'),
+    { retryable: status >= 500 },
+  ));
+}

--- a/apps/auth-service/src/lib/commerce/ids.ts
+++ b/apps/auth-service/src/lib/commerce/ids.ts
@@ -1,0 +1,8 @@
+import { ulid } from 'ulid';
+
+export const newCommerceTenantId = (): string => `cten_${ulid()}`;
+export const newMerchantId = (): string => `mch_${ulid()}`;
+export const newCommerceAgentId = (): string => `cag_${ulid()}`;
+export const newCommerceProductId = (): string => `cprd_${ulid()}`;
+export const newCommerceVariantId = (): string => `cvar_${ulid()}`;
+export const newCommerceAuditId = (): string => `caud_${ulid()}`;

--- a/apps/auth-service/src/lib/commerce/presets.ts
+++ b/apps/auth-service/src/lib/commerce/presets.ts
@@ -1,0 +1,10 @@
+export const ELECTRONICS_APPLIANCES = 'electronics_appliances' as const;
+
+export const COMMERCE_CATEGORY_PRESETS = [ELECTRONICS_APPLIANCES] as const;
+
+export type CommerceCategoryPreset = typeof COMMERCE_CATEGORY_PRESETS[number];
+
+export function isCommerceCategoryPreset(value: unknown): value is CommerceCategoryPreset {
+  return typeof value === 'string'
+    && (COMMERCE_CATEGORY_PRESETS as readonly string[]).includes(value);
+}

--- a/apps/auth-service/src/lib/commerce/tenant.ts
+++ b/apps/auth-service/src/lib/commerce/tenant.ts
@@ -1,0 +1,101 @@
+import type postgres from 'postgres';
+import { type TxSql } from '../../db/client.js';
+import { newCommerceTenantId } from './ids.js';
+
+type Sql = ReturnType<typeof postgres>;
+
+/**
+ * Three-state resolution of a developer's default commerce tenant.
+ * Distinguishing "no mapping" from "mapping exists but tenant is disabled"
+ * matters because the policy on each is different:
+ *   - `not_provisioned`  → 422 tenant_not_provisioned; auto-create only in
+ *                          explicitly-enabled test/local sandbox.
+ *   - `disabled`         → 403 tenant_disabled; never auto-create a
+ *                          replacement (would let a disabled tenant be
+ *                          silently bypassed).
+ *   - `resolved`         → request proceeds with the returned tenantId.
+ */
+export type TenantResolution =
+  | { kind: 'resolved'; tenantId: string }
+  | { kind: 'not_provisioned' }
+  | { kind: 'disabled'; tenantId: string };
+
+/**
+ * Pure lookup. Joins commerce_developer_tenants → commerce_tenants so the
+ * caller learns both whether a mapping exists and whether the mapped
+ * tenant is currently active.
+ */
+export async function resolveTenantForDeveloper(
+  sql: Sql,
+  developerId: string,
+): Promise<TenantResolution> {
+  const rows = await sql<{ id: string; status: string }[]>`
+    SELECT t.id, t.status
+      FROM commerce_developer_tenants dt
+      JOIN commerce_tenants t ON t.id = dt.tenant_id
+     WHERE dt.developer_id = ${developerId}
+       AND dt.is_default = TRUE
+     LIMIT 1
+  `;
+  const row = rows[0];
+  if (!row) return { kind: 'not_provisioned' };
+  if (row.status === 'disabled') return { kind: 'disabled', tenantId: row.id };
+  return { kind: 'resolved', tenantId: row.id };
+}
+
+/**
+ * True only when COMMERCE_ALLOW_AUTO_TENANT === 'true'. Read at call time
+ * so tests can flip it via vi.stubEnv. Must remain false in staging and
+ * production; M2 introduces explicit provisioning endpoints
+ * (POST /v1/commerce/tenants and POST /v1/commerce/developer-tenants).
+ */
+export function isAutoTenantAllowed(): boolean {
+  return process.env['COMMERCE_ALLOW_AUTO_TENANT'] === 'true';
+}
+
+/**
+ * Test/local-sandbox-only. Throws if the auto-tenant flag is not set —
+ * defense in depth against accidental production use. The route
+ * preHandler additionally guards by checking isAutoTenantAllowed before
+ * calling, so a misconfigured caller cannot silently provision tenants.
+ */
+export async function resolveOrCreateTenantForDeveloper(
+  sql: Sql,
+  developerId: string,
+  developerDisplayName: string,
+): Promise<string> {
+  if (!isAutoTenantAllowed()) {
+    throw new Error(
+      'Tenant auto-provisioning is disabled. Set COMMERCE_ALLOW_AUTO_TENANT=true ' +
+      'for test/local sandbox use only. Staging and production must provision ' +
+      'tenants explicitly via the M2 admin endpoints.',
+    );
+  }
+
+  // Re-check whether a mapping already exists; if so, prefer it (even if
+  // disabled — disabled tenants are NEVER replaced by auto-create).
+  const existing = await resolveTenantForDeveloper(sql, developerId);
+  if (existing.kind === 'resolved') return existing.tenantId;
+  if (existing.kind === 'disabled') {
+    throw new Error(
+      `Cannot auto-provision: developer ${developerId} is mapped to disabled tenant ` +
+      `${existing.tenantId}. Re-enable the tenant or remove the mapping.`,
+    );
+  }
+
+  const tenantId = newCommerceTenantId();
+  await sql.begin(async (_tx) => {
+    const tx = _tx as unknown as TxSql;
+    await tx`
+      INSERT INTO commerce_tenants (id, display_name)
+      VALUES (${tenantId}, ${developerDisplayName})
+      ON CONFLICT (id) DO NOTHING
+    `;
+    await tx`
+      INSERT INTO commerce_developer_tenants (developer_id, tenant_id, is_default)
+      VALUES (${developerId}, ${tenantId}, TRUE)
+      ON CONFLICT (developer_id, tenant_id) DO NOTHING
+    `;
+  });
+  return tenantId;
+}

--- a/apps/auth-service/src/lib/commerce/tenant.ts
+++ b/apps/auth-service/src/lib/commerce/tenant.ts
@@ -44,12 +44,18 @@ export async function resolveTenantForDeveloper(
 }
 
 /**
- * True only when COMMERCE_ALLOW_AUTO_TENANT === 'true'. Read at call time
- * so tests can flip it via vi.stubEnv. Must remain false in staging and
- * production; M2 introduces explicit provisioning endpoints
- * (POST /v1/commerce/tenants and POST /v1/commerce/developer-tenants).
+ * True only when COMMERCE_ALLOW_AUTO_TENANT === 'true' AND the process is
+ * not running in production. The NODE_ENV gate is unconditional: even an
+ * accidental COMMERCE_ALLOW_AUTO_TENANT=true in a production deploy must
+ * not silently provision tenants. Read at call time so tests can flip
+ * either env var via vi.stubEnv.
+ *
+ * M2 introduces explicit provisioning endpoints
+ * (POST /v1/commerce/tenants and POST /v1/commerce/developer-tenants);
+ * the auto path is for local/sandbox iteration only.
  */
 export function isAutoTenantAllowed(): boolean {
+  if (process.env['NODE_ENV'] === 'production') return false;
   return process.env['COMMERCE_ALLOW_AUTO_TENANT'] === 'true';
 }
 

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -1,0 +1,588 @@
+import type { FastifyInstance } from 'fastify';
+import type postgres from 'postgres';
+import { getSql, type TxSql } from '../db/client.js';
+import {
+  resolveTenantForDeveloper,
+  resolveOrCreateTenantForDeveloper,
+  isAutoTenantAllowed,
+} from '../lib/commerce/tenant.js';
+import { commerceErrorHandler, CommerceHttpError } from '../lib/commerce/errors.js';
+import { appendCommerceAudit } from '../lib/commerce/audit.js';
+import {
+  newMerchantId,
+  newCommerceAgentId,
+  newCommerceProductId,
+  newCommerceVariantId,
+} from '../lib/commerce/ids.js';
+import { isCommerceCategoryPreset } from '../lib/commerce/presets.js';
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    commerceTenantId: string;
+  }
+}
+
+function isCommerceV1Enabled(): boolean {
+  return process.env['COMMERCE_V1_ENABLED'] === 'true';
+}
+
+type Sql = ReturnType<typeof postgres>;
+
+interface MerchantCreateBody {
+  legal_name?: unknown;
+  display_name?: unknown;
+  category_preset?: unknown;
+  country_code?: unknown;
+  default_currency?: unknown;
+  support_email?: unknown;
+}
+
+interface AgentCreateBody {
+  display_name?: unknown;
+  agent_type?: unknown;
+  public_key_jwk?: unknown;
+  api_key_hash?: unknown;
+  trust_status?: unknown;
+}
+
+interface VariantInput {
+  sku?: unknown;
+  parent_sku?: unknown;
+  model?: unknown;
+  variant_title?: unknown;
+  attributes?: unknown;
+  price_amount?: unknown;
+  currency?: unknown;
+  tax_inclusive?: unknown;
+  gst_slab?: unknown;
+  tax_rate?: unknown;
+  hsn_code?: unknown;
+  availability_status?: unknown;
+  warranty_summary?: unknown;
+  return_policy_summary?: unknown;
+  source_system?: unknown;
+}
+
+interface ProductCreateBody {
+  product_id?: unknown;
+  title?: unknown;
+  brand?: unknown;
+  description?: unknown;
+  image_url?: unknown;
+  category_preset?: unknown;
+  source_system?: unknown;
+  manually_maintained?: unknown;
+  merchant_id?: unknown;
+  variants?: unknown;
+}
+
+const TRUST_STATUS = new Set(['pending', 'trusted', 'suspended', 'disabled']);
+const AVAILABILITY = new Set(['in_stock', 'out_of_stock', 'pre_order', 'back_order', 'unknown']);
+
+function isString(v: unknown): v is string {
+  return typeof v === 'string' && v.length > 0;
+}
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+function asInt(v: unknown): number | null {
+  if (typeof v === 'number' && Number.isFinite(v) && Math.trunc(v) === v) return v;
+  if (typeof v === 'string' && /^\d+$/.test(v)) return Number.parseInt(v, 10);
+  return null;
+}
+
+export async function commerceRoutes(app: FastifyInstance): Promise<void> {
+  app.setErrorHandler(commerceErrorHandler);
+
+  // Single preHandler: feature-flag gate + tenant resolution.
+  // Auth (request.developer) is already populated by the global authPlugin.
+  app.addHook('preHandler', async (request) => {
+    if (!isCommerceV1Enabled()) {
+      throw new CommerceHttpError(
+        503,
+        'commerce_disabled',
+        'Grantex Commerce V1 is not enabled in this environment',
+        { retryable: false },
+      );
+    }
+    const sql = getSql();
+    const resolution = await resolveTenantForDeveloper(sql, request.developer.id);
+
+    if (resolution.kind === 'resolved') {
+      request.commerceTenantId = resolution.tenantId;
+      return;
+    }
+    if (resolution.kind === 'disabled') {
+      throw new CommerceHttpError(
+        403,
+        'tenant_disabled',
+        'The commerce tenant mapped to this developer is disabled',
+        {
+          remediation:
+            'Contact Grantex support to re-enable the tenant or to provision a replacement mapping.',
+          retryable: false,
+        },
+      );
+    }
+    // resolution.kind === 'not_provisioned'
+    if (isAutoTenantAllowed()) {
+      request.commerceTenantId = await resolveOrCreateTenantForDeveloper(
+        sql,
+        request.developer.id,
+        request.developer.name,
+      );
+      return;
+    }
+    throw new CommerceHttpError(
+      422,
+      'tenant_not_provisioned',
+      'No commerce tenant is mapped to this developer in this environment',
+      {
+        remediation:
+          'In staging/production, an operator must provision a commerce tenant and bind ' +
+          'this developer to it via the M2 admin endpoints (POST /v1/commerce/tenants then ' +
+          'POST /v1/commerce/developer-tenants). For local/sandbox testing only, ' +
+          'set COMMERCE_ALLOW_AUTO_TENANT=true to enable auto-provisioning.',
+        retryable: false,
+      },
+    );
+  });
+
+  // ----------------------------------------------------------------------
+  // POST /merchants
+  // ----------------------------------------------------------------------
+  app.post<{ Body: MerchantCreateBody }>('/merchants', async (request, reply) => {
+    const body = request.body ?? {};
+    const fieldErrors: Record<string, string> = {};
+    if (!isString(body.legal_name)) fieldErrors['legal_name'] = 'required string';
+    if (!isString(body.display_name)) fieldErrors['display_name'] = 'required string';
+    if (!isCommerceCategoryPreset(body.category_preset)) {
+      fieldErrors['category_preset'] = 'must be a known commerce category preset';
+    }
+    if (Object.keys(fieldErrors).length > 0) {
+      throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+        details: { fields: fieldErrors }, retryable: false,
+      });
+    }
+
+    const sql = getSql();
+    const id = newMerchantId();
+    const tenantId = request.commerceTenantId;
+
+    const result = await sql.begin(async (_tx) => {
+      const tx = _tx as unknown as TxSql;
+      const rows = await tx<Record<string, unknown>[]>`
+        INSERT INTO commerce_merchants (
+          id, tenant_id, legal_name, display_name, category_preset,
+          default_currency, country_code, support_email
+        ) VALUES (
+          ${id}, ${tenantId},
+          ${body.legal_name as string},
+          ${body.display_name as string},
+          ${body.category_preset as string},
+          ${isString(body.default_currency) ? (body.default_currency as string) : 'INR'},
+          ${isString(body.country_code) ? (body.country_code as string) : 'IN'},
+          ${isString(body.support_email) ? (body.support_email as string) : null}
+        )
+        RETURNING id, tenant_id, legal_name, display_name, category_preset,
+                  verification_status, environment, agentic_commerce_enabled,
+                  default_currency, country_code, support_email,
+                  created_at, updated_at
+      `;
+      const audit = await appendCommerceAudit(tx as unknown as Sql, {
+        tenantId,
+        merchantId: id,
+        eventType: 'merchant.created',
+        resourceType: 'merchant',
+        resourceId: id,
+        requestId: request.id,
+        metadata: { display_name: body.display_name },
+      });
+      return { merchant: rows[0], auditEventId: audit.id };
+    });
+
+    return reply.status(201).send({
+      data: result.merchant,
+      audit_event_id: result.auditEventId,
+    });
+  });
+
+  // ----------------------------------------------------------------------
+  // GET /merchants/:merchantId
+  // ----------------------------------------------------------------------
+  app.get<{ Params: { merchantId: string } }>('/merchants/:merchantId', async (request, reply) => {
+    const sql = getSql();
+    const rows = await sql<Record<string, unknown>[]>`
+      SELECT id, tenant_id, legal_name, display_name, category_preset,
+             verification_status, environment, agentic_commerce_enabled,
+             default_currency, country_code, support_email,
+             disabled_at, created_at, updated_at
+      FROM commerce_merchants
+      WHERE id = ${request.params.merchantId}
+        AND tenant_id = ${request.commerceTenantId}
+      LIMIT 1
+    `;
+    if (!rows[0]) {
+      throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
+    }
+    return reply.status(200).send({ data: rows[0] });
+  });
+
+  // ----------------------------------------------------------------------
+  // POST /agents
+  // ----------------------------------------------------------------------
+  app.post<{ Body: AgentCreateBody }>('/agents', async (request, reply) => {
+    const body = request.body ?? {};
+    const fieldErrors: Record<string, string> = {};
+    if (!isString(body.display_name)) fieldErrors['display_name'] = 'required string';
+    const agentType = isString(body.agent_type) ? body.agent_type : 'sales';
+    const trustStatus = isString(body.trust_status) ? body.trust_status : 'pending';
+    if (!TRUST_STATUS.has(trustStatus)) {
+      fieldErrors['trust_status'] = 'must be one of: pending, trusted, suspended, disabled';
+    }
+    const hasJwk = isPlainObject(body.public_key_jwk);
+    const hasKeyHash = isString(body.api_key_hash);
+    if (!hasJwk && !hasKeyHash) {
+      fieldErrors['public_key_jwk'] = 'either public_key_jwk or api_key_hash is required';
+    }
+    if (Object.keys(fieldErrors).length > 0) {
+      throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+        details: { fields: fieldErrors }, retryable: false,
+      });
+    }
+
+    const sql = getSql();
+    const id = newCommerceAgentId();
+    const tenantId = request.commerceTenantId;
+
+    const result = await sql.begin(async (_tx) => {
+      const tx = _tx as unknown as TxSql;
+      const rows = await tx<Record<string, unknown>[]>`
+        INSERT INTO commerce_agents (
+          id, tenant_id, display_name, agent_type,
+          public_key_jwk, api_key_hash, trust_status
+        ) VALUES (
+          ${id}, ${tenantId},
+          ${body.display_name as string},
+          ${agentType},
+          ${hasJwk ? JSON.stringify(body.public_key_jwk) : null}::jsonb,
+          ${hasKeyHash ? (body.api_key_hash as string) : null},
+          ${trustStatus}
+        )
+        RETURNING id, tenant_id, display_name, agent_type,
+                  public_key_jwk, trust_status,
+                  disabled_at, created_at, updated_at
+      `;
+      const audit = await appendCommerceAudit(tx as unknown as Sql, {
+        tenantId,
+        agentId: id,
+        eventType: 'commerce_agent.created',
+        resourceType: 'commerce_agent',
+        resourceId: id,
+        requestId: request.id,
+        metadata: { agent_type: agentType, trust_status: trustStatus },
+      });
+      return { agent: rows[0], auditEventId: audit.id };
+    });
+
+    return reply.status(201).send({
+      data: result.agent,
+      audit_event_id: result.auditEventId,
+    });
+  });
+
+  // ----------------------------------------------------------------------
+  // GET /agents/:agentId
+  // ----------------------------------------------------------------------
+  app.get<{ Params: { agentId: string } }>('/agents/:agentId', async (request, reply) => {
+    const sql = getSql();
+    const rows = await sql<Record<string, unknown>[]>`
+      SELECT id, tenant_id, display_name, agent_type,
+             public_key_jwk, trust_status,
+             disabled_at, created_at, updated_at
+      FROM commerce_agents
+      WHERE id = ${request.params.agentId}
+        AND tenant_id = ${request.commerceTenantId}
+      LIMIT 1
+    `;
+    if (!rows[0]) {
+      throw new CommerceHttpError(404, 'agent_not_found', 'Agent not found in this tenant');
+    }
+    return reply.status(200).send({ data: rows[0] });
+  });
+
+  // ----------------------------------------------------------------------
+  // POST /catalog/products  — creates product + variants atomically
+  // ----------------------------------------------------------------------
+  app.post<{ Body: ProductCreateBody }>('/catalog/products', async (request, reply) => {
+    const body = request.body ?? {};
+    const fieldErrors: Record<string, string> = {};
+    if (!isString(body.merchant_id)) fieldErrors['merchant_id'] = 'required string';
+    if (!isString(body.product_id)) fieldErrors['product_id'] = 'required string';
+    if (!isString(body.title)) fieldErrors['title'] = 'required string';
+    if (!isCommerceCategoryPreset(body.category_preset)) {
+      fieldErrors['category_preset'] = 'must be a known commerce category preset';
+    }
+    if (!Array.isArray(body.variants) || body.variants.length === 0) {
+      fieldErrors['variants'] = 'at least one variant is required';
+    } else {
+      body.variants.forEach((v, i) => {
+        const variant = v as VariantInput;
+        if (!isString(variant.sku)) fieldErrors[`variants[${i}].sku`] = 'required string';
+        if (asInt(variant.price_amount) === null || (asInt(variant.price_amount) as number) < 0) {
+          fieldErrors[`variants[${i}].price_amount`] = 'required non-negative integer (minor units)';
+        }
+        const avail = isString(variant.availability_status) ? variant.availability_status : 'unknown';
+        if (!AVAILABILITY.has(avail)) {
+          fieldErrors[`variants[${i}].availability_status`] =
+            'must be one of: in_stock, out_of_stock, pre_order, back_order, unknown';
+        }
+      });
+    }
+    if (Object.keys(fieldErrors).length > 0) {
+      throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+        details: { fields: fieldErrors }, retryable: false,
+      });
+    }
+
+    const sql = getSql();
+    const tenantId = request.commerceTenantId;
+    const merchantId = body.merchant_id as string;
+
+    // Tenant boundary: refuse cross-tenant merchant access up front.
+    const merchantRows = await sql<{ id: string }[]>`
+      SELECT id FROM commerce_merchants
+      WHERE id = ${merchantId} AND tenant_id = ${tenantId}
+      LIMIT 1
+    `;
+    if (!merchantRows[0]) {
+      throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
+    }
+
+    const productId = newCommerceProductId();
+    const variants = body.variants as VariantInput[];
+
+    const result = await sql.begin(async (_tx) => {
+      const tx = _tx as unknown as TxSql;
+      const productRows = await tx<Record<string, unknown>[]>`
+        INSERT INTO commerce_products (
+          id, tenant_id, merchant_id, product_id, title, brand, description,
+          image_url, category_preset, source_system, manually_maintained
+        ) VALUES (
+          ${productId}, ${tenantId}, ${merchantId},
+          ${body.product_id as string},
+          ${body.title as string},
+          ${isString(body.brand) ? (body.brand as string) : null},
+          ${isString(body.description) ? (body.description as string) : null},
+          ${isString(body.image_url) ? (body.image_url as string) : null},
+          ${body.category_preset as string},
+          ${isString(body.source_system) ? (body.source_system as string) : 'manual'},
+          ${typeof body.manually_maintained === 'boolean' ? body.manually_maintained : false}
+        )
+        RETURNING id, tenant_id, merchant_id, product_id, title, brand,
+                  description, image_url, category_preset, source_system,
+                  manually_maintained, archived_at, created_at, updated_at
+      `;
+
+      const variantRows: Record<string, unknown>[] = [];
+      for (const v of variants) {
+        const vid = newCommerceVariantId();
+        const inserted = await tx<Record<string, unknown>[]>`
+          INSERT INTO commerce_product_variants (
+            id, tenant_id, merchant_id, product_id, sku, parent_sku, model,
+            variant_title, attributes, price_amount, currency, tax_inclusive,
+            gst_slab, tax_rate, hsn_code, availability_status,
+            warranty_summary, return_policy_summary, source_system
+          ) VALUES (
+            ${vid}, ${tenantId}, ${merchantId}, ${productId},
+            ${v.sku as string},
+            ${isString(v.parent_sku) ? (v.parent_sku as string) : null},
+            ${isString(v.model) ? (v.model as string) : null},
+            ${isString(v.variant_title) ? (v.variant_title as string) : null},
+            ${JSON.stringify(isPlainObject(v.attributes) ? v.attributes : {})}::jsonb,
+            ${asInt(v.price_amount) as number},
+            ${isString(v.currency) ? (v.currency as string) : 'INR'},
+            ${typeof v.tax_inclusive === 'boolean' ? v.tax_inclusive : true},
+            ${isString(v.gst_slab) ? (v.gst_slab as string) : null},
+            ${typeof v.tax_rate === 'number' ? v.tax_rate : null},
+            ${isString(v.hsn_code) ? (v.hsn_code as string) : null},
+            ${isString(v.availability_status) ? (v.availability_status as string) : 'unknown'},
+            ${isString(v.warranty_summary) ? (v.warranty_summary as string) : null},
+            ${isString(v.return_policy_summary) ? (v.return_policy_summary as string) : null},
+            ${isString(v.source_system) ? (v.source_system as string) : 'manual'}
+          )
+          RETURNING id, sku, price_amount, currency, tax_inclusive, gst_slab,
+                    tax_rate, hsn_code, availability_status, archived_at
+        `;
+        if (inserted[0]) variantRows.push(inserted[0]);
+      }
+
+      const audit = await appendCommerceAudit(tx as unknown as Sql, {
+        tenantId,
+        merchantId,
+        eventType: 'product.created',
+        resourceType: 'product',
+        resourceId: productId,
+        requestId: request.id,
+        metadata: { product_id: body.product_id, variant_count: variantRows.length },
+      });
+      return { product: productRows[0], variants: variantRows, auditEventId: audit.id };
+    });
+
+    return reply.status(201).send({
+      data: { ...result.product, variants: result.variants },
+      audit_event_id: result.auditEventId,
+    });
+  });
+
+  // ----------------------------------------------------------------------
+  // GET /catalog/products/:productId
+  // ----------------------------------------------------------------------
+  app.get<{ Params: { productId: string } }>('/catalog/products/:productId', async (request, reply) => {
+    const sql = getSql();
+    const productRows = await sql<Record<string, unknown>[]>`
+      SELECT id, tenant_id, merchant_id, product_id, title, brand, description,
+             image_url, category_preset, source_system, manually_maintained,
+             archived_at, created_at, updated_at
+      FROM commerce_products
+      WHERE id = ${request.params.productId}
+        AND tenant_id = ${request.commerceTenantId}
+      LIMIT 1
+    `;
+    if (!productRows[0]) {
+      throw new CommerceHttpError(404, 'product_not_found', 'Product not found in this tenant');
+    }
+    const variantRows = await sql<Record<string, unknown>[]>`
+      SELECT id, sku, parent_sku, model, variant_title, attributes,
+             price_amount, currency, tax_inclusive, gst_slab, tax_rate,
+             hsn_code, availability_status, warranty_summary,
+             return_policy_summary, source_system, last_synced_at,
+             archived_at
+      FROM commerce_product_variants
+      WHERE product_id = ${request.params.productId}
+        AND tenant_id = ${request.commerceTenantId}
+      ORDER BY created_at ASC
+    `;
+    return reply.status(200).send({
+      data: { ...productRows[0], variants: variantRows },
+    });
+  });
+
+  // ----------------------------------------------------------------------
+  // DELETE /catalog/products/:productId  — soft-delete (archive)
+  // ----------------------------------------------------------------------
+  app.delete<{ Params: { productId: string } }>('/catalog/products/:productId', async (request, reply) => {
+    const sql = getSql();
+    const tenantId = request.commerceTenantId;
+    const result = await sql.begin(async (_tx) => {
+      const tx = _tx as unknown as TxSql;
+      const updated = await tx<Record<string, unknown>[]>`
+        UPDATE commerce_products
+           SET archived_at = NOW(), updated_at = NOW()
+         WHERE id = ${request.params.productId}
+           AND tenant_id = ${tenantId}
+           AND archived_at IS NULL
+         RETURNING id, merchant_id, archived_at
+      `;
+      if (!updated[0]) return null;
+      // Archive all active variants of this product.
+      await tx`
+        UPDATE commerce_product_variants
+           SET archived_at = NOW(), updated_at = NOW()
+         WHERE product_id = ${request.params.productId}
+           AND tenant_id = ${tenantId}
+           AND archived_at IS NULL
+      `;
+      const audit = await appendCommerceAudit(tx as unknown as Sql, {
+        tenantId,
+        merchantId: updated[0]['merchant_id'] as string,
+        eventType: 'product.archived',
+        resourceType: 'product',
+        resourceId: request.params.productId,
+        requestId: request.id,
+      });
+      return { product: updated[0], auditEventId: audit.id };
+    });
+    if (!result) {
+      throw new CommerceHttpError(404, 'product_not_found',
+        'Product not found in this tenant or already archived');
+    }
+    return reply.status(200).send({
+      data: result.product,
+      audit_event_id: result.auditEventId,
+    });
+  });
+
+  // ----------------------------------------------------------------------
+  // GET /audit/events
+  // ----------------------------------------------------------------------
+  app.get<{
+    Querystring: {
+      merchant_id?: string;
+      agent_id?: string;
+      event_type?: string;
+      passport_jti?: string;
+      from?: string;
+      to?: string;
+      limit?: string;
+      cursor?: string;
+    };
+  }>('/audit/events', async (request, reply) => {
+    const sql = getSql();
+    const tenantId = request.commerceTenantId;
+    const limit = Math.min(Math.max(asInt(request.query.limit) ?? 25, 1), 100);
+    // Cursor: opaque base64 of "<occurred_at_iso>|<id>". Tail-only paging.
+    let cursorOccurred: string | null = null;
+    let cursorId: string | null = null;
+    if (request.query.cursor) {
+      try {
+        const decoded = Buffer.from(request.query.cursor, 'base64url').toString('utf8');
+        const [occ, id] = decoded.split('|');
+        if (occ && id) { cursorOccurred = occ; cursorId = id; }
+      } catch { /* ignore malformed cursor */ }
+    }
+    const merchantId = isString(request.query.merchant_id) ? request.query.merchant_id : null;
+    const agentId = isString(request.query.agent_id) ? request.query.agent_id : null;
+    const eventType = isString(request.query.event_type) ? request.query.event_type : null;
+    const passportJti = isString(request.query.passport_jti) ? request.query.passport_jti : null;
+    const fromTs = isString(request.query.from) ? request.query.from : null;
+    const toTs = isString(request.query.to) ? request.query.to : null;
+
+    // Single tagged template: NULL-checks on each optional filter keep the
+    // shape stable (no SQL fragment composition required by the test mock).
+    const rows = await sql<Record<string, unknown>[]>`
+      SELECT id, tenant_id, merchant_id, agent_id, user_principal_id,
+             event_type, resource_type, resource_id, passport_jti,
+             policy_version, decision_id, idempotency_key_hash, request_id,
+             occurred_at, metadata
+        FROM commerce_audit_events
+       WHERE tenant_id = ${tenantId}
+         AND (${merchantId}::text IS NULL OR merchant_id = ${merchantId})
+         AND (${agentId}::text IS NULL OR agent_id = ${agentId})
+         AND (${eventType}::text IS NULL OR event_type = ${eventType})
+         AND (${passportJti}::text IS NULL OR passport_jti = ${passportJti})
+         AND (${fromTs}::timestamptz IS NULL OR occurred_at >= ${fromTs}::timestamptz)
+         AND (${toTs}::timestamptz IS NULL OR occurred_at <= ${toTs}::timestamptz)
+         AND (
+           ${cursorOccurred}::timestamptz IS NULL
+           OR (occurred_at, id) < (${cursorOccurred}::timestamptz, ${cursorId}::text)
+         )
+       ORDER BY occurred_at DESC, id DESC
+       LIMIT ${limit + 1}
+    `;
+    let nextCursor: string | null = null;
+    if (rows.length > limit) {
+      const last = rows[limit - 1];
+      if (last) {
+        const occVal = last['occurred_at'];
+        const occIso = occVal instanceof Date
+          ? occVal.toISOString()
+          : String(occVal);
+        const enc = `${occIso}|${last['id'] as string}`;
+        nextCursor = Buffer.from(enc, 'utf8').toString('base64url');
+      }
+      rows.length = limit;
+    }
+    return reply.status(200).send({ items: rows, next_cursor: nextCursor });
+  });
+}

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -76,7 +76,6 @@ interface ProductCreateBody {
   variants?: unknown;
 }
 
-const TRUST_STATUS = new Set(['pending', 'trusted', 'suspended', 'disabled']);
 const AVAILABILITY = new Set(['in_stock', 'out_of_stock', 'pre_order', 'back_order', 'unknown']);
 
 function isString(v: unknown): v is string {
@@ -230,15 +229,25 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
 
   // ----------------------------------------------------------------------
   // POST /agents
+  //
+  // Trust-status policy (M1 hardening): trust_status is server-controlled.
+  // Every new CommerceAgent is created in 'pending' state regardless of
+  // what the caller sends. Trust changes belong on a future admin/operator
+  // endpoint with its own auth surface (planned for M2). Accepting
+  // trust_status from a normal create caller would let any operator mint
+  // a 'trusted' agent and bypass the trust review workflow entirely.
+  // We allow callers to send trust_status=pending (a no-op) for
+  // forward compatibility, but reject any other value with 422.
   // ----------------------------------------------------------------------
   app.post<{ Body: AgentCreateBody }>('/agents', async (request, reply) => {
     const body = request.body ?? {};
     const fieldErrors: Record<string, string> = {};
     if (!isString(body.display_name)) fieldErrors['display_name'] = 'required string';
     const agentType = isString(body.agent_type) ? body.agent_type : 'sales';
-    const trustStatus = isString(body.trust_status) ? body.trust_status : 'pending';
-    if (!TRUST_STATUS.has(trustStatus)) {
-      fieldErrors['trust_status'] = 'must be one of: pending, trusted, suspended, disabled';
+    if (body.trust_status !== undefined && body.trust_status !== 'pending') {
+      fieldErrors['trust_status'] =
+        'trust_status is server-controlled; new agents are always created as "pending". '
+        + 'Omit this field or send "pending". Trust changes will land on a future admin endpoint.';
     }
     const hasJwk = isPlainObject(body.public_key_jwk);
     const hasKeyHash = isString(body.api_key_hash);
@@ -254,6 +263,8 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
     const sql = getSql();
     const id = newCommerceAgentId();
     const tenantId = request.commerceTenantId;
+    // Hardcoded — see policy comment above. Not derived from request body.
+    const trustStatus = 'pending';
 
     const result = await sql.begin(async (_tx) => {
       const tx = _tx as unknown as TxSql;

--- a/apps/auth-service/src/server.ts
+++ b/apps/auth-service/src/server.ts
@@ -43,6 +43,7 @@ import { trustRegistryRoutes } from './routes/trust-registry.js';
 import { consentBundlesRoutes } from './routes/consent-bundles.js';
 import { mcpServersRoutes } from './routes/mcp-servers.js';
 import { dpdpRoutes } from './routes/dpdp.js';
+import { commerceRoutes } from './routes/commerce.js';
 import { metricsHookPlugin } from './plugins/metricsHook.js';
 import websocket from '@fastify/websocket';
 
@@ -172,6 +173,12 @@ export async function buildApp(opts: AppOptions = {}) {
   await app.register(consentBundlesRoutes);
   await app.register(mcpServersRoutes);
   await app.register(dpdpRoutes);
+
+  // Grantex Commerce V1 — registered with prefix so all commerce paths
+  // share the spec §16 envelope via the sub-instance error handler.
+  // The plugin's preHandler enforces the COMMERCE_V1_ENABLED flag and
+  // resolves request.commerceTenantId.
+  await app.register(commerceRoutes, { prefix: '/v1/commerce' });
 
   return app;
 }

--- a/apps/auth-service/tests/commerce-agents.test.ts
+++ b/apps/auth-service/tests/commerce-agents.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { authHeader, sqlMock, buildTestApp } from './helpers.js';
+import { seedCommerceContext, TEST_COMMERCE_TENANT_ID } from './commerce-helpers.js';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+const VALID_JWK = {
+  kty: 'EC',
+  crv: 'P-256',
+  x: 'f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU',
+  y: 'x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0',
+};
+
+describe('POST /v1/commerce/agents', () => {
+  it('creates a CommerceAgent with public_key_jwk and returns 201', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_NEW',
+      tenant_id: TEST_COMMERCE_TENANT_ID,
+      display_name: 'Acme Sales Bot',
+      agent_type: 'sales',
+      public_key_jwk: VALID_JWK,
+      trust_status: 'pending',
+      disabled_at: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_A', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/agents',
+      headers: authHeader(),
+      payload: { display_name: 'Acme Sales Bot', public_key_jwk: VALID_JWK },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ data: { id: string; trust_status: string }; audit_event_id: string }>();
+    expect(body.data.trust_status).toBe('pending');
+    expect(body.audit_event_id).toBe('caud_A');
+  });
+
+  it('accepts api_key_hash as the credential when public_key_jwk omitted', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([{ id: 'cag_NEW', trust_status: 'pending' }]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_A', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/agents',
+      headers: authHeader(),
+      payload: { display_name: 'Server Agent', api_key_hash: 'sha256:abcd1234' },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('rejects request with neither public_key_jwk nor api_key_hash (422)', async () => {
+    seedCommerceContext();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/agents',
+      headers: authHeader(),
+      payload: { display_name: 'Bare' },
+    });
+    expect(res.statusCode).toBe(422);
+    expect(res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields)
+      .toHaveProperty('public_key_jwk');
+  });
+
+  it.each([
+    ['pending'],
+    ['trusted'],
+    ['suspended'],
+    ['disabled'],
+  ])('accepts trust_status=%s', async (trust_status) => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([{ id: 'cag_X', trust_status }]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_A', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/agents',
+      headers: authHeader(),
+      payload: { display_name: 'X', public_key_jwk: VALID_JWK, trust_status },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('rejects invalid trust_status with 422', async () => {
+    seedCommerceContext();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/agents',
+      headers: authHeader(),
+      payload: { display_name: 'X', public_key_jwk: VALID_JWK, trust_status: 'untrusted' },
+    });
+    expect(res.statusCode).toBe(422);
+    expect(res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields)
+      .toHaveProperty('trust_status');
+  });
+});
+
+describe('GET /v1/commerce/agents/:agentId', () => {
+  it('returns 404 commerce envelope when missing', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([]);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/agents/cag_MISSING',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('agent_not_found');
+  });
+});

--- a/apps/auth-service/tests/commerce-agents.test.ts
+++ b/apps/auth-service/tests/commerce-agents.test.ts
@@ -73,15 +73,54 @@ describe('POST /v1/commerce/agents', () => {
       .toHaveProperty('public_key_jwk');
   });
 
+  it('hardcodes trust_status=pending when caller omits the field', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([{ id: 'cag_X', trust_status: 'pending' }]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_A', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/agents',
+      headers: authHeader(),
+      payload: { display_name: 'X', public_key_jwk: VALID_JWK },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json<{ data: { trust_status: string } }>().data.trust_status).toBe('pending');
+
+    // Verify the route INSERT bound the literal 'pending' regardless of input.
+    const insertCall = sqlMock.mock.calls.find((c) => {
+      const tpl = c[0] as unknown;
+      if (!Array.isArray(tpl)) return false;
+      return tpl.some((s) => typeof s === 'string' && /INSERT INTO commerce_agents/i.test(s));
+    });
+    expect(insertCall).toBeDefined();
+    // Slice off the template strings array; the rest are the bound values.
+    expect(insertCall!.slice(1)).toContain('pending');
+  });
+
+  it('accepts trust_status="pending" explicitly as a no-op (forward-compat)', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([{ id: 'cag_X', trust_status: 'pending' }]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_A', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/agents',
+      headers: authHeader(),
+      payload: { display_name: 'X', public_key_jwk: VALID_JWK, trust_status: 'pending' },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json<{ data: { trust_status: string } }>().data.trust_status).toBe('pending');
+  });
+
   it.each([
-    ['pending'],
     ['trusted'],
     ['suspended'],
     ['disabled'],
-  ])('accepts trust_status=%s', async (trust_status) => {
+    ['untrusted'],   // also covers the previous "invalid value" case
+    ['admin'],
+  ])('rejects caller-supplied trust_status=%s with 422 (server-controlled)', async (trust_status) => {
     seedCommerceContext();
-    sqlMock.mockResolvedValueOnce([{ id: 'cag_X', trust_status }]);
-    sqlMock.mockResolvedValueOnce([{ id: 'caud_A', occurred_at: new Date().toISOString() }]);
 
     const res = await app.inject({
       method: 'POST',
@@ -89,21 +128,11 @@ describe('POST /v1/commerce/agents', () => {
       headers: authHeader(),
       payload: { display_name: 'X', public_key_jwk: VALID_JWK, trust_status },
     });
-    expect(res.statusCode).toBe(201);
-  });
-
-  it('rejects invalid trust_status with 422', async () => {
-    seedCommerceContext();
-
-    const res = await app.inject({
-      method: 'POST',
-      url: '/v1/commerce/agents',
-      headers: authHeader(),
-      payload: { display_name: 'X', public_key_jwk: VALID_JWK, trust_status: 'untrusted' },
-    });
     expect(res.statusCode).toBe(422);
-    expect(res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields)
-      .toHaveProperty('trust_status');
+    const body = res.json<{ error: { code: string; details: { fields: Record<string, string> } } }>();
+    expect(body.error.code).toBe('validation_failed');
+    expect(body.error.details.fields).toHaveProperty('trust_status');
+    expect(body.error.details.fields['trust_status']).toMatch(/server-controlled/i);
   });
 });
 

--- a/apps/auth-service/tests/commerce-audit.test.ts
+++ b/apps/auth-service/tests/commerce-audit.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { authHeader, sqlMock, buildTestApp } from './helpers.js';
+import { seedCommerceContext } from './commerce-helpers.js';
+import * as auditModule from '../src/lib/commerce/audit.js';
+
+let app: FastifyInstance;
+beforeAll(async () => { app = await buildTestApp(); });
+
+describe('GET /v1/commerce/audit/events', () => {
+  it('returns items array and a null cursor when fewer than limit rows', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([
+      { id: 'caud_1', tenant_id: 'cten_TESTTENANT', event_type: 'merchant.created', occurred_at: new Date(), metadata: {} },
+      { id: 'caud_2', tenant_id: 'cten_TESTTENANT', event_type: 'product.created', occurred_at: new Date(), metadata: {} },
+    ]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/audit/events',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ items: { id: string }[]; next_cursor: string | null }>();
+    expect(body.items).toHaveLength(2);
+    expect(body.next_cursor).toBeNull();
+  });
+
+  it('emits a next_cursor when result count exceeds limit', async () => {
+    seedCommerceContext();
+    // limit=2 -> route asks for limit+1 = 3 rows; first 2 returned, cursor emitted
+    sqlMock.mockResolvedValueOnce([
+      { id: 'caud_a', occurred_at: new Date(), metadata: {} },
+      { id: 'caud_b', occurred_at: new Date(), metadata: {} },
+      { id: 'caud_c', occurred_at: new Date(), metadata: {} },
+    ]);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/audit/events?limit=2',
+      headers: authHeader(),
+    });
+    const body = res.json<{ items: unknown[]; next_cursor: string | null }>();
+    expect(body.items).toHaveLength(2);
+    expect(body.next_cursor).toBeTruthy();
+  });
+});
+
+describe('Commerce audit writer module surface', () => {
+  it('exports appendCommerceAudit', () => {
+    expect(typeof auditModule.appendCommerceAudit).toBe('function');
+  });
+
+  it('does NOT export updateCommerceAudit or deleteCommerceAudit (append-only)', () => {
+    expect((auditModule as unknown as Record<string, unknown>)['updateCommerceAudit']).toBeUndefined();
+    expect((auditModule as unknown as Record<string, unknown>)['deleteCommerceAudit']).toBeUndefined();
+  });
+});
+
+describe('Commerce audit append-only DDL (verified by reading the migration file)', () => {
+  it('migration 036 declares the trigger function and BEFORE UPDATE/DELETE triggers', async () => {
+    const fs = await import('node:fs/promises');
+    const url = new URL('../src/db/migrations/036_commerce_audit_events.sql', import.meta.url);
+    const sql = await fs.readFile(url, 'utf8');
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS commerce_audit_events/);
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION commerce_audit_events_block_mutation/);
+    expect(sql).toMatch(/RAISE EXCEPTION 'commerce_audit_events is append-only/);
+    expect(sql).toMatch(/BEFORE UPDATE ON commerce_audit_events/);
+    expect(sql).toMatch(/BEFORE DELETE ON commerce_audit_events/);
+    // Layer (2): role-based grant/revoke wrapped in DO block
+    expect(sql).toMatch(/REVOKE UPDATE, DELETE, TRUNCATE ON commerce_audit_events/);
+    expect(sql).toMatch(/GRANT INSERT, SELECT ON commerce_audit_events/);
+  });
+});

--- a/apps/auth-service/tests/commerce-feature-flags.test.ts
+++ b/apps/auth-service/tests/commerce-feature-flags.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { authHeader, sqlMock, TEST_DEVELOPER } from './helpers.js';
+import { buildTestApp } from './helpers.js';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('Commerce feature flag (COMMERCE_V1_ENABLED)', () => {
+  it('returns 503 with commerce_disabled envelope when flag is unset', async () => {
+    vi.stubEnv('COMMERCE_V1_ENABLED', '');
+    sqlMock.mockResolvedValueOnce([TEST_DEVELOPER]);  // auth only
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_does_not_matter',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(503);
+    const body = res.json<{ error: { code: string; message: string; retryable: boolean } }>();
+    expect(body.error.code).toBe('commerce_disabled');
+    expect(body.error.retryable).toBe(false);
+    expect(typeof body.error.message).toBe('string');
+  });
+
+  it('returns 503 with commerce_disabled when flag is literal "false"', async () => {
+    vi.stubEnv('COMMERCE_V1_ENABLED', 'false');
+    sqlMock.mockResolvedValueOnce([TEST_DEVELOPER]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/merchants',
+      headers: authHeader(),
+      payload: { legal_name: 'X', display_name: 'X', category_preset: 'electronics_appliances' },
+    });
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('commerce_disabled');
+  });
+
+  it('passes the flag check when COMMERCE_V1_ENABLED=true', async () => {
+    // vitest.config.ts sets it to 'true' by default; verify the gate lets
+    // the request through to the next stage (tenant lookup / 404).
+    sqlMock.mockResolvedValueOnce([TEST_DEVELOPER]);
+    sqlMock.mockResolvedValueOnce([{ tenant_id: 'cten_TESTTENANT' }]);
+    sqlMock.mockResolvedValueOnce([]);  // merchant lookup empty -> 404
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_NOPE',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('merchant_not_found');
+  });
+});
+
+describe('Commerce flags exposed on config', () => {
+  it('config.commerceV1Enabled is true in test env', async () => {
+    const { config } = await import('../src/config.js');
+    expect(config.commerceV1Enabled).toBe(true);
+    expect(config).toHaveProperty('pluralSandboxEnabled');
+    expect(config).toHaveProperty('pluralLiveEnabled');
+    expect(config).toHaveProperty('commerceLiveModeEnabled');
+    expect(config).toHaveProperty('commerceSandboxEnabled');
+    // Auto-tenant flag MUST default off; turning it on is a sandbox-only opt-in.
+    expect(config).toHaveProperty('commerceAllowAutoTenant');
+    expect(config.commerceAllowAutoTenant).toBe(false);
+  });
+});

--- a/apps/auth-service/tests/commerce-helpers.ts
+++ b/apps/auth-service/tests/commerce-helpers.ts
@@ -1,0 +1,46 @@
+/**
+ * Commerce-specific test helpers. Layered on top of helpers.ts:
+ * `seedCommerceContext` primes the auth lookup AND the tenant resolver
+ * lookup (developer→tenant join) so commerce route tests can focus on the
+ * route's own SQL.
+ *
+ * The resolver returns rows of shape `{ id, status }` from the join
+ * `commerce_developer_tenants → commerce_tenants`. These helpers honour
+ * that shape; tests that need the disabled or unmapped variants use the
+ * dedicated helpers below.
+ */
+import { sqlMock, TEST_DEVELOPER } from './helpers.js';
+
+export const TEST_COMMERCE_TENANT_ID = 'cten_TESTTENANT';
+
+/**
+ * Mapped, active tenant — the common case. Primes:
+ *   1. authPlugin developer SELECT
+ *   2. resolveTenantForDeveloper join → returns { id, status: 'active' }
+ */
+export function seedCommerceContext(tenantId: string = TEST_COMMERCE_TENANT_ID): void {
+  sqlMock.mockResolvedValueOnce([TEST_DEVELOPER]);
+  sqlMock.mockResolvedValueOnce([{ id: tenantId, status: 'active' }]);
+}
+
+/**
+ * No developer→tenant mapping exists. Resolver returns
+ * `{ kind: 'not_provisioned' }`; the route preHandler then either
+ * 422s (default) or auto-provisions (if COMMERCE_ALLOW_AUTO_TENANT=true).
+ */
+export function seedCommerceContextNoMapping(): void {
+  sqlMock.mockResolvedValueOnce([TEST_DEVELOPER]);
+  sqlMock.mockResolvedValueOnce([]);
+}
+
+/**
+ * Mapping exists but the tenant is disabled. Resolver returns
+ * `{ kind: 'disabled' }`; the route preHandler must 403 and must NOT
+ * auto-provision a replacement.
+ */
+export function seedCommerceContextDisabledTenant(
+  tenantId: string = TEST_COMMERCE_TENANT_ID,
+): void {
+  sqlMock.mockResolvedValueOnce([TEST_DEVELOPER]);
+  sqlMock.mockResolvedValueOnce([{ id: tenantId, status: 'disabled' }]);
+}

--- a/apps/auth-service/tests/commerce-merchants.test.ts
+++ b/apps/auth-service/tests/commerce-merchants.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { authHeader, sqlMock, buildTestApp } from './helpers.js';
+import { seedCommerceContext, TEST_COMMERCE_TENANT_ID } from './commerce-helpers.js';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+const validBody = {
+  legal_name: 'Acme Electronics Pvt Ltd',
+  display_name: 'Acme Electronics',
+  category_preset: 'electronics_appliances',
+  default_currency: 'INR',
+  country_code: 'IN',
+  support_email: 'support@acme.example',
+};
+
+describe('POST /v1/commerce/merchants', () => {
+  it('creates a merchant and returns 201 with audit_event_id', async () => {
+    seedCommerceContext();
+    // INSERT commerce_merchants RETURNING ...
+    sqlMock.mockResolvedValueOnce([{
+      id: 'mch_NEW',
+      tenant_id: TEST_COMMERCE_TENANT_ID,
+      legal_name: validBody.legal_name,
+      display_name: validBody.display_name,
+      category_preset: 'electronics_appliances',
+      verification_status: 'unverified',
+      environment: 'sandbox',
+      agentic_commerce_enabled: false,
+      default_currency: 'INR',
+      country_code: 'IN',
+      support_email: validBody.support_email,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }]);
+    // INSERT commerce_audit_events RETURNING id, occurred_at
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_AUDIT', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/merchants',
+      headers: authHeader(),
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ data: { id: string; tenant_id: string; category_preset: string }; audit_event_id: string }>();
+    expect(body.data.id).toBe('mch_NEW');
+    expect(body.data.tenant_id).toBe(TEST_COMMERCE_TENANT_ID);
+    expect(body.data.category_preset).toBe('electronics_appliances');
+    expect(body.audit_event_id).toBe('caud_AUDIT');
+  });
+
+  it('returns 422 with field-level details when required fields missing', async () => {
+    seedCommerceContext();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/merchants',
+      headers: authHeader(),
+      payload: { display_name: 'Only display' },
+    });
+
+    expect(res.statusCode).toBe(422);
+    const body = res.json<{ error: { code: string; details: { fields: Record<string, string> } } }>();
+    expect(body.error.code).toBe('validation_failed');
+    expect(body.error.details.fields).toHaveProperty('legal_name');
+    expect(body.error.details.fields).toHaveProperty('category_preset');
+  });
+
+  it('rejects unknown category_preset', async () => {
+    seedCommerceContext();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/merchants',
+      headers: authHeader(),
+      payload: { ...validBody, category_preset: 'fashion_lifestyle' },  // not in V1
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields)
+      .toHaveProperty('category_preset');
+  });
+
+  it('returns 401 with no Authorization header (platform envelope, NOT commerce envelope)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/merchants',
+      payload: validBody,
+    });
+    // Auth runs at the global preHandler before commerce sub-instance kicks in,
+    // so the response uses the platform error envelope { message, code, requestId }.
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ code: string }>().code).toBe('UNAUTHORIZED');
+  });
+});
+
+describe('GET /v1/commerce/merchants/:merchantId', () => {
+  it('returns the merchant when in caller tenant', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([{
+      id: 'mch_GET',
+      tenant_id: TEST_COMMERCE_TENANT_ID,
+      legal_name: 'Acme Pvt Ltd',
+      display_name: 'Acme',
+      category_preset: 'electronics_appliances',
+      verification_status: 'unverified',
+      environment: 'sandbox',
+      agentic_commerce_enabled: false,
+      default_currency: 'INR',
+      country_code: 'IN',
+      support_email: null,
+      disabled_at: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_GET',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ data: { id: string } }>().data.id).toBe('mch_GET');
+  });
+
+  it('returns 404 with commerce envelope when merchant absent', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([]);  // merchant lookup empty
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_MISSING',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(404);
+    const body = res.json<{ error: { code: string; message: string } }>();
+    expect(body.error.code).toBe('merchant_not_found');
+    expect(body).not.toHaveProperty('message');  // commerce envelope nests under .error
+  });
+});

--- a/apps/auth-service/tests/commerce-no-plural-leak.test.ts
+++ b/apps/auth-service/tests/commerce-no-plural-leak.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Architecture rule (SKILL §"Architecture Rules"): "Do not put Plural-specific
+ * fields into core tables except under namespaced provider metadata or explicit
+ * neutral provider reference fields."
+ *
+ * This test scans every commerce-domain SQL migration and lib module and
+ * fails if "plural" appears as a column name, table name, identifier, or
+ * literal value. Plural references are allowed only in (a) inline comments
+ * (per the architecture-rules narrative) or (b) provider-adapter modules
+ * once they exist (M4).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..', 'src');
+
+function gather(dir: string, ext: string[]): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...gather(full, ext));
+    } else if (ext.some((e) => entry.name.endsWith(e))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function stripSqlComments(src: string): string {
+  // Remove `-- ...` line comments and `/* ... */` block comments.
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map((line) => line.replace(/--.*$/, ''))
+    .join('\n');
+}
+
+function stripTsComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map((line) => line.replace(/\/\/.*$/, ''))
+    .join('\n');
+}
+
+describe('Plural neutrality — core commerce models carry no Plural-specific identifiers', () => {
+  it('commerce migration files have no "plural" outside of comments', () => {
+    const files = gather(join(root, 'db', 'migrations'), ['.sql'])
+      .filter((f) => /\d{3}_commerce_/.test(f.split(/[\\/]/).pop()!));
+    expect(files.length, 'expected commerce-* migration files to exist').toBeGreaterThan(0);
+    for (const f of files) {
+      const content = stripSqlComments(readFileSync(f, 'utf8'));
+      expect(content.toLowerCase(), `file ${f} mentions "plural" outside comments`).not.toMatch(/plural/);
+    }
+  });
+
+  it('lib/commerce/* modules have no "plural" outside of comments', () => {
+    const files = gather(join(root, 'lib', 'commerce'), ['.ts']);
+    expect(files.length).toBeGreaterThan(0);
+    for (const f of files) {
+      const content = stripTsComments(readFileSync(f, 'utf8'));
+      expect(content.toLowerCase(), `module ${f} mentions "plural" outside comments`).not.toMatch(/plural/);
+    }
+  });
+
+  it('routes/commerce.ts has no "plural" outside of comments', () => {
+    const f = join(root, 'routes', 'commerce.ts');
+    const content = stripTsComments(readFileSync(f, 'utf8'));
+    expect(content.toLowerCase()).not.toMatch(/plural/);
+  });
+});

--- a/apps/auth-service/tests/commerce-openapi.test.ts
+++ b/apps/auth-service/tests/commerce-openapi.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const yamlPath = join(__dirname, '..', '..', '..', 'docs', 'api', 'grantex-commerce-v1.openapi.yaml');
+
+describe('Grantex Commerce V1 OpenAPI 3.1 contract', () => {
+  it('docs/api/grantex-commerce-v1.openapi.yaml exists', () => {
+    expect(() => readFileSync(yamlPath, 'utf8')).not.toThrow();
+  });
+
+  it('declares openapi: 3.1.x and is non-empty', () => {
+    const content = readFileSync(yamlPath, 'utf8');
+    expect(content).toMatch(/openapi:\s*"?3\.1/);
+    expect(content.length).toBeGreaterThan(1000);
+  });
+
+  it('declares the standard error envelope shape (error.code, error.message)', () => {
+    const content = readFileSync(yamlPath, 'utf8');
+    expect(content).toMatch(/Error:\s*\n\s+type:\s+object/);
+    expect(content).toMatch(/code:\s*\{\s*type:\s*string/);
+    expect(content).toMatch(/decision_id:/);
+    expect(content).toMatch(/audit_event_id:/);
+    expect(content).toMatch(/retryable:/);
+  });
+
+  it('lists every M1-implemented path with x-implemented: true', () => {
+    const content = readFileSync(yamlPath, 'utf8');
+    const expected = [
+      '/v1/commerce/merchants',
+      '/v1/commerce/merchants/{merchant_id}',
+      '/v1/commerce/agents',
+      '/v1/commerce/agents/{agent_id}',
+      '/v1/commerce/catalog/products',
+      '/v1/commerce/catalog/products/{product_id}',
+      '/v1/commerce/audit/events',
+    ];
+    for (const path of expected) {
+      expect(content, `OpenAPI must include ${path}`).toContain(path);
+    }
+    // At least one explicit x-implemented: true marker per implemented op
+    const trueCount = (content.match(/x-implemented:\s*true/g) ?? []).length;
+    expect(trueCount).toBeGreaterThanOrEqual(expected.length);
+  });
+
+  it('declares stub paths for M2-M5 surface (passports, payments, MCP, providers)', () => {
+    const content = readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('/v1/commerce/passports/consent-requests');
+    expect(content).toContain('/v1/commerce/payments/intents');
+    expect(content).toContain('/v1/commerce/provider-credentials');
+    expect(content).toContain('/v1/webhooks/providers/{provider_key}');
+    expect(content).toContain('/.well-known/grantex-commerce');
+    expect(content).toContain('/mcp');
+  });
+
+  it('declares M2 explicit tenant provisioning stubs (paired with the 422 tenant_not_provisioned posture)', () => {
+    const content = readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('/v1/commerce/tenants');
+    expect(content).toContain('/v1/commerce/developer-tenants');
+    expect(content).toMatch(/x-milestone:\s*M2/);
+  });
+});

--- a/apps/auth-service/tests/commerce-products.test.ts
+++ b/apps/auth-service/tests/commerce-products.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { authHeader, sqlMock, buildTestApp } from './helpers.js';
+import { seedCommerceContext, TEST_COMMERCE_TENANT_ID } from './commerce-helpers.js';
+
+let app: FastifyInstance;
+beforeAll(async () => { app = await buildTestApp(); });
+
+const productPayload = {
+  merchant_id: 'mch_OK',
+  product_id: 'TOASTER-V2',
+  title: 'Acme Pop-Up Toaster',
+  brand: 'Acme',
+  description: '4-slice toaster',
+  category_preset: 'electronics_appliances',
+  variants: [
+    { sku: 'TOASTER-V2-WHITE', price_amount: 250000, currency: 'INR', tax_inclusive: true, gst_slab: '18', hsn_code: '8516', availability_status: 'in_stock' },
+    { sku: 'TOASTER-V2-BLACK', price_amount: 250000, currency: 'INR', tax_inclusive: true, gst_slab: '18', hsn_code: '8516', availability_status: 'out_of_stock' },
+  ],
+};
+
+describe('POST /v1/commerce/catalog/products', () => {
+  it('creates product with multiple variants atomically', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([{ id: 'mch_OK' }]);  // merchant lookup ok
+    // INSERT product
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cprd_X', tenant_id: TEST_COMMERCE_TENANT_ID, merchant_id: 'mch_OK',
+      product_id: 'TOASTER-V2', title: 'Acme Pop-Up Toaster', brand: 'Acme',
+      description: '4-slice toaster', image_url: null,
+      category_preset: 'electronics_appliances', source_system: 'manual',
+      manually_maintained: false, archived_at: null,
+      created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+    }]);
+    // INSERT variant 1
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cvar_1', sku: 'TOASTER-V2-WHITE', price_amount: 250000,
+      currency: 'INR', tax_inclusive: true, gst_slab: '18', tax_rate: null,
+      hsn_code: '8516', availability_status: 'in_stock', archived_at: null,
+    }]);
+    // INSERT variant 2
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cvar_2', sku: 'TOASTER-V2-BLACK', price_amount: 250000,
+      currency: 'INR', tax_inclusive: true, gst_slab: '18', tax_rate: null,
+      hsn_code: '8516', availability_status: 'out_of_stock', archived_at: null,
+    }]);
+    // INSERT audit
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_P', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/catalog/products',
+      headers: authHeader(),
+      payload: productPayload,
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ data: { id: string; variants: { id: string; sku: string }[] }; audit_event_id: string }>();
+    expect(body.data.id).toBe('cprd_X');
+    expect(body.data.variants).toHaveLength(2);
+    expect(body.audit_event_id).toBe('caud_P');
+  });
+
+  it('rejects payload with no variants (422)', async () => {
+    seedCommerceContext();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/catalog/products',
+      headers: authHeader(),
+      payload: { ...productPayload, variants: [] },
+    });
+    expect(res.statusCode).toBe(422);
+    expect(res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields)
+      .toHaveProperty('variants');
+  });
+
+  it('rejects negative price_amount (422)', async () => {
+    seedCommerceContext();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/catalog/products',
+      headers: authHeader(),
+      payload: { ...productPayload, variants: [{ sku: 'NEG', price_amount: -1, currency: 'INR' }] },
+    });
+    expect(res.statusCode).toBe(422);
+    expect(res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields)
+      .toHaveProperty('variants[0].price_amount');
+  });
+
+  it('rejects invalid availability_status (422)', async () => {
+    seedCommerceContext();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/catalog/products',
+      headers: authHeader(),
+      payload: { ...productPayload, variants: [{ sku: 'X', price_amount: 100, availability_status: 'maybe' }] },
+    });
+    expect(res.statusCode).toBe(422);
+    expect(res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields)
+      .toHaveProperty('variants[0].availability_status');
+  });
+});
+
+describe('DELETE /v1/commerce/catalog/products/:productId (soft-delete)', () => {
+  it('archives product and variants, returns 200 with audit_event_id', async () => {
+    seedCommerceContext();
+    // UPDATE product RETURNING
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cprd_DEL', merchant_id: 'mch_OK',
+      archived_at: new Date().toISOString(),
+    }]);
+    // UPDATE variants (no RETURNING in our SQL; mock returns empty)
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT audit
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_D', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/v1/commerce/catalog/products/cprd_DEL',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { id: string; archived_at: string }; audit_event_id: string }>();
+    expect(body.data.id).toBe('cprd_DEL');
+    expect(body.data.archived_at).toBeTruthy();
+    expect(body.audit_event_id).toBe('caud_D');
+  });
+
+  it('returns 404 when product is absent or already archived', async () => {
+    seedCommerceContext();
+    // UPDATE...WHERE archived_at IS NULL RETURNING [] when nothing matched
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/v1/commerce/catalog/products/cprd_GONE',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('product_not_found');
+  });
+});

--- a/apps/auth-service/tests/commerce-schema.test.ts
+++ b/apps/auth-service/tests/commerce-schema.test.ts
@@ -37,9 +37,13 @@ describe('Commerce schema — tenant_id presence on every tenant-owned table', (
 });
 
 describe('Commerce schema — required indexes/constraints from spec §15', () => {
-  it('commerce_merchants has unique (tenant_id, id)', () => {
+  it('commerce_merchants has unique (tenant_id, id) — as CONSTRAINT, not bare index', () => {
+    // The hardening migration converted the original CREATE UNIQUE INDEX
+    // to a table CONSTRAINT so it can be referenced by composite FKs from
+    // commerce_products and commerce_product_variants. PG rejects bare
+    // unique indexes as FK targets.
     expect(read('033_commerce_merchants.sql')).toMatch(
-      /CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_merchants_tenant_id\s*\n\s*ON commerce_merchants\(tenant_id, id\)/,
+      /CONSTRAINT uq_commerce_merchants_tenant_id UNIQUE \(tenant_id, id\)/,
     );
   });
 
@@ -62,10 +66,11 @@ describe('Commerce schema — required indexes/constraints from spec §15', () =
     );
   });
 
-  it('commerce_product_variants has FK to products and merchants and tenants', () => {
+  it('commerce_product_variants has tenant_id FK to commerce_tenants', () => {
+    // merchant_id and product_id FKs are no longer single-column — they
+    // moved to composite tenant-safe FKs asserted in the dedicated
+    // describe block below.
     const s = read('035_commerce_products.sql');
-    expect(s).toMatch(/product_id\s+TEXT NOT NULL REFERENCES commerce_products\(id\)/);
-    expect(s).toMatch(/merchant_id\s+TEXT NOT NULL REFERENCES commerce_merchants\(id\)/);
     expect(s).toMatch(/tenant_id\s+TEXT NOT NULL REFERENCES commerce_tenants\(id\)/);
   });
 
@@ -91,6 +96,50 @@ describe('Commerce schema — required indexes/constraints from spec §15', () =
     expect(read('031_commerce_tenants.sql')).toMatch(
       /CONSTRAINT chk_commerce_tenants_status CHECK \(status IN \('active','disabled'\)\)/,
     );
+  });
+});
+
+describe('Commerce schema — composite tenant-safe foreign keys (M1 hardening)', () => {
+  it('commerce_merchants exposes UNIQUE CONSTRAINT (tenant_id, id) usable as an FK target', () => {
+    // PG requires the referenced columns to be a UNIQUE/PK constraint, not
+    // a bare unique index, before another table can FK to them. The
+    // hardening migration converted the original CREATE UNIQUE INDEX to a
+    // table CONSTRAINT inside CREATE TABLE.
+    const s = read('033_commerce_merchants.sql');
+    expect(s).toMatch(
+      /CONSTRAINT uq_commerce_merchants_tenant_id UNIQUE \(tenant_id, id\)/,
+    );
+  });
+
+  it('commerce_products has composite FK (tenant_id, merchant_id) → commerce_merchants(tenant_id, id)', () => {
+    const s = read('035_commerce_products.sql');
+    expect(s).toMatch(
+      /CONSTRAINT fk_commerce_products_merchant_tenant\s*\n?\s*FOREIGN KEY \(tenant_id, merchant_id\)\s*\n?\s*REFERENCES commerce_merchants\(tenant_id, id\)/,
+    );
+    // The legacy single-column FK to commerce_merchants(id) on products.merchant_id is gone.
+    expect(s).not.toMatch(/merchant_id\s+TEXT NOT NULL REFERENCES commerce_merchants\(id\)/);
+  });
+
+  it('commerce_products has UNIQUE CONSTRAINT (tenant_id, id) so variants can FK back', () => {
+    expect(read('035_commerce_products.sql')).toMatch(
+      /CONSTRAINT uq_commerce_products_tenant_id UNIQUE \(tenant_id, id\)/,
+    );
+  });
+
+  it('commerce_product_variants has composite FK (tenant_id, merchant_id) → commerce_merchants(tenant_id, id)', () => {
+    const s = read('035_commerce_products.sql');
+    expect(s).toMatch(
+      /CONSTRAINT fk_commerce_variants_merchant_tenant\s*\n?\s*FOREIGN KEY \(tenant_id, merchant_id\)\s*\n?\s*REFERENCES commerce_merchants\(tenant_id, id\)/,
+    );
+    expect(s).not.toMatch(/merchant_id\s+TEXT NOT NULL REFERENCES commerce_merchants\(id\)/);
+  });
+
+  it('commerce_product_variants has composite FK (tenant_id, product_id) → commerce_products(tenant_id, id)', () => {
+    const s = read('035_commerce_products.sql');
+    expect(s).toMatch(
+      /CONSTRAINT fk_commerce_variants_product_tenant\s*\n?\s*FOREIGN KEY \(tenant_id, product_id\)\s*\n?\s*REFERENCES commerce_products\(tenant_id, id\)/,
+    );
+    expect(s).not.toMatch(/product_id\s+TEXT NOT NULL REFERENCES commerce_products\(id\)/);
   });
 });
 

--- a/apps/auth-service/tests/commerce-schema.test.ts
+++ b/apps/auth-service/tests/commerce-schema.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Schema-level invariants. These tests read the migration files directly
+ * because the unit-test harness mocks the SQL client (no real Postgres
+ * runs). They guard against silent edits that would weaken structural
+ * guarantees the V1 spec mandates.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(__dirname, '..', 'src', 'db', 'migrations');
+
+function read(name: string): string {
+  return readFileSync(join(migrationsDir, name), 'utf8');
+}
+
+describe('Commerce schema — tenant_id presence on every tenant-owned table', () => {
+  // Every commerce-* migration that defines a tenant-owned table must
+  // declare `tenant_id` as a non-null column with FK to commerce_tenants.
+  const tenantOwned = [
+    ['033_commerce_merchants.sql', 'commerce_merchants'],
+    ['034_commerce_agents.sql', 'commerce_agents'],
+    ['035_commerce_products.sql', 'commerce_products'],
+    ['035_commerce_products.sql', 'commerce_product_variants'],
+    ['036_commerce_audit_events.sql', 'commerce_audit_events'],
+  ] as const;
+
+  it.each(tenantOwned)('%s: %s carries tenant_id NOT NULL with FK', (file, table) => {
+    const sql = read(file);
+    const tableMatch = sql.split(`CREATE TABLE IF NOT EXISTS ${table}`)[1];
+    expect(tableMatch, `table ${table} missing from ${file}`).toBeDefined();
+    const tableBlock = tableMatch!.split(/CREATE TABLE|CREATE OR REPLACE|CREATE INDEX|CREATE UNIQUE|DROP TRIGGER|CREATE TRIGGER|DO \$\$/)[0]!;
+    expect(tableBlock).toMatch(/tenant_id\s+TEXT NOT NULL REFERENCES commerce_tenants\(id\)/);
+  });
+});
+
+describe('Commerce schema — required indexes/constraints from spec §15', () => {
+  it('commerce_merchants has unique (tenant_id, id)', () => {
+    expect(read('033_commerce_merchants.sql')).toMatch(
+      /CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_merchants_tenant_id\s*\n\s*ON commerce_merchants\(tenant_id, id\)/,
+    );
+  });
+
+  it('commerce_agents has unique (tenant_id, id) and trust_status check', () => {
+    const s = read('034_commerce_agents.sql');
+    expect(s).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_agents_tenant_id/);
+    expect(s).toMatch(/trust_status IN \('pending','trusted','suspended','disabled'\)/);
+    expect(s).toMatch(/public_key_jwk IS NOT NULL OR api_key_hash IS NOT NULL/);
+  });
+
+  it('commerce_products has partial unique on (tenant_id, merchant_id, product_id) WHERE archived_at IS NULL', () => {
+    expect(read('035_commerce_products.sql')).toMatch(
+      /CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_products_active[\s\S]*?ON commerce_products\(tenant_id, merchant_id, product_id\)[\s\S]*?WHERE archived_at IS NULL/,
+    );
+  });
+
+  it('commerce_product_variants has partial unique on SKU for active rows', () => {
+    expect(read('035_commerce_products.sql')).toMatch(
+      /CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_variants_active_sku[\s\S]*?ON commerce_product_variants\(tenant_id, merchant_id, sku\)[\s\S]*?WHERE archived_at IS NULL/,
+    );
+  });
+
+  it('commerce_product_variants has FK to products and merchants and tenants', () => {
+    const s = read('035_commerce_products.sql');
+    expect(s).toMatch(/product_id\s+TEXT NOT NULL REFERENCES commerce_products\(id\)/);
+    expect(s).toMatch(/merchant_id\s+TEXT NOT NULL REFERENCES commerce_merchants\(id\)/);
+    expect(s).toMatch(/tenant_id\s+TEXT NOT NULL REFERENCES commerce_tenants\(id\)/);
+  });
+
+  it('commerce_product_variants has availability_status enum check', () => {
+    expect(read('035_commerce_products.sql')).toMatch(
+      /availability_status IN \('in_stock','out_of_stock','pre_order','back_order','unknown'\)/,
+    );
+  });
+
+  it('commerce_audit_events has the spec-required (tenant_id, merchant_id, occurred_at) index', () => {
+    expect(read('036_commerce_audit_events.sql')).toMatch(
+      /idx_commerce_audit_tenant_merchant_occurred[\s\S]*?ON commerce_audit_events\(tenant_id, merchant_id, occurred_at DESC\)/,
+    );
+  });
+
+  it('commerce_developer_tenants has at most one default tenant per developer', () => {
+    expect(read('031_commerce_tenants.sql')).toMatch(
+      /uq_commerce_dev_tenants_default[\s\S]*?ON commerce_developer_tenants\(developer_id\) WHERE is_default = TRUE/,
+    );
+  });
+
+  it('commerce_tenants has status CHECK limiting values to active|disabled', () => {
+    expect(read('031_commerce_tenants.sql')).toMatch(
+      /CONSTRAINT chk_commerce_tenants_status CHECK \(status IN \('active','disabled'\)\)/,
+    );
+  });
+});
+
+describe('Commerce schema — electronics_appliances preset is seeded', () => {
+  it('migration 032 inserts electronics_appliances with required_fields and default_policy_rules', () => {
+    const s = read('032_commerce_category_presets.sql');
+    expect(s).toMatch(/INSERT INTO commerce_category_presets/);
+    expect(s).toMatch(/'electronics_appliances'/);
+    expect(s).toMatch(/ON CONFLICT \(preset_key\) DO NOTHING/);
+    // Spec §16.1 default_policy_rules shape
+    expect(s).toMatch(/"max_amount_minor_units":\s*50000000/);
+    expect(s).toMatch(/"currency":\s*"INR"/);
+    expect(s).toMatch(/"emergency_disable":\s+false/);
+  });
+});

--- a/apps/auth-service/tests/commerce-tenant-boundary.test.ts
+++ b/apps/auth-service/tests/commerce-tenant-boundary.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { authHeader, sqlMock, buildTestApp } from './helpers.js';
+import { seedCommerceContext, TEST_COMMERCE_TENANT_ID } from './commerce-helpers.js';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+describe('Commerce tenant boundary', () => {
+  it('GET /merchants/:id from tenant A returns 404 (not 403) for tenant B merchant', async () => {
+    // Caller resolves to TEST_COMMERCE_TENANT_ID; the SELECT filters by
+    // tenant_id, so the row owned by another tenant is invisible. Returning
+    // 404 (not 403) avoids leaking existence across tenants.
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([]);  // SELECT WHERE tenant_id = caller's returns empty
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_OWNED_BY_OTHER_TENANT',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('merchant_not_found');
+  });
+
+  it('POST /catalog/products refuses cross-tenant merchant_id with 404', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([]);  // merchant lookup (cross-tenant) returns empty
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/catalog/products',
+      headers: authHeader(),
+      payload: {
+        merchant_id: 'mch_OTHER_TENANT',
+        product_id: 'PROD-1',
+        title: 'Toaster',
+        category_preset: 'electronics_appliances',
+        variants: [{ sku: 'SKU-1', price_amount: 100000, currency: 'INR' }],
+      },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('merchant_not_found');
+  });
+
+  it('GET /audit/events SELECT carries tenant_id filter', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([]);  // empty audit list
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/audit/events',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(200);
+    // Inspect the SQL template strings emitted by sqlMock to confirm
+    // tenant_id filtering is wired into the query, not just the WHERE
+    // for a hypothetical other call.
+    const calls = sqlMock.mock.calls;
+    const tagged = calls.find((c) => {
+      const tpl = c[0] as unknown;
+      if (Array.isArray(tpl)) {
+        return tpl.some((s) => typeof s === 'string' && s.includes('FROM commerce_audit_events'));
+      }
+      return false;
+    });
+    expect(tagged).toBeDefined();
+    // The first SQL fragment (created via sql`tenant_id = ${tenantId}`)
+    // appears earlier in the same logical statement; verify by searching
+    // ALL tagged-template fragments in the test for the literal 'tenant_id'.
+    const allTplStrings = calls.flatMap((c) => {
+      const tpl = c[0] as unknown;
+      return Array.isArray(tpl) ? tpl.filter((s): s is string => typeof s === 'string') : [];
+    });
+    expect(allTplStrings.some((s) => s.includes('tenant_id'))).toBe(true);
+  });
+});

--- a/apps/auth-service/tests/commerce-tenant-boundary.test.ts
+++ b/apps/auth-service/tests/commerce-tenant-boundary.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 import { authHeader, sqlMock, buildTestApp } from './helpers.js';
-import { seedCommerceContext, TEST_COMMERCE_TENANT_ID } from './commerce-helpers.js';
+import { seedCommerceContext } from './commerce-helpers.js';
 
 let app: FastifyInstance;
 

--- a/apps/auth-service/tests/commerce-tenant-resolution.test.ts
+++ b/apps/auth-service/tests/commerce-tenant-resolution.test.ts
@@ -147,6 +147,48 @@ describe('Tenant resolution — auto-provision (test/sandbox only)', () => {
   });
 });
 
+describe('Tenant resolution — production guard (NODE_ENV=production)', () => {
+  it('route returns 422 tenant_not_provisioned even with COMMERCE_ALLOW_AUTO_TENANT=true in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('COMMERCE_ALLOW_AUTO_TENANT', 'true');
+    seedCommerceContextNoMapping();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_X',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('tenant_not_provisioned');
+
+    // No INSERT to commerce_tenants happened.
+    const insertedAnyTenant = sqlMock.mock.calls.some((c) => {
+      const tpl = c[0] as unknown;
+      if (!Array.isArray(tpl)) return false;
+      return tpl.some((s) => typeof s === 'string'
+        && /INSERT INTO commerce_tenants/i.test(s));
+    });
+    expect(insertedAnyTenant).toBe(false);
+  });
+
+  it('isAutoTenantAllowed() returns false in production regardless of the flag', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('COMMERCE_ALLOW_AUTO_TENANT', 'true');
+    const { isAutoTenantAllowed } = await import('../src/lib/commerce/tenant.js');
+    expect(isAutoTenantAllowed()).toBe(false);
+  });
+
+  it('lib resolveOrCreateTenantForDeveloper throws in production even with flag set', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('COMMERCE_ALLOW_AUTO_TENANT', 'true');
+    const { resolveOrCreateTenantForDeveloper } = await import('../src/lib/commerce/tenant.js');
+    await expect(
+      resolveOrCreateTenantForDeveloper(sqlMock as unknown as never, 'dev_X', 'X'),
+    ).rejects.toThrow(/auto-provisioning is disabled/i);
+  });
+});
+
 describe('Tenant resolution — disabled tenant', () => {
   it('returns 403 tenant_disabled (does NOT 422 and does NOT auto-create a replacement)', async () => {
     seedCommerceContextDisabledTenant();

--- a/apps/auth-service/tests/commerce-tenant-resolution.test.ts
+++ b/apps/auth-service/tests/commerce-tenant-resolution.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import {
+  authHeader,
+  sqlMock,
+  TEST_DEVELOPER,
+  buildTestApp,
+} from './helpers.js';
+import {
+  seedCommerceContext,
+  seedCommerceContextNoMapping,
+  seedCommerceContextDisabledTenant,
+  TEST_COMMERCE_TENANT_ID,
+} from './commerce-helpers.js';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('Tenant resolution — mapped developer (active tenant)', () => {
+  it('resolves the mapped tenant and proceeds to the route handler', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([{
+      id: 'mch_OK',
+      tenant_id: TEST_COMMERCE_TENANT_ID,
+      legal_name: 'Acme',
+      display_name: 'Acme',
+      category_preset: 'electronics_appliances',
+      verification_status: 'unverified',
+      environment: 'sandbox',
+      agentic_commerce_enabled: false,
+      default_currency: 'INR',
+      country_code: 'IN',
+      support_email: null,
+      disabled_at: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_OK',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ data: { tenant_id: string } }>().data.tenant_id)
+      .toBe(TEST_COMMERCE_TENANT_ID);
+  });
+});
+
+describe('Tenant resolution — unmapped developer', () => {
+  it('returns 422 tenant_not_provisioned with remediation when auto-tenant is OFF (default)', async () => {
+    // Default vitest env does not set COMMERCE_ALLOW_AUTO_TENANT, so the
+    // staging/production posture (explicit provisioning required) is in
+    // effect. No need to stub anything off.
+    seedCommerceContextNoMapping();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_DOES_NOT_MATTER',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(422);
+    const body = res.json<{
+      error: { code: string; message: string; remediation: string; retryable: boolean }
+    }>();
+    expect(body.error.code).toBe('tenant_not_provisioned');
+    expect(body.error.retryable).toBe(false);
+    expect(body.error.remediation).toMatch(/POST \/v1\/commerce\/tenants/);
+    expect(body.error.remediation).toMatch(/POST \/v1\/commerce\/developer-tenants/);
+  });
+
+  it('does NOT touch the database beyond the resolver lookup when 422-ing', async () => {
+    seedCommerceContextNoMapping();
+    sqlMock.mockClear();
+    seedCommerceContextNoMapping();
+
+    await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_X',
+      headers: authHeader(),
+    });
+
+    // Two SQL calls expected: authPlugin developer SELECT + resolver join.
+    // Crucially, NO INSERT into commerce_tenants or commerce_developer_tenants.
+    expect(sqlMock).toHaveBeenCalledTimes(2);
+    const insertedAnyTenant = sqlMock.mock.calls.some((c) => {
+      const tpl = c[0] as unknown;
+      if (!Array.isArray(tpl)) return false;
+      return tpl.some((s) => typeof s === 'string'
+        && /INSERT INTO commerce_(tenants|developer_tenants)/i.test(s));
+    });
+    expect(insertedAnyTenant).toBe(false);
+  });
+});
+
+describe('Tenant resolution — auto-provision (test/sandbox only)', () => {
+  it('auto-provisions a tenant when COMMERCE_ALLOW_AUTO_TENANT=true', async () => {
+    vi.stubEnv('COMMERCE_ALLOW_AUTO_TENANT', 'true');
+    sqlMock.mockResolvedValueOnce([TEST_DEVELOPER]);  // authPlugin
+    sqlMock.mockResolvedValueOnce([]);                // resolver: no mapping
+    sqlMock.mockResolvedValueOnce([]);                // resolver re-check inside auto-provision: still none
+    sqlMock.mockResolvedValueOnce([]);                // INSERT commerce_tenants (begin)
+    sqlMock.mockResolvedValueOnce([]);                // INSERT commerce_developer_tenants
+    sqlMock.mockResolvedValueOnce([]);                // route SQL: merchant lookup (returns empty -> 404)
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_X',
+      headers: authHeader(),
+    });
+    // The auto-provision path completes; the route then 404s because no
+    // merchant exists. Importantly NOT 422.
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('merchant_not_found');
+
+    // Confirm the tenant INSERTs actually fired.
+    const insertedTenants = sqlMock.mock.calls.some((c) => {
+      const tpl = c[0] as unknown;
+      if (!Array.isArray(tpl)) return false;
+      return tpl.some((s) => typeof s === 'string'
+        && /INSERT INTO commerce_tenants/i.test(s));
+    });
+    const insertedMapping = sqlMock.mock.calls.some((c) => {
+      const tpl = c[0] as unknown;
+      if (!Array.isArray(tpl)) return false;
+      return tpl.some((s) => typeof s === 'string'
+        && /INSERT INTO commerce_developer_tenants/i.test(s));
+    });
+    expect(insertedTenants).toBe(true);
+    expect(insertedMapping).toBe(true);
+  });
+
+  it('refuses to auto-provision when flag is unset (defense in depth at the lib layer)', async () => {
+    const { resolveOrCreateTenantForDeveloper } = await import('../src/lib/commerce/tenant.js');
+    // Flag not stubbed — should be undefined/empty.
+    await expect(
+      resolveOrCreateTenantForDeveloper(sqlMock as unknown as never, 'dev_X', 'X'),
+    ).rejects.toThrow(/auto-provisioning is disabled/i);
+  });
+});
+
+describe('Tenant resolution — disabled tenant', () => {
+  it('returns 403 tenant_disabled (does NOT 422 and does NOT auto-create a replacement)', async () => {
+    seedCommerceContextDisabledTenant();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_X',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    const body = res.json<{ error: { code: string; remediation: string } }>();
+    expect(body.error.code).toBe('tenant_disabled');
+    expect(body.error.remediation).toMatch(/Contact Grantex support/);
+  });
+
+  it('does NOT auto-create a replacement even when COMMERCE_ALLOW_AUTO_TENANT=true', async () => {
+    vi.stubEnv('COMMERCE_ALLOW_AUTO_TENANT', 'true');
+    seedCommerceContextDisabledTenant();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_X',
+      headers: authHeader(),
+    });
+
+    // Disabled mapping is preserved; auto-create is bypassed by design.
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('tenant_disabled');
+
+    // Confirm no commerce_tenants INSERT happened.
+    const insertedAnyTenant = sqlMock.mock.calls.some((c) => {
+      const tpl = c[0] as unknown;
+      if (!Array.isArray(tpl)) return false;
+      return tpl.some((s) => typeof s === 'string'
+        && /INSERT INTO commerce_tenants/i.test(s));
+    });
+    expect(insertedAnyTenant).toBe(false);
+  });
+
+  it('library function refuses to provision when caller is mapped to a disabled tenant', async () => {
+    vi.stubEnv('COMMERCE_ALLOW_AUTO_TENANT', 'true');
+    sqlMock.mockResolvedValueOnce([{ id: 'cten_DIS', status: 'disabled' }]);
+
+    const { resolveOrCreateTenantForDeveloper } = await import('../src/lib/commerce/tenant.js');
+    await expect(
+      resolveOrCreateTenantForDeveloper(sqlMock as unknown as never, 'dev_X', 'X'),
+    ).rejects.toThrow(/disabled tenant/i);
+  });
+});

--- a/apps/auth-service/vitest.config.ts
+++ b/apps/auth-service/vitest.config.ts
@@ -27,6 +27,9 @@ export default defineConfig({
       STRIPE_PRICE_ENTERPRISE: 'price_enterprise_fake',
       VAULT_ENCRYPTION_KEY: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
       ADMIN_API_KEY: 'test-admin-key-secret',
+      // Grantex Commerce M1 — flag is checked at request time so tests can
+      // toggle it via vi.stubEnv. The feature-flag test stubs it back off.
+      COMMERCE_V1_ENABLED: 'true',
     },
   },
 });

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -1,0 +1,624 @@
+openapi: "3.1.0"
+info:
+  title: Grantex Commerce V1
+  version: "0.1.0"
+  description: >-
+    Authorization-as-a-service for agent-initiated commerce actions.
+    Source of truth: GRANTEX_COMMERCE_V1_BUILD_SPEC.md.
+    Milestone 1 (Foundations) implements feature flags, tenant boundary,
+    merchant/agent/product/variant models, the electronics_appliances
+    category preset, and the append-only audit ledger. Passport, policy,
+    payment, MCP, and provider-credential routes are listed but
+    unimplemented in M1 (each carries `x-implemented: false`).
+servers:
+  - url: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+    description: Production (Cloud Run)
+  - url: http://localhost:3001
+    description: Local
+
+tags:
+  - name: Tenants
+  - name: Merchants
+  - name: Provider Credentials
+  - name: Catalog
+  - name: Commerce Agents
+  - name: Policy
+  - name: Cart
+  - name: Passports
+  - name: Payments
+  - name: Audit
+  - name: Webhooks
+  - name: Well-Known
+
+components:
+  securitySchemes:
+    developerApiKey:
+      type: http
+      scheme: bearer
+      bearerFormat: opaque
+      description: >-
+        Existing platform API key (`grtx_*`). M1 commerce routes auto-resolve
+        the tenant from this caller. M2 will add merchant API keys
+        (`grtx_sk_<env>_*`) and agent JWT/API-key callers.
+    merchantApiKey:
+      type: http
+      scheme: bearer
+      bearerFormat: opaque
+      description: M2 — `grtx_sk_<env>_<secret>`. Not implemented in M1.
+    agentJwt:
+      type: http
+      scheme: bearer
+      bearerFormat: jwt
+      description: M2 — agent JWT assertion verified vs CommerceAgent.public_key_jwk.
+
+  responses:
+    Unauthorized:
+      description: Missing or invalid authentication
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    NotFound:
+      description: Resource not found in this tenant
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    ValidationFailed:
+      description: Request body failed validation
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    CommerceDisabled:
+      description: COMMERCE_V1_ENABLED is not set in this environment
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+
+  schemas:
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+              examples: [validation_failed, merchant_not_found, commerce_disabled]
+            message: { type: string }
+            decision_id: { type: string, nullable: true }
+            audit_event_id: { type: string, nullable: true }
+            remediation: { type: string, nullable: true }
+            retryable: { type: boolean, nullable: true }
+            details:
+              type: object
+              additionalProperties: true
+
+    Merchant:
+      type: object
+      properties:
+        id: { type: string, examples: [mch_01HXYZ] }
+        tenant_id: { type: string, examples: [cten_01HXYZ] }
+        legal_name: { type: string }
+        display_name: { type: string }
+        category_preset: { type: string, enum: [electronics_appliances] }
+        verification_status: { type: string, enum: [unverified, pending, verified, rejected] }
+        environment: { type: string, enum: [sandbox, live] }
+        agentic_commerce_enabled: { type: boolean }
+        default_currency: { type: string }
+        country_code: { type: string }
+        support_email: { type: string, nullable: true }
+        disabled_at: { type: string, format: date-time, nullable: true }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+
+    CreateMerchantRequest:
+      type: object
+      required: [legal_name, display_name, category_preset]
+      properties:
+        legal_name: { type: string }
+        display_name: { type: string }
+        category_preset: { type: string, enum: [electronics_appliances] }
+        default_currency: { type: string, default: INR }
+        country_code: { type: string, default: IN }
+        support_email: { type: string, nullable: true }
+
+    Agent:
+      type: object
+      properties:
+        id: { type: string, examples: [cag_01HXYZ] }
+        tenant_id: { type: string }
+        display_name: { type: string }
+        agent_type: { type: string }
+        public_key_jwk: { type: object, additionalProperties: true, nullable: true }
+        trust_status: { type: string, enum: [pending, trusted, suspended, disabled] }
+        disabled_at: { type: string, format: date-time, nullable: true }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+
+    CreateAgentRequest:
+      type: object
+      required: [display_name]
+      properties:
+        display_name: { type: string }
+        agent_type: { type: string, default: sales }
+        public_key_jwk: { type: object, additionalProperties: true }
+        api_key_hash: { type: string, description: "Salted hash of grtx_agent_<secret>; never raw" }
+        trust_status:
+          type: string
+          enum: [pending, trusted, suspended, disabled]
+          default: pending
+
+    Variant:
+      type: object
+      properties:
+        id: { type: string }
+        sku: { type: string }
+        parent_sku: { type: string, nullable: true }
+        model: { type: string, nullable: true }
+        variant_title: { type: string, nullable: true }
+        attributes: { type: object, additionalProperties: true }
+        price_amount: { type: integer }
+        currency: { type: string }
+        tax_inclusive: { type: boolean }
+        gst_slab: { type: string, nullable: true }
+        tax_rate: { type: number, nullable: true }
+        hsn_code: { type: string, nullable: true }
+        availability_status:
+          type: string
+          enum: [in_stock, out_of_stock, pre_order, back_order, unknown]
+        warranty_summary: { type: string, nullable: true }
+        return_policy_summary: { type: string, nullable: true }
+        archived_at: { type: string, format: date-time, nullable: true }
+
+    Product:
+      type: object
+      properties:
+        id: { type: string }
+        tenant_id: { type: string }
+        merchant_id: { type: string }
+        product_id: { type: string }
+        title: { type: string }
+        brand: { type: string, nullable: true }
+        description: { type: string, nullable: true }
+        image_url: { type: string, nullable: true }
+        category_preset: { type: string }
+        source_system: { type: string }
+        manually_maintained: { type: boolean }
+        archived_at: { type: string, format: date-time, nullable: true }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+        variants:
+          type: array
+          items: { $ref: "#/components/schemas/Variant" }
+
+    CreateProductRequest:
+      type: object
+      required: [merchant_id, product_id, title, category_preset, variants]
+      properties:
+        merchant_id: { type: string }
+        product_id: { type: string }
+        title: { type: string }
+        brand: { type: string }
+        description: { type: string }
+        image_url: { type: string }
+        category_preset: { type: string, enum: [electronics_appliances] }
+        source_system: { type: string, default: manual }
+        manually_maintained: { type: boolean, default: false }
+        variants:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            required: [sku, price_amount]
+            properties:
+              sku: { type: string }
+              price_amount: { type: integer, minimum: 0 }
+              currency: { type: string, default: INR }
+              tax_inclusive: { type: boolean, default: true }
+              gst_slab: { type: string }
+              hsn_code: { type: string }
+              availability_status:
+                type: string
+                enum: [in_stock, out_of_stock, pre_order, back_order, unknown]
+                default: unknown
+              warranty_summary: { type: string }
+              return_policy_summary: { type: string }
+
+    AuditEvent:
+      type: object
+      properties:
+        id: { type: string }
+        tenant_id: { type: string }
+        merchant_id: { type: string, nullable: true }
+        agent_id: { type: string, nullable: true }
+        user_principal_id: { type: string, nullable: true }
+        event_type: { type: string }
+        resource_type: { type: string, nullable: true }
+        resource_id: { type: string, nullable: true }
+        passport_jti: { type: string, nullable: true }
+        policy_version: { type: string, nullable: true }
+        decision_id: { type: string, nullable: true }
+        idempotency_key_hash: { type: string, nullable: true }
+        request_id: { type: string, nullable: true }
+        occurred_at: { type: string, format: date-time }
+        metadata: { type: object, additionalProperties: true }
+
+security:
+  - developerApiKey: []
+
+paths:
+  # =====================================================================
+  # M1 — implemented
+  # =====================================================================
+  /v1/commerce/merchants:
+    post:
+      tags: [Merchants]
+      summary: Create a merchant
+      operationId: createMerchant
+      x-implemented: true
+      x-milestone: M1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/CreateMerchantRequest" }
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/Merchant" }
+                  audit_event_id: { type: string }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "422": { $ref: "#/components/responses/ValidationFailed" }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+
+  /v1/commerce/merchants/{merchant_id}:
+    parameters:
+      - { in: path, name: merchant_id, required: true, schema: { type: string } }
+    get:
+      tags: [Merchants]
+      summary: Get a merchant
+      operationId: getMerchant
+      x-implemented: true
+      x-milestone: M1
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/Merchant" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+    patch:
+      tags: [Merchants]
+      summary: Update merchant (mutable fields only)
+      x-implemented: false
+      x-milestone: M2
+      responses:
+        "501": { description: Not implemented in M1 }
+
+  /v1/commerce/merchants/{merchant_id}/disable-agentic-commerce:
+    parameters:
+      - { in: path, name: merchant_id, required: true, schema: { type: string } }
+    post:
+      tags: [Merchants]
+      summary: Emergency disable
+      x-implemented: false
+      x-milestone: M3
+      responses:
+        "501": { description: Not implemented in M1 }
+
+  /v1/commerce/agents:
+    post:
+      tags: [Commerce Agents]
+      summary: Register a CommerceAgent
+      operationId: createAgent
+      x-implemented: true
+      x-milestone: M1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/CreateAgentRequest" }
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/Agent" }
+                  audit_event_id: { type: string }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "422": { $ref: "#/components/responses/ValidationFailed" }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+    get:
+      tags: [Commerce Agents]
+      summary: List CommerceAgents
+      x-implemented: false
+      x-milestone: M2
+      responses:
+        "501": { description: Not implemented in M1 }
+
+  /v1/commerce/agents/{agent_id}:
+    parameters:
+      - { in: path, name: agent_id, required: true, schema: { type: string } }
+    get:
+      tags: [Commerce Agents]
+      summary: Get a CommerceAgent
+      operationId: getAgent
+      x-implemented: true
+      x-milestone: M1
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/Agent" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+    patch:
+      tags: [Commerce Agents]
+      summary: Update agent
+      x-implemented: false
+      x-milestone: M2
+      responses:
+        "501": { description: Not implemented in M1 }
+
+  /v1/commerce/catalog/products:
+    post:
+      tags: [Catalog]
+      summary: Create a product with variants
+      operationId: createProduct
+      x-implemented: true
+      x-milestone: M1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/CreateProductRequest" }
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/Product" }
+                  audit_event_id: { type: string }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "422": { $ref: "#/components/responses/ValidationFailed" }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+    get:
+      tags: [Catalog]
+      summary: List products
+      x-implemented: false
+      x-milestone: M2
+      responses:
+        "501": { description: Not implemented in M1 }
+
+  /v1/commerce/catalog/products/bulk:
+    post:
+      tags: [Catalog]
+      summary: Bulk create products
+      x-implemented: false
+      x-milestone: M2
+      responses:
+        "501": { description: Not implemented in M1 }
+
+  /v1/commerce/catalog/products/{product_id}:
+    parameters:
+      - { in: path, name: product_id, required: true, schema: { type: string } }
+    get:
+      tags: [Catalog]
+      summary: Get a product (with variants)
+      operationId: getProduct
+      x-implemented: true
+      x-milestone: M1
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/Product" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+    patch:
+      tags: [Catalog]
+      summary: Update product
+      x-implemented: false
+      x-milestone: M2
+      responses:
+        "501": { description: Not implemented in M1 }
+    delete:
+      tags: [Catalog]
+      summary: Soft-delete (archive) a product
+      operationId: archiveProduct
+      x-implemented: true
+      x-milestone: M1
+      responses:
+        "200": { description: Archived }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+
+  /v1/commerce/catalog/search:
+    post:
+      tags: [Catalog]
+      summary: Catalog search (also exposed via MCP catalog.search)
+      x-implemented: false
+      x-milestone: M5
+      responses:
+        "501": { description: Not implemented in M1 }
+
+  /v1/commerce/audit/events:
+    get:
+      tags: [Audit]
+      summary: List audit events
+      operationId: listAuditEvents
+      x-implemented: true
+      x-milestone: M1
+      parameters:
+        - { in: query, name: merchant_id, schema: { type: string } }
+        - { in: query, name: agent_id, schema: { type: string } }
+        - { in: query, name: passport_jti, schema: { type: string } }
+        - { in: query, name: event_type, schema: { type: string } }
+        - { in: query, name: from, schema: { type: string, format: date-time } }
+        - { in: query, name: to, schema: { type: string, format: date-time } }
+        - { in: query, name: limit, schema: { type: integer, default: 25, minimum: 1, maximum: 100 } }
+        - { in: query, name: cursor, schema: { type: string } }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items: { $ref: "#/components/schemas/AuditEvent" }
+                  next_cursor: { type: string, nullable: true }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+
+  # =====================================================================
+  # Stubs for V1 surface implemented in later milestones
+  # =====================================================================
+  # ---------------------------------------------------------------------
+  # M2 — explicit tenant provisioning. M1 ships the tenant boundary in
+  # schema only; staging/production return 422 tenant_not_provisioned
+  # until these endpoints land. For local/sandbox use only,
+  # COMMERCE_ALLOW_AUTO_TENANT=true bypasses the requirement.
+  # ---------------------------------------------------------------------
+  /v1/commerce/tenants:
+    post:
+      tags: [Tenants]
+      summary: "M2 — create a commerce tenant (operator-only)"
+      x-implemented: false
+      x-milestone: M2
+      responses:
+        "501": { description: Not implemented in M1 }
+  /v1/commerce/developer-tenants:
+    post:
+      tags: [Tenants]
+      summary: "M2 — bind a developer to a commerce tenant (operator-only)"
+      x-implemented: false
+      x-milestone: M2
+      responses:
+        "501": { description: Not implemented in M1 }
+
+  /v1/commerce/provider-credentials:
+    post: { tags: [Provider Credentials], summary: M4, x-implemented: false, x-milestone: M4, responses: { "501": { description: Not implemented in M1 } } }
+    get:  { tags: [Provider Credentials], summary: M4, x-implemented: false, x-milestone: M4, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/commerce/provider-credentials/{credential_id}:
+    parameters:
+      - { in: path, name: credential_id, required: true, schema: { type: string } }
+    patch: { tags: [Provider Credentials], summary: M4, x-implemented: false, x-milestone: M4, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/commerce/provider-credentials/{credential_id}/validate:
+    parameters:
+      - { in: path, name: credential_id, required: true, schema: { type: string } }
+    post: { tags: [Provider Credentials], summary: M4, x-implemented: false, x-milestone: M4, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/commerce/policies:
+    post: { tags: [Policy], summary: M3, x-implemented: false, x-milestone: M3, responses: { "501": { description: Not implemented in M1 } } }
+    get:  { tags: [Policy], summary: M3, x-implemented: false, x-milestone: M3, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/commerce/policies/{policy_id}:
+    parameters:
+      - { in: path, name: policy_id, required: true, schema: { type: string } }
+    get: { tags: [Policy], summary: M3, x-implemented: false, x-milestone: M3, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/commerce/policies/{policy_id}/activate:
+    parameters:
+      - { in: path, name: policy_id, required: true, schema: { type: string } }
+    post: { tags: [Policy], summary: M3, x-implemented: false, x-milestone: M3, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/commerce/policies/evaluate:
+    post: { tags: [Policy], summary: M3, x-implemented: false, x-milestone: M3, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/commerce/carts:
+    post: { tags: [Cart], summary: M3, x-implemented: false, x-milestone: M3, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/commerce/carts/{cart_id}:
+    parameters:
+      - { in: path, name: cart_id, required: true, schema: { type: string } }
+    get: { tags: [Cart], summary: M3, x-implemented: false, x-milestone: M3, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/commerce/passports/consent-requests:
+    post: { tags: [Passports], summary: M2, x-implemented: false, x-milestone: M2, responses: { "501": { description: Not implemented in M1 } } }
+  /v1/commerce/passports/exchange:
+    post: { tags: [Passports], summary: M2, x-implemented: false, x-milestone: M2, responses: { "501": { description: Not implemented in M1 } } }
+  /v1/commerce/passports:
+    get:  { tags: [Passports], summary: M2, x-implemented: false, x-milestone: M2, responses: { "501": { description: Not implemented in M1 } } }
+  /v1/commerce/passports/verify:
+    post: { tags: [Passports], summary: M2, x-implemented: false, x-milestone: M2, responses: { "501": { description: Not implemented in M1 } } }
+  /v1/commerce/passports/revoke:
+    post: { tags: [Passports], summary: M2, x-implemented: false, x-milestone: M2, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/commerce/payments/intents:
+    post: { tags: [Payments], summary: M4, x-implemented: false, x-milestone: M4, responses: { "501": { description: Not implemented in M1 } } }
+    get:  { tags: [Payments], summary: M4, x-implemented: false, x-milestone: M4, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/commerce/payments/intents/{id}:
+    parameters:
+      - { in: path, name: id, required: true, schema: { type: string } }
+    get: { tags: [Payments], summary: M4, x-implemented: false, x-milestone: M4, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/commerce/payments/intents/{id}/checkout-link:
+    parameters:
+      - { in: path, name: id, required: true, schema: { type: string } }
+    post: { tags: [Payments], summary: M4, x-implemented: false, x-milestone: M4, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/webhooks/providers/{provider_key}:
+    parameters:
+      - { in: path, name: provider_key, required: true, schema: { type: string } }
+    post: { tags: [Webhooks], summary: "M4 — Plural webhook signature scheme is an external blocker", x-implemented: false, x-milestone: M4, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/webhooks/merchant/{merchant_id}/{source_key}:
+    parameters:
+      - { in: path, name: merchant_id, required: true, schema: { type: string } }
+      - { in: path, name: source_key, required: true, schema: { type: string } }
+    post: { tags: [Webhooks], summary: "M2/M5 — catalog.product.updated only", x-implemented: false, x-milestone: M2, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/commerce/webhook-sources:
+    post: { tags: [Webhooks], summary: M2, x-implemented: false, x-milestone: M2, responses: { "501": { description: Not implemented in M1 } } }
+    get:  { tags: [Webhooks], summary: M2, x-implemented: false, x-milestone: M2, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/commerce/webhook-sources/{source_key}:
+    parameters:
+      - { in: path, name: source_key, required: true, schema: { type: string } }
+    patch: { tags: [Webhooks], summary: M2, x-implemented: false, x-milestone: M2, responses: { "501": { description: Not implemented in M1 } } }
+
+  /v1/commerce/webhook-sources/{source_key}/rotate-secret:
+    parameters:
+      - { in: path, name: source_key, required: true, schema: { type: string } }
+    post: { tags: [Webhooks], summary: M2, x-implemented: false, x-milestone: M2, responses: { "501": { description: Not implemented in M1 } } }
+
+  /.well-known/grantex-commerce:
+    get: { tags: [Well-Known], summary: "M5 — merchant publishing profile", x-implemented: false, x-milestone: M5, responses: { "501": { description: Not implemented in M1 } } }
+
+  /mcp:
+    get: { tags: [Well-Known], summary: "M5 — MCP streamable-HTTP", x-implemented: false, x-milestone: M5, responses: { "501": { description: Not implemented in M1 } } }

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -144,10 +144,11 @@ components:
         agent_type: { type: string, default: sales }
         public_key_jwk: { type: object, additionalProperties: true }
         api_key_hash: { type: string, description: "Salted hash of grtx_agent_<secret>; never raw" }
-        trust_status:
-          type: string
-          enum: [pending, trusted, suspended, disabled]
-          default: pending
+      description: >-
+        Note: trust_status is server-controlled. New agents are always
+        created in 'pending'. The field accepts 'pending' (no-op) for
+        forward compatibility but rejects any other value with 422. Trust
+        changes will land on a future admin/operator endpoint (M2+).
 
     Variant:
       type: object

--- a/skills/grantex-commerce-enterprise-implementation/SKILL.md
+++ b/skills/grantex-commerce-enterprise-implementation/SKILL.md
@@ -1,0 +1,790 @@
+---
+name: grantex-commerce-enterprise-implementation
+description: Enterprise implementation guardrails for Grantex Commerce V1 across grantex.dev and agenticorg.ai. Use when reviewing, planning, implementing, testing, or signing off Grantex Commerce, agentic commerce, merchant AI-native onboarding, MCP/UCP/ACP publishing, merchant catalog/inventory/pricing, Commerce Passports, Plural payments, webhooks, APIs, database models, UI/UX, retries, observability, release gates, or production hardening from GRANTEX_COMMERCE_V1_BUILD_SPEC.md.
+effort: max
+---
+
+# Grantex Commerce Enterprise Implementation
+
+Use this skill to implement Grantex Commerce V1 as a finished pilot-production product, not as a demo, proof of concept, thin MCP wrapper, or payment-link prototype.
+
+The implementation source of truth is `GRANTEX_COMMERCE_V1_BUILD_SPEC.md`. The master context file is `GRANTEX_COMMERCE_PRD.md`. Read the V1 build spec before changing code. Use the master PRD only for strategic context and future compatibility.
+
+## Non-Negotiable Product Boundary
+
+Build V1 around this claim:
+
+> An AI agent can initiate a commerce checkout through a payment provider only when Grantex can verify user consent, scope, merchant policy, revocation status, tenant boundary, agent identity, and audit evidence.
+
+Do not expand V1 into the full master PRD. Do not silently drop any V1 requirement. If a requirement cannot be implemented because an external API, credential, legal approval, or codebase dependency is missing, build the provider-neutral abstraction, mock/sandbox path, feature flag, tests, and explicit blocker.
+
+## Repo Ownership
+
+When working in `grantex.dev`, own:
+
+- merchant onboarding and control plane;
+- commerce data models and migrations;
+- catalog, variant, inventory, pricing, and import APIs;
+- provider credential setup and validation;
+- inbound merchant webhook source management;
+- CommerceAgent registry and authentication;
+- Commerce Passport consent, issuance, verification, revocation, and JWKS;
+- policy engine;
+- cart and checkout/payment intent APIs;
+- Plural sandbox adapter behind provider-neutral interface;
+- Plural webhook handling and payment reconciliation;
+- MCP-compatible publishing layer and demo MCP client;
+- audit ledger, metering, observability, tests, and release gates.
+
+When working in `agenticorg.ai`, own:
+
+- merchant commerce Sales Agent pack;
+- workflows that call Grantex tools only;
+- agent authentication against Grantex;
+- demo flows and evals;
+- refusal behavior for missing consent, stale inventory, unsupported offers, disabled merchants, and policy denial.
+
+AgenticOrg must not duplicate Grantex-owned commerce infrastructure. AgenticOrg must not hold Plural credentials or call Plural directly.
+
+## First Operating Rule
+
+Before implementation:
+
+1. Read `GRANTEX_COMMERCE_V1_BUILD_SPEC.md`.
+2. Read the codebase's existing auth, database, API, routing, background job, frontend, test, observability, and configuration patterns.
+3. Map every V1 requirement to existing modules or new modules.
+4. Create a task plan ordered by dependency.
+5. Implement in vertical slices that can be tested end to end.
+
+Do not implement from memory. Do not hand-roll patterns that the codebase already has.
+
+## Anti-Shortcut Protocol
+
+Before editing files, create a traceability matrix in the working notes or implementation plan with:
+
+- V1 build spec section;
+- requirement summary;
+- owning repo: `grantex.dev`, `agenticorg.ai`, or external blocker;
+- implementation files/modules;
+- migration or schema impact;
+- API/UI impact;
+- test coverage;
+- release-gate evidence;
+- status: not started, implemented, tested, blocked, or deferred by explicit V1 scope.
+
+Before writing migrations or endpoints, verify the V1 spec has contract-level definitions for:
+
+- provider interface signatures and normalized provider errors;
+- all required entity field lists, indexes, relationships, and constraints;
+- API authentication schemes for dashboard, merchant API, agent API, and internal jobs;
+- Commerce Passport JWT algorithm, JWKS endpoint, `kid` rotation, and clock skew;
+- `CommercePolicy.rules` schema;
+- endpoint request/response/error contracts and OpenAPI location;
+- MCP tool input/output schemas and required scopes;
+- webhook envelope, signature scheme, replay window, and idempotency;
+- PATCH mutable field allowlists;
+- rate-limit source IP trust rules;
+- security, secrets, logging, operations, backup, rollback, and SLA gates.
+
+If any of these are missing or contradicted by the codebase, stop and update the implementation plan or spec before coding. Do not infer critical security/payment contracts silently.
+
+Do not mark a requirement complete unless implementation and test evidence exist. If a requirement is intentionally not implemented, label it with one of:
+
+- out of V1 scope according to the build spec;
+- blocked by missing external credential/API/legal approval;
+- not applicable to this repo because owned by the other repo.
+
+Never use these as completion substitutes:
+
+- TODO comments;
+- placeholder UI;
+- mocked success without a real mock-provider contract;
+- untested endpoint stubs;
+- dashboard-only implementation without API;
+- API-only implementation for a required dashboard workflow;
+- provider-specific shortcut in core models;
+- happy-path-only tests;
+- manual verification where an automated test is practical.
+
+If the implementation becomes too large for one session, stop only at a clean vertical boundary and leave a machine-readable continuation checklist with completed, pending, blocked, and verified items.
+
+## Definition Of Done Per Requirement
+
+For every feature, all applicable layers must be done:
+
+- schema or persistence;
+- validation;
+- auth and tenant boundary;
+- business policy;
+- API endpoint or MCP tool;
+- UI workflow if merchant/operator-facing;
+- webhook/background job if event-driven;
+- audit event;
+- observability/logging;
+- automated tests;
+- documentation or inline admin help where needed;
+- release-gate entry.
+
+A feature is incomplete if any required layer is missing and not explicitly marked as blocked or out of scope.
+
+## Architecture Rules
+
+- Keep Plural behind `PaymentProvider` or equivalent neutral interface.
+- Implement `MockPaymentProvider` for local tests and deterministic E2E.
+- Implement `PluralPaymentProvider` for sandbox; live mode stays feature-flagged.
+- Do not put Plural-specific fields into core tables except under namespaced provider metadata or explicit neutral provider reference fields.
+- Every UI flow must have an equivalent API.
+- Every payment-affecting action must require a valid checkout Commerce Passport.
+- Creating a pre-consent cart draft may be allowed for an authenticated registered `CommerceAgent`; checkout/payment still requires a valid user-bound checkout passport.
+- Every protected action must write audit evidence.
+- Every tenant-owned query must filter by `tenant_id`.
+- Every tenant-owned row must include `tenant_id`.
+- Prefer existing framework primitives for validation, auth, migrations, queues, forms, tests, and telemetry.
+- Do not store raw card/payment credentials.
+- Do not claim certified UCP, ACP, AP2, MPP, or A2A compliance in V1.
+
+## Data Model Requirements
+
+Implement the V1 entity set only:
+
+- `CommerceMerchant`
+- `CommerceCategoryPreset`
+- `CommerceAgent`
+- `CommerceProduct`
+- `CommerceProductVariant`
+- `CommerceConsentRecord`
+- `CommercePassport`
+- `CommercePolicy`
+- `CommerceCart`
+- `CommercePaymentIntent`
+- `CommerceAuditEvent`
+- `CommerceProviderCredential`
+- `CommerceWebhookEvent`
+- `CommerceAgentSession`
+- `CommerceMeterEvent`
+
+Every tenant-owned table must include:
+
+- `tenant_id`
+- `created_at`
+- `updated_at` where mutable
+- stable primary key
+- indexes for tenant-scoped listing and lookup
+
+Use database constraints for invariants that must never be bypassed:
+
+- required tenant ownership;
+- merchant ownership;
+- product/variant SKU uniqueness within merchant/tenant as appropriate;
+- payment status enum/state machine;
+- idempotency key uniqueness by merchant, endpoint, environment;
+- webhook event ID uniqueness by merchant/source/provider;
+- active policy version uniqueness per merchant when applicable;
+- passport `jti` uniqueness;
+- not-null required commerce fields;
+- foreign keys for merchant, tenant, cart, passport, agent, product, and payment references.
+
+Audit table rules:
+
+- append-only at database permission level;
+- app role has `INSERT` and `SELECT` only;
+- no app-level `UPDATE` or `DELETE`;
+- corrections are compensating events;
+- dashboard must not expose audit mutation controls.
+
+Product deletion:
+
+- implement soft-delete/archive;
+- never hard-delete product or variant rows referenced by carts, payment intents, audit events, or webhooks.
+
+## Merchant Data Requirements
+
+Support all V1 merchant data paths:
+
+- dashboard manual product entry;
+- CSV upload with documented columns;
+- REST upsert APIs;
+- complete-state inbound merchant webhook for `catalog.product.updated`.
+
+Required product/variant fields include:
+
+- product ID;
+- title;
+- brand;
+- description;
+- image URL;
+- category/preset;
+- variant ID;
+- SKU;
+- parent SKU;
+- model;
+- variant title;
+- attributes;
+- price amount;
+- currency;
+- tax-inclusive flag;
+- GST slab or tax rate;
+- HSN code;
+- availability status;
+- warranty summary;
+- return policy summary;
+- source system;
+- last synced timestamp.
+
+V1 must support products with variants. A product with no visible variant grouping still needs one purchasable variant.
+
+Do not silently update active payment intent amounts when catalog price changes. If a new price exceeds passport `max_amount`, require fresh consent before creating a new checkout link.
+
+## Agent Identity And Commerce Passport
+
+Agents must authenticate as registered `CommerceAgent` identities. V1 may support:
+
+- signed JWT bearer assertions using `public_key_jwk`; or
+- agent API key bound to `CommerceAgent`.
+
+Record agent auth method on consent, passport, cart, payment, and audit events.
+
+Agent authentication is not user consent. Checkout/payment requires a valid checkout Commerce Passport.
+
+Commerce Passport must include or enforce:
+
+- `iss`
+- `sub`
+- `aud`
+- `tenant_id`
+- `merchant_id`
+- `agent_id`
+- `scope`
+- `max_amount`
+- `currency`
+- `iat`
+- `nbf`
+- `exp`
+- `jti`
+- `ver`
+
+Default scope bundles:
+
+- `browse`: `commerce:catalog.read`, `commerce:inventory.read`
+- `checkout`: `commerce:catalog.read`, `commerce:inventory.read`, `commerce:checkout.create`, `commerce:payment.initiate`, `commerce:payment.status.read`
+
+Default expiry:
+
+- browse: 60 minutes;
+- checkout: 10 minutes.
+
+Payment-affecting actions require online revocation check. Merchant emergency disable must block protected actions immediately.
+
+## Policy Engine
+
+Policy evaluation must cover at least:
+
+- merchant match;
+- tenant match;
+- agent status;
+- agent trust status;
+- scope allowlist;
+- amount cap;
+- currency;
+- emergency disable;
+- passport expiry;
+- passport revocation;
+- category/product constraints where implemented;
+- sandbox/live environment mismatch.
+
+Policy decisions:
+
+- `allow`
+- `deny`
+- `requires_user_consent`
+
+Audit `policy.evaluated` when decision is `deny` or `requires_user_consent`. For `allow`, include policy version and decision reference on the resulting action audit event.
+
+## REST API Contract
+
+Implement these V1 routes unless the codebase has an established versioning convention that requires a documented equivalent path.
+
+Merchant:
+
+- `POST /v1/commerce/merchants`
+- `GET /v1/commerce/merchants/{merchant_id}`
+- `PATCH /v1/commerce/merchants/{merchant_id}`
+- `POST /v1/commerce/merchants/{merchant_id}/disable-agentic-commerce`
+
+Provider credentials:
+
+- `POST /v1/commerce/provider-credentials`
+- `GET /v1/commerce/provider-credentials`
+- `PATCH /v1/commerce/provider-credentials/{credential_id}`
+- `POST /v1/commerce/provider-credentials/{credential_id}/validate`
+
+Products:
+
+- `POST /v1/commerce/catalog/products`
+- `POST /v1/commerce/catalog/products/bulk`
+- `GET /v1/commerce/catalog/products`
+- `GET /v1/commerce/catalog/products/{product_id}`
+- `PATCH /v1/commerce/catalog/products/{product_id}`
+- `DELETE /v1/commerce/catalog/products/{product_id}`
+- `POST /v1/commerce/catalog/search`
+
+Agents:
+
+- `POST /v1/commerce/agents`
+- `GET /v1/commerce/agents`
+- `GET /v1/commerce/agents/{agent_id}`
+- `PATCH /v1/commerce/agents/{agent_id}`
+
+Policy:
+
+- `POST /v1/commerce/policies`
+- `GET /v1/commerce/policies`
+- `GET /v1/commerce/policies/{policy_id}`
+- `POST /v1/commerce/policies/{policy_id}/activate`
+- `POST /v1/commerce/policies/evaluate`
+
+Cart:
+
+- `POST /v1/commerce/carts`
+- `GET /v1/commerce/carts/{cart_id}`
+
+Passport:
+
+- `POST /v1/commerce/passports/consent-requests`
+- `POST /v1/commerce/passports/exchange`
+- `GET /v1/commerce/passports`
+- `POST /v1/commerce/passports/verify`
+- `POST /v1/commerce/passports/revoke`
+
+Payments:
+
+- `POST /v1/commerce/payments/intents`
+- `GET /v1/commerce/payments/intents`
+- `GET /v1/commerce/payments/intents/{id}`
+- `POST /v1/commerce/payments/intents/{id}/checkout-link`
+- `POST /v1/webhooks/providers/{provider_key}`
+
+Audit:
+
+- `GET /v1/commerce/audit/events`
+
+Well-known and MCP:
+
+- `GET /.well-known/grantex-commerce`
+- MCP streamable HTTP endpoint at `/mcp`
+
+Inbound merchant webhooks:
+
+- `POST /v1/webhooks/merchant/{merchant_id}/{source_key}`
+
+Inbound webhook sources:
+
+- `POST /v1/commerce/webhook-sources`
+- `GET /v1/commerce/webhook-sources`
+- `PATCH /v1/commerce/webhook-sources/{source_key}`
+- `POST /v1/commerce/webhook-sources/{source_key}/rotate-secret`
+
+For every route:
+
+- enforce auth and tenant boundary;
+- validate request body with structured schema;
+- return consistent error codes and error shapes;
+- write audit events for protected actions;
+- include tests for success, validation failure, unauthorized, forbidden, tenant mismatch, disabled merchant/agent, and idempotency where applicable.
+
+## Idempotency, Retries, And Reconciliation
+
+Require `Idempotency-Key` for:
+
+- `POST /v1/commerce/payments/intents`
+- `POST /v1/commerce/payments/intents/{id}/checkout-link`
+- `POST /v1/commerce/carts`
+
+Rules:
+
+- key scope is merchant, endpoint, and environment;
+- same key plus same body returns original response;
+- same key plus different body returns HTTP `409`;
+- records persist at least 24 hours;
+- idempotency conflicts are audited.
+
+Retries:
+
+- retry transient provider/network failures with bounded exponential backoff and jitter;
+- do not retry validation, auth, policy, amount-cap, consent, or tenant errors;
+- make webhook handling idempotent;
+- make background reconciliation idempotent;
+- persist retry attempts and final failure reasons;
+- never double-create provider payments from retried requests.
+
+Reconciliation:
+
+- payment intents older than 2 minutes in `payment_pending` must reconcile by provider status lookup;
+- dashboard must expose manual "reconcile now" for stuck intents;
+- reconciliation must write audit evidence.
+
+## Payment State Machine
+
+Implement explicit allowed transitions:
+
+- `created` -> `authorized`
+- `authorized` -> `checkout_created`
+- `checkout_created` -> `payment_pending`
+- `payment_pending` -> `paid`
+- `payment_pending` -> `failed`
+- `payment_pending` -> `expired`
+- `created|authorized|checkout_created|payment_pending` -> `cancelled`
+
+Reject and audit invalid transitions.
+
+AFA/OTP behavior:
+
+- hosted checkout or bank authorization keeps status as `payment_pending`;
+- successful provider webhook or reconciliation transitions to `paid`;
+- provider failure transitions to `failed`;
+- abandonment timeout transitions to `expired`;
+- live V1 payment requires final user confirmation;
+- autonomous delegated payment is not allowed in V1.
+
+## Webhook Requirements
+
+Plural webhook:
+
+- verify signature;
+- reject replay;
+- store raw payload or safe hashed/reference form according to data policy;
+- idempotently process provider event ID;
+- update payment state only through allowed transitions;
+- audit received, signature failure, status update, and ignored duplicate.
+
+Merchant inbound webhook:
+
+- support only `catalog.product.updated` in V1;
+- require merchant/source-specific secret;
+- require event ID, event type, occurred-at timestamp, source key, and payload version;
+- reject unsigned events;
+- reject timestamps outside replay window, default 5 minutes;
+- idempotently process repeated event IDs;
+- store failed events for dashboard visibility and manual replay;
+- return explicit `unsupported_event_type` for all other event types.
+
+Outbound Grantex webhooks are not V1. Agents poll `payment.get_status`; merchants use dashboard or `GET /v1/commerce/payments/intents/{id}`.
+
+## MCP And Protocol Publishing
+
+Publish:
+
+- `GET /.well-known/grantex-commerce`
+- MCP streamable HTTP endpoint at `/mcp`
+
+MCP tools:
+
+- `merchant.get_profile`
+- `catalog.search`
+- `catalog.get_item`
+- `inventory.check`
+- `cart.create`
+- `checkout.create`
+- `payment.create_intent`
+- `payment.get_status`
+
+Rules:
+
+- well-known profile must list supported tools, auth requirements, scopes, environment, merchant identity, and MCP transport URL;
+- use current MCP streamable HTTP transport;
+- SSE is not supported in V1;
+- protect tool calls with agent auth and passport checks as required;
+- implement a demo MCP client in Grantex playground;
+- do not claim full UCP/ACP/AP2/MPP/A2A certification.
+
+## Merchant Dashboard UI/UX
+
+Build usable operator workflows, not placeholder pages.
+
+Routes:
+
+- `/dashboard/commerce/onboarding`
+- `/dashboard/commerce/passports`
+- `/dashboard/commerce/payments`
+- `/dashboard/commerce/audit`
+- `/dashboard/commerce/settings`
+- `/dashboard/commerce/playground`
+
+Required dashboard capabilities:
+
+- create merchant;
+- select electronics category preset;
+- configure Plural sandbox credentials;
+- validate provider credentials;
+- configure webhook sources and rotate source secrets;
+- add product manually;
+- upload product CSV;
+- view product variants, tax, GST/HSN, availability, warranty, return summary;
+- configure amount cap and emergency disable;
+- view passports and revocation state;
+- view payment attempts and status timeline;
+- trigger manual reconciliation for stuck payment intents;
+- view audit timeline;
+- run sandbox agent/MCP demo.
+
+UI quality bar:
+
+- responsive desktop and mobile layouts;
+- accessible forms, labels, focus states, keyboard navigation, and screen reader text;
+- clear empty, loading, error, success, disabled, and pending states;
+- no text overflow in buttons, cards, tables, or dialogs;
+- destructive actions require confirmation;
+- live/sandbox/test merchants are visibly marked;
+- provider secrets are never displayed after save;
+- validation errors identify exact fields;
+- all dashboard flows call the same APIs external integrators can call.
+
+## AgenticOrg Requirements
+
+Implement `commerce-sales-agent` with workflows for:
+
+- product discovery;
+- product Q&A from Grantex tool data;
+- cart draft creation;
+- consent request;
+- checkout/payment intent creation through Grantex tools.
+
+Agent behavior:
+
+- no checkout without consent;
+- no amount above passport cap;
+- no unsupported offer claims;
+- no guaranteed inventory when status is `unknown`;
+- no direct payment provider calls;
+- no direct provider credential handling;
+- no hallucinated EMI, discount, availability, warranty, tax, or return policy.
+
+Agent evals must prove refusals and safe behavior for denied consent, missing consent, stale inventory, disabled merchant, disabled agent, amount cap breach, unsupported offer, and payment status polling.
+
+## Observability And Operations
+
+Add structured logs, metrics, and traces for:
+
+- request ID;
+- tenant ID;
+- merchant ID;
+- agent ID;
+- passport `jti`;
+- cart ID;
+- payment intent ID;
+- provider reference ID;
+- webhook event ID;
+- policy version;
+- idempotency key hash;
+- error code.
+
+Never log secrets, raw credentials, raw card details, or sensitive authentication material.
+
+Operational hardening:
+
+- background jobs for reconciliation and webhook retry/replay;
+- dead-letter or failed-event view for webhooks;
+- stuck payment dashboard;
+- runbook notes for provider outage, webhook backlog, reconciliation failure, audit write failure, and emergency disable;
+- load test target: sustain 10 RPS on payment intent creation with p95 under 500 ms excluding provider latency.
+
+## Security, Privacy, And Regulatory Gates
+
+Implement:
+
+- encrypted storage for provider credentials;
+- secret rotation for webhook sources;
+- CSRF protection on consent approval/deny;
+- frame-busting headers on consent page;
+- Content Security Policy on consent page;
+- signed webhooks and replay defense;
+- rate limits from the V1 build spec;
+- tenant isolation tests;
+- sandbox/live separation;
+- feature flag for live Plural mode.
+
+India live mode:
+
+- no live payment without legal approval;
+- no autonomous delegated payment in V1;
+- every live payment requires final user confirmation;
+- payment-related data must be India-resident unless legal review explicitly approves otherwise;
+- document legal blockers before enabling live mode.
+
+## Required Tests
+
+Add or update tests for:
+
+- passport issue, verify, revoke;
+- CommerceAgent registration and disabled-agent behavior;
+- CommerceAgent trust-status updates;
+- agent authentication;
+- expired passport;
+- revoked passport;
+- not-before passport;
+- passport version;
+- JWT `alg=none`, algorithm downgrade, missing `kid`, unknown `kid`, and `kid` confusion rejection;
+- JWKS endpoint availability and key rotation;
+- amount cap;
+- merchant mismatch;
+- cross-tenant passport rejection;
+- emergency disable;
+- idempotency;
+- idempotency outside-retention-window behavior;
+- rate limits;
+- trusted-proxy/forwarded-IP rate-limit behavior;
+- provider credential validation;
+- provider credential encryption and plaintext-not-in-logs;
+- webhook source secret rotation;
+- payment state machine;
+- AFA/OTP abandonment timeout;
+- payment reconciliation polling;
+- mock payment provider;
+- Plural sandbox adapter or mocked Plural contract;
+- Plural webhook signature and replay;
+- inbound merchant webhook signature and replay;
+- inbound merchant webhook schema validation;
+- unsupported inbound event type;
+- audit write;
+- audit table update/delete permission denial;
+- multi-tenant isolation;
+- product variants;
+- stale-price-blocks-checkout behavior;
+- tenant ID presence for all tenant-owned entities;
+- GST/tax-inclusive amounts;
+- mass-assignment on PATCH endpoints;
+- CSRF protection for consent approval/deny;
+- clickjacking/frame-header protection for consent UI;
+- Sales Agent evals;
+- end-to-end agent -> consent -> checkout -> webhook -> audit.
+
+No route is complete without tests for auth, tenant boundary, validation failure, and happy path.
+
+Testing discipline:
+
+- Run the smallest relevant test while implementing each slice.
+- Run the full affected backend test suite before sign-off.
+- Run the full affected frontend test suite before sign-off.
+- Run lint/typecheck/build commands used by the repo before sign-off.
+- For UI changes, verify responsive behavior, empty/loading/error/success states, and form validation.
+- For payment/webhook changes, include deterministic replay, duplicate, invalid signature, stale timestamp, and invalid transition tests.
+- For tenant isolation, include cross-tenant negative tests, not only same-tenant happy path.
+- For release sign-off, produce a command log summary with pass/fail status and unresolved failures.
+
+Do not ignore failing tests. Fix them or clearly identify them as unrelated pre-existing failures with evidence.
+
+## Release Gate
+
+Do not call the work done unless all are true:
+
+- OpenAPI 3.1 V1 contract exists and matches implementation;
+- merchant can onboard in sandbox;
+- merchant can configure and validate Plural sandbox credentials;
+- provider credential storage is encrypted and raw credentials are not logged or displayed after save;
+- products and variants can be added by dashboard, CSV, API, and complete-state inbound webhook;
+- product price supports tax-inclusive totals and GST/HSN metadata;
+- CommerceAgent is registered and used in passport issuance;
+- agent API calls authenticate as registered `CommerceAgent`;
+- agent can discover product via MCP;
+- Commerce Passport signing uses pinned ES256 and JWKS key rotation is tested;
+- user can approve Commerce Passport;
+- agent can create checkout only with valid passport;
+- Plural sandbox checkout works or a contract-compatible mock is explicitly used while sandbox access is blocked;
+- payment pending timeout and reconciliation work;
+- webhook updates payment status;
+- audit timeline proves every step;
+- audit table is database-level append-only;
+- revocation blocks new protected actions;
+- emergency disable blocks new protected actions immediately;
+- Sales Agent passes evals;
+- demo MCP client works in playground;
+- first pilot merchant is named or internal test merchant is explicitly approved;
+- legal blocker list is documented before live mode.
+
+V1 is not ready if:
+
+- checkout works without consent;
+- payment intent works without audit;
+- provider code is hardcoded to Plural in core models;
+- user revocation does not block protected actions;
+- merchant emergency disable is delayed by cache TTL;
+- dashboard-only flows exist without APIs;
+- AgenticOrg calls payment provider directly;
+- passport can be issued for an unknown or disabled agent;
+- protected agent API calls work without agent authentication;
+- same idempotency key with different body does not return `409`;
+- audit rows can be updated or deleted by the application database role;
+- tenant-owned records can be created without `tenant_id`;
+- unsigned inbound merchant webhooks are accepted;
+- live payment-related data is hosted outside India without legal approval.
+
+## Implementation Review Pass
+
+Before final answer or handoff, perform a self-review in this order:
+
+1. Re-read the V1 build spec sign-off and not-ready sections.
+2. Compare implemented files against the traceability matrix.
+3. Search the codebase for TODO, FIXME, placeholder, mock-only, hardcoded tenant, hardcoded merchant, hardcoded Plural, missing tenant filters, and unsafe logging in touched modules.
+4. Inspect every new route for auth, tenant scoping, validation, rate limiting where required, and error shape consistency.
+5. Inspect every payment-affecting flow for passport verification, policy evaluation, revocation check, idempotency, state-machine enforcement, and audit event.
+6. Inspect every webhook for signature verification, replay defense, idempotency, error persistence, and audit event.
+7. Inspect every merchant dashboard workflow for API equivalence.
+8. Confirm no AgenticOrg code handles payment provider credentials or calls Plural directly.
+9. Confirm tests cover negative cases, not only the happy path.
+10. Confirm live mode remains feature-flagged and legal blockers are documented.
+
+If any item fails, do not claim completion. Continue fixing or mark the exact blocker.
+
+## Human Review Gates
+
+Require explicit human review before merge for these high-risk areas:
+
+- first commerce schema migration, especially tenant ownership, foreign keys, indexes, uniqueness, and append-only audit permissions;
+- JWT/JWKS verification code, especially ES256 pinning, `kid` handling, clock skew, revocation checks, and rejection of `alg=none` or algorithm-confusion attacks;
+- consent screen security, especially CSP, `X-Frame-Options`, CSRF model, single-use approval/deny, and absence of unsafe inline script/style unless the existing framework has a reviewed nonce pattern;
+- webhook signature verification, especially raw-body handling, replay window, event idempotency, and timing-safe signature comparison;
+- Plural adapter after Pine/Plural confirms the real API and webhook signature scheme.
+
+Do not self-approve these gates. If human review is unavailable, mark the release gate as blocked and explain the risk.
+
+## Handoff Evidence Pack
+
+Final handoff must include:
+
+- requirements completed;
+- requirements not applicable to this repo;
+- requirements blocked and why;
+- files changed;
+- migrations added;
+- API endpoints implemented;
+- MCP tools implemented;
+- webhooks implemented;
+- dashboard routes implemented;
+- tests added;
+- commands run and results;
+- known external dependencies;
+- release gate pass/fail table.
+
+Do not give a vague "implemented successfully" response without evidence.
+
+## Final Implementation Discipline
+
+When uncertain:
+
+- prefer the V1 build spec over the master PRD;
+- prefer codebase patterns over new abstractions;
+- prefer explicit feature flags over hidden behavior;
+- prefer provider-neutral interfaces over Plural coupling;
+- prefer failing closed over permissive commerce actions;
+- prefer auditability over convenience;
+- prefer complete negative tests over optimistic happy-path demos.
+
+Before final response, report:
+
+- files changed;
+- migrations added;
+- APIs implemented;
+- UI routes implemented;
+- tests run and results;
+- known blockers;
+- release gate status.


### PR DESCRIPTION
- Adds Grantex Commerce V1 M1 foundations.
- Includes V1 spec, PRD, and Claude implementation skill.
- Adds commerce feature flags.
- Adds commerce tenant model and developer-to-tenant mapping.
- Adds merchant, agent, product, variant, category preset, and audit schemas.
- Adds tenant-safe composite foreign keys.
- Adds append-only audit enforcement.
- Adds M1 commerce APIs and standard commerce error envelope.
- Adds OpenAPI 3.1 contract.
- Adds 75 commerce tests.
- Real Postgres 16 migration validation completed.

## Verification

- `npx vitest run tests/commerce --reporter=dot`
- `npm run typecheck`
- `npm run build`
- Full test suite previously passed with one unrelated dynamic-import flake that passed on rerun.

## Not included in M1

- Commerce Passport / consent / JWKS
- policy engine
- cart/payment/Plural integration
- MCP tools
- AgenticOrg workflows
- POS bridge

## Known follow-ups

- M2 explicit tenant provisioning endpoints:
  - `POST /v1/commerce/tenants`
  - `POST /v1/commerce/developer-tenants`
- M2 dashboard/operator auth decision
- M2 consent host/DNS decision
- deploy hardening for separate `grantex_app` DB role
- M4 Plural API and webhook signature confirmation
- first pilot merchant before M4