### PR TITLE
fix(security): pin outbound DNS resolutions

### DIFF
--- a/apps/auth-service/src/lib/ldap.ts
+++ b/apps/auth-service/src/lib/ldap.ts
@@ -12,7 +12,7 @@
  */
 
 import { config as appConfig } from '../config.js';
-import { validateOutboundUrl } from './url-security.js';
+import { safeConnect, validateOutboundUrl } from './url-security.js';
 
 export interface LdapConfig {
   ldapUrl: string;
@@ -109,10 +109,6 @@ export function getLdapClient(): LdapClient {
 function createDefaultLdapClient(): LdapClient {
   return {
     async authenticate(config, username, password): Promise<LdapUserInfo> {
-      // Dynamic import to avoid loading net/tls in test environments
-      const net = await import('node:net');
-      const tls = await import('node:tls');
-
       const url = validateOutboundUrl(config.ldapUrl, {
         allowedProtocols: ['ldap:', 'ldaps:'],
         allowPrivateHosts: appConfig.allowPrivateSsoHosts,
@@ -121,18 +117,20 @@ function createDefaultLdapClient(): LdapClient {
       if (url.protocol === 'ldap:' && !config.tlsEnabled && !appConfig.allowInsecureSsoUrls) {
         throw new Error('Insecure LDAP URLs are disabled; use LDAPS or enable SSO_ALLOW_INSECURE_URLS');
       }
-      const host = url.hostname;
       const port = parseInt(url.port || (config.tlsEnabled ? '636' : '389'), 10);
 
       // Helper: create a connected socket
       const connect = (): Promise<import('node:net').Socket> =>
-        new Promise((resolve, reject) => {
-          const socket = config.tlsEnabled
-            ? tls.connect({ host, port, servername: host, rejectUnauthorized: appConfig.ldapTlsRejectUnauthorized }, () => resolve(socket as unknown as import('node:net').Socket))
-            : net.createConnection({ host, port }, () => resolve(socket));
-          socket.on('error', reject);
-          socket.setTimeout(10_000);
-          socket.on('timeout', () => { socket.destroy(); reject(new Error('LDAP connection timeout')); });
+        safeConnect(config.ldapUrl, {
+          port,
+          tls: config.tlsEnabled,
+          rejectUnauthorized: appConfig.ldapTlsRejectUnauthorized,
+          timeoutMs: 10_000,
+          policy: {
+            allowedProtocols: ['ldap:', 'ldaps:'],
+            allowPrivateHosts: appConfig.allowPrivateSsoHosts,
+            allowInsecureHttp: true,
+          },
         });
 
       // Helper: send LDAP bind request (simplified BER encoding)
@@ -201,9 +199,6 @@ function createDefaultLdapClient(): LdapClient {
     },
 
     async testConnection(config): Promise<{ success: boolean; error?: string }> {
-      const net = await import('node:net');
-      const tls = await import('node:tls');
-
       try {
         const url = validateOutboundUrl(config.ldapUrl, {
           allowedProtocols: ['ldap:', 'ldaps:'],
@@ -213,17 +208,20 @@ function createDefaultLdapClient(): LdapClient {
         if (url.protocol === 'ldap:' && !config.tlsEnabled && !appConfig.allowInsecureSsoUrls) {
           throw new Error('Insecure LDAP URLs are disabled; use LDAPS or enable SSO_ALLOW_INSECURE_URLS');
         }
-        const host = url.hostname;
         const port = parseInt(url.port || (config.tlsEnabled ? '636' : '389'), 10);
 
-        await new Promise<void>((resolve, reject) => {
-          const socket = config.tlsEnabled
-            ? tls.connect({ host, port, servername: host, rejectUnauthorized: appConfig.ldapTlsRejectUnauthorized }, () => { socket.destroy(); resolve(); })
-            : net.createConnection({ host, port }, () => { socket.destroy(); resolve(); });
-          socket.on('error', reject);
-          socket.setTimeout(5_000);
-          socket.on('timeout', () => { socket.destroy(); reject(new Error('Connection timeout')); });
+        const socket = await safeConnect(config.ldapUrl, {
+          port,
+          tls: config.tlsEnabled,
+          rejectUnauthorized: appConfig.ldapTlsRejectUnauthorized,
+          timeoutMs: 5_000,
+          policy: {
+            allowedProtocols: ['ldap:', 'ldaps:'],
+            allowPrivateHosts: appConfig.allowPrivateSsoHosts,
+            allowInsecureHttp: true,
+          },
         });
+        socket.destroy();
 
         return { success: true };
       } catch (err) {

--- a/apps/auth-service/src/lib/sso.ts
+++ b/apps/auth-service/src/lib/sso.ts
@@ -9,7 +9,7 @@ import crypto from 'node:crypto';
 import { getSql } from '../db/client.js';
 import { newSsoSessionId, newScimUserId } from './ids.js';
 import { config } from '../config.js';
-import { validateOutboundUrl } from './url-security.js';
+import { safeFetch, validateOutboundUrl } from './url-security.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -103,7 +103,11 @@ export async function discoverOidcProvider(issuerUrl: string): Promise<OidcDisco
     allowPrivateHosts: config.allowPrivateSsoHosts,
   });
   const url = `${issuer.toString().replace(/\/$/, '')}/.well-known/openid-configuration`;
-  const res = await fetch(url);
+  const res = await safeFetch(url, {}, {
+    allowedProtocols: ['https:', 'http:'],
+    allowInsecureHttp: config.allowInsecureSsoUrls,
+    allowPrivateHosts: config.allowPrivateSsoHosts,
+  });
   if (!res.ok) {
     throw new Error(`OIDC discovery failed for ${issuerUrl}: ${res.status}`);
   }
@@ -139,12 +143,11 @@ export async function verifyIdToken(
   // Fetch or use cached JWKS
   let jwks = jwksCache.get(jwksUri);
   if (!jwks || Date.now() - jwks.fetchedAt > JWKS_TTL_MS) {
-    validateOutboundUrl(jwksUri, {
+    const res = await safeFetch(jwksUri, {}, {
       allowedProtocols: ['https:', 'http:'],
       allowInsecureHttp: config.allowInsecureSsoUrls,
       allowPrivateHosts: config.allowPrivateSsoHosts,
     });
-    const res = await fetch(jwksUri);
     if (!res.ok) {
       throw new Error(`Failed to fetch JWKS from ${jwksUri}: ${res.status}`);
     }

--- a/apps/auth-service/src/lib/url-security.ts
+++ b/apps/auth-service/src/lib/url-security.ts
@@ -1,4 +1,8 @@
+import dns from 'node:dns/promises';
+import http from 'node:http';
+import https from 'node:https';
 import net from 'node:net';
+import tls from 'node:tls';
 
 export interface OutboundUrlPolicy {
   allowedProtocols: readonly string[];
@@ -6,11 +10,50 @@ export interface OutboundUrlPolicy {
   allowPrivateHosts?: boolean;
 }
 
+export interface ResolvedOutboundAddress {
+  address: string;
+  family: 4 | 6;
+}
+
+export type OutboundDnsResolver = (hostname: string) => Promise<ResolvedOutboundAddress[]>;
+
+export interface PinnedOutboundTarget {
+  url: URL;
+  address: string;
+  family: 4 | 6;
+}
+
+export interface SafeConnectOptions {
+  policy: OutboundUrlPolicy;
+  port?: number;
+  tls?: boolean;
+  timeoutMs?: number;
+  rejectUnauthorized?: boolean;
+  resolver?: OutboundDnsResolver;
+}
+
+type SafeFetchOverride = (
+  value: string,
+  init: RequestInit,
+  policy: OutboundUrlPolicy,
+  resolver?: OutboundDnsResolver,
+) => Promise<Response>;
+
 const LOCAL_HOSTNAMES = new Set([
   'localhost',
   'localhost.localdomain',
   '0.0.0.0',
 ]);
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+let safeFetchOverride: SafeFetchOverride | null = null;
+
+export function setSafeFetchForTests(override: SafeFetchOverride | null): void {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('safeFetch test override is only available in test');
+  }
+  safeFetchOverride = override;
+}
 
 function parseIpv4(hostname: string): number[] | null {
   const parts = hostname.split('.');
@@ -82,17 +125,6 @@ export function isBlockedPrivateHost(hostname: string): boolean {
 
 /**
  * Validate an outbound URL string against the supplied policy.
- *
- * Known limitation: this validator inspects the URL string only. It does
- * not resolve DNS, so an attacker-controlled hostname like
- * `attacker.example` whose A record points to 127.0.0.1 / RFC1918 space
- * will pass even when `allowPrivateHosts` is false. Full SSRF defense
- * requires resolving the hostname once and pinning the connection to the
- * resolved IP, which is tracked in #313 (DNS-pinned outbound fetch).
- *
- * Until that lands, this function is still a meaningful defense-in-depth
- * layer: it blocks literal private IPs, localhost variants, IPv6
- * link-local (fe80::/10), embedded credentials, and disallowed protocols.
  */
 export function validateOutboundUrl(value: string, policy: OutboundUrlPolicy): URL {
   if (typeof value !== 'string' || value.length === 0 || value.length > 2048) {
@@ -130,6 +162,177 @@ export function validateOutboundUrl(value: string, policy: OutboundUrlPolicy): U
   }
 
   return parsed;
+}
+
+async function defaultResolver(hostname: string): Promise<ResolvedOutboundAddress[]> {
+  const results = await dns.lookup(hostname, { all: true, verbatim: true });
+  return results
+    .filter((entry): entry is ResolvedOutboundAddress => entry.family === 4 || entry.family === 6)
+    .map((entry) => ({ address: entry.address, family: entry.family }));
+}
+
+export async function resolvePinnedOutboundTarget(
+  value: string,
+  policy: OutboundUrlPolicy,
+  resolver: OutboundDnsResolver = defaultResolver,
+): Promise<PinnedOutboundTarget> {
+  const url = validateOutboundUrl(value, policy);
+  const addresses = await resolver(url.hostname);
+  if (addresses.length === 0) {
+    throw new Error('URL hostname could not be resolved');
+  }
+
+  if (!policy.allowPrivateHosts) {
+    const blocked = addresses.find((entry) => isBlockedPrivateHost(entry.address));
+    if (blocked) {
+      throw new Error('Resolved private, loopback, and link-local addresses are not allowed');
+    }
+  }
+
+  const first = addresses[0]!;
+  return { url, address: first.address, family: first.family };
+}
+
+function createPinnedLookup(target: PinnedOutboundTarget) {
+  return (_hostname: string, _options: unknown, callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void): void => {
+    callback(null, target.address, target.family);
+  };
+}
+
+function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> {
+  const normalized = new Headers(headers);
+  if (normalized.has('host')) {
+    throw new Error('Host header override is not allowed for pinned outbound requests');
+  }
+
+  const result: Record<string, string> = {};
+  normalized.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
+}
+
+function normalizeRequestBody(body: BodyInit | null | undefined): string | Buffer | Uint8Array | undefined {
+  if (body === null || body === undefined) return undefined;
+  if (typeof body === 'string') return body;
+  if (body instanceof URLSearchParams) return body.toString();
+  if (Buffer.isBuffer(body)) return body;
+  if (body instanceof ArrayBuffer) return Buffer.from(body);
+  if (ArrayBuffer.isView(body)) {
+    return Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+  }
+  throw new Error('Unsupported safeFetch request body type');
+}
+
+function responseHeaders(headers: http.IncomingHttpHeaders): Headers {
+  const result = new Headers();
+  for (const [key, value] of Object.entries(headers)) {
+    if (Array.isArray(value)) {
+      for (const item of value) result.append(key, item);
+    } else if (value !== undefined) {
+      result.set(key, value);
+    }
+  }
+  return result;
+}
+
+export async function safeFetch(
+  value: string,
+  init: RequestInit,
+  policy: OutboundUrlPolicy,
+  resolver?: OutboundDnsResolver,
+): Promise<Response> {
+  if (safeFetchOverride) {
+    return safeFetchOverride(value, init, policy, resolver);
+  }
+
+  const target = await resolvePinnedOutboundTarget(value, policy, resolver);
+  if (target.url.protocol !== 'http:' && target.url.protocol !== 'https:') {
+    throw new Error('safeFetch supports only HTTP and HTTPS URLs');
+  }
+
+  const body = normalizeRequestBody(init.body);
+  const headers = normalizeHeaders(init.headers);
+  const requestImpl = target.url.protocol === 'https:' ? https.request : http.request;
+  const lookup = createPinnedLookup(target);
+
+  return await new Promise<Response>((resolve, reject) => {
+    if (init.signal?.aborted) {
+      reject(new Error('Outbound request aborted'));
+      return;
+    }
+
+    const request = requestImpl({
+      protocol: target.url.protocol,
+      hostname: target.url.hostname,
+      port: target.url.port || undefined,
+      path: `${target.url.pathname}${target.url.search}`,
+      method: init.method ?? 'GET',
+      headers,
+      lookup,
+      servername: target.url.protocol === 'https:' ? target.url.hostname : undefined,
+      timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+    }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (chunk: Buffer | string) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      res.on('end', () => {
+        resolve(new Response(Buffer.concat(chunks), {
+          status: res.statusCode ?? 502,
+          statusText: res.statusMessage ?? '',
+          headers: responseHeaders(res.headers),
+        }));
+      });
+    });
+
+    const abort = (): void => {
+      request.destroy(new Error('Outbound request aborted'));
+    };
+    init.signal?.addEventListener('abort', abort, { once: true });
+    request.on('error', reject);
+    request.on('timeout', () => {
+      request.destroy(new Error('Outbound request timeout'));
+    });
+    request.on('close', () => {
+      init.signal?.removeEventListener('abort', abort);
+    });
+    if (body !== undefined) request.write(body);
+    request.end();
+  });
+}
+
+export async function safeConnect(
+  value: string,
+  options: SafeConnectOptions,
+): Promise<net.Socket> {
+  const target = await resolvePinnedOutboundTarget(value, options.policy, options.resolver);
+  const port = options.port ?? parseInt(target.url.port || (options.tls ? '443' : '80'), 10);
+  const lookup = createPinnedLookup(target);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+
+  return await new Promise<net.Socket>((resolve, reject) => {
+    const socket = options.tls
+      ? tls.connect({
+          host: target.url.hostname,
+          port,
+          servername: target.url.hostname,
+          rejectUnauthorized: options.rejectUnauthorized,
+          lookup,
+        }, () => resolve(socket as unknown as net.Socket))
+      : net.createConnection({
+          host: target.url.hostname,
+          port,
+          lookup,
+        }, () => resolve(socket));
+
+    socket.on('error', reject);
+    socket.setTimeout(timeoutMs);
+    socket.on('timeout', () => {
+      socket.destroy();
+      reject(new Error('Connection timeout'));
+    });
+  });
 }
 
 export function assertValidRedirectUri(value: string): void {

--- a/apps/auth-service/src/routes/sso.ts
+++ b/apps/auth-service/src/routes/sso.ts
@@ -16,7 +16,7 @@ import {
 import { authenticateLdap, testLdapConnection, type LdapConfig } from '../lib/ldap.js';
 import { config } from '../config.js';
 import { getKeyPair } from '../lib/crypto.js';
-import { assertValidRedirectUri, validateOutboundUrl } from '../lib/url-security.js';
+import { assertValidRedirectUri, safeFetch, validateOutboundUrl } from '../lib/url-security.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -669,7 +669,7 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
       }
 
       // Exchange authorization code for tokens
-      const tokenRes = await fetch(tokenEndpoint, {
+      const tokenRes = await safeFetch(tokenEndpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: new URLSearchParams({
@@ -679,6 +679,10 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
           client_id: conn.client_id!,
           client_secret: conn.client_secret!,
         }).toString(),
+      }, {
+        allowedProtocols: ['https:', 'http:'],
+        allowInsecureHttp: config.allowInsecureSsoUrls,
+        allowPrivateHosts: config.allowPrivateSsoHosts,
       });
 
       if (!tokenRes.ok) {
@@ -1058,7 +1062,7 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
         return reply.status(400).send({ message: tokenEndpointError, code: 'BAD_REQUEST', requestId: request.id });
       }
 
-      const tokenRes = await fetch(tokenEndpoint, {
+      const tokenRes = await safeFetch(tokenEndpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: new URLSearchParams({
@@ -1068,6 +1072,10 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
           client_id: String(cfg['client_id']),
           client_secret: String(cfg['client_secret']),
         }).toString(),
+      }, {
+        allowedProtocols: ['https:', 'http:'],
+        allowInsecureHttp: config.allowInsecureSsoUrls,
+        allowPrivateHosts: config.allowPrivateSsoHosts,
       });
 
       if (!tokenRes.ok) {

--- a/apps/auth-service/src/workers/webhookDelivery.ts
+++ b/apps/auth-service/src/workers/webhookDelivery.ts
@@ -1,7 +1,7 @@
 import type postgres from 'postgres';
 import { webhookDeliveriesTotal } from '../lib/metrics.js';
 import { config } from '../config.js';
-import { validateOutboundUrl } from '../lib/url-security.js';
+import { safeFetch } from '../lib/url-security.js';
 
 interface PendingDelivery {
   id: string;
@@ -34,13 +34,7 @@ async function processDeliveries(sql: ReturnType<typeof postgres>): Promise<void
     const nextAttempt = row.attempts + 1;
 
     try {
-      validateOutboundUrl(row.url, {
-        allowedProtocols: ['https:', 'http:'],
-        allowInsecureHttp: config.allowInsecureWebhookUrls,
-        allowPrivateHosts: config.allowPrivateWebhookHosts,
-      });
-
-      const res = await fetch(row.url, {
+      const res = await safeFetch(row.url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -49,6 +43,10 @@ async function processDeliveries(sql: ReturnType<typeof postgres>): Promise<void
         },
         body: row.payload,
         signal: AbortSignal.timeout(10_000),
+      }, {
+        allowedProtocols: ['https:', 'http:'],
+        allowInsecureHttp: config.allowInsecureWebhookUrls,
+        allowPrivateHosts: config.allowPrivateWebhookHosts,
       });
 
       if (res.ok) {

--- a/apps/auth-service/tests/sso-lib.test.ts
+++ b/apps/auth-service/tests/sso-lib.test.ts
@@ -5,12 +5,18 @@ import {
   clearDiscoveryCache,
   clearJwksCache,
 } from '../src/lib/sso.js';
-import { validateOutboundUrl, isBlockedPrivateHost } from '../src/lib/url-security.js';
+import {
+  validateOutboundUrl,
+  isBlockedPrivateHost,
+  resolvePinnedOutboundTarget,
+  setSafeFetchForTests,
+} from '../src/lib/url-security.js';
 import { escapeLdapFilter } from '../src/lib/ldap.js';
 
 beforeEach(() => {
   clearDiscoveryCache();
   clearJwksCache();
+  setSafeFetchForTests(null);
   sqlMock.mockReset().mockResolvedValue([]);
 });
 
@@ -82,6 +88,36 @@ describe('isBlockedPrivateHost', () => {
     expect(isBlockedPrivateHost('fec0::1')).toBe(false);
     expect(isBlockedPrivateHost('ff00::1')).toBe(false); // multicast — not private
     expect(isBlockedPrivateHost('2001:db8::1')).toBe(false); // doc range
+  });
+});
+
+describe('resolvePinnedOutboundTarget', () => {
+  it('rejects hostnames that resolve to loopback addresses', async () => {
+    await expect(resolvePinnedOutboundTarget('https://attacker.example/metadata', {
+      allowedProtocols: ['https:'],
+    }, async () => [{ address: '127.0.0.1', family: 4 }])).rejects.toThrow(/Resolved private/);
+  });
+
+  it('rejects mixed public and private DNS answers', async () => {
+    await expect(resolvePinnedOutboundTarget('https://attacker.example/metadata', {
+      allowedProtocols: ['https:'],
+    }, async () => [
+      { address: '203.0.113.10', family: 4 },
+      { address: '10.0.0.8', family: 4 },
+    ])).rejects.toThrow(/Resolved private/);
+  });
+
+  it('pins to the first public resolved address', async () => {
+    const target = await resolvePinnedOutboundTarget('https://idp.example.com/.well-known/openid-configuration', {
+      allowedProtocols: ['https:'],
+    }, async () => [
+      { address: '203.0.113.10', family: 4 },
+      { address: '2001:db8::10', family: 6 },
+    ]);
+
+    expect(target.url.hostname).toBe('idp.example.com');
+    expect(target.address).toBe('203.0.113.10');
+    expect(target.family).toBe(4);
   });
 });
 
@@ -174,11 +210,8 @@ describe('discoverOidcProvider', () => {
       jwks_uri: 'https://idp.example.com/.well-known/jwks.json',
     };
 
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(mockDoc),
-    });
-    vi.stubGlobal('fetch', fetchMock);
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify(mockDoc), { status: 200 }));
+    setSafeFetchForTests(async (url, init, policy) => fetchMock(url, init, policy));
 
     const doc1 = await discoverOidcProvider('https://idp.example.com');
     expect(doc1.issuer).toBe('https://idp.example.com');
@@ -189,29 +222,29 @@ describe('discoverOidcProvider', () => {
     expect(doc2.issuer).toBe('https://idp.example.com');
     expect(fetchMock).toHaveBeenCalledTimes(1); // Still 1
 
-    vi.unstubAllGlobals();
+    setSafeFetchForTests(null);
   });
 
   it('throws when discovery fails', async () => {
     const { discoverOidcProvider } = await import('../src/lib/sso.js');
     clearDiscoveryCache();
 
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+    setSafeFetchForTests(async () => new Response('', { status: 404 }));
 
     await expect(discoverOidcProvider('https://bad.example.com')).rejects.toThrow('OIDC discovery failed');
 
-    vi.unstubAllGlobals();
+    setSafeFetchForTests(null);
   });
 
   it('rejects loopback discovery URLs before fetch', async () => {
     const { discoverOidcProvider } = await import('../src/lib/sso.js');
     const fetchMock = vi.fn();
-    vi.stubGlobal('fetch', fetchMock);
+    setSafeFetchForTests(async (url, init, policy) => fetchMock(url, init, policy));
 
     await expect(discoverOidcProvider('http://127.0.0.1:8080')).rejects.toThrow(/HTTP URLs|Private/);
     expect(fetchMock).not.toHaveBeenCalled();
 
-    vi.unstubAllGlobals();
+    setSafeFetchForTests(null);
   });
 });
 

--- a/apps/auth-service/tests/sso.test.ts
+++ b/apps/auth-service/tests/sso.test.ts
@@ -47,6 +47,7 @@ import {
   verifyIdToken,
   parseSamlResponse,
 } from '../src/lib/sso.js';
+import { setSafeFetchForTests } from '../src/lib/url-security.js';
 import { signSsoState } from '../src/routes/sso.js';
 
 const mockedResolveConnection = vi.mocked(resolveConnection);
@@ -61,6 +62,7 @@ beforeAll(async () => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  setSafeFetchForTests(null);
   mockedResolveConnection.mockReset();
   mockedVerifyIdToken.mockReset().mockResolvedValue({
     sub: 'idp_user_01',
@@ -600,6 +602,7 @@ describe('POST /sso/callback/oidc', () => {
         json: () => Promise.resolve({ id_token: 'mock.id.token', access_token: 'at_xxx' }),
       }),
     );
+    setSafeFetchForTests(async (url, init, _policy) => fetch(url, init));
 
     const res = await app.inject({
       method: 'POST',
@@ -634,6 +637,7 @@ describe('POST /sso/callback/oidc', () => {
       json: () => Promise.resolve({ id_token: 'mock.id.token', access_token: 'at_xxx' }),
     });
     vi.stubGlobal('fetch', fetchMock);
+    setSafeFetchForTests(async (url, init, policy) => fetchMock(url, init, policy));
 
     const res = await app.inject({
       method: 'POST',
@@ -711,6 +715,7 @@ describe('POST /sso/callback/oidc', () => {
       'fetch',
       vi.fn().mockResolvedValue({ ok: false, status: 400 }),
     );
+    setSafeFetchForTests(async (url, init, _policy) => fetch(url, init));
 
     const res = await app.inject({
       method: 'POST',
@@ -732,6 +737,7 @@ describe('POST /sso/callback/oidc', () => {
         json: () => Promise.resolve({ id_token: 'bad.token.sig', access_token: 'at_xxx' }),
       }),
     );
+    setSafeFetchForTests(async (url, init, _policy) => fetch(url, init));
 
     const res = await app.inject({
       method: 'POST',
@@ -915,6 +921,7 @@ describe('GET /sso/callback (legacy)', () => {
         json: () => Promise.resolve({ id_token: mockIdToken, access_token: 'at_xxx' }),
       }),
     );
+    setSafeFetchForTests(async (url, init, _policy) => fetch(url, init));
 
     const res = await app.inject({
       method: 'GET',
@@ -938,6 +945,7 @@ describe('GET /sso/callback (legacy)', () => {
         json: () => Promise.resolve({ id_token: 'bad.token.sig', access_token: 'at_xxx' }),
       }),
     );
+    setSafeFetchForTests(async (url, init, _policy) => fetch(url, init));
 
     const res = await app.inject({
       method: 'GET',
@@ -953,6 +961,7 @@ describe('GET /sso/callback (legacy)', () => {
     sqlMock.mockResolvedValueOnce([SSO_CONFIG_ROW]);
 
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 400 }));
+    setSafeFetchForTests(async (url, init, _policy) => fetch(url, init));
 
     const res = await app.inject({
       method: 'GET',

--- a/apps/auth-service/tests/webhookDelivery.test.ts
+++ b/apps/auth-service/tests/webhookDelivery.test.ts
@@ -1,18 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { startWebhookDeliveryWorker } from '../src/workers/webhookDelivery.js';
 import { sqlMock } from './setup.js';
+import { setSafeFetchForTests } from '../src/lib/url-security.js';
 
-// Mock global fetch
-const mockFetch = vi.fn();
-vi.stubGlobal('fetch', mockFetch);
+const mockSafeFetch = vi.fn();
 
 beforeEach(() => {
   vi.useFakeTimers();
-  mockFetch.mockReset();
+  mockSafeFetch.mockReset();
+  setSafeFetchForTests(mockSafeFetch);
 });
 
 afterEach(() => {
   vi.useRealTimers();
+  setSafeFetchForTests(null);
 });
 
 const pendingDelivery = {
@@ -27,7 +28,7 @@ const pendingDelivery = {
 describe('startWebhookDeliveryWorker', () => {
   it('processes pending deliveries on startup', async () => {
     sqlMock.mockResolvedValueOnce([pendingDelivery]); // SELECT pending
-    mockFetch.mockResolvedValueOnce({ ok: true });
+    mockSafeFetch.mockResolvedValueOnce(new Response('', { status: 200 }));
     sqlMock.mockResolvedValueOnce([]);                 // UPDATE delivered
 
     const timer = startWebhookDeliveryWorker(sqlMock as never, 60_000);
@@ -35,12 +36,16 @@ describe('startWebhookDeliveryWorker', () => {
     // Let the immediate run complete
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(mockFetch).toHaveBeenCalledWith(
+    expect(mockSafeFetch).toHaveBeenCalledWith(
       'https://example.com/webhook',
       expect.objectContaining({
         method: 'POST',
         body: '{"type":"grant.created"}',
       }),
+      expect.objectContaining({
+        allowedProtocols: ['https:', 'http:'],
+      }),
+      undefined,
     );
 
     clearInterval(timer);
@@ -48,7 +53,7 @@ describe('startWebhookDeliveryWorker', () => {
 
   it('marks delivery as delivered on successful HTTP response', async () => {
     sqlMock.mockResolvedValueOnce([pendingDelivery]);
-    mockFetch.mockResolvedValueOnce({ ok: true });
+    mockSafeFetch.mockResolvedValueOnce(new Response('', { status: 200 }));
     sqlMock.mockResolvedValueOnce([]); // UPDATE status = 'delivered'
 
     const timer = startWebhookDeliveryWorker(sqlMock as never, 60_000);
@@ -63,7 +68,7 @@ describe('startWebhookDeliveryWorker', () => {
 
   it('schedules retry on HTTP failure', async () => {
     sqlMock.mockResolvedValueOnce([pendingDelivery]);
-    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    mockSafeFetch.mockResolvedValueOnce(new Response('', { status: 500 }));
     sqlMock.mockResolvedValueOnce([]); // UPDATE with retry
 
     const timer = startWebhookDeliveryWorker(sqlMock as never, 60_000);
@@ -75,7 +80,7 @@ describe('startWebhookDeliveryWorker', () => {
   it('marks delivery as failed when max attempts reached', async () => {
     const exhaustedDelivery = { ...pendingDelivery, attempts: 4, max_attempts: 5 };
     sqlMock.mockResolvedValueOnce([exhaustedDelivery]);
-    mockFetch.mockResolvedValueOnce({ ok: false, status: 503 });
+    mockSafeFetch.mockResolvedValueOnce(new Response('', { status: 503 }));
     sqlMock.mockResolvedValueOnce([]); // UPDATE status = 'failed'
 
     const timer = startWebhookDeliveryWorker(sqlMock as never, 60_000);
@@ -86,7 +91,7 @@ describe('startWebhookDeliveryWorker', () => {
 
   it('handles fetch errors gracefully', async () => {
     sqlMock.mockResolvedValueOnce([pendingDelivery]);
-    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    mockSafeFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
     sqlMock.mockResolvedValueOnce([]); // UPDATE with retry
 
     const timer = startWebhookDeliveryWorker(sqlMock as never, 60_000);
@@ -101,7 +106,7 @@ describe('startWebhookDeliveryWorker', () => {
     const timer = startWebhookDeliveryWorker(sqlMock as never, 60_000);
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockSafeFetch).not.toHaveBeenCalled();
 
     clearInterval(timer);
   });

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1007,12 +1007,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1252,9 +1252,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
## Summary

- Implements DNS-pinned outbound request helpers for auth-service HTTP(S) and LDAP call paths.
- Applies `safeFetch` to webhook delivery, OIDC discovery/JWKS, and OIDC token exchange paths.
- Applies `safeConnect` to LDAP socket connection paths.
- Adds regression coverage for DNS answers resolving to loopback/private ranges, mixed public/private DNS answers, and pinned public target selection.
- Updates `packages/mcp` lockfile so `express-rate-limit` resolves to `ip-address@10.2.0`, clearing Dependabot alert #133 / GHSA-v2v4-37r5-5v8g.

Fixes #313.

## Verification

Clean temporary worktree `.tmp/issue313-ci`:

- `apps/auth-service: npm ci` - pass, 0 vulnerabilities
- `apps/auth-service: npm run typecheck` - pass
- `apps/auth-service: npm test -- sso-lib.test.ts sso.test.ts webhookDelivery.test.ts` - pass, 93 tests
- `apps/auth-service: npm test` - pass, 103 files / 1404 tests
- `packages/mcp: npm ci` - pass, 0 vulnerabilities
- `packages/mcp: npm run typecheck` - pass
- `packages/mcp: npm test` - pass, 1 file / 45 tests

## Safety

No deployment performed. No production config or secrets changed.