### PR TITLE
fix(commerce): harden M2 agent assertion validation

### DIFF
--- a/apps/auth-service/src/lib/commerce/agent-auth.ts
+++ b/apps/auth-service/src/lib/commerce/agent-auth.ts
@@ -49,6 +49,7 @@ export type AgentResolutionFailure =
   | { kind: 'assertion_too_long_lived'; lifetimeSeconds: number }
   | { kind: 'assertion_wrong_audience'; aud: unknown }
   | { kind: 'assertion_missing_claims'; fields: string[] }
+  | { kind: 'assertion_temporal_claim_invalid'; reason: string }
   | { kind: 'assertion_replay' }
   | { kind: 'replay_check_unavailable'; error: string };
 
@@ -230,7 +231,23 @@ export async function verifyAgentAssertion(
   if (String(payload['tenant_id']) !== agent.tenant_id) {
     return { ok: false, failure: { kind: 'assertion_signature_invalid', reason: 'tenant_id mismatch with registered agent' } };
   }
-  const lifetime = (payload.exp as number) - (payload.iat as number);
+  // Validate temporal claim TYPES before doing arithmetic. Required-claim
+  // check above only confirms presence, but jose's decoded payload exposes
+  // these as `unknown`. Non-numeric values (e.g. iat/exp passed as JSON
+  // strings) would coerce to NaN below, and `NaN > MAX` is false — silently
+  // bypassing the lifetime cap.
+  const iatRaw = payload.iat;
+  const expRaw = payload.exp;
+  if (typeof iatRaw !== 'number' || !Number.isFinite(iatRaw)) {
+    return { ok: false, failure: { kind: 'assertion_temporal_claim_invalid', reason: 'iat must be a finite number' } };
+  }
+  if (typeof expRaw !== 'number' || !Number.isFinite(expRaw)) {
+    return { ok: false, failure: { kind: 'assertion_temporal_claim_invalid', reason: 'exp must be a finite number' } };
+  }
+  if (expRaw <= iatRaw) {
+    return { ok: false, failure: { kind: 'assertion_temporal_claim_invalid', reason: 'exp must be greater than iat' } };
+  }
+  const lifetime = expRaw - iatRaw;
   if (lifetime > ASSERTION_MAX_LIFETIME_SECONDS) {
     return { ok: false, failure: { kind: 'assertion_too_long_lived', lifetimeSeconds: lifetime } };
   }
@@ -239,9 +256,14 @@ export async function verifyAgentAssertion(
 
   // Replay protection. Use Redis SET key with NX + EX so first writer
   // wins. If Redis unavailable, fail closed (caller surfaces 503).
+  //
+  // Key is scoped by the VERIFIED agent's tenant_id + id (from the DB
+  // row, not from JWT claims) so two different agents that happen to
+  // pick the same jti value cannot collide, and a malicious agent
+  // cannot pre-empt jti values that another agent might use.
   if (redis) {
     try {
-      const setKey = `${REDIS_REPLAY_KEY_PREFIX}${jti}`;
+      const setKey = `${REDIS_REPLAY_KEY_PREFIX}${agent.tenant_id}:${agent.id}:${jti}`;
       const ttl = Math.max(1, ASSERTION_MAX_LIFETIME_SECONDS);
       // ioredis SET with options: ['EX', ttl, 'NX']
       const result = await redis.set(setKey, '1', 'EX', ttl, 'NX');

--- a/apps/auth-service/tests/commerce-caller-resolver.test.ts
+++ b/apps/auth-service/tests/commerce-caller-resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
 import type { FastifyInstance } from 'fastify';
-import { generateKeyPair, exportJWK, SignJWT, type KeyLike, type JWK } from 'jose';
+import { generateKeyPair, exportJWK, SignJWT, type KeyLike, type JWK, type JWTPayload } from 'jose';
 import { authHeader, sqlMock, mockRedis, TEST_DEVELOPER, buildTestApp } from './helpers.js';
 import { TEST_COMMERCE_TENANT_ID } from './commerce-helpers.js';
 
@@ -262,5 +262,194 @@ describe('Commerce caller resolver — agent JWT assertion', () => {
     });
     expect(res.statusCode).toBe(403);
     expect(res.json<{ error: { code: string } }>().error.code).toBe('agent_not_trusted');
+  });
+});
+
+// ----------------------------------------------------------------------
+// Codex P1 — Validate numeric JWT temporal claims before lifetime check.
+// Codex P2 — Scope replay cache key by tenant + agent identity so two
+// different agents cannot collide on a shared jti.
+// ----------------------------------------------------------------------
+describe('Commerce caller resolver — agent JWT temporal claims and replay scoping', () => {
+  let agentKp: { privateKey: KeyLike; publicKey: KeyLike };
+  let agentJwk: JWK;
+  beforeAll(async () => {
+    agentKp = await generateKeyPair('ES256');
+    agentJwk = await exportJWK(agentKp.publicKey) as JWK;
+  });
+
+  // Build a signed JWT from a raw payload object — bypasses SignJWT's
+  // typed setters so we can produce assertions with non-numeric or
+  // missing temporal claims that a syntactically-valid JWS could carry.
+  async function makeRawJwt(payload: Record<string, unknown>): Promise<string> {
+    return new SignJWT(payload as JWTPayload)
+      .setProtectedHeader({ alg: 'ES256' })
+      .sign(agentKp.privateKey);
+  }
+
+  function trustedAgentRow(agentId = 'cag_AGENT', tenantId = 'cten_TEST') {
+    return {
+      id: agentId, tenant_id: tenantId, trust_status: 'trusted',
+      public_key_jwk: agentJwk, api_key_hash: null,
+    };
+  }
+
+  it('iat as string (non-numeric) → 401 invalid_agent_credential', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const jwt = await makeRawJwt({
+      iss: 'cag_AGENT', sub: 'cag_AGENT', aud: 'grantex-commerce',
+      tenant_id: 'cten_TEST', jti: `jti_iat_str_${now}`,
+      iat: 'not-a-number', exp: now + 60,
+    });
+    sqlMock.mockResolvedValueOnce([trustedAgentRow()]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('invalid_agent_credential');
+    // Replay cache must NOT have been touched — we rejected before that point.
+    expect(mockRedis.set).not.toHaveBeenCalled();
+  });
+
+  it('exp as string (non-numeric) → 401 invalid_agent_credential', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const jwt = await makeRawJwt({
+      iss: 'cag_AGENT', sub: 'cag_AGENT', aud: 'grantex-commerce',
+      tenant_id: 'cten_TEST', jti: `jti_exp_str_${now}`,
+      iat: now, exp: 'not-a-number',
+    });
+    sqlMock.mockResolvedValueOnce([trustedAgentRow()]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('invalid_agent_credential');
+    expect(mockRedis.set).not.toHaveBeenCalled();
+  });
+
+  it('missing iat → 401 invalid_agent_credential', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const jwt = await makeRawJwt({
+      iss: 'cag_AGENT', sub: 'cag_AGENT', aud: 'grantex-commerce',
+      tenant_id: 'cten_TEST', jti: `jti_no_iat_${now}`,
+      exp: now + 60,
+    });
+    sqlMock.mockResolvedValueOnce([trustedAgentRow()]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('invalid_agent_credential');
+    expect(mockRedis.set).not.toHaveBeenCalled();
+  });
+
+  it('missing exp → 401 invalid_agent_credential', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const jwt = await makeRawJwt({
+      iss: 'cag_AGENT', sub: 'cag_AGENT', aud: 'grantex-commerce',
+      tenant_id: 'cten_TEST', jti: `jti_no_exp_${now}`,
+      iat: now,
+    });
+    sqlMock.mockResolvedValueOnce([trustedAgentRow()]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('invalid_agent_credential');
+    expect(mockRedis.set).not.toHaveBeenCalled();
+  });
+
+  it('exp <= iat (zero or negative lifetime) → 401 invalid_agent_credential', async () => {
+    // exp == iat — both in the future to satisfy jose's expiry check
+    // (so the temporal-validity guard, not jose, is what rejects).
+    const future = Math.floor(Date.now() / 1000) + 120;
+    const jwt = await makeRawJwt({
+      iss: 'cag_AGENT', sub: 'cag_AGENT', aud: 'grantex-commerce',
+      tenant_id: 'cten_TEST', jti: `jti_eq_${future}`,
+      iat: future, exp: future,
+    });
+    sqlMock.mockResolvedValueOnce([trustedAgentRow()]);
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('invalid_agent_credential');
+    expect(mockRedis.set).not.toHaveBeenCalled();
+  });
+
+  it('two different agents reusing the same jti both succeed; replay keys differ and include agent identity', async () => {
+    const sharedJti = `jti_shared_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    const now = Math.floor(Date.now() / 1000);
+
+    // Agent A in tenant T1
+    const jwtA = await makeRawJwt({
+      iss: 'cag_A', sub: 'cag_A', aud: 'grantex-commerce',
+      tenant_id: 'cten_T1', jti: sharedJti,
+      iat: now, exp: now + 60,
+    });
+    sqlMock.mockResolvedValueOnce([trustedAgentRow('cag_A', 'cten_T1')]);
+    sqlMock.mockResolvedValueOnce([]);  // GET own agent → 404 (no row)
+    mockRedis.set.mockResolvedValueOnce('OK');
+    const resA = await app.inject({
+      method: 'GET', url: '/v1/commerce/agents/cag_A',
+      headers: { authorization: `Bearer ${jwtA}` },
+    });
+    expect(resA.statusCode).toBe(404);
+    expect(resA.json<{ error: { code: string } }>().error.code).toBe('agent_not_found');
+
+    // Agent B in tenant T2 — same JTI
+    const jwtB = await makeRawJwt({
+      iss: 'cag_B', sub: 'cag_B', aud: 'grantex-commerce',
+      tenant_id: 'cten_T2', jti: sharedJti,
+      iat: now, exp: now + 60,
+    });
+    sqlMock.mockResolvedValueOnce([trustedAgentRow('cag_B', 'cten_T2')]);
+    sqlMock.mockResolvedValueOnce([]);  // GET own agent → 404
+    mockRedis.set.mockResolvedValueOnce('OK');
+    const resB = await app.inject({
+      method: 'GET', url: '/v1/commerce/agents/cag_B',
+      headers: { authorization: `Bearer ${jwtB}` },
+    });
+    expect(resB.statusCode).toBe(404);
+    expect(resB.json<{ error: { code: string } }>().error.code).toBe('agent_not_found');
+
+    // Verify Redis SET keys included both tenant + agent identity and
+    // differ between the two callers despite the shared jti.
+    expect(mockRedis.set).toHaveBeenCalledTimes(2);
+    const keyA = mockRedis.set.mock.calls[0]?.[0] as string;
+    const keyB = mockRedis.set.mock.calls[1]?.[0] as string;
+    expect(keyA).toContain('cten_T1');
+    expect(keyA).toContain('cag_A');
+    expect(keyA).toContain(sharedJti);
+    expect(keyB).toContain('cten_T2');
+    expect(keyB).toContain('cag_B');
+    expect(keyB).toContain(sharedJti);
+    expect(keyA).not.toBe(keyB);
+  });
+
+  it('same agent reusing jti → 401 agent_assertion_replay (existing behavior preserved); key carries agent identity', async () => {
+    const jti = `jti_replay_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    const now = Math.floor(Date.now() / 1000);
+    const jwt = await makeRawJwt({
+      iss: 'cag_AGENT', sub: 'cag_AGENT', aud: 'grantex-commerce',
+      tenant_id: 'cten_TEST', jti, iat: now, exp: now + 60,
+    });
+    sqlMock.mockResolvedValueOnce([trustedAgentRow()]);
+    mockRedis.set.mockResolvedValueOnce(null);  // jti already seen by THIS agent
+    const res = await app.inject({
+      method: 'GET', url: '/v1/commerce/merchants/mch_X',
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('agent_assertion_replay');
+    const setKey = mockRedis.set.mock.calls[0]?.[0] as string;
+    expect(setKey).toContain('cten_TEST');
+    expect(setKey).toContain('cag_AGENT');
+    expect(setKey).toContain(jti);
   });
 });


### PR DESCRIPTION
## Summary

Post-merge hotfix addressing the two Codex review findings on PR #315 (Grantex Commerce V1 Milestone 2). Both findings are real and land in `apps/auth-service/src/lib/commerce/agent-auth.ts`.

This is an **M2 hotfix**, not M3 work.

### P1 — Validate numeric JWT temporal claims before lifetime check

`verifyAgentAssertion` previously checked that `iat` and `exp` were *present* but did not validate their *type*. The lifetime computation `(payload.exp as number) - (payload.iat as number)` would silently produce `NaN` if either claim was a non-numeric string (e.g. `"123"` instead of `123`). Because `NaN > ASSERTION_MAX_LIFETIME_SECONDS` is `false`, the 5-minute lifetime cap could be bypassed without any error surfacing. A trusted agent could submit assertions with arbitrarily long `exp` values.

Fix: a new failure kind `assertion_temporal_claim_invalid` is added to `AgentResolutionFailure`, and `verifyAgentAssertion` now requires both `iat` and `exp` to satisfy `typeof === 'number'` AND `Number.isFinite(...)`, plus `exp > iat`. The route maps any unrecognized failure kind to `401 invalid_agent_credential` (existing fallthrough in `caller.ts:190`), so no consumer-side change is needed and the user-facing response is unchanged.

### P2 — Scope replay cache keys by agent identity

The Redis JTI replay key was `commerce:agent_assertion:jti:<jti>` — a global namespace keyed only by the JWT's `jti`. Two agents (or two tenants) that picked the same JTI value would collide: the second valid assertion would be rejected as a replay, and a malicious agent could intentionally pre-empt commonly-chosen JTI values to deny service to other agents.

Fix: the replay key now embeds the **verified** `tenant_id` and `agent.id` from the database row (not from JWT claims): `commerce:agent_assertion:jti:<tenant_id>:<agent_id>:<jti>`. Same-agent same-JTI replay protection is preserved. Different agents can now use overlapping JTI values without collision. TTL behavior is unchanged.

### Migration

**No migration required.** Redis keys are ephemeral and the existing TTL (`ASSERTION_MAX_LIFETIME_SECONDS = 300s`) ages out the old single-segment keys naturally. Any in-flight assertions racing the deploy will at worst experience a one-window window where their JTI is allowed twice (old key + new key); not a security regression because they're still single-use within their own scope, and the lifetime cap fix above is the more material change.

## Tests

Added 7 tests to `apps/auth-service/tests/commerce-caller-resolver.test.ts` in a new `describe('agent JWT temporal claims and replay scoping', …)` block:

P1 (5 tests, all → `401 invalid_agent_credential`, replay cache untouched):
- `iat` as string (non-numeric)
- `exp` as string (non-numeric)
- missing `iat`
- missing `exp`
- `exp <= iat` (zero or negative lifetime, both timestamps in the future to bypass jose's expiry check so our guard, not jose, is what rejects)

P2 (2 tests):
- Two different agents reusing the same `jti` both succeed; Redis SET keys differ and each contains both the tenant id and agent id
- Same agent reusing `jti` → `401 agent_assertion_replay` (existing replay behavior preserved); the recorded key contains the tenant + agent identity

Tests use `SignJWT` with a raw payload object so we can construct syntactically-valid signed JWTs that carry non-numeric or missing temporal claims (the typed setters would refuse).

## Verification

From `apps/auth-service`:

| Command | Result |
|---|---|
| `npm run typecheck` | clean |
| `npx vitest run tests/commerce-caller-resolver.test.ts --reporter=dot` | **23 / 23 pass** in 5.76s |
| `npx vitest run tests/commerce --reporter=dot` | **19 files / 248 tests pass** in 28.88s (was 241; +7) |
| `npm run build` | clean |
| `npm test -- --run` | 94 / 95 files pass; 1 file failed: known rotating 5s dynamic-import flake on `tests/crypto.test.ts` (cold-cache contention in full suite) |
| `npx vitest run tests/crypto.test.ts --reporter=dot` (isolated rerun) | **27 / 27 pass** in 2.85s — confirms the unrelated flake |

## Confirmations

- **No migration needed** (Redis-only state change, ephemeral, TTL ages out old keys).
- **`skills/expert-code-review/SKILL.md` was untouched** — never staged, committed, pushed, or referenced this session.
- **No unrelated files modified.** Staged exactly two files by explicit path: `agent-auth.ts` and `commerce-caller-resolver.test.ts`.
- **No M3 work.** No consent challenge changes, no real OTP/email delivery, no policy engine.

## Out of scope

- M2 consent approvals remain fail-closed outside `NODE_ENV === 'test'`. Real OTP/email delivery is still deferred to M3.