### PR TITLE
docs(commerce): define staging seed data setup

### DIFF
--- a/docs/commerce-v1-pilot-readiness.validate.mjs
+++ b/docs/commerce-v1-pilot-readiness.validate.mjs
@@ -9,8 +9,10 @@ const repoRoot = join(docsDir, '..');
 const guide = readFileSync(join(docsDir, 'guides', 'commerce-v1-operations.mdx'), 'utf8');
 const openapi = readFileSync(join(docsDir, 'api', 'grantex-commerce-v1.openapi.yaml'), 'utf8');
 const template = readFileSync(join(docsDir, 'examples', 'commerce-pilot-merchant.sandbox.json'), 'utf8');
+const stagingSeedManifestText = readFileSync(join(docsDir, 'examples', 'commerce-staging-seed.manifest.json'), 'utf8');
 const loadReport = readFileSync(join(docsDir, 'reports', 'commerce-v1-local-pilot-load.md'), 'utf8');
 const hostedStagingPlan = readFileSync(join(docsDir, 'guides', 'commerce-v1-hosted-staging-plan.md'), 'utf8');
+const stagingDataSetup = readFileSync(join(docsDir, 'guides', 'commerce-v1-staging-data-setup.md'), 'utf8');
 const harness = readFileSync(join(repoRoot, 'scripts', 'commerce-pilot-load-harness.mjs'), 'utf8');
 const seed = readFileSync(join(repoRoot, 'scripts', 'commerce-pilot-seed-local.mjs'), 'utf8');
 
@@ -79,6 +81,124 @@ const parsedTemplate = JSON.parse(template);
 assert.equal(parsedTemplate.environment, 'sandbox', 'pilot template is sandbox only');
 assert.equal(parsedTemplate.provider.plural_live_enabled, false, 'pilot template does not enable live Plural');
 assert.equal(parsedTemplate.provider.provider_key, 'mock', 'pilot template uses mock provider');
+
+const stagingManifest = JSON.parse(stagingSeedManifestText);
+assert.equal(stagingManifest.tenant.id, 'cten_staging_commerce', 'staging seed tenant id is pinned');
+assert.equal(stagingManifest.merchant.id, 'mch_staging_electronics_pilot', 'staging seed merchant id is pinned');
+assert.equal(stagingManifest.agent.id, 'cag_staging_agenticorg_sales', 'staging seed agent id is pinned');
+assert.equal(stagingManifest.category.id, 'electronics_appliances', 'staging seed category is pinned');
+assert.equal(stagingManifest.provider.provider_key, 'mock', 'staging seed uses mock provider');
+assert.equal(stagingManifest.provider.live_payments_enabled, false, 'staging seed does not enable live payments');
+assert.equal(stagingManifest.provider.plural_live_enabled, false, 'staging seed does not enable live Plural');
+assert.equal(stagingManifest.live_flags.commerce_live_mode_enabled, false, 'staging seed live commerce flag is false');
+assert.equal(stagingManifest.live_flags.plural_live_enabled, false, 'staging seed live Plural flag is false');
+assert.equal(stagingManifest.policy.status, 'active', 'staging seed has an active policy');
+assert.equal(stagingManifest.catalog.currency, 'INR', 'staging seed catalog uses INR');
+assert.equal(stagingManifest.catalog.tax_inclusive_pricing, true, 'staging seed catalog is tax-inclusive');
+assert.ok(stagingManifest.catalog.default_gst_rate > 0, 'staging seed catalog has GST rate');
+
+const products = stagingManifest.catalog.products;
+assert.ok(Array.isArray(products), 'staging seed products are present');
+assert.ok(products.length >= 10 && products.length <= 25, 'staging seed product count is 10-25');
+assert.ok(
+  products.filter((product) => Array.isArray(product.variants) && product.variants.length > 0).length >= 3,
+  'staging seed includes at least 3 products with variants',
+);
+for (const product of products) {
+  assert.equal(product.category, 'electronics_appliances', `product ${product.id} uses electronics category`);
+  assert.equal(product.currency, 'INR', `product ${product.id} uses INR`);
+  assert.equal(product.tax_inclusive, true, `product ${product.id} is tax-inclusive`);
+  assert.ok(Number.isInteger(product.price_minor_units), `product ${product.id} has minor-unit price`);
+  assert.ok(product.gst_rate > 0, `product ${product.id} has GST rate`);
+  assert.ok(product.hsn_code, `product ${product.id} has HSN code`);
+  assert.ok(product.warranty_summary, `product ${product.id} has warranty summary`);
+  assert.ok(product.return_policy_summary, `product ${product.id} has return policy summary`);
+  assert.ok(product.availability_status, `product ${product.id} has availability status`);
+  assert.equal(product.source_system, 'synthetic_staging_manifest', `product ${product.id} has synthetic source system`);
+  assert.ok(product.last_synced_at, `product ${product.id} has last synced timestamp`);
+}
+assert.ok(
+  stagingManifest.webhook_test_reference_requirements.required_cases.includes('invalid_signature'),
+  'staging seed includes webhook invalid-signature requirement',
+);
+assert.ok(
+  stagingManifest.consent_passport_test_user_requirements.required_cases.includes('revoked_passport'),
+  'staging seed includes revoked-passport requirement',
+);
+
+function assertNoForbiddenSeedSecrets(value, path = 'manifest') {
+  const forbiddenKeyFragments = [
+    'api_key',
+    'bearer',
+    'credential_ref',
+    'idempotency',
+    'private_key',
+    'raw_passport',
+    'secret',
+    'token',
+    'webhook_secret',
+  ];
+  const forbiddenValueFragments = [
+    'Bearer ',
+    'sk_live_',
+    'pk_live_',
+    '-----BEGIN',
+    'passport.jwt',
+    'idempotency-key:',
+    'mock-webhook-secret',
+  ];
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoForbiddenSeedSecrets(item, `${path}[${index}]`));
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, nested] of Object.entries(value)) {
+      const lowered = key.toLowerCase();
+      assert.equal(
+        forbiddenKeyFragments.some((fragment) => lowered.includes(fragment)),
+        false,
+        `staging seed manifest does not include forbidden key ${path}.${key}`,
+      );
+      assertNoForbiddenSeedSecrets(nested, `${path}.${key}`);
+    }
+    return;
+  }
+  if (typeof value === 'string') {
+    for (const forbidden of forbiddenValueFragments) {
+      assert.equal(value.includes(forbidden), false, `staging seed manifest does not include ${forbidden} at ${path}`);
+    }
+  }
+}
+assertNoForbiddenSeedSecrets(stagingManifest);
+
+for (const required of [
+  'Seed Purpose',
+  'Seed Safety Rules',
+  'Production Refusal Rules',
+  'Staging DNS Prerequisites',
+  'Staging DB And Redis Prerequisites',
+  'Staging Secret Inventory By Name Only',
+  'Staging Seed Data Model',
+  'Staging Seed Command Plan For Later',
+  'Staging Smoke-Test Command Plan For Later',
+  'Cleanup And Reset Plan',
+  'does not create resources',
+  'no live Plural',
+  'No production database',
+  'No production Redis',
+  'Do not copy production secret versions',
+]) {
+  assert.ok(stagingDataSetup.includes(required), `staging data setup guide includes ${required}`);
+}
+for (const forbidden of [
+  'COMMERCE_LIVE_MODE_ENABLED=true',
+  'PLURAL_LIVE_ENABLED=true',
+  'sk_live_',
+  'pk_live_',
+  'Bearer ',
+]) {
+  assert.equal(stagingDataSetup.includes(forbidden), false, `staging data setup guide does not include ${forbidden}`);
+}
 
 assert.ok(harness.includes('Refusing to run commerce pilot load harness against a non-local API base URL'));
 assert.ok(harness.includes('/v1/commerce/payments/intents'));
@@ -182,8 +302,10 @@ for (const required of [
 
 assert.equal(/[^\u0000-\u007F]/.test(guide), false, 'operations guide stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(template), false, 'pilot template stays ASCII-only');
+assert.equal(/[^\u0000-\u007F]/.test(stagingSeedManifestText), false, 'staging seed manifest stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(loadReport), false, 'pilot load report stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(hostedStagingPlan), false, 'hosted staging plan stays ASCII-only');
+assert.equal(/[^\u0000-\u007F]/.test(stagingDataSetup), false, 'staging data setup guide stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(harness), false, 'load harness stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(seed), false, 'local seed script stays ASCII-only');
 

--- a/docs/examples/commerce-staging-seed.manifest.json
+++ b/docs/examples/commerce-staging-seed.manifest.json
@@ -1,0 +1,403 @@
+{
+  "manifest_version": "m10-staging-seed-v1",
+  "purpose": "Synthetic hosted staging seed manifest for Grantex Commerce V1. Planning and validation only; no resources are created by this file.",
+  "environment": "staging",
+  "synthetic_only": true,
+  "resource_creation_allowed": false,
+  "live_flags": {
+    "commerce_live_mode_enabled": false,
+    "plural_live_enabled": false,
+    "plural_sandbox_enabled": false
+  },
+  "tenant": {
+    "id": "cten_staging_commerce",
+    "display_name": "Grantex Commerce Staging Tenant",
+    "status": "active",
+    "data_classification": "synthetic"
+  },
+  "merchant": {
+    "id": "mch_staging_electronics_pilot",
+    "tenant_id": "cten_staging_commerce",
+    "display_name": "Staging Electronics Pilot",
+    "category": "electronics_appliances",
+    "country_code": "IN",
+    "currency": "INR",
+    "verification_status": "staging_verified",
+    "agentic_commerce_enabled": true,
+    "environment": "staging",
+    "data_classification": "synthetic"
+  },
+  "agent": {
+    "id": "cag_staging_agenticorg_sales",
+    "tenant_id": "cten_staging_commerce",
+    "display_name": "AgenticOrg Commerce Sales Agent Staging",
+    "agent_type": "sales",
+    "trust_status": "trusted",
+    "enabled_for_staging": true,
+    "data_classification": "synthetic"
+  },
+  "category": {
+    "id": "electronics_appliances",
+    "scope_allowlist": [
+      "commerce:catalog.read",
+      "commerce:inventory.read",
+      "commerce:checkout.create",
+      "commerce:payment.initiate",
+      "commerce:payment.status.read"
+    ]
+  },
+  "provider": {
+    "provider_key": "mock",
+    "environment": "sandbox",
+    "credential_material_included": false,
+    "live_payments_enabled": false,
+    "plural_live_enabled": false,
+    "plural_sandbox_enabled": false,
+    "capabilities": [
+      "payment_intent.create",
+      "checkout_link.create",
+      "payment_status.read",
+      "mock_webhook.receive"
+    ]
+  },
+  "policy": {
+    "id": "cpol_staging_commerce_v1",
+    "version": "m10-staging-commerce-v1",
+    "status": "active",
+    "currency": "INR",
+    "amount_cap_minor_units": 750000,
+    "checkout_passport_max_ttl_seconds": 600,
+    "browse_passport_max_ttl_seconds": 3600,
+    "stale_price_max_age_seconds": 86400,
+    "allow_unknown_inventory_checkout": false,
+    "emergency_disable": false
+  },
+  "catalog": {
+    "currency": "INR",
+    "tax_inclusive_pricing": true,
+    "default_gst_rate": 0.18,
+    "source_system": "synthetic_staging_manifest",
+    "last_synced_at": "2026-05-14T00:00:00Z",
+    "products": [
+      {
+        "id": "cprd_stg_induction_cooktop",
+        "title": "Staging Induction Cooktop",
+        "brand": "Grantex Demo",
+        "category": "electronics_appliances",
+        "price_minor_units": 329900,
+        "currency": "INR",
+        "tax_inclusive": true,
+        "gst_rate": 0.18,
+        "hsn_code": "85166000",
+        "warranty_summary": "Synthetic staging warranty: 12 months parts coverage.",
+        "return_policy_summary": "Synthetic staging returns: 7 days for unopened units.",
+        "availability_status": "in_stock",
+        "source_system": "synthetic_staging_manifest",
+        "last_synced_at": "2026-05-14T00:00:00Z",
+        "variants": [
+          {
+            "id": "cvar_stg_induction_black",
+            "sku": "STG-COOKTOP-BLK",
+            "title": "Black 1800W",
+            "attributes": {
+              "color": "black",
+              "wattage": "1800W"
+            },
+            "price_minor_units": 329900,
+            "availability_status": "in_stock"
+          },
+          {
+            "id": "cvar_stg_induction_silver",
+            "sku": "STG-COOKTOP-SLV",
+            "title": "Silver 2000W",
+            "attributes": {
+              "color": "silver",
+              "wattage": "2000W"
+            },
+            "price_minor_units": 359900,
+            "availability_status": "in_stock"
+          }
+        ]
+      },
+      {
+        "id": "cprd_stg_air_purifier",
+        "title": "Staging Smart Air Purifier",
+        "brand": "Grantex Demo",
+        "category": "electronics_appliances",
+        "price_minor_units": 899900,
+        "currency": "INR",
+        "tax_inclusive": true,
+        "gst_rate": 0.18,
+        "hsn_code": "84213990",
+        "warranty_summary": "Synthetic staging warranty: 24 months motor coverage.",
+        "return_policy_summary": "Synthetic staging returns: 10 days after delivery.",
+        "availability_status": "in_stock",
+        "source_system": "synthetic_staging_manifest",
+        "last_synced_at": "2026-05-14T00:00:00Z",
+        "variants": [
+          {
+            "id": "cvar_stg_air_purifier_room",
+            "sku": "STG-AIR-ROOM",
+            "title": "Room 300 sqft",
+            "attributes": {
+              "coverage": "300 sqft"
+            },
+            "price_minor_units": 899900,
+            "availability_status": "in_stock"
+          },
+          {
+            "id": "cvar_stg_air_purifier_hall",
+            "sku": "STG-AIR-HALL",
+            "title": "Hall 600 sqft",
+            "attributes": {
+              "coverage": "600 sqft"
+            },
+            "price_minor_units": 1299900,
+            "availability_status": "limited"
+          }
+        ]
+      },
+      {
+        "id": "cprd_stg_mixer_grinder",
+        "title": "Staging Mixer Grinder",
+        "brand": "Grantex Demo",
+        "category": "electronics_appliances",
+        "price_minor_units": 459900,
+        "currency": "INR",
+        "tax_inclusive": true,
+        "gst_rate": 0.18,
+        "hsn_code": "85094090",
+        "warranty_summary": "Synthetic staging warranty: 18 months appliance coverage.",
+        "return_policy_summary": "Synthetic staging returns: 7 days for sealed jars.",
+        "availability_status": "in_stock",
+        "source_system": "synthetic_staging_manifest",
+        "last_synced_at": "2026-05-14T00:00:00Z",
+        "variants": [
+          {
+            "id": "cvar_stg_mixer_500w",
+            "sku": "STG-MIX-500",
+            "title": "500W 3 Jar",
+            "attributes": {
+              "power": "500W",
+              "jars": "3"
+            },
+            "price_minor_units": 459900,
+            "availability_status": "in_stock"
+          },
+          {
+            "id": "cvar_stg_mixer_750w",
+            "sku": "STG-MIX-750",
+            "title": "750W 4 Jar",
+            "attributes": {
+              "power": "750W",
+              "jars": "4"
+            },
+            "price_minor_units": 629900,
+            "availability_status": "in_stock"
+          }
+        ]
+      },
+      {
+        "id": "cprd_stg_water_purifier",
+        "title": "Staging RO Water Purifier",
+        "brand": "Grantex Demo",
+        "category": "electronics_appliances",
+        "price_minor_units": 1149900,
+        "currency": "INR",
+        "tax_inclusive": true,
+        "gst_rate": 0.18,
+        "hsn_code": "84212190",
+        "warranty_summary": "Synthetic staging warranty: 12 months filter system coverage.",
+        "return_policy_summary": "Synthetic staging returns: service inspection required.",
+        "availability_status": "limited",
+        "source_system": "synthetic_staging_manifest",
+        "last_synced_at": "2026-05-14T00:00:00Z",
+        "variants": [
+          {
+            "id": "cvar_stg_ro_7l",
+            "sku": "STG-RO-7L",
+            "title": "7L Storage",
+            "attributes": {
+              "storage": "7L"
+            },
+            "price_minor_units": 1149900,
+            "availability_status": "limited"
+          },
+          {
+            "id": "cvar_stg_ro_10l",
+            "sku": "STG-RO-10L",
+            "title": "10L Storage",
+            "attributes": {
+              "storage": "10L"
+            },
+            "price_minor_units": 1399900,
+            "availability_status": "in_stock"
+          }
+        ]
+      },
+      {
+        "id": "cprd_stg_egg_boiler",
+        "title": "Staging Electric Egg Boiler",
+        "brand": "Grantex Demo",
+        "category": "electronics_appliances",
+        "price_minor_units": 129900,
+        "currency": "INR",
+        "tax_inclusive": true,
+        "gst_rate": 0.18,
+        "hsn_code": "85167990",
+        "warranty_summary": "Synthetic staging warranty: 6 months appliance coverage.",
+        "return_policy_summary": "Synthetic staging returns: 7 days unused.",
+        "availability_status": "in_stock",
+        "source_system": "synthetic_staging_manifest",
+        "last_synced_at": "2026-05-14T00:00:00Z",
+        "variants": []
+      },
+      {
+        "id": "cprd_stg_hand_blender",
+        "title": "Staging Hand Blender",
+        "brand": "Grantex Demo",
+        "category": "electronics_appliances",
+        "price_minor_units": 219900,
+        "currency": "INR",
+        "tax_inclusive": true,
+        "gst_rate": 0.18,
+        "hsn_code": "85094090",
+        "warranty_summary": "Synthetic staging warranty: 12 months motor coverage.",
+        "return_policy_summary": "Synthetic staging returns: 7 days for sealed units.",
+        "availability_status": "in_stock",
+        "source_system": "synthetic_staging_manifest",
+        "last_synced_at": "2026-05-14T00:00:00Z",
+        "variants": []
+      },
+      {
+        "id": "cprd_stg_room_heater",
+        "title": "Staging Room Heater",
+        "brand": "Grantex Demo",
+        "category": "electronics_appliances",
+        "price_minor_units": 279900,
+        "currency": "INR",
+        "tax_inclusive": true,
+        "gst_rate": 0.18,
+        "hsn_code": "85162900",
+        "warranty_summary": "Synthetic staging warranty: 12 months heating element coverage.",
+        "return_policy_summary": "Synthetic staging returns: 7 days unopened.",
+        "availability_status": "in_stock",
+        "source_system": "synthetic_staging_manifest",
+        "last_synced_at": "2026-05-14T00:00:00Z",
+        "variants": []
+      },
+      {
+        "id": "cprd_stg_robot_vacuum",
+        "title": "Staging Robot Vacuum",
+        "brand": "Grantex Demo",
+        "category": "electronics_appliances",
+        "price_minor_units": 2299900,
+        "currency": "INR",
+        "tax_inclusive": true,
+        "gst_rate": 0.18,
+        "hsn_code": "85081100",
+        "warranty_summary": "Synthetic staging warranty: 24 months device coverage.",
+        "return_policy_summary": "Synthetic staging returns: 10 days with accessory check.",
+        "availability_status": "preorder",
+        "source_system": "synthetic_staging_manifest",
+        "last_synced_at": "2026-05-14T00:00:00Z",
+        "variants": []
+      },
+      {
+        "id": "cprd_stg_smart_kettle",
+        "title": "Staging Smart Electric Kettle",
+        "brand": "Grantex Demo",
+        "category": "electronics_appliances",
+        "price_minor_units": 349900,
+        "currency": "INR",
+        "tax_inclusive": true,
+        "gst_rate": 0.18,
+        "hsn_code": "85167990",
+        "warranty_summary": "Synthetic staging warranty: 12 months heating element coverage.",
+        "return_policy_summary": "Synthetic staging returns: 7 days unused.",
+        "availability_status": "in_stock",
+        "source_system": "synthetic_staging_manifest",
+        "last_synced_at": "2026-05-14T00:00:00Z",
+        "variants": []
+      },
+      {
+        "id": "cprd_stg_table_fan",
+        "title": "Staging BLDC Table Fan",
+        "brand": "Grantex Demo",
+        "category": "electronics_appliances",
+        "price_minor_units": 399900,
+        "currency": "INR",
+        "tax_inclusive": true,
+        "gst_rate": 0.18,
+        "hsn_code": "84145190",
+        "warranty_summary": "Synthetic staging warranty: 24 months motor coverage.",
+        "return_policy_summary": "Synthetic staging returns: 7 days for complete package.",
+        "availability_status": "in_stock",
+        "source_system": "synthetic_staging_manifest",
+        "last_synced_at": "2026-05-14T00:00:00Z",
+        "variants": []
+      },
+      {
+        "id": "cprd_stg_toaster",
+        "title": "Staging Pop-Up Toaster",
+        "brand": "Grantex Demo",
+        "category": "electronics_appliances",
+        "price_minor_units": 259900,
+        "currency": "INR",
+        "tax_inclusive": true,
+        "gst_rate": 0.18,
+        "hsn_code": "85167200",
+        "warranty_summary": "Synthetic staging warranty: 12 months appliance coverage.",
+        "return_policy_summary": "Synthetic staging returns: 7 days unopened.",
+        "availability_status": "in_stock",
+        "source_system": "synthetic_staging_manifest",
+        "last_synced_at": "2026-05-14T00:00:00Z",
+        "variants": []
+      },
+      {
+        "id": "cprd_stg_washing_machine",
+        "title": "Staging Compact Washing Machine",
+        "brand": "Grantex Demo",
+        "category": "electronics_appliances",
+        "price_minor_units": 1849900,
+        "currency": "INR",
+        "tax_inclusive": true,
+        "gst_rate": 0.18,
+        "hsn_code": "84501100",
+        "warranty_summary": "Synthetic staging warranty: 24 months motor coverage.",
+        "return_policy_summary": "Synthetic staging returns: installation inspection required.",
+        "availability_status": "in_stock",
+        "source_system": "synthetic_staging_manifest",
+        "last_synced_at": "2026-05-14T00:00:00Z",
+        "variants": []
+      }
+    ]
+  },
+  "webhook_test_reference_requirements": {
+    "reference_generation": "Generate mock payment references at staging seed execution time only; do not commit generated references.",
+    "required_cases": [
+      "paid",
+      "failed",
+      "expired",
+      "duplicate",
+      "invalid_signature",
+      "stale_timestamp",
+      "unsupported_event"
+    ],
+    "raw_payloads_included": false
+  },
+  "consent_passport_test_user_requirements": {
+    "synthetic_user_principal_id": "user_staging_synthetic_buyer",
+    "real_contact_data_allowed": false,
+    "passport_material_included": false,
+    "required_cases": [
+      "approved_consent",
+      "denied_consent",
+      "missing_consent",
+      "revoked_passport",
+      "expired_passport",
+      "amount_cap_exceeded",
+      "untrusted_agent"
+    ]
+  }
+}

--- a/docs/guides/commerce-v1-staging-data-setup.md
+++ b/docs/guides/commerce-v1-staging-data-setup.md
@@ -1,0 +1,187 @@
+# Commerce V1 Staging Data Setup
+
+Status: M10 planning, fixture, and validator work only. This pass does not create resources, connect to hosted services, deploy code, or write secrets.
+
+## Seed Purpose
+
+The staging seed prepares realistic but synthetic commerce data for the hosted Grantex Commerce V1 and AgenticOrg Commerce Sales Agent staging pair. It is intended to support later M11 hosted E2E evidence after the M9 infrastructure plan exists in a real staging environment.
+
+The seed scope is narrow:
+
+- Tenant: `cten_staging_commerce`
+- Merchant: `mch_staging_electronics_pilot`
+- Agent: `cag_staging_agenticorg_sales`
+- Category: `electronics_appliances`
+- Provider: `mock`
+- Currency: `INR`
+- Catalog size: 10-25 synthetic electronics/appliances products
+- Commerce flags: sandbox only, no live payments, no live Plural
+
+The source fixture is `docs/examples/commerce-staging-seed.manifest.json`.
+
+## Seed Safety Rules
+
+- Use synthetic staging-only data.
+- Do not use production data.
+- Do not use real customer names, emails, phones, addresses, payment details, or merchant credentials.
+- Do not write raw Commerce Passports into docs, fixtures, logs, PRs, or reports.
+- Do not write bearer tokens, API keys, provider credentials, webhook signing values, or idempotency keys into docs, fixtures, logs, PRs, or reports.
+- Use `provider_key=mock` only.
+- Keep `COMMERCE_LIVE_MODE_ENABLED=false`.
+- Keep `PLURAL_LIVE_ENABLED=false`.
+- Keep `PLURAL_SANDBOX_ENABLED=false` unless a real Plural sandbox contract is confirmed in a later milestone.
+- Keep seed output redacted: IDs and counts are okay; secret values and generated references are not.
+- Treat generated staging payment references as ephemeral evidence, not commit material.
+
+## Production Refusal Rules
+
+Any future staging seed script or job must refuse to run when any of these are true:
+
+- `NODE_ENV=production`
+- API base is `https://grantex.dev`
+- API base is not `https://api-staging.grantex.dev`
+- `PUBLIC_BASE_URL` is `https://grantex.dev`
+- `JWT_ISSUER` is `https://grantex.dev`
+- `COMMERCE_LIVE_MODE_ENABLED` is true
+- `PLURAL_LIVE_ENABLED` is true
+- `COMMERCE_SANDBOX_ENABLED` is false
+- `COMMERCE_V1_ENABLED` is false for hosted staging
+- Database host, database name, username, project ID, or Cloud SQL instance name contains `prod`, `production`, or `live`
+- Redis host, Redis instance, or project ID contains `prod`, `production`, or `live`
+- GCP project is the production project
+- Cloud Run service is not `grantex-auth-staging`
+- Provider is not `mock`
+- Secret source is a production GitHub environment or production Secret Manager namespace
+
+These are production refusal checks. They are not instructions to create staging resources in M10.
+
+## Staging DNS Prerequisites
+
+Do not seed until DNS and routing are confirmed:
+
+- `api-staging.grantex.dev` resolves to the staging API only.
+- `staging.grantex.dev` resolves to staging portal hosting only.
+- AgenticOrg staging is allowed by CORS: `https://staging.agenticorg.ai`.
+- Production domains must not be used in seed or smoke commands.
+
+## Staging DB And Redis Prerequisites
+
+Do not seed until dedicated staging data stores exist:
+
+- Dedicated staging Postgres or staging database.
+- Dedicated staging Redis or isolated staging Redis database/keyspace.
+- No production database.
+- No production Redis.
+- Migrations applied to the staging database.
+- Staging application role cannot mutate append-only audit rows except through approved audit writer paths.
+- Staging backup/reset decision documented before destructive reset commands are used.
+
+## Staging Secret Inventory By Name Only
+
+Create staging-only secret values later using these names or documented staging-prefixed equivalents:
+
+- `DATABASE_URL`
+- `REDIS_URL`
+- `ADMIN_API_KEY`
+- `VAULT_ENCRYPTION_KEY`
+- `RSA_PRIVATE_KEY`, if fixed app JWT signing is used
+- `ED25519_PRIVATE_KEY`, if DID/signing paths are enabled
+- `SSO_STATE_SECRET`
+- `METRICS_API_KEY`
+- `RESEND_API_KEY`, only if staging email/OTP is enabled
+- `MOCK_PAYMENT_WEBHOOK_SECRET`
+- Commerce Passport signing key material, according to the existing key path
+
+Secret handling rules:
+
+- Store values in staging Secret Manager and staging GitHub environment secrets only.
+- Do not copy production secret versions.
+- Do not commit `.env`, `.tmp`, generated env files, secret exports, tokens, raw passports, provider credentials, or local reports.
+- Do not paste secret values into PR bodies, logs, or docs.
+
+## Staging Seed Data Model
+
+The manifest describes:
+
+- One synthetic tenant: `cten_staging_commerce`.
+- One synthetic electronics merchant: `mch_staging_electronics_pilot`.
+- One trusted AgenticOrg sales agent identity: `cag_staging_agenticorg_sales`.
+- One active policy with INR amount cap, scope allowlist, TTL caps, stale-price guard, and emergency disable false.
+- One mock provider profile with live flags false.
+- A tax-inclusive INR catalog with GST rate and HSN metadata.
+- Warranty and return summaries for every product.
+- Availability status for every product.
+- Source system and last synced timestamp for every product.
+- At least three products with variants.
+- Webhook test reference requirements for paid, failed, expired, duplicate, invalid signature, stale timestamp, and unsupported event cases.
+- Consent and Commerce Passport test user requirements for approved, denied, missing, revoked, expired, amount cap, and untrusted agent cases.
+
+The manifest intentionally does not include tokens, raw passports, real emails, real phones, provider credentials, or signing values.
+
+## Staging Seed Command Plan For Later
+
+M10 does not add an executable hosted seed script. M10.1 should add a dry-run-only planner or a guarded staging seed script after infrastructure decisions are final.
+
+Expected future command shape:
+
+```bash
+node scripts/commerce-staging-seed-plan.mjs --dry-run --manifest=docs/examples/commerce-staging-seed.manifest.json
+node scripts/commerce-staging-seed-plan.mjs --dry-run --api-base=https://api-staging.grantex.dev --manifest=docs/examples/commerce-staging-seed.manifest.json
+```
+
+Expected later execution shape, after explicit approval:
+
+```bash
+node scripts/commerce-staging-seed.mjs --run --api-base=https://api-staging.grantex.dev --manifest=docs/examples/commerce-staging-seed.manifest.json
+```
+
+The future `--run` command must refuse production domains, production project IDs, production databases, production Redis, live commerce flags, live Plural flags, non-mock provider keys, and missing staging-only secret sources.
+
+## Staging Smoke-Test Command Plan For Later
+
+M11 should add a hosted staging E2E harness rather than reusing the local-only load harness unchanged.
+
+Expected command shape:
+
+```bash
+node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=https://api-staging.grantex.dev --merchant-id=mch_staging_electronics_pilot --agent-id=cag_staging_agenticorg_sales
+node scripts/commerce-staging-e2e-harness.mjs --run --api-base=https://api-staging.grantex.dev --merchant-id=mch_staging_electronics_pilot --agent-id=cag_staging_agenticorg_sales --report=docs/reports/commerce-v1-hosted-staging-e2e.md
+```
+
+Smoke coverage should include:
+
+- Health.
+- JWKS.
+- Commerce well-known.
+- MCP initialize, tools/list, and tools/call.
+- Catalog search and get item.
+- Inventory check.
+- Cart create.
+- Consent request.
+- Passport exchange.
+- Payment intent create.
+- Checkout create.
+- Mock webhook paid, failed, expired, duplicate, and invalid signature.
+- Manual reconciliation.
+- Audit timeline.
+- Portal payments, audit, passports, settings, and ops views.
+- AgenticOrg demo/eval against `https://api-staging.grantex.dev`.
+
+The hosted harness must not emit bearer tokens, raw passports, provider credentials, idempotency keys, or webhook signing values.
+
+## Cleanup And Reset Plan
+
+Reset must be staging-only and explicitly approved:
+
+- Disable AgenticOrg staging traffic to Grantex commerce before destructive reset.
+- Pause or disable staging reconciliation worker.
+- Export staging evidence that is intentionally retained.
+- Delete or truncate only records for `cten_staging_commerce`.
+- Preserve append-only audit evidence when required by the pilot evidence plan.
+- Rotate staging-only mock webhook signing material if generated events were shared outside the staging team.
+- Re-run the seed and smoke checks.
+- Never run cleanup against production DB, production Redis, production Cloud Run service, or production Firebase target.
+
+## M10 Confirmation
+
+This current pass does not create resources. It does not deploy. It does not merge. It does not change production config. It does not enable production Commerce V1. It does not enable live payments. It does not enable live Plural. It does not write real secret values.


### PR DESCRIPTION
## Scope

M10 staging data setup and secret inventory only. This is stacked on the M9 hosted staging plan branch so the diff stays focused on seed data prep rather than duplicating M9 docs.

Changed files:
- `docs/examples/commerce-staging-seed.manifest.json`
- `docs/guides/commerce-v1-staging-data-setup.md`
- `docs/commerce-v1-pilot-readiness.validate.mjs`

## Staging Seed Manifest Summary

The manifest defines synthetic staging-only data for:
- Tenant `cten_staging_commerce`
- Merchant `mch_staging_electronics_pilot`
- Agent `cag_staging_agenticorg_sales`
- Category `electronics_appliances`
- Provider `mock`
- Live payment and live Plural flags set false
- Active INR policy with amount cap, TTL caps, stale-price guard, and emergency disable false
- 12 electronics/appliances products, with at least 3 products carrying variants
- Tax-inclusive INR minor-unit prices, GST rate, HSN codes, warranties, returns, availability, source system, and last synced timestamps
- Webhook test reference requirements and consent/passport test-user requirements without generated secret material

## Secret Inventory By Name Only

The setup guide lists staging-only secret names only:
- `DATABASE_URL`
- `REDIS_URL`
- `ADMIN_API_KEY`
- `VAULT_ENCRYPTION_KEY`
- `RSA_PRIVATE_KEY`, if fixed app JWT signing is used
- `ED25519_PRIVATE_KEY`, if DID/signing paths are enabled
- `SSO_STATE_SECRET`
- `METRICS_API_KEY`
- `RESEND_API_KEY`, only if staging email/OTP is enabled
- `MOCK_PAYMENT_WEBHOOK_SECRET`
- Commerce Passport signing key material, according to the existing key path

## Safety Guardrails

- No real secret values are included.
- No raw passports, bearer tokens, provider credentials, idempotency keys, generated webhook signing values, or local env artifacts are included.
- The guide documents production refusal rules for production domains, production DB/Redis, production project IDs, live commerce flags, live Plural flags, non-mock providers, and production secret sources.
- The validator asserts manifest shape, mock provider, live flags false, staging IDs, product count, variants, no forbidden secret-like keys/values, and no-resource/no-production/no-live language.

## Validation

- `node docs/commerce-v1-pilot-readiness.validate.mjs` - passed.
- `git diff --check` - passed.
- `git diff --cached --check` - passed before commit.
- Targeted forbidden-value scan on the new Grantex docs/manifest - no matches.

## Confirmations

- No deploy was performed.
- No merge was performed.
- No cloud resources were created.
- No production config was changed.
- Production Commerce V1 was not enabled.
- Live payments were not enabled.
- Live Plural was not enabled.
- `.tmp`, synthetic env files containing generated auth material, local reports, bearer tokens, passports, idempotency keys, provider credentials, and secrets were not committed.

## Remaining Blockers

- M9 hosted staging infrastructure PR must land or remain the base for this stacked PR.
- Staging GCP project, DNS, Cloud SQL/Redis, GitHub environment secrets, and access model still need approval.
- M10.1 can add an executable dry-run-only seed planner after the exact staging execution surface is approved.
- M11 still needs the hosted staging E2E harness and evidence report.