### PR TITLE
fix(commerce): align mock payment intent checkout state

### DIFF
--- a/apps/auth-service/src/lib/commerce/payment-providers/mock.ts
+++ b/apps/auth-service/src/lib/commerce/payment-providers/mock.ts
@@ -92,7 +92,7 @@ export class MockPaymentProvider implements PaymentProvider {
   }): Promise<{
     provider_payment_id: string;
     provider_order_id: string;
-    status: 'created';
+    status: 'authorized';
     raw_status: string;
     provider_metadata: Record<string, unknown>;
   }> {
@@ -110,8 +110,8 @@ export class MockPaymentProvider implements PaymentProvider {
     return {
       provider_payment_id: `mock_pay_${input.payment_intent_id}`,
       provider_order_id: `mock_order_${input.payment_intent_id}`,
-      status: 'created',
-      raw_status: 'mock_created',
+      status: 'authorized',
+      raw_status: 'mock_authorized',
       provider_metadata: {
         environment: input.environment,
         amount_minor_units: input.amount.amount_minor_units,

--- a/apps/auth-service/tests/commerce-cart-payment.test.ts
+++ b/apps/auth-service/tests/commerce-cart-payment.test.ts
@@ -282,7 +282,10 @@ function primePaymentBase(opts: {
   sqlMock.mockResolvedValueOnce([opts.agentRow ?? agentContext()]);
   sqlMock.mockResolvedValueOnce([{ public_key_jwk: publicJwk, retired_at: null }]);
   sqlMock.mockResolvedValueOnce(opts.revocationRows ?? []);
-  sqlMock.mockResolvedValueOnce([opts.paymentRow ?? paymentIntentRow()]);
+  sqlMock.mockResolvedValueOnce([opts.paymentRow ?? paymentIntentRow({
+    status: 'authorized',
+    provider_raw_status: 'mock_authorized',
+  })]);
   sqlMock.mockResolvedValueOnce([]);
   sqlMock.mockResolvedValueOnce([{ id: opts.auditIds?.[0] ?? 'caud_PAYMENT_CREATED', occurred_at: new Date().toISOString() }]);
   sqlMock.mockResolvedValueOnce([{ id: opts.auditIds?.[1] ?? 'caud_PAYMENT_METER', occurred_at: new Date().toISOString() }]);
@@ -472,7 +475,7 @@ describe('Commerce payment intent APIs', () => {
     const body = res.json<{ data: { payment_intent_id: string; status: string; provider_payment_id: string }; audit_event_id: string; meter_event_id: string }>();
     expect(body.data).toMatchObject({
       payment_intent_id: PAYMENT_INTENT,
-      status: 'created',
+      status: 'authorized',
       provider_payment_id: `mock_pay_${PAYMENT_INTENT}`,
     });
     expect(body.audit_event_id).toBe('caud_PAYMENT_CREATED');
@@ -697,6 +700,8 @@ describe('Commerce checkout link API', () => {
     expect(flattenedSqlCalls()).toContain('checkout_expires_at');
     expect(flattenedSqlCalls()).toContain('checkout_created');
     expect(flattenedSqlCalls()).toContain('payment_pending');
+    expect(flattenedSqlCalls()).toContain('authorized->checkout_created');
+    expect(flattenedSqlCalls()).toContain('checkout_created->payment_pending');
   });
 
   it('requires Idempotency-Key for checkout link creation', async () => {

--- a/apps/auth-service/tests/commerce-payment-foundations.test.ts
+++ b/apps/auth-service/tests/commerce-payment-foundations.test.ts
@@ -87,8 +87,8 @@ describe('Payment provider adapters', () => {
     expect(result).toMatchObject({
       provider_payment_id: 'mock_pay_cpi_TEST',
       provider_order_id: 'mock_order_cpi_TEST',
-      status: 'created',
-      raw_status: 'mock_created',
+      status: 'authorized',
+      raw_status: 'mock_authorized',
     });
   });
 


### PR DESCRIPTION
## Why

Checkout-link creation requires the payment intent state machine path `authorized -> checkout_created -> payment_pending`. The mock payment provider was returning fresh payment intents as `created`, which causes checkout creation to reject the handoff with `invalid_payment_status_transition` before the mock checkout link can be created.

This PR aligns the deterministic mock provider with the checkout-ready internal sandbox flow by returning `authorized` / `mock_authorized` for successful mock payment intents.

## Files changed

- `apps/auth-service/src/lib/commerce/payment-providers/mock.ts`
- `apps/auth-service/tests/commerce-cart-payment.test.ts`
- `apps/auth-service/tests/commerce-payment-foundations.test.ts`

## Validation

From `apps/auth-service`:

- `npm run typecheck` - passed
- `npm test -- commerce-cart-payment.test.ts commerce-payment-foundations.test.ts` - passed, 39 tests
- `npm test -- commerce` - passed, 377 tests
- `npm test` - passed, 1404 tests

From repo root:

- `node docs/commerce-v1-hardening.validate.mjs` - passed
- `node web/commerce-playground.validate.mjs` - passed
- `node docs/commerce-v1-pilot-readiness.validate.mjs` - passed
- `git diff --check` - passed

## Safety confirmations

- No production config changed.
- No secrets, bearer tokens, passports, idempotency keys, provider credentials, or synthetic env files were committed.
- No live payment flags changed.
- No live Plural settings changed.
- `.tmp/` and `.tmp/commerce-pilot-load.env` were not committed.
- Local report files were not committed.
- No deployment was performed.