### PR TITLE
feat(commerce): add Grantex Commerce V1 Milestone 2 passports and consent

### DIFF
--- a/apps/auth-service/src/db/migrations/037_commerce_tenant_operators.sql
+++ b/apps/auth-service/src/db/migrations/037_commerce_tenant_operators.sql
@@ -1,0 +1,31 @@
+-- Grantex Commerce V1 — Milestone 2: tenant operator model.
+-- Decision C (hybrid):
+--   1. Platform/admin key (ADMIN_API_KEY) can create commerce tenants.
+--   2. commerce_tenant_operators.role='owner' can manage/bind developers
+--      only within tenants they own.
+--   3. A tenant owner cannot create arbitrary new unrelated tenants
+--      unless they ALSO present the admin key.
+--
+-- Backfill: any developer with a default commerce_developer_tenants
+-- mapping (created during M1, including the auto-provision sandbox path)
+-- becomes an owner of that tenant. Without this, M1 sandbox developers
+-- would lose access to their own data the moment M2 ships.
+
+CREATE TABLE IF NOT EXISTS commerce_tenant_operators (
+  developer_id  TEXT NOT NULL REFERENCES developers(id) ON DELETE CASCADE,
+  tenant_id     TEXT NOT NULL REFERENCES commerce_tenants(id) ON DELETE CASCADE,
+  role          TEXT NOT NULL DEFAULT 'owner',
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (developer_id, tenant_id),
+  CONSTRAINT chk_commerce_tenant_operators_role
+    CHECK (role IN ('owner','operator'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_commerce_tenant_operators_tenant
+  ON commerce_tenant_operators(tenant_id);
+
+INSERT INTO commerce_tenant_operators (developer_id, tenant_id, role)
+SELECT developer_id, tenant_id, 'owner'
+  FROM commerce_developer_tenants
+  WHERE is_default = TRUE
+ON CONFLICT (developer_id, tenant_id) DO NOTHING;

--- a/apps/auth-service/src/db/migrations/038_commerce_merchant_api_keys.sql
+++ b/apps/auth-service/src/db/migrations/038_commerce_merchant_api_keys.sql
@@ -1,0 +1,34 @@
+-- Grantex Commerce V1 — Milestone 2: merchant server-to-server API keys.
+-- Spec §6: `Authorization: Bearer grtx_sk_<environment>_<secret>` keys
+-- store only the salted hash. Resolve (tenant_id, merchant_id) from the
+-- key record; never trust caller-supplied tenant/merchant for this caller
+-- type.
+--
+-- M2 ships the schema and the auth resolver. Operator endpoints to
+-- create/rotate keys are deferred to M3 (will surface POST
+-- /v1/commerce/merchants/{id}/api-keys); for M2, keys are seeded via
+-- direct SQL during deploy provisioning or via test fixtures.
+
+CREATE TABLE IF NOT EXISTS commerce_merchant_api_keys (
+  id            TEXT PRIMARY KEY,                                       -- mkey_<ulid>
+  tenant_id     TEXT NOT NULL REFERENCES commerce_tenants(id),
+  merchant_id   TEXT NOT NULL,
+  environment   TEXT NOT NULL,                                          -- sandbox | live
+  key_hash      TEXT NOT NULL,                                          -- sha256 of grtx_sk_<env>_<secret>
+  display_name  TEXT,
+  created_by    TEXT,                                                   -- developer_id of the operator who created it
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_used_at  TIMESTAMPTZ,
+  revoked_at    TIMESTAMPTZ,
+  CONSTRAINT chk_merchant_api_key_env CHECK (environment IN ('sandbox','live')),
+  CONSTRAINT fk_merchant_api_key_merchant
+    FOREIGN KEY (tenant_id, merchant_id)
+    REFERENCES commerce_merchants(tenant_id, id)
+);
+
+-- Lookup by hash; only active (non-revoked) keys must be unique on hash —
+-- a revoked key's hash can be left in place for forensic linkage.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_merchant_api_keys_hash
+  ON commerce_merchant_api_keys(key_hash) WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_commerce_merchant_api_keys_merchant
+  ON commerce_merchant_api_keys(tenant_id, merchant_id);

--- a/apps/auth-service/src/db/migrations/039_commerce_passport_keys.sql
+++ b/apps/auth-service/src/db/migrations/039_commerce_passport_keys.sql
@@ -1,0 +1,36 @@
+-- Grantex Commerce V1 — Milestone 2: ES256 passport key store.
+-- Decision D: DB-backed; private JWK encrypted with the existing vault
+-- encryption key (lib/vault-crypto.ts AES-256-GCM, base64-stored).
+-- Production must refuse silent auto-generation on restart;
+-- COMMERCE_AUTO_GENERATE_PASSPORT_KEY=true gates the dev/test path
+-- (see lib/commerce/passport-keys.ts).
+--
+-- kid format `commerce-passport-YYYYMMDD-XXXXXXXX` (spec §6) — namespace
+-- enforced at the constraint level so an unknown-namespace kid can never
+-- enter via the backing store, only via attacker-supplied JWT headers
+-- (which the verifier rejects on lookup miss).
+
+CREATE TABLE IF NOT EXISTS commerce_passport_keys (
+  kid                       TEXT PRIMARY KEY,
+  algorithm                 TEXT NOT NULL,                              -- ES256 only in V1
+  public_key_jwk            JSONB NOT NULL,
+  encrypted_private_key_jwk TEXT NOT NULL,                              -- AES-256-GCM via vault-crypto.encrypt()
+  status                    TEXT NOT NULL DEFAULT 'active',             -- active | retired | compromised
+  created_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  retired_at                TIMESTAMPTZ,
+  last_used_at              TIMESTAMPTZ,
+  CONSTRAINT chk_commerce_passport_keys_kid_format
+    CHECK (kid ~ '^commerce-passport-[0-9]{8}-[a-z0-9]{8}$'),
+  CONSTRAINT chk_commerce_passport_keys_algorithm
+    CHECK (algorithm = 'ES256'),
+  CONSTRAINT chk_commerce_passport_keys_status
+    CHECK (status IN ('active','retired','compromised'))
+);
+
+-- Exactly one active key at a time. Retired keys remain queryable for
+-- JWKS publication during the rotation grace window (spec §6).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_passport_keys_active
+  ON commerce_passport_keys(status) WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_commerce_passport_keys_status
+  ON commerce_passport_keys(status);

--- a/apps/auth-service/src/db/migrations/040_commerce_consent_records.sql
+++ b/apps/auth-service/src/db/migrations/040_commerce_consent_records.sql
@@ -1,0 +1,67 @@
+-- Grantex Commerce V1 — Milestone 2: consent records.
+-- Spec §15 + §14. Single-use enforced in app via SELECT...FOR UPDATE on
+-- the status field; presented_payload_hash captured at first GET so the
+-- exchange step can verify the user saw the same payload that gets
+-- bound into the passport.
+--
+-- expires_at default 10 minutes from creation (spec §14 consent TTL).
+-- chk_consent_expires_required guarantees no consent can outlive its
+-- declared window.
+
+CREATE TABLE IF NOT EXISTS commerce_consent_records (
+  id                      TEXT PRIMARY KEY,                                 -- crec_<ulid>
+  tenant_id               TEXT NOT NULL REFERENCES commerce_tenants(id),
+  merchant_id             TEXT NOT NULL,
+  agent_id                TEXT NOT NULL,
+  -- user_principal_id is set ONLY at approval time from the authenticated
+  -- principal session JWT. The agent never writes this field directly —
+  -- they may supply user_principal_hint (below) which the approve flow
+  -- enforces against the authenticated principal.
+  user_principal_id       TEXT,
+  -- Optional agent-supplied hint of which user is expected to authorize.
+  -- If set, the approve flow rejects when the authenticated principal
+  -- does not match. Prevents the "agent self-approves for any user"
+  -- attack while still letting agents pre-bind a session.
+  user_principal_hint     TEXT,
+  consent_request_id      TEXT NOT NULL UNIQUE,                             -- opaque CSPRNG, shown in URL
+  passport_type           TEXT NOT NULL,                                    -- browse | checkout
+  requested_scopes        TEXT[] NOT NULL,
+  approved_scopes         TEXT[],                                           -- nullable until granted
+  max_amount              BIGINT,
+  currency                TEXT,
+  consent_text_version    TEXT NOT NULL,
+  presented_payload_hash  TEXT,                                             -- sha256 captured at first GET
+  status                  TEXT NOT NULL DEFAULT 'requested',                -- requested | granted | denied | expired
+  agent_auth_method       TEXT,                                             -- jwt | api_key — recorded at create
+  ip_hash                 TEXT,
+  user_agent_hash         TEXT,
+  -- CSRF model (Finding 1 redesign): per-form CSRF token is HMAC-derived
+  -- from the principal session token + consent_request_id, computed at
+  -- render time and verified at POST. No per-consent secret stored in DB.
+  expires_at              TIMESTAMPTZ NOT NULL,
+  approved_at             TIMESTAMPTZ,
+  denied_at               TIMESTAMPTZ,
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_consent_status
+    CHECK (status IN ('requested','granted','denied','expired')),
+  CONSTRAINT chk_consent_passport_type
+    CHECK (passport_type IN ('browse','checkout')),
+  CONSTRAINT chk_consent_agent_auth_method
+    CHECK (agent_auth_method IN ('jwt','api_key') OR agent_auth_method IS NULL),
+  CONSTRAINT fk_consent_merchant
+    FOREIGN KEY (tenant_id, merchant_id)
+    REFERENCES commerce_merchants(tenant_id, id),
+  CONSTRAINT fk_consent_agent
+    FOREIGN KEY (tenant_id, agent_id)
+    REFERENCES commerce_agents(tenant_id, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_commerce_consent_request_id
+  ON commerce_consent_records(consent_request_id);
+CREATE INDEX IF NOT EXISTS idx_commerce_consent_tenant_status
+  ON commerce_consent_records(tenant_id, status);
+-- Pending (requested) consent records past expires_at are reaped by the
+-- consent expiry sweep (M2 ships the writer; sweep job lands in M3).
+CREATE INDEX IF NOT EXISTS idx_commerce_consent_expires_pending
+  ON commerce_consent_records(expires_at) WHERE status = 'requested';

--- a/apps/auth-service/src/db/migrations/041_commerce_passports.sql
+++ b/apps/auth-service/src/db/migrations/041_commerce_passports.sql
@@ -1,0 +1,110 @@
+-- Grantex Commerce V1 — Milestone 2: Commerce Passport storage.
+-- Spec §15. Passports are append-only (BEFORE UPDATE/DELETE trigger);
+-- revocation lives in a sibling commerce_passport_revocations table so
+-- the passport row itself stays immutable forensic evidence.
+--
+-- jti is globally unique (spec §15). FK to commerce_passport_keys(kid)
+-- pins which key signed this passport — required for the rotation grace
+-- window logic (a retired key's passports stay verifiable until they
+-- naturally expire).
+
+CREATE TABLE IF NOT EXISTS commerce_passports (
+  jti                 TEXT PRIMARY KEY,                                       -- globally unique
+  tenant_id           TEXT NOT NULL REFERENCES commerce_tenants(id),
+  merchant_id         TEXT NOT NULL,
+  agent_id            TEXT NOT NULL,
+  consent_record_id   TEXT NOT NULL UNIQUE REFERENCES commerce_consent_records(id),
+  passport_type       TEXT NOT NULL,                                          -- browse | checkout
+  kid                 TEXT NOT NULL REFERENCES commerce_passport_keys(kid),
+  subject             TEXT NOT NULL,                                          -- user_principal_id
+  scopes              TEXT[] NOT NULL,
+  max_amount          BIGINT,
+  currency            TEXT,
+  policy_version      TEXT,                                                   -- nullable; M3 lands policy
+  environment         TEXT NOT NULL,                                          -- sandbox | live
+  audience            TEXT,
+  issued_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  not_before          TIMESTAMPTZ NOT NULL,
+  expires_at          TIMESTAMPTZ NOT NULL,
+  agent_auth_method   TEXT NOT NULL,                                          -- jwt | api_key
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_passport_type CHECK (passport_type IN ('browse','checkout')),
+  CONSTRAINT chk_passport_environment CHECK (environment IN ('sandbox','live')),
+  CONSTRAINT chk_passport_agent_auth_method CHECK (agent_auth_method IN ('jwt','api_key')),
+  CONSTRAINT fk_passport_merchant
+    FOREIGN KEY (tenant_id, merchant_id)
+    REFERENCES commerce_merchants(tenant_id, id),
+  CONSTRAINT fk_passport_agent
+    FOREIGN KEY (tenant_id, agent_id)
+    REFERENCES commerce_agents(tenant_id, id)
+);
+
+-- Belt-and-braces: when an older deployment applied this migration before
+-- the UNIQUE was added inline, add the constraint via ALTER. Idempotent.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'commerce_passports_consent_record_id_key'
+       AND conrelid = 'commerce_passports'::regclass
+  ) THEN
+    BEGIN
+      ALTER TABLE commerce_passports
+        ADD CONSTRAINT commerce_passports_consent_record_id_key
+        UNIQUE (consent_record_id);
+    EXCEPTION WHEN duplicate_table OR duplicate_object THEN
+      -- Constraint exists under a different name; tolerate.
+      NULL;
+    END;
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_commerce_passports_tenant_merchant_agent_exp
+  ON commerce_passports(tenant_id, merchant_id, agent_id, expires_at);
+CREATE INDEX IF NOT EXISTS idx_commerce_passports_consent_record
+  ON commerce_passports(consent_record_id);
+
+-- Append-only enforcement (mirror of commerce_audit_events from M1).
+CREATE OR REPLACE FUNCTION commerce_passports_block_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'commerce_passports is append-only; % is not permitted', TG_OP
+    USING ERRCODE = 'insufficient_privilege';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS commerce_passports_no_update ON commerce_passports;
+CREATE TRIGGER commerce_passports_no_update
+  BEFORE UPDATE ON commerce_passports
+  FOR EACH ROW EXECUTE FUNCTION commerce_passports_block_mutation();
+
+DROP TRIGGER IF EXISTS commerce_passports_no_delete ON commerce_passports;
+CREATE TRIGGER commerce_passports_no_delete
+  BEFORE DELETE ON commerce_passports
+  FOR EACH ROW EXECUTE FUNCTION commerce_passports_block_mutation();
+
+CREATE TABLE IF NOT EXISTS commerce_passport_revocations (
+  jti           TEXT PRIMARY KEY REFERENCES commerce_passports(jti),
+  tenant_id     TEXT NOT NULL REFERENCES commerce_tenants(id),
+  reason        TEXT NOT NULL,                                                -- explicit | user_revoked | merchant_disabled | agent_disabled | tenant_disabled | scope_violation
+  revoked_by    TEXT,                                                         -- caller identifier (operator id / merchant key id / agent id / 'system')
+  revoked_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_commerce_passport_revocations_tenant
+  ON commerce_passport_revocations(tenant_id);
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'grantex_app') THEN
+    -- Mirror the audit append-only grant model on the passport table.
+    EXECUTE 'REVOKE UPDATE, DELETE, TRUNCATE ON commerce_passports FROM grantex_app';
+    EXECUTE 'GRANT INSERT, SELECT ON commerce_passports TO grantex_app';
+    -- Revocations are append-only at the app layer (no UPDATE path
+    -- exposed in the lib); REVOKE for defense in depth.
+    EXECUTE 'REVOKE UPDATE, DELETE, TRUNCATE ON commerce_passport_revocations FROM grantex_app';
+    EXECUTE 'GRANT INSERT, SELECT ON commerce_passport_revocations TO grantex_app';
+  END IF;
+END
+$$;

--- a/apps/auth-service/src/db/migrations/042_commerce_consent_challenges.sql
+++ b/apps/auth-service/src/db/migrations/042_commerce_consent_challenges.sql
@@ -1,0 +1,60 @@
+-- Grantex Commerce V1 — Milestone 2 (P0 fix): consent challenge.
+--
+-- Background: developer-minted principal sessions are issued by
+-- POST /v1/principal-sessions and authenticate the developer's view of
+-- "who the user is". A trusted agent / its developer can therefore mint
+-- a session for any of their principals (anyone with an active grant)
+-- and bypass user consent end-to-end:
+--   1. Agent creates a consent request.
+--   2. Developer mints a principal session JWT for the hinted principal.
+--   3. Agent uses ?session= bootstrap, the cookie is set.
+--   4. Agent computes csrf = sha256(session_token + ':' + reqId).
+--   5. Agent POSTs approve.  No human is in the loop.
+--
+-- This table records a SECOND, server-issued, single-use credential —
+-- the "consent challenge" — which the agent/developer cannot read,
+-- mint, or compute. Approve/deny require a verified challenge for the
+-- same (consent_request_id, principal_id) pair, consumed atomically
+-- with the status transition.
+--
+-- Code is never stored in plaintext. challenge_hash is sha256(code +
+-- ':' + consent_request_id + ':' + principal_id) — domain-separated so
+-- a hash leak from one consent cannot be replayed against another.
+
+CREATE TABLE IF NOT EXISTS commerce_consent_challenges (
+  id                    TEXT PRIMARY KEY,                                       -- ccch_<ulid>
+  tenant_id             TEXT NOT NULL REFERENCES commerce_tenants(id),
+  consent_record_id     TEXT NOT NULL REFERENCES commerce_consent_records(id),
+  consent_request_id    TEXT NOT NULL,
+  principal_id          TEXT NOT NULL,
+  developer_id          TEXT NOT NULL,                                          -- the developer of the session that requested the challenge
+  challenge_hash        TEXT NOT NULL,                                          -- sha256(code:reqId:principalId)
+  delivery_channel      TEXT NOT NULL,                                          -- test_sink | email_otp
+  status                TEXT NOT NULL DEFAULT 'requested',                      -- requested | verified | used | expired
+  attempts_count        INTEGER NOT NULL DEFAULT 0,
+  max_attempts          INTEGER NOT NULL DEFAULT 5,
+  expires_at            TIMESTAMPTZ NOT NULL,
+  verified_at           TIMESTAMPTZ,
+  used_at               TIMESTAMPTZ,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_consent_challenge_status
+    CHECK (status IN ('requested','verified','used','expired')),
+  CONSTRAINT chk_consent_challenge_delivery
+    CHECK (delivery_channel IN ('test_sink','email_otp'))
+);
+
+-- Only ONE active (requested|verified) challenge per consent_request_id +
+-- principal_id at a time. Forces explicit rotation; prevents an agent
+-- from spamming many parallel challenges to brute-force codes.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_consent_challenges_active
+  ON commerce_consent_challenges(consent_request_id, principal_id)
+  WHERE status IN ('requested','verified');
+
+CREATE INDEX IF NOT EXISTS idx_commerce_consent_challenges_request
+  ON commerce_consent_challenges(consent_request_id);
+CREATE INDEX IF NOT EXISTS idx_commerce_consent_challenges_expires
+  ON commerce_consent_challenges(expires_at)
+  WHERE status IN ('requested','verified');
+CREATE INDEX IF NOT EXISTS idx_commerce_consent_challenges_consent_record
+  ON commerce_consent_challenges(consent_record_id);

--- a/apps/auth-service/src/lib/commerce/agent-auth.ts
+++ b/apps/auth-service/src/lib/commerce/agent-auth.ts
@@ -1,0 +1,282 @@
+import {
+  jwtVerify,
+  decodeProtectedHeader,
+  decodeJwt,
+  importJWK,
+  type KeyLike,
+  type JWTPayload,
+} from 'jose';
+import type postgres from 'postgres';
+import type { Redis } from 'ioredis';
+import type { JWK } from 'jose';
+import { sha256hex } from '../hash.js';
+
+type Sql = ReturnType<typeof postgres>;
+
+const AGENT_API_KEY_PREFIX = 'grtx_agent_';
+const ASSERTION_AUDIENCE = 'grantex-commerce';
+const ASSERTION_MAX_LIFETIME_SECONDS = 5 * 60;
+const ASSERTION_CLOCK_SKEW_SECONDS = 30;
+const REDIS_REPLAY_KEY_PREFIX = 'commerce:agent_assertion:jti:';
+
+export function looksLikeAgentApiKey(token: string): boolean {
+  return token.startsWith(AGENT_API_KEY_PREFIX);
+}
+
+export function looksLikeJwt(token: string): boolean {
+  // Three URL-safe-base64 segments separated by dots; we don't parse here.
+  return /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(token);
+}
+
+export interface ResolvedAgentCaller {
+  agentId: string;
+  tenantId: string;
+  authMethod: 'jwt' | 'api_key';
+  trustStatus: 'trusted';
+  /** Present when the assertion JWT carried a session_id claim. */
+  sessionId?: string;
+}
+
+export type AgentResolutionFailure =
+  | { kind: 'unknown_credential' }
+  | { kind: 'unknown_agent' }
+  | { kind: 'agent_not_trusted'; trustStatus: 'pending' | 'suspended' | 'disabled' }
+  | { kind: 'tenant_disabled' }
+  | { kind: 'assertion_malformed'; reason: string }
+  | { kind: 'assertion_kid_mismatch' }
+  | { kind: 'assertion_signature_invalid'; reason: string }
+  | { kind: 'assertion_expired' }
+  | { kind: 'assertion_too_long_lived'; lifetimeSeconds: number }
+  | { kind: 'assertion_wrong_audience'; aud: unknown }
+  | { kind: 'assertion_missing_claims'; fields: string[] }
+  | { kind: 'assertion_replay' }
+  | { kind: 'replay_check_unavailable'; error: string };
+
+export type AgentAuthResult =
+  | { ok: true; resolved: ResolvedAgentCaller }
+  | { ok: false; failure: AgentResolutionFailure };
+
+interface AgentRow {
+  id: string;
+  tenant_id: string;
+  trust_status: string;
+  public_key_jwk: Record<string, unknown> | null;
+  api_key_hash: string | null;
+  tenant_status: string;
+}
+
+async function loadAgentByApiKeyHash(sql: Sql, hash: string): Promise<AgentRow | null> {
+  const rows = await sql<AgentRow[]>`
+    SELECT a.id, a.tenant_id, a.trust_status, a.public_key_jwk, a.api_key_hash,
+           t.status AS tenant_status
+      FROM commerce_agents a
+      JOIN commerce_tenants t ON t.id = a.tenant_id
+     WHERE a.api_key_hash = ${hash}
+       AND a.disabled_at IS NULL
+     LIMIT 1
+  `;
+  return rows[0] ?? null;
+}
+
+async function loadAgentById(sql: Sql, agentId: string): Promise<AgentRow | null> {
+  const rows = await sql<AgentRow[]>`
+    SELECT a.id, a.tenant_id, a.trust_status, a.public_key_jwk, a.api_key_hash,
+           t.status AS tenant_status
+      FROM commerce_agents a
+      JOIN commerce_tenants t ON t.id = a.tenant_id
+     WHERE a.id = ${agentId}
+       AND a.disabled_at IS NULL
+     LIMIT 1
+  `;
+  return rows[0] ?? null;
+}
+
+/**
+ * Combined trust + tenant-active gate. Trust check runs first (an agent
+ * in a disabled tenant is also untrusted-by-effect, but we surface the
+ * more specific reason). tenant_disabled returned when trust passes but
+ * the agent's tenant is no longer active (Finding 3).
+ */
+function trustGate(row: AgentRow): AgentResolutionFailure | null {
+  if (row.trust_status !== 'trusted') {
+    return {
+      kind: 'agent_not_trusted',
+      trustStatus: row.trust_status as 'pending' | 'suspended' | 'disabled',
+    };
+  }
+  if (row.tenant_status === 'disabled') {
+    return { kind: 'tenant_disabled' };
+  }
+  return null;
+}
+
+/**
+ * API-key path. Looks up the agent by sha256(token) and applies the
+ * trust gate.
+ */
+export async function resolveAgentByApiKey(sql: Sql, token: string): Promise<AgentAuthResult> {
+  if (!looksLikeAgentApiKey(token)) return { ok: false, failure: { kind: 'unknown_credential' } };
+  const row = await loadAgentByApiKeyHash(sql, sha256hex(token));
+  if (!row) return { ok: false, failure: { kind: 'unknown_agent' } };
+  const trust = trustGate(row);
+  if (trust) return { ok: false, failure: trust };
+  return {
+    ok: true,
+    resolved: {
+      agentId: row.id,
+      tenantId: row.tenant_id,
+      authMethod: 'api_key',
+      trustStatus: 'trusted',
+    },
+  };
+}
+
+/**
+ * JWT assertion path.
+ *
+ * Spec §6: assertion must include `iss=agent_id`, `sub=agent_id`,
+ * `aud=grantex-commerce`, `tenant_id`, `iat`, `exp`, `jti`. Lifetime
+ * capped at 5 minutes. Replay jti tracked in Redis with TTL = lifetime.
+ *
+ * Decision E: Redis unavailable → replay_check_unavailable (caller
+ * should return 503 assertion_replay_check_unavailable, NOT 401, since
+ * this is auth infrastructure unavailable rather than bad credentials).
+ */
+export async function verifyAgentAssertion(
+  sql: Sql,
+  redis: Redis | null,
+  token: string,
+): Promise<AgentAuthResult> {
+  if (!looksLikeJwt(token)) return { ok: false, failure: { kind: 'unknown_credential' } };
+
+  let header: ReturnType<typeof decodeProtectedHeader>;
+  let unverifiedPayload: JWTPayload;
+  try {
+    header = decodeProtectedHeader(token);
+    unverifiedPayload = decodeJwt(token);
+  } catch (err) {
+    return {
+      ok: false,
+      failure: { kind: 'assertion_malformed', reason: err instanceof Error ? err.message : 'decode failed' },
+    };
+  }
+
+  // alg must be a public-key JOSE alg (ES256 or EdDSA preferred). We
+  // explicitly reject HS* and 'none'. The verifier below uses 'algorithms'
+  // for defense in depth but checking here lets us return a precise error.
+  const ALLOWED_AGENT_ALGS = new Set(['ES256', 'ES384', 'EdDSA', 'RS256', 'PS256']);
+  if (!header.alg || !ALLOWED_AGENT_ALGS.has(String(header.alg))) {
+    return {
+      ok: false,
+      failure: { kind: 'assertion_signature_invalid', reason: `algorithm ${header.alg} not allowed` },
+    };
+  }
+
+  const issAgentId = unverifiedPayload.iss;
+  if (typeof issAgentId !== 'string') {
+    return { ok: false, failure: { kind: 'assertion_missing_claims', fields: ['iss'] } };
+  }
+  const agent = await loadAgentById(sql, issAgentId);
+  if (!agent) return { ok: false, failure: { kind: 'unknown_agent' } };
+  if (!agent.public_key_jwk) {
+    return { ok: false, failure: { kind: 'assertion_signature_invalid', reason: 'agent has no public_key_jwk' } };
+  }
+  const trust = trustGate(agent);
+  if (trust) return { ok: false, failure: trust };
+
+  // Verify signature with the algorithm we accepted from the header
+  // (after allowlist filter above).
+  let publicKey: KeyLike;
+  try {
+    publicKey = await importJWK(agent.public_key_jwk as unknown as JWK, String(header.alg)) as KeyLike;
+  } catch (err) {
+    return {
+      ok: false,
+      failure: { kind: 'assertion_signature_invalid', reason: err instanceof Error ? err.message : 'jwk import failed' },
+    };
+  }
+
+  let payload: JWTPayload;
+  try {
+    const verified = await jwtVerify(token, publicKey, {
+      audience: ASSERTION_AUDIENCE,
+      algorithms: [String(header.alg)],
+      clockTolerance: ASSERTION_CLOCK_SKEW_SECONDS,
+    });
+    payload = verified.payload;
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === 'ERR_JWT_EXPIRED') return { ok: false, failure: { kind: 'assertion_expired' } };
+    if (code === 'ERR_JWT_CLAIM_VALIDATION_FAILED') {
+      const claim = (err as { claim?: string }).claim;
+      if (claim === 'aud') return { ok: false, failure: { kind: 'assertion_wrong_audience', aud: unverifiedPayload.aud } };
+    }
+    return {
+      ok: false,
+      failure: { kind: 'assertion_signature_invalid', reason: err instanceof Error ? err.message : 'verify failed' },
+    };
+  }
+
+  // Required claims present?
+  const missing: string[] = [];
+  for (const f of ['sub', 'jti', 'iat', 'exp', 'tenant_id']) {
+    if (payload[f] === undefined || payload[f] === null) missing.push(f);
+  }
+  if (missing.length) return { ok: false, failure: { kind: 'assertion_missing_claims', fields: missing } };
+
+  if (payload.sub !== issAgentId) {
+    return { ok: false, failure: { kind: 'assertion_signature_invalid', reason: 'sub != iss' } };
+  }
+  if (String(payload['tenant_id']) !== agent.tenant_id) {
+    return { ok: false, failure: { kind: 'assertion_signature_invalid', reason: 'tenant_id mismatch with registered agent' } };
+  }
+  const lifetime = (payload.exp as number) - (payload.iat as number);
+  if (lifetime > ASSERTION_MAX_LIFETIME_SECONDS) {
+    return { ok: false, failure: { kind: 'assertion_too_long_lived', lifetimeSeconds: lifetime } };
+  }
+
+  const jti = String(payload.jti);
+
+  // Replay protection. Use Redis SET key with NX + EX so first writer
+  // wins. If Redis unavailable, fail closed (caller surfaces 503).
+  if (redis) {
+    try {
+      const setKey = `${REDIS_REPLAY_KEY_PREFIX}${jti}`;
+      const ttl = Math.max(1, ASSERTION_MAX_LIFETIME_SECONDS);
+      // ioredis SET with options: ['EX', ttl, 'NX']
+      const result = await redis.set(setKey, '1', 'EX', ttl, 'NX');
+      if (result !== 'OK') {
+        return { ok: false, failure: { kind: 'assertion_replay' } };
+      }
+    } catch (err) {
+      return {
+        ok: false,
+        failure: { kind: 'replay_check_unavailable', error: err instanceof Error ? err.message : 'redis unavailable' },
+      };
+    }
+  } else {
+    return {
+      ok: false,
+      failure: { kind: 'replay_check_unavailable', error: 'redis client not initialized' },
+    };
+  }
+
+  const sessionId = typeof payload['session_id'] === 'string' ? (payload['session_id'] as string) : undefined;
+
+  return {
+    ok: true,
+    resolved: {
+      agentId: agent.id,
+      tenantId: agent.tenant_id,
+      authMethod: 'jwt',
+      trustStatus: 'trusted',
+      ...(sessionId ? { sessionId } : {}),
+    },
+  };
+}
+
+export const _internal = {
+  ASSERTION_MAX_LIFETIME_SECONDS,
+  ASSERTION_AUDIENCE,
+  REDIS_REPLAY_KEY_PREFIX,
+};

--- a/apps/auth-service/src/lib/commerce/audit.ts
+++ b/apps/auth-service/src/lib/commerce/audit.ts
@@ -22,10 +22,17 @@ export type CommerceAuditEventType =
   | 'consent.requested'
   | 'consent.granted'
   | 'consent.denied'
+  | 'consent.expired'
+  | 'consent.challenge.requested'
+  | 'consent.challenge.verified'
+  | 'consent.challenge.failed'
+  | 'consent.challenge.expired'
+  | 'consent.challenge.used'
   | 'passport.issued'
   | 'passport.verified'
   | 'passport.revoked'
   | 'passport.expired'
+  | 'passport.verification_failed'
   | 'policy.evaluated'
   | 'cart.created'
   | 'payment_intent.created'
@@ -40,7 +47,14 @@ export type CommerceAuditEventType =
   | 'idempotency.conflict'
   | 'rate_limit.exceeded'
   | 'meter.passport_issued'
-  | 'meter.payment_intent_created';
+  | 'meter.payment_intent_created'
+  // M2 — tenant operator + provisioning lifecycle
+  | 'tenant.created'
+  | 'tenant.updated'
+  | 'tenant.disabled'
+  | 'developer_tenant.bound'
+  | 'developer_tenant.unbound'
+  | 'commerce_passport_key.rotated';
 
 export interface AppendCommerceAuditInput {
   tenantId: string;

--- a/apps/auth-service/src/lib/commerce/caller.ts
+++ b/apps/auth-service/src/lib/commerce/caller.ts
@@ -1,0 +1,234 @@
+import type postgres from 'postgres';
+import type { FastifyRequest } from 'fastify';
+import type { Redis } from 'ioredis';
+import { hashApiKey } from '../hash.js';
+import { resolveMerchantApiKey, looksLikeMerchantApiKey } from './merchant-auth.js';
+import {
+  resolveAgentByApiKey,
+  verifyAgentAssertion,
+  looksLikeAgentApiKey,
+  looksLikeJwt,
+} from './agent-auth.js';
+
+type Sql = ReturnType<typeof postgres>;
+
+export type CommerceCaller =
+  | {
+      kind: 'operator';
+      developerId: string;
+      developerName: string;
+      tenantId: string;
+      /** null when no developer→tenant mapping exists (then tenantId === ''). */
+      tenantStatus: 'active' | 'disabled' | null;
+      isOwnerOfTenant: boolean;
+      isPlatformAdmin: boolean;
+    }
+  | {
+      kind: 'merchant';
+      apiKeyId: string;
+      tenantId: string;
+      merchantId: string;
+      environment: 'sandbox' | 'live';
+    }
+  | {
+      kind: 'agent';
+      agentId: string;
+      tenantId: string;
+      authMethod: 'jwt' | 'api_key';
+      sessionId?: string;
+    }
+  | {
+      kind: 'service';
+      serviceId: string;
+      tenantId: string;
+      scopes: string[];
+    };
+
+export type CallerResolutionFailure =
+  | { status: 401; code: 'missing_authorization'; message: string }
+  | { status: 401; code: 'unknown_credential_format'; message: string }
+  | { status: 401; code: 'invalid_developer_key'; message: string }
+  | { status: 401; code: 'invalid_merchant_key'; message: string }
+  | { status: 401; code: 'invalid_agent_credential'; message: string; details?: Record<string, unknown> }
+  | { status: 401; code: 'agent_assertion_replay'; message: string }
+  | { status: 403; code: 'agent_not_trusted'; message: string; details?: Record<string, unknown> }
+  | { status: 403; code: 'tenant_disabled'; message: string }
+  | { status: 503; code: 'assertion_replay_check_unavailable'; message: string };
+
+export type CallerResolution =
+  | { ok: true; caller: CommerceCaller }
+  | { ok: false; failure: CallerResolutionFailure };
+
+interface DeveloperRow {
+  id: string;
+  name: string;
+  mode: string;
+}
+
+function extractBearer(request: FastifyRequest): string | null {
+  const header = request.headers['authorization'];
+  if (typeof header !== 'string' || !header.startsWith('Bearer ')) return null;
+  const token = header.slice(7).trim();
+  if (!token || token.length < 16 || token.length > 4096) return null;
+  return token;
+}
+
+async function loadDeveloperByApiKey(sql: Sql, token: string): Promise<DeveloperRow | null> {
+  const keyHash = hashApiKey(token);
+  const rows = await sql<DeveloperRow[]>`
+    SELECT id, name, mode FROM developers WHERE api_key_hash = ${keyHash} LIMIT 1
+  `;
+  return rows[0] ?? null;
+}
+
+/**
+ * Single JOIN that resolves the operator's default tenant + tenant
+ * status + role. Returns null when no developer→tenant mapping exists
+ * (caller decides auto-provision vs 422). Returns status='disabled' so
+ * the route preHandler can 403 without an extra round-trip.
+ */
+async function loadOperatorContext(
+  sql: Sql,
+  developerId: string,
+): Promise<{ tenantId: string; tenantStatus: 'active' | 'disabled'; isOwner: boolean } | null> {
+  const rows = await sql<Array<{ tenant_id: string; status: string; role: string | null }>>`
+    SELECT dt.tenant_id, t.status, op.role
+      FROM commerce_developer_tenants dt
+      JOIN commerce_tenants t ON t.id = dt.tenant_id
+      LEFT JOIN commerce_tenant_operators op
+             ON op.developer_id = dt.developer_id AND op.tenant_id = dt.tenant_id
+     WHERE dt.developer_id = ${developerId}
+       AND dt.is_default = TRUE
+     LIMIT 1
+  `;
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    tenantId: row.tenant_id,
+    tenantStatus: row.status === 'disabled' ? 'disabled' : 'active',
+    isOwner: row.role === 'owner',
+  };
+}
+
+function isPlatformAdminToken(token: string): boolean {
+  const adminKey = process.env['ADMIN_API_KEY'];
+  if (!adminKey || adminKey.length < 16) return false;
+  // Constant-time compare to avoid leaking key length via timing.
+  if (token.length !== adminKey.length) return false;
+  let diff = 0;
+  for (let i = 0; i < token.length; i++) diff |= token.charCodeAt(i) ^ adminKey.charCodeAt(i);
+  return diff === 0;
+}
+
+/**
+ * Single entry point for commerce route auth. Detects token shape and
+ * dispatches to the appropriate resolver. Sets request.commerceCaller
+ * and request.commerceTenantId on success.
+ *
+ * Decision F: every commerce route must have config.skipAuth=true so the
+ * global authPlugin doesn't try to resolve as a developer first; the
+ * commerce sub-instance's onRoute hook in routes/commerce.ts ensures
+ * this. A test in commerce-caller-bypass.test.ts confirms merchant and
+ * agent tokens reach this resolver without being rejected upstream.
+ */
+export async function resolveCommerceCaller(
+  request: FastifyRequest,
+  sql: Sql,
+  redis: Redis | null,
+): Promise<CallerResolution> {
+  const token = extractBearer(request);
+  if (!token) {
+    return { ok: false, failure: { status: 401, code: 'missing_authorization', message: 'Missing or malformed Authorization header' } };
+  }
+
+  // Order matters: check the most specific shapes first so an opaque
+  // token doesn't accidentally match the operator fallback.
+  if (looksLikeMerchantApiKey(token)) {
+    const r = await resolveMerchantApiKey(sql, token);
+    if (!r.ok) {
+      if (r.reason === 'tenant_disabled') {
+        return { ok: false, failure: { status: 403, code: 'tenant_disabled',
+          message: 'Commerce tenant for this merchant key is disabled' } };
+      }
+      return { ok: false, failure: { status: 401, code: 'invalid_merchant_key', message: 'Merchant API key not recognized or revoked' } };
+    }
+    return { ok: true, caller: { kind: 'merchant', ...r.resolved } };
+  }
+
+  if (looksLikeAgentApiKey(token)) {
+    const r = await resolveAgentByApiKey(sql, token);
+    if (!r.ok) {
+      if (r.failure.kind === 'agent_not_trusted') {
+        return { ok: false, failure: { status: 403, code: 'agent_not_trusted', message: `Agent trust_status is ${r.failure.trustStatus}`, details: { trust_status: r.failure.trustStatus } } };
+      }
+      if (r.failure.kind === 'tenant_disabled') {
+        return { ok: false, failure: { status: 403, code: 'tenant_disabled',
+          message: 'Commerce tenant for this agent is disabled' } };
+      }
+      return { ok: false, failure: { status: 401, code: 'invalid_agent_credential', message: 'Agent API key not recognized', details: { reason: r.failure.kind } } };
+    }
+    return { ok: true, caller: { kind: 'agent', ...r.resolved } };
+  }
+
+  if (looksLikeJwt(token)) {
+    const r = await verifyAgentAssertion(sql, redis, token);
+    if (!r.ok) {
+      const f = r.failure;
+      if (f.kind === 'agent_not_trusted') {
+        return { ok: false, failure: { status: 403, code: 'agent_not_trusted', message: `Agent trust_status is ${f.trustStatus}`, details: { trust_status: f.trustStatus } } };
+      }
+      if (f.kind === 'tenant_disabled') {
+        return { ok: false, failure: { status: 403, code: 'tenant_disabled',
+          message: 'Commerce tenant for this agent is disabled' } };
+      }
+      if (f.kind === 'assertion_replay') {
+        return { ok: false, failure: { status: 401, code: 'agent_assertion_replay', message: 'Agent assertion jti has already been used' } };
+      }
+      if (f.kind === 'replay_check_unavailable') {
+        return { ok: false, failure: { status: 503, code: 'assertion_replay_check_unavailable', message: 'Agent assertion replay protection unavailable; refusing fail-open' } };
+      }
+      return { ok: false, failure: { status: 401, code: 'invalid_agent_credential', message: 'Agent assertion failed verification', details: { reason: f.kind } } };
+    }
+    return { ok: true, caller: { kind: 'agent', ...r.resolved } };
+  }
+
+  // Fallback: operator (developer API key OR platform admin key).
+  const isAdmin = isPlatformAdminToken(token);
+  const developer = await loadDeveloperByApiKey(sql, token);
+  if (!developer && !isAdmin) {
+    return { ok: false, failure: { status: 401, code: 'invalid_developer_key', message: 'Developer API key not recognized' } };
+  }
+  // Admin without a backing developer record: synthesize an operator caller
+  // marked as platform admin. The admin caller has no implicit tenant —
+  // operator endpoints that require a tenant context must accept a
+  // tenant_id parameter and validate the admin gate.
+  if (isAdmin && !developer) {
+    return {
+      ok: true,
+      caller: {
+        kind: 'operator',
+        developerId: '__admin__',
+        developerName: 'platform admin',
+        tenantId: '',
+        tenantStatus: null,
+        isOwnerOfTenant: false,
+        isPlatformAdmin: true,
+      },
+    };
+  }
+  // Real developer (with optional admin elevation).
+  const dev = developer!;
+  const ctx = await loadOperatorContext(sql, dev.id);
+  return {
+    ok: true,
+    caller: {
+      kind: 'operator',
+      developerId: dev.id,
+      developerName: dev.name,
+      tenantId: ctx?.tenantId ?? '',
+      tenantStatus: ctx?.tenantStatus ?? null,
+      isOwnerOfTenant: ctx?.isOwner ?? false,
+      isPlatformAdmin: isAdmin,
+    },
+  };
+}

--- a/apps/auth-service/src/lib/commerce/consent-challenge.ts
+++ b/apps/auth-service/src/lib/commerce/consent-challenge.ts
@@ -1,0 +1,370 @@
+import { createHash, randomInt, timingSafeEqual } from 'node:crypto';
+import type postgres from 'postgres';
+import { ulid } from 'ulid';
+import { type TxSql } from '../../db/client.js';
+
+type Sql = ReturnType<typeof postgres>;
+
+export const CHALLENGE_TTL_SECONDS = 300;             // 5 minutes
+export const CHALLENGE_DEFAULT_MAX_ATTEMPTS = 5;
+export const CHALLENGE_CODE_LENGTH = 6;
+
+export type DeliveryChannel = 'test_sink' | 'email_otp';
+
+export interface CreateChallengeInput {
+  tenantId: string;
+  consentRecordId: string;
+  consentRequestId: string;
+  principalId: string;
+  developerId: string;
+}
+
+export type ChallengeCreateResult =
+  | {
+      ok: true;
+      challengeId: string;
+      deliveryChannel: DeliveryChannel;
+      expiresAt: string;
+      /**
+       * Raw challenge code, returned ONLY when
+       * delivery_channel === 'test_sink' AND NODE_ENV === 'test'. This
+       * is the vitest harness path; staging, preview, QA, development,
+       * and production never see this field. Both gates are required
+       * and re-checked at the route boundary so a misconfiguration in
+       * either layer cannot leak the secret.
+       */
+      testOnlyCode?: string;
+    }
+  | {
+      ok: false;
+      reason: 'no_delivery_provider_configured' | 'active_challenge_exists';
+    };
+
+export type ChallengeVerifyResult =
+  | { ok: true; challengeId: string; remainingAttempts: number }
+  | { ok: false; reason: 'not_found' | 'expired' | 'invalid_code'; remainingAttempts?: number };
+
+/**
+ * Pick a delivery channel that we can actually deliver through. Fail
+ * closed everywhere a real out-of-band delivery is not implemented:
+ *
+ *   - `test_sink` is selected ONLY when NODE_ENV === 'test'. It is the
+ *     vitest harness path — the raw code is returned in the API
+ *     response so test code can complete the verify step. Selecting
+ *     this channel anywhere else (development, staging, preview,
+ *     production) would mean a caller could obtain session + CSRF + the
+ *     raw OTP and self-approve, which is the original P0 attack.
+ *   - `email_otp` is reserved in the schema enum but DEFERRED in M2 —
+ *     no real email delivery is wired up. Treating
+ *     `COMMERCE_CONSENT_CHALLENGE_PROVIDER=email_otp` as functional
+ *     would create a green-looking production where users are asked
+ *     for a code that is never sent. M2 always fails closed for
+ *     email_otp; M3 wires real delivery (verified-email lookup +
+ *     existing lib/email.ts Resend integration) and flips this gate.
+ */
+function selectDeliveryChannel(): DeliveryChannel | null {
+  const provider = process.env['COMMERCE_CONSENT_CHALLENGE_PROVIDER'];
+  // Allow an explicit override only inside the test runner. The double
+  // gate (`NODE_ENV === 'test'` AND explicit provider, OR NODE_ENV ===
+  // 'test' as default) means no shared environment can accidentally
+  // surface the test-sink channel.
+  if (process.env['NODE_ENV'] === 'test') {
+    if (provider === 'email_otp') {
+      // Even tests can opt out of test_sink and exercise the
+      // fail-closed email_otp path explicitly.
+      return null;
+    }
+    return 'test_sink';
+  }
+  // Outside NODE_ENV='test': everything fails closed in M2.
+  // M3 adds real email_otp delivery and changes this branch to:
+  //   if (provider === 'email_otp' && verifiedEmailDeliveryConfigured())
+  //     return 'email_otp';
+  void provider;
+  return null;
+}
+
+function sha256hex(s: string): string {
+  return createHash('sha256').update(s).digest('hex');
+}
+
+/**
+ * Domain-separated challenge hash. Includes consent_request_id and
+ * principal_id so a hash leaked from one challenge cannot be replayed
+ * against another consent or principal.
+ */
+function hashChallengeCode(code: string, consentRequestId: string, principalId: string): string {
+  return sha256hex(`commerce_consent_challenge:v1:${consentRequestId}:${principalId}:${code}`);
+}
+
+function generateNumericCode(): string {
+  let s = '';
+  for (let i = 0; i < CHALLENGE_CODE_LENGTH; i++) {
+    s += String(randomInt(0, 10));
+  }
+  return s;
+}
+
+/**
+ * Create a one-time challenge for the given consent + principal. Returns
+ * the test_only_code only when NODE_ENV === 'test' AND
+ * delivery_channel === 'test_sink' (the vitest harness path).
+ * Development, staging, preview, and production never return the raw
+ * code in the response — those environments fail closed with
+ * `no_delivery_provider_configured` until M3 wires real delivery.
+ */
+export async function createChallenge(
+  sql: Sql,
+  input: CreateChallengeInput,
+): Promise<ChallengeCreateResult> {
+  const channel = selectDeliveryChannel();
+  if (!channel) {
+    return { ok: false, reason: 'no_delivery_provider_configured' };
+  }
+  const code = generateNumericCode();
+  const challengeHash = hashChallengeCode(code, input.consentRequestId, input.principalId);
+  const id = `ccch_${ulid()}`;
+  const expiresAt = new Date(Date.now() + CHALLENGE_TTL_SECONDS * 1000);
+
+  // Atomic: expire any active challenges for this (reqId, principalId)
+  // first, then insert new. If the unique partial index would conflict
+  // (concurrent creator), expire-and-retry once.
+  try {
+    await sql.begin(async (_tx) => {
+      const tx = _tx as unknown as TxSql;
+      await tx`
+        UPDATE commerce_consent_challenges
+           SET status = 'expired', updated_at = NOW()
+         WHERE consent_request_id = ${input.consentRequestId}
+           AND principal_id = ${input.principalId}
+           AND status IN ('requested','verified')
+      `;
+      await tx`
+        INSERT INTO commerce_consent_challenges (
+          id, tenant_id, consent_record_id, consent_request_id,
+          principal_id, developer_id, challenge_hash, delivery_channel,
+          status, expires_at, max_attempts
+        ) VALUES (
+          ${id}, ${input.tenantId}, ${input.consentRecordId}, ${input.consentRequestId},
+          ${input.principalId}, ${input.developerId}, ${challengeHash}, ${channel},
+          'requested', ${expiresAt.toISOString()}, ${CHALLENGE_DEFAULT_MAX_ATTEMPTS}
+        )
+      `;
+    });
+  } catch (err) {
+    // 23505 = unique_violation (rare race with concurrent creator).
+    if ((err as { code?: string }).code === '23505') {
+      return { ok: false, reason: 'active_challenge_exists' };
+    }
+    throw err;
+  }
+
+  const result: ChallengeCreateResult = {
+    ok: true,
+    challengeId: id,
+    deliveryChannel: channel,
+    expiresAt: expiresAt.toISOString(),
+  };
+  // Raw code disclosure is gated to NODE_ENV === 'test' only AND the
+  // test_sink delivery channel. Both gates required. Anywhere outside
+  // the vitest harness (development, staging, preview, production), no
+  // raw code is ever returned in the response — the channel is null
+  // upstream and we never reach this point.
+  if (channel === 'test_sink' && process.env['NODE_ENV'] === 'test') {
+    result.testOnlyCode = code;
+  }
+  return result;
+}
+
+interface ChallengeRow {
+  id: string;
+  tenant_id: string;
+  consent_request_id: string;
+  principal_id: string;
+  challenge_hash: string;
+  status: string;
+  attempts_count: number;
+  max_attempts: number;
+  expires_at: Date | string;
+}
+
+/**
+ * Verify a candidate code against the active challenge for
+ * (consent_request_id, principal_id). Increments attempts; expires the
+ * challenge when attempts reach max. Constant-time hash compare. On
+ * success, marks status='verified' (still single-use until consumed by
+ * approve/deny).
+ */
+export async function verifyChallenge(
+  sql: Sql,
+  input: { consentRequestId: string; principalId: string; code: string },
+): Promise<ChallengeVerifyResult> {
+  const expectedHash = hashChallengeCode(input.code, input.consentRequestId, input.principalId);
+
+  return await sql.begin(async (_tx) => {
+    const tx = _tx as unknown as TxSql;
+    const rows = await tx<ChallengeRow[]>`
+      SELECT id, tenant_id, consent_request_id, principal_id, challenge_hash,
+             status, attempts_count, max_attempts, expires_at
+        FROM commerce_consent_challenges
+       WHERE consent_request_id = ${input.consentRequestId}
+         AND principal_id = ${input.principalId}
+         AND status IN ('requested','verified')
+       FOR UPDATE
+    `;
+    const row = rows[0];
+    if (!row) return { ok: false as const, reason: 'not_found' as const };
+
+    const expiresAt = row.expires_at instanceof Date
+      ? row.expires_at
+      : new Date(row.expires_at);
+    if (expiresAt.getTime() < Date.now()) {
+      await tx`
+        UPDATE commerce_consent_challenges
+           SET status = 'expired', updated_at = NOW()
+         WHERE id = ${row.id}
+      `;
+      return { ok: false as const, reason: 'expired' as const };
+    }
+
+    // Already-verified challenges should not be re-verified — caller
+    // should proceed straight to approve/deny. Treat re-submit as a
+    // no-op success (idempotent) so a network retry doesn't burn the
+    // verification.
+    if (row.status === 'verified') {
+      return {
+        ok: true as const,
+        challengeId: row.id,
+        remainingAttempts: row.max_attempts - row.attempts_count,
+      };
+    }
+
+    const attempts = row.attempts_count + 1;
+    const a = Buffer.from(expectedHash, 'hex');
+    const b = Buffer.from(row.challenge_hash, 'hex');
+    const codeMatches = a.length === b.length && timingSafeEqual(a, b);
+
+    if (codeMatches) {
+      await tx`
+        UPDATE commerce_consent_challenges
+           SET status = 'verified', verified_at = NOW(),
+               attempts_count = ${attempts}, updated_at = NOW()
+         WHERE id = ${row.id}
+      `;
+      return {
+        ok: true as const,
+        challengeId: row.id,
+        remainingAttempts: row.max_attempts - attempts,
+      };
+    }
+
+    // Wrong code; bump attempts. Expire if over the cap.
+    if (attempts >= row.max_attempts) {
+      await tx`
+        UPDATE commerce_consent_challenges
+           SET status = 'expired', attempts_count = ${attempts}, updated_at = NOW()
+         WHERE id = ${row.id}
+      `;
+      return { ok: false as const, reason: 'expired' as const, remainingAttempts: 0 };
+    }
+    await tx`
+      UPDATE commerce_consent_challenges
+         SET attempts_count = ${attempts}, updated_at = NOW()
+       WHERE id = ${row.id}
+    `;
+    return {
+      ok: false as const,
+      reason: 'invalid_code' as const,
+      remainingAttempts: row.max_attempts - attempts,
+    };
+  });
+}
+
+/**
+ * Atomic SELECT FOR UPDATE + UPDATE that consumes a verified challenge.
+ * Run inside the same sql.begin() block as the consent state transition
+ * so approve/deny + challenge consumption are one atomic unit.
+ *
+ * Returns true when a verified challenge was consumed. Returns false
+ * when no verified challenge exists for (consent_request_id,
+ * principal_id) — the route MUST then refuse the decision.
+ */
+export async function consumeVerifiedChallengeTx(
+  tx: TxSql,
+  input: { consentRequestId: string; principalId: string },
+): Promise<{ consumed: true; challengeId: string } | { consumed: false }> {
+  const rows = await tx<{ id: string; expires_at: Date | string }[]>`
+    SELECT id, expires_at FROM commerce_consent_challenges
+     WHERE consent_request_id = ${input.consentRequestId}
+       AND principal_id = ${input.principalId}
+       AND status = 'verified'
+     FOR UPDATE
+  `;
+  const row = rows[0];
+  if (!row) return { consumed: false };
+  const expiresAt = row.expires_at instanceof Date
+    ? row.expires_at
+    : new Date(row.expires_at);
+  if (expiresAt.getTime() < Date.now()) {
+    await tx`UPDATE commerce_consent_challenges SET status = 'expired', updated_at = NOW() WHERE id = ${row.id}`;
+    return { consumed: false };
+  }
+  await tx`
+    UPDATE commerce_consent_challenges
+       SET status = 'used', used_at = NOW(), updated_at = NOW()
+     WHERE id = ${row.id}
+  `;
+  return { consumed: true, challengeId: row.id };
+}
+
+/**
+ * Read-only check used by the page renderer to decide whether to show
+ * the "enter code" form vs the approve/deny forms. Returns the current
+ * status without mutating; route handlers that need to consume use
+ * consumeVerifiedChallengeTx.
+ *
+ * P2 fix: filters out rows past `expires_at`. Without this, a verified
+ * challenge that has expired would still cause the page to render the
+ * approve/deny forms — only for the decision POST to fail downstream
+ * with a confusing `challenge_required`. Stale rows get cleaned up by
+ * the next createChallenge (its expire-then-insert path); we don't
+ * mutate here because the renderer must remain a pure read.
+ */
+export async function findActiveChallenge(
+  sql: Sql,
+  input: { consentRequestId: string; principalId: string },
+): Promise<{ id: string; status: 'requested' | 'verified'; expiresAt: string } | null> {
+  const rows = await sql<{ id: string; status: string; expires_at: Date | string }[]>`
+    SELECT id, status, expires_at
+      FROM commerce_consent_challenges
+     WHERE consent_request_id = ${input.consentRequestId}
+       AND principal_id = ${input.principalId}
+       AND status IN ('requested','verified')
+       AND expires_at > NOW()
+     LIMIT 1
+  `;
+  const row = rows[0];
+  if (!row) return null;
+  const exp = row.expires_at instanceof Date ? row.expires_at : new Date(row.expires_at);
+  return {
+    id: row.id,
+    status: row.status as 'requested' | 'verified',
+    expiresAt: exp.toISOString(),
+  };
+}
+
+/**
+ * Predicate version of selectDeliveryChannel — true iff
+ * createChallenge would succeed in this environment with the current
+ * provider configuration. Page renderer uses this to choose between
+ * `challenge_request` and `challenge_unavailable` without trying to
+ * create a challenge.
+ */
+export function isChallengeProviderAvailable(): boolean {
+  return selectDeliveryChannel() !== null;
+}
+
+export const _internal = {
+  hashChallengeCode,
+  selectDeliveryChannel,
+};

--- a/apps/auth-service/src/lib/commerce/consent.ts
+++ b/apps/auth-service/src/lib/commerce/consent.ts
@@ -1,0 +1,392 @@
+import { createHash } from 'node:crypto';
+import type postgres from 'postgres';
+import { type TxSql } from '../../db/client.js';
+import {
+  newCommerceConsentRecordId,
+  newConsentRequestId,
+} from './ids.js';
+import { consumeVerifiedChallengeTx } from './consent-challenge.js';
+
+type Sql = ReturnType<typeof postgres>;
+
+export const CONSENT_TTL_SECONDS_DEFAULT = 600;          // spec §14: 10 min
+export const CONSENT_TEXT_VERSION = '2026-05-01';
+
+export type PassportType = 'browse' | 'checkout';
+
+export interface CreateConsentInput {
+  tenantId: string;
+  merchantId: string;
+  agentId: string;
+  passportType: PassportType;
+  requestedScopes: string[];
+  maxAmount: number | null;
+  currency: string | null;
+  agentAuthMethod: 'jwt' | 'api_key';
+  ipHash: string | null;
+  userAgentHash: string | null;
+  ttlSeconds?: number;
+  /**
+   * Optional hint: the agent claims it expects this user_principal_id
+   * to authorize. Approval enforces the authenticated principal matches
+   * this hint when set. The hint is NEVER trusted as the user identity —
+   * approval always sets user_principal_id from the verified session.
+   */
+  userPrincipalHint?: string | null;
+}
+
+export interface CreatedConsent {
+  id: string;
+  consentRequestId: string;
+  expiresAt: string;
+}
+
+export async function createConsentRequest(
+  sql: Sql,
+  input: CreateConsentInput,
+): Promise<CreatedConsent> {
+  const id = newCommerceConsentRecordId();
+  const consentRequestId = newConsentRequestId();
+  const ttl = Math.max(60, Math.min(input.ttlSeconds ?? CONSENT_TTL_SECONDS_DEFAULT, CONSENT_TTL_SECONDS_DEFAULT));
+  const expiresAt = new Date(Date.now() + ttl * 1000);
+  await sql`
+    INSERT INTO commerce_consent_records (
+      id, tenant_id, merchant_id, agent_id, consent_request_id,
+      passport_type, requested_scopes, max_amount, currency,
+      consent_text_version, agent_auth_method, ip_hash, user_agent_hash,
+      user_principal_hint, expires_at
+    ) VALUES (
+      ${id}, ${input.tenantId}, ${input.merchantId}, ${input.agentId}, ${consentRequestId},
+      ${input.passportType}, ${input.requestedScopes}, ${input.maxAmount}, ${input.currency},
+      ${CONSENT_TEXT_VERSION}, ${input.agentAuthMethod}, ${input.ipHash}, ${input.userAgentHash},
+      ${input.userPrincipalHint ?? null}, ${expiresAt.toISOString()}
+    )
+  `;
+  return { id, consentRequestId, expiresAt: expiresAt.toISOString() };
+}
+
+export interface ConsentRecord {
+  id: string;
+  tenantId: string;
+  merchantId: string;
+  agentId: string;
+  consentRequestId: string;
+  passportType: PassportType;
+  requestedScopes: string[];
+  approvedScopes: string[] | null;
+  maxAmount: number | null;
+  currency: string | null;
+  consentTextVersion: string;
+  presentedPayloadHash: string | null;
+  status: 'requested' | 'granted' | 'denied' | 'expired';
+  agentAuthMethod: 'jwt' | 'api_key' | null;
+  expiresAt: string;
+  approvedAt: string | null;
+  deniedAt: string | null;
+  userPrincipalId: string | null;
+  userPrincipalHint: string | null;
+  createdAt: string;
+}
+
+interface ConsentRow {
+  id: string;
+  tenant_id: string;
+  merchant_id: string;
+  agent_id: string;
+  consent_request_id: string;
+  passport_type: string;
+  requested_scopes: string[];
+  approved_scopes: string[] | null;
+  max_amount: string | number | null;
+  currency: string | null;
+  consent_text_version: string;
+  presented_payload_hash: string | null;
+  status: string;
+  agent_auth_method: string | null;
+  expires_at: Date | string;
+  approved_at: Date | string | null;
+  denied_at: Date | string | null;
+  user_principal_id: string | null;
+  user_principal_hint: string | null;
+  created_at: Date | string;
+}
+
+function asIso(v: Date | string | null): string | null {
+  if (v == null) return null;
+  return v instanceof Date ? v.toISOString() : String(v);
+}
+
+function rowToRecord(row: ConsentRow): ConsentRecord {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    merchantId: row.merchant_id,
+    agentId: row.agent_id,
+    consentRequestId: row.consent_request_id,
+    passportType: row.passport_type as PassportType,
+    requestedScopes: row.requested_scopes,
+    approvedScopes: row.approved_scopes,
+    maxAmount: row.max_amount == null ? null : Number(row.max_amount),
+    currency: row.currency,
+    consentTextVersion: row.consent_text_version,
+    presentedPayloadHash: row.presented_payload_hash,
+    status: row.status as ConsentRecord['status'],
+    agentAuthMethod: row.agent_auth_method as ConsentRecord['agentAuthMethod'],
+    expiresAt: asIso(row.expires_at) ?? '',
+    approvedAt: asIso(row.approved_at),
+    deniedAt: asIso(row.denied_at),
+    userPrincipalId: row.user_principal_id,
+    userPrincipalHint: row.user_principal_hint,
+    createdAt: asIso(row.created_at) ?? '',
+  };
+}
+
+export async function findConsentByRequestId(
+  sql: Sql,
+  consentRequestId: string,
+): Promise<ConsentRecord | null> {
+  const rows = await sql<ConsentRow[]>`
+    SELECT * FROM commerce_consent_records WHERE consent_request_id = ${consentRequestId} LIMIT 1
+  `;
+  return rows[0] ? rowToRecord(rows[0]) : null;
+}
+
+export async function findConsentById(sql: Sql, id: string): Promise<ConsentRecord | null> {
+  const rows = await sql<ConsentRow[]>`
+    SELECT * FROM commerce_consent_records WHERE id = ${id} LIMIT 1
+  `;
+  return rows[0] ? rowToRecord(rows[0]) : null;
+}
+
+/**
+ * Canonical JSON of the displayed consent payload. Hash of this is
+ * stored as presented_payload_hash on first GET; exchange recomputes
+ * and compares (Finding 4) to defend against bait-and-switch.
+ */
+export function canonicalPresentedPayload(record: ConsentRecord): string {
+  return JSON.stringify({
+    consent_request_id: record.consentRequestId,
+    tenant_id: record.tenantId,
+    merchant_id: record.merchantId,
+    agent_id: record.agentId,
+    passport_type: record.passportType,
+    requested_scopes: [...record.requestedScopes].sort(),
+    max_amount: record.maxAmount,
+    currency: record.currency,
+    consent_text_version: record.consentTextVersion,
+    expires_at: record.expiresAt,
+  });
+}
+
+export function sha256hex(s: string): string {
+  return createHash('sha256').update(s).digest('hex');
+}
+
+/**
+ * Capture-on-first-GET semantics:
+ *   - If the record is `requested` and has no presented_payload_hash,
+ *     compute and store it under SELECT...FOR UPDATE.
+ *   - If the record is `requested` and already has a hash (multi-tab
+ *     re-render), return the existing record.
+ *   - If the record is past expires_at and still `requested`, transition
+ *     to `expired` and return that.
+ *   - If the record is already `granted`/`denied`/`expired`, return as-is.
+ *
+ * Returns null when no such consent_request_id exists. CSRF concerns
+ * are now the route's responsibility (Finding 1 redesign — the per-form
+ * CSRF token is derived from the principal session token, so no
+ * per-consent CSRF state lives in the DB).
+ */
+export async function presentConsentForUser(
+  sql: Sql,
+  consentRequestId: string,
+): Promise<ConsentRecord | null> {
+  return await sql.begin(async (_tx) => {
+    const tx = _tx as unknown as TxSql;
+    const rows = await tx<ConsentRow[]>`
+      SELECT * FROM commerce_consent_records
+       WHERE consent_request_id = ${consentRequestId}
+       FOR UPDATE
+    `;
+    const row = rows[0];
+    if (!row) return null;
+    const record = rowToRecord(row);
+
+    if (record.status !== 'requested') return record;
+
+    if (new Date(record.expiresAt).getTime() < Date.now()) {
+      await tx`
+        UPDATE commerce_consent_records SET status = 'expired', updated_at = NOW()
+         WHERE id = ${record.id} AND status = 'requested'
+      `;
+      return { ...record, status: 'expired' as const };
+    }
+
+    if (record.presentedPayloadHash) {
+      // Already presented (multi-tab refresh) — same hash, same payload.
+      return record;
+    }
+
+    // First presentation: capture the hash now.
+    const newRecord = { ...record, presentedPayloadHash: null };
+    const presentedPayloadHash = sha256hex(canonicalPresentedPayload(newRecord));
+    await tx`
+      UPDATE commerce_consent_records
+         SET presented_payload_hash = ${presentedPayloadHash},
+             updated_at = NOW()
+       WHERE id = ${record.id}
+    `;
+    return { ...record, presentedPayloadHash };
+  });
+}
+
+export type ConsentDecisionResult =
+  | { ok: true; record: ConsentRecord; consumedChallengeId: string }
+  | {
+      ok: false;
+      reason:
+        | 'not_found'
+        | 'expired'
+        | 'already_decided'
+        | 'principal_hint_mismatch'
+        | 'challenge_required';
+    };
+
+/**
+ * Atomically:
+ *   1. SELECT FOR UPDATE the consent record.
+ *   2. Validate state, hint match.
+ *   3. SELECT FOR UPDATE the verified challenge for this
+ *      (consent_request_id, principal_id) pair and mark it `used`.
+ *      Without a verified challenge, refuse the decision —
+ *      challenge_required closes the M2 P0: a developer-minted
+ *      principal session alone is no longer sufficient.
+ *   4. UPDATE the consent → granted/denied.
+ *
+ * All four steps run inside one sql.begin() so a successful decision
+ * always coincides with challenge consumption — the agent cannot reuse
+ * a verified challenge to approve/deny a different consent.
+ *
+ * Hint enforcement (P2 fix): user_principal_hint is now checked for
+ * BOTH approve AND deny. Previously deny ignored the hint, which let a
+ * different principal in the same tenant burn the single-use consent.
+ */
+async function decideConsent(
+  sql: Sql,
+  consentRequestId: string,
+  decision: 'granted' | 'denied',
+  principalId: string,
+): Promise<ConsentDecisionResult> {
+  return await sql.begin(async (_tx) => {
+    const tx = _tx as unknown as TxSql;
+    const rows = await tx<ConsentRow[]>`
+      SELECT * FROM commerce_consent_records
+       WHERE consent_request_id = ${consentRequestId}
+       FOR UPDATE
+    `;
+    const row = rows[0];
+    if (!row) return { ok: false as const, reason: 'not_found' as const };
+    const record = rowToRecord(row);
+
+    if (record.status === 'expired'
+      || new Date(record.expiresAt).getTime() < Date.now()) {
+      if (record.status === 'requested') {
+        await tx`
+          UPDATE commerce_consent_records SET status = 'expired', updated_at = NOW()
+           WHERE id = ${record.id} AND status = 'requested'
+        `;
+      }
+      return { ok: false as const, reason: 'expired' as const };
+    }
+    if (record.status !== 'requested') {
+      return { ok: false as const, reason: 'already_decided' as const };
+    }
+
+    // P2 fix: enforce hint match for BOTH approve and deny. Previously
+    // only granted enforced; deny path let any same-tenant principal burn
+    // the single-use consent intended for someone else.
+    if (record.userPrincipalHint && record.userPrincipalHint !== principalId) {
+      return { ok: false as const, reason: 'principal_hint_mismatch' as const };
+    }
+
+    // P0 fix: consume a verified consent challenge for this specific
+    // (consent_request_id, principal_id) atomically with the status
+    // transition. Without a verified challenge — independently issued
+    // by Grantex through a channel the agent/developer cannot read —
+    // refuse the decision.
+    const consumed = await consumeVerifiedChallengeTx(tx, {
+      consentRequestId, principalId,
+    });
+    if (!consumed.consumed) {
+      return { ok: false as const, reason: 'challenge_required' as const };
+    }
+
+    if (decision === 'granted') {
+      const updated = await tx<ConsentRow[]>`
+        UPDATE commerce_consent_records
+           SET status = 'granted',
+               approved_scopes = requested_scopes,
+               approved_at = NOW(),
+               user_principal_id = ${principalId},
+               updated_at = NOW()
+         WHERE id = ${record.id} AND status = 'requested'
+         RETURNING *
+      `;
+      if (!updated[0]) return { ok: false as const, reason: 'already_decided' as const };
+      return {
+        ok: true as const,
+        record: rowToRecord(updated[0]),
+        consumedChallengeId: consumed.challengeId,
+      };
+    } else {
+      const updated = await tx<ConsentRow[]>`
+        UPDATE commerce_consent_records
+           SET status = 'denied',
+               denied_at = NOW(),
+               user_principal_id = ${principalId},
+               updated_at = NOW()
+         WHERE id = ${record.id} AND status = 'requested'
+         RETURNING *
+      `;
+      if (!updated[0]) return { ok: false as const, reason: 'already_decided' as const };
+      return {
+        ok: true as const,
+        record: rowToRecord(updated[0]),
+        consumedChallengeId: consumed.challengeId,
+      };
+    }
+  });
+}
+
+export function approveConsent(
+  sql: Sql,
+  consentRequestId: string,
+  authenticatedPrincipalId: string,
+): Promise<ConsentDecisionResult> {
+  return decideConsent(sql, consentRequestId, 'granted', authenticatedPrincipalId);
+}
+
+export function denyConsent(
+  sql: Sql,
+  consentRequestId: string,
+  authenticatedPrincipalId: string,
+): Promise<ConsentDecisionResult> {
+  return decideConsent(sql, consentRequestId, 'denied', authenticatedPrincipalId);
+}
+
+/**
+ * Per-form CSRF token derivation (Finding 1):
+ *   csrf = sha256(principal_session_token + ':' + consent_request_id)
+ *
+ * The principal session token is the secret. An attacker on another
+ * origin cannot read the cookie (HttpOnly, SameSite=Strict) and cannot
+ * compute this token without it. The token is bound to the specific
+ * consent_request_id so a leaked token from one consent can't approve
+ * another.
+ */
+export function deriveConsentCsrfToken(
+  principalSessionToken: string,
+  consentRequestId: string,
+): string {
+  return sha256hex(`${principalSessionToken}:${consentRequestId}`);
+}

--- a/apps/auth-service/src/lib/commerce/ids.ts
+++ b/apps/auth-service/src/lib/commerce/ids.ts
@@ -1,4 +1,5 @@
 import { ulid } from 'ulid';
+import { randomBytes } from 'node:crypto';
 
 export const newCommerceTenantId = (): string => `cten_${ulid()}`;
 export const newMerchantId = (): string => `mch_${ulid()}`;
@@ -6,3 +7,21 @@ export const newCommerceAgentId = (): string => `cag_${ulid()}`;
 export const newCommerceProductId = (): string => `cprd_${ulid()}`;
 export const newCommerceVariantId = (): string => `cvar_${ulid()}`;
 export const newCommerceAuditId = (): string => `caud_${ulid()}`;
+
+// M2 — passport / consent / merchant key / passport key id generators.
+export const newCommerceConsentRecordId = (): string => `crec_${ulid()}`;
+export const newCommercePassportJti = (): string => `cpsp_${ulid()}`;
+export const newCommerceMerchantApiKeyId = (): string => `mkey_${ulid()}`;
+
+// Opaque CSPRNG identifier shown in consent URL. 192 bits to comfortably
+// exceed spec §14's 128-bit minimum.
+export const newConsentRequestId = (): string => randomBytes(24).toString('base64url');
+
+// commerce-passport-YYYYMMDD-XXXXXXXX (spec §6).
+export function newCommercePassportKid(now: Date = new Date()): string {
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(now.getUTCDate()).padStart(2, '0');
+  const suffix = randomBytes(4).toString('hex');  // 8 hex chars
+  return `commerce-passport-${y}${m}${d}-${suffix}`;
+}

--- a/apps/auth-service/src/lib/commerce/merchant-auth.ts
+++ b/apps/auth-service/src/lib/commerce/merchant-auth.ts
@@ -1,0 +1,64 @@
+import type postgres from 'postgres';
+import { sha256hex } from '../hash.js';
+
+type Sql = ReturnType<typeof postgres>;
+
+const MERCHANT_KEY_PREFIXES = ['grtx_sk_sandbox_', 'grtx_sk_live_'] as const;
+
+export function looksLikeMerchantApiKey(token: string): boolean {
+  return MERCHANT_KEY_PREFIXES.some((p) => token.startsWith(p));
+}
+
+export interface ResolvedMerchantApiKey {
+  apiKeyId: string;
+  tenantId: string;
+  merchantId: string;
+  environment: 'sandbox' | 'live';
+}
+
+export type MerchantApiKeyResolution =
+  | { ok: true; resolved: ResolvedMerchantApiKey }
+  | { ok: false; reason: 'unknown_key' | 'tenant_disabled' };
+
+/**
+ * Look up a merchant API key. Joins commerce_tenants so a disabled
+ * tenant is rejected at auth time (Finding 3). Returns tenant_disabled
+ * separately from unknown_key so the route can surface a clear 403.
+ */
+export async function resolveMerchantApiKey(
+  sql: Sql,
+  token: string,
+): Promise<MerchantApiKeyResolution> {
+  if (!looksLikeMerchantApiKey(token)) return { ok: false, reason: 'unknown_key' };
+  const keyHash = sha256hex(token);
+  const rows = await sql<Array<{
+    id: string;
+    tenant_id: string;
+    merchant_id: string;
+    environment: string;
+    tenant_status: string;
+  }>>`
+    SELECT k.id, k.tenant_id, k.merchant_id, k.environment, t.status AS tenant_status
+      FROM commerce_merchant_api_keys k
+      JOIN commerce_tenants t ON t.id = k.tenant_id
+     WHERE k.key_hash = ${keyHash}
+       AND k.revoked_at IS NULL
+     LIMIT 1
+  `;
+  const row = rows[0];
+  if (!row) return { ok: false, reason: 'unknown_key' };
+  if (row.tenant_status === 'disabled') return { ok: false, reason: 'tenant_disabled' };
+  // Best-effort last_used_at update; not in critical path.
+  void sql`
+    UPDATE commerce_merchant_api_keys SET last_used_at = NOW() WHERE id = ${row.id}
+  `.catch(() => undefined);
+  return {
+    ok: true,
+    resolved: {
+      apiKeyId: row.id,
+      tenantId: row.tenant_id,
+      merchantId: row.merchant_id,
+      environment: row.environment === 'live' ? 'live' : 'sandbox',
+    },
+  };
+}

--- a/apps/auth-service/src/lib/commerce/passport-keys.ts
+++ b/apps/auth-service/src/lib/commerce/passport-keys.ts
@@ -1,0 +1,268 @@
+import { generateKeyPair, exportJWK, importJWK, type KeyLike, type JWK } from 'jose';
+import type postgres from 'postgres';
+import { encrypt, decrypt } from '../vault-crypto.js';
+import { newCommercePassportKid } from './ids.js';
+
+type Sql = ReturnType<typeof postgres>;
+
+export interface CommercePassportKey {
+  kid: string;
+  algorithm: 'ES256';
+  status: 'active' | 'retired' | 'compromised';
+  publicKeyJwk: Record<string, unknown>;
+  createdAt: string;
+  retiredAt: string | null;
+}
+
+export interface ActiveCommercePassportSigner {
+  kid: string;
+  algorithm: 'ES256';
+  privateKey: KeyLike;
+  publicKey: KeyLike;
+}
+
+interface CachedSigner {
+  signer: ActiveCommercePassportSigner;
+  fetchedAt: number;          // epoch ms
+}
+
+/**
+ * Active signer cache TTL. A long-running instance must not keep signing
+ * with a key that has been rotated out by another instance / ops action.
+ * 60 s gives us low DB pressure (1 SELECT/min/instance) while bounding
+ * the worst-case "still signing with stale key" window.
+ */
+const ACTIVE_SIGNER_TTL_MS = 60_000;
+
+/**
+ * JWKS retired-key grace window. Retired keys remain in JWKS and remain
+ * verifiable for tokens issued BEFORE retired_at (verifier enforces the
+ * iat cutoff separately). After this many seconds past retired_at, the
+ * key is dropped from JWKS entirely. = max passport TTL (1h browse) +
+ * 24h spec §6 safety margin.
+ */
+const RETIRED_KEY_GRACE_SECONDS = 3600 + 86_400;
+
+const ACTIVE_SIGNER_CACHE = new Map<string, CachedSigner>();
+const ACTIVE_CACHE_KEY = '__active__';
+
+function isAutoGenerateAllowed(): boolean {
+  if (process.env['NODE_ENV'] === 'production') return false;
+  return process.env['COMMERCE_AUTO_GENERATE_PASSPORT_KEY'] === 'true';
+}
+
+function rowToKey(row: {
+  kid: string;
+  algorithm: string;
+  status: string;
+  public_key_jwk: Record<string, unknown>;
+  created_at: Date | string;
+  retired_at: Date | string | null;
+}): CommercePassportKey {
+  return {
+    kid: row.kid,
+    algorithm: 'ES256',
+    status: row.status as CommercePassportKey['status'],
+    publicKeyJwk: row.public_key_jwk,
+    createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at),
+    retiredAt: row.retired_at == null
+      ? null
+      : (row.retired_at instanceof Date ? row.retired_at.toISOString() : String(row.retired_at)),
+  };
+}
+
+/**
+ * Look up the active key (if any) without triggering generation.
+ */
+export async function findActiveCommercePassportKey(sql: Sql): Promise<CommercePassportKey | null> {
+  const rows = await sql<Array<{
+    kid: string;
+    algorithm: string;
+    status: string;
+    public_key_jwk: Record<string, unknown>;
+    created_at: Date;
+    retired_at: Date | null;
+  }>>`
+    SELECT kid, algorithm, status, public_key_jwk, created_at, retired_at
+      FROM commerce_passport_keys
+     WHERE status = 'active'
+     LIMIT 1
+  `;
+  return rows[0] ? rowToKey(rows[0]) : null;
+}
+
+/**
+ * Return keys eligible for inclusion in JWKS:
+ *   - status='active' always
+ *   - status='retired' only if NOW() - retired_at < RETIRED_KEY_GRACE_SECONDS.
+ * After the grace window passes, the retired key is dropped from JWKS so
+ * a leaked retired private key can no longer be matched to a published
+ * public key. Verification additionally enforces an iat cutoff so a
+ * leaked retired key cannot mint NEW valid passports.
+ */
+export async function listCommercePassportKeysForJwks(sql: Sql): Promise<CommercePassportKey[]> {
+  const rows = await sql<Array<{
+    kid: string;
+    algorithm: string;
+    status: string;
+    public_key_jwk: Record<string, unknown>;
+    created_at: Date;
+    retired_at: Date | null;
+  }>>`
+    SELECT kid, algorithm, status, public_key_jwk, created_at, retired_at
+      FROM commerce_passport_keys
+     WHERE status = 'active'
+        OR (status = 'retired'
+            AND retired_at IS NOT NULL
+            AND retired_at > NOW() - (${RETIRED_KEY_GRACE_SECONDS} || ' seconds')::interval)
+     ORDER BY created_at DESC
+  `;
+  return rows.map(rowToKey);
+}
+
+/**
+ * Resolve the public key JWK + retired_at for a given kid. The verifier
+ * uses retired_at to reject tokens with `iat > retired_at` for retired
+ * keys (a stolen retired private key must not be able to mint NEW
+ * valid passports). Returns null for unknown or compromised kids.
+ */
+export async function findPublicKeyByKid(
+  sql: Sql,
+  kid: string,
+): Promise<{ publicKeyJwk: Record<string, unknown>; retiredAt: Date | null } | null> {
+  const rows = await sql<Array<{
+    public_key_jwk: Record<string, unknown>;
+    retired_at: Date | null;
+  }>>`
+    SELECT public_key_jwk, retired_at
+      FROM commerce_passport_keys
+     WHERE kid = ${kid}
+       AND status IN ('active','retired')
+     LIMIT 1
+  `;
+  const row = rows[0];
+  if (!row) return null;
+  return { publicKeyJwk: row.public_key_jwk, retiredAt: row.retired_at };
+}
+
+/** @deprecated kept for back-compat tests; new code uses findPublicKeyByKid. */
+export async function findPublicKeyJwkByKid(
+  sql: Sql,
+  kid: string,
+): Promise<Record<string, unknown> | null> {
+  const r = await findPublicKeyByKid(sql, kid);
+  return r?.publicKeyJwk ?? null;
+}
+
+/**
+ * Insert a brand-new ES256 keypair with status='active'. Atomic with the
+ * partial-unique constraint uq_commerce_passport_keys_active so a
+ * concurrent caller can't create two active keys.
+ */
+async function insertNewActiveKey(sql: Sql): Promise<ActiveCommercePassportSigner> {
+  const { privateKey, publicKey } = await generateKeyPair('ES256');
+  const publicJwk = await exportJWK(publicKey);
+  const privateJwk = await exportJWK(privateKey);
+  const kid = newCommercePassportKid();
+  const encryptedPrivate = encrypt(JSON.stringify({ ...privateJwk, kid, alg: 'ES256' }));
+  const publicJwkWithKid = { ...publicJwk, kid, alg: 'ES256', use: 'sig' };
+
+  await sql`
+    INSERT INTO commerce_passport_keys (
+      kid, algorithm, public_key_jwk, encrypted_private_key_jwk, status
+    ) VALUES (
+      ${kid}, 'ES256', ${JSON.stringify(publicJwkWithKid)}::jsonb,
+      ${encryptedPrivate}, 'active'
+    )
+  `;
+
+  return { kid, algorithm: 'ES256', privateKey, publicKey };
+}
+
+/**
+ * Get the currently-active signing keypair.
+ *
+ *  - If an active row exists, decrypt and return it.
+ *  - Process-local cache has a TTL (ACTIVE_SIGNER_TTL_MS) so a long-running
+ *    instance picks up rotation done by another instance / ops action
+ *    instead of signing forever with a key that's been rotated out.
+ *  - If no active key exists AND COMMERCE_AUTO_GENERATE_PASSPORT_KEY=true
+ *    AND NODE_ENV != production, generate one.
+ *  - In production with no active key → throw. Operators must provision
+ *    explicitly via the M2 admin runbook.
+ *
+ * The cache also re-validates on each call that the cached kid is still
+ * the active one in the DB; if the active kid changed, the cache is
+ * busted regardless of TTL. This handles the "rotation just happened"
+ * window.
+ */
+export async function getActiveCommercePassportSigner(
+  sql: Sql,
+): Promise<ActiveCommercePassportSigner> {
+  const cached = ACTIVE_SIGNER_CACHE.get(ACTIVE_CACHE_KEY);
+  const now = Date.now();
+  if (cached && now - cached.fetchedAt < ACTIVE_SIGNER_TTL_MS) {
+    // Within TTL, but verify it's still the active kid before serving.
+    // One small SELECT to defend against rotation-mid-flight.
+    const stillActive = await sql<Array<{ kid: string }>>`
+      SELECT kid FROM commerce_passport_keys
+       WHERE status = 'active' LIMIT 1
+    `;
+    if (stillActive[0]?.kid === cached.signer.kid) {
+      return cached.signer;
+    }
+    // Active kid changed — busted cache. Fall through to refetch.
+  }
+
+  const active = await findActiveCommercePassportKey(sql);
+  if (active) {
+    const decryptedRows = await sql<Array<{ encrypted_private_key_jwk: string }>>`
+      SELECT encrypted_private_key_jwk
+        FROM commerce_passport_keys
+       WHERE kid = ${active.kid}
+       LIMIT 1
+    `;
+    const encryptedPrivate = decryptedRows[0]?.encrypted_private_key_jwk;
+    if (!encryptedPrivate) {
+      throw new Error(`active commerce passport key ${active.kid} missing encrypted material`);
+    }
+    const privateJwk = JSON.parse(decrypt(encryptedPrivate)) as Record<string, unknown>;
+    const privateKey = await importJWK(privateJwk as unknown as JWK, 'ES256') as KeyLike;
+    const publicKey = await importJWK(active.publicKeyJwk as unknown as JWK, 'ES256') as KeyLike;
+    const signer: ActiveCommercePassportSigner = {
+      kid: active.kid,
+      algorithm: 'ES256',
+      privateKey,
+      publicKey,
+    };
+    ACTIVE_SIGNER_CACHE.set(ACTIVE_CACHE_KEY, { signer, fetchedAt: now });
+    return signer;
+  }
+
+  if (!isAutoGenerateAllowed()) {
+    throw new Error(
+      'No active commerce passport key. Production must provision a key '
+      + 'explicitly via the M2 admin runbook. Set '
+      + 'COMMERCE_AUTO_GENERATE_PASSPORT_KEY=true (and NODE_ENV != production) '
+      + 'to enable dev/test auto-generation.',
+    );
+  }
+
+  const generated = await insertNewActiveKey(sql);
+  ACTIVE_SIGNER_CACHE.set(ACTIVE_CACHE_KEY, { signer: generated, fetchedAt: now });
+  return generated;
+}
+
+/**
+ * Test-only — clear the in-process key cache so a test can simulate
+ * service restart or rotation. NOT exported via index — direct named
+ * import only.
+ */
+export function _resetCommercePassportKeyCacheForTests(): void {
+  ACTIVE_SIGNER_CACHE.clear();
+}
+
+export const _internal = {
+  ACTIVE_SIGNER_TTL_MS,
+  RETIRED_KEY_GRACE_SECONDS,
+};

--- a/apps/auth-service/src/lib/commerce/passport.ts
+++ b/apps/auth-service/src/lib/commerce/passport.ts
@@ -1,0 +1,336 @@
+import {
+  SignJWT,
+  jwtVerify,
+  importJWK,
+  decodeProtectedHeader,
+  decodeJwt,
+  type KeyLike,
+  type JWTPayload,
+  type JWK,
+} from 'jose';
+import type postgres from 'postgres';
+import type { Redis } from 'ioredis';
+import { config } from '../../config.js';
+import { newCommercePassportJti } from './ids.js';
+import {
+  getActiveCommercePassportSigner,
+  findPublicKeyByKid,
+} from './passport-keys.js';
+import { checkPassportRevocation, type RevocationCheck } from './revocation.js';
+
+type Sql = ReturnType<typeof postgres>;
+
+// Spec §6: kid format namespace. Verifier rejects any header.kid that
+// doesn't match this prefix, blocking cross-namespace kid confusion
+// (e.g., a forged passport claiming to be signed by the platform RS256
+// kid `grantex-2026-05`).
+const COMMERCE_KID_RE = /^commerce-passport-[0-9]{8}-[a-z0-9]{8}$/;
+
+const PASSPORT_AUDIENCE = 'grantex-commerce';
+const CLOCK_SKEW_SECONDS = 30;
+
+export type PassportType = 'browse' | 'checkout';
+export type Environment = 'sandbox' | 'live';
+
+/**
+ * Spec §6 maximum passport lifetimes. Verification rejects any token
+ * whose declared (exp - iat) exceeds these caps. This blocks the
+ * "stolen retired key sets a far-future exp" vector — even if a key
+ * were leaked the verifier refuses to honour any token claiming a
+ * lifetime longer than what the platform issues.
+ */
+export const MAX_PASSPORT_LIFETIME_SECONDS: Record<PassportType, number> = {
+  browse: 3600,
+  checkout: 600,
+};
+
+export interface PassportClaimsToSign {
+  jti: string;
+  passportType: PassportType;
+  tenantId: string;
+  merchantId: string;
+  agentId: string;
+  consentRecordId: string;
+  subject: string;                      // user_principal_id
+  scopes: string[];
+  maxAmount?: number | null;
+  currency?: string | null;
+  policyVersion?: string | null;
+  environment: Environment;
+  issuedAt: number;                     // epoch seconds
+  notBefore: number;
+  expiresAt: number;
+}
+
+export interface SignPassportResult {
+  jwt: string;
+  kid: string;
+  jti: string;
+}
+
+export async function signCommercePassport(
+  sql: Sql,
+  claims: PassportClaimsToSign,
+): Promise<SignPassportResult> {
+  const signer = await getActiveCommercePassportSigner(sql);
+  const jwt = await new SignJWT({
+    passport_type: claims.passportType,
+    tenant_id: claims.tenantId,
+    merchant_id: claims.merchantId,
+    agent_id: claims.agentId,
+    consent_record_id: claims.consentRecordId,
+    scopes: claims.scopes,
+    ...(claims.maxAmount !== undefined && claims.maxAmount !== null
+      ? { max_amount: claims.maxAmount } : {}),
+    ...(claims.currency ? { currency: claims.currency } : {}),
+    ...(claims.policyVersion ? { policy_version: claims.policyVersion } : {}),
+    env: claims.environment,
+    ver: '1',
+  } satisfies JWTPayload)
+    .setProtectedHeader({ alg: 'ES256', kid: signer.kid })
+    .setIssuer(config.jwtIssuer)
+    .setAudience(PASSPORT_AUDIENCE)
+    .setSubject(claims.subject)
+    .setJti(claims.jti)
+    .setIssuedAt(claims.issuedAt)
+    .setNotBefore(claims.notBefore)
+    .setExpirationTime(claims.expiresAt)
+    .sign(signer.privateKey);
+
+  return { jwt, kid: signer.kid, jti: claims.jti };
+}
+
+export interface VerifiedPassport {
+  jti: string;
+  kid: string;
+  passportType: PassportType;
+  tenantId: string;
+  merchantId: string;
+  agentId: string;
+  consentRecordId: string;
+  subject: string;
+  scopes: string[];
+  maxAmount: number | null;
+  currency: string | null;
+  policyVersion: string | null;
+  environment: Environment;
+  issuedAt: number;
+  notBefore: number;
+  expiresAt: number;
+}
+
+export type VerifyPassportError =
+  | { kind: 'malformed'; reason: string }
+  | { kind: 'kid_required' }
+  | { kind: 'kid_unknown'; kid: string }
+  | { kind: 'kid_wrong_namespace'; kid: string }
+  | { kind: 'kid_retired_iat_after'; kid: string; retiredAtUnix: number }
+  | { kind: 'kid_retired_window_exceeded'; kid: string; retiredAtUnix: number; maxExpUnix: number }
+  | { kind: 'algorithm_rejected'; alg: string }
+  | { kind: 'signature_invalid'; reason: string }
+  | { kind: 'expired' }
+  | { kind: 'not_yet_valid' }
+  | { kind: 'wrong_audience'; aud: unknown }
+  | { kind: 'wrong_issuer'; iss: unknown }
+  | { kind: 'missing_claims'; fields: string[] }
+  | { kind: 'temporal_claim_invalid'; reason: string }
+  | { kind: 'lifetime_exceeded'; passportType: PassportType; declaredLifetime: number; maxLifetime: number }
+  | { kind: 'invalid_passport_type'; value: unknown }
+  | { kind: 'revoked'; reason?: string }
+  | { kind: 'revocation_unavailable'; error: string }
+  | { kind: 'tenant_mismatch'; expected: string; actual: string }
+  | { kind: 'merchant_mismatch'; expected: string; actual: string };
+
+export type VerifyPassportResult =
+  | { ok: true; passport: VerifiedPassport }
+  | { ok: false; error: VerifyPassportError };
+
+export interface VerifyOptions {
+  /** When set, rejects with tenant_mismatch if passport.tenant_id !== expectedTenantId. */
+  expectedTenantId?: string;
+  /** When set, rejects with merchant_mismatch. */
+  expectedMerchantId?: string;
+  /**
+   * `payment_affecting` triggers an online revocation check; on
+   * revocation infrastructure failure the result is `revocation_unavailable`
+   * (caller fails closed). `read_only` skips the online check and returns
+   * ok=true even when Redis/Postgres are degraded — appropriate only for
+   * non-payment reads.
+   */
+  mode: 'payment_affecting' | 'read_only';
+}
+
+export async function verifyCommercePassport(
+  sql: Sql,
+  redis: Redis | null,
+  token: string,
+  options: VerifyOptions,
+): Promise<VerifyPassportResult> {
+  let header: ReturnType<typeof decodeProtectedHeader>;
+  try {
+    header = decodeProtectedHeader(token);
+  } catch (err) {
+    return { ok: false, error: { kind: 'malformed', reason: err instanceof Error ? err.message : 'decode failed' } };
+  }
+  if (header.alg && header.alg !== 'ES256') {
+    return { ok: false, error: { kind: 'algorithm_rejected', alg: String(header.alg) } };
+  }
+  if (!header.kid) {
+    return { ok: false, error: { kind: 'kid_required' } };
+  }
+  if (!COMMERCE_KID_RE.test(header.kid)) {
+    return { ok: false, error: { kind: 'kid_wrong_namespace', kid: header.kid } };
+  }
+
+  const keyRecord = await findPublicKeyByKid(sql, header.kid);
+  if (!keyRecord) {
+    return { ok: false, error: { kind: 'kid_unknown', kid: header.kid } };
+  }
+  const publicKey = await importJWK(keyRecord.publicKeyJwk as unknown as JWK, 'ES256') as KeyLike;
+
+  let payload: JWTPayload;
+  try {
+    const verified = await jwtVerify(token, publicKey, {
+      issuer: config.jwtIssuer,
+      audience: PASSPORT_AUDIENCE,
+      algorithms: ['ES256'],
+      clockTolerance: CLOCK_SKEW_SECONDS,
+    });
+    payload = verified.payload;
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === 'ERR_JWT_EXPIRED') return { ok: false, error: { kind: 'expired' } };
+    if (code === 'ERR_JWT_CLAIM_VALIDATION_FAILED') {
+      const reason = (err as { reason?: string }).reason;
+      const claim = (err as { claim?: string }).claim;
+      // Recover the unverified payload for error context (signature
+      // already failed, but the raw values are useful for the caller).
+      let rawPayload: JWTPayload | null = null;
+      try { rawPayload = decodeJwt(token); } catch { /* ignore */ }
+      if (claim === 'aud') return { ok: false, error: { kind: 'wrong_audience', aud: rawPayload?.aud } };
+      if (claim === 'iss') return { ok: false, error: { kind: 'wrong_issuer', iss: rawPayload?.iss } };
+      if (claim === 'nbf' || reason === 'nbf') return { ok: false, error: { kind: 'not_yet_valid' } };
+    }
+    return {
+      ok: false,
+      error: { kind: 'signature_invalid', reason: err instanceof Error ? err.message : 'verify failed' },
+    };
+  }
+
+  const required = ['jti', 'sub', 'tenant_id', 'merchant_id', 'agent_id', 'consent_record_id', 'passport_type', 'scopes', 'env'];
+  const missing = required.filter((k) => payload[k] === undefined || payload[k] === null);
+  if (missing.length) return { ok: false, error: { kind: 'missing_claims', fields: missing } };
+
+  // Temporal claims must be present and numeric. jose's jwtVerify
+  // already validates exp/nbf semantics with clock-skew tolerance, but
+  // it does NOT check that exp/iat/nbf exist or that exp - iat falls
+  // within a sane window. Defense in depth.
+  const iat = payload.iat;
+  const exp = payload.exp;
+  const nbf = payload.nbf;
+  if (typeof iat !== 'number' || !Number.isFinite(iat)) {
+    return { ok: false, error: { kind: 'temporal_claim_invalid', reason: 'iat missing or non-numeric' } };
+  }
+  if (typeof exp !== 'number' || !Number.isFinite(exp)) {
+    return { ok: false, error: { kind: 'temporal_claim_invalid', reason: 'exp missing or non-numeric' } };
+  }
+  if (typeof nbf !== 'number' || !Number.isFinite(nbf)) {
+    return { ok: false, error: { kind: 'temporal_claim_invalid', reason: 'nbf missing or non-numeric' } };
+  }
+  if (exp <= iat) {
+    return { ok: false, error: { kind: 'temporal_claim_invalid', reason: 'exp must be greater than iat' } };
+  }
+
+  // Spec §6 max lifetime per passport type. Blocks "leaked key signs a
+  // token with iat=valid + exp=999999999" — verifier refuses to honour
+  // any token claiming a lifetime longer than what we ever issue. The
+  // 30s tolerance matches the JWT clock-skew tolerance everywhere.
+  const passportTypeRaw = payload['passport_type'];
+  if (passportTypeRaw !== 'browse' && passportTypeRaw !== 'checkout') {
+    return { ok: false, error: { kind: 'invalid_passport_type', value: passportTypeRaw } };
+  }
+  const passportType: PassportType = passportTypeRaw;
+  const maxLifetime = MAX_PASSPORT_LIFETIME_SECONDS[passportType];
+  const declaredLifetime = exp - iat;
+  if (declaredLifetime > maxLifetime + CLOCK_SKEW_SECONDS) {
+    return {
+      ok: false,
+      error: {
+        kind: 'lifetime_exceeded',
+        passportType,
+        declaredLifetime,
+        maxLifetime,
+      },
+    };
+  }
+
+  // Retired-key gates. Two separate failure modes:
+  //   1. iat AFTER retired_at — stolen key trying to mint NEW passports
+  //      timestamped post-retirement.
+  //   2. iat BEFORE retired_at but exp BEYOND the retired-key window —
+  //      stolen key backdates iat then sets exp far in the future to
+  //      live on after retirement. Cap exp at retired_at + max_lifetime.
+  if (keyRecord.retiredAt) {
+    const retiredAtUnix = Math.floor(keyRecord.retiredAt.getTime() / 1000);
+    if (iat > retiredAtUnix) {
+      return {
+        ok: false,
+        error: { kind: 'kid_retired_iat_after', kid: header.kid, retiredAtUnix },
+      };
+    }
+    const maxExpUnix = retiredAtUnix + maxLifetime + CLOCK_SKEW_SECONDS;
+    if (exp > maxExpUnix) {
+      return {
+        ok: false,
+        error: {
+          kind: 'kid_retired_window_exceeded',
+          kid: header.kid,
+          retiredAtUnix,
+          maxExpUnix,
+        },
+      };
+    }
+  }
+
+  const tenantId = String(payload['tenant_id']);
+  const merchantId = String(payload['merchant_id']);
+
+  if (options.expectedTenantId && options.expectedTenantId !== tenantId) {
+    return { ok: false, error: { kind: 'tenant_mismatch', expected: options.expectedTenantId, actual: tenantId } };
+  }
+  if (options.expectedMerchantId && options.expectedMerchantId !== merchantId) {
+    return { ok: false, error: { kind: 'merchant_mismatch', expected: options.expectedMerchantId, actual: merchantId } };
+  }
+
+  if (options.mode === 'payment_affecting') {
+    const revocation: RevocationCheck = await checkPassportRevocation(sql, redis, String(payload.jti));
+    if (revocation.source === 'fail_closed_unavailable') {
+      return { ok: false, error: { kind: 'revocation_unavailable', error: revocation.error } };
+    }
+    if (revocation.revoked) {
+      return { ok: false, error: { kind: 'revoked', ...(revocation.source === 'postgres' && revocation.reason !== undefined ? { reason: revocation.reason } : {}) } };
+    }
+  }
+
+  const passport: VerifiedPassport = {
+    jti: String(payload.jti),
+    kid: header.kid,
+    passportType,                     // narrowed earlier
+    tenantId,
+    merchantId,
+    agentId: String(payload['agent_id']),
+    consentRecordId: String(payload['consent_record_id']),
+    subject: String(payload.sub),
+    scopes: payload['scopes'] as string[],
+    maxAmount: typeof payload['max_amount'] === 'number' ? payload['max_amount'] : null,
+    currency: typeof payload['currency'] === 'string' ? payload['currency'] : null,
+    policyVersion: typeof payload['policy_version'] === 'string' ? payload['policy_version'] : null,
+    environment: payload['env'] as Environment,
+    issuedAt: iat,
+    notBefore: nbf,
+    expiresAt: exp,
+  };
+  return { ok: true, passport };
+}
+
+export { newCommercePassportJti };

--- a/apps/auth-service/src/lib/commerce/revocation.ts
+++ b/apps/auth-service/src/lib/commerce/revocation.ts
@@ -1,0 +1,99 @@
+import type postgres from 'postgres';
+import type { Redis } from 'ioredis';
+
+type Sql = ReturnType<typeof postgres>;
+
+const REDIS_REVOKED_PASSPORT_KEY = 'commerce:revoked:passport';
+
+export type RevocationCheck =
+  | { revoked: false; source: 'redis' | 'postgres' }
+  | { revoked: true; source: 'redis' | 'postgres'; reason?: string }
+  | { revoked: false; source: 'fail_closed_unavailable'; error: string };
+
+/**
+ * Check whether a passport jti is revoked.
+ *
+ * Strategy:
+ *   1. Redis SISMEMBER on commerce:revoked:passport (fast path).
+ *   2. On Redis miss or error, fall through to Postgres lookup.
+ *   3. If Postgres also unavailable → return source='fail_closed_unavailable'.
+ *      The CALLER decides what to do; for payment-affecting actions, the
+ *      route layer must treat this as deny (fail closed). For browse
+ *      reads the route layer may degrade.
+ *
+ * NB: The check is a positive-existence check on a revocation row, so a
+ * Redis miss is informative only when accompanied by a successful
+ * Postgres confirmation. We do not assume "Redis miss = not revoked" —
+ * the tombstone could simply not be cached yet.
+ */
+export async function checkPassportRevocation(
+  sql: Sql,
+  redis: Redis | null,
+  jti: string,
+): Promise<RevocationCheck> {
+  if (redis) {
+    try {
+      const isMember = await redis.sismember(REDIS_REVOKED_PASSPORT_KEY, jti);
+      if (isMember === 1) {
+        return { revoked: true, source: 'redis' };
+      }
+      // Cache miss — fall through to Postgres for authoritative answer.
+    } catch {
+      // Redis error — fall through to Postgres; do not throw yet.
+    }
+  }
+
+  try {
+    const rows = await sql<Array<{ reason: string }>>`
+      SELECT reason FROM commerce_passport_revocations
+       WHERE jti = ${jti}
+       LIMIT 1
+    `;
+    if (rows[0]) {
+      // Warm Redis on the way out so subsequent checks hit the cache.
+      if (redis) {
+        try {
+          await redis.sadd(REDIS_REVOKED_PASSPORT_KEY, jti);
+        } catch {
+          // best-effort
+        }
+      }
+      return { revoked: true, source: 'postgres', reason: rows[0].reason };
+    }
+    return { revoked: false, source: 'postgres' };
+  } catch (err) {
+    return {
+      revoked: false,
+      source: 'fail_closed_unavailable',
+      error: err instanceof Error ? err.message : 'unknown',
+    };
+  }
+}
+
+/**
+ * Insert a revocation row and warm the Redis cache. Idempotent on
+ * repeated calls for the same jti (PK conflict ignored).
+ */
+export async function revokeCommercePassport(
+  sql: Sql,
+  redis: Redis | null,
+  input: {
+    jti: string;
+    tenantId: string;
+    reason: string;
+    revokedBy: string | null;
+  },
+): Promise<void> {
+  await sql`
+    INSERT INTO commerce_passport_revocations (jti, tenant_id, reason, revoked_by)
+    VALUES (${input.jti}, ${input.tenantId}, ${input.reason}, ${input.revokedBy ?? null})
+    ON CONFLICT (jti) DO NOTHING
+  `;
+  if (redis) {
+    try {
+      await redis.sadd(REDIS_REVOKED_PASSPORT_KEY, input.jti);
+    } catch {
+      // best-effort; Postgres is the source of truth.
+    }
+  }
+}

--- a/apps/auth-service/src/lib/crypto.ts
+++ b/apps/auth-service/src/lib/crypto.ts
@@ -242,6 +242,25 @@ export async function buildJwks(): Promise<{ keys: Record<string, unknown>[] }> 
     });
   }
 
+  // Commerce Passport ES256 keys (M2). Include both active and retired so
+  // passports signed with a recently-rotated key keep verifying through
+  // the rotation grace window. Lazy-imported to avoid pulling the
+  // commerce module surface into pure-platform call sites that may run
+  // before commerce config is wired.
+  try {
+    const { getSql } = await import('../db/client.js');
+    const { listCommercePassportKeysForJwks } = await import('./commerce/passport-keys.js');
+    const commerceKeys = await listCommercePassportKeysForJwks(getSql());
+    for (const k of commerceKeys) {
+      // public_key_jwk in DB already carries kid + alg + use=sig; emit as-is.
+      keys.push(k.publicKeyJwk);
+    }
+  } catch {
+    // Commerce keys are optional in the JWKS — if the DB is unavailable
+    // here we still serve the platform RS256/EdDSA keys. Log via the
+    // route layer (this lib should not depend on pino directly).
+  }
+
   return { keys };
 }
 

--- a/apps/auth-service/src/routes/commerce-consent.ts
+++ b/apps/auth-service/src/routes/commerce-consent.ts
@@ -157,29 +157,21 @@ async function ensurePrincipalCanActOnTenant(
   };
 }
 
-function parseFormBody(body: unknown): Record<string, string> {
-  // Use a null-prototype object and skip well-known prototype-pollution
-  // keys so user-supplied form keys cannot mutate Object.prototype or
-  // override built-in methods. Callers only ever read fixed known fields
-  // (csrf, code, etc.) from the result.
-  const out: Record<string, string> = Object.create(null) as Record<string, string>;
-  const isUnsafeKey = (k: string): boolean =>
-    k === '__proto__' || k === 'constructor' || k === 'prototype';
+function parseFormBody(body: unknown): URLSearchParams {
+  // Return URLSearchParams rather than a plain object so user-supplied
+  // form keys cannot pollute Object.prototype via bracket-assignment.
+  // Callers read fixed known fields with `.get('csrf')` etc.
   if (typeof body === 'string') {
-    const params = new URLSearchParams(body);
-    for (const [k, v] of params) {
-      if (isUnsafeKey(k)) continue;
-      out[k] = v;
-    }
-    return out;
+    return new URLSearchParams(body);
   }
   if (body && typeof body === 'object') {
+    const init: Array<[string, string]> = [];
     for (const [k, v] of Object.entries(body as Record<string, unknown>)) {
-      if (isUnsafeKey(k)) continue;
-      if (typeof v === 'string') out[k] = v;
+      if (typeof v === 'string') init.push([k, v]);
     }
+    return new URLSearchParams(init);
   }
-  return out;
+  return new URLSearchParams();
 }
 
 type RenderState =
@@ -491,7 +483,7 @@ export async function commerceConsentRoutes(app: FastifyInstance): Promise<void>
           'Requesting a verification code requires an authenticated principal session');
       }
       const form = parseFormBody(request.body);
-      const formCsrf = form['csrf'] ?? '';
+      const formCsrf = form.get('csrf') ?? '';
       const expected = deriveConsentCsrfToken(principal.rawToken, request.params.reqId);
       const a = Buffer.from(formCsrf);
       const b = Buffer.from(expected);
@@ -587,14 +579,14 @@ export async function commerceConsentRoutes(app: FastifyInstance): Promise<void>
           'Verifying a challenge requires an authenticated principal session');
       }
       const form = parseFormBody(request.body);
-      const formCsrf = form['csrf'] ?? '';
+      const formCsrf = form.get('csrf') ?? '';
       const expected = deriveConsentCsrfToken(principal.rawToken, request.params.reqId);
       const a = Buffer.from(formCsrf);
       const b = Buffer.from(expected);
       if (a.length !== b.length || !timingSafeEqual(a, b)) {
         throw new CommerceHttpError(403, 'csrf_invalid', 'CSRF token mismatch');
       }
-      const code = (form['code'] ?? '').trim();
+      const code = (form.get('code') ?? '').trim();
       if (!/^\d{4,10}$/.test(code)) {
         throw new CommerceHttpError(422, 'validation_failed', 'Code must be a 4-10 digit numeric string',
           { details: { fields: { code: 'numeric, 4-10 digits' } }, retryable: false });
@@ -682,7 +674,7 @@ export async function commerceConsentRoutes(app: FastifyInstance): Promise<void>
       }
       // 2. CSRF token bound to (session_token, consent_request_id).
       const form = parseFormBody(request.body);
-      const formCsrf = form['csrf'] ?? '';
+      const formCsrf = form.get('csrf') ?? '';
       const expected = deriveConsentCsrfToken(principal.rawToken, request.params.reqId);
       const a = Buffer.from(formCsrf);
       const b = Buffer.from(expected);
@@ -776,7 +768,7 @@ export async function commerceConsentRoutes(app: FastifyInstance): Promise<void>
           'Denying consent requires an authenticated principal session');
       }
       const form = parseFormBody(request.body);
-      const formCsrf = form['csrf'] ?? '';
+      const formCsrf = form.get('csrf') ?? '';
       const expected = deriveConsentCsrfToken(principal.rawToken, request.params.reqId);
       const a = Buffer.from(formCsrf);
       const b = Buffer.from(expected);

--- a/apps/auth-service/src/routes/commerce-consent.ts
+++ b/apps/auth-service/src/routes/commerce-consent.ts
@@ -158,16 +158,28 @@ async function ensurePrincipalCanActOnTenant(
 }
 
 function parseFormBody(body: unknown): Record<string, string> {
+  // Use a null-prototype object and skip well-known prototype-pollution
+  // keys so user-supplied form keys cannot mutate Object.prototype or
+  // override built-in methods. Callers only ever read fixed known fields
+  // (csrf, code, etc.) from the result.
+  const out: Record<string, string> = Object.create(null) as Record<string, string>;
+  const isUnsafeKey = (k: string): boolean =>
+    k === '__proto__' || k === 'constructor' || k === 'prototype';
   if (typeof body === 'string') {
-    const out: Record<string, string> = {};
-    for (const pair of body.split('&')) {
-      const [k, v] = pair.split('=');
-      if (k) out[decodeURIComponent(k)] = decodeURIComponent((v ?? '').replace(/\+/g, ' '));
+    const params = new URLSearchParams(body);
+    for (const [k, v] of params) {
+      if (isUnsafeKey(k)) continue;
+      out[k] = v;
     }
     return out;
   }
-  if (body && typeof body === 'object') return body as Record<string, string>;
-  return {};
+  if (body && typeof body === 'object') {
+    for (const [k, v] of Object.entries(body as Record<string, unknown>)) {
+      if (isUnsafeKey(k)) continue;
+      if (typeof v === 'string') out[k] = v;
+    }
+  }
+  return out;
 }
 
 type RenderState =
@@ -303,39 +315,45 @@ export async function commerceConsentRoutes(app: FastifyInstance): Promise<void>
       // The token must NOT linger in browser history, server logs,
       // screenshots, or referrers. Render is deferred to the follow-up
       // request that the browser will make against the clean URL.
+      //
+      // The sensitive action (cookie set + redirect) is gated solely on
+      // verifiedSession, which is bound only after server-side
+      // cryptographic verification of the JWT succeeds. The user-controlled
+      // presence/length test is only used to decide whether to attempt
+      // verification, never as the security gate itself.
       const querySession = request.query.session;
+      let verifiedSession: string | null = null;
       if (typeof querySession === 'string' && querySession.length > 0) {
-        let sessionValid = false;
         try {
           await verifyPrincipalSessionToken(querySession);
-          sessionValid = true;
+          verifiedSession = querySession;
         } catch {
           // Invalid session in the URL — do NOT set a cookie, do NOT
           // redirect. Fall through and render sign_in_required so the
           // user sees a useful error rather than a redirect loop.
         }
-        if (sessionValid) {
-          setSessionCookie(reply, querySession);
-          // Build a clean URL that preserves the req param and any other
-          // future query params except session. encodeURIComponent here
-          // because reqId is reflected from user input.
-          const reqIdParam = typeof request.query.req === 'string' && request.query.req
-            ? `?req=${encodeURIComponent(request.query.req)}`
-            : '';
-          // 303 See Other forces the browser to GET the new location
-          // without resending any body, and explicitly without keeping
-          // the query string. Cache-Control: no-store + Pragma:
-          // no-cache prevent intermediaries from caching the redirect
-          // (the cookie set in this response is the side-effect we
-          // need preserved). The browser drops the old URL from the
-          // address bar and history navigation.
-          return reply
-            .status(303)
-            .header('Location', `/v1/commerce/consent/page${reqIdParam}`)
-            .header('Cache-Control', 'no-store')
-            .header('Pragma', 'no-cache')
-            .send('');
-        }
+      }
+      if (verifiedSession !== null) {
+        setSessionCookie(reply, verifiedSession);
+        // Build a clean URL that preserves the req param and any other
+        // future query params except session. encodeURIComponent here
+        // because reqId is reflected from user input.
+        const reqIdParam = typeof request.query.req === 'string' && request.query.req
+          ? `?req=${encodeURIComponent(request.query.req)}`
+          : '';
+        // 303 See Other forces the browser to GET the new location
+        // without resending any body, and explicitly without keeping
+        // the query string. Cache-Control: no-store + Pragma:
+        // no-cache prevent intermediaries from caching the redirect
+        // (the cookie set in this response is the side-effect we
+        // need preserved). The browser drops the old URL from the
+        // address bar and history navigation.
+        return reply
+          .status(303)
+          .header('Location', `/v1/commerce/consent/page${reqIdParam}`)
+          .header('Cache-Control', 'no-store')
+          .header('Pragma', 'no-cache')
+          .send('');
       }
 
       const reqId = request.query.req;

--- a/apps/auth-service/src/routes/commerce-consent.ts
+++ b/apps/auth-service/src/routes/commerce-consent.ts
@@ -1,0 +1,830 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { getSql } from '../db/client.js';
+import { verifyPrincipalSessionToken } from '../lib/crypto.js';
+import { CommerceHttpError } from '../lib/commerce/errors.js';
+import {
+  findConsentByRequestId,
+  presentConsentForUser,
+  approveConsent,
+  denyConsent,
+  canonicalPresentedPayload,
+  sha256hex,
+  deriveConsentCsrfToken,
+  type ConsentRecord,
+} from '../lib/commerce/consent.js';
+import {
+  createChallenge,
+  verifyChallenge,
+  findActiveChallenge,
+  isChallengeProviderAvailable,
+} from '../lib/commerce/consent-challenge.js';
+import { appendCommerceAudit } from '../lib/commerce/audit.js';
+
+const SESSION_COOKIE_PROD = '__Host-grantex_principal_session';
+const SESSION_COOKIE_DEV = 'grantex_principal_session';
+
+function sessionCookieName(): string {
+  return process.env['NODE_ENV'] === 'production' ? SESSION_COOKIE_PROD : SESSION_COOKIE_DEV;
+}
+
+function isAcceptableConsentHost(host: string | undefined): boolean {
+  if (!host) return false;
+  const bare = host.split(':')[0];
+  if (process.env['NODE_ENV'] === 'production') {
+    const required = process.env['COMMERCE_CONSENT_HOST'] ?? 'consent.grantex.dev';
+    return bare === required;
+  }
+  if (bare === 'localhost' || bare === '127.0.0.1') return true;
+  if (bare === 'consent.grantex.dev') return true;
+  const dev = process.env['COMMERCE_CONSENT_HOST'];
+  if (dev && bare === dev) return true;
+  return false;
+}
+
+function escapeHtml(s: string | null | undefined): string {
+  if (s == null) return '';
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function applySecurityHeaders(reply: FastifyReply, nonce: string): void {
+  // Spec §14 strict CSP. Inline scripts use a per-request nonce.
+  const csp = [
+    "default-src 'self'",
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    `script-src 'self' 'nonce-${nonce}'`,
+    `style-src 'self' 'nonce-${nonce}'`,
+    "img-src 'self' data: https:",
+    "connect-src 'self'",
+  ].join('; ');
+  void reply.header('Content-Security-Policy', csp);
+  void reply.header('X-Frame-Options', 'DENY');
+  void reply.header('X-Content-Type-Options', 'nosniff');
+  void reply.header('Cache-Control', 'no-store');
+  void reply.header('Pragma', 'no-cache');
+  void reply.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');
+  // Finding 2: consent URLs may transiently carry a principal session
+  // token in the query string (which we strip via 303 immediately, but
+  // belt-and-braces). no-referrer keeps the token from leaking via the
+  // browser Referer header to any subresource, even within the same
+  // origin. Server-level onSend respects this when set per-route.
+  void reply.header('Referrer-Policy', 'no-referrer');
+}
+
+function setSessionCookie(reply: FastifyReply, sessionToken: string): void {
+  const isProd = process.env['NODE_ENV'] === 'production';
+  const parts = [
+    `${sessionCookieName()}=${sessionToken}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Strict',
+  ];
+  if (isProd) parts.push('Secure');
+  void reply.header('Set-Cookie', parts.join('; '));
+}
+
+function getSessionFromCookie(request: FastifyRequest): string | null {
+  const raw = request.headers['cookie'];
+  if (typeof raw !== 'string') return null;
+  const name = sessionCookieName();
+  const re = new RegExp(`(?:^|;\\s*)${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}=([^;]+)`);
+  const match = re.exec(raw);
+  return match?.[1] ?? null;
+}
+
+interface AuthenticatedPrincipal {
+  principalId: string;
+  developerId: string;
+  rawToken: string;
+}
+
+/**
+ * Resolve the authenticated principal for the consent flow. Reads the
+ * session token from the cookie; on first GET the route promotes a
+ * `?session=<token>` query param to the cookie before this is called.
+ *
+ * Returns null when no session is present or it fails verification.
+ * Callers that REQUIRE a principal must respond accordingly (the GET
+ * handler renders a sign-in screen; POST approve/deny return 401).
+ */
+async function resolvePrincipalSession(request: FastifyRequest): Promise<AuthenticatedPrincipal | null> {
+  const token = getSessionFromCookie(request);
+  if (!token) return null;
+  try {
+    const claims = await verifyPrincipalSessionToken(token);
+    return { principalId: claims.principalId, developerId: claims.developerId, rawToken: token };
+  } catch {
+    return null;
+  }
+}
+
+type PrincipalTenantBinding =
+  | { bound: false }
+  | { bound: true; tenantStatus: 'active' | 'disabled' };
+
+/**
+ * Verify the authenticated principal's developer is bound to the
+ * consent record's tenant AND that the tenant is active (Finding 3).
+ * Returns the tenant status alongside the binding so the caller can
+ * surface a precise tenant_disabled response without a second query.
+ */
+async function ensurePrincipalCanActOnTenant(
+  developerId: string,
+  tenantId: string,
+): Promise<PrincipalTenantBinding> {
+  const sql = getSql();
+  const rows = await sql<{ status: string }[]>`
+    SELECT t.status
+      FROM commerce_developer_tenants dt
+      JOIN commerce_tenants t ON t.id = dt.tenant_id
+     WHERE dt.developer_id = ${developerId}
+       AND dt.tenant_id = ${tenantId}
+     LIMIT 1
+  `;
+  const row = rows[0];
+  if (!row) return { bound: false };
+  return {
+    bound: true,
+    tenantStatus: row.status === 'disabled' ? 'disabled' : 'active',
+  };
+}
+
+function parseFormBody(body: unknown): Record<string, string> {
+  if (typeof body === 'string') {
+    const out: Record<string, string> = {};
+    for (const pair of body.split('&')) {
+      const [k, v] = pair.split('=');
+      if (k) out[decodeURIComponent(k)] = decodeURIComponent((v ?? '').replace(/\+/g, ' '));
+    }
+    return out;
+  }
+  if (body && typeof body === 'object') return body as Record<string, string>;
+  return {};
+}
+
+type RenderState =
+  | 'present'                    // verified challenge → approve/deny forms
+  | 'challenge_request'          // session ok, no challenge yet → "send code" form
+  | 'challenge_verify'           // challenge requested → "enter code" form
+  | 'challenge_unavailable'      // production with no provider → fail closed
+  | 'expired'
+  | 'already_decided'
+  | 'not_found'
+  | 'sign_in_required';
+
+function renderConsentPage(
+  record: ConsentRecord | null,
+  csrfToken: string | null,
+  nonce: string,
+  state: RenderState,
+): string {
+  const title =
+    state === 'present' ? 'Authorize agent action'
+    : state === 'challenge_request' ? 'Verify it’s you'
+    : state === 'challenge_verify' ? 'Enter your verification code'
+    : state === 'challenge_unavailable' ? 'Verification temporarily unavailable'
+    : state === 'expired' ? 'Consent expired'
+    : state === 'not_found' ? 'Consent not found'
+    : state === 'sign_in_required' ? 'Sign in to authorize'
+    : `Consent ${record?.status ?? 'closed'}`;
+  const reqIdAttr = escapeHtml(record?.consentRequestId ?? '');
+  const csrfField = csrfToken
+    ? `<input type="hidden" name="csrf" value="${escapeHtml(csrfToken)}">`
+    : '';
+  const scopesHtml = record
+    ? record.requestedScopes.map((s) => `<li>${escapeHtml(s)}</li>`).join('')
+    : '';
+  const decisionForms = (state === 'present' && csrfToken && record)
+    ? `
+      <form method="POST" action="/v1/commerce/consent/${reqIdAttr}/approve" class="row">
+        ${csrfField}
+        <button class="btn btn-primary" type="submit">Approve</button>
+      </form>
+      <form method="POST" action="/v1/commerce/consent/${reqIdAttr}/deny" class="row">
+        ${csrfField}
+        <button class="btn btn-secondary" type="submit">Deny</button>
+      </form>`
+    : '';
+  const challengeRequestForm = (state === 'challenge_request' && csrfToken && record)
+    ? `
+      <p class="msg">For your security, Grantex will send you a one-time verification code before your decision is recorded.</p>
+      <form method="POST" action="/v1/commerce/consent/${reqIdAttr}/challenge" class="row">
+        ${csrfField}
+        <button class="btn btn-primary" type="submit">Send verification code</button>
+      </form>`
+    : '';
+  const challengeVerifyForm = (state === 'challenge_verify' && csrfToken && record)
+    ? `
+      <p class="msg">Enter the 6-digit verification code sent to you. The code expires in a few minutes.</p>
+      <form method="POST" action="/v1/commerce/consent/${reqIdAttr}/challenge/verify" class="row">
+        ${csrfField}
+        <input type="text" name="code" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" required class="code-input" placeholder="123456">
+        <button class="btn btn-primary" type="submit">Verify</button>
+      </form>`
+    : '';
+  const challengeUnavailableBlock = state === 'challenge_unavailable'
+    ? `<p class="msg">User verification is required before this decision can be recorded, but the verification provider is not configured in this environment. Please contact your platform operator.</p>`
+    : '';
+  const signInBlock = state === 'sign_in_required'
+    ? `<p class="msg">You must sign in with the application that requested this authorization. The agent must include your principal session in the consent link (<code>?session=&lt;token&gt;</code>) for you to authorize.</p>`
+    : '';
+  const closedBlock = (state === 'expired' || state === 'already_decided' || state === 'not_found')
+    ? `<p class="msg">${escapeHtml(title)}. You may close this window.</p>`
+    : '';
+
+  return `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<style nonce="${nonce}">
+  body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f5f5f5;margin:0;padding:24px;display:flex;align-items:center;justify-content:center;min-height:100vh}
+  .card{background:#fff;max-width:460px;width:100%;border-radius:12px;box-shadow:0 4px 24px rgba(0,0,0,.08);padding:28px}
+  h1{font-size:20px;margin:0 0 12px}
+  .meta{color:#444;font-size:14px;line-height:1.6;margin-bottom:18px}
+  .meta .k{color:#888;display:inline-block;min-width:96px}
+  ul.scopes{list-style:none;padding-left:0;margin:8px 0 18px}
+  ul.scopes li{padding:6px 10px;background:#f8f8f8;border-radius:6px;font-size:13px;margin-bottom:6px}
+  .row{margin:0}
+  .btn{display:inline-block;width:100%;padding:12px;border:none;border-radius:8px;font-size:15px;font-weight:600;cursor:pointer;margin-top:8px}
+  .btn-primary{background:#111;color:#fff}
+  .btn-secondary{background:#f3f4f6;color:#374151}
+  .msg{color:#555;line-height:1.6;margin-bottom:12px}
+  code{background:#f3f4f6;padding:2px 6px;border-radius:4px;font-size:12px}
+  .code-input{width:100%;font-size:22px;letter-spacing:.4em;text-align:center;padding:12px;border:1px solid #d1d5db;border-radius:8px;font-family:'SF Mono','Fira Code',monospace}
+</style>
+</head><body>
+<main class="card">
+  <h1>${escapeHtml(title)}</h1>
+  ${(state === 'present' || state === 'challenge_request' || state === 'challenge_verify') && record ? `
+    <div class="meta">
+      <div><span class="k">Merchant</span> <strong>${escapeHtml(record.merchantId)}</strong></div>
+      <div><span class="k">Agent</span> <strong>${escapeHtml(record.agentId)}</strong></div>
+      <div><span class="k">Type</span> ${escapeHtml(record.passportType)}</div>
+      ${record.maxAmount != null ? `<div><span class="k">Max amount</span> ${escapeHtml(String(record.maxAmount))} (${escapeHtml(record.currency ?? '')}, minor units, tax-inclusive)</div>` : ''}
+      <div><span class="k">Expires</span> ${escapeHtml(record.expiresAt)}</div>
+      <div><span class="k">Confirmation</span> Final payment requires a separate user confirmation step.</div>
+    </div>
+    <div><strong>Scopes requested:</strong></div>
+    <ul class="scopes">${scopesHtml}</ul>
+    ${decisionForms}${challengeRequestForm}${challengeVerifyForm}` : signInBlock + closedBlock + challengeUnavailableBlock}
+</main>
+</body></html>`;
+}
+
+export async function commerceConsentRoutes(app: FastifyInstance): Promise<void> {
+  app.addContentTypeParser(
+    'application/x-www-form-urlencoded',
+    { parseAs: 'string' },
+    (_req, body, done) => done(null, body),
+  );
+
+  // GET /v1/commerce/consent/page?req=<id>[&session=<token>]
+  app.get<{ Querystring: { req?: string; session?: string } }>(
+    '/consent/page',
+    { config: { publicConsent: true } },
+    async (request, reply) => {
+      if (!isAcceptableConsentHost(request.headers['host'])) {
+        return reply.status(404).type('text/html').send('<!doctype html><title>Not Found</title>');
+      }
+      const nonce = randomBytes(16).toString('base64url');
+      applySecurityHeaders(reply, nonce);
+
+      // Finding 2: when ?session=<token> is supplied, verify, set the
+      // session cookie, and 303 to the same URL with session stripped.
+      // The token must NOT linger in browser history, server logs,
+      // screenshots, or referrers. Render is deferred to the follow-up
+      // request that the browser will make against the clean URL.
+      const querySession = request.query.session;
+      if (typeof querySession === 'string' && querySession.length > 0) {
+        let sessionValid = false;
+        try {
+          await verifyPrincipalSessionToken(querySession);
+          sessionValid = true;
+        } catch {
+          // Invalid session in the URL — do NOT set a cookie, do NOT
+          // redirect. Fall through and render sign_in_required so the
+          // user sees a useful error rather than a redirect loop.
+        }
+        if (sessionValid) {
+          setSessionCookie(reply, querySession);
+          // Build a clean URL that preserves the req param and any other
+          // future query params except session. encodeURIComponent here
+          // because reqId is reflected from user input.
+          const reqIdParam = typeof request.query.req === 'string' && request.query.req
+            ? `?req=${encodeURIComponent(request.query.req)}`
+            : '';
+          // 303 See Other forces the browser to GET the new location
+          // without resending any body, and explicitly without keeping
+          // the query string. Cache-Control: no-store + Pragma:
+          // no-cache prevent intermediaries from caching the redirect
+          // (the cookie set in this response is the side-effect we
+          // need preserved). The browser drops the old URL from the
+          // address bar and history navigation.
+          return reply
+            .status(303)
+            .header('Location', `/v1/commerce/consent/page${reqIdParam}`)
+            .header('Cache-Control', 'no-store')
+            .header('Pragma', 'no-cache')
+            .send('');
+        }
+      }
+
+      const reqId = request.query.req;
+      if (typeof reqId !== 'string' || !reqId) {
+        return reply.status(400).type('text/html')
+          .send(renderConsentPage(null, null, nonce, 'not_found'));
+      }
+
+      const sql = getSql();
+      const record = await presentConsentForUser(sql, reqId);
+      if (!record) {
+        return reply.status(404).type('text/html')
+          .send(renderConsentPage(null, null, nonce, 'not_found'));
+      }
+
+      // Determine render state.
+      if (record.status === 'expired') {
+        return reply.status(410).type('text/html')
+          .send(renderConsentPage(record, null, nonce, 'expired'));
+      }
+      if (record.status !== 'requested') {
+        return reply.status(200).type('text/html')
+          .send(renderConsentPage(record, null, nonce, 'already_decided'));
+      }
+
+      // Status === 'requested' — render only when there's a valid
+      // session in the COOKIE (the query-param path was redirected).
+      const principal = await resolvePrincipalSession(request);
+
+      if (!principal) {
+        return reply.status(200).type('text/html; charset=utf-8')
+          .send(renderConsentPage(record, null, nonce, 'sign_in_required'));
+      }
+
+      // Tenant binding + tenant-active check (Finding 3).
+      const tenantOk = await ensurePrincipalCanActOnTenant(principal.developerId, record.tenantId);
+      if (!tenantOk.bound) {
+        return reply.status(403).type('text/html')
+          .send(renderConsentPage(record, null, nonce, 'sign_in_required'));
+      }
+      if (tenantOk.bound && tenantOk.tenantStatus === 'disabled') {
+        // Tenant disabled — surface the explicit code via the JSON
+        // route; for the SSR page we render a closed screen.
+        return reply.status(403).type('text/html')
+          .send(renderConsentPage(record, null, nonce, 'already_decided'));
+      }
+
+      // Hint pre-check.
+      if (record.userPrincipalHint && record.userPrincipalHint !== principal.principalId) {
+        return reply.status(200).type('text/html; charset=utf-8')
+          .send(renderConsentPage(record, null, nonce, 'sign_in_required'));
+      }
+
+      // P0 fix: gate the approve/deny forms behind a verified
+      // user-presence challenge. Only after a server-issued, single-use
+      // challenge has been verified for THIS (consent_request_id,
+      // principal_id) pair do we render the approve/deny forms. Without
+      // that gate, a developer-minted principal session would still be
+      // sufficient to self-approve.
+      const csrfToken = deriveConsentCsrfToken(principal.rawToken, record.consentRequestId);
+      const active = await findActiveChallenge(sql, {
+        consentRequestId: record.consentRequestId,
+        principalId: principal.principalId,
+      });
+      if (active?.status === 'verified') {
+        return reply.status(200).type('text/html; charset=utf-8')
+          .send(renderConsentPage(record, csrfToken, nonce, 'present'));
+      }
+      if (active?.status === 'requested') {
+        return reply.status(200).type('text/html; charset=utf-8')
+          .send(renderConsentPage(record, csrfToken, nonce, 'challenge_verify'));
+      }
+      // No active challenge: render `challenge_request` only if the
+      // environment can actually deliver a challenge. Anywhere a real
+      // delivery provider isn't wired (M2: everything except
+      // NODE_ENV=test), surface the unavailable screen instead of a
+      // button that would only 503 on POST.
+      if (!isChallengeProviderAvailable()) {
+        return reply.status(503).type('text/html; charset=utf-8')
+          .send(renderConsentPage(record, null, nonce, 'challenge_unavailable'));
+      }
+      return reply.status(200).type('text/html; charset=utf-8')
+        .send(renderConsentPage(record, csrfToken, nonce, 'challenge_request'));
+    },
+  );
+
+  // GET /v1/commerce/consent/:reqId — JSON metadata (publicConsent)
+  app.get<{ Params: { reqId: string } }>(
+    '/consent/:reqId',
+    { config: { publicConsent: true } },
+    async (request, reply) => {
+      if (!isAcceptableConsentHost(request.headers['host'])) {
+        throw new CommerceHttpError(404, 'not_found', 'Resource not found');
+      }
+      applySecurityHeaders(reply, randomBytes(8).toString('base64url'));
+      const sql = getSql();
+      const r = await findConsentByRequestId(sql, request.params.reqId);
+      if (!r) {
+        throw new CommerceHttpError(404, 'consent_not_found', 'Consent request not found');
+      }
+      const canonical = canonicalPresentedPayload(r);
+      return reply.status(200).send({
+        consent_request_id: r.consentRequestId,
+        merchant_id: r.merchantId,
+        agent_id: r.agentId,
+        passport_type: r.passportType,
+        requested_scopes: r.requestedScopes,
+        max_amount: r.maxAmount,
+        currency: r.currency,
+        consent_text_version: r.consentTextVersion,
+        expires_at: r.expiresAt,
+        status: r.status,
+        presented_payload_hash: r.presentedPayloadHash ?? sha256hex(canonical),
+        // Hint surfaces so an SPA can confirm with the user before POST.
+        // Not the verified identity — that comes only from the principal session.
+        user_principal_hint: r.userPrincipalHint,
+      });
+    },
+  );
+
+  // -----------------------------------------------------------------
+  // POST /v1/commerce/consent/:reqId/challenge — request a one-time
+  // verification code that the agent/developer cannot read or compute.
+  // -----------------------------------------------------------------
+  app.post<{ Params: { reqId: string }; Body: string | Record<string, string> }>(
+    '/consent/:reqId/challenge',
+    { config: { publicConsent: true } },
+    async (request, reply) => {
+      if (!isAcceptableConsentHost(request.headers['host'])) {
+        throw new CommerceHttpError(404, 'not_found', 'Resource not found');
+      }
+      const principal = await resolvePrincipalSession(request);
+      if (!principal) {
+        throw new CommerceHttpError(401, 'principal_session_required',
+          'Requesting a verification code requires an authenticated principal session');
+      }
+      const form = parseFormBody(request.body);
+      const formCsrf = form['csrf'] ?? '';
+      const expected = deriveConsentCsrfToken(principal.rawToken, request.params.reqId);
+      const a = Buffer.from(formCsrf);
+      const b = Buffer.from(expected);
+      if (a.length !== b.length || !timingSafeEqual(a, b)) {
+        throw new CommerceHttpError(403, 'csrf_invalid', 'CSRF token mismatch');
+      }
+
+      const sql = getSql();
+      const consent = await findConsentByRequestId(sql, request.params.reqId);
+      if (!consent) {
+        throw new CommerceHttpError(404, 'consent_not_found', 'Consent request not found');
+      }
+      const tenantOk = await ensurePrincipalCanActOnTenant(principal.developerId, consent.tenantId);
+      if (!tenantOk.bound) {
+        throw new CommerceHttpError(403, 'principal_not_authorized_for_tenant',
+          'Authenticated principal is not bound to this commerce tenant');
+      }
+      if (tenantOk.tenantStatus === 'disabled') {
+        throw new CommerceHttpError(403, 'tenant_disabled',
+          'Commerce tenant is disabled', { retryable: false });
+      }
+      if (consent.userPrincipalHint && consent.userPrincipalHint !== principal.principalId) {
+        throw new CommerceHttpError(403, 'principal_hint_mismatch',
+          'Authenticated principal does not match the user this consent was created for');
+      }
+
+      const result = await createChallenge(sql, {
+        tenantId: consent.tenantId,
+        consentRecordId: consent.id,
+        consentRequestId: consent.consentRequestId,
+        principalId: principal.principalId,
+        developerId: principal.developerId,
+      });
+      if (!result.ok) {
+        if (result.reason === 'no_delivery_provider_configured') {
+          throw new CommerceHttpError(503, 'challenge_provider_unavailable',
+            'Consent challenge delivery provider is not configured in this environment',
+            { retryable: false });
+        }
+        // active_challenge_exists — a parallel request created one; let
+        // the user proceed with the existing challenge by reloading the
+        // page (which will render challenge_verify state).
+        throw new CommerceHttpError(409, 'challenge_already_active',
+          'A verification code has already been sent for this consent and principal',
+          { retryable: false });
+      }
+
+      await appendCommerceAudit(sql, {
+        tenantId: consent.tenantId, merchantId: consent.merchantId, agentId: consent.agentId,
+        userPrincipalId: principal.principalId,
+        eventType: 'consent.challenge.requested',
+        resourceType: 'commerce_consent_challenge', resourceId: result.challengeId,
+        requestId: request.id,
+        metadata: {
+          delivery_channel: result.deliveryChannel,
+          consent_request_id: consent.consentRequestId,
+        },
+      });
+
+      // Raw code is included ONLY when NODE_ENV === 'test' AND the
+      // selected delivery channel is `test_sink`. Both gates required;
+      // the lib also re-checks before populating `result.testOnlyCode`
+      // so any single regression cannot leak the secret. Staging,
+      // preview, QA, development, and production never reach this
+      // branch (channel is null upstream → 503 challenge_provider_unavailable).
+      const body: Record<string, unknown> = {
+        data: {
+          challenge_id: result.challengeId,
+          delivery_channel: result.deliveryChannel,
+          expires_at: result.expiresAt,
+        },
+      };
+      if (result.testOnlyCode !== undefined) {
+        (body['data'] as Record<string, unknown>)['test_only_code'] = result.testOnlyCode;
+      }
+      return reply.status(201).send(body);
+    },
+  );
+
+  // -----------------------------------------------------------------
+  // POST /v1/commerce/consent/:reqId/challenge/verify — submit the code
+  // -----------------------------------------------------------------
+  app.post<{ Params: { reqId: string }; Body: string | Record<string, string> }>(
+    '/consent/:reqId/challenge/verify',
+    { config: { publicConsent: true } },
+    async (request, reply) => {
+      if (!isAcceptableConsentHost(request.headers['host'])) {
+        throw new CommerceHttpError(404, 'not_found', 'Resource not found');
+      }
+      const principal = await resolvePrincipalSession(request);
+      if (!principal) {
+        throw new CommerceHttpError(401, 'principal_session_required',
+          'Verifying a challenge requires an authenticated principal session');
+      }
+      const form = parseFormBody(request.body);
+      const formCsrf = form['csrf'] ?? '';
+      const expected = deriveConsentCsrfToken(principal.rawToken, request.params.reqId);
+      const a = Buffer.from(formCsrf);
+      const b = Buffer.from(expected);
+      if (a.length !== b.length || !timingSafeEqual(a, b)) {
+        throw new CommerceHttpError(403, 'csrf_invalid', 'CSRF token mismatch');
+      }
+      const code = (form['code'] ?? '').trim();
+      if (!/^\d{4,10}$/.test(code)) {
+        throw new CommerceHttpError(422, 'validation_failed', 'Code must be a 4-10 digit numeric string',
+          { details: { fields: { code: 'numeric, 4-10 digits' } }, retryable: false });
+      }
+
+      const sql = getSql();
+      const consent = await findConsentByRequestId(sql, request.params.reqId);
+      if (!consent) {
+        throw new CommerceHttpError(404, 'consent_not_found', 'Consent request not found');
+      }
+      const tenantOk = await ensurePrincipalCanActOnTenant(principal.developerId, consent.tenantId);
+      if (!tenantOk.bound) {
+        throw new CommerceHttpError(403, 'principal_not_authorized_for_tenant',
+          'Authenticated principal is not bound to this commerce tenant');
+      }
+      if (tenantOk.tenantStatus === 'disabled') {
+        throw new CommerceHttpError(403, 'tenant_disabled',
+          'Commerce tenant is disabled', { retryable: false });
+      }
+      if (consent.userPrincipalHint && consent.userPrincipalHint !== principal.principalId) {
+        throw new CommerceHttpError(403, 'principal_hint_mismatch',
+          'Authenticated principal does not match the user this consent was created for');
+      }
+
+      const r = await verifyChallenge(sql, {
+        consentRequestId: consent.consentRequestId,
+        principalId: principal.principalId,
+        code,
+      });
+      if (!r.ok) {
+        const failureKindMap: Record<string, { status: number; code: string }> = {
+          not_found:    { status: 404, code: 'challenge_not_found' },
+          expired:      { status: 410, code: 'challenge_expired' },
+          invalid_code: { status: 403, code: 'challenge_invalid' },
+        };
+        const mapped = failureKindMap[r.reason];
+        await appendCommerceAudit(sql, {
+          tenantId: consent.tenantId, merchantId: consent.merchantId, agentId: consent.agentId,
+          userPrincipalId: principal.principalId,
+          eventType: r.reason === 'expired' ? 'consent.challenge.expired' : 'consent.challenge.failed',
+          resourceType: 'commerce_consent_challenge',
+          resourceId: '(verification rejected)',
+          requestId: request.id,
+          metadata: {
+            reason: r.reason,
+            consent_request_id: consent.consentRequestId,
+            ...(r.remainingAttempts !== undefined ? { remaining_attempts: r.remainingAttempts } : {}),
+          },
+        }).catch(() => undefined);
+        throw new CommerceHttpError(mapped!.status, mapped!.code,
+          'Challenge verification failed',
+          {
+            retryable: r.reason === 'invalid_code',
+            ...(r.remainingAttempts !== undefined
+              ? { details: { remaining_attempts: r.remainingAttempts } } : {}),
+          });
+      }
+      await appendCommerceAudit(sql, {
+        tenantId: consent.tenantId, merchantId: consent.merchantId, agentId: consent.agentId,
+        userPrincipalId: principal.principalId,
+        eventType: 'consent.challenge.verified',
+        resourceType: 'commerce_consent_challenge', resourceId: r.challengeId,
+        requestId: request.id,
+        metadata: { consent_request_id: consent.consentRequestId },
+      });
+      return reply.status(200).send({
+        data: { challenge_id: r.challengeId, status: 'verified' },
+      });
+    },
+  );
+
+  // POST /v1/commerce/consent/:reqId/approve
+  app.post<{ Params: { reqId: string }; Body: string | Record<string, string> }>(
+    '/consent/:reqId/approve',
+    { config: { publicConsent: true } },
+    async (request, reply) => {
+      if (!isAcceptableConsentHost(request.headers['host'])) {
+        throw new CommerceHttpError(404, 'not_found', 'Resource not found');
+      }
+      // 1. Authenticated principal session is REQUIRED.
+      const principal = await resolvePrincipalSession(request);
+      if (!principal) {
+        throw new CommerceHttpError(401, 'principal_session_required',
+          'Approving consent requires an authenticated principal session');
+      }
+      // 2. CSRF token bound to (session_token, consent_request_id).
+      const form = parseFormBody(request.body);
+      const formCsrf = form['csrf'] ?? '';
+      const expected = deriveConsentCsrfToken(principal.rawToken, request.params.reqId);
+      const a = Buffer.from(formCsrf);
+      const b = Buffer.from(expected);
+      if (a.length !== b.length || !timingSafeEqual(a, b)) {
+        throw new CommerceHttpError(403, 'csrf_invalid',
+          'CSRF token missing or does not match the session');
+      }
+
+      const sql = getSql();
+      // 3. Tenant binding — principal's developer must own the consent's tenant.
+      const existing = await findConsentByRequestId(sql, request.params.reqId);
+      if (!existing) {
+        throw new CommerceHttpError(404, 'consent_not_found', 'Consent request not found');
+      }
+      const tenantOk = await ensurePrincipalCanActOnTenant(principal.developerId, existing.tenantId);
+      if (!tenantOk.bound) {
+        throw new CommerceHttpError(403, 'principal_not_authorized_for_tenant',
+          'Authenticated principal\'s developer is not bound to this commerce tenant');
+      }
+      // Finding 3 (P1): tenant must be active even if developer is bound.
+      if (tenantOk.tenantStatus === 'disabled') {
+        throw new CommerceHttpError(403, 'tenant_disabled',
+          'Commerce tenant is disabled', { retryable: false });
+      }
+
+      // 4. Decide. user_principal_id is set from the verified session,
+      //    NEVER from the agent. The lib also enforces hint match
+      //    (defense in depth) — when present, hint must == principalId.
+      const r = await approveConsent(sql, request.params.reqId, principal.principalId);
+      if (!r.ok) {
+        if (r.reason === 'expired') throw new CommerceHttpError(410, 'consent_expired', 'Consent request has expired');
+        if (r.reason === 'already_decided') throw new CommerceHttpError(409, 'consent_already_decided', 'Consent request was already approved or denied');
+        if (r.reason === 'principal_hint_mismatch') {
+          throw new CommerceHttpError(403, 'principal_hint_mismatch',
+            'Authenticated principal does not match the user this consent was created for');
+        }
+        if (r.reason === 'challenge_required') {
+          throw new CommerceHttpError(403, 'challenge_required',
+            'A verified consent challenge is required before this decision can be recorded',
+            { retryable: false });
+        }
+        throw new CommerceHttpError(404, 'consent_not_found', 'Consent request not found');
+      }
+      await appendCommerceAudit(sql, {
+        tenantId: r.record.tenantId,
+        merchantId: r.record.merchantId,
+        agentId: r.record.agentId,
+        userPrincipalId: r.record.userPrincipalId,
+        eventType: 'consent.granted',
+        resourceType: 'commerce_consent_record',
+        resourceId: r.record.id,
+        requestId: request.id,
+        metadata: {
+          passport_type: r.record.passportType,
+          principal_developer_id: principal.developerId,
+          consumed_challenge_id: r.consumedChallengeId,
+        },
+      });
+      // Mark the challenge as used in the audit trail explicitly (the
+      // DB transition to 'used' already happened atomically inside
+      // approveConsent; this is the forensic record).
+      await appendCommerceAudit(sql, {
+        tenantId: r.record.tenantId, merchantId: r.record.merchantId, agentId: r.record.agentId,
+        userPrincipalId: r.record.userPrincipalId,
+        eventType: 'consent.challenge.used',
+        resourceType: 'commerce_consent_challenge', resourceId: r.consumedChallengeId,
+        requestId: request.id,
+        metadata: { decision: 'granted', consent_request_id: r.record.consentRequestId },
+      }).catch(() => undefined);
+      const nonce = randomBytes(8).toString('base64url');
+      applySecurityHeaders(reply, nonce);
+      return reply.status(200).type('text/html; charset=utf-8').send(
+        `<!doctype html><html><head><meta charset="utf-8"><title>Approved</title></head>`
+        + `<body style="font-family:sans-serif;padding:24px"><h1>Approved</h1>`
+        + `<p>You may now return to your agent. You can close this tab.</p></body></html>`,
+      );
+    },
+  );
+
+  // POST /v1/commerce/consent/:reqId/deny
+  app.post<{ Params: { reqId: string }; Body: string | Record<string, string> }>(
+    '/consent/:reqId/deny',
+    { config: { publicConsent: true } },
+    async (request, reply) => {
+      if (!isAcceptableConsentHost(request.headers['host'])) {
+        throw new CommerceHttpError(404, 'not_found', 'Resource not found');
+      }
+      const principal = await resolvePrincipalSession(request);
+      if (!principal) {
+        throw new CommerceHttpError(401, 'principal_session_required',
+          'Denying consent requires an authenticated principal session');
+      }
+      const form = parseFormBody(request.body);
+      const formCsrf = form['csrf'] ?? '';
+      const expected = deriveConsentCsrfToken(principal.rawToken, request.params.reqId);
+      const a = Buffer.from(formCsrf);
+      const b = Buffer.from(expected);
+      if (a.length !== b.length || !timingSafeEqual(a, b)) {
+        throw new CommerceHttpError(403, 'csrf_invalid', 'CSRF token mismatch');
+      }
+      const sql = getSql();
+      const existing = await findConsentByRequestId(sql, request.params.reqId);
+      if (!existing) {
+        throw new CommerceHttpError(404, 'consent_not_found', 'Consent request not found');
+      }
+      const tenantOk = await ensurePrincipalCanActOnTenant(principal.developerId, existing.tenantId);
+      if (!tenantOk.bound) {
+        throw new CommerceHttpError(403, 'principal_not_authorized_for_tenant',
+          'Authenticated principal\'s developer is not bound to this commerce tenant');
+      }
+      if (tenantOk.tenantStatus === 'disabled') {
+        throw new CommerceHttpError(403, 'tenant_disabled',
+          'Commerce tenant is disabled', { retryable: false });
+      }
+      const r = await denyConsent(sql, request.params.reqId, principal.principalId);
+      if (!r.ok) {
+        if (r.reason === 'expired') throw new CommerceHttpError(410, 'consent_expired', 'Consent request has expired');
+        if (r.reason === 'already_decided') throw new CommerceHttpError(409, 'consent_already_decided', 'Consent request was already approved or denied');
+        if (r.reason === 'principal_hint_mismatch') {
+          // P2 fix: deny now enforces hint match too.
+          throw new CommerceHttpError(403, 'principal_hint_mismatch',
+            'Authenticated principal does not match the user this consent was created for');
+        }
+        if (r.reason === 'challenge_required') {
+          throw new CommerceHttpError(403, 'challenge_required',
+            'A verified consent challenge is required before this decision can be recorded',
+            { retryable: false });
+        }
+        throw new CommerceHttpError(404, 'consent_not_found', 'Consent request not found');
+      }
+      await appendCommerceAudit(sql, {
+        tenantId: r.record.tenantId,
+        merchantId: r.record.merchantId,
+        agentId: r.record.agentId,
+        userPrincipalId: principal.principalId,
+        eventType: 'consent.denied',
+        resourceType: 'commerce_consent_record',
+        resourceId: r.record.id,
+        requestId: request.id,
+        metadata: {
+          passport_type: r.record.passportType,
+          principal_developer_id: principal.developerId,
+          consumed_challenge_id: r.consumedChallengeId,
+        },
+      });
+      await appendCommerceAudit(sql, {
+        tenantId: r.record.tenantId, merchantId: r.record.merchantId, agentId: r.record.agentId,
+        userPrincipalId: principal.principalId,
+        eventType: 'consent.challenge.used',
+        resourceType: 'commerce_consent_challenge', resourceId: r.consumedChallengeId,
+        requestId: request.id,
+        metadata: { decision: 'denied', consent_request_id: r.record.consentRequestId },
+      }).catch(() => undefined);
+      const nonce = randomBytes(8).toString('base64url');
+      applySecurityHeaders(reply, nonce);
+      return reply.status(200).type('text/html; charset=utf-8').send(
+        `<!doctype html><html><head><meta charset="utf-8"><title>Denied</title></head>`
+        + `<body style="font-family:sans-serif;padding:24px"><h1>Denied</h1>`
+        + `<p>The agent has been notified. You may close this tab.</p></body></html>`,
+      );
+    },
+  );
+}

--- a/apps/auth-service/src/routes/commerce-passport.ts
+++ b/apps/auth-service/src/routes/commerce-passport.ts
@@ -15,7 +15,6 @@ import {
 import {
   createConsentRequest,
   findConsentByRequestId,
-  findConsentById,
   canonicalPresentedPayload,
   sha256hex,
   type CreateConsentInput,

--- a/apps/auth-service/src/routes/commerce-passport.ts
+++ b/apps/auth-service/src/routes/commerce-passport.ts
@@ -1,0 +1,595 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import type postgres from 'postgres';
+import { getSql, type TxSql } from '../db/client.js';
+import { getRedis } from '../redis/client.js';
+import { config } from '../config.js';
+import { CommerceHttpError } from '../lib/commerce/errors.js';
+import { appendCommerceAudit } from '../lib/commerce/audit.js';
+import { newCommercePassportJti } from '../lib/commerce/ids.js';
+import {
+  signCommercePassport,
+  verifyCommercePassport,
+  type PassportType,
+  type Environment,
+} from '../lib/commerce/passport.js';
+import {
+  createConsentRequest,
+  findConsentByRequestId,
+  findConsentById,
+  canonicalPresentedPayload,
+  sha256hex,
+  type CreateConsentInput,
+} from '../lib/commerce/consent.js';
+import { timingSafeEqual } from 'node:crypto';
+import { revokeCommercePassport } from '../lib/commerce/revocation.js';
+import type { CommerceCaller } from '../lib/commerce/caller.js';
+
+type Sql = ReturnType<typeof postgres>;
+
+function isString(v: unknown): v is string {
+  return typeof v === 'string' && v.length > 0;
+}
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((s) => typeof s === 'string' && s.length > 0);
+}
+function asInt(v: unknown): number | null {
+  if (typeof v === 'number' && Number.isFinite(v) && Math.trunc(v) === v) return v;
+  return null;
+}
+
+const SCOPE_BUNDLE: Record<PassportType, string[]> = {
+  browse: ['commerce:catalog.read', 'commerce:inventory.read'],
+  checkout: [
+    'commerce:catalog.read',
+    'commerce:inventory.read',
+    'commerce:checkout.create',
+    'commerce:payment.initiate',
+    'commerce:payment.status.read',
+  ],
+};
+
+const DEFAULT_TTL: Record<PassportType, number> = {
+  browse: 3600,        // 60 min — spec §6
+  checkout: 600,       // 10 min — spec §6
+};
+
+function consentRequiresUserConfirmation(passportType: PassportType): boolean {
+  return passportType === 'checkout';
+}
+
+function publicConsentBaseUrl(): string {
+  return process.env['COMMERCE_CONSENT_HOST']
+    ? `https://${process.env['COMMERCE_CONSENT_HOST']}`
+    : 'https://consent.grantex.dev';
+}
+
+function agentCallerOrThrow(req: FastifyRequest): Extract<CommerceCaller, { kind: 'agent' }> {
+  if (req.commerceCaller.kind !== 'agent') {
+    throw new CommerceHttpError(403, 'agent_required',
+      'This endpoint requires an agent caller (JWT assertion or agent API key)');
+  }
+  return req.commerceCaller;
+}
+
+export async function commercePassportRoutes(app: FastifyInstance): Promise<void> {
+  // --------------------------------------------------------------------
+  // POST /passports/consent-requests — agent only
+  // --------------------------------------------------------------------
+  app.post('/passports/consent-requests', async (request, reply) => {
+    const caller = agentCallerOrThrow(request);
+    const body = (request.body ?? {}) as {
+      merchant_id?: unknown;
+      passport_type?: unknown;
+      requested_scopes?: unknown;
+      max_amount?: unknown;
+      currency?: unknown;
+      // Renamed from user_principal_id (Finding 1). The agent supplies a
+      // HINT of the user it expects to authorize. The actual user
+      // identity is set ONLY at approval from the verified principal
+      // session, and approve rejects when hint != authenticated principal.
+      user_principal_hint?: unknown;
+      ttl_seconds?: unknown;
+    };
+
+    const fieldErrors: Record<string, string> = {};
+    if (!isString(body.merchant_id)) fieldErrors['merchant_id'] = 'required string';
+    if (body.passport_type !== 'browse' && body.passport_type !== 'checkout') {
+      fieldErrors['passport_type'] = 'must be "browse" or "checkout"';
+    }
+    const passportType = (body.passport_type === 'checkout' ? 'checkout' : 'browse') as PassportType;
+    const requestedScopes = isStringArray(body.requested_scopes)
+      ? (body.requested_scopes as string[])
+      : SCOPE_BUNDLE[passportType];
+    // Subset enforcement: agent cannot request scopes outside the bundle for the type.
+    const allowed = new Set(SCOPE_BUNDLE[passportType]);
+    const overreach = requestedScopes.filter((s) => !allowed.has(s));
+    if (overreach.length) {
+      fieldErrors['requested_scopes'] = `scopes outside the ${passportType} bundle: ${overreach.join(', ')}`;
+    }
+    if (passportType === 'checkout') {
+      if (asInt(body.max_amount) === null || (asInt(body.max_amount) as number) < 0) {
+        fieldErrors['max_amount'] = 'required non-negative integer (minor units) for checkout passports';
+      }
+      if (!isString(body.currency)) {
+        fieldErrors['currency'] = 'required string for checkout passports';
+      }
+    }
+    if (Object.keys(fieldErrors).length) {
+      throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed',
+        { details: { fields: fieldErrors }, retryable: false });
+    }
+
+    const sql = getSql();
+    // Verify merchant exists in caller's tenant.
+    const merchantRows = await sql<{ id: string; environment: string }[]>`
+      SELECT id, environment FROM commerce_merchants
+       WHERE id = ${body.merchant_id as string}
+         AND tenant_id = ${caller.tenantId}
+       LIMIT 1
+    `;
+    if (!merchantRows[0]) {
+      throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
+    }
+
+    const ttlSeconds = asInt(body.ttl_seconds) ?? DEFAULT_TTL[passportType];
+    const cappedTtl = Math.min(ttlSeconds, DEFAULT_TTL[passportType]);
+
+    const userPrincipalHint = isString(body.user_principal_hint)
+      ? (body.user_principal_hint as string)
+      : null;
+
+    const created = await sql.begin(async (_tx) => {
+      const tx = _tx as unknown as TxSql;
+      // createConsentRequest writes user_principal_hint (agent-supplied).
+      // user_principal_id is set ONLY at approval from the verified
+      // principal session — the agent never writes it.
+      const c = await createConsentRequest(tx as unknown as Sql, {
+        tenantId: caller.tenantId,
+        merchantId: body.merchant_id as string,
+        agentId: caller.agentId,
+        passportType,
+        requestedScopes,
+        maxAmount: passportType === 'checkout' ? (asInt(body.max_amount) as number) : null,
+        currency: passportType === 'checkout' ? (body.currency as string) : null,
+        agentAuthMethod: caller.authMethod,
+        ipHash: null,
+        userAgentHash: null,
+        ttlSeconds: cappedTtl,
+        userPrincipalHint,
+      } satisfies CreateConsentInput);
+      const audit = await appendCommerceAudit(tx as unknown as Sql, {
+        tenantId: caller.tenantId,
+        merchantId: body.merchant_id as string,
+        agentId: caller.agentId,
+        // The hint is recorded in metadata for forensic clarity; it is
+        // NOT a verified user_principal_id. (When set as
+        // userPrincipalId on the audit row it would imply verification,
+        // which it does not have at this stage.)
+        eventType: 'consent.requested',
+        resourceType: 'commerce_consent_record',
+        resourceId: c.id,
+        requestId: request.id,
+        metadata: {
+          passport_type: passportType,
+          agent_auth_method: caller.authMethod,
+          ttl_seconds: cappedTtl,
+          requires_final_user_confirmation: consentRequiresUserConfirmation(passportType),
+          user_principal_hint: userPrincipalHint,
+        },
+      });
+      return { ...c, auditEventId: audit.id };
+    });
+
+    const consentUrl = `${publicConsentBaseUrl()}/v1/commerce/consent/page?req=${encodeURIComponent(created.consentRequestId)}`;
+    return reply.status(201).send({
+      data: {
+        consent_request_id: created.consentRequestId,
+        consent_record_id: created.id,
+        consent_url: consentUrl,
+        expires_at: created.expiresAt,
+        passport_type: passportType,
+      },
+      audit_event_id: created.auditEventId,
+    });
+  });
+
+  // --------------------------------------------------------------------
+  // POST /passports/exchange — agent only; mints the passport
+  // --------------------------------------------------------------------
+  app.post('/passports/exchange', async (request, reply) => {
+    const caller = agentCallerOrThrow(request);
+    const body = (request.body ?? {}) as { consent_request_id?: unknown };
+    if (!isString(body.consent_request_id)) {
+      throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed',
+        { details: { fields: { consent_request_id: 'required string' } }, retryable: false });
+    }
+
+    const sql = getSql();
+    const consent = await findConsentByRequestId(sql, body.consent_request_id as string);
+    if (!consent) {
+      throw new CommerceHttpError(404, 'consent_not_found', 'Consent request not found');
+    }
+    if (consent.tenantId !== caller.tenantId || consent.agentId !== caller.agentId) {
+      // Cross-agent or cross-tenant — same-shape 404 to avoid leaks.
+      throw new CommerceHttpError(404, 'consent_not_found', 'Consent request not found');
+    }
+    if (consent.status === 'denied') {
+      throw new CommerceHttpError(403, 'consent_denied', 'User denied this consent request');
+    }
+    if (consent.status === 'expired' || new Date(consent.expiresAt).getTime() < Date.now()) {
+      throw new CommerceHttpError(410, 'consent_expired', 'Consent request has expired');
+    }
+    if (consent.status !== 'granted') {
+      throw new CommerceHttpError(409, 'consent_not_granted',
+        'Consent request has not been granted yet; redirect the user to the consent page');
+    }
+    if (!consent.presentedPayloadHash) {
+      // Granted but never presented — defensive.
+      throw new CommerceHttpError(409, 'consent_not_presented',
+        'Consent record is missing presented_payload_hash; this should not happen for granted records');
+    }
+    if (!consent.userPrincipalId) {
+      // user_principal_id is set at approval time from the authenticated
+      // principal session (Finding 1 fix). If it's missing on a granted
+      // consent, the approve path was bypassed — refuse to mint.
+      throw new CommerceHttpError(409, 'consent_missing_subject',
+        'Consent record has no authenticated user_principal_id; cannot mint passport');
+    }
+    // Defense in depth: if the agent supplied a hint, it must match the
+    // authenticated principal recorded at approval. The approve lib
+    // already enforces this, but checking here guards against a granted
+    // record being mutated post-approval (which the schema prevents but
+    // a future schema change could regress).
+    if (consent.userPrincipalHint
+      && consent.userPrincipalHint !== consent.userPrincipalId) {
+      throw new CommerceHttpError(409, 'consent_principal_mismatch',
+        'Authenticated principal does not match the user this consent was created for');
+    }
+
+    // Finding 4: recompute the canonical presented payload hash and
+    // compare timing-safe to the value captured at first GET. A mismatch
+    // means a row that's claimed to be presented now no longer matches
+    // what the user actually saw — defense in depth against tampering.
+    const recomputed = sha256hex(canonicalPresentedPayload(consent));
+    const storedBuf = Buffer.from(consent.presentedPayloadHash, 'hex');
+    const recomputedBuf = Buffer.from(recomputed, 'hex');
+    if (storedBuf.length !== recomputedBuf.length || !timingSafeEqual(storedBuf, recomputedBuf)) {
+      throw new CommerceHttpError(409, 'consent_payload_changed',
+        'The consent payload differs from what the user approved. Re-request consent.',
+        { retryable: false });
+    }
+
+    // Finding 3 (lib-side guard): refuse if a passport was already minted
+    // for this consent record. The DB-level UNIQUE on
+    // commerce_passports.consent_record_id provides the authoritative
+    // single-use guarantee under concurrency; this pre-check returns the
+    // friendlier 409 without depending on the FK violation message.
+    const existingPassport = await sql<{ jti: string; expires_at: Date }[]>`
+      SELECT jti, expires_at FROM commerce_passports
+       WHERE consent_record_id = ${consent.id} LIMIT 1
+    `;
+    if (existingPassport[0]) {
+      throw new CommerceHttpError(409, 'consent_already_exchanged',
+        'A passport has already been issued for this consent. Each consent is single-use.',
+        {
+          retryable: false,
+          details: {
+            existing_jti: existingPassport[0].jti,
+            existing_expires_at: existingPassport[0].expires_at instanceof Date
+              ? existingPassport[0].expires_at.toISOString()
+              : String(existingPassport[0].expires_at),
+          },
+        });
+    }
+
+    // Determine environment from merchant + check tenant is active
+    // (Finding 3). Joined into one SELECT for efficiency.
+    const merchant = await sql<{ environment: string; tenant_status: string }[]>`
+      SELECT m.environment, t.status AS tenant_status
+        FROM commerce_merchants m
+        JOIN commerce_tenants t ON t.id = m.tenant_id
+       WHERE m.id = ${consent.merchantId}
+         AND m.tenant_id = ${consent.tenantId}
+       LIMIT 1
+    `;
+    if (!merchant[0]) {
+      throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
+    }
+    if (merchant[0].tenant_status === 'disabled') {
+      throw new CommerceHttpError(403, 'tenant_disabled',
+        'Commerce tenant is disabled; cannot mint new passports',
+        { retryable: false });
+    }
+    const environment = (merchant[0].environment === 'live' ? 'live' : 'sandbox') as Environment;
+
+    const now = Math.floor(Date.now() / 1000);
+    const ttl = consent.passportType === 'checkout' ? DEFAULT_TTL.checkout : DEFAULT_TTL.browse;
+    const expiresAt = now + ttl;
+    const jti = newCommercePassportJti();
+
+    const signed = await signCommercePassport(sql, {
+      jti,
+      passportType: consent.passportType,
+      tenantId: consent.tenantId,
+      merchantId: consent.merchantId,
+      agentId: consent.agentId,
+      consentRecordId: consent.id,
+      subject: consent.userPrincipalId,
+      scopes: consent.approvedScopes ?? consent.requestedScopes,
+      maxAmount: consent.maxAmount,
+      currency: consent.currency,
+      environment,
+      issuedAt: now,
+      notBefore: now,
+      expiresAt,
+    });
+
+    let result: { auditEventId: string; meterEventId: string };
+    try {
+      result = await sql.begin(async (_tx) => {
+        const tx = _tx as unknown as TxSql;
+        await tx`
+          INSERT INTO commerce_passports (
+            jti, tenant_id, merchant_id, agent_id, consent_record_id,
+            passport_type, kid, subject, scopes, max_amount, currency,
+            environment, audience, issued_at, not_before, expires_at,
+            agent_auth_method
+          ) VALUES (
+            ${signed.jti}, ${consent.tenantId}, ${consent.merchantId}, ${consent.agentId}, ${consent.id},
+            ${consent.passportType}, ${signed.kid}, ${consent.userPrincipalId},
+            ${consent.approvedScopes ?? consent.requestedScopes},
+            ${consent.maxAmount}, ${consent.currency},
+            ${environment}, ${'grantex-commerce'},
+            to_timestamp(${now}), to_timestamp(${now}), to_timestamp(${expiresAt}),
+            ${caller.authMethod}
+          )
+        `;
+      const audit = await appendCommerceAudit(tx as unknown as Sql, {
+        tenantId: consent.tenantId,
+        merchantId: consent.merchantId,
+        agentId: consent.agentId,
+        userPrincipalId: consent.userPrincipalId,
+        eventType: 'passport.issued',
+        resourceType: 'commerce_passport',
+        resourceId: signed.jti,
+        passportJti: signed.jti,
+        requestId: request.id,
+        metadata: {
+          passport_type: consent.passportType,
+          kid: signed.kid,
+          environment,
+          agent_auth_method: caller.authMethod,
+          ttl_seconds: ttl,
+        },
+      });
+      const meter = await appendCommerceAudit(tx as unknown as Sql, {
+        tenantId: consent.tenantId,
+        merchantId: consent.merchantId,
+        agentId: consent.agentId,
+        eventType: 'meter.passport_issued',
+        resourceType: 'commerce_passport',
+        resourceId: signed.jti,
+        passportJti: signed.jti,
+        requestId: request.id,
+        metadata: { passport_type: consent.passportType },
+      });
+        return { auditEventId: audit.id, meterEventId: meter.id };
+      });
+    } catch (err) {
+      // Concurrent exchange — the UNIQUE on consent_record_id fired.
+      // Translate the postgres error to the friendly 409.
+      const code = (err as { code?: string }).code;
+      if (code === '23505') {
+        throw new CommerceHttpError(409, 'consent_already_exchanged',
+          'A passport was already issued for this consent (concurrent exchange).',
+          { retryable: false });
+      }
+      throw err;
+    }
+
+    return reply.status(201).send({
+      data: {
+        passport_jwt: signed.jwt,
+        jti: signed.jti,
+        kid: signed.kid,
+        passport_type: consent.passportType,
+        scopes: consent.approvedScopes ?? consent.requestedScopes,
+        max_amount: consent.maxAmount,
+        currency: consent.currency,
+        expires_at: new Date(expiresAt * 1000).toISOString(),
+      },
+      audit_event_id: result.auditEventId,
+    });
+  });
+
+  // --------------------------------------------------------------------
+  // GET /passports — list (operator + merchant + agent for own)
+  // --------------------------------------------------------------------
+  app.get('/passports', async (request, reply) => {
+    const sql = getSql();
+    const caller = request.commerceCaller;
+    let rows: Record<string, unknown>[];
+    if (caller.kind === 'merchant') {
+      rows = await sql<Record<string, unknown>[]>`
+        SELECT p.jti, p.tenant_id, p.merchant_id, p.agent_id, p.passport_type,
+               p.subject, p.scopes, p.max_amount, p.currency, p.environment,
+               p.issued_at, p.expires_at,
+               (rv.jti IS NOT NULL) AS revoked, rv.reason AS revocation_reason
+          FROM commerce_passports p
+          LEFT JOIN commerce_passport_revocations rv ON rv.jti = p.jti
+         WHERE p.tenant_id = ${caller.tenantId}
+           AND p.merchant_id = ${caller.merchantId}
+         ORDER BY p.issued_at DESC
+         LIMIT 100
+      `;
+    } else if (caller.kind === 'agent') {
+      rows = await sql<Record<string, unknown>[]>`
+        SELECT p.jti, p.tenant_id, p.merchant_id, p.agent_id, p.passport_type,
+               p.subject, p.scopes, p.max_amount, p.currency, p.environment,
+               p.issued_at, p.expires_at,
+               (rv.jti IS NOT NULL) AS revoked, rv.reason AS revocation_reason
+          FROM commerce_passports p
+          LEFT JOIN commerce_passport_revocations rv ON rv.jti = p.jti
+         WHERE p.tenant_id = ${caller.tenantId}
+           AND p.agent_id = ${caller.agentId}
+         ORDER BY p.issued_at DESC
+         LIMIT 100
+      `;
+    } else {
+      // operator
+      rows = await sql<Record<string, unknown>[]>`
+        SELECT p.jti, p.tenant_id, p.merchant_id, p.agent_id, p.passport_type,
+               p.subject, p.scopes, p.max_amount, p.currency, p.environment,
+               p.issued_at, p.expires_at,
+               (rv.jti IS NOT NULL) AS revoked, rv.reason AS revocation_reason
+          FROM commerce_passports p
+          LEFT JOIN commerce_passport_revocations rv ON rv.jti = p.jti
+         WHERE p.tenant_id = ${request.commerceTenantId}
+         ORDER BY p.issued_at DESC
+         LIMIT 100
+      `;
+    }
+    return reply.status(200).send({ items: rows, next_cursor: null });
+  });
+
+  // --------------------------------------------------------------------
+  // POST /passports/verify — agent / merchant / operator
+  // Body: { passport_jwt, mode? }
+  // --------------------------------------------------------------------
+  app.post('/passports/verify', async (request, reply) => {
+    const body = (request.body ?? {}) as { passport_jwt?: unknown; mode?: unknown; expected_merchant_id?: unknown };
+    if (!isString(body.passport_jwt)) {
+      throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed',
+        { details: { fields: { passport_jwt: 'required string' } }, retryable: false });
+    }
+    const mode = body.mode === 'payment_affecting' ? 'payment_affecting' : 'read_only';
+    const sql = getSql();
+    let redis: import('ioredis').Redis | null = null;
+    try { redis = getRedis(); } catch { redis = null; }
+
+    const expectedTenantId = request.commerceTenantId || undefined;
+    const expectedMerchantId = isString(body.expected_merchant_id)
+      ? (body.expected_merchant_id as string)
+      : (request.commerceCaller.kind === 'merchant' ? request.commerceCaller.merchantId : undefined);
+
+    const result = await verifyCommercePassport(sql, redis, body.passport_jwt as string, {
+      mode,
+      ...(expectedTenantId ? { expectedTenantId } : {}),
+      ...(expectedMerchantId ? { expectedMerchantId } : {}),
+    });
+
+    if (!result.ok) {
+      // Audit the failure for forensic visibility.
+      await appendCommerceAudit(sql, {
+        tenantId: request.commerceTenantId || 'unknown',
+        eventType: 'passport.verification_failed',
+        resourceType: 'commerce_passport',
+        resourceId: '(verification rejected)',
+        requestId: request.id,
+        metadata: { error_kind: result.error.kind, mode },
+      }).catch(() => undefined);
+      // Map error kinds to HTTP statuses.
+      const status =
+        result.error.kind === 'revocation_unavailable' ? 503 :
+        result.error.kind === 'tenant_mismatch' || result.error.kind === 'merchant_mismatch' ? 403 :
+        400;
+      const codeMap: Record<string, string> = {
+        malformed: 'passport_malformed',
+        kid_required: 'passport_kid_required',
+        kid_unknown: 'passport_kid_unknown',
+        kid_wrong_namespace: 'passport_kid_wrong_namespace',
+        kid_retired_iat_after: 'passport_kid_retired_iat_after',
+        kid_retired_window_exceeded: 'passport_kid_retired_window_exceeded',
+        algorithm_rejected: 'passport_algorithm_rejected',
+        signature_invalid: 'passport_signature_invalid',
+        expired: 'passport_expired',
+        not_yet_valid: 'passport_not_yet_valid',
+        wrong_audience: 'passport_wrong_audience',
+        wrong_issuer: 'passport_wrong_issuer',
+        missing_claims: 'passport_missing_claims',
+        temporal_claim_invalid: 'passport_temporal_claim_invalid',
+        lifetime_exceeded: 'passport_lifetime_exceeded',
+        invalid_passport_type: 'passport_invalid_type',
+        revoked: 'passport_revoked',
+        revocation_unavailable: 'revocation_unavailable',
+        tenant_mismatch: 'passport_tenant_mismatch',
+        merchant_mismatch: 'passport_merchant_mismatch',
+      };
+      const code = codeMap[result.error.kind] ?? 'passport_invalid';
+      throw new CommerceHttpError(status, code,
+        `Passport verification failed (${result.error.kind})`, {
+          retryable: result.error.kind === 'revocation_unavailable',
+          details: result.error as unknown as Record<string, unknown>,
+        });
+    }
+
+    return reply.status(200).send({ data: { valid: true, passport: result.passport, mode } });
+  });
+
+  // --------------------------------------------------------------------
+  // POST /passports/revoke — operator + merchant (own) + agent (own)
+  // Body: { jti, reason? }
+  // --------------------------------------------------------------------
+  app.post('/passports/revoke', async (request, reply) => {
+    const body = (request.body ?? {}) as { jti?: unknown; reason?: unknown };
+    if (!isString(body.jti)) {
+      throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed',
+        { details: { fields: { jti: 'required string' } }, retryable: false });
+    }
+    const sql = getSql();
+    const rows = await sql<{
+      jti: string; tenant_id: string; merchant_id: string; agent_id: string;
+    }[]>`
+      SELECT jti, tenant_id, merchant_id, agent_id
+        FROM commerce_passports WHERE jti = ${body.jti as string} LIMIT 1
+    `;
+    if (!rows[0]) {
+      throw new CommerceHttpError(404, 'passport_not_found', 'Passport not found');
+    }
+    const passport = rows[0];
+    if (passport.tenant_id !== request.commerceTenantId) {
+      throw new CommerceHttpError(404, 'passport_not_found', 'Passport not found');
+    }
+    const caller = request.commerceCaller;
+    if (caller.kind === 'merchant' && passport.merchant_id !== caller.merchantId) {
+      throw new CommerceHttpError(403, 'merchant_scope_violation',
+        'Merchant callers may only revoke passports for their own merchant');
+    }
+    if (caller.kind === 'agent' && passport.agent_id !== caller.agentId) {
+      throw new CommerceHttpError(403, 'agent_scope_violation',
+        'Agent callers may only revoke their own passports');
+    }
+
+    let redis: import('ioredis').Redis | null = null;
+    try { redis = getRedis(); } catch { redis = null; }
+    const reason = isString(body.reason) ? (body.reason as string) : 'explicit';
+    const revokedBy =
+      caller.kind === 'operator' ? caller.developerId :
+      caller.kind === 'merchant' ? `merchant_key:${caller.apiKeyId}` :
+      caller.kind === 'agent' ? `agent:${caller.agentId}` :
+      `service:${caller.kind === 'service' ? caller.serviceId : 'unknown'}`;
+
+    await revokeCommercePassport(sql, redis, {
+      jti: body.jti as string,
+      tenantId: passport.tenant_id,
+      reason,
+      revokedBy,
+    });
+
+    const audit = await appendCommerceAudit(sql, {
+      tenantId: passport.tenant_id,
+      merchantId: passport.merchant_id,
+      agentId: passport.agent_id,
+      eventType: 'passport.revoked',
+      resourceType: 'commerce_passport',
+      resourceId: body.jti as string,
+      passportJti: body.jti as string,
+      requestId: request.id,
+      metadata: { reason, revoked_by: revokedBy },
+    });
+    return reply.status(200).send({ data: { jti: body.jti, revoked: true, reason }, audit_event_id: audit.id });
+  });
+}
+
+// Side-effect-free re-export to keep the module surface lint-friendly.
+export const _routesUseConfig = config;

--- a/apps/auth-service/src/routes/commerce-tenants.ts
+++ b/apps/auth-service/src/routes/commerce-tenants.ts
@@ -1,0 +1,238 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import type postgres from 'postgres';
+import { getSql, type TxSql } from '../db/client.js';
+import { CommerceHttpError } from '../lib/commerce/errors.js';
+import { newCommerceTenantId } from '../lib/commerce/ids.js';
+import { appendCommerceAudit } from '../lib/commerce/audit.js';
+import type { CommerceCaller } from '../lib/commerce/caller.js';
+
+type Sql = ReturnType<typeof postgres>;
+
+function isString(v: unknown): v is string {
+  return typeof v === 'string' && v.length > 0;
+}
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function operatorFromRequest(request: FastifyRequest): Extract<CommerceCaller, { kind: 'operator' }> {
+  if (request.commerceCaller.kind !== 'operator') {
+    throw new CommerceHttpError(403, 'operator_required',
+      'Tenant provisioning requires operator (developer API key or platform admin) credentials');
+  }
+  return request.commerceCaller;
+}
+
+/**
+ * Decision C — hybrid tenant authorization model:
+ *   - createTenant: requires platform admin (ADMIN_API_KEY)
+ *   - bindDeveloperToTenant: requires admin OR commerce_tenant_operators.role='owner'
+ *     of that specific tenant
+ *   - listTenants / patchTenant: requires admin OR owner of THAT tenant
+ *
+ * Tenant owners cannot create unrelated tenants, preserving the
+ * separation of concerns the M1 acceptance report flagged.
+ */
+export async function commerceTenantsRoutes(app: FastifyInstance): Promise<void> {
+  // POST /tenants — admin only
+  app.post('/tenants', async (request, reply) => {
+    const op = operatorFromRequest(request);
+    if (!op.isPlatformAdmin) {
+      throw new CommerceHttpError(403, 'admin_required',
+        'Creating commerce tenants requires the platform admin key');
+    }
+    const body = (request.body ?? {}) as { display_name?: unknown; metadata?: unknown };
+    if (!isString(body.display_name)) {
+      throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+        details: { fields: { display_name: 'required string' } }, retryable: false,
+      });
+    }
+    const sql = getSql();
+    const id = newCommerceTenantId();
+
+    const result = await sql.begin(async (_tx) => {
+      const tx = _tx as unknown as TxSql;
+      const rows = await tx<Record<string, unknown>[]>`
+        INSERT INTO commerce_tenants (id, display_name, metadata)
+        VALUES (
+          ${id}, ${body.display_name as string},
+          ${JSON.stringify(isPlainObject(body.metadata) ? body.metadata : {})}::jsonb
+        )
+        RETURNING id, display_name, status, metadata, created_at, updated_at
+      `;
+      const audit = await appendCommerceAudit(tx as unknown as Sql, {
+        tenantId: id,
+        eventType: 'tenant.created',
+        resourceType: 'commerce_tenant',
+        resourceId: id,
+        requestId: request.id,
+        metadata: { display_name: body.display_name, created_by_admin: true },
+      });
+      return { tenant: rows[0], auditEventId: audit.id };
+    });
+    return reply.status(201).send({ data: result.tenant, audit_event_id: result.auditEventId });
+  });
+
+  // GET /tenants — admin sees all; owner sees their own
+  app.get('/tenants', async (request, reply) => {
+    const op = operatorFromRequest(request);
+    const sql = getSql();
+    const rows = op.isPlatformAdmin
+      ? await sql<Record<string, unknown>[]>`
+          SELECT id, display_name, status, metadata, created_at, updated_at
+            FROM commerce_tenants
+           ORDER BY created_at DESC
+           LIMIT 100
+        `
+      : await sql<Record<string, unknown>[]>`
+          SELECT t.id, t.display_name, t.status, t.metadata, t.created_at, t.updated_at
+            FROM commerce_tenants t
+            JOIN commerce_tenant_operators op ON op.tenant_id = t.id
+           WHERE op.developer_id = ${op.developerId}
+           ORDER BY t.created_at DESC
+           LIMIT 100
+        `;
+    return reply.status(200).send({ items: rows, next_cursor: null });
+  });
+
+  // PATCH /tenants/:tenant_id — admin or owner; mutable: display_name, status
+  app.patch<{ Params: { tenant_id: string }; Body: { display_name?: unknown; status?: unknown } }>(
+    '/tenants/:tenant_id',
+    async (request, reply) => {
+      const op = operatorFromRequest(request);
+      const tenantId = request.params.tenant_id;
+      if (!op.isPlatformAdmin) {
+        const sql = getSql();
+        const owns = await sql<{ ok: boolean }[]>`
+          SELECT TRUE AS ok FROM commerce_tenant_operators
+           WHERE developer_id = ${op.developerId} AND tenant_id = ${tenantId} AND role = 'owner'
+           LIMIT 1
+        `;
+        if (!owns[0]) {
+          throw new CommerceHttpError(403, 'tenant_owner_required',
+            'Updating a commerce tenant requires admin or owner role on that tenant');
+        }
+      }
+      const body = request.body ?? {};
+      const fieldErrors: Record<string, string> = {};
+      if (body.display_name !== undefined && !isString(body.display_name)) {
+        fieldErrors['display_name'] = 'must be a non-empty string when provided';
+      }
+      if (body.status !== undefined
+        && (typeof body.status !== 'string' || !['active', 'disabled'].includes(body.status))) {
+        fieldErrors['status'] = 'must be "active" or "disabled" when provided';
+      }
+      if (Object.keys(fieldErrors).length) {
+        throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed',
+          { details: { fields: fieldErrors }, retryable: false });
+      }
+
+      const sql = getSql();
+      const result = await sql.begin(async (_tx) => {
+        const tx = _tx as unknown as TxSql;
+        const newDisplay = body.display_name as string | undefined;
+        const newStatus = body.status as string | undefined;
+        const rows = await tx<Record<string, unknown>[]>`
+          UPDATE commerce_tenants
+             SET display_name = COALESCE(${newDisplay ?? null}::text, display_name),
+                 status = COALESCE(${newStatus ?? null}::text, status),
+                 updated_at = NOW()
+           WHERE id = ${tenantId}
+           RETURNING id, display_name, status, metadata, created_at, updated_at
+        `;
+        if (!rows[0]) return null;
+        const eventType = newStatus === 'disabled' ? 'tenant.disabled' : 'tenant.updated';
+        const audit = await appendCommerceAudit(tx as unknown as Sql, {
+          tenantId,
+          eventType,
+          resourceType: 'commerce_tenant',
+          resourceId: tenantId,
+          requestId: request.id,
+          metadata: {
+            ...(newDisplay !== undefined ? { display_name: newDisplay } : {}),
+            ...(newStatus !== undefined ? { status: newStatus } : {}),
+          },
+        });
+        return { tenant: rows[0], auditEventId: audit.id };
+      });
+      if (!result) {
+        throw new CommerceHttpError(404, 'tenant_not_found', 'Tenant not found');
+      }
+      return reply.status(200).send({ data: result.tenant, audit_event_id: result.auditEventId });
+    },
+  );
+
+  // POST /developer-tenants — admin or owner
+  app.post('/developer-tenants', async (request, reply) => {
+    const op = operatorFromRequest(request);
+    const body = (request.body ?? {}) as {
+      developer_id?: unknown;
+      tenant_id?: unknown;
+      is_default?: unknown;
+    };
+    const fieldErrors: Record<string, string> = {};
+    if (!isString(body.developer_id)) fieldErrors['developer_id'] = 'required string';
+    if (!isString(body.tenant_id)) fieldErrors['tenant_id'] = 'required string';
+    const isDefault = body.is_default === true;
+    if (Object.keys(fieldErrors).length) {
+      throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed',
+        { details: { fields: fieldErrors }, retryable: false });
+    }
+    const developerId = body.developer_id as string;
+    const tenantId = body.tenant_id as string;
+
+    const sql = getSql();
+
+    if (!op.isPlatformAdmin) {
+      const owns = await sql<{ ok: boolean }[]>`
+        SELECT TRUE AS ok FROM commerce_tenant_operators
+         WHERE developer_id = ${op.developerId} AND tenant_id = ${tenantId} AND role = 'owner'
+         LIMIT 1
+      `;
+      if (!owns[0]) {
+        throw new CommerceHttpError(403, 'tenant_owner_required',
+          'Binding a developer to a tenant requires admin or owner role on that tenant');
+      }
+    }
+
+    // Validate the tenant exists (FK alone allows orphaned devs to be bound).
+    const tenant = await sql<{ id: string; status: string }[]>`
+      SELECT id, status FROM commerce_tenants WHERE id = ${tenantId} LIMIT 1
+    `;
+    if (!tenant[0]) {
+      throw new CommerceHttpError(404, 'tenant_not_found', 'Tenant not found');
+    }
+    if (tenant[0].status === 'disabled') {
+      throw new CommerceHttpError(409, 'tenant_disabled',
+        'Cannot bind developers to a disabled tenant');
+    }
+
+    const result = await sql.begin(async (_tx) => {
+      const tx = _tx as unknown as TxSql;
+      // If is_default=true, clear the existing default first.
+      if (isDefault) {
+        await tx`
+          UPDATE commerce_developer_tenants SET is_default = FALSE
+           WHERE developer_id = ${developerId} AND is_default = TRUE
+        `;
+      }
+      const rows = await tx<Record<string, unknown>[]>`
+        INSERT INTO commerce_developer_tenants (developer_id, tenant_id, is_default)
+        VALUES (${developerId}, ${tenantId}, ${isDefault})
+        ON CONFLICT (developer_id, tenant_id)
+          DO UPDATE SET is_default = EXCLUDED.is_default
+        RETURNING developer_id, tenant_id, is_default, created_at
+      `;
+      const audit = await appendCommerceAudit(tx as unknown as Sql, {
+        tenantId,
+        eventType: 'developer_tenant.bound',
+        resourceType: 'commerce_developer_tenant',
+        resourceId: `${developerId}:${tenantId}`,
+        requestId: request.id,
+        metadata: { developer_id: developerId, is_default: isDefault },
+      });
+      return { mapping: rows[0], auditEventId: audit.id };
+    });
+    return reply.status(201).send({ data: result.mapping, audit_event_id: result.auditEventId });
+  });
+}

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -1,8 +1,8 @@
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyRequest } from 'fastify';
 import type postgres from 'postgres';
 import { getSql, type TxSql } from '../db/client.js';
+import { getRedis } from '../redis/client.js';
 import {
-  resolveTenantForDeveloper,
   resolveOrCreateTenantForDeveloper,
   isAutoTenantAllowed,
 } from '../lib/commerce/tenant.js';
@@ -15,10 +15,19 @@ import {
   newCommerceVariantId,
 } from '../lib/commerce/ids.js';
 import { isCommerceCategoryPreset } from '../lib/commerce/presets.js';
+import { resolveCommerceCaller, type CommerceCaller } from '../lib/commerce/caller.js';
+import { commerceTenantsRoutes } from './commerce-tenants.js';
+import { commercePassportRoutes } from './commerce-passport.js';
+import { commerceConsentRoutes } from './commerce-consent.js';
 
 declare module 'fastify' {
   interface FastifyRequest {
     commerceTenantId: string;
+    commerceCaller: CommerceCaller;
+  }
+  interface FastifyContextConfig {
+    /** Set on consent SSR routes to opt out of commerce caller resolution. */
+    publicConsent?: boolean;
   }
 }
 
@@ -90,11 +99,36 @@ function asInt(v: unknown): number | null {
   return null;
 }
 
+/**
+ * Commerce route registration. Decision F: every route inside this
+ * plugin is opted out of the global authPlugin via an onRoute hook that
+ * sets config.skipAuth=true. Auth is then re-imposed by our own
+ * commerceCaller preHandler. A test
+ * (commerce-caller-bypass.test.ts) confirms merchant/agent tokens reach
+ * the resolver instead of being rejected by the platform authPlugin.
+ */
 export async function commerceRoutes(app: FastifyInstance): Promise<void> {
   app.setErrorHandler(commerceErrorHandler);
 
-  // Single preHandler: feature-flag gate + tenant resolution.
-  // Auth (request.developer) is already populated by the global authPlugin.
+  // Decision F: every commerce route bypasses the global authPlugin.
+  // The hook fires for each app.get/.post/etc registered in this scope,
+  // including the routes registered inside the sub-route plugins below.
+  app.addHook('onRoute', (routeOptions) => {
+    if (!routeOptions.config) {
+      (routeOptions as unknown as { config: Record<string, unknown> }).config = {};
+    }
+    (routeOptions.config as unknown as Record<string, unknown>)['skipAuth'] = true;
+  });
+
+  // Single preHandler: feature-flag gate + commerce caller resolution +
+  // tenant materialization. Tenant rules:
+  //   - Operator with explicit mapping → use it.
+  //   - Operator with no mapping AND isAutoTenantAllowed() → auto-provision
+  //     (sandbox/test only; production blocked at the lib layer).
+  //   - Operator with no mapping AND not auto-allowed → 422 tenant_not_provisioned.
+  //   - Merchant/agent caller → caller carries its own tenantId.
+  //   - Platform admin caller (no developer record) → tenantId left empty;
+  //     operator endpoints accepting admin must consume tenant_id from path/body.
   app.addHook('preHandler', async (request) => {
     if (!isCommerceV1Enabled()) {
       throw new CommerceHttpError(
@@ -104,53 +138,127 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
         { retryable: false },
       );
     }
-    const sql = getSql();
-    const resolution = await resolveTenantForDeveloper(sql, request.developer.id);
+    // Public consent endpoints (the SSR page + approve/deny) do not have
+    // a Bearer caller — the user reaches them via a magic link from
+    // their agent. Those routes opt in to publicConsent in their own
+    // route config and handle Host isolation + CSRF themselves.
+    if (request.routeOptions.config?.publicConsent === true) return;
 
-    if (resolution.kind === 'resolved') {
-      request.commerceTenantId = resolution.tenantId;
-      return;
+    const sql = getSql();
+    let redis: import('ioredis').Redis | null = null;
+    try {
+      redis = getRedis();
+    } catch {
+      redis = null;
     }
-    if (resolution.kind === 'disabled') {
+    const r = await resolveCommerceCaller(request, sql, redis);
+    if (!r.ok) {
+      throw new CommerceHttpError(r.failure.status, r.failure.code, r.failure.message,
+        { retryable: r.failure.status === 503,
+          ...(('details' in r.failure && r.failure.details !== undefined) ? { details: r.failure.details } : {}) });
+    }
+    request.commerceCaller = r.caller;
+
+    if (r.caller.kind === 'operator') {
+      // Platform admin without a developer-bound tenant: leave empty;
+      // tenant-aware routes must accept tenant_id explicitly.
+      if (r.caller.isPlatformAdmin && !r.caller.developerId.startsWith('dev_')) {
+        request.commerceTenantId = '';
+        return;
+      }
+      // The caller resolver's JOIN already produced tenantId + tenantStatus
+      // for the operator. Trust it instead of running another SELECT.
+      if (r.caller.tenantStatus === 'active') {
+        request.commerceTenantId = r.caller.tenantId;
+        return;
+      }
+      if (r.caller.tenantStatus === 'disabled') {
+        throw new CommerceHttpError(
+          403,
+          'tenant_disabled',
+          'The commerce tenant mapped to this developer is disabled',
+          {
+            remediation:
+              'Contact Grantex support to re-enable the tenant or to provision a replacement mapping.',
+            retryable: false,
+          },
+        );
+      }
+      // tenantStatus === null → no mapping. Optional auto-provision (test/sandbox only).
+      if (isAutoTenantAllowed()) {
+        request.commerceTenantId = await resolveOrCreateTenantForDeveloper(
+          sql,
+          r.caller.developerId,
+          r.caller.developerName,
+        );
+        return;
+      }
       throw new CommerceHttpError(
-        403,
-        'tenant_disabled',
-        'The commerce tenant mapped to this developer is disabled',
+        422,
+        'tenant_not_provisioned',
+        'No commerce tenant is mapped to this developer in this environment',
         {
           remediation:
-            'Contact Grantex support to re-enable the tenant or to provision a replacement mapping.',
+            'In staging/production, an operator must provision a commerce tenant and bind '
+            + 'this developer to it via POST /v1/commerce/tenants and '
+            + 'POST /v1/commerce/developer-tenants. For local/sandbox testing only, '
+            + 'set COMMERCE_ALLOW_AUTO_TENANT=true to enable auto-provisioning.',
           retryable: false,
         },
       );
     }
-    // resolution.kind === 'not_provisioned'
-    if (isAutoTenantAllowed()) {
-      request.commerceTenantId = await resolveOrCreateTenantForDeveloper(
-        sql,
-        request.developer.id,
-        request.developer.name,
-      );
-      return;
-    }
-    throw new CommerceHttpError(
-      422,
-      'tenant_not_provisioned',
-      'No commerce tenant is mapped to this developer in this environment',
-      {
-        remediation:
-          'In staging/production, an operator must provision a commerce tenant and bind ' +
-          'this developer to it via the M2 admin endpoints (POST /v1/commerce/tenants then ' +
-          'POST /v1/commerce/developer-tenants). For local/sandbox testing only, ' +
-          'set COMMERCE_ALLOW_AUTO_TENANT=true to enable auto-provisioning.',
-        retryable: false,
-      },
-    );
+
+    // merchant / agent / service: tenantId is intrinsic to the caller.
+    request.commerceTenantId = r.caller.tenantId;
   });
 
   // ----------------------------------------------------------------------
-  // POST /merchants
+  // Per-route caller-kind enforcement helpers (Finding 2 — promised
+  // M2 caller matrix). The shape is `requireX(request)` throws 403 when
+  // the resolved caller kind isn't in the route's allowlist.
+  // ----------------------------------------------------------------------
+  function requireOperator(request: FastifyRequest): Extract<CommerceCaller, { kind: 'operator' }> {
+    if (request.commerceCaller.kind !== 'operator') {
+      throw new CommerceHttpError(403, 'operator_required',
+        'This endpoint is only callable by operator (developer API key) callers');
+    }
+    return request.commerceCaller;
+  }
+  /**
+   * Operator OR merchant for the merchant_id the caller is reading.
+   * Agents are explicitly denied — admin merchant data is not part of
+   * any agent's surface in M2.
+   */
+  function requireOperatorOrSelfMerchant(
+    request: FastifyRequest,
+    merchantId: string,
+  ): void {
+    const c = request.commerceCaller;
+    if (c.kind === 'operator') return;
+    if (c.kind === 'merchant' && c.merchantId === merchantId) return;
+    throw new CommerceHttpError(403, 'caller_not_authorized',
+      'This endpoint requires operator or the merchant whose data is being read');
+  }
+  /**
+   * Operator OR the agent reading their own record. Merchants are
+   * explicitly denied — they don't enumerate arbitrary agents.
+   */
+  function requireOperatorOrSelfAgent(
+    request: FastifyRequest,
+    agentId: string,
+  ): void {
+    const c = request.commerceCaller;
+    if (c.kind === 'operator') return;
+    if (c.kind === 'agent' && c.agentId === agentId) return;
+    throw new CommerceHttpError(403, 'caller_not_authorized',
+      'This endpoint requires operator or the agent reading their own record');
+  }
+
+  // ----------------------------------------------------------------------
+  // POST /merchants  — operator only
   // ----------------------------------------------------------------------
   app.post<{ Body: MerchantCreateBody }>('/merchants', async (request, reply) => {
+    requireOperator(request);
     const body = request.body ?? {};
     const fieldErrors: Record<string, string> = {};
     if (!isString(body.legal_name)) fieldErrors['legal_name'] = 'required string';
@@ -200,16 +308,15 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
       return { merchant: rows[0], auditEventId: audit.id };
     });
 
-    return reply.status(201).send({
-      data: result.merchant,
-      audit_event_id: result.auditEventId,
-    });
+    return reply.status(201).send({ data: result.merchant, audit_event_id: result.auditEventId });
   });
 
   // ----------------------------------------------------------------------
-  // GET /merchants/:merchantId
+  // GET /merchants/:merchantId — operator OR merchant for own merchant.
+  // Agent denied (admin merchant data is not in any agent's M2 surface).
   // ----------------------------------------------------------------------
   app.get<{ Params: { merchantId: string } }>('/merchants/:merchantId', async (request, reply) => {
+    requireOperatorOrSelfMerchant(request, request.params.merchantId);
     const sql = getSql();
     const rows = await sql<Record<string, unknown>[]>`
       SELECT id, tenant_id, legal_name, display_name, category_preset,
@@ -228,18 +335,10 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
   });
 
   // ----------------------------------------------------------------------
-  // POST /agents
-  //
-  // Trust-status policy (M1 hardening): trust_status is server-controlled.
-  // Every new CommerceAgent is created in 'pending' state regardless of
-  // what the caller sends. Trust changes belong on a future admin/operator
-  // endpoint with its own auth surface (planned for M2). Accepting
-  // trust_status from a normal create caller would let any operator mint
-  // a 'trusted' agent and bypass the trust review workflow entirely.
-  // We allow callers to send trust_status=pending (a no-op) for
-  // forward compatibility, but reject any other value with 422.
+  // POST /agents — operator only; trust_status server-controlled (M1 hardening)
   // ----------------------------------------------------------------------
   app.post<{ Body: AgentCreateBody }>('/agents', async (request, reply) => {
+    requireOperator(request);
     const body = request.body ?? {};
     const fieldErrors: Record<string, string> = {};
     if (!isString(body.display_name)) fieldErrors['display_name'] = 'required string';
@@ -263,7 +362,6 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
     const sql = getSql();
     const id = newCommerceAgentId();
     const tenantId = request.commerceTenantId;
-    // Hardcoded — see policy comment above. Not derived from request body.
     const trustStatus = 'pending';
 
     const result = await sql.begin(async (_tx) => {
@@ -296,16 +394,15 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
       return { agent: rows[0], auditEventId: audit.id };
     });
 
-    return reply.status(201).send({
-      data: result.agent,
-      audit_event_id: result.auditEventId,
-    });
+    return reply.status(201).send({ data: result.agent, audit_event_id: result.auditEventId });
   });
 
   // ----------------------------------------------------------------------
-  // GET /agents/:agentId
+  // GET /agents/:agentId — operator OR the agent reading own record.
+  // Merchant denied.
   // ----------------------------------------------------------------------
   app.get<{ Params: { agentId: string } }>('/agents/:agentId', async (request, reply) => {
+    requireOperatorOrSelfAgent(request, request.params.agentId);
     const sql = getSql();
     const rows = await sql<Record<string, unknown>[]>`
       SELECT id, tenant_id, display_name, agent_type,
@@ -323,9 +420,10 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
   });
 
   // ----------------------------------------------------------------------
-  // POST /catalog/products  — creates product + variants atomically
+  // POST /catalog/products — operator only
   // ----------------------------------------------------------------------
   app.post<{ Body: ProductCreateBody }>('/catalog/products', async (request, reply) => {
+    requireOperator(request);
     const body = request.body ?? {};
     const fieldErrors: Record<string, string> = {};
     if (!isString(body.merchant_id)) fieldErrors['merchant_id'] = 'required string';
@@ -360,7 +458,6 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
     const tenantId = request.commerceTenantId;
     const merchantId = body.merchant_id as string;
 
-    // Tenant boundary: refuse cross-tenant merchant access up front.
     const merchantRows = await sql<{ id: string }[]>`
       SELECT id FROM commerce_merchants
       WHERE id = ${merchantId} AND tenant_id = ${tenantId}
@@ -446,20 +543,47 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
     });
   });
 
-  // ----------------------------------------------------------------------
-  // GET /catalog/products/:productId
-  // ----------------------------------------------------------------------
   app.get<{ Params: { productId: string } }>('/catalog/products/:productId', async (request, reply) => {
+    // GET /catalog/products/:productId — operator OR merchant for own
+    // merchant. Agent denied (this is the admin product detail endpoint;
+    // agent-facing catalog reads land in M5 via MCP catalog tools with
+    // their own caller-kind matrix and read-scoping rules).
+    //
+    // Finding 4 (P2): authorize BEFORE the product lookup so a denied
+    // caller never receives information about whether the product
+    // exists. Specifically:
+    //   - agent/service callers → 403 immediately, no SQL.
+    //   - merchant callers → product query bound to (tenant_id,
+    //     merchant_id), so cross-merchant product IDs return 404 (same
+    //     shape as not-in-tenant), not 403.
+    //   - operator → existing tenant-scoped query.
+    const caller = request.commerceCaller;
+    if (caller.kind === 'agent' || caller.kind === 'service') {
+      throw new CommerceHttpError(403, 'caller_not_authorized',
+        'This endpoint requires operator or the merchant whose data is being read');
+    }
+
     const sql = getSql();
-    const productRows = await sql<Record<string, unknown>[]>`
-      SELECT id, tenant_id, merchant_id, product_id, title, brand, description,
-             image_url, category_preset, source_system, manually_maintained,
-             archived_at, created_at, updated_at
-      FROM commerce_products
-      WHERE id = ${request.params.productId}
-        AND tenant_id = ${request.commerceTenantId}
-      LIMIT 1
-    `;
+    const productRows = caller.kind === 'merchant'
+      ? await sql<Record<string, unknown>[]>`
+          SELECT id, tenant_id, merchant_id, product_id, title, brand, description,
+                 image_url, category_preset, source_system, manually_maintained,
+                 archived_at, created_at, updated_at
+            FROM commerce_products
+           WHERE id = ${request.params.productId}
+             AND tenant_id = ${caller.tenantId}
+             AND merchant_id = ${caller.merchantId}
+           LIMIT 1
+        `
+      : await sql<Record<string, unknown>[]>`
+          SELECT id, tenant_id, merchant_id, product_id, title, brand, description,
+                 image_url, category_preset, source_system, manually_maintained,
+                 archived_at, created_at, updated_at
+            FROM commerce_products
+           WHERE id = ${request.params.productId}
+             AND tenant_id = ${request.commerceTenantId}
+           LIMIT 1
+        `;
     if (!productRows[0]) {
       throw new CommerceHttpError(404, 'product_not_found', 'Product not found in this tenant');
     }
@@ -479,10 +603,8 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
     });
   });
 
-  // ----------------------------------------------------------------------
-  // DELETE /catalog/products/:productId  — soft-delete (archive)
-  // ----------------------------------------------------------------------
   app.delete<{ Params: { productId: string } }>('/catalog/products/:productId', async (request, reply) => {
+    requireOperator(request);
     const sql = getSql();
     const tenantId = request.commerceTenantId;
     const result = await sql.begin(async (_tx) => {
@@ -496,7 +618,6 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
          RETURNING id, merchant_id, archived_at
       `;
       if (!updated[0]) return null;
-      // Archive all active variants of this product.
       await tx`
         UPDATE commerce_product_variants
            SET archived_at = NOW(), updated_at = NOW()
@@ -524,9 +645,6 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
     });
   });
 
-  // ----------------------------------------------------------------------
-  // GET /audit/events
-  // ----------------------------------------------------------------------
   app.get<{
     Querystring: {
       merchant_id?: string;
@@ -539,10 +657,13 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
       cursor?: string;
     };
   }>('/audit/events', async (request, reply) => {
+    // GET /audit/events — operator only in M2. Merchant + agent audit
+    // surfaces (scoped reads) land in M5/M6 once the SDK and dashboard
+    // need them.
+    requireOperator(request);
     const sql = getSql();
     const tenantId = request.commerceTenantId;
     const limit = Math.min(Math.max(asInt(request.query.limit) ?? 25, 1), 100);
-    // Cursor: opaque base64 of "<occurred_at_iso>|<id>". Tail-only paging.
     let cursorOccurred: string | null = null;
     let cursorId: string | null = null;
     if (request.query.cursor) {
@@ -559,8 +680,6 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
     const fromTs = isString(request.query.from) ? request.query.from : null;
     const toTs = isString(request.query.to) ? request.query.to : null;
 
-    // Single tagged template: NULL-checks on each optional filter keep the
-    // shape stable (no SQL fragment composition required by the test mock).
     const rows = await sql<Record<string, unknown>[]>`
       SELECT id, tenant_id, merchant_id, agent_id, user_principal_id,
              event_type, resource_type, resource_id, passport_jti,
@@ -586,9 +705,7 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
       const last = rows[limit - 1];
       if (last) {
         const occVal = last['occurred_at'];
-        const occIso = occVal instanceof Date
-          ? occVal.toISOString()
-          : String(occVal);
+        const occIso = occVal instanceof Date ? occVal.toISOString() : String(occVal);
         const enc = `${occIso}|${last['id'] as string}`;
         nextCursor = Buffer.from(enc, 'utf8').toString('base64url');
       }
@@ -596,4 +713,12 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
     }
     return reply.status(200).send({ items: rows, next_cursor: nextCursor });
   });
+
+  // M2 sub-route plugins. They inherit the onRoute hook and the commerce
+  // preHandler from this scope (Fastify scope inheritance), so all their
+  // routes also bypass authPlugin and go through the commerce caller
+  // resolver.
+  await app.register(commerceTenantsRoutes);
+  await app.register(commercePassportRoutes);
+  await app.register(commerceConsentRoutes);
 }

--- a/apps/auth-service/src/server.ts
+++ b/apps/auth-service/src/server.ts
@@ -88,13 +88,18 @@ export async function buildApp(opts: AppOptions = {}) {
   });
   await app.register(websocket);
 
-  // HTTP security headers
+  // HTTP security headers. Most are unconditional defaults; CSP and
+  // Referrer-Policy are conditional so individual routes can apply
+  // stricter policies (e.g., commerce consent uses Referrer-Policy:
+  // no-referrer because the URL may carry one-shot session tokens).
   app.addHook('onSend', async (_request, reply) => {
     reply.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
     reply.header('X-Content-Type-Options', 'nosniff');
     reply.header('X-Frame-Options', 'DENY');
     reply.header('X-XSS-Protection', '0');
-    reply.header('Referrer-Policy', 'strict-origin-when-cross-origin');
+    if (!reply.getHeader('Referrer-Policy')) {
+      reply.header('Referrer-Policy', 'strict-origin-when-cross-origin');
+    }
     reply.header('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
     reply.header('Cache-Control', 'no-store');
     if (!reply.getHeader('Content-Security-Policy')) {

--- a/apps/auth-service/tests/commerce-authplugin-bypass.test.ts
+++ b/apps/auth-service/tests/commerce-authplugin-bypass.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Decision F enforcement test: every commerce route must bypass the
+ * global authPlugin (which only knows about developer API keys) and
+ * route through the commerce caller resolver instead. This file proves
+ * that merchant API keys and agent JWT/API-key tokens — which would all
+ * be rejected by authPlugin's developer-key lookup — reach the commerce
+ * resolver and are recognized.
+ *
+ * The proof shape: every assertion checks that the response uses the
+ * COMMERCE envelope `{ error: { code, ... } }` rather than the platform
+ * envelope `{ message, code, requestId }`. The platform envelope appears
+ * only when authPlugin handles the request; if commerce caller takes
+ * over, the commerce envelope is what surfaces.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { generateKeyPair, exportJWK, SignJWT, type KeyLike, type JWK } from 'jose';
+import { sqlMock, mockRedis, buildTestApp } from './helpers.js';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+function expectsCommerceEnvelope(body: unknown): { error: { code: string } } {
+  // Platform envelope is { message, code, requestId } — top-level. Commerce
+  // envelope nests under .error. If body has .error, it's commerce.
+  expect(body).toHaveProperty('error');
+  expect(body).not.toHaveProperty('requestId');
+  expect((body as { error: { code: string } }).error).toHaveProperty('code');
+  return body as { error: { code: string } };
+}
+
+describe('authPlugin bypass — commerce routes must skip global developer-key auth', () => {
+  it('merchant API key reaches commerce resolver (not rejected by authPlugin)', async () => {
+    sqlMock.mockResolvedValueOnce([]);  // merchant key lookup empty
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: 'Bearer grtx_sk_sandbox_AAAAAAAAAAAAAAAAAAAAAAAA' },
+    });
+    expect(res.statusCode).toBe(401);
+    const body = expectsCommerceEnvelope(res.json());
+    // The 401 came from commerce resolver — code is `invalid_merchant_key`
+    // (commerce-namespaced), NOT `UNAUTHORIZED` (platform).
+    expect(body.error.code).toBe('invalid_merchant_key');
+  });
+
+  it('agent API key reaches commerce resolver (not rejected by authPlugin)', async () => {
+    sqlMock.mockResolvedValueOnce([]);  // agent lookup empty
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: 'Bearer grtx_agent_BBBBBBBBBBBBBBBBBBBBBBBB' },
+    });
+    expect(res.statusCode).toBe(401);
+    const body = expectsCommerceEnvelope(res.json());
+    expect(body.error.code).toBe('invalid_agent_credential');
+  });
+
+  it('agent JWT (3-segment) reaches commerce resolver (not rejected as opaque developer key)', async () => {
+    const { privateKey, publicKey } = await generateKeyPair('ES256');
+    const jwk = await exportJWK(publicKey) as JWK;
+    const now = Math.floor(Date.now() / 1000);
+    const jwt = await new SignJWT({ tenant_id: 'cten_X' })
+      .setProtectedHeader({ alg: 'ES256' })
+      .setIssuer('cag_NOPE')
+      .setSubject('cag_NOPE')
+      .setAudience('grantex-commerce')
+      .setJti(`jti_${now}`)
+      .setIssuedAt(now)
+      .setExpirationTime(now + 60)
+      .sign(privateKey);
+    void jwk;
+    void privateKey as unknown as KeyLike;
+    sqlMock.mockResolvedValueOnce([]);   // agent lookup empty (unknown agent_id)
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(401);
+    const body = expectsCommerceEnvelope(res.json());
+    // Reaches commerce resolver, fails at agent lookup → invalid_agent_credential.
+    expect(body.error.code).toBe('invalid_agent_credential');
+  });
+
+  it('non-commerce routes still use authPlugin (control case — uses platform envelope)', async () => {
+    // /v1/agents requires the global authPlugin. Posting a merchant key
+    // there should produce the platform envelope, NOT the commerce one.
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/agents',
+      headers: { authorization: 'Bearer grtx_sk_sandbox_NOPE_NOPE_NOPE_NOPE_NOPE' },
+    });
+    expect(res.statusCode).toBe(401);
+    const body = res.json<Record<string, unknown>>();
+    // Platform envelope: top-level message + code + requestId. NOT { error: { ... } }.
+    expect(body).toHaveProperty('code');
+    expect(body).toHaveProperty('requestId');
+    expect(body['code']).toBe('UNAUTHORIZED');
+    expect(body).not.toHaveProperty('error');
+  });
+
+  // Use mockRedis to silence eslint about unused imports — Redis isn't
+  // hit in these specific tests but the harness mock must be loaded.
+  it('mockRedis is wired (sanity)', () => {
+    expect(typeof mockRedis.set).toBe('function');
+  });
+});

--- a/apps/auth-service/tests/commerce-caller-resolver.test.ts
+++ b/apps/auth-service/tests/commerce-caller-resolver.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { generateKeyPair, exportJWK, SignJWT, type KeyLike, type JWK } from 'jose';
+import { authHeader, sqlMock, mockRedis, TEST_DEVELOPER, buildTestApp } from './helpers.js';
+import { TEST_COMMERCE_TENANT_ID } from './commerce-helpers.js';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('Commerce caller resolver — token-shape detection', () => {
+  it('operator (developer key) reaches the route via operator path', async () => {
+    sqlMock.mockResolvedValueOnce([TEST_DEVELOPER]);
+    sqlMock.mockResolvedValueOnce([{ tenant_id: TEST_COMMERCE_TENANT_ID, status: 'active', role: 'owner' }]);
+    sqlMock.mockResolvedValueOnce([]);  // merchant lookup empty -> 404
+
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X', headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('merchant_not_found');
+  });
+
+  it('missing Authorization header → 401 commerce envelope', async () => {
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('missing_authorization');
+  });
+
+  it('merchant API key (grtx_sk_sandbox_…) is detected and resolved (own merchant)', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      id: 'mkey_TEST', tenant_id: TEST_COMMERCE_TENANT_ID,
+      merchant_id: 'mch_M', environment: 'sandbox',
+    }]);
+    // Reading own merchant: requireOperatorOrSelfMerchant passes; route
+    // hits SELECT and returns 404 because no merchant row primed.
+    sqlMock.mockResolvedValueOnce([]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_M',
+      headers: { authorization: 'Bearer grtx_sk_sandbox_abcd1234abcd1234abcd1234abcd1234' },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('merchant_not_found');
+  });
+
+  it('merchant API key denied on cross-merchant GET (Finding 2)', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      id: 'mkey_TEST', tenant_id: TEST_COMMERCE_TENANT_ID,
+      merchant_id: 'mch_M', environment: 'sandbox',
+    }]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_OTHER',
+      headers: { authorization: 'Bearer grtx_sk_sandbox_abcd1234abcd1234abcd1234abcd1234' },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('caller_not_authorized');
+  });
+
+  it('merchant API key not in DB → 401 invalid_merchant_key', async () => {
+    sqlMock.mockResolvedValueOnce([]);  // key lookup empty
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: 'Bearer grtx_sk_live_unknownunknownunknownunknown' },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('invalid_merchant_key');
+  });
+
+  it('agent API key (grtx_agent_…) untrusted agent → 403 agent_not_trusted', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_X', tenant_id: TEST_COMMERCE_TENANT_ID,
+      trust_status: 'pending', public_key_jwk: null, api_key_hash: 'h',
+    }]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: 'Bearer grtx_agent_xxxxxxxxxxxxxxxxxxxxxxxx' },
+    });
+    expect(res.statusCode).toBe(403);
+    const body = res.json<{ error: { code: string; details?: { trust_status?: string } } }>();
+    expect(body.error.code).toBe('agent_not_trusted');
+    expect(body.error.details?.trust_status).toBe('pending');
+  });
+
+  it('agent API key not in DB → 401 invalid_agent_credential', async () => {
+    sqlMock.mockResolvedValueOnce([]);  // agent lookup empty
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: 'Bearer grtx_agent_unknownunknownunknownunknown' },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('invalid_agent_credential');
+  });
+
+  it('developer key not in DB → 401 invalid_developer_key', async () => {
+    sqlMock.mockResolvedValueOnce([]);  // developer lookup empty
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: 'Bearer some-unknown-opaque-token-1234' },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('invalid_developer_key');
+  });
+
+  it('platform admin key falls through to operator with isPlatformAdmin=true', async () => {
+    // The vitest config sets ADMIN_API_KEY='test-admin-key-secret'.
+    // The admin token isn't in `developers`; loadDeveloperByApiKey returns [].
+    sqlMock.mockResolvedValueOnce([]);  // developer lookup empty (admin only)
+
+    // Hit a route the admin caller can use without a tenant (the
+    // commerce-disabled flag check). With NO tenant context, GET merchants
+    // would 404 immediately. Use POST /tenants which admin can call.
+    sqlMock.mockResolvedValueOnce([
+      { id: 'cten_NEW', display_name: 'X', status: 'active', metadata: {}, created_at: new Date(), updated_at: new Date() },
+    ]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_T', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST', url: '/v1/commerce/tenants',
+      headers: { authorization: 'Bearer test-admin-key-secret' },
+      payload: { display_name: 'New Tenant' },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+});
+
+describe('Commerce caller resolver — agent JWT assertion', () => {
+  let agentKp: { privateKey: KeyLike; publicKey: KeyLike };
+  let agentJwk: JWK;
+  beforeAll(async () => {
+    agentKp = await generateKeyPair('ES256');
+    agentJwk = await exportJWK(agentKp.publicKey) as JWK;
+  });
+
+  async function makeAssertion(opts: {
+    iss?: string; sub?: string; aud?: string; tenantId?: string;
+    iat?: number; exp?: number; jti?: string;
+  } = {}): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    return new SignJWT({ tenant_id: opts.tenantId ?? 'cten_TEST' })
+      .setProtectedHeader({ alg: 'ES256' })
+      .setIssuer(opts.iss ?? 'cag_AGENT')
+      .setSubject(opts.sub ?? 'cag_AGENT')
+      .setAudience(opts.aud ?? 'grantex-commerce')
+      .setJti(opts.jti ?? `jti_${now}_${Math.random().toString(36).slice(2)}`)
+      .setIssuedAt(opts.iat ?? now)
+      .setExpirationTime(opts.exp ?? now + 60)
+      .sign(agentKp.privateKey);
+  }
+
+  it('valid assertion + trusted agent + Redis SET=OK → caller resolved (reads own agent)', async () => {
+    const jwt = await makeAssertion();
+    // agent lookup (caller resolver)
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_AGENT', tenant_id: 'cten_TEST', trust_status: 'trusted',
+      public_key_jwk: agentJwk, api_key_hash: null,
+    }]);
+    // GET /agents/:agentId for OWN agent — requireOperatorOrSelfAgent passes;
+    // route hits SELECT and returns 404 because no agent row primed.
+    sqlMock.mockResolvedValueOnce([]);
+    mockRedis.set.mockResolvedValueOnce('OK');
+
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/agents/cag_AGENT',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('agent_not_found');
+  });
+
+  it('agent denied on GET /merchants/:id (Finding 2)', async () => {
+    const jwt = await makeAssertion();
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_AGENT', tenant_id: 'cten_TEST', trust_status: 'trusted',
+      public_key_jwk: agentJwk, api_key_hash: null,
+    }]);
+    mockRedis.set.mockResolvedValueOnce('OK');
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('caller_not_authorized');
+  });
+
+  it('replay (Redis SET returns null) → 401 agent_assertion_replay', async () => {
+    const jwt = await makeAssertion();
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_AGENT', tenant_id: 'cten_TEST', trust_status: 'trusted',
+      public_key_jwk: agentJwk, api_key_hash: null,
+    }]);
+    mockRedis.set.mockResolvedValueOnce(null);  // jti already seen
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('agent_assertion_replay');
+  });
+
+  it('Redis throws (replay infra unavailable) → 503 assertion_replay_check_unavailable (Decision E)', async () => {
+    const jwt = await makeAssertion();
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_AGENT', tenant_id: 'cten_TEST', trust_status: 'trusted',
+      public_key_jwk: agentJwk, api_key_hash: null,
+    }]);
+    mockRedis.set.mockRejectedValueOnce(new Error('redis down'));
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(503);
+    expect(res.json<{ error: { code: string; retryable: boolean } }>().error.code)
+      .toBe('assertion_replay_check_unavailable');
+    expect(res.json<{ error: { retryable: boolean } }>().error.retryable).toBe(true);
+  });
+
+  it('expired assertion (exp in past) → 401', async () => {
+    const past = Math.floor(Date.now() / 1000) - 600;
+    const jwt = await makeAssertion({ iat: past, exp: past + 60 });
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_AGENT', tenant_id: 'cten_TEST', trust_status: 'trusted',
+      public_key_jwk: agentJwk, api_key_hash: null,
+    }]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('invalid_agent_credential');
+  });
+
+  it('wrong audience → 401', async () => {
+    const jwt = await makeAssertion({ aud: 'not-grantex-commerce' });
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_AGENT', tenant_id: 'cten_TEST', trust_status: 'trusted',
+      public_key_jwk: agentJwk, api_key_hash: null,
+    }]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('disabled agent → 403 agent_not_trusted', async () => {
+    const jwt = await makeAssertion();
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_AGENT', tenant_id: 'cten_TEST', trust_status: 'disabled',
+      public_key_jwk: agentJwk, api_key_hash: null,
+    }]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('agent_not_trusted');
+  });
+});

--- a/apps/auth-service/tests/commerce-consent-challenge.test.ts
+++ b/apps/auth-service/tests/commerce-consent-challenge.test.ts
@@ -1,0 +1,735 @@
+/**
+ * Tests for the consent challenge — the user-presence credential
+ * introduced to close the M2 P0 self-approval hole. The attack the
+ * challenge defeats:
+ *
+ *   1. Trusted agent creates a consent request with hint=user_X.
+ *   2. Agent's developer mints a principal session JWT for user_X
+ *      (legitimate flow because user_X has an active grant).
+ *   3. Agent uses ?session=… bootstrap; cookie is set.
+ *   4. Agent computes csrf = sha256(session_token + ':' + reqId).
+ *   5. Agent POSTs approve with no human gesture in the loop.
+ *
+ * The fix: a server-issued, single-use challenge that the
+ * agent/developer cannot read or compute. Approve/deny consume a
+ * verified challenge atomically with the consent state transition.
+ */
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { sqlMock, buildTestApp } from './helpers.js';
+import { signPrincipalSessionToken } from '../src/lib/crypto.js';
+import { deriveConsentCsrfToken } from '../src/lib/commerce/consent.js';
+import { _internal as challengeInternal } from '../src/lib/commerce/consent-challenge.js';
+
+let app: FastifyInstance;
+beforeAll(async () => { app = await buildTestApp(); });
+afterEach(() => { vi.unstubAllEnvs(); });
+
+const HOST = 'consent.grantex.dev';
+const REQ = 'req_TEST';
+const PRINCIPAL = 'user_X';
+const DEVELOPER = 'dev_TEST';
+const TENANT = 'cten_T';
+
+function fakeConsent(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    id: 'crec_TEST', tenant_id: TENANT, merchant_id: 'mch_M', agent_id: 'cag_A',
+    consent_request_id: REQ, passport_type: 'browse',
+    requested_scopes: ['commerce:catalog.read'],
+    approved_scopes: null, max_amount: null, currency: null,
+    consent_text_version: '2026-05-01',
+    presented_payload_hash: null, status: 'requested',
+    agent_auth_method: 'jwt',
+    expires_at: new Date(Date.now() + 600_000), approved_at: null, denied_at: null,
+    user_principal_id: null, user_principal_hint: null, created_at: new Date(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------
+// P0 — original self-approval attack now fails
+// ---------------------------------------------------------------------
+describe('P0 — agent/developer cannot self-approve via principal session alone', () => {
+  it('agent has session + CSRF + tenant binding but no verified challenge → 403 challenge_required', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    // Mocks for the approve route up to the decideConsent call:
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);                  // findConsentByRequestId
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);           // tenant binding
+    // approveConsent inside sql.begin:
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);                  // SELECT FOR UPDATE consent
+    sqlMock.mockResolvedValueOnce([]);                               // SELECT FOR UPDATE challenge → none
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/approve`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string; retryable?: boolean } }>().error.code)
+      .toBe('challenge_required');
+  });
+
+  it('GET /page with valid session but no challenge → renders challenge_request, NOT approve/deny', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);                  // present FOR UPDATE
+    sqlMock.mockResolvedValueOnce([]);                               // present UPDATE
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);           // tenant binding
+    sqlMock.mockResolvedValueOnce([]);                               // findActiveChallenge → none
+
+    const res = await app.inject({
+      method: 'GET', url: `/v1/commerce/consent/page?req=${REQ}`,
+      headers: { host: HOST, cookie: `grantex_principal_session=${sessionToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    // The page surface offers code request, not approve/deny, until
+    // the challenge is verified.
+    expect(res.body).toMatch(/<form[^>]*\/challenge"/);
+    expect(res.body).not.toMatch(/<form[^>]*\/approve"/);
+    expect(res.body).not.toMatch(/<form[^>]*\/deny"/);
+  });
+
+  it('CSRF + session alone is insufficient even when attacker knows session token and reqId', async () => {
+    // Same setup as the first test — the attacker has all the inputs
+    // (session, reqId, computed CSRF). The 403 confirms the challenge
+    // gate cannot be bypassed by guessing or recomputing.
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);
+    sqlMock.mockResolvedValueOnce([]);  // no verified challenge
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/approve`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('challenge_required');
+  });
+
+  it('challenge hash derivation includes consent_request_id + principal_id (cross-consent replay impossible)', () => {
+    const codeA = '123456';
+    const reqA = 'req_A';
+    const reqB = 'req_B';
+    const principalA = 'user_A';
+    const principalB = 'user_B';
+    const hAA = challengeInternal.hashChallengeCode(codeA, reqA, principalA);
+    const hAB = challengeInternal.hashChallengeCode(codeA, reqA, principalB);
+    const hBA = challengeInternal.hashChallengeCode(codeA, reqB, principalA);
+    expect(hAA).not.toBe(hAB);
+    expect(hAA).not.toBe(hBA);
+    expect(hAB).not.toBe(hBA);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Challenge create endpoint
+// ---------------------------------------------------------------------
+describe('POST /v1/commerce/consent/{reqId}/challenge', () => {
+  it('returns test_only_code in test_sink + non-production mode', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    // Route flow: findConsentByRequestId, tenant binding, then createChallenge
+    // which inside sql.begin runs an UPDATE (expire previous) + INSERT.
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);                  // findConsentByRequestId
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);           // tenant binding
+    sqlMock.mockResolvedValueOnce([]);                               // UPDATE expire-old
+    sqlMock.mockResolvedValueOnce([]);                               // INSERT challenge
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_R', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/challenge`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ data: { delivery_channel: string; test_only_code?: string; challenge_id: string } }>();
+    expect(body.data.delivery_channel).toBe('test_sink');
+    expect(typeof body.data.test_only_code).toBe('string');
+    expect(body.data.test_only_code).toMatch(/^\d{6}$/);
+    expect(body.data.challenge_id).toMatch(/^ccch_/);
+  });
+
+  it('fail-closed in production with no provider configured → 503 challenge_provider_unavailable', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('COMMERCE_CONSENT_CHALLENGE_PROVIDER', '');
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/challenge`,
+      headers: {
+        host: 'consent.grantex.dev',
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `__Host-grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(res.statusCode).toBe(503);
+    expect(res.json<{ error: { code: string; retryable?: boolean } }>().error.code)
+      .toBe('challenge_provider_unavailable');
+  });
+
+  it('rejects challenge create without principal session → 401', async () => {
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/challenge`,
+      headers: { host: HOST, 'content-type': 'application/x-www-form-urlencoded' },
+      payload: 'csrf=anything',
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('principal_session_required');
+  });
+
+  it('rejects challenge create with mismatched CSRF → 403', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/challenge`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: 'csrf=wrong',
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('csrf_invalid');
+  });
+
+  it('rejects challenge create when principal hint does not match → 403', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    sqlMock.mockResolvedValueOnce([fakeConsent({ user_principal_hint: 'user_OTHER' })]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/challenge`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('principal_hint_mismatch');
+  });
+});
+
+// ---------------------------------------------------------------------
+// Challenge verify endpoint
+// ---------------------------------------------------------------------
+describe('POST /v1/commerce/consent/{reqId}/challenge/verify', () => {
+  it('correct code marks the challenge verified + audit', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    const code = '123456';
+    const goodHash = challengeInternal.hashChallengeCode(code, REQ, PRINCIPAL);
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);                          // findConsentByRequestId
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);                   // tenant binding
+    // verifyChallenge inside sql.begin:
+    sqlMock.mockResolvedValueOnce([{
+      id: 'ccch_X', tenant_id: TENANT,
+      consent_request_id: REQ, principal_id: PRINCIPAL,
+      challenge_hash: goodHash,
+      status: 'requested', attempts_count: 0, max_attempts: 5,
+      expires_at: new Date(Date.now() + 60_000),
+    }]);                                                                      // SELECT FOR UPDATE
+    sqlMock.mockResolvedValueOnce([]);                                        // UPDATE → verified
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_V', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/challenge/verify`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}&code=${code}`,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { status: string; challenge_id: string } }>();
+    expect(body.data.status).toBe('verified');
+    expect(body.data.challenge_id).toBe('ccch_X');
+  });
+
+  it('wrong code increments attempts → 403 challenge_invalid with remaining_attempts', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    const goodHash = challengeInternal.hashChallengeCode('999999', REQ, PRINCIPAL);
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    sqlMock.mockResolvedValueOnce([{
+      id: 'ccch_X', tenant_id: TENANT, consent_request_id: REQ, principal_id: PRINCIPAL,
+      challenge_hash: goodHash,
+      status: 'requested', attempts_count: 0, max_attempts: 5,
+      expires_at: new Date(Date.now() + 60_000),
+    }]);
+    sqlMock.mockResolvedValueOnce([]);  // UPDATE attempts_count
+
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/challenge/verify`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}&code=000000`,
+    });
+    expect(res.statusCode).toBe(403);
+    const body = res.json<{ error: { code: string; details?: { remaining_attempts: number } } }>();
+    expect(body.error.code).toBe('challenge_invalid');
+    expect(body.error.details?.remaining_attempts).toBe(4);
+  });
+
+  it('exceeded max_attempts → 410 challenge_expired (challenge marked expired)', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    const goodHash = challengeInternal.hashChallengeCode('999999', REQ, PRINCIPAL);
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    // attempts_count: 4 of 5 (next attempt is the 5th and final).
+    sqlMock.mockResolvedValueOnce([{
+      id: 'ccch_X', tenant_id: TENANT, consent_request_id: REQ, principal_id: PRINCIPAL,
+      challenge_hash: goodHash, status: 'requested',
+      attempts_count: 4, max_attempts: 5,
+      expires_at: new Date(Date.now() + 60_000),
+    }]);
+    sqlMock.mockResolvedValueOnce([]);   // UPDATE → expired
+
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/challenge/verify`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}&code=000000`,
+    });
+    expect(res.statusCode).toBe(410);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('challenge_expired');
+  });
+
+  it('expired challenge (past expires_at) → 410 challenge_expired', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    sqlMock.mockResolvedValueOnce([{
+      id: 'ccch_X', tenant_id: TENANT, consent_request_id: REQ, principal_id: PRINCIPAL,
+      challenge_hash: 'h', status: 'requested',
+      attempts_count: 0, max_attempts: 5,
+      expires_at: new Date(Date.now() - 1000),     // already expired
+    }]);
+    sqlMock.mockResolvedValueOnce([]);   // UPDATE → expired
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/challenge/verify`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}&code=123456`,
+    });
+    expect(res.statusCode).toBe(410);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('challenge_expired');
+  });
+
+  it('no active challenge for (reqId, principalId) → 404 challenge_not_found', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    sqlMock.mockResolvedValueOnce([]);  // verifyChallenge SELECT FOR UPDATE → none
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/challenge/verify`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}&code=123456`,
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('challenge_not_found');
+  });
+
+  it('rejects non-numeric code → 422 validation_failed', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/challenge/verify`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}&code=abc`,
+    });
+    expect(res.statusCode).toBe(422);
+  });
+});
+
+// ---------------------------------------------------------------------
+// End-to-end: verify challenge then approve / re-approve fails
+// ---------------------------------------------------------------------
+describe('Approve/deny consume the verified challenge atomically', () => {
+  it('successful approve consumes the challenge; second approve fails (no more verified challenges)', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    // First approve — supplies all mocks for: findConsent, tenant,
+    // consent FOR UPDATE, challenge FOR UPDATE (verified), challenge UPDATE used,
+    // consent UPDATE granted, audit consent.granted, audit consent.challenge.used.
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);
+    sqlMock.mockResolvedValueOnce([{
+      id: 'ccch_V', expires_at: new Date(Date.now() + 60_000),
+    }]);
+    sqlMock.mockResolvedValueOnce([]);                               // challenge → 'used'
+    sqlMock.mockResolvedValueOnce([fakeConsent({
+      status: 'granted', approved_scopes: ['commerce:catalog.read'],
+      approved_at: new Date(), user_principal_id: PRINCIPAL,
+    })]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_G', occurred_at: new Date().toISOString() }]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_C', occurred_at: new Date().toISOString() }]);
+
+    const ok = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/approve`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(ok.statusCode).toBe(200);
+
+    // Second approve — consent now status='granted'; SELECT FOR UPDATE
+    // returns granted row → already_decided. (Even before that, the
+    // challenge was consumed so this would also fail challenge_required.)
+    sqlMock.mockResolvedValueOnce([fakeConsent({ status: 'granted' })]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    sqlMock.mockResolvedValueOnce([fakeConsent({ status: 'granted' })]);
+
+    const second = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/approve`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(second.statusCode).toBe(409);
+    expect(second.json<{ error: { code: string } }>().error.code)
+      .toBe('consent_already_decided');
+  });
+});
+
+// ---------------------------------------------------------------------
+// Round-5 P1 fixes — fail-closed on email_otp / non-test environments
+// ---------------------------------------------------------------------
+describe('Delivery channel selection — fail-closed everywhere except NODE_ENV=test', () => {
+  // Defensive lib-level reads. The route paths are covered separately
+  // in the integration tests below.
+  it('NODE_ENV=test (default vitest env) → test_sink', () => {
+    expect(challengeInternal.selectDeliveryChannel()).toBe('test_sink');
+  });
+
+  it('NODE_ENV=development without provider → null (fail closed)', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    expect(challengeInternal.selectDeliveryChannel()).toBeNull();
+  });
+
+  it('NODE_ENV=staging without provider → null', () => {
+    vi.stubEnv('NODE_ENV', 'staging');
+    expect(challengeInternal.selectDeliveryChannel()).toBeNull();
+  });
+
+  it('NODE_ENV=production without provider → null', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    expect(challengeInternal.selectDeliveryChannel()).toBeNull();
+  });
+
+  it('NODE_ENV=production with COMMERCE_CONSENT_CHALLENGE_PROVIDER=email_otp → STILL null (M2 fail-closed)', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('COMMERCE_CONSENT_CHALLENGE_PROVIDER', 'email_otp');
+    // M2 deferral: setting the env var must NOT enable delivery,
+    // because no real delivery is implemented yet. Route returns 503.
+    expect(challengeInternal.selectDeliveryChannel()).toBeNull();
+  });
+
+  it('NODE_ENV=development with email_otp → STILL null (M2 fail-closed)', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('COMMERCE_CONSENT_CHALLENGE_PROVIDER', 'email_otp');
+    expect(challengeInternal.selectDeliveryChannel()).toBeNull();
+  });
+
+  it('NODE_ENV=test with email_otp → null (lets tests cover the email_otp deferred path)', () => {
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('COMMERCE_CONSENT_CHALLENGE_PROVIDER', 'email_otp');
+    expect(challengeInternal.selectDeliveryChannel()).toBeNull();
+  });
+});
+
+describe('Route — challenge create reflects the strict fail-closed posture', () => {
+  it('POST /challenge in NODE_ENV=development → 503 challenge_provider_unavailable', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/challenge`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(res.statusCode).toBe(503);
+    expect(res.json<{ error: { code: string } }>().error.code)
+      .toBe('challenge_provider_unavailable');
+  });
+
+  it('POST /challenge in NODE_ENV=production with email_otp → STILL 503 (M2 deferred)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('COMMERCE_CONSENT_CHALLENGE_PROVIDER', 'email_otp');
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/challenge`,
+      headers: {
+        // production cookie name in this NODE_ENV
+        host: 'consent.grantex.dev',
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `__Host-grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(res.statusCode).toBe(503);
+    expect(res.json<{ error: { code: string } }>().error.code)
+      .toBe('challenge_provider_unavailable');
+  });
+
+  it('test_only_code is returned ONLY in NODE_ENV=test', async () => {
+    // Default vitest env IS NODE_ENV=test (per vitest.config.ts).
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_R', occurred_at: new Date().toISOString() }]);
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/challenge`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ data: { test_only_code?: string } }>();
+    expect(typeof body.data.test_only_code).toBe('string');
+  });
+});
+
+describe('GET /page renders challenge_unavailable in any non-test env without a real provider', () => {
+  it('NODE_ENV=development → 503 challenge_unavailable (no green button to a 503 POST)', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);                  // present FOR UPDATE
+    sqlMock.mockResolvedValueOnce([]);                               // present UPDATE
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);           // tenant binding
+    sqlMock.mockResolvedValueOnce([]);                               // findActiveChallenge → none
+    const res = await app.inject({
+      method: 'GET', url: `/v1/commerce/consent/page?req=${REQ}`,
+      headers: { host: HOST, cookie: `grantex_principal_session=${sessionToken}` },
+    });
+    expect(res.statusCode).toBe(503);
+    // Page surface must NOT show approve/deny OR a request-code button.
+    expect(res.body).not.toMatch(/<form[^>]*\/approve"/);
+    expect(res.body).not.toMatch(/<form[^>]*\/deny"/);
+    expect(res.body).not.toMatch(/<form[^>]*\/challenge"/);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Round-5 P2 fix — expired challenges don't render decision forms
+// ---------------------------------------------------------------------
+describe('findActiveChallenge filters by expires_at (P2)', () => {
+  it('expired requested challenge → page renders challenge_request, NOT challenge_verify', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);
+    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    // findActiveChallenge SELECT ... AND expires_at > NOW() → empty
+    // (the expired row is not returned). Even though there IS a stale
+    // row in the DB, the filter hides it. Page renders challenge_request.
+    sqlMock.mockResolvedValueOnce([]);
+    const res = await app.inject({
+      method: 'GET', url: `/v1/commerce/consent/page?req=${REQ}`,
+      headers: { host: HOST, cookie: `grantex_principal_session=${sessionToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    // Decision forms NOT rendered.
+    expect(res.body).not.toMatch(/<form[^>]*\/approve"/);
+    expect(res.body).not.toMatch(/<form[^>]*\/deny"/);
+    // Code-entry form NOT rendered (we don't have an active requested challenge).
+    expect(res.body).not.toMatch(/<form[^>]*\/challenge\/verify"/);
+    // Send-code form IS rendered.
+    expect(res.body).toMatch(/<form[^>]*\/challenge"/);
+  });
+
+  it('expired VERIFIED challenge → page does NOT render approve/deny forms', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);
+    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    // The DB has a verified row but it's past expires_at; the WHERE
+    // expires_at > NOW() filter excludes it. Page renders the request
+    // form instead of the now-broken approve/deny.
+    sqlMock.mockResolvedValueOnce([]);
+    const res = await app.inject({
+      method: 'GET', url: `/v1/commerce/consent/page?req=${REQ}`,
+      headers: { host: HOST, cookie: `grantex_principal_session=${sessionToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).not.toMatch(/<form[^>]*\/approve"/);
+    expect(res.body).not.toMatch(/<form[^>]*\/deny"/);
+    expect(res.body).toMatch(/<form[^>]*\/challenge"/);
+  });
+
+  it('NOT-yet-expired verified challenge still renders approve/deny (regression check)', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    sqlMock.mockResolvedValueOnce([fakeConsent()]);
+    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    sqlMock.mockResolvedValueOnce([{
+      id: 'ccch_X', status: 'verified', expires_at: new Date(Date.now() + 60_000),
+    }]);
+    const res = await app.inject({
+      method: 'GET', url: `/v1/commerce/consent/page?req=${REQ}`,
+      headers: { host: HOST, cookie: `grantex_principal_session=${sessionToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatch(/<form[^>]*\/approve"/);
+    expect(res.body).toMatch(/<form[^>]*\/deny"/);
+  });
+});
+
+// ---------------------------------------------------------------------
+// P2 — deny enforces principal_hint_mismatch
+// ---------------------------------------------------------------------
+describe('P2 — deny enforces user_principal_hint', () => {
+  it('deny with mismatched hint → 403 principal_hint_mismatch', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    sqlMock.mockResolvedValueOnce([fakeConsent({ user_principal_hint: 'user_OTHER' })]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    sqlMock.mockResolvedValueOnce([fakeConsent({ user_principal_hint: 'user_OTHER' })]);
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/deny`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code)
+      .toBe('principal_hint_mismatch');
+  });
+
+  it('deny with matching hint + verified challenge → 200', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: PRINCIPAL, developerId: DEVELOPER }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, REQ);
+    sqlMock.mockResolvedValueOnce([fakeConsent({ user_principal_hint: PRINCIPAL })]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    sqlMock.mockResolvedValueOnce([fakeConsent({ user_principal_hint: PRINCIPAL })]);
+    sqlMock.mockResolvedValueOnce([{
+      id: 'ccch_V', expires_at: new Date(Date.now() + 60_000),
+    }]);
+    sqlMock.mockResolvedValueOnce([]);                                 // UPDATE challenge used
+    sqlMock.mockResolvedValueOnce([fakeConsent({
+      status: 'denied', user_principal_id: PRINCIPAL, user_principal_hint: PRINCIPAL,
+    })]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_D', occurred_at: new Date().toISOString() }]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_C', occurred_at: new Date().toISOString() }]);
+    const res = await app.inject({
+      method: 'POST', url: `/v1/commerce/consent/${REQ}/deny`,
+      headers: {
+        host: HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatch(/Denied/);
+  });
+});

--- a/apps/auth-service/tests/commerce-consent-flow.test.ts
+++ b/apps/auth-service/tests/commerce-consent-flow.test.ts
@@ -1,0 +1,395 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { sqlMock, buildTestApp } from './helpers.js';
+import { signPrincipalSessionToken } from '../src/lib/crypto.js';
+import { deriveConsentCsrfToken, sha256hex, canonicalPresentedPayload } from '../src/lib/commerce/consent.js';
+
+let app: FastifyInstance;
+beforeAll(async () => { app = await buildTestApp(); });
+afterEach(() => { vi.unstubAllEnvs(); });
+
+const CONSENT_HOST = 'consent.grantex.dev';
+const TEST_DEVELOPER_ID = 'dev_TEST';
+const TEST_PRINCIPAL_ID = 'user_X';
+
+function fakeConsentRow(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    id: 'crec_TEST', tenant_id: 'cten_T', merchant_id: 'mch_M', agent_id: 'cag_A',
+    consent_request_id: 'req_TEST', passport_type: 'browse',
+    requested_scopes: ['commerce:catalog.read'],
+    approved_scopes: null, max_amount: null, currency: null,
+    consent_text_version: '2026-05-01',
+    presented_payload_hash: null, status: 'requested',
+    agent_auth_method: 'jwt',
+    expires_at: new Date(Date.now() + 600_000), approved_at: null, denied_at: null,
+    user_principal_id: null,
+    user_principal_hint: null,
+    created_at: new Date(),
+    ...overrides,
+  };
+}
+
+describe('GET /v1/commerce/consent/page — host isolation + sign-in gating', () => {
+  it('host isolation — returns 404 when Host is the API origin (production)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/consent/page?req=req_TEST',
+      headers: { host: 'api.grantex.dev' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('renders sign_in_required when no principal session is present', async () => {
+    sqlMock.mockResolvedValueOnce([fakeConsentRow()]);  // FOR UPDATE
+    sqlMock.mockResolvedValueOnce([]);                  // UPDATE presented_payload_hash
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/consent/page?req=req_TEST',
+      headers: { host: CONSENT_HOST },
+    });
+    expect(res.statusCode).toBe(200);
+    // Strict CSP enforced regardless of state.
+    expect(res.headers['content-security-policy']).toMatch(/default-src 'self'/);
+    expect(res.headers['content-security-policy']).not.toMatch(/'unsafe-inline'/);
+    expect(res.headers['x-frame-options']).toBe('DENY');
+    expect(res.headers['cache-control']).toBe('no-store');
+    // No CSRF/principal cookie set when sign-in required.
+    expect(res.headers['set-cookie']).toBeUndefined();
+    // No approve/deny forms rendered.
+    expect(res.body).toMatch(/Sign in to authorize/);
+    expect(res.body).not.toMatch(/<form[^>]*action="\/v1\/commerce\/consent\//);
+  });
+
+  it('first GET with ?session= returns 303 redirect (Finding 2 — token must not linger in URL)', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: TEST_PRINCIPAL_ID, developerId: TEST_DEVELOPER_ID }, 600,
+    );
+    const res = await app.inject({
+      method: 'GET',
+      url: `/v1/commerce/consent/page?req=req_TEST&session=${encodeURIComponent(sessionToken)}`,
+      headers: { host: CONSENT_HOST },
+    });
+    expect(res.statusCode).toBe(303);
+    // Location preserves req but excludes session.
+    expect(res.headers['location']).toBe('/v1/commerce/consent/page?req=req_TEST');
+    expect(res.headers['location']).not.toMatch(/session=/);
+    // Cookie set on the redirect itself so the follow-up GET carries it.
+    expect(res.headers['set-cookie']).toMatch(/grantex_principal_session=/);
+    expect(res.headers['set-cookie']).toMatch(/HttpOnly/);
+    expect(res.headers['set-cookie']).toMatch(/SameSite=Strict/);
+    expect(res.headers['cache-control']).toBe('no-store');
+    expect(res.headers['pragma']).toBe('no-cache');
+    // Referrer-Policy must be no-referrer so the redirect itself doesn't
+    // leak the source URL (which still contains the session) to any
+    // intermediary that follows the Referer chain.
+    expect(res.headers['referrer-policy']).toBe('no-referrer');
+  });
+
+  it('follow-up GET (with cookie, no ?session=) — no challenge yet → renders challenge_request', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: TEST_PRINCIPAL_ID, developerId: TEST_DEVELOPER_ID }, 600,
+    );
+    sqlMock.mockResolvedValueOnce([fakeConsentRow()]);          // present FOR UPDATE
+    sqlMock.mockResolvedValueOnce([]);                          // present UPDATE
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);      // tenant binding
+    sqlMock.mockResolvedValueOnce([]);                          // findActiveChallenge → none
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/v1/commerce/consent/page?req=req_TEST`,
+      headers: {
+        host: CONSENT_HOST,
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['referrer-policy']).toBe('no-referrer');
+    // Per P0 fix: approve/deny are NOT rendered until a verified challenge
+    // exists. The page shows the "send verification code" form instead.
+    expect(res.body).toMatch(/Verify it/);
+    expect(res.body).toMatch(/<form[^>]*\/challenge"/);
+    expect(res.body).not.toMatch(/<form[^>]*\/approve"/);
+    expect(res.body).not.toMatch(/<form[^>]*\/deny"/);
+  });
+
+  it('follow-up GET with verified challenge → renders approve/deny forms', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: TEST_PRINCIPAL_ID, developerId: TEST_DEVELOPER_ID }, 600,
+    );
+    sqlMock.mockResolvedValueOnce([fakeConsentRow()]);          // present FOR UPDATE
+    sqlMock.mockResolvedValueOnce([]);                          // present UPDATE
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);      // tenant binding
+    sqlMock.mockResolvedValueOnce([{
+      id: 'ccch_TEST', status: 'verified',
+      expires_at: new Date(Date.now() + 60_000),
+    }]);                                                         // findActiveChallenge → verified
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/v1/commerce/consent/page?req=req_TEST`,
+      headers: {
+        host: CONSENT_HOST,
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['referrer-policy']).toBe('no-referrer');
+    expect(res.body).toMatch(/<form[^>]+action="\/v1\/commerce\/consent\/req_TEST\/approve"/);
+    expect(res.body).toMatch(/<form[^>]+action="\/v1\/commerce\/consent\/req_TEST\/deny"/);
+    const expectedCsrf = deriveConsentCsrfToken(sessionToken, 'req_TEST');
+    expect(res.body).toContain(expectedCsrf);
+  });
+
+  it('invalid ?session= does NOT set cookie and does NOT redirect — renders sign_in_required', async () => {
+    sqlMock.mockResolvedValueOnce([fakeConsentRow()]);
+    sqlMock.mockResolvedValueOnce([]);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/consent/page?req=req_TEST&session=garbage',
+      headers: { host: CONSENT_HOST },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['set-cookie']).toBeUndefined();
+    expect(res.body).toMatch(/Sign in to authorize/);
+  });
+
+  it('follow-up GET with cookie but developer NOT bound to tenant returns 403', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: TEST_PRINCIPAL_ID, developerId: 'dev_OTHER' }, 600,
+    );
+    sqlMock.mockResolvedValueOnce([fakeConsentRow()]);
+    sqlMock.mockResolvedValueOnce([]);                  // UPDATE presented hash
+    sqlMock.mockResolvedValueOnce([]);                  // tenant binding lookup empty (no row)
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/v1/commerce/consent/page?req=req_TEST`,
+      headers: {
+        host: CONSENT_HOST,
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.body).not.toMatch(/<form/);
+  });
+
+  it('follow-up GET with cookie but disabled tenant renders closed screen (Finding 3)', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: TEST_PRINCIPAL_ID, developerId: TEST_DEVELOPER_ID }, 600,
+    );
+    sqlMock.mockResolvedValueOnce([fakeConsentRow()]);
+    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([{ status: 'disabled' }]);  // tenant disabled
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/v1/commerce/consent/page?req=req_TEST`,
+      headers: {
+        host: CONSENT_HOST,
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.body).not.toMatch(/<form[^>]*\/approve"/);
+  });
+
+  it('follow-up GET with cookie + hint mismatch renders sign_in_required', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: TEST_PRINCIPAL_ID, developerId: TEST_DEVELOPER_ID }, 600,
+    );
+    sqlMock.mockResolvedValueOnce([fakeConsentRow({ user_principal_hint: 'user_DIFFERENT' })]);
+    sqlMock.mockResolvedValueOnce([]);                  // UPDATE presented hash
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);  // tenant binding ok + active
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/v1/commerce/consent/page?req=req_TEST`,
+      headers: {
+        host: CONSENT_HOST,
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatch(/Sign in to authorize/);
+    expect(res.body).not.toMatch(/<form[^>]*\/approve"/);
+  });
+});
+
+describe('GET /v1/commerce/consent/page — multi-tab re-render (bonus bug fix)', () => {
+  it('returns the same presented_payload_hash on second present (no regeneration)', async () => {
+    const fixedHash = 'a'.repeat(64);
+    sqlMock.mockResolvedValueOnce([fakeConsentRow({ presented_payload_hash: fixedHash })]);
+    // No UPDATE on subsequent present (hash already set; lib short-circuits).
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);  // tenant binding lookup → bound + active
+    // With a verified challenge, the page renders the approve/deny forms.
+    sqlMock.mockResolvedValueOnce([{
+      id: 'ccch_TEST', status: 'verified',
+      expires_at: new Date(Date.now() + 60_000),
+    }]);
+
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: TEST_PRINCIPAL_ID, developerId: TEST_DEVELOPER_ID }, 600,
+    );
+    const res = await app.inject({
+      method: 'GET',
+      url: `/v1/commerce/consent/page?req=req_TEST`,
+      headers: {
+        host: CONSENT_HOST,
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatch(/Authorize agent action/);
+    expect(res.body).toMatch(/<form[^>]*\/approve"/);
+  });
+});
+
+describe('POST /v1/commerce/consent/:reqId/approve — Finding 1 enforcement', () => {
+  it('rejects approve without principal session cookie → 401 principal_session_required', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/consent/req_TEST/approve',
+      headers: {
+        host: CONSENT_HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      payload: 'csrf=anything',
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('principal_session_required');
+  });
+
+  it('rejects approve when principal session JWT is invalid', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/consent/req_TEST/approve',
+      headers: {
+        host: CONSENT_HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: 'grantex_principal_session=garbage',
+      },
+      payload: 'csrf=anything',
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('principal_session_required');
+  });
+
+  it('rejects approve with valid session but mismatched CSRF → 403 csrf_invalid', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: TEST_PRINCIPAL_ID, developerId: TEST_DEVELOPER_ID }, 600,
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/consent/req_TEST/approve',
+      headers: {
+        host: CONSENT_HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: 'csrf=wrong-token',
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('csrf_invalid');
+  });
+
+  it('rejects approve when principal\'s developer is not bound to consent tenant → 403', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: TEST_PRINCIPAL_ID, developerId: 'dev_NOT_BOUND' }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, 'req_TEST');
+    // findConsentByRequestId
+    sqlMock.mockResolvedValueOnce([fakeConsentRow()]);
+    // ensurePrincipalCanActOnTenant — empty
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/consent/req_TEST/approve',
+      headers: {
+        host: CONSENT_HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('principal_not_authorized_for_tenant');
+  });
+
+  it('happy path: valid session + verified challenge + matching CSRF + tenant binding → 200 + audit', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: TEST_PRINCIPAL_ID, developerId: TEST_DEVELOPER_ID }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, 'req_TEST');
+    sqlMock.mockResolvedValueOnce([fakeConsentRow()]);                       // findConsentByRequestId
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);                   // tenant binding
+    // approveConsent inside sql.begin:
+    sqlMock.mockResolvedValueOnce([fakeConsentRow()]);                       // SELECT FOR UPDATE consent
+    // consumeVerifiedChallengeTx — SELECT FOR UPDATE then UPDATE used.
+    sqlMock.mockResolvedValueOnce([{
+      id: 'ccch_VERIFIED', expires_at: new Date(Date.now() + 60_000),
+    }]);
+    sqlMock.mockResolvedValueOnce([]);                                        // UPDATE challenge → 'used'
+    sqlMock.mockResolvedValueOnce([fakeConsentRow({
+      status: 'granted', approved_scopes: ['commerce:catalog.read'],
+      approved_at: new Date(), user_principal_id: TEST_PRINCIPAL_ID,
+    })]);                                                                     // UPDATE...RETURNING
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_G', occurred_at: new Date().toISOString() }]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_C', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/consent/req_TEST/approve',
+      headers: {
+        host: CONSENT_HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatch(/Approved/);
+
+    // Confirm both audit events fired: consent.granted AND consent.challenge.used.
+    const auditEventTypes = sqlMock.mock.calls
+      .filter((c) => {
+        const tpl = c[0] as unknown;
+        return Array.isArray(tpl)
+          && tpl.some((s) => typeof s === 'string' && /INSERT INTO commerce_audit_events/i.test(s));
+      })
+      .flatMap((c) => c.slice(1));
+    expect(auditEventTypes).toContain('consent.granted');
+    expect(auditEventTypes).toContain('consent.challenge.used');
+    expect(auditEventTypes).toContain(TEST_PRINCIPAL_ID);
+  });
+
+  it('rejects approve when consent has hint that does NOT match authenticated principal → 403', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: TEST_PRINCIPAL_ID, developerId: TEST_DEVELOPER_ID }, 600,
+    );
+    const csrf = deriveConsentCsrfToken(sessionToken, 'req_TEST');
+    sqlMock.mockResolvedValueOnce([fakeConsentRow({ user_principal_hint: 'user_OTHER' })]);
+    sqlMock.mockResolvedValueOnce([{ status: 'active' }]);
+    // approveConsent: SELECT FOR UPDATE returns the same row with hint.
+    // Hint check fires BEFORE challenge consumption, so no challenge mocks needed.
+    sqlMock.mockResolvedValueOnce([fakeConsentRow({ user_principal_hint: 'user_OTHER' })]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/consent/req_TEST/approve',
+      headers: {
+        host: CONSENT_HOST,
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('principal_hint_mismatch');
+  });
+});
+
+// Use the canonical hash function so the unused-import lint doesn't fire.
+void canonicalPresentedPayload;
+void sha256hex;

--- a/apps/auth-service/tests/commerce-finding-fixes.test.ts
+++ b/apps/auth-service/tests/commerce-finding-fixes.test.ts
@@ -1,0 +1,826 @@
+/**
+ * Targeted tests for the M2 hardening findings raised by Codex review.
+ * Each describe block maps to one finding from the review.
+ */
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import {
+  generateKeyPair, exportJWK, SignJWT, type KeyLike, type JWK,
+} from 'jose';
+import { sqlMock, mockRedis, buildTestApp, authHeader, TEST_DEVELOPER } from './helpers.js';
+import { signPrincipalSessionToken } from '../src/lib/crypto.js';
+import { seedCommerceContext, TEST_COMMERCE_TENANT_ID } from './commerce-helpers.js';
+import {
+  signCommercePassport,
+  verifyCommercePassport,
+  newCommercePassportJti,
+} from '../src/lib/commerce/passport.js';
+import {
+  _resetCommercePassportKeyCacheForTests,
+  getActiveCommercePassportSigner,
+} from '../src/lib/commerce/passport-keys.js';
+
+let app: FastifyInstance;
+beforeAll(async () => { app = await buildTestApp(); });
+afterEach(() => { vi.unstubAllEnvs(); });
+
+// ---------------------------------------------------------------------
+// Finding 2 — per-route caller matrix
+// ---------------------------------------------------------------------
+describe('Finding 2 — caller matrix enforcement', () => {
+  let agentKp: { privateKey: KeyLike; publicKey: KeyLike };
+  let agentJwk: JWK;
+  beforeAll(async () => {
+    agentKp = await generateKeyPair('ES256');
+    agentJwk = await exportJWK(agentKp.publicKey) as JWK;
+  });
+  async function agentJwt(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    return new SignJWT({ tenant_id: TEST_COMMERCE_TENANT_ID })
+      .setProtectedHeader({ alg: 'ES256' })
+      .setIssuer('cag_AGENT').setSubject('cag_AGENT')
+      .setAudience('grantex-commerce')
+      .setJti(`jti_${now}_${Math.random().toString(36).slice(2)}`)
+      .setIssuedAt(now).setExpirationTime(now + 60)
+      .sign(agentKp.privateKey);
+  }
+  function primeTrustedAgent(): void {
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_AGENT', tenant_id: TEST_COMMERCE_TENANT_ID, trust_status: 'trusted',
+      public_key_jwk: agentJwk, api_key_hash: null,
+    }]);
+    mockRedis.set.mockResolvedValueOnce('OK');
+  }
+  function primeMerchantKey(): void {
+    sqlMock.mockResolvedValueOnce([{
+      id: 'mkey_TEST', tenant_id: TEST_COMMERCE_TENANT_ID,
+      merchant_id: 'mch_M', environment: 'sandbox',
+    }]);
+  }
+
+  it('GET /audit/events denies agent → 403 operator_required', async () => {
+    primeTrustedAgent();
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/audit/events',
+      headers: { authorization: `Bearer ${await agentJwt()}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('operator_required');
+  });
+
+  it('GET /audit/events denies merchant → 403 operator_required', async () => {
+    primeMerchantKey();
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/audit/events',
+      headers: { authorization: 'Bearer grtx_sk_sandbox_AAAAAAAAAAAAAAAAAAAAAAAA' },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('operator_required');
+  });
+
+  it('GET /agents/:id denies merchant (caller_not_authorized)', async () => {
+    primeMerchantKey();
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/agents/cag_X',
+      headers: { authorization: 'Bearer grtx_sk_sandbox_AAAAAAAAAAAAAAAAAAAAAAAA' },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('caller_not_authorized');
+  });
+
+  it('GET /agents/:id allows agent reading own record (operator_or_self_agent)', async () => {
+    primeTrustedAgent();
+    sqlMock.mockResolvedValueOnce([]);  // agent SELECT empty → 404 (proves caller check passed)
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/agents/cag_AGENT',
+      headers: { authorization: `Bearer ${await agentJwt()}` },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('agent_not_found');
+  });
+
+  it('GET /agents/:id denies agent for OTHER agent (caller_not_authorized)', async () => {
+    primeTrustedAgent();
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/agents/cag_OTHER',
+      headers: { authorization: `Bearer ${await agentJwt()}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('caller_not_authorized');
+  });
+
+  it('GET /merchants/:id allows operator', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X', headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('merchant_not_found');
+  });
+
+  it('GET /catalog/products/:id denies agent (admin endpoint, not for MCP catalog use)', async () => {
+    primeTrustedAgent();
+    // The route loads the product first, then runs requireOperatorOrSelfMerchant.
+    // Prime a product so we reach the caller check.
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cprd_X', tenant_id: TEST_COMMERCE_TENANT_ID, merchant_id: 'mch_M',
+      product_id: 'P1', title: 'X', brand: null, description: null, image_url: null,
+      category_preset: 'electronics_appliances', source_system: 'manual',
+      manually_maintained: false, archived_at: null,
+      created_at: new Date(), updated_at: new Date(),
+    }]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/catalog/products/cprd_X',
+      headers: { authorization: `Bearer ${await agentJwt()}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('caller_not_authorized');
+  });
+});
+
+// ---------------------------------------------------------------------
+// Finding 4 — presented_payload_hash recomputation at exchange
+// ---------------------------------------------------------------------
+describe('Finding 4 — exchange recomputes presented_payload_hash and rejects mismatch', () => {
+  let agentKp: { privateKey: KeyLike; publicKey: KeyLike };
+  let agentJwk: JWK;
+  beforeAll(async () => {
+    agentKp = await generateKeyPair('ES256');
+    agentJwk = await exportJWK(agentKp.publicKey) as JWK;
+  });
+  async function agentJwt(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    return new SignJWT({ tenant_id: TEST_COMMERCE_TENANT_ID })
+      .setProtectedHeader({ alg: 'ES256' })
+      .setIssuer('cag_AGENT').setSubject('cag_AGENT')
+      .setAudience('grantex-commerce')
+      .setJti(`jti_${now}_${Math.random().toString(36).slice(2)}`)
+      .setIssuedAt(now).setExpirationTime(now + 60).sign(agentKp.privateKey);
+  }
+  function primeTrustedAgent(): void {
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_AGENT', tenant_id: TEST_COMMERCE_TENANT_ID, trust_status: 'trusted',
+      public_key_jwk: agentJwk, api_key_hash: null,
+    }]);
+    mockRedis.set.mockResolvedValueOnce('OK');
+  }
+  it('exchange rejects when stored hash does not match recomputed canonical payload (e.g. scopes mutated post-presentation)', async () => {
+    primeTrustedAgent();
+    // findConsentByRequestId — return a granted consent with a STALE hash
+    // that doesn't match the current canonical payload (simulates a
+    // tamper attack).
+    sqlMock.mockResolvedValueOnce([{
+      id: 'crec_X', tenant_id: TEST_COMMERCE_TENANT_ID, merchant_id: 'mch_M',
+      agent_id: 'cag_AGENT', consent_request_id: 'req_X',
+      passport_type: 'browse',
+      requested_scopes: ['commerce:catalog.read', 'commerce:inventory.read'],  // mutated
+      approved_scopes: ['commerce:catalog.read', 'commerce:inventory.read'],
+      max_amount: null, currency: null,
+      consent_text_version: '2026-05-01',
+      // Stored hash is for an OLD payload (just catalog.read, before mutation)
+      presented_payload_hash: 'deadbeef'.repeat(8),
+      status: 'granted',
+      agent_auth_method: 'jwt',
+      expires_at: new Date(Date.now() + 60_000),
+      approved_at: new Date(),
+      denied_at: null,
+      user_principal_id: 'user_X',
+      user_principal_hint: null,
+      created_at: new Date(),
+    }]);
+
+    const res = await app.inject({
+      method: 'POST', url: '/v1/commerce/passports/exchange',
+      headers: { authorization: `Bearer ${await agentJwt()}`, 'content-type': 'application/json' },
+      payload: { consent_request_id: 'req_X' },
+    });
+    expect(res.statusCode).toBe(409);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('consent_payload_changed');
+  });
+});
+
+// ---------------------------------------------------------------------
+// Finding 3 — single-use exchange (existing passport short-circuit)
+// ---------------------------------------------------------------------
+describe('Finding 3 — exchange is single-use', () => {
+  let agentKp: { privateKey: KeyLike; publicKey: KeyLike };
+  let agentJwk: JWK;
+  beforeAll(async () => {
+    agentKp = await generateKeyPair('ES256');
+    agentJwk = await exportJWK(agentKp.publicKey) as JWK;
+  });
+  async function agentJwt(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    return new SignJWT({ tenant_id: TEST_COMMERCE_TENANT_ID })
+      .setProtectedHeader({ alg: 'ES256' })
+      .setIssuer('cag_AGENT').setSubject('cag_AGENT')
+      .setAudience('grantex-commerce')
+      .setJti(`jti_${now}_${Math.random().toString(36).slice(2)}`)
+      .setIssuedAt(now).setExpirationTime(now + 60).sign(agentKp.privateKey);
+  }
+
+  it('returns 409 consent_already_exchanged when a passport already exists for the consent', async () => {
+    // agent lookup (caller resolver)
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_AGENT', tenant_id: TEST_COMMERCE_TENANT_ID, trust_status: 'trusted',
+      public_key_jwk: agentJwk, api_key_hash: null,
+    }]);
+    mockRedis.set.mockResolvedValueOnce('OK');
+
+    // Build a consent record whose canonical hash matches the stored
+    // hash so we don't false-positive on Finding 4. The canonical
+    // encoder is deterministic; capture the expires timestamp ONCE and
+    // reuse the exact same string in both the hash computation and the
+    // mocked DB row.
+    const expiresIso = new Date(Date.now() + 60_000).toISOString();
+    const { canonicalPresentedPayload, sha256hex } = await import('../src/lib/commerce/consent.js');
+    const hash = sha256hex(canonicalPresentedPayload({
+      id: 'crec_X', tenantId: TEST_COMMERCE_TENANT_ID,
+      merchantId: 'mch_M', agentId: 'cag_AGENT',
+      consentRequestId: 'req_OK',
+      passportType: 'browse',
+      requestedScopes: ['commerce:catalog.read'],
+      approvedScopes: ['commerce:catalog.read'],
+      maxAmount: null, currency: null,
+      consentTextVersion: '2026-05-01',
+      presentedPayloadHash: null,
+      status: 'granted', agentAuthMethod: 'jwt',
+      expiresAt: expiresIso,
+      approvedAt: null, deniedAt: null,
+      userPrincipalId: 'user_X', userPrincipalHint: null, createdAt: '',
+    }));
+    sqlMock.mockResolvedValueOnce([{
+      id: 'crec_X', tenant_id: TEST_COMMERCE_TENANT_ID, merchant_id: 'mch_M',
+      agent_id: 'cag_AGENT', consent_request_id: 'req_OK',
+      passport_type: 'browse',
+      requested_scopes: ['commerce:catalog.read'],
+      approved_scopes: ['commerce:catalog.read'],
+      max_amount: null, currency: null,
+      consent_text_version: '2026-05-01',
+      presented_payload_hash: hash, status: 'granted',
+      agent_auth_method: 'jwt',
+      expires_at: expiresIso,         // SAME string used in hash above
+      approved_at: new Date(), denied_at: null,
+      user_principal_id: 'user_X', user_principal_hint: null,
+      created_at: new Date(),
+    }]);
+    // Existing passport check fires BEFORE the merchant lookup; route
+    // returns 409 immediately so the merchant SELECT is never reached.
+    sqlMock.mockResolvedValueOnce([{
+      jti: 'cpsp_EXISTING',
+      expires_at: new Date(Date.now() + 60_000),
+    }]);
+
+    const res = await app.inject({
+      method: 'POST', url: '/v1/commerce/passports/exchange',
+      headers: { authorization: `Bearer ${await agentJwt()}`, 'content-type': 'application/json' },
+      payload: { consent_request_id: 'req_OK' },
+    });
+    expect(res.statusCode).toBe(409);
+    const body = res.json<{ error: { code: string; details: { existing_jti: string } } }>();
+    expect(body.error.code).toBe('consent_already_exchanged');
+    expect(body.error.details.existing_jti).toBe('cpsp_EXISTING');
+  });
+});
+
+// ---------------------------------------------------------------------
+// Finding 5 — key rotation (cache TTL + retired-key iat enforcement)
+// ---------------------------------------------------------------------
+describe('Finding 5 — key rotation', () => {
+  let kpA: { privateKey: KeyLike; publicKey: KeyLike };
+  let kpB: { privateKey: KeyLike; publicKey: KeyLike };
+  let jwkA: JWK; let jwkB: JWK;
+
+  beforeAll(async () => {
+    kpA = await generateKeyPair('ES256');
+    kpB = await generateKeyPair('ES256');
+    jwkA = await exportJWK(kpA.publicKey) as JWK;
+    jwkB = await exportJWK(kpB.publicKey) as JWK;
+  });
+
+  async function primeSignerWith(kid: string, kp: { privateKey: KeyLike }): Promise<void> {
+    const { encrypt } = await import('../src/lib/vault-crypto.js');
+    const { exportJWK: ek } = await import('jose');
+    const privateJwk = await ek(kp.privateKey);
+    const encryptedPrivate = encrypt(JSON.stringify({ ...privateJwk, kid, alg: 'ES256' }));
+    sqlMock.mockResolvedValueOnce([{
+      kid, algorithm: 'ES256', status: 'active',
+      public_key_jwk: kid === 'commerce-passport-20260101-aaaaaaaa'
+        ? { ...jwkA, kid, alg: 'ES256', use: 'sig' }
+        : { ...jwkB, kid, alg: 'ES256', use: 'sig' },
+      created_at: new Date(), retired_at: null,
+    }]);
+    sqlMock.mockResolvedValueOnce([{ encrypted_private_key_jwk: encryptedPrivate }]);
+  }
+
+  it('cache busts when DB-active kid changes (rotation mid-flight)', async () => {
+    _resetCommercePassportKeyCacheForTests();
+    // First call — no cache. findActive (1 mock), decrypt (1 mock).
+    await primeSignerWith('commerce-passport-20260101-aaaaaaaa', kpA);
+    const s1 = await getActiveCommercePassportSigner(sqlMock as unknown as never);
+    expect(s1.kid).toBe('commerce-passport-20260101-aaaaaaaa');
+
+    // Second call within TTL: cache "still active?" check fires.
+    // Mock returns DIFFERENT kid → cache busts → full refetch.
+    sqlMock.mockResolvedValueOnce([{ kid: 'commerce-passport-20260102-bbbbbbbb' }]);
+    await primeSignerWith('commerce-passport-20260102-bbbbbbbb', kpB);
+    const s2 = await getActiveCommercePassportSigner(sqlMock as unknown as never);
+    expect(s2.kid).toBe('commerce-passport-20260102-bbbbbbbb');
+  });
+
+  it('verify accepts token signed BEFORE retired_at (within JWKS grace)', async () => {
+    _resetCommercePassportKeyCacheForTests();
+    const kid = 'commerce-passport-20260201-cccccccc';
+    await primeSignerWith(kid, kpA);
+    const issuedAt = Math.floor(Date.now() / 1000) - 600;  // 10 min ago
+    const r = await signCommercePassport(sqlMock as unknown as never, {
+      jti: newCommercePassportJti(),
+      passportType: 'browse',
+      tenantId: 'cten_T', merchantId: 'mch_M', agentId: 'cag_A',
+      consentRecordId: 'crec_C', subject: 'user_X',
+      scopes: ['commerce:catalog.read'], maxAmount: null, currency: null,
+      environment: 'sandbox',
+      issuedAt, notBefore: issuedAt, expiresAt: issuedAt + 3600,
+    });
+    // Now the kid is retired (retired_at AFTER iat → token still valid).
+    sqlMock.mockResolvedValueOnce([{
+      public_key_jwk: { ...jwkA, kid, alg: 'ES256', use: 'sig' },
+      retired_at: new Date(),  // retired now, AFTER token's iat
+    }]);
+    const v = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, r.jwt, { mode: 'read_only' });
+    expect(v.ok).toBe(true);
+  });
+
+  it('verify REJECTS token signed AFTER retired_at (stolen retired key cannot mint new passports)', async () => {
+    _resetCommercePassportKeyCacheForTests();
+    const kid = 'commerce-passport-20260301-dddddddd';
+    // Sign a token with iat = now (so far ahead of any reasonable retired_at).
+    await primeSignerWith(kid, kpA);
+    const now = Math.floor(Date.now() / 1000);
+    const r = await signCommercePassport(sqlMock as unknown as never, {
+      jti: newCommercePassportJti(),
+      passportType: 'browse',
+      tenantId: 'cten_T', merchantId: 'mch_M', agentId: 'cag_A',
+      consentRecordId: 'crec_D', subject: 'user_X',
+      scopes: ['commerce:catalog.read'], maxAmount: null, currency: null,
+      environment: 'sandbox',
+      issuedAt: now, notBefore: now, expiresAt: now + 3600,
+    });
+    // Verifier sees: kid retired_at = 1 hour BEFORE the token's iat.
+    sqlMock.mockResolvedValueOnce([{
+      public_key_jwk: { ...jwkA, kid, alg: 'ES256', use: 'sig' },
+      retired_at: new Date((now - 3600) * 1000),
+    }]);
+    const v = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, r.jwt, { mode: 'read_only' });
+    expect(v.ok).toBe(false);
+    if (!v.ok) {
+      expect(v.error.kind).toBe('kid_retired_iat_after');
+      if (v.error.kind === 'kid_retired_iat_after') {
+        expect(v.error.kid).toBe(kid);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------
+// Finding 1 — agent self-approval cannot succeed
+// ---------------------------------------------------------------------
+describe('Finding 1 — agent cannot self-approve consent', () => {
+  it('agent can fetch consent page but page does not render approve forms (sign-in required)', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      id: 'crec_X', tenant_id: 'cten_T', merchant_id: 'mch_M', agent_id: 'cag_A',
+      consent_request_id: 'req_X', passport_type: 'browse',
+      requested_scopes: ['commerce:catalog.read'],
+      approved_scopes: null, max_amount: null, currency: null,
+      consent_text_version: '2026-05-01',
+      presented_payload_hash: null, status: 'requested',
+      agent_auth_method: 'jwt',
+      expires_at: new Date(Date.now() + 600_000), approved_at: null, denied_at: null,
+      user_principal_id: null, user_principal_hint: null, created_at: new Date(),
+    }]);
+    sqlMock.mockResolvedValueOnce([]);  // UPDATE presented hash
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/consent/page?req=req_X',
+      headers: { host: 'consent.grantex.dev' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatch(/Sign in to authorize/);
+    expect(res.body).not.toMatch(/<form[^>]*\/approve"/);
+    expect(res.body).not.toMatch(/<form[^>]*\/deny"/);
+    expect(res.headers['set-cookie']).toBeUndefined();
+  });
+
+  it('approve without principal session → 401 (cannot self-approve via CSRF cookie alone)', async () => {
+    const res = await app.inject({
+      method: 'POST', url: '/v1/commerce/consent/req_X/approve',
+      headers: {
+        host: 'consent.grantex.dev',
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      payload: 'csrf=anything',
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('principal_session_required');
+  });
+});
+
+// ---------------------------------------------------------------------
+// Second-pass findings (P1/P1/P1/P2 from Codex review #2)
+// ---------------------------------------------------------------------
+
+describe('Finding 1 (round 2) — max passport lifetime + retired-key window', () => {
+  let kp: { privateKey: KeyLike; publicKey: KeyLike };
+  let kid: string;
+  let publicJwk: JWK;
+  beforeAll(async () => {
+    kp = await generateKeyPair('ES256');
+    publicJwk = await exportJWK(kp.publicKey) as JWK;
+    kid = 'commerce-passport-20260601-aaaa1111';
+  });
+  async function primeSigner(): Promise<void> {
+    const { encrypt } = await import('../src/lib/vault-crypto.js');
+    const { exportJWK: ek } = await import('jose');
+    const privateJwk = await ek(kp.privateKey);
+    const enc = encrypt(JSON.stringify({ ...privateJwk, kid, alg: 'ES256' }));
+    sqlMock.mockResolvedValueOnce([{
+      kid, algorithm: 'ES256', status: 'active',
+      public_key_jwk: { ...publicJwk, kid, alg: 'ES256', use: 'sig' },
+      created_at: new Date(), retired_at: null,
+    }]);
+    sqlMock.mockResolvedValueOnce([{ encrypted_private_key_jwk: enc }]);
+  }
+  function primePublicLookup(retiredAt: Date | null = null): void {
+    sqlMock.mockResolvedValueOnce([{
+      public_key_jwk: { ...publicJwk, kid, alg: 'ES256', use: 'sig' },
+      retired_at: retiredAt,
+    }]);
+  }
+  async function signWithLifetime(passportType: 'browse' | 'checkout', iat: number, exp: number): Promise<string> {
+    _resetCommercePassportKeyCacheForTests();
+    await primeSigner();
+    const { signCommercePassport: sign } = await import('../src/lib/commerce/passport.js');
+    const { newCommercePassportJti: newJti } = await import('../src/lib/commerce/passport.js');
+    const r = await sign(sqlMock as unknown as never, {
+      jti: newJti(),
+      passportType,
+      tenantId: 'cten_T', merchantId: 'mch_M', agentId: 'cag_A',
+      consentRecordId: 'crec_C', subject: 'user_X',
+      scopes: ['commerce:catalog.read'], maxAmount: null, currency: null,
+      environment: 'sandbox',
+      issuedAt: iat, notBefore: iat, expiresAt: exp,
+    });
+    return r.jwt;
+  }
+
+  it('browse passport with lifetime > 3600 + skew is rejected (lifetime_exceeded)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const jwt = await signWithLifetime('browse', now, now + 7200);   // 2h, way over 1h cap
+    primePublicLookup();
+    const { verifyCommercePassport: vp } = await import('../src/lib/commerce/passport.js');
+    const r = await vp(sqlMock as unknown as never, mockRedis as unknown as never, jwt, { mode: 'read_only' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.kind).toBe('lifetime_exceeded');
+      if (r.error.kind === 'lifetime_exceeded') {
+        expect(r.error.passportType).toBe('browse');
+        expect(r.error.maxLifetime).toBe(3600);
+      }
+    }
+  });
+
+  it('checkout passport with lifetime > 600 + skew is rejected (lifetime_exceeded)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const jwt = await signWithLifetime('checkout', now, now + 1200);  // 20m, over 10m cap
+    primePublicLookup();
+    const { verifyCommercePassport: vp } = await import('../src/lib/commerce/passport.js');
+    const r = await vp(sqlMock as unknown as never, mockRedis as unknown as never, jwt, { mode: 'read_only' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe('lifetime_exceeded');
+  });
+
+  it('browse passport with lifetime exactly = 3600 + 30s skew is accepted', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    // Sign with iat way in the past to keep us inside not-yet-valid skew
+    // and ensure exp is past, then verify with read_only mode.
+    const iat = now - 4000;
+    const jwt = await signWithLifetime('browse', iat, iat + 3600);
+    primePublicLookup();
+    const { verifyCommercePassport: vp } = await import('../src/lib/commerce/passport.js');
+    const r = await vp(sqlMock as unknown as never, mockRedis as unknown as never, jwt, { mode: 'read_only' });
+    // Note: would be 'expired' (exp < now) — that's fine for the lifetime
+    // gate test; the lifetime check passes, expiry check fires after.
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe('expired');
+  });
+
+  it('retired key REJECTS token with iat before retired_at but exp far beyond window (kid_retired_window_exceeded)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    // Token issued 10min ago, retiring "now", exp far future (1 day).
+    const iat = now - 600;
+    const exp = now + 86_400;
+    const jwt = await signWithLifetime('browse', iat, exp);
+    primePublicLookup(new Date(now * 1000));   // retired right now
+    const { verifyCommercePassport: vp } = await import('../src/lib/commerce/passport.js');
+    const r = await vp(sqlMock as unknown as never, mockRedis as unknown as never, jwt, { mode: 'read_only' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      // Either lifetime_exceeded (1 day vs 1h cap) fires first, or
+      // kid_retired_window_exceeded. Either is correct rejection.
+      expect(['lifetime_exceeded', 'kid_retired_window_exceeded']).toContain(r.error.kind);
+    }
+  });
+
+  it('retired key ACCEPTS token signed before retirement with sane lifetime', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    // iat = 10 min ago, exp = 50 min from now (lifetime = 60 min, fits).
+    const iat = now - 600;
+    const exp = now + 3000;
+    const jwt = await signWithLifetime('browse', iat, exp);
+    // Retired AFTER iat, exp within retired_at + 1h cap.
+    primePublicLookup(new Date((iat + 60) * 1000));
+    const { verifyCommercePassport: vp } = await import('../src/lib/commerce/passport.js');
+    const r = await vp(sqlMock as unknown as never, mockRedis as unknown as never, jwt, { mode: 'read_only' });
+    expect(r.ok).toBe(true);
+  });
+
+  it('temporal_claim_invalid when exp <= iat', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    // exp == iat
+    const jwt = await signWithLifetime('browse', now, now);
+    primePublicLookup();
+    const { verifyCommercePassport: vp } = await import('../src/lib/commerce/passport.js');
+    const r = await vp(sqlMock as unknown as never, mockRedis as unknown as never, jwt, { mode: 'read_only' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe('temporal_claim_invalid');
+  });
+});
+
+describe('Finding 2 (round 2) — session JWT 303 strip', () => {
+  // The full happy/sad paths live in commerce-consent-flow.test.ts.
+  // Smoke test here just to keep the finding numbering complete.
+  it('GET with valid ?session= returns 303 with no-referrer + cookie', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: 'user_X', developerId: 'dev_TEST' }, 600,
+    );
+    const res = await app.inject({
+      method: 'GET',
+      url: `/v1/commerce/consent/page?req=req_X&session=${encodeURIComponent(sessionToken)}`,
+      headers: { host: 'consent.grantex.dev' },
+    });
+    expect(res.statusCode).toBe(303);
+    expect(res.headers['location']).toBe('/v1/commerce/consent/page?req=req_X');
+    expect(res.headers['referrer-policy']).toBe('no-referrer');
+    expect(res.headers['set-cookie']).toMatch(/grantex_principal_session=/);
+  });
+});
+
+describe('Finding 3 (round 2) — disabled tenant blocks merchant/agent/consent/exchange', () => {
+  it('merchant API key for disabled tenant → 403 tenant_disabled', async () => {
+    // Single SQL: the resolver JOINs commerce_tenants and surfaces
+    // tenant_status. Disabled → resolver returns failure BEFORE the
+    // last_used_at update, so only one mock is consumed.
+    sqlMock.mockResolvedValueOnce([{
+      id: 'mkey_X', tenant_id: 'cten_DISABLED',
+      merchant_id: 'mch_M', environment: 'sandbox',
+      tenant_status: 'disabled',
+    }]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_M',
+      headers: { authorization: 'Bearer grtx_sk_sandbox_AAAAAAAAAAAAAAAAAAAAAAAA' },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('tenant_disabled');
+  });
+
+  it('agent API key for disabled tenant → 403 tenant_disabled', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_X', tenant_id: 'cten_DISABLED', trust_status: 'trusted',
+      public_key_jwk: { kty: 'EC' }, api_key_hash: 'h',
+      tenant_status: 'disabled',
+    }]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/agents/cag_X',
+      headers: { authorization: 'Bearer grtx_agent_BBBBBBBBBBBBBBBBBBBBBBBB' },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('tenant_disabled');
+  });
+
+  it('agent JWT for disabled tenant → 403 tenant_disabled', async () => {
+    const kp = await generateKeyPair('ES256');
+    const jwk = await exportJWK(kp.publicKey) as JWK;
+    const now = Math.floor(Date.now() / 1000);
+    const jwt = await new SignJWT({ tenant_id: 'cten_DISABLED' })
+      .setProtectedHeader({ alg: 'ES256' })
+      .setIssuer('cag_X').setSubject('cag_X')
+      .setAudience('grantex-commerce')
+      .setJti(`jti_${now}`).setIssuedAt(now).setExpirationTime(now + 60)
+      .sign(kp.privateKey);
+    // Agent lookup via JWT: returns disabled tenant_status.
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_X', tenant_id: 'cten_DISABLED', trust_status: 'trusted',
+      public_key_jwk: jwk, api_key_hash: null,
+      tenant_status: 'disabled',
+    }]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/agents/cag_X',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('tenant_disabled');
+  });
+
+  it('consent approve for disabled tenant → 403 tenant_disabled (after CSRF + binding pass)', async () => {
+    const sessionToken = await signPrincipalSessionToken(
+      { principalId: 'user_X', developerId: 'dev_TEST' }, 600,
+    );
+    const csrf = (await import('../src/lib/commerce/consent.js'))
+      .deriveConsentCsrfToken(sessionToken, 'req_X');
+    // findConsentByRequestId — record exists
+    sqlMock.mockResolvedValueOnce([{
+      id: 'crec_X', tenant_id: 'cten_DISABLED', merchant_id: 'mch_M', agent_id: 'cag_A',
+      consent_request_id: 'req_X', passport_type: 'browse',
+      requested_scopes: ['x'], approved_scopes: null, max_amount: null, currency: null,
+      consent_text_version: '2026-05-01', presented_payload_hash: 'h',
+      status: 'requested', agent_auth_method: 'jwt',
+      expires_at: new Date(Date.now() + 600_000), approved_at: null, denied_at: null,
+      user_principal_id: null, user_principal_hint: null, created_at: new Date(),
+    }]);
+    // ensurePrincipalCanActOnTenant — bound, but tenant disabled
+    sqlMock.mockResolvedValueOnce([{ status: 'disabled' }]);
+
+    const res = await app.inject({
+      method: 'POST', url: '/v1/commerce/consent/req_X/approve',
+      headers: {
+        host: 'consent.grantex.dev',
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: `grantex_principal_session=${sessionToken}`,
+      },
+      payload: `csrf=${csrf}`,
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('tenant_disabled');
+  });
+
+  it('passport exchange for disabled tenant → 403 tenant_disabled (before signing)', async () => {
+    const kp = await generateKeyPair('ES256');
+    const jwk = await exportJWK(kp.publicKey) as JWK;
+    const now = Math.floor(Date.now() / 1000);
+    const agentJwt = await new SignJWT({ tenant_id: 'cten_T' })
+      .setProtectedHeader({ alg: 'ES256' })
+      .setIssuer('cag_AGENT').setSubject('cag_AGENT')
+      .setAudience('grantex-commerce')
+      .setJti(`jti_${now}`).setIssuedAt(now).setExpirationTime(now + 60)
+      .sign(kp.privateKey);
+    // Agent lookup — agent's tenant 'cten_T' is active (so caller resolves)
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_AGENT', tenant_id: 'cten_T', trust_status: 'trusted',
+      public_key_jwk: jwk, api_key_hash: null,
+      tenant_status: 'active',
+    }]);
+    mockRedis.set.mockResolvedValueOnce('OK');
+    // findConsentByRequestId — granted, valid hash
+    const expiresIso = new Date(Date.now() + 60_000).toISOString();
+    const { canonicalPresentedPayload, sha256hex } = await import('../src/lib/commerce/consent.js');
+    const hash = sha256hex(canonicalPresentedPayload({
+      id: 'crec_OK', tenantId: 'cten_T', merchantId: 'mch_M', agentId: 'cag_AGENT',
+      consentRequestId: 'req_OK', passportType: 'browse',
+      requestedScopes: ['commerce:catalog.read'],
+      approvedScopes: ['commerce:catalog.read'],
+      maxAmount: null, currency: null, consentTextVersion: '2026-05-01',
+      presentedPayloadHash: null, status: 'granted', agentAuthMethod: 'jwt',
+      expiresAt: expiresIso, approvedAt: null, deniedAt: null,
+      userPrincipalId: 'user_X', userPrincipalHint: null, createdAt: '',
+    }));
+    sqlMock.mockResolvedValueOnce([{
+      id: 'crec_OK', tenant_id: 'cten_T', merchant_id: 'mch_M',
+      agent_id: 'cag_AGENT', consent_request_id: 'req_OK',
+      passport_type: 'browse',
+      requested_scopes: ['commerce:catalog.read'],
+      approved_scopes: ['commerce:catalog.read'],
+      max_amount: null, currency: null,
+      consent_text_version: '2026-05-01',
+      presented_payload_hash: hash, status: 'granted',
+      agent_auth_method: 'jwt',
+      expires_at: expiresIso,
+      approved_at: new Date(), denied_at: null,
+      user_principal_id: 'user_X', user_principal_hint: null,
+      created_at: new Date(),
+    }]);
+    // Existing-passport check empty
+    sqlMock.mockResolvedValueOnce([]);
+    // Merchant + tenant JOIN — tenant disabled
+    sqlMock.mockResolvedValueOnce([{ environment: 'sandbox', tenant_status: 'disabled' }]);
+
+    const res = await app.inject({
+      method: 'POST', url: '/v1/commerce/passports/exchange',
+      headers: { authorization: `Bearer ${agentJwt}`, 'content-type': 'application/json' },
+      payload: { consent_request_id: 'req_OK' },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('tenant_disabled');
+  });
+
+  it('platform admin tenant provisioning still works (admin path bypasses tenant check)', async () => {
+    sqlMock.mockResolvedValueOnce([]);  // developer lookup empty (admin)
+    sqlMock.mockResolvedValueOnce([
+      { id: 'cten_NEW', display_name: 'X', status: 'active', metadata: {}, created_at: new Date(), updated_at: new Date() },
+    ]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_T', occurred_at: new Date().toISOString() }]);
+    const res = await app.inject({
+      method: 'POST', url: '/v1/commerce/tenants',
+      headers: { authorization: 'Bearer test-admin-key-secret' },
+      payload: { display_name: 'X' },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+});
+
+describe('Finding 4 (round 2) — product GET no existence leak', () => {
+  it('agent caller → 403 caller_not_authorized BEFORE any product SQL', async () => {
+    const kp = await generateKeyPair('ES256');
+    const jwk = await exportJWK(kp.publicKey) as JWK;
+    const now = Math.floor(Date.now() / 1000);
+    const jwt = await new SignJWT({ tenant_id: TEST_COMMERCE_TENANT_ID })
+      .setProtectedHeader({ alg: 'ES256' })
+      .setIssuer('cag_X').setSubject('cag_X')
+      .setAudience('grantex-commerce')
+      .setJti(`jti_${now}_${Math.random()}`)
+      .setIssuedAt(now).setExpirationTime(now + 60)
+      .sign(kp.privateKey);
+    // Only the agent-resolution mocks are needed; product SQL must NOT run.
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_X', tenant_id: TEST_COMMERCE_TENANT_ID, trust_status: 'trusted',
+      public_key_jwk: jwk, api_key_hash: null,
+      tenant_status: 'active',
+    }]);
+    mockRedis.set.mockResolvedValueOnce('OK');
+
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/catalog/products/cprd_X',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('caller_not_authorized');
+
+    // Crucially: NO SELECT against commerce_products fired.
+    const productSelect = sqlMock.mock.calls.find((c) => {
+      const tpl = c[0] as unknown;
+      return Array.isArray(tpl)
+        && tpl.some((s) => typeof s === 'string' && /FROM commerce_products/i.test(s));
+    });
+    expect(productSelect).toBeUndefined();
+  });
+
+  it('merchant caller for cross-merchant product → 404 (existence not leaked, even though product is in tenant)', async () => {
+    // Merchant key bound to mch_OWN. Resolver: SELECT key (mock 1) +
+    // fire-and-forget UPDATE last_used_at (mock 2 — default []).
+    sqlMock.mockResolvedValueOnce([{
+      id: 'mkey_X', tenant_id: TEST_COMMERCE_TENANT_ID,
+      merchant_id: 'mch_OWN', environment: 'sandbox',
+      tenant_status: 'active',
+    }]);
+    sqlMock.mockResolvedValueOnce([]);  // soak the last_used_at UPDATE
+    // Product SELECT bound to (tenant_id, merchant_id=mch_OWN). The
+    // product cprd_OTHER actually belongs to mch_OTHER, so this query
+    // returns empty even though the product exists in the tenant. The
+    // route returns 404 (same shape as not-in-tenant). Existence not leaked.
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/catalog/products/cprd_OTHER',
+      headers: { authorization: 'Bearer grtx_sk_sandbox_CCCCCCCCCCCCCCCCCCCCCCCC' },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('product_not_found');
+  });
+
+  it('merchant caller for own-merchant product → 200 (or 404 if not present)', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      id: 'mkey_X', tenant_id: TEST_COMMERCE_TENANT_ID,
+      merchant_id: 'mch_OWN', environment: 'sandbox',
+      tenant_status: 'active',
+    }]);
+    sqlMock.mockResolvedValueOnce([]);  // soak the last_used_at UPDATE
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cprd_OWN', tenant_id: TEST_COMMERCE_TENANT_ID, merchant_id: 'mch_OWN',
+      product_id: 'P1', title: 'Toaster', brand: null, description: null, image_url: null,
+      category_preset: 'electronics_appliances', source_system: 'manual',
+      manually_maintained: false, archived_at: null,
+      created_at: new Date(), updated_at: new Date(),
+    }]);
+    sqlMock.mockResolvedValueOnce([]);  // variants empty
+
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/catalog/products/cprd_OWN',
+      headers: { authorization: 'Bearer grtx_sk_sandbox_CCCCCCCCCCCCCCCCCCCCCCCC' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ data: { id: string } }>().data.id).toBe('cprd_OWN');
+  });
+});
+
+// Use TEST_DEVELOPER to silence unused-import lint.
+void TEST_DEVELOPER;

--- a/apps/auth-service/tests/commerce-helpers.ts
+++ b/apps/auth-service/tests/commerce-helpers.ts
@@ -14,19 +14,23 @@ import { sqlMock, TEST_DEVELOPER } from './helpers.js';
 export const TEST_COMMERCE_TENANT_ID = 'cten_TESTTENANT';
 
 /**
- * Mapped, active tenant — the common case. Primes:
- *   1. authPlugin developer SELECT
- *   2. resolveTenantForDeveloper join → returns { id, status: 'active' }
+ * Mapped, active tenant — operator caller (developer API key). Primes:
+ *   1. caller.ts loadDeveloperByApiKey → developer row
+ *   2. caller.ts loadOperatorContext JOIN → { tenant_id, status, role }
+ *
+ * Token shape detection in caller.ts: anything that is not merchant key
+ * prefix / agent key prefix / 3-segment JWT falls through to the
+ * operator path. The TEST_API_KEY ('test-api-key-1234') matches that.
  */
 export function seedCommerceContext(tenantId: string = TEST_COMMERCE_TENANT_ID): void {
   sqlMock.mockResolvedValueOnce([TEST_DEVELOPER]);
-  sqlMock.mockResolvedValueOnce([{ id: tenantId, status: 'active' }]);
+  sqlMock.mockResolvedValueOnce([{ tenant_id: tenantId, status: 'active', role: 'owner' }]);
 }
 
 /**
- * No developer→tenant mapping exists. Resolver returns
- * `{ kind: 'not_provisioned' }`; the route preHandler then either
- * 422s (default) or auto-provisions (if COMMERCE_ALLOW_AUTO_TENANT=true).
+ * No developer→tenant mapping exists. JOIN returns []; the route
+ * preHandler either 422s (default) or auto-provisions (if
+ * COMMERCE_ALLOW_AUTO_TENANT=true).
  */
 export function seedCommerceContextNoMapping(): void {
   sqlMock.mockResolvedValueOnce([TEST_DEVELOPER]);
@@ -34,13 +38,13 @@ export function seedCommerceContextNoMapping(): void {
 }
 
 /**
- * Mapping exists but the tenant is disabled. Resolver returns
- * `{ kind: 'disabled' }`; the route preHandler must 403 and must NOT
+ * Mapping exists but the tenant is disabled. JOIN returns
+ * status='disabled'; the route preHandler must 403 and must NOT
  * auto-provision a replacement.
  */
 export function seedCommerceContextDisabledTenant(
   tenantId: string = TEST_COMMERCE_TENANT_ID,
 ): void {
   sqlMock.mockResolvedValueOnce([TEST_DEVELOPER]);
-  sqlMock.mockResolvedValueOnce([{ id: tenantId, status: 'disabled' }]);
+  sqlMock.mockResolvedValueOnce([{ tenant_id: tenantId, status: 'disabled', role: 'owner' }]);
 }

--- a/apps/auth-service/tests/commerce-jwks.test.ts
+++ b/apps/auth-service/tests/commerce-jwks.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { generateKeyPair, exportJWK } from 'jose';
+import { sqlMock, buildTestApp } from './helpers.js';
+
+let app: FastifyInstance;
+beforeAll(async () => { app = await buildTestApp(); });
+
+describe('GET /.well-known/jwks.json — RS256 platform + ES256 commerce coexist', () => {
+  it('serves both the platform RS256 key and any active commerce ES256 keys', async () => {
+    const { publicKey } = await generateKeyPair('ES256');
+    const ecJwk = await exportJWK(publicKey);
+    // The buildJwks extension queries listCommercePassportKeysForJwks
+    // which selects status IN ('active','retired'). Prime two keys: one
+    // active, one retired — both must show up.
+    sqlMock.mockResolvedValueOnce([
+      {
+        kid: 'commerce-passport-20260503-aabbccdd',
+        algorithm: 'ES256',
+        status: 'active',
+        public_key_jwk: { ...ecJwk, kid: 'commerce-passport-20260503-aabbccdd', alg: 'ES256', use: 'sig' },
+        created_at: new Date(),
+        retired_at: null,
+      },
+      {
+        kid: 'commerce-passport-20260501-eeff0011',
+        algorithm: 'ES256',
+        status: 'retired',
+        public_key_jwk: { ...ecJwk, kid: 'commerce-passport-20260501-eeff0011', alg: 'ES256', use: 'sig' },
+        created_at: new Date(Date.now() - 86_400_000 * 2),
+        retired_at: new Date(Date.now() - 86_400_000),
+      },
+    ]);
+
+    const res = await app.inject({ method: 'GET', url: '/.well-known/jwks.json' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ keys: { kid: string; alg: string }[] }>();
+    expect(Array.isArray(body.keys)).toBe(true);
+
+    const algs = body.keys.map((k) => k.alg);
+    expect(algs).toContain('RS256');                // platform grant token key still present
+    expect(algs).toContain('ES256');                // commerce passport key present
+
+    const kids = body.keys.map((k) => k.kid);
+    expect(kids).toContain('commerce-passport-20260503-aabbccdd');  // active
+    expect(kids).toContain('commerce-passport-20260501-eeff0011');  // retired (within grace window)
+  });
+
+  it('still serves platform RS256 key when commerce key DB query fails', async () => {
+    sqlMock.mockRejectedValueOnce(new Error('db down'));
+    const res = await app.inject({ method: 'GET', url: '/.well-known/jwks.json' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ keys: { alg: string }[] }>();
+    expect(body.keys.some((k) => k.alg === 'RS256')).toBe(true);
+  });
+});

--- a/apps/auth-service/tests/commerce-merchants.test.ts
+++ b/apps/auth-service/tests/commerce-merchants.test.ts
@@ -87,16 +87,19 @@ describe('POST /v1/commerce/merchants', () => {
       .toHaveProperty('category_preset');
   });
 
-  it('returns 401 with no Authorization header (platform envelope, NOT commerce envelope)', async () => {
+  it('returns 401 with the commerce envelope on missing Authorization (M2 caller refactor)', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/v1/commerce/merchants',
       payload: validBody,
     });
-    // Auth runs at the global preHandler before commerce sub-instance kicks in,
-    // so the response uses the platform error envelope { message, code, requestId }.
+    // M2 Decision F: commerce routes opt out of the global authPlugin and
+    // run their own commerce caller resolver. 401s now use the commerce
+    // envelope { error: { code, message, ... } } scoped to /v1/commerce/*.
     expect(res.statusCode).toBe(401);
-    expect(res.json<{ code: string }>().code).toBe('UNAUTHORIZED');
+    const body = res.json<{ error: { code: string; message: string } }>();
+    expect(body.error.code).toBe('missing_authorization');
+    expect(typeof body.error.message).toBe('string');
   });
 });
 

--- a/apps/auth-service/tests/commerce-no-plural-leak.test.ts
+++ b/apps/auth-service/tests/commerce-no-plural-leak.test.ts
@@ -31,19 +31,22 @@ function gather(dir: string, ext: string[]): string[] {
 }
 
 function stripSqlComments(src: string): string {
-  // Remove `-- ...` line comments and `/* ... */` block comments.
+  // Remove `-- ...` line comments and `/* ... */` block comments. The
+  // SQL comment regex uses `[^\r\n]*` (not `.*$`) because `.` doesn't
+  // cross `\r` and CRLF-checkout files would otherwise leave the
+  // comment text intact.
   return src
     .replace(/\/\*[\s\S]*?\*\//g, '')
-    .split('\n')
-    .map((line) => line.replace(/--.*$/, ''))
+    .split(/\r?\n/)
+    .map((line) => line.replace(/--[^\r\n]*/, ''))
     .join('\n');
 }
 
 function stripTsComments(src: string): string {
   return src
     .replace(/\/\*[\s\S]*?\*\//g, '')
-    .split('\n')
-    .map((line) => line.replace(/\/\/.*$/, ''))
+    .split(/\r?\n/)
+    .map((line) => line.replace(/\/\/[^\r\n]*/, ''))
     .join('\n');
 }
 

--- a/apps/auth-service/tests/commerce-openapi.test.ts
+++ b/apps/auth-service/tests/commerce-openapi.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -60,5 +60,294 @@ describe('Grantex Commerce V1 OpenAPI 3.1 contract', () => {
     expect(content).toContain('/v1/commerce/tenants');
     expect(content).toContain('/v1/commerce/developer-tenants');
     expect(content).toMatch(/x-milestone:\s*M2/);
+  });
+
+  it('M2 passport endpoints flipped to x-implemented: true', () => {
+    const content = readFileSync(yamlPath, 'utf8');
+    // Each of the five passport routes must now carry x-implemented: true
+    // (or be replaced with full operation specs that imply implementation).
+    const passportPaths = [
+      '/v1/commerce/passports/consent-requests',
+      '/v1/commerce/passports/exchange',
+      '/v1/commerce/passports',
+      '/v1/commerce/passports/verify',
+      '/v1/commerce/passports/revoke',
+    ];
+    for (const p of passportPaths) {
+      expect(content, `OpenAPI must include ${p}`).toContain(p);
+    }
+    // Heuristic check: at least 5 more `x-implemented: true` markers than M1
+    // (M1 had 7 implemented endpoints). M2 adds: 5 passport + 4 tenant +
+    // 4 consent = 13 more. Total ≥ 7 + 13 = 20.
+    const trueCount = (content.match(/x-implemented:\s*true/g) ?? []).length;
+    expect(trueCount).toBeGreaterThanOrEqual(15);
+  });
+});
+
+/**
+ * Drift guard for the consent contract. The implementation in
+ * apps/auth-service/src/routes/commerce-consent.ts diverged from the
+ * OpenAPI yaml during M2 (P2 finding: session-bootstrap query param,
+ * 303 redirect, principal-session-gated approve/deny, expanded 4xx
+ * codes). These assertions fail if anything regresses to the older,
+ * looser contract.
+ */
+describe('Consent endpoints — OpenAPI matches the implementation', () => {
+  /** Returns the YAML body of `/v1/commerce/consent/<suffix>`. */
+  function pathBlock(suffix: string): string {
+    const content = readFileSync(yamlPath, 'utf8');
+    const headerLine = `/v1/commerce/consent/${suffix}:`;
+    const start = content.indexOf(headerLine);
+    expect(start, `OpenAPI must declare /v1/commerce/consent/${suffix}`).toBeGreaterThan(-1);
+    // Block ends at the next path key at the same 2-space indent. Match
+    // both `/letter…` and `/{path-param}…` so /{reqId}/* siblings don't
+    // accidentally extend the page block all the way to the next /v1/…
+    // path.
+    const after = content.slice(start + headerLine.length);
+    const nextPath = after.search(/\n {2}\/[A-Za-z0-9{]/);
+    return nextPath === -1 ? after : after.slice(0, nextPath);
+  }
+
+  describe('GET /v1/commerce/consent/page', () => {
+    let block: string;
+    beforeAll(() => { block = pathBlock('page'); });
+
+    it('declares the optional `session` query parameter (Finding 2 bootstrap)', () => {
+      expect(block).toMatch(/in:\s*query[\s\S]*?name:\s*session[\s\S]*?required:\s*false/);
+      // Description must mention the bootstrap behavior so the contract
+      // tells the truth about what the server does with the token.
+      expect(block.toLowerCase()).toMatch(/bootstrap principal session jwt/);
+      expect(block.toLowerCase()).toMatch(/sets the principal-session cookie/);
+      expect(block.toLowerCase()).toMatch(/strip|stripped/);
+    });
+
+    it('declares the 303 See Other response with Location + security headers', () => {
+      expect(block).toMatch(/"303"/);
+      // Location header is documented under the 303 response.
+      const after303 = block.split('"303"')[1] ?? '';
+      const next = after303.match(/"\d{3}"/);
+      const block303 = next ? after303.slice(0, after303.indexOf(next[0])) : after303;
+      expect(block303).toMatch(/Location:/);
+      expect(block303).toMatch(/Cache-Control:/);
+      expect(block303).toMatch(/no-store/);
+      expect(block303).toMatch(/Pragma:/);
+      expect(block303).toMatch(/no-cache/);
+      expect(block303).toMatch(/Referrer-Policy:/);
+      expect(block303).toMatch(/no-referrer/);
+    });
+
+    it('keeps `req` required and adds 400 for missing/invalid req', () => {
+      expect(block).toMatch(/name:\s*req[\s\S]*?required:\s*true/);
+      expect(block).toMatch(/"400"/);
+    });
+
+    it('200 description clarifies sign-in-required render path', () => {
+      const m = block.match(/"200"[\s\S]*?(?=\n\s*"\d{3}"|\n\s*\/|$)/);
+      expect(m).not.toBeNull();
+      // Allow either spelling: "sign-in-required" / "sign in required" /
+      // "sign_in_required" — all three are reasonable in docs.
+      expect(m![0].toLowerCase()).toMatch(/sign[-_ ]in[-_ ]required/);
+    });
+
+    it('200 advertises strict security headers (CSP, X-Frame-Options, no-store, no-referrer)', () => {
+      const m = block.match(/"200"[\s\S]*?(?=\n\s*"\d{3}"|\n\s*\/|$)/);
+      expect(m).not.toBeNull();
+      const block200 = m![0];
+      expect(block200).toMatch(/Content-Security-Policy/);
+      expect(block200).toMatch(/X-Frame-Options/);
+      expect(block200).toMatch(/no-store/);
+      expect(block200).toMatch(/no-referrer/);
+    });
+
+    it('declares 403 for principal-not-bound or tenant-disabled', () => {
+      expect(block).toMatch(/"403"/);
+      const m = block.match(/"403"[\s\S]*?(?=\n\s*"\d{3}"|\n\s*\/|$)/);
+      expect(m).not.toBeNull();
+      const text = m![0].toLowerCase();
+      // Description must mention BOTH the not-bound and tenant-disabled
+      // failure conditions. Multi-line descriptions are flattened with
+      // [\s\S] matchers because YAML folded scalars wrap.
+      expect(text).toMatch(/not bound/);
+      expect(text).toMatch(/tenant/);
+      expect(text).toMatch(/disabled/);
+    });
+
+    it('keeps 404 (wrong host / unknown req) and 410 (expired)', () => {
+      expect(block).toMatch(/"404"/);
+      expect(block).toMatch(/"410"/);
+    });
+  });
+
+  describe('POST /v1/commerce/consent/{reqId}/approve', () => {
+    let block: string;
+    beforeAll(() => { block = pathBlock('{reqId}/approve'); });
+
+    it('documents application/x-www-form-urlencoded body with required csrf field', () => {
+      expect(block).toMatch(/application\/x-www-form-urlencoded/);
+      expect(block).toMatch(/required:\s*\[csrf\]/);
+      expect(block).toMatch(/name="?csrf"?|csrf:\s*\n/);
+    });
+
+    it('description states principal identity comes from session, not agent input', () => {
+      expect(block.toLowerCase()).toMatch(/principal[\s\S]*session/);
+      // Folded YAML wraps; allow whitespace including newline.
+      expect(block.toLowerCase()).toMatch(/never\s+from\s+agent/);
+    });
+
+    it('declares 401 principal_session_required', () => {
+      expect(block).toMatch(/"401"/);
+      const m = block.match(/"401"[\s\S]*?(?=\n\s*"\d{3}"|\n\s*\/|$)/);
+      expect(m).not.toBeNull();
+      expect(m![0]).toMatch(/principal_session_required/);
+    });
+
+    it('declares 403 with all five codes including challenge_required (P0 fix)', () => {
+      const m = block.match(/"403"[\s\S]*?(?=\n\s*"\d{3}"|\n\s*\/|$)/);
+      expect(m).not.toBeNull();
+      const text = m![0];
+      expect(text).toMatch(/csrf_invalid/);
+      expect(text).toMatch(/principal_not_authorized_for_tenant/);
+      expect(text).toMatch(/tenant_disabled/);
+      expect(text).toMatch(/principal_hint_mismatch/);
+      expect(text).toMatch(/challenge_required/);
+    });
+
+    it('keeps 404, 409 (consent_already_decided), 410 (consent_expired)', () => {
+      expect(block).toMatch(/"404"/);
+      expect(block).toMatch(/"409"[\s\S]*?consent_already_decided/);
+      expect(block).toMatch(/"410"[\s\S]*?consent_expired/);
+    });
+
+    it('still x-implemented: true and x-milestone: M2', () => {
+      expect(block).toMatch(/x-implemented:\s*true/);
+      expect(block).toMatch(/x-milestone:\s*M2/);
+    });
+  });
+
+  describe('POST /v1/commerce/consent/{reqId}/challenge — challenge create endpoint', () => {
+    let block: string;
+    beforeAll(() => { block = pathBlock('{reqId}/challenge'); });
+
+    it('exists and is x-implemented: true at M2', () => {
+      expect(block).toMatch(/x-implemented:\s*true/);
+      expect(block).toMatch(/x-milestone:\s*M2/);
+    });
+    it('requires application/x-www-form-urlencoded body with csrf', () => {
+      expect(block).toMatch(/application\/x-www-form-urlencoded/);
+      expect(block).toMatch(/required:\s*\[csrf\]/);
+    });
+    it('description states the challenge is server-issued, single-use, and not derivable by the agent', () => {
+      expect(block.toLowerCase()).toMatch(/single-use/);
+      // YAML folded scalar wraps long descriptions; allow whitespace
+      // (including \n) between words.
+      expect(block.toLowerCase()).toMatch(/agent\/developer\s+cannot\s+read\s+or\s+compute/);
+    });
+    it('declares the four expected error codes (401/403/404/503) and the test_only_code disclosure rule', () => {
+      expect(block).toMatch(/"401"[\s\S]*?principal_session_required/);
+      const four03 = block.match(/"403"[\s\S]*?(?=\n\s*"\d{3}"|\n\s*\/|$)/);
+      expect(four03).not.toBeNull();
+      expect(four03![0]).toMatch(/csrf_invalid/);
+      expect(four03![0]).toMatch(/principal_not_authorized_for_tenant/);
+      expect(four03![0]).toMatch(/tenant_disabled/);
+      expect(four03![0]).toMatch(/principal_hint_mismatch/);
+      expect(block).toMatch(/"503"[\s\S]*?challenge_provider_unavailable/);
+      // 201 description must call out the TEST-ONLY disclosure rule:
+      // raw code only when NODE_ENV === 'test'. Earlier drafts said
+      // "non-production" — that wording is now banned because staging /
+      // preview / dev would also leak.
+      expect(block).toMatch(/"201"[\s\S]*?test_only_code/);
+      expect(block).toMatch(/"201"[\s\S]*?NODE_ENV\s*===\s*'test'/);
+    });
+
+    it('test_only_code disclosure rule is NODE_ENV === test only (not "non-production")', () => {
+      // Search the entire challenge-create block plus the surrounding
+      // description block.
+      const wide = block;
+      // Affirmative: must say NODE_ENV === 'test' near test_only_code.
+      expect(wide).toMatch(/test_only_code[\s\S]{0,200}?NODE_ENV\s*===\s*'test'/);
+      // Negative: must NOT say "non-production" or "NODE_ENV !== 'production'"
+      // anywhere in the disclosure rationale.
+      expect(wide).not.toMatch(/non-production/);
+      expect(wide).not.toMatch(/NODE_ENV\s*!==\s*'production'/);
+    });
+
+    it('email_otp is documented as deferred / not implemented in M2 (no claim that it is production-ready)', () => {
+      // Description must clearly say email_otp is NOT implemented and
+      // production fails closed regardless. No wording suggesting that
+      // setting `COMMERCE_CONSENT_CHALLENGE_PROVIDER=email_otp` enables
+      // production delivery.
+      expect(block).toMatch(/email_otp[\s\S]{0,500}?(?:NOT\s+implemented|deferred to M3|fails\s+closed)/i);
+      // The 503 description must explicitly mention that
+      // COMMERCE_CONSENT_CHALLENGE_PROVIDER=email_otp is ignored in M2.
+      const five03 = block.match(/"503"[\s\S]*?(?=\n\s*"\d{3}"|\n\s*\/|$)/);
+      expect(five03).not.toBeNull();
+      expect(five03![0]).toMatch(/email_otp/);
+      expect(five03![0]).toMatch(/(?:does NOT enable delivery|deferred to M3|ignored)/i);
+    });
+  });
+
+  describe('POST /v1/commerce/consent/{reqId}/challenge/verify — challenge verify endpoint', () => {
+    let block: string;
+    beforeAll(() => { block = pathBlock('{reqId}/challenge/verify'); });
+
+    it('exists and is x-implemented: true at M2', () => {
+      expect(block).toMatch(/x-implemented:\s*true/);
+      expect(block).toMatch(/x-milestone:\s*M2/);
+    });
+    it('requires application/x-www-form-urlencoded body with csrf + code', () => {
+      expect(block).toMatch(/application\/x-www-form-urlencoded/);
+      expect(block).toMatch(/required:\s*\[csrf,\s*code\]/);
+    });
+    it('declares 403 challenge_invalid, 410 challenge_expired, 404 challenge_not_found, 422 validation_failed', () => {
+      expect(block).toMatch(/"403"[\s\S]*?challenge_invalid/);
+      expect(block).toMatch(/"410"[\s\S]*?challenge_expired/);
+      expect(block).toMatch(/"404"[\s\S]*?challenge_not_found/);
+      expect(block).toMatch(/"422"[\s\S]*?validation_failed/);
+    });
+  });
+
+  describe('POST /v1/commerce/consent/{reqId}/deny', () => {
+    let block: string;
+    beforeAll(() => { block = pathBlock('{reqId}/deny'); });
+
+    it('requires application/x-www-form-urlencoded body with csrf field', () => {
+      expect(block).toMatch(/application\/x-www-form-urlencoded/);
+      expect(block).toMatch(/required:\s*\[csrf\]/);
+    });
+
+    it('description states principal session cookie + CSRF are required', () => {
+      expect(block.toLowerCase()).toMatch(/principal session/);
+      expect(block.toLowerCase()).toMatch(/csrf/);
+    });
+
+    it('declares 401 principal_session_required', () => {
+      const m = block.match(/"401"[\s\S]*?(?=\n\s*"\d{3}"|\n\s*\/|$)/);
+      expect(m).not.toBeNull();
+      expect(m![0]).toMatch(/principal_session_required/);
+    });
+
+    it('declares 403 with all applicable codes including principal_hint_mismatch (P2 fix) and challenge_required (P0 fix)', () => {
+      const m = block.match(/"403"[\s\S]*?(?=\n\s*"\d{3}"|\n\s*\/|$)/);
+      expect(m).not.toBeNull();
+      const text = m![0];
+      expect(text).toMatch(/csrf_invalid/);
+      expect(text).toMatch(/principal_not_authorized_for_tenant/);
+      expect(text).toMatch(/tenant_disabled/);
+      // P2 fix — deny now enforces hint match too.
+      expect(text).toMatch(/principal_hint_mismatch/);
+      // P0 fix — challenge gate applies to deny as well.
+      expect(text).toMatch(/challenge_required/);
+    });
+
+    it('keeps 404, 409, 410', () => {
+      expect(block).toMatch(/"404"/);
+      expect(block).toMatch(/"409"/);
+      expect(block).toMatch(/"410"/);
+    });
+
+    it('still x-implemented: true and x-milestone: M2', () => {
+      expect(block).toMatch(/x-implemented:\s*true/);
+      expect(block).toMatch(/x-milestone:\s*M2/);
+    });
   });
 });

--- a/apps/auth-service/tests/commerce-passport-sign-verify.test.ts
+++ b/apps/auth-service/tests/commerce-passport-sign-verify.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Lib-level tests for commerce passport signing and verification.
+ * Exercises the security-critical paths:
+ *   - alg=none rejection
+ *   - HS256/algorithm confusion rejection
+ *   - missing kid rejection
+ *   - unknown kid rejection
+ *   - cross-namespace kid rejection (passport claims to be signed by a
+ *     platform RS256 kid like "grantex-2026-05")
+ *   - expired / not-yet-valid (with 30s clock-skew tolerance)
+ *   - wrong audience / wrong issuer
+ *   - cross-tenant / cross-merchant verification gates
+ *   - online revocation (payment_affecting) returns deny
+ *   - revocation infrastructure unavailable → fail-closed result
+ */
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import {
+  generateKeyPair,
+  exportJWK,
+  importJWK,
+  SignJWT,
+  type KeyLike,
+  type JWK,
+} from 'jose';
+import { sqlMock, mockRedis } from './helpers.js';
+
+// Stub out crypto.initKeys if it tries to read RSA env — tests use AUTO_GENERATE_KEYS.
+import {
+  signCommercePassport,
+  verifyCommercePassport,
+  newCommercePassportJti,
+} from '../src/lib/commerce/passport.js';
+import { _resetCommercePassportKeyCacheForTests } from '../src/lib/commerce/passport-keys.js';
+
+const TENANT = 'cten_TEST';
+const MERCHANT = 'mch_TEST';
+const AGENT = 'cag_TEST';
+const CONSENT = 'crec_TEST';
+const SUBJECT = 'user_TEST';
+const SCOPES = ['commerce:catalog.read'];
+
+let activeKp: { privateKey: KeyLike; publicKey: KeyLike };
+let activeKid: string;
+let activePublicJwk: JWK;
+
+async function setupActiveKey(): Promise<void> {
+  activeKp = await generateKeyPair('ES256');
+  const jwk = await exportJWK(activeKp.publicKey);
+  activeKid = 'commerce-passport-20260503-aabbccdd';
+  activePublicJwk = { ...jwk, kid: activeKid, alg: 'ES256', use: 'sig' } as JWK;
+}
+
+/**
+ * Prime sqlMock for getActiveCommercePassportSigner. The lib first calls
+ * findActiveCommercePassportKey (one SELECT) which returns the active
+ * row, then a second SELECT that returns encrypted_private_key_jwk.
+ *
+ * We use a real ES256 keypair generated in test setup; the encrypted
+ * field is a base64 of an AES-GCM ciphertext produced by vault-crypto
+ * (uses VAULT_ENCRYPTION_KEY from vitest env).
+ */
+async function primeActiveKeyForSigner(): Promise<void> {
+  const { encrypt } = await import('../src/lib/vault-crypto.js');
+  const privateJwk = await exportJWK(activeKp.privateKey);
+  const encryptedPrivate = encrypt(JSON.stringify({ ...privateJwk, kid: activeKid, alg: 'ES256' }));
+  // Find active
+  sqlMock.mockResolvedValueOnce([{
+    kid: activeKid, algorithm: 'ES256', status: 'active',
+    public_key_jwk: activePublicJwk, created_at: new Date(), retired_at: null,
+  }]);
+  // Decrypt key fetch
+  sqlMock.mockResolvedValueOnce([{ encrypted_private_key_jwk: encryptedPrivate }]);
+}
+
+function primePublicKeyLookup(kid: string = activeKid, jwk: JWK = activePublicJwk): void {
+  sqlMock.mockResolvedValueOnce([{ public_key_jwk: jwk }]);
+}
+
+function primeNoSuchKey(): void {
+  sqlMock.mockResolvedValueOnce([]);
+}
+
+beforeAll(async () => {
+  await setupActiveKey();
+});
+
+async function signValidPassport(opts: { iat?: number; exp?: number; nbf?: number; passportType?: 'browse' | 'checkout' } = {}): Promise<string> {
+  _resetCommercePassportKeyCacheForTests();
+  await primeActiveKeyForSigner();
+  const now = Math.floor(Date.now() / 1000);
+  const iat = opts.iat ?? now;
+  const r = await signCommercePassport(sqlMock as unknown as never, {
+    jti: newCommercePassportJti(),
+    passportType: opts.passportType ?? 'browse',
+    tenantId: TENANT, merchantId: MERCHANT, agentId: AGENT,
+    consentRecordId: CONSENT, subject: SUBJECT,
+    scopes: SCOPES, maxAmount: null, currency: null,
+    environment: 'sandbox',
+    issuedAt: iat, notBefore: opts.nbf ?? iat, expiresAt: opts.exp ?? now + 600,
+  });
+  return r.jwt;
+}
+
+describe('Commerce passport — round-trip signing + verification', () => {
+  it('signs and verifies (read_only) with the active key', async () => {
+    const jwt = await signValidPassport();
+    primePublicKeyLookup();
+    const r = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, jwt, { mode: 'read_only' });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.passport.kid).toBe(activeKid);
+      expect(r.passport.tenantId).toBe(TENANT);
+      expect(r.passport.merchantId).toBe(MERCHANT);
+      expect(r.passport.scopes).toEqual(SCOPES);
+    }
+  });
+});
+
+describe('Commerce passport — algorithm attacks rejected', () => {
+  it('rejects alg=none', async () => {
+    // Construct an unsigned token with alg=none manually.
+    const header = Buffer.from(JSON.stringify({ alg: 'none', kid: activeKid })).toString('base64url');
+    const payload = Buffer.from(JSON.stringify({ jti: 'x', sub: SUBJECT })).toString('base64url');
+    const token = `${header}.${payload}.`;
+    primePublicKeyLookup();  // (won't be reached but be defensive)
+    const r = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, token, { mode: 'read_only' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe('algorithm_rejected');
+  });
+
+  it('rejects HS256 confusion (HMAC token claiming the EC public key as secret)', async () => {
+    const { SignJWT } = await import('jose');
+    const ecJwk = await exportJWK(activeKp.publicKey);
+    // Use the EC public key bytes as an HMAC secret — classic alg-confusion.
+    const fakeSecret = Buffer.from(JSON.stringify(ecJwk));
+    const now = Math.floor(Date.now() / 1000);
+    const forged = await new SignJWT({})
+      .setProtectedHeader({ alg: 'HS256', kid: activeKid })
+      .setIssuer(process.env['JWT_ISSUER'] ?? 'https://grantex.dev')
+      .setAudience('grantex-commerce')
+      .setSubject(SUBJECT).setJti('x').setIssuedAt(now).setExpirationTime(now + 60)
+      .sign(fakeSecret);
+    primePublicKeyLookup();
+    const r = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, forged, { mode: 'read_only' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe('algorithm_rejected');
+  });
+});
+
+describe('Commerce passport — kid attacks rejected', () => {
+  it('rejects missing kid', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = await new SignJWT({})
+      .setProtectedHeader({ alg: 'ES256' })   // no kid
+      .setIssuer(process.env['JWT_ISSUER'] ?? 'https://grantex.dev')
+      .setAudience('grantex-commerce')
+      .setSubject(SUBJECT).setJti('x').setIssuedAt(now).setExpirationTime(now + 60)
+      .sign(activeKp.privateKey);
+    const r = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, token, { mode: 'read_only' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe('kid_required');
+  });
+
+  it('rejects wrong-namespace kid (forged claim of platform RS256 kid)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = await new SignJWT({})
+      .setProtectedHeader({ alg: 'ES256', kid: 'grantex-2026-05' })   // platform namespace
+      .setIssuer(process.env['JWT_ISSUER'] ?? 'https://grantex.dev')
+      .setAudience('grantex-commerce')
+      .setSubject(SUBJECT).setJti('x').setIssuedAt(now).setExpirationTime(now + 60)
+      .sign(activeKp.privateKey);
+    const r = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, token, { mode: 'read_only' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe('kid_wrong_namespace');
+  });
+
+  it('rejects unknown kid (matches namespace but not in DB)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = await new SignJWT({})
+      .setProtectedHeader({ alg: 'ES256', kid: 'commerce-passport-20990101-deadbeef' })
+      .setIssuer(process.env['JWT_ISSUER'] ?? 'https://grantex.dev')
+      .setAudience('grantex-commerce')
+      .setSubject(SUBJECT).setJti('x').setIssuedAt(now).setExpirationTime(now + 60)
+      .sign(activeKp.privateKey);
+    primeNoSuchKey();
+    const r = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, token, { mode: 'read_only' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe('kid_unknown');
+  });
+});
+
+describe('Commerce passport — temporal claims', () => {
+  it('rejects expired (more than 30s past exp)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const jwt = await signValidPassport({ exp: now - 60 });    // 60s past
+    primePublicKeyLookup();
+    const r = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, jwt, { mode: 'read_only' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe('expired');
+  });
+
+  it('accepts within 30s clock-skew tolerance past exp', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    // Issue 60s ago, exp 5s ago — within 30s skew but exp > iat (lifetime = 55s).
+    const jwt = await signValidPassport({ iat: now - 60, exp: now - 5 });
+    primePublicKeyLookup();
+    const r = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, jwt, { mode: 'read_only' });
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('Commerce passport — context invariants', () => {
+  it('rejects on tenant mismatch when expectedTenantId provided', async () => {
+    const jwt = await signValidPassport();
+    primePublicKeyLookup();
+    const r = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, jwt, { mode: 'read_only', expectedTenantId: 'cten_OTHER' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe('tenant_mismatch');
+  });
+
+  it('rejects on merchant mismatch when expectedMerchantId provided', async () => {
+    const jwt = await signValidPassport();
+    primePublicKeyLookup();
+    const r = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, jwt, { mode: 'read_only', expectedMerchantId: 'mch_OTHER' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe('merchant_mismatch');
+  });
+});
+
+describe('Commerce passport — online revocation (payment_affecting)', () => {
+  it('rejects revoked passport (Redis hit)', async () => {
+    const jwt = await signValidPassport();
+    primePublicKeyLookup();
+    mockRedis.sismember.mockResolvedValueOnce(1);
+    const r = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, jwt, { mode: 'payment_affecting' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe('revoked');
+  });
+
+  it('rejects revoked passport (Postgres hit when Redis miss)', async () => {
+    const jwt = await signValidPassport();
+    primePublicKeyLookup();
+    mockRedis.sismember.mockResolvedValueOnce(0);
+    sqlMock.mockResolvedValueOnce([{ reason: 'merchant_disabled' }]);  // postgres lookup
+    const r = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, jwt, { mode: 'payment_affecting' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.kind).toBe('revoked');
+      if (r.error.kind === 'revoked') expect(r.error.reason).toBe('merchant_disabled');
+    }
+  });
+
+  it('fail-closed when both Redis AND Postgres revocation lookup fail', async () => {
+    const jwt = await signValidPassport();
+    primePublicKeyLookup();
+    mockRedis.sismember.mockRejectedValueOnce(new Error('redis down'));
+    sqlMock.mockRejectedValueOnce(new Error('pg down'));
+    const r = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, jwt, { mode: 'payment_affecting' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe('revocation_unavailable');
+  });
+
+  it('read_only mode skips revocation check (degrades gracefully)', async () => {
+    const jwt = await signValidPassport();
+    primePublicKeyLookup();
+    // Redis NOT primed and Postgres NOT primed — no lookup happens.
+    const r = await verifyCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, jwt, { mode: 'read_only' });
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('Commerce passport-keys — production guardrail (Decision D)', () => {
+  it('refuses to auto-generate when NODE_ENV=production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('COMMERCE_AUTO_GENERATE_PASSPORT_KEY', 'true');
+    _resetCommercePassportKeyCacheForTests();
+    sqlMock.mockResolvedValueOnce([]);  // findActiveCommercePassportKey returns null
+    const { getActiveCommercePassportSigner } = await import('../src/lib/commerce/passport-keys.js');
+    await expect(getActiveCommercePassportSigner(sqlMock as unknown as never))
+      .rejects.toThrow(/explicit/i);
+    vi.unstubAllEnvs();
+  });
+});
+
+// Use importJWK to silence unused-import warnings; this also smoke-tests
+// that jose is available in the test runtime.
+void importJWK;

--- a/apps/auth-service/tests/commerce-revocation.test.ts
+++ b/apps/auth-service/tests/commerce-revocation.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { sqlMock, mockRedis } from './helpers.js';
+import {
+  checkPassportRevocation,
+  revokeCommercePassport,
+} from '../src/lib/commerce/revocation.js';
+
+beforeEach(() => {
+  // Reset sismember to default 0 (not revoked) for these tests.
+  mockRedis.sismember.mockReset().mockResolvedValue(0);
+  mockRedis.sadd.mockReset().mockResolvedValue(1);
+});
+
+describe('Revocation lookup', () => {
+  it('Redis hit → revoked: true, source: redis', async () => {
+    mockRedis.sismember.mockResolvedValueOnce(1);
+    const r = await checkPassportRevocation(sqlMock as unknown as never, mockRedis as unknown as never, 'jti_X');
+    expect(r.revoked).toBe(true);
+    expect(r.source).toBe('redis');
+  });
+
+  it('Redis miss + Postgres hit → revoked: true, source: postgres + Redis warmed', async () => {
+    mockRedis.sismember.mockResolvedValueOnce(0);
+    sqlMock.mockResolvedValueOnce([{ reason: 'user_revoked' }]);
+    const r = await checkPassportRevocation(sqlMock as unknown as never, mockRedis as unknown as never, 'jti_X');
+    expect(r.revoked).toBe(true);
+    expect(r.source).toBe('postgres');
+    if (r.revoked && r.source === 'postgres') expect(r.reason).toBe('user_revoked');
+    expect(mockRedis.sadd).toHaveBeenCalledWith('commerce:revoked:passport', 'jti_X');
+  });
+
+  it('Redis miss + Postgres miss → revoked: false, source: postgres', async () => {
+    mockRedis.sismember.mockResolvedValueOnce(0);
+    sqlMock.mockResolvedValueOnce([]);
+    const r = await checkPassportRevocation(sqlMock as unknown as never, mockRedis as unknown as never, 'jti_X');
+    expect(r.revoked).toBe(false);
+    expect(r.source).toBe('postgres');
+  });
+
+  it('Redis throws + Postgres hit → still positively revoked via Postgres', async () => {
+    mockRedis.sismember.mockRejectedValueOnce(new Error('redis down'));
+    sqlMock.mockResolvedValueOnce([{ reason: 'merchant_disabled' }]);
+    const r = await checkPassportRevocation(sqlMock as unknown as never, mockRedis as unknown as never, 'jti_X');
+    expect(r.revoked).toBe(true);
+    expect(r.source).toBe('postgres');
+  });
+
+  it('Redis throws + Postgres throws → fail-closed (source: fail_closed_unavailable)', async () => {
+    mockRedis.sismember.mockRejectedValueOnce(new Error('redis down'));
+    sqlMock.mockRejectedValueOnce(new Error('pg down'));
+    const r = await checkPassportRevocation(sqlMock as unknown as never, mockRedis as unknown as never, 'jti_X');
+    expect(r.revoked).toBe(false);
+    expect(r.source).toBe('fail_closed_unavailable');
+    if (r.source === 'fail_closed_unavailable') expect(typeof r.error).toBe('string');
+  });
+});
+
+describe('Revocation write', () => {
+  it('inserts into Postgres and warms Redis', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+    await revokeCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, {
+      jti: 'jti_R', tenantId: 'cten_T', reason: 'user_revoked', revokedBy: 'user_X',
+    });
+    expect(mockRedis.sadd).toHaveBeenCalledWith('commerce:revoked:passport', 'jti_R');
+  });
+
+  it('survives Redis warm-up failure (Postgres remains source of truth)', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+    mockRedis.sadd.mockRejectedValueOnce(new Error('redis down'));
+    // Should not throw.
+    await expect(
+      revokeCommercePassport(sqlMock as unknown as never, mockRedis as unknown as never, {
+        jti: 'jti_R', tenantId: 'cten_T', reason: 'explicit', revokedBy: null,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+// Silence unused-import warning when adjusting.
+void vi;

--- a/apps/auth-service/tests/commerce-schema.test.ts
+++ b/apps/auth-service/tests/commerce-schema.test.ts
@@ -143,6 +143,74 @@ describe('Commerce schema — composite tenant-safe foreign keys (M1 hardening)'
   });
 });
 
+describe('Commerce schema — M2 migrations (037-041)', () => {
+  it('037 commerce_tenant_operators has role CHECK and backfill from M1 default mappings', () => {
+    const s = read('037_commerce_tenant_operators.sql');
+    expect(s).toMatch(/CREATE TABLE IF NOT EXISTS commerce_tenant_operators/);
+    expect(s).toMatch(/CHECK \(role IN \('owner','operator'\)\)/);
+    expect(s).toMatch(/INSERT INTO commerce_tenant_operators[\s\S]*FROM commerce_developer_tenants/);
+    expect(s).toMatch(/ON CONFLICT \(developer_id, tenant_id\) DO NOTHING/);
+  });
+
+  it('038 commerce_merchant_api_keys uses sha256 hash + composite tenant FK + partial unique on active', () => {
+    const s = read('038_commerce_merchant_api_keys.sql');
+    expect(s).toMatch(/CREATE TABLE IF NOT EXISTS commerce_merchant_api_keys/);
+    expect(s).toMatch(/key_hash\s+TEXT NOT NULL/);
+    expect(s).toMatch(/CONSTRAINT fk_merchant_api_key_merchant\s*\n?\s*FOREIGN KEY \(tenant_id, merchant_id\)\s*\n?\s*REFERENCES commerce_merchants\(tenant_id, id\)/);
+    expect(s).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_merchant_api_keys_hash[\s\S]*WHERE revoked_at IS NULL/);
+    expect(s).toMatch(/CHECK \(environment IN \('sandbox','live'\)\)/);
+  });
+
+  it('039 commerce_passport_keys enforces ES256 algorithm and kid namespace at the DB layer', () => {
+    const s = read('039_commerce_passport_keys.sql');
+    expect(s).toMatch(/CREATE TABLE IF NOT EXISTS commerce_passport_keys/);
+    expect(s).toMatch(/CHECK \(algorithm = 'ES256'\)/);
+    expect(s).toMatch(/CHECK \(\s*kid ~ '\^commerce-passport-\[0-9\]\{8\}-\[a-z0-9\]\{8\}\$'\s*\)/);
+    expect(s).toMatch(/CHECK \(status IN \('active','retired','compromised'\)\)/);
+    // Exactly one active key at any time.
+    expect(s).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_passport_keys_active[\s\S]*WHERE status = 'active'/);
+    // Private key is encrypted.
+    expect(s).toMatch(/encrypted_private_key_jwk\s+TEXT NOT NULL/);
+  });
+
+  it('040 commerce_consent_records has composite tenant FKs + status CHECK + presented_payload_hash + user_principal_hint', () => {
+    const s = read('040_commerce_consent_records.sql');
+    expect(s).toMatch(/CREATE TABLE IF NOT EXISTS commerce_consent_records/);
+    expect(s).toMatch(/CHECK \(status IN \('requested','granted','denied','expired'\)\)/);
+    expect(s).toMatch(/CHECK \(passport_type IN \('browse','checkout'\)\)/);
+    expect(s).toMatch(/presented_payload_hash\s+TEXT/);
+    // Finding 1 redesign: csrf_secret_hash dropped (CSRF derived per-form
+    // from principal session token); user_principal_hint added (agent
+    // hint that's enforced at approval against verified principal).
+    expect(s).not.toMatch(/csrf_secret_hash/);
+    expect(s).toMatch(/user_principal_hint\s+TEXT/);
+    expect(s).toMatch(/consent_request_id\s+TEXT NOT NULL UNIQUE/);
+    expect(s).toMatch(/CONSTRAINT fk_consent_merchant\s*\n?\s*FOREIGN KEY \(tenant_id, merchant_id\)\s*\n?\s*REFERENCES commerce_merchants\(tenant_id, id\)/);
+    expect(s).toMatch(/CONSTRAINT fk_consent_agent\s*\n?\s*FOREIGN KEY \(tenant_id, agent_id\)\s*\n?\s*REFERENCES commerce_agents\(tenant_id, id\)/);
+  });
+
+  it('041 commerce_passports has UNIQUE consent_record_id (Finding 3 — single-use exchange)', () => {
+    const s = read('041_commerce_passports.sql');
+    expect(s).toMatch(/consent_record_id\s+TEXT NOT NULL UNIQUE/);
+    // Belt-and-braces idempotent ALTER TABLE for upgrade scenarios.
+    expect(s).toMatch(/ADD CONSTRAINT commerce_passports_consent_record_id_key/);
+  });
+
+  it('041 commerce_passports is append-only with BEFORE UPDATE/DELETE triggers + revocations sibling table', () => {
+    const s = read('041_commerce_passports.sql');
+    expect(s).toMatch(/CREATE TABLE IF NOT EXISTS commerce_passports/);
+    expect(s).toMatch(/jti\s+TEXT PRIMARY KEY/);
+    expect(s).toMatch(/kid\s+TEXT NOT NULL REFERENCES commerce_passport_keys\(kid\)/);
+    expect(s).toMatch(/CREATE OR REPLACE FUNCTION commerce_passports_block_mutation/);
+    expect(s).toMatch(/BEFORE UPDATE ON commerce_passports/);
+    expect(s).toMatch(/BEFORE DELETE ON commerce_passports/);
+    // Revocations sibling table exists and is itself append-only at the role layer.
+    expect(s).toMatch(/CREATE TABLE IF NOT EXISTS commerce_passport_revocations/);
+    expect(s).toMatch(/REVOKE UPDATE, DELETE, TRUNCATE ON commerce_passports FROM grantex_app/);
+    expect(s).toMatch(/GRANT INSERT, SELECT ON commerce_passports TO grantex_app/);
+  });
+});
+
 describe('Commerce schema — electronics_appliances preset is seeded', () => {
   it('migration 032 inserts electronics_appliances with required_fields and default_policy_rules', () => {
     const s = read('032_commerce_category_presets.sql');

--- a/apps/auth-service/tests/commerce-tenant-provisioning.test.ts
+++ b/apps/auth-service/tests/commerce-tenant-provisioning.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { sqlMock, buildTestApp, TEST_DEVELOPER, authHeader } from './helpers.js';
+import { TEST_COMMERCE_TENANT_ID, seedCommerceContext } from './commerce-helpers.js';
+
+let app: FastifyInstance;
+beforeAll(async () => { app = await buildTestApp(); });
+
+const adminAuth = { authorization: 'Bearer test-admin-key-secret' };
+
+describe('POST /v1/commerce/tenants — admin only (Decision C)', () => {
+  it('admin caller creates a tenant', async () => {
+    // Admin path: developer lookup empty + isPlatformAdmin true → caller resolved without tenant.
+    sqlMock.mockResolvedValueOnce([]);  // developer lookup empty
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cten_NEW', display_name: 'Acme Org', status: 'active',
+      metadata: {}, created_at: new Date(), updated_at: new Date(),
+    }]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_T', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST', url: '/v1/commerce/tenants', headers: adminAuth,
+      payload: { display_name: 'Acme Org' },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ data: { id: string }; audit_event_id: string }>();
+    expect(body.data.id).toBe('cten_NEW');
+    expect(body.audit_event_id).toBe('caud_T');
+  });
+
+  it('non-admin operator → 403 admin_required', async () => {
+    seedCommerceContext();  // operator (developer) caller, NOT admin
+    const res = await app.inject({
+      method: 'POST', url: '/v1/commerce/tenants', headers: authHeader(),
+      payload: { display_name: 'X' },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('admin_required');
+  });
+
+  it('missing display_name → 422', async () => {
+    sqlMock.mockResolvedValueOnce([]);  // admin path — no developer
+    const res = await app.inject({
+      method: 'POST', url: '/v1/commerce/tenants', headers: adminAuth,
+      payload: {},
+    });
+    expect(res.statusCode).toBe(422);
+  });
+});
+
+describe('POST /v1/commerce/developer-tenants — owner or admin', () => {
+  it('admin can bind any developer to any tenant', async () => {
+    sqlMock.mockResolvedValueOnce([]);  // admin path
+    sqlMock.mockResolvedValueOnce([{ id: TEST_COMMERCE_TENANT_ID, status: 'active' }]);  // tenant lookup
+    // begin: clear default + insert + audit (3 mock slots inside begin)
+    sqlMock.mockResolvedValueOnce([]);  // UPDATE clear default
+    sqlMock.mockResolvedValueOnce([{
+      developer_id: 'dev_OTHER', tenant_id: TEST_COMMERCE_TENANT_ID, is_default: true, created_at: new Date(),
+    }]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_B', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST', url: '/v1/commerce/developer-tenants', headers: adminAuth,
+      payload: { developer_id: 'dev_OTHER', tenant_id: TEST_COMMERCE_TENANT_ID, is_default: true },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('non-owner operator → 403 tenant_owner_required', async () => {
+    // Operator caller exists but doesn't own the target tenant.
+    sqlMock.mockResolvedValueOnce([TEST_DEVELOPER]);
+    sqlMock.mockResolvedValueOnce([{ tenant_id: TEST_COMMERCE_TENANT_ID, status: 'active', role: 'owner' }]);
+    sqlMock.mockResolvedValueOnce([]);  // ownership check on cten_OTHER returns no row
+    const res = await app.inject({
+      method: 'POST', url: '/v1/commerce/developer-tenants', headers: authHeader(),
+      payload: { developer_id: 'dev_OTHER', tenant_id: 'cten_OTHER', is_default: true },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('tenant_owner_required');
+  });
+
+  it('disabled tenant cannot accept new bindings → 409 tenant_disabled', async () => {
+    sqlMock.mockResolvedValueOnce([]);  // admin path
+    sqlMock.mockResolvedValueOnce([{ id: TEST_COMMERCE_TENANT_ID, status: 'disabled' }]);
+    const res = await app.inject({
+      method: 'POST', url: '/v1/commerce/developer-tenants', headers: adminAuth,
+      payload: { developer_id: 'dev_X', tenant_id: TEST_COMMERCE_TENANT_ID },
+    });
+    expect(res.statusCode).toBe(409);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('tenant_disabled');
+  });
+});
+
+describe('PATCH /v1/commerce/tenants/:id — owner or admin', () => {
+  it('owner can update display_name', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([{ ok: true }]);  // ownership check passes
+    // begin: UPDATE + audit
+    sqlMock.mockResolvedValueOnce([{
+      id: TEST_COMMERCE_TENANT_ID, display_name: 'New Name', status: 'active',
+      metadata: {}, created_at: new Date(), updated_at: new Date(),
+    }]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_U', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'PATCH', url: `/v1/commerce/tenants/${TEST_COMMERCE_TENANT_ID}`,
+      headers: authHeader(), payload: { display_name: 'New Name' },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('admin disabling a tenant emits tenant.disabled audit event', async () => {
+    sqlMock.mockResolvedValueOnce([]);  // admin path
+    sqlMock.mockResolvedValueOnce([{
+      id: TEST_COMMERCE_TENANT_ID, display_name: 'X', status: 'disabled',
+      metadata: {}, created_at: new Date(), updated_at: new Date(),
+    }]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_D', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'PATCH', url: `/v1/commerce/tenants/${TEST_COMMERCE_TENANT_ID}`,
+      headers: adminAuth, payload: { status: 'disabled' },
+    });
+    expect(res.statusCode).toBe(200);
+    // Inspect the audit insert — last sqlMock call before reply.
+    const auditCall = sqlMock.mock.calls.find((c) => {
+      const tpl = c[0] as unknown;
+      return Array.isArray(tpl)
+        && tpl.some((s) => typeof s === 'string' && /INSERT INTO commerce_audit_events/i.test(s));
+    });
+    expect(auditCall).toBeDefined();
+    expect(auditCall!.slice(1)).toContain('tenant.disabled');
+  });
+});

--- a/apps/auth-service/tests/setup.ts
+++ b/apps/auth-service/tests/setup.ts
@@ -31,6 +31,11 @@ export const mockRedis = {
   quit: vi.fn().mockResolvedValue(undefined),
   on: vi.fn(),
   duplicate: vi.fn(),
+  // M2 commerce — set ops for revocation cache + replay tracking.
+  sadd: vi.fn().mockResolvedValue(1),
+  sismember: vi.fn().mockResolvedValue(0),
+  srem: vi.fn().mockResolvedValue(1),
+  smembers: vi.fn().mockResolvedValue([]),
   options: { host: 'localhost', port: 6379 },
 };
 // Returning self from duplicate() keeps the subscriber-side mocks in sync.
@@ -244,6 +249,9 @@ beforeEach(() => {
   mockRedis.incr.mockReset().mockResolvedValue(1);
   mockRedis.decr.mockReset().mockResolvedValue(0);
   mockRedis.expire.mockReset().mockResolvedValue(1);
+  mockRedis.sadd.mockReset().mockResolvedValue(1);
+  mockRedis.sismember.mockReset().mockResolvedValue(0);
+  mockRedis.srem.mockReset().mockResolvedValue(1);
   mockGetStripe.mockReset().mockReturnValue(mockStripe);
   mockStripe.checkout.sessions.create.mockReset().mockResolvedValue({ url: 'https://checkout.stripe.com/test' });
   mockStripe.billingPortal.sessions.create.mockReset().mockResolvedValue({ url: 'https://billing.stripe.com/test' });

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -507,27 +507,54 @@ paths:
   # Stubs for V1 surface implemented in later milestones
   # =====================================================================
   # ---------------------------------------------------------------------
-  # M2 — explicit tenant provisioning. M1 ships the tenant boundary in
-  # schema only; staging/production return 422 tenant_not_provisioned
-  # until these endpoints land. For local/sandbox use only,
-  # COMMERCE_ALLOW_AUTO_TENANT=true bypasses the requirement.
+  # M2 — explicit tenant provisioning (Decision C hybrid model).
   # ---------------------------------------------------------------------
   /v1/commerce/tenants:
     post:
       tags: [Tenants]
-      summary: "M2 — create a commerce tenant (operator-only)"
-      x-implemented: false
+      summary: Create a commerce tenant — admin only
+      operationId: createTenant
+      x-implemented: true
       x-milestone: M2
       responses:
-        "501": { description: Not implemented in M1 }
+        "201": { description: Tenant created }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Admin key required }
+        "422": { $ref: "#/components/responses/ValidationFailed" }
+    get:
+      tags: [Tenants]
+      summary: List tenants (admin sees all; owner sees their own)
+      operationId: listTenants
+      x-implemented: true
+      x-milestone: M2
+      responses:
+        "200": { description: Tenant list }
+  /v1/commerce/tenants/{tenant_id}:
+    parameters:
+      - { in: path, name: tenant_id, required: true, schema: { type: string } }
+    patch:
+      tags: [Tenants]
+      summary: Update mutable tenant fields (display_name, status) — admin or owner
+      operationId: updateTenant
+      x-implemented: true
+      x-milestone: M2
+      responses:
+        "200": { description: Updated }
+        "403": { description: Tenant owner role required }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "422": { $ref: "#/components/responses/ValidationFailed" }
   /v1/commerce/developer-tenants:
     post:
       tags: [Tenants]
-      summary: "M2 — bind a developer to a commerce tenant (operator-only)"
-      x-implemented: false
+      summary: Bind a developer to a commerce tenant — admin or tenant owner
+      operationId: bindDeveloperTenant
+      x-implemented: true
       x-milestone: M2
       responses:
-        "501": { description: Not implemented in M1 }
+        "201": { description: Mapping created }
+        "403": { description: Tenant owner role required }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { description: Tenant disabled }
 
   /v1/commerce/provider-credentials:
     post: { tags: [Provider Credentials], summary: M4, x-implemented: false, x-milestone: M4, responses: { "501": { description: Not implemented in M1 } } }
@@ -568,16 +595,586 @@ paths:
       - { in: path, name: cart_id, required: true, schema: { type: string } }
     get: { tags: [Cart], summary: M3, x-implemented: false, x-milestone: M3, responses: { "501": { description: Not implemented in M1 } } }
 
+  # ---------------------------------------------------------------------
+  # M2 — Commerce Passport flow
+  # ---------------------------------------------------------------------
   /v1/commerce/passports/consent-requests:
-    post: { tags: [Passports], summary: M2, x-implemented: false, x-milestone: M2, responses: { "501": { description: Not implemented in M1 } } }
+    post:
+      tags: [Passports]
+      summary: Agent creates a consent request and receives a user-facing URL
+      operationId: createConsentRequest
+      x-implemented: true
+      x-milestone: M2
+      responses:
+        "201": { description: Consent request created }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "422": { $ref: "#/components/responses/ValidationFailed" }
   /v1/commerce/passports/exchange:
-    post: { tags: [Passports], summary: M2, x-implemented: false, x-milestone: M2, responses: { "501": { description: Not implemented in M1 } } }
+    post:
+      tags: [Passports]
+      summary: Agent exchanges a granted consent for a Commerce Passport JWT
+      operationId: exchangeConsentForPassport
+      x-implemented: true
+      x-milestone: M2
+      responses:
+        "201": { description: Passport issued }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Consent denied }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { description: Consent not granted yet, missing subject, or missing presented payload hash }
+        "410": { description: Consent expired }
   /v1/commerce/passports:
-    get:  { tags: [Passports], summary: M2, x-implemented: false, x-milestone: M2, responses: { "501": { description: Not implemented in M1 } } }
+    get:
+      tags: [Passports]
+      summary: List passports (operator sees tenant; merchant sees own; agent sees own)
+      operationId: listPassports
+      x-implemented: true
+      x-milestone: M2
+      responses:
+        "200": { description: OK }
+        "401": { $ref: "#/components/responses/Unauthorized" }
   /v1/commerce/passports/verify:
-    post: { tags: [Passports], summary: M2, x-implemented: false, x-milestone: M2, responses: { "501": { description: Not implemented in M1 } } }
+    post:
+      tags: [Passports]
+      summary: Verify a Commerce Passport JWT (mode=read_only or payment_affecting)
+      operationId: verifyPassport
+      x-implemented: true
+      x-milestone: M2
+      responses:
+        "200": { description: Verified }
+        "400": { description: Passport malformed, kid invalid, alg rejected, expired, etc. }
+        "403": { description: Tenant or merchant mismatch }
+        "503": { description: Revocation infrastructure unavailable (fail closed) }
   /v1/commerce/passports/revoke:
-    post: { tags: [Passports], summary: M2, x-implemented: false, x-milestone: M2, responses: { "501": { description: Not implemented in M1 } } }
+    post:
+      tags: [Passports]
+      summary: Revoke a Commerce Passport (operator anywhere; merchant/agent only their own)
+      operationId: revokePassport
+      x-implemented: true
+      x-milestone: M2
+      responses:
+        "200": { description: Revoked }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Caller scope violation }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  # ---------------------------------------------------------------------
+  # M2 — User-facing consent SSR (publicConsent — no Bearer)
+  #
+  # Authentication model:
+  #   - Approving or denying a consent requires THREE independent things:
+  #       1. an authenticated PRINCIPAL SESSION cookie (platform-signed
+  #          RS256 JWT minted by POST /v1/principal-sessions; the agent's
+  #          developer must hold a binding to the consent's tenant);
+  #       2. a matching CSRF token derived as
+  #          sha256(session_token + ':' + reqId);
+  #       3. a verified, single-use CONSENT CHALLENGE bound to the
+  #          (consent_request_id, principal_id) pair — see the new
+  #          /challenge and /challenge/verify endpoints below.
+  #   - The challenge is the user-presence gate that closes the M2 P0:
+  #     a developer-minted principal session alone is NOT sufficient,
+  #     because the agent/developer cannot mint, read, or compute the
+  #     challenge code. M2 ships a `test_sink` delivery channel for the
+  #     test harness only (NODE_ENV='test') and reserves `email_otp` in
+  #     the enum for M3+. Production deployments of M2 cannot complete
+  #     the consent flow — /challenge fails closed with 503; operators
+  #     should not enable commerce passports in production until M3
+  #     wires real out-of-band delivery.
+  #   - The user_principal_id bound into the resulting Commerce Passport
+  #     is taken from the verified session, NEVER from agent-supplied
+  #     input. user_principal_hint on the consent (if present) is
+  #     enforced to match the verified principal for BOTH approve and
+  #     deny.
+  #   - The bootstrap pattern is to land users at the page via a one-shot
+  #     URL of the form `?req=<id>&session=<jwt>`. The server promotes
+  #     the query token to an HttpOnly cookie and 303-redirects to the
+  #     clean URL so the token never sits in browser history, server
+  #     logs, screenshots, or referrers.
+  # ---------------------------------------------------------------------
+  /v1/commerce/consent/page:
+    get:
+      tags: [Passports]
+      summary: SSR consent HTML page (host-isolated, principal-session gated)
+      description: >-
+        Renders the consent decision page. Requires Host = consent.grantex.dev
+        in production (configurable via COMMERCE_CONSENT_HOST). The page only
+        renders approve/deny FORMS when an authenticated principal session is
+        present; otherwise it renders a "sign-in required" screen.
+
+        Bootstrap flow: the agent's developer mints a principal session token
+        via POST /v1/principal-sessions, then directs the user to
+        `/v1/commerce/consent/page?req=<id>&session=<jwt>`. The server
+        verifies the session, sets the principal-session cookie, and returns
+        303 See Other to `/v1/commerce/consent/page?req=<id>` (session
+        stripped). The browser follows the redirect, the cookie is now in
+        place, and the page renders normally.
+      operationId: getConsentPage
+      x-implemented: true
+      x-milestone: M2
+      parameters:
+        - in: query
+          name: req
+          required: true
+          description: Consent request id returned from POST /v1/commerce/passports/consent-requests
+          schema: { type: string }
+        - in: query
+          name: session
+          required: false
+          description: >-
+            Bootstrap principal session JWT. If valid, the server sets the
+            principal-session cookie and immediately returns 303 See Other
+            to the same URL with the `session` parameter stripped. If
+            invalid or missing, the page renders without setting a cookie
+            (sign-in-required state).
+          schema: { type: string }
+      responses:
+        "200":
+          description: >-
+            HTML page. The principal session cookie ALONE only identifies
+            the user; it does NOT authorize a decision. Render states:
+
+            - `sign_in_required`: no valid principal-session cookie.
+
+            - `challenge_request`: principal session OK, tenant binding
+              OK, hint matches, but no challenge has been requested yet
+              for this (consent_request_id, principal_id). The page
+              shows a "Send verification code" form pointing at
+              POST /v1/commerce/consent/{reqId}/challenge.
+
+            - `challenge_verify`: a challenge exists in `requested`
+              status. The page shows a "Enter code" form pointing at
+              POST /v1/commerce/consent/{reqId}/challenge/verify.
+
+            - `present`: a challenge in `verified` status exists. ONLY
+              now does the page render the approve/deny forms (each
+              with a CSRF hidden field). Approve/deny atomically
+              consume the verified challenge — no second decision is
+              possible without a fresh challenge.
+
+            May also render `already_decided` when the consent has
+            already been granted/denied, or the closed screen when the
+            tenant is disabled.
+          headers:
+            Content-Security-Policy:
+              schema: { type: string }
+              description: Strict per-page CSP with per-request nonce; no 'unsafe-inline'.
+            X-Frame-Options:
+              schema: { type: string, enum: [DENY] }
+            Cache-Control:
+              schema: { type: string, enum: [no-store] }
+            Pragma:
+              schema: { type: string, enum: [no-cache] }
+            Referrer-Policy:
+              schema: { type: string, enum: [no-referrer] }
+        "303":
+          description: >-
+            See Other. Returned when the request carried a valid
+            `?session=<jwt>` query param. The server has set the principal
+            session cookie on this response and redirects the browser to
+            the same consent URL with the session token stripped from the
+            query string. The token must NOT remain in browser history,
+            server logs, screenshots, or referrers — see Referrer-Policy.
+          headers:
+            Location:
+              schema: { type: string }
+              description: >-
+                Clean redirect target, format `/v1/commerce/consent/page?req=<id>`.
+                The `session` query parameter is always absent.
+            Set-Cookie:
+              schema: { type: string }
+              description: >-
+                Principal session cookie. Production: `__Host-grantex_principal_session`,
+                `Secure`, `HttpOnly`, `SameSite=Strict`, `Path=/`. Non-production:
+                `grantex_principal_session` (no Secure prefix) for HTTP test setups.
+            Cache-Control:
+              schema: { type: string, enum: [no-store] }
+            Pragma:
+              schema: { type: string, enum: [no-cache] }
+            Referrer-Policy:
+              schema: { type: string, enum: [no-referrer] }
+        "400":
+          description: Missing or empty `req` query parameter.
+        "403":
+          description: >-
+            Authenticated principal's developer is not bound to the consent's
+            tenant, OR the tenant is disabled. Page renders the closed
+            screen.
+        "404":
+          description: >-
+            Wrong Host header (production must be the configured consent
+            host), or the consent request id is unknown.
+        "410":
+          description: Consent has expired (past `expires_at`).
+  /v1/commerce/consent/{reqId}:
+    parameters:
+      - in: path
+        name: reqId
+        required: true
+        schema: { type: string }
+    get:
+      tags: [Passports]
+      summary: JSON metadata for a consent request
+      description: >-
+        Returns the consent record's user-visible fields plus the canonical
+        presented_payload_hash. Public read (no Bearer) but Host-isolated
+        like the SSR page. Useful for SPAs that want to render their own
+        consent UI; the actual approve/deny endpoints still require the
+        principal session cookie + CSRF.
+      operationId: getConsentMetadata
+      x-implemented: true
+      x-milestone: M2
+      responses:
+        "200":
+          description: Consent metadata.
+          headers:
+            Content-Security-Policy:
+              schema: { type: string }
+            Cache-Control:
+              schema: { type: string, enum: [no-store] }
+            Referrer-Policy:
+              schema: { type: string, enum: [no-referrer] }
+        "404":
+          description: Wrong Host header or consent not found.
+  # ---------------------------------------------------------------------
+  # M2 — Consent challenge endpoints (P0 user-presence gate)
+  # ---------------------------------------------------------------------
+  /v1/commerce/consent/{reqId}/challenge:
+    parameters:
+      - in: path
+        name: reqId
+        required: true
+        schema: { type: string }
+    post:
+      tags: [Passports]
+      summary: Request a one-time user-presence challenge
+      description: >-
+        Issues a single-use, server-issued challenge for the
+        (consent_request_id, principal_id) pair. The challenge code is
+        delivered through a channel the agent/developer cannot read or
+        compute. Without a verified challenge, approve/deny return 403
+        `challenge_required`.
+
+        Delivery channel selection (M2 posture):
+
+        - `test_sink` is selected ONLY when `NODE_ENV === 'test'`. In
+          this mode the raw code is returned in the response body under
+          `data.test_only_code` so the vitest harness can complete
+          verify. This is a TEST-ONLY disclosure — staging, preview,
+          QA, development, and production never return the raw code.
+
+        - `email_otp` is reserved in the schema enum but is NOT
+          implemented in M2. Setting
+          `COMMERCE_CONSENT_CHALLENGE_PROVIDER=email_otp` does NOT
+          enable production delivery; M2 always fails closed for
+          non-test environments. Real out-of-band delivery (verified
+          email + Resend integration) lands in M3.
+
+        - In any non-test environment without an implemented provider
+          (every M2 deployment), this endpoint returns 503
+          `challenge_provider_unavailable`. Operators MUST treat M2
+          consent as non-functional in production until M3 wires the
+          real delivery channel.
+      operationId: createConsentChallenge
+      x-implemented: true
+      x-milestone: M2
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [csrf]
+              properties:
+                csrf: { type: string }
+      responses:
+        "201":
+          description: >-
+            Challenge created. Body shape:
+            `{ data: { challenge_id, delivery_channel, expires_at,
+            test_only_code? } }`. The `test_only_code` field is present
+            ONLY when `NODE_ENV === 'test'` AND `delivery_channel ===
+            'test_sink'`. Both gates are required and enforced in lib +
+            route. No other environment ever surfaces the raw code in a
+            response.
+        "401":
+          description: >-
+            `principal_session_required` — missing or invalid principal
+            session cookie.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: >-
+            `csrf_invalid`, `principal_not_authorized_for_tenant`,
+            `tenant_disabled`, or `principal_hint_mismatch`.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Wrong Host header or `consent_not_found`.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "409":
+          description: >-
+            `challenge_already_active` — a parallel writer just created a
+            challenge for the same (reqId, principalId) pair. Reload the
+            page to enter the existing code.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "503":
+          description: >-
+            `challenge_provider_unavailable` — no production delivery
+            provider is implemented or configured. M2 always returns
+            this in non-test environments because real out-of-band
+            delivery (verified email + Resend) is deferred to M3.
+            `COMMERCE_CONSENT_CHALLENGE_PROVIDER=email_otp` is accepted
+            in the env but does NOT enable delivery in M2 — it is
+            ignored and this 503 is still returned.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+  /v1/commerce/consent/{reqId}/challenge/verify:
+    parameters:
+      - in: path
+        name: reqId
+        required: true
+        schema: { type: string }
+    post:
+      tags: [Passports]
+      summary: Submit the challenge code; mark challenge `verified`
+      description: >-
+        Validates a candidate challenge code against the active
+        challenge for (consent_request_id, principal_id). On success the
+        challenge transitions to `verified` and the page re-renders the
+        approve/deny forms. The challenge is consumed atomically by the
+        approve/deny POST — a verified challenge cannot be replayed
+        across consents or principals. Wrong codes increment an attempt
+        counter; the challenge transitions to `expired` after
+        `max_attempts` reached (default 5).
+      operationId: verifyConsentChallenge
+      x-implemented: true
+      x-milestone: M2
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [csrf, code]
+              properties:
+                csrf: { type: string }
+                code:
+                  type: string
+                  description: 4-10 digit numeric code.
+      responses:
+        "200":
+          description: >-
+            Verified. Body: `{ data: { challenge_id, status: 'verified' } }`.
+        "401":
+          description: `principal_session_required`.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: >-
+            `csrf_invalid`, `principal_not_authorized_for_tenant`,
+            `tenant_disabled`, `principal_hint_mismatch`, or
+            `challenge_invalid` (wrong code; response includes
+            `details.remaining_attempts`).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: >-
+            `consent_not_found` (wrong host or unknown reqId), or
+            `challenge_not_found` (no active challenge for this pair).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "410":
+          description: >-
+            `challenge_expired` — past `expires_at`, or `max_attempts`
+            reached.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "422":
+          description: `validation_failed` — code missing or non-numeric.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+  /v1/commerce/consent/{reqId}/approve:
+    parameters:
+      - in: path
+        name: reqId
+        required: true
+        schema: { type: string }
+    post:
+      tags: [Passports]
+      summary: Approve a consent (principal session + CSRF + verified challenge, single-use)
+      description: >-
+        Approves a consent request. ALL THREE are required: (a)
+        authenticated principal session cookie, (b) CSRF token in the
+        form body, (c) a verified, single-use consent challenge for
+        this (consent_request_id, principal_id). The verified challenge
+        is consumed atomically with the consent state transition.
+
+        The user_principal_id bound into the eventual Commerce Passport
+        is taken from the AUTHENTICATED PRINCIPAL SESSION COOKIE — never
+        from agent-supplied input or form fields. The optional
+        user_principal_hint on the consent record is enforced to match
+        the authenticated principal. Single-use: a successful approve
+        transitions status to `granted`; subsequent calls return 409
+        `consent_already_decided`.
+      operationId: approveConsent
+      x-implemented: true
+      x-milestone: M2
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [csrf]
+              properties:
+                csrf:
+                  type: string
+                  description: >-
+                    Per-request CSRF token, derived as
+                    `sha256(principal_session_token + ':' + reqId)`. The page
+                    renders this in a hidden form field; the server compares
+                    it timing-safely to the value recomputed from the cookie.
+      responses:
+        "200":
+          description: Approved. Returns a small HTML success page.
+          headers:
+            Content-Security-Policy:
+              schema: { type: string }
+            Cache-Control:
+              schema: { type: string, enum: [no-store] }
+            Referrer-Policy:
+              schema: { type: string, enum: [no-referrer] }
+        "401":
+          description: >-
+            `principal_session_required`. The principal session cookie is
+            missing or fails JWT verification.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: >-
+            One of:
+            `csrf_invalid` (form CSRF does not match cookie-derived value);
+            `principal_not_authorized_for_tenant` (authenticated principal's
+            developer is not bound to the consent's commerce tenant);
+            `tenant_disabled` (developer is bound but the tenant is
+            disabled);
+            `principal_hint_mismatch` (consent has user_principal_hint set
+            and it does not match the authenticated principal);
+            `challenge_required` (no verified consent challenge exists
+            for this (consent_request_id, principal_id) — the agent's
+            session/CSRF alone is not sufficient).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: >-
+            Wrong Host header, or the consent request id is unknown
+            (`consent_not_found`).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "409":
+          description: >-
+            `consent_already_decided` — the consent was previously approved
+            or denied; single-use enforced.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "410":
+          description: >-
+            `consent_expired` — the consent passed its expires_at before
+            the user acted.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+  /v1/commerce/consent/{reqId}/deny:
+    parameters:
+      - in: path
+        name: reqId
+        required: true
+        schema: { type: string }
+    post:
+      tags: [Passports]
+      summary: Deny a consent (principal session + CSRF + verified challenge, single-use)
+      description: >-
+        Denies a consent request. Same auth model and request body as
+        approve — requires the principal session cookie, a matching
+        CSRF token, AND a verified consent challenge. The denied state
+        is recorded under the authenticated principal so the audit
+        trail is complete. No passport will be issued for a denied
+        consent. user_principal_hint enforcement now applies to deny
+        too: a different authenticated principal cannot burn a
+        single-use consent intended for someone else.
+      operationId: denyConsent
+      x-implemented: true
+      x-milestone: M2
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [csrf]
+              properties:
+                csrf:
+                  type: string
+                  description: Same derivation as approve — sha256(session_token + ':' + reqId).
+      responses:
+        "200":
+          description: Denied. Returns a small HTML confirmation page.
+          headers:
+            Content-Security-Policy:
+              schema: { type: string }
+            Cache-Control:
+              schema: { type: string, enum: [no-store] }
+            Referrer-Policy:
+              schema: { type: string, enum: [no-referrer] }
+        "401":
+          description: >-
+            `principal_session_required` — missing or invalid principal
+            session cookie.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: >-
+            `csrf_invalid`, `principal_not_authorized_for_tenant`,
+            `tenant_disabled`, `principal_hint_mismatch`, or
+            `challenge_required`. The hint enforcement closes the P2:
+            without it, any same-tenant principal could burn the
+            single-use consent intended for someone else.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Wrong Host header, or `consent_not_found`.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "409":
+          description: `consent_already_decided`.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "410":
+          description: `consent_expired`.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /v1/commerce/payments/intents:
     post: { tags: [Payments], summary: M4, x-implemented: false, x-milestone: M4, responses: { "501": { description: Not implemented in M1 } } }


### PR DESCRIPTION
## Summary

- Adds M2 Commerce Passport foundations: tenant operator provisioning, merchant API keys, ES256 passport keys, consent records, passports, revocations, and consent challenges.
- Adds commerce caller separation for operator / merchant / agent credentials.
- Adds Commerce Passport signing and verification with ES256 kid namespace pinning, max lifetime enforcement, retired-key checks, and online revocation fail-closed for payment-affecting verification.
- Adds SSR consent flow with strict CSP, host isolation, CSRF, session URL stripping via 303, tenant-active checks, and single-use consent challenge requirement.
- Adds tenant provisioning, passport, consent, and challenge routes.
- Extends JWKS with commerce ES256 keys.
- Updates OpenAPI 3.1 contract.
- Adds 241 commerce tests covering M2.

## Critical caveat — DO NOT enable in production until M3

**M2 consent is intentionally fail-closed outside `NODE_ENV === 'test'`.**

- `POST /v1/commerce/consent/{reqId}/challenge` returns `503 challenge_provider_unavailable` in development / staging / preview / production because real OTP / email delivery is deferred to M3.
- `COMMERCE_CONSENT_CHALLENGE_PROVIDER=email_otp` is reserved in the schema enum and OpenAPI but **ignored in M2**. Setting it does NOT enable production delivery.
- Operators **must NOT** enable commerce consent / passport approval in production until M3 wires real verified-email OTP delivery.
- The OpenAPI contract documents this fail-closed posture explicitly in the challenge endpoint description, the 503 description, and the section header. The OpenAPI contract test enforces this textually so the doc cannot drift back.

## Security notes

- **Raw `test_only_code`** is returned ONLY when `NODE_ENV === 'test'` AND `delivery_channel === 'test_sink'`. Both gates are enforced in lib + route. Staging, preview, QA, development, and production never see this field.
- **Agent / developer self-approval is blocked.** Principal session + CSRF alone returns `403 challenge_required`. The agent / developer cannot mint, read, or compute the consent challenge code.
- **Approve / deny require all of:** principal session cookie, CSRF (HMAC-derived from session + reqId), tenant binding, active tenant, principal hint match, and a verified single-use challenge.
- **Passport exchange is single-use** via `UNIQUE(consent_record_id)` on `commerce_passports` (DB-enforced) plus a route-level pre-check; concurrent exchange races translate to `409 consent_already_exchanged`.
- **Presented payload hash is recomputed** at exchange time and timing-safe compared to the value captured at first GET.
- **Disabled tenants are blocked** across operator, merchant, agent, consent, and exchange paths via composite JOINs on `commerce_tenants`.
- **Product GET no longer leaks existence** to agents (403 before any SQL) or to cross-merchant callers (query bound to `(tenant_id, merchant_id)` so cross-merchant reads return 404, not 403).

## Verification (results from this push run)

| Command | Result |
|---|---|
| ` npm run typecheck` | clean |
| `npx vitest run tests/commerce-consent-challenge.test.ts tests/commerce-consent-flow.test.ts tests/commerce-openapi.test.ts --reporter=dot` | **3 files / 83 tests pass** |
| `npx vitest run tests/commerce --reporter=dot` | **19 files / 241 tests pass** |
| `npm run build` | clean |
| `npm test -- --run` | 94 / 95 files pass on first run; the known rotating 5s dynamic-import flake hit `tests/domains.test.ts > Dynamic rate limiting > getRateLimitForPlan returns correct values` |
| `npx vitest run tests/domains.test.ts` (isolated re-run) | **13 / 13 pass in 3.75s** — confirms unrelated flake |
| Real Postgres 16.13 (prior round) | all 42 migrations apply clean; idempotent re-apply; cross-tenant inserts rejected; partial uniques enforced; append-only triggers fire |

## Human review focus

1. **Migrations 037–042** — composite FKs, append-only `commerce_passports` (BEFORE UPDATE/DELETE trigger), `commerce_consent_challenges` partial-unique active index, idempotent re-apply.
2. **JWT / JWKS / passport verification** — ES256 pinning, kid-namespace prefix check, retired-key behavior (iat-after AND exp-window), max-lifetime caps (browse 3600s, checkout 600s).
3. **Consent security** — 303 session stripping, strict CSP + per-request nonce, `Referrer-Policy: no-referrer` (route-level override), CSRF model, principal session, `challenge_required` gate, tenant + hint checks.
4. **Caller separation** — \`authPlugin\` bypass for commerce routes via per-route \`skipAuth\`; operator / merchant / agent access matrix in \`commerce.ts\`; \`requireOperatorOrSelfMerchant\` / \`requireOperatorOrSelfAgent\` helpers.
5. **M2 fail-closed caveat** for consent challenge delivery outside tests (see "Critical caveat" above). Confirm operators receive clear deployment guidance.
6. **OpenAPI contract accuracy** — the new contract drift test (\`tests/commerce-openapi.test.ts\`) locks the consent / challenge surface against regression.

## Out of scope (M3+)

- Policy engine.
- Real OTP / email delivery for consent challenge (M3).
- Payments / Plural adapter (M4).
- MCP / well-known agent publishing (M5).
- AgenticOrg repo changes.

## Commits

- 553af84 feat(commerce): add M2 passport and consent schema
- 3327986 feat(commerce): add M2 passport auth, keys, revocation, and challenge core
- 81485c0 feat(commerce): add M2 passport, tenant, and consent routes
- 319bfd4 test(commerce): cover M2 passport consent and tenant flows