### PR TITLE
docs(commerce): define hosted staging e2e harness

### DIFF
--- a/docs/commerce-v1-pilot-readiness.validate.mjs
+++ b/docs/commerce-v1-pilot-readiness.validate.mjs
@@ -13,7 +13,10 @@ const stagingSeedManifestText = readFileSync(join(docsDir, 'examples', 'commerce
 const loadReport = readFileSync(join(docsDir, 'reports', 'commerce-v1-local-pilot-load.md'), 'utf8');
 const hostedStagingPlan = readFileSync(join(docsDir, 'guides', 'commerce-v1-hosted-staging-plan.md'), 'utf8');
 const stagingDataSetup = readFileSync(join(docsDir, 'guides', 'commerce-v1-staging-data-setup.md'), 'utf8');
+const hostedStagingE2E = readFileSync(join(docsDir, 'guides', 'commerce-v1-hosted-staging-e2e.md'), 'utf8');
+const hostedStagingE2ETemplate = readFileSync(join(docsDir, 'reports', 'commerce-v1-hosted-staging-e2e.template.md'), 'utf8');
 const harness = readFileSync(join(repoRoot, 'scripts', 'commerce-pilot-load-harness.mjs'), 'utf8');
+const stagingE2EHarness = readFileSync(join(repoRoot, 'scripts', 'commerce-staging-e2e-harness.mjs'), 'utf8');
 const seed = readFileSync(join(repoRoot, 'scripts', 'commerce-pilot-seed-local.mjs'), 'utf8');
 
 for (const required of [
@@ -200,6 +203,98 @@ for (const forbidden of [
   assert.equal(stagingDataSetup.includes(forbidden), false, `staging data setup guide does not include ${forbidden}`);
 }
 
+for (const required of [
+  'Commerce V1 Hosted Staging E2E Harness',
+  'does not create resources',
+  'No production URL may be used as an E2E target',
+  'https://api-staging.grantex.dev',
+  'https://staging.grantex.dev',
+  'https://staging.agenticorg.ai',
+  'https://grantex.dev',
+  'https://api.grantex.dev',
+  'https://app.agenticorg.ai',
+  'cten_staging_commerce',
+  'mch_staging_electronics_pilot',
+  'cag_staging_agenticorg_sales',
+  'ADMIN_API_KEY',
+  'MOCK_PAYMENT_WEBHOOK_SECRET',
+  'Commerce Passport signing key material',
+  'Grantex health',
+  'Grantex JWKS',
+  'Grantex commerce well-known',
+  'MCP initialize',
+  'MCP tools/list',
+  'MCP catalog search/get item',
+  'MCP inventory check',
+  'REST cart create',
+  'REST consent request',
+  'passport exchange',
+  'payment intent create',
+  'checkout create',
+  'mock webhook paid/failed/expired',
+  'duplicate webhook check',
+  'manual reconciliation',
+  'audit timeline check',
+  'portal route smoke',
+  'AgenticOrg real-staging demo/eval handoff',
+  'missing consent',
+  'denied consent',
+  'revoked passport',
+  'expired passport',
+  'amount cap breach',
+  'disabled merchant',
+  'untrusted agent',
+  'stale inventory',
+  'unsupported EMI/discount/warranty claim',
+  'invalid webhook signature',
+  'docs/reports/commerce-v1-hosted-staging-e2e.md',
+]) {
+  assert.ok(hostedStagingE2E.includes(required), `hosted staging E2E guide includes ${required}`);
+}
+
+for (const required of [
+  'https://api-staging.grantex.dev',
+  'https://staging.grantex.dev',
+  'https://staging.agenticorg.ai',
+  'https://grantex.dev',
+  'https://api.grantex.dev',
+  'https://app.agenticorg.ai',
+  "const dryRun = boolArg('--dry-run') || !run;",
+  'docs/reports/commerce-v1-hosted-staging-e2e.md',
+  'Refusing production domain',
+  'Refusing credentialed URL',
+  'Refusing COMMERCE_LIVE_MODE_ENABLED=true',
+  'Refusing PLURAL_LIVE_ENABLED=true',
+  'Refusing non-mock provider',
+  'Run mode is intentionally disabled for M11 dry-run-only harness',
+]) {
+  assert.ok(stagingE2EHarness.includes(required), `hosted staging E2E harness includes ${required}`);
+}
+
+for (const forbiddenDefault of [
+  "DEFAULT_API_BASE = 'https://api.grantex.dev'",
+  "DEFAULT_PORTAL_BASE = 'https://grantex.dev'",
+  "DEFAULT_AGENTICORG_BASE = 'https://app.agenticorg.ai'",
+]) {
+  assert.equal(stagingE2EHarness.includes(forbiddenDefault), false, `hosted staging E2E harness does not default to ${forbiddenDefault}`);
+}
+
+for (const required of [
+  'Commerce V1 Hosted Staging E2E Evidence Template',
+  'https://api-staging.grantex.dev',
+  'https://staging.grantex.dev',
+  'https://staging.agenticorg.ai',
+  'cten_staging_commerce',
+  'mch_staging_electronics_pilot',
+  'cag_staging_agenticorg_sales',
+  'Provider: mock',
+  'Live payments enabled: false',
+  'Live Plural enabled: false',
+  'secret values recorded: false',
+]) {
+  assert.ok(hostedStagingE2ETemplate.includes(required), `hosted staging E2E template includes ${required}`);
+}
+
 assert.ok(harness.includes('Refusing to run commerce pilot load harness against a non-local API base URL'));
 assert.ok(harness.includes('/v1/commerce/payments/intents'));
 assert.ok(harness.includes('/v1/commerce/catalog/search'));
@@ -239,6 +334,37 @@ assert.equal(seedReport.local_only, true);
 assert.equal(seedReport.database_url_allowed, true);
 assert.equal(seedReport.would_seed.cart_count, 100);
 assert.equal(seedReport.would_seed.pending_provider_payment_count, 51);
+
+const stagingE2EDryRun = execFileSync(
+  process.execPath,
+  [join(repoRoot, 'scripts', 'commerce-staging-e2e-harness.mjs'), '--dry-run'],
+  { encoding: 'utf8' },
+);
+const stagingE2EReport = JSON.parse(stagingE2EDryRun);
+assert.equal(stagingE2EReport.mode, 'dry-run');
+assert.equal(stagingE2EReport.status, 'not_executed');
+assert.equal(stagingE2EReport.safety.no_requests_made, true);
+assert.equal(stagingE2EReport.targets.api_base, 'https://api-staging.grantex.dev');
+assert.equal(stagingE2EReport.targets.agenticorg_base, 'https://staging.agenticorg.ai');
+assert.equal(stagingE2EReport.report_path, 'docs/reports/commerce-v1-hosted-staging-e2e.md');
+assert.equal(stagingE2EReport.manifest.provider, 'mock');
+assert.ok(stagingE2EReport.positive_checks.includes('checkout create'));
+assert.ok(stagingE2EReport.negative_checks.includes('invalid webhook signature'));
+
+const stagingE2EProdRefusal = spawnSync(
+  process.execPath,
+  [
+    join(repoRoot, 'scripts', 'commerce-staging-e2e-harness.mjs'),
+    '--dry-run',
+    '--api-base=https://api.grantex.dev',
+  ],
+  { encoding: 'utf8' },
+);
+assert.notEqual(stagingE2EProdRefusal.status, 0, 'hosted staging E2E harness refuses production API base');
+assert.ok(
+  `${stagingE2EProdRefusal.stdout}${stagingE2EProdRefusal.stderr}`.includes('Refusing production domain'),
+  'hosted staging E2E production refusal explains the safety guard',
+);
 
 const nonLocalSeed = spawnSync(
   process.execPath,
@@ -306,7 +432,10 @@ assert.equal(/[^\u0000-\u007F]/.test(stagingSeedManifestText), false, 'staging s
 assert.equal(/[^\u0000-\u007F]/.test(loadReport), false, 'pilot load report stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(hostedStagingPlan), false, 'hosted staging plan stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(stagingDataSetup), false, 'staging data setup guide stays ASCII-only');
+assert.equal(/[^\u0000-\u007F]/.test(hostedStagingE2E), false, 'hosted staging E2E guide stays ASCII-only');
+assert.equal(/[^\u0000-\u007F]/.test(hostedStagingE2ETemplate), false, 'hosted staging E2E template stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(harness), false, 'load harness stays ASCII-only');
+assert.equal(/[^\u0000-\u007F]/.test(stagingE2EHarness), false, 'hosted staging E2E harness stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(seed), false, 'local seed script stays ASCII-only');
 
 console.log('commerce-v1 pilot readiness validation passed');

--- a/docs/guides/commerce-v1-hosted-staging-e2e.md
+++ b/docs/guides/commerce-v1-hosted-staging-e2e.md
@@ -1,0 +1,205 @@
+# Commerce V1 Hosted Staging E2E Harness
+
+## Purpose And Scope
+
+This guide defines the M11 hosted staging E2E harness plan for Grantex Commerce V1 and the AgenticOrg Commerce Sales Agent handoff. It is a pre-cloud, pre-deploy planning artifact plus a dry-run safety harness. It does not create resources, deploy services, merge branches, change production config, write secrets, enable production Commerce V1, enable live payments, or enable live Plural.
+
+The current pass is documentation and dry-run validation only. Hosted execution is a later milestone after the M9 infrastructure and M10 staging data prerequisites are complete.
+
+## Safety Rules
+
+- No production URL may be used as an E2E target.
+- No live payment path may be enabled.
+- No live Plural path may be enabled.
+- No production secret version may be copied into staging.
+- No production database, Redis, bucket, or queue may be used.
+- No bearer token, raw passport, idempotency key, provider credential, webhook secret value, or private key may be written to a report.
+- All evidence must be redacted before it is committed or attached to a PR.
+- The dry-run harness must fail closed before any hosted request can run.
+
+## Staging-Only Allowed Domains
+
+The M11 harness may plan checks only for these staging domains:
+
+- `https://api-staging.grantex.dev`
+- `https://staging.grantex.dev`
+- `https://staging.agenticorg.ai`
+
+Localhost may be used only for explicit local dry-run comparison. Localhost is not a hosted staging target.
+
+## Refused Production Domains
+
+The M11 harness must refuse these domains in all modes:
+
+- `https://grantex.dev`
+- `https://api.grantex.dev`
+- `https://app.agenticorg.ai`
+
+Any URL with embedded username, password, token, secret, key, passport, bearer, or credential query material is also refused.
+
+## Preconditions From M9 And M10
+
+- Grantex staging infrastructure is approved but not created by this pass.
+- Grantex API target is `grantex-auth-staging` behind `https://api-staging.grantex.dev`.
+- Grantex portal target is `grantex-portal-staging` behind `https://staging.grantex.dev`.
+- AgenticOrg staging services are planned behind `https://staging.agenticorg.ai`.
+- Dedicated staging Postgres exists before any real seed.
+- Dedicated staging Redis exists before any real seed.
+- Dedicated staging Secret Manager entries exist before any real run.
+- Staging data uses tenant `cten_staging_commerce`.
+- Staging data uses merchant `mch_staging_electronics_pilot`.
+- Staging data uses agent `cag_staging_agenticorg_sales`.
+- Staging data uses category `electronics_appliances`.
+- Staging provider is `mock`.
+- Live flags are false.
+- M8 mock provider checkout-state fix is present so payment intent state starts at `authorized`.
+- M10 seed manifest is reviewed and ready: `docs/examples/commerce-staging-seed.manifest.json`.
+
+## Required Auth Material Names Only
+
+The hosted run will need staging-only secret values loaded from the approved staging runtime, but this guide records names only:
+
+- `ADMIN_API_KEY`
+- `MOCK_PAYMENT_WEBHOOK_SECRET`
+- `METRICS_API_KEY`
+- Commerce Passport signing key material
+- One AgenticOrg connector credential: `GRANTEX_COMMERCE_BEARER_TOKEN`, `GRANTEX_AGENT_ASSERTION`, or `GRANTEX_API_KEY`
+
+Do not paste values into shell history, docs, reports, PR descriptions, or logs.
+
+## E2E Sequence
+
+1. Grantex health
+2. Grantex JWKS
+3. Grantex commerce well-known
+4. MCP initialize
+5. MCP tools/list
+6. MCP catalog search/get item
+7. MCP inventory check
+8. REST cart create
+9. REST consent request
+10. passport exchange
+11. payment intent create
+12. checkout create
+13. mock webhook paid/failed/expired
+14. duplicate webhook check
+15. manual reconciliation
+16. audit timeline check
+17. portal route smoke
+18. AgenticOrg real-staging demo/eval handoff
+
+## Negative Checks
+
+- missing consent
+- denied consent
+- revoked passport
+- expired passport
+- amount cap breach
+- disabled merchant
+- untrusted agent
+- stale inventory
+- unsupported EMI/discount/warranty claim
+- invalid webhook signature
+
+Each negative check must prove refusal without creating a successful checkout or irreversible state transition.
+
+## Redacted Evidence Report Schema
+
+The later hosted report should follow this shape and omit all secret values:
+
+```json
+{
+  "report_type": "commerce-v1-hosted-staging-e2e",
+  "generated_at": "ISO-8601 timestamp",
+  "mode": "hosted-staging",
+  "targets": {
+    "api_base": "https://api-staging.grantex.dev",
+    "portal_base": "https://staging.grantex.dev",
+    "agenticorg_base": "https://staging.agenticorg.ai"
+  },
+  "seed_manifest": {
+    "tenant_id": "cten_staging_commerce",
+    "merchant_id": "mch_staging_electronics_pilot",
+    "agent_id": "cag_staging_agenticorg_sales",
+    "provider": "mock",
+    "product_count": 12
+  },
+  "preconditions": [
+    "staging DNS verified",
+    "dedicated staging DB verified",
+    "dedicated staging Redis verified",
+    "staging secrets available by name"
+  ],
+  "checks": [
+    {
+      "name": "Grantex health",
+      "status": "pass|fail|blocked",
+      "http_status": 200,
+      "duration_ms": 0,
+      "evidence_ref": "redacted log line or request id only"
+    }
+  ],
+  "negative_checks": [
+    {
+      "name": "invalid webhook signature",
+      "status": "pass|fail|blocked",
+      "expected_refusal": true,
+      "evidence_ref": "redacted log line or request id only"
+    }
+  ],
+  "redaction": {
+    "secret_values_recorded": false,
+    "bearer_tokens_recorded": false,
+    "passports_recorded": false,
+    "provider_credentials_recorded": false
+  },
+  "no_go": [],
+  "rollback_notes": []
+}
+```
+
+## Rollback And No-Go Criteria
+
+Stop the hosted run and mark the report blocked if any of these occur:
+
+- A target resolves to a production domain.
+- A target uses a production database, Redis, or secret version.
+- `COMMERCE_LIVE_MODE_ENABLED` or `PLURAL_LIVE_ENABLED` is true.
+- Provider is anything other than `mock`.
+- AgenticOrg tries to use direct Stripe, Plural, Pine, or provider credentials for commerce.
+- Checkout succeeds without consent, with denied consent, with a revoked or expired passport, or above amount cap.
+- Duplicate webhook changes state twice.
+- Audit timeline is missing required events.
+- Evidence contains unredacted auth material.
+
+Rollback for a later hosted run is limited to disabling staging traffic, disabling staging commerce discovery, stopping staging workers, and restoring the previous staging revision. Production must not be touched.
+
+## Exact Later-Run Commands
+
+M11 dry-run planning:
+
+```powershell
+node scripts/commerce-staging-e2e-harness.mjs --dry-run
+node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=https://api-staging.grantex.dev --agenticorg-base=https://staging.agenticorg.ai
+node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=https://api.grantex.dev
+```
+
+The third command is a refusal check and must fail before any network request.
+
+Later hosted staging execution, after M9/M10 prerequisites and a reviewed implementation of run mode:
+
+```powershell
+node scripts/commerce-staging-e2e-harness.mjs --run --api-base=https://api-staging.grantex.dev --agenticorg-base=https://staging.agenticorg.ai --manifest=docs/examples/commerce-staging-seed.manifest.json --report=docs/reports/commerce-v1-hosted-staging-e2e.md
+```
+
+AgenticOrg later real-staging handoff commands:
+
+```powershell
+$env:AGENTICORG_BASE_URL='https://staging.agenticorg.ai'
+$env:GRANTEX_COMMERCE_BASE_URL='https://api-staging.grantex.dev'
+$env:GRANTEX_BASE_URL='https://api-staging.grantex.dev'
+python demos/commerce_sales_agent_demo.py --mode=hosted-staging
+python -m pytest tests/evals/test_commerce_sales_agent_evals.py -q --hosted-staging
+```
+
+Those AgenticOrg commands are a command plan. They must not be treated as passing hosted evidence until the demo/eval supports non-mocked staging connectors and redacted reporting.

--- a/docs/reports/commerce-v1-hosted-staging-e2e.template.md
+++ b/docs/reports/commerce-v1-hosted-staging-e2e.template.md
@@ -1,0 +1,93 @@
+# Commerce V1 Hosted Staging E2E Evidence Template
+
+Status: template only. Do not record bearer tokens, raw passports, idempotency keys, provider credentials, webhook secret values, private keys, or production data.
+
+## Run Metadata
+
+- Report type: commerce-v1-hosted-staging-e2e
+- Generated at:
+- Operator:
+- Grantex API base: https://api-staging.grantex.dev
+- Grantex portal base: https://staging.grantex.dev
+- AgenticOrg base: https://staging.agenticorg.ai
+- Seed manifest: docs/examples/commerce-staging-seed.manifest.json
+- Tenant: cten_staging_commerce
+- Merchant: mch_staging_electronics_pilot
+- Agent: cag_staging_agenticorg_sales
+- Provider: mock
+- Live payments enabled: false
+- Live Plural enabled: false
+
+## Preconditions
+
+- Staging DNS verified:
+- Dedicated staging Postgres verified:
+- Dedicated staging Redis verified:
+- Staging secrets available by name:
+- No production DB, Redis, or secrets used:
+- No cloud resources created by this run:
+
+## Required Secret Names
+
+- ADMIN_API_KEY
+- MOCK_PAYMENT_WEBHOOK_SECRET
+- METRICS_API_KEY
+- Commerce Passport signing key material
+- GRANTEX_COMMERCE_BEARER_TOKEN or GRANTEX_AGENT_ASSERTION or GRANTEX_API_KEY
+
+## Positive Checks
+
+| Check | Status | HTTP status | Evidence reference |
+| --- | --- | --- | --- |
+| Grantex health | blocked |  |  |
+| Grantex JWKS | blocked |  |  |
+| Grantex commerce well-known | blocked |  |  |
+| MCP initialize | blocked |  |  |
+| MCP tools/list | blocked |  |  |
+| MCP catalog search/get item | blocked |  |  |
+| MCP inventory check | blocked |  |  |
+| REST cart create | blocked |  |  |
+| REST consent request | blocked |  |  |
+| passport exchange | blocked |  |  |
+| payment intent create | blocked |  |  |
+| checkout create | blocked |  |  |
+| mock webhook paid/failed/expired | blocked |  |  |
+| duplicate webhook check | blocked |  |  |
+| manual reconciliation | blocked |  |  |
+| audit timeline check | blocked |  |  |
+| portal route smoke | blocked |  |  |
+| AgenticOrg real-staging demo/eval handoff | blocked |  |  |
+
+## Negative Checks
+
+| Check | Expected result | Status | Evidence reference |
+| --- | --- | --- | --- |
+| missing consent | refused | blocked |  |
+| denied consent | refused | blocked |  |
+| revoked passport | refused | blocked |  |
+| expired passport | refused | blocked |  |
+| amount cap breach | refused | blocked |  |
+| disabled merchant | refused | blocked |  |
+| untrusted agent | refused | blocked |  |
+| stale inventory | refused | blocked |  |
+| unsupported EMI/discount/warranty claim | refused | blocked |  |
+| invalid webhook signature | refused | blocked |  |
+
+## Redaction Confirmation
+
+- secret values recorded: false
+- bearer tokens recorded: false
+- Raw passports recorded: false
+- Idempotency keys recorded: false
+- Provider credentials recorded: false
+- Production data recorded: false
+
+## No-Go Findings
+
+- None recorded.
+
+## Rollback Notes
+
+- If staging commerce discovery must be hidden, disable staging discovery and stop staging workers.
+- If a bad staging revision is active, roll back only the staging service revision.
+- Production must not be changed.

--- a/scripts/commerce-staging-e2e-harness.mjs
+++ b/scripts/commerce-staging-e2e-harness.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, '..');
+
+const ALLOWED_STAGING_ORIGINS = [
+  'https://api-staging.grantex.dev',
+  'https://staging.grantex.dev',
+  'https://staging.agenticorg.ai',
+];
+
+const REFUSED_PRODUCTION_ORIGINS = [
+  'https://grantex.dev',
+  'https://api.grantex.dev',
+  'https://app.agenticorg.ai',
+];
+
+const DEFAULT_API_BASE = 'https://api-staging.grantex.dev';
+const DEFAULT_PORTAL_BASE = 'https://staging.grantex.dev';
+const DEFAULT_AGENTICORG_BASE = 'https://staging.agenticorg.ai';
+const DEFAULT_MANIFEST = 'docs/examples/commerce-staging-seed.manifest.json';
+const DEFAULT_REPORT = 'docs/reports/commerce-v1-hosted-staging-e2e.md';
+
+const POSITIVE_CHECKS = [
+  'Grantex health',
+  'Grantex JWKS',
+  'Grantex commerce well-known',
+  'MCP initialize',
+  'MCP tools/list',
+  'MCP catalog search/get item',
+  'MCP inventory check',
+  'REST cart create',
+  'REST consent request',
+  'passport exchange',
+  'payment intent create',
+  'checkout create',
+  'mock webhook paid/failed/expired',
+  'duplicate webhook check',
+  'manual reconciliation',
+  'audit timeline check',
+  'portal route smoke',
+  'AgenticOrg real-staging demo/eval handoff',
+];
+
+const NEGATIVE_CHECKS = [
+  'missing consent',
+  'denied consent',
+  'revoked passport',
+  'expired passport',
+  'amount cap breach',
+  'disabled merchant',
+  'untrusted agent',
+  'stale inventory',
+  'unsupported EMI/discount/warranty claim',
+  'invalid webhook signature',
+];
+
+const REQUIRED_ENV_VAR_NAMES = [
+  'ADMIN_API_KEY',
+  'MOCK_PAYMENT_WEBHOOK_SECRET',
+  'METRICS_API_KEY',
+  'GRANTEX_COMMERCE_BASE_URL',
+  'GRANTEX_BASE_URL',
+  'AGENTICORG_BASE_URL',
+];
+
+const REQUIRED_ONE_OF_ENV_VAR_NAMES = [
+  ['GRANTEX_COMMERCE_BEARER_TOKEN', 'GRANTEX_AGENT_ASSERTION', 'GRANTEX_API_KEY'],
+];
+
+function argValue(name, fallback) {
+  const prefix = `${name}=`;
+  for (let index = 0; index < process.argv.length; index += 1) {
+    const arg = process.argv[index];
+    if (arg === name && process.argv[index + 1] && !process.argv[index + 1].startsWith('--')) {
+      return process.argv[index + 1];
+    }
+    if (arg.startsWith(prefix)) {
+      return arg.slice(prefix.length);
+    }
+  }
+  return fallback;
+}
+
+function boolArg(name) {
+  return process.argv.includes(name);
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function isTrue(value) {
+  return String(value ?? '').trim().toLowerCase() === 'true';
+}
+
+function isLocalhost(url) {
+  return ['localhost', '127.0.0.1', '::1', '[::1]'].includes(url.hostname);
+}
+
+function validateUrl(input, label, dryRun, allowLocalhost) {
+  let url;
+  try {
+    url = new URL(input);
+  } catch {
+    fail(`Refusing invalid ${label}: ${input}`);
+  }
+
+  if (url.username || url.password) {
+    fail(`Refusing credentialed URL for ${label}`);
+  }
+
+  for (const key of url.searchParams.keys()) {
+    const lowered = key.toLowerCase();
+    if (['token', 'secret', 'key', 'passport', 'bearer', 'credential'].some((fragment) => lowered.includes(fragment))) {
+      fail(`Refusing credential material in ${label} query string`);
+    }
+  }
+
+  if (REFUSED_PRODUCTION_ORIGINS.includes(url.origin)) {
+    fail(`Refusing production domain for ${label}: ${url.origin}`);
+  }
+
+  if (isLocalhost(url)) {
+    if (!dryRun || !allowLocalhost) {
+      fail(`Refusing localhost ${label} unless --allow-localhost is used for local dry-run comparison`);
+    }
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      fail(`Refusing unsupported localhost protocol for ${label}`);
+    }
+    return url.origin;
+  }
+
+  if (url.protocol !== 'https:') {
+    fail(`Refusing non-HTTPS staging URL for ${label}`);
+  }
+
+  if (!ALLOWED_STAGING_ORIGINS.includes(url.origin)) {
+    fail(`Refusing non-staging ${label}: ${url.origin}`);
+  }
+
+  return url.origin;
+}
+
+function loadManifest(pathInput) {
+  const manifestPath = resolve(repoRoot, pathInput);
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch (error) {
+    fail(`Unable to read staging manifest at ${pathInput}: ${error.message}`);
+  }
+
+  assertNoForbiddenManifestSecrets(parsed);
+
+  if (parsed.provider?.provider_key !== 'mock') {
+    fail('Refusing non-mock provider in staging manifest; future --allow-provider-sandbox mode is not implemented');
+  }
+  if (parsed.provider?.live_payments_enabled !== false || parsed.provider?.plural_live_enabled !== false) {
+    fail('Refusing staging manifest with live provider flags');
+  }
+  if (
+    parsed.live_flags?.commerce_live_mode_enabled !== false
+    || parsed.live_flags?.plural_live_enabled !== false
+  ) {
+    fail('Refusing staging manifest with live commerce or live Plural flags');
+  }
+
+  const products = parsed.catalog?.products;
+  if (!Array.isArray(products) || products.length < 10 || products.length > 25) {
+    fail('Refusing staging manifest without 10-25 synthetic products');
+  }
+  if (products.filter((product) => Array.isArray(product.variants) && product.variants.length > 0).length < 3) {
+    fail('Refusing staging manifest without at least 3 products with variants');
+  }
+
+  return {
+    tenant_id: parsed.tenant?.id,
+    merchant_id: parsed.merchant?.id,
+    agent_id: parsed.agent?.id,
+    category_id: parsed.category?.id,
+    provider: parsed.provider?.provider_key,
+    product_count: products.length,
+    products_with_variants: products.filter((product) => Array.isArray(product.variants) && product.variants.length > 0).length,
+  };
+}
+
+function assertNoForbiddenManifestSecrets(value, path = 'manifest') {
+  const forbiddenKeyFragments = [
+    'api_key',
+    'bearer',
+    'credential_ref',
+    'idempotency',
+    'private_key',
+    'raw_passport',
+    'secret',
+    'token',
+    'webhook_secret',
+  ];
+  const forbiddenValueFragments = [
+    'Bearer ',
+    'sk_live_',
+    'pk_live_',
+    '-----BEGIN',
+    'passport.jwt',
+    'idempotency-key:',
+    'mock-webhook-secret',
+  ];
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoForbiddenManifestSecrets(item, `${path}[${index}]`));
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, nested] of Object.entries(value)) {
+      const lowered = key.toLowerCase();
+      if (forbiddenKeyFragments.some((fragment) => lowered.includes(fragment))) {
+        fail(`Refusing forbidden secret-like key in staging manifest at ${path}.${key}`);
+      }
+      assertNoForbiddenManifestSecrets(nested, `${path}.${key}`);
+    }
+    return;
+  }
+  if (typeof value === 'string') {
+    for (const forbidden of forbiddenValueFragments) {
+      if (value.includes(forbidden)) {
+        fail(`Refusing forbidden secret-like value in staging manifest at ${path}`);
+      }
+    }
+  }
+}
+
+const run = boolArg('--run');
+const dryRun = boolArg('--dry-run') || !run;
+const allowLocalhost = boolArg('--allow-localhost');
+const provider = argValue('--provider', 'mock');
+const apiBase = argValue('--api-base', DEFAULT_API_BASE);
+const portalBase = argValue('--portal-base', DEFAULT_PORTAL_BASE);
+const agenticorgBase = argValue('--agenticorg-base', DEFAULT_AGENTICORG_BASE);
+const manifestPath = argValue('--manifest', DEFAULT_MANIFEST);
+const reportPath = argValue('--report', DEFAULT_REPORT);
+
+if (provider !== 'mock') {
+  fail('Refusing non-mock provider; future --allow-provider-sandbox mode is not implemented');
+}
+if (isTrue(process.env.COMMERCE_LIVE_MODE_ENABLED)) {
+  fail('Refusing COMMERCE_LIVE_MODE_ENABLED=true for hosted staging E2E harness');
+}
+if (isTrue(process.env.PLURAL_LIVE_ENABLED)) {
+  fail('Refusing PLURAL_LIVE_ENABLED=true for hosted staging E2E harness');
+}
+if (reportPath.includes('.tmp') || !reportPath.includes('hosted-staging-e2e')) {
+  fail('Refusing non-staging or local-only report path');
+}
+
+const normalizedApiBase = validateUrl(apiBase, 'Grantex API base', dryRun, allowLocalhost);
+const normalizedPortalBase = validateUrl(portalBase, 'Grantex portal base', dryRun, allowLocalhost);
+const normalizedAgenticOrgBase = validateUrl(agenticorgBase, 'AgenticOrg base', dryRun, allowLocalhost);
+const manifestSummary = loadManifest(manifestPath);
+
+const output = {
+  mode: dryRun ? 'dry-run' : 'run',
+  status: 'not_executed',
+  safety: {
+    no_requests_made: true,
+    production_domains_refused: REFUSED_PRODUCTION_ORIGINS,
+    staging_domains_allowed: ALLOWED_STAGING_ORIGINS,
+    non_mock_provider_refused: true,
+    live_payment_flags_refused: true,
+    secret_values_printed: false,
+  },
+  targets: {
+    api_base: normalizedApiBase,
+    portal_base: normalizedPortalBase,
+    agenticorg_base: normalizedAgenticOrgBase,
+  },
+  manifest: manifestSummary,
+  report_path: reportPath,
+  required_env_var_names: REQUIRED_ENV_VAR_NAMES,
+  required_one_of_env_var_names: REQUIRED_ONE_OF_ENV_VAR_NAMES,
+  positive_checks: POSITIVE_CHECKS,
+  negative_checks: NEGATIVE_CHECKS,
+  evidence_schema: {
+    report_type: 'commerce-v1-hosted-staging-e2e',
+    generated_at: 'ISO-8601 timestamp',
+    checks: 'array of redacted check results',
+    negative_checks: 'array of redacted refusal results',
+    redaction: {
+      secret_values_recorded: false,
+      bearer_tokens_recorded: false,
+      passports_recorded: false,
+      provider_credentials_recorded: false,
+    },
+  },
+};
+
+if (run) {
+  const missingNames = REQUIRED_ENV_VAR_NAMES.filter((name) => !process.env[name]);
+  const missingOneOf = REQUIRED_ONE_OF_ENV_VAR_NAMES.filter((group) => !group.some((name) => process.env[name]));
+  const missingText = [
+    ...missingNames,
+    ...missingOneOf.map((group) => `one of ${group.join(', ')}`),
+  ];
+  if (missingText.length > 0) {
+    fail(`Run mode is disabled for M11 dry-run-only harness and missing staging env names: ${missingText.join('; ')}. No requests were made.`);
+  }
+  fail('Run mode is intentionally disabled for M11 dry-run-only harness. No requests were made.');
+}
+
+console.log(JSON.stringify(output, null, 2));


### PR DESCRIPTION
## Scope

M11 docs/harness/validator only, stacked on `codex/commerce-m10-staging-data-setup`.

Files changed:
- `docs/guides/commerce-v1-hosted-staging-e2e.md`
- `docs/reports/commerce-v1-hosted-staging-e2e.template.md`
- `scripts/commerce-staging-e2e-harness.mjs`
- `docs/commerce-v1-pilot-readiness.validate.mjs`

## Harness behavior

- Defaults to dry-run unless `--run` is explicitly requested.
- `--run` is intentionally disabled for M11 and exits without requests.
- Allows only staging domains: `https://api-staging.grantex.dev`, `https://staging.grantex.dev`, `https://staging.agenticorg.ai`.
- Refuses production domains: `https://grantex.dev`, `https://api.grantex.dev`, `https://app.agenticorg.ai`.
- Refuses credentialed URLs, non-HTTPS staging URLs, live Commerce/Plural flags, and non-mock providers.
- Prints planned checks and required env/secret names only; it does not print secret values.

## Safety confirmations

- No deploy was performed.
- No cloud resources were created.
- No production config was changed.
- Production Commerce V1 was not enabled.
- Live payments were not enabled.
- Live Plural was not enabled.
- `.tmp`, synthetic env files, bearer tokens, passports, idempotency keys, provider credentials, secrets, and local-only reports were not committed.

## Validation

- `node docs/commerce-v1-pilot-readiness.validate.mjs` - pass
- `node scripts/commerce-staging-e2e-harness.mjs --dry-run` - pass
- `node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=https://api-staging.grantex.dev --agenticorg-base=https://staging.agenticorg.ai` - pass
- `node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=https://api.grantex.dev` - expected fail-closed production refusal
- `git diff --check` - pass
- `git diff --cached --check` - pass

## Blockers before hosted execution

- Hosted staging infrastructure, DNS, DB, Redis, and staging secrets still need to exist.
- Grantex hosted run mode must be explicitly implemented and reviewed before any network requests.
- AgenticOrg non-mocked real-staging demo/eval mode must exist before evidence can be claimed.
- Staging evidence must remain redacted and staging-only.