### PR TITLE
feat(commerce): add merchant and agent update APIs

### DIFF
--- a/apps/auth-service/src/lib/commerce/audit.ts
+++ b/apps/auth-service/src/lib/commerce/audit.ts
@@ -6,6 +6,7 @@ type Sql = ReturnType<typeof postgres>;
 
 export type CommerceAuditEventType =
   | 'merchant.created'
+  | 'merchant.updated'
   | 'merchant.disabled'
   | 'merchant.credentials.updated'
   | 'merchant.feature_flag.updated'
@@ -13,6 +14,7 @@ export type CommerceAuditEventType =
   | 'merchant.webhook_source.created'
   | 'merchant.webhook_source.secret_rotated'
   | 'commerce_agent.created'
+  | 'agent.updated'
   | 'commerce_agent.trust_status.updated'
   | 'commerce_agent.disabled'
   | 'product.created'

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -54,11 +54,35 @@ interface MerchantCreateBody {
   support_email?: unknown;
 }
 
+interface MerchantPatchBody {
+  legal_name?: unknown;
+  display_name?: unknown;
+  category_preset?: unknown;
+  country_code?: unknown;
+  default_currency?: unknown;
+  support_email?: unknown;
+  agentic_commerce_enabled?: unknown;
+}
+
 interface AgentCreateBody {
   display_name?: unknown;
   agent_type?: unknown;
   public_key_jwk?: unknown;
   api_key_hash?: unknown;
+  trust_status?: unknown;
+}
+
+interface AgentListQuery {
+  merchant_id?: string;
+  status?: string;
+  trust_status?: string;
+  limit?: string;
+  cursor?: string;
+}
+
+interface AgentPatchBody {
+  display_name?: unknown;
+  status?: unknown;
   trust_status?: unknown;
 }
 
@@ -102,6 +126,24 @@ interface CatalogSearchBody {
 }
 
 const AVAILABILITY = new Set(['in_stock', 'out_of_stock', 'pre_order', 'back_order', 'unknown']);
+const AGENT_TRUST_STATUSES = new Set(['pending', 'trusted', 'suspended', 'disabled']);
+const AGENT_STATUSES = new Set(['active', 'disabled']);
+
+const MERCHANT_PATCH_FIELDS = new Set([
+  'legal_name',
+  'display_name',
+  'category_preset',
+  'country_code',
+  'default_currency',
+  'support_email',
+  'agentic_commerce_enabled',
+]);
+
+const AGENT_PATCH_FIELDS = new Set([
+  'display_name',
+  'status',
+  'trust_status',
+]);
 
 function isString(v: unknown): v is string {
   return typeof v === 'string' && v.length > 0;
@@ -113,6 +155,20 @@ function asInt(v: unknown): number | null {
   if (typeof v === 'number' && Number.isFinite(v) && Math.trunc(v) === v) return v;
   if (typeof v === 'string' && /^\d+$/.test(v)) return Number.parseInt(v, 10);
   return null;
+}
+
+function validatePatchKeys(
+  body: Record<string, unknown>,
+  allowed: Set<string>,
+  fieldErrors: Record<string, string>,
+): string[] {
+  const changedFields = Object.keys(body);
+  for (const key of changedFields) {
+    if (!allowed.has(key)) {
+      fieldErrors[key] = 'field is immutable or unsupported';
+    }
+  }
+  return changedFields.filter((key) => allowed.has(key));
 }
 
 function merchantIdForCatalogRead(request: FastifyRequest, rawMerchantId: unknown): string {
@@ -408,6 +464,119 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
   });
 
   // ----------------------------------------------------------------------
+  // PATCH /merchants/:merchantId — operator OR merchant for own merchant.
+  // Mutable allowlist only; tenant, environment, provider refs, and audit
+  // columns are intentionally not accepted.
+  // ----------------------------------------------------------------------
+  app.patch<{ Params: { merchantId: string }; Body: MerchantPatchBody }>(
+    '/merchants/:merchantId',
+    async (request, reply) => {
+      requireOperatorOrSelfMerchant(request, request.params.merchantId);
+      if (request.body !== undefined && !isPlainObject(request.body)) {
+        throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+          details: { fields: { body: 'must be a JSON object' } },
+          retryable: false,
+        });
+      }
+
+      const body = (request.body ?? {}) as Record<string, unknown>;
+      const fieldErrors: Record<string, string> = {};
+      const changedFields = validatePatchKeys(body, MERCHANT_PATCH_FIELDS, fieldErrors);
+      if (changedFields.length === 0 && Object.keys(fieldErrors).length === 0) {
+        fieldErrors['body'] = 'at least one mutable field is required';
+      }
+
+      if (body['legal_name'] !== undefined && !isString(body['legal_name'])) {
+        fieldErrors['legal_name'] = 'must be a non-empty string';
+      }
+      if (body['display_name'] !== undefined && !isString(body['display_name'])) {
+        fieldErrors['display_name'] = 'must be a non-empty string';
+      }
+      if (body['category_preset'] !== undefined && !isCommerceCategoryPreset(body['category_preset'])) {
+        fieldErrors['category_preset'] = 'must be a known commerce category preset';
+      }
+      if (body['default_currency'] !== undefined
+        && (!isString(body['default_currency']) || !/^[A-Z]{3}$/.test(body['default_currency']))) {
+        fieldErrors['default_currency'] = 'must be an ISO 4217 uppercase currency code';
+      }
+      if (body['country_code'] !== undefined
+        && (!isString(body['country_code']) || !/^[A-Z]{2}$/.test(body['country_code']))) {
+        fieldErrors['country_code'] = 'must be an ISO 3166-1 alpha-2 uppercase country code';
+      }
+      if (body['support_email'] !== undefined
+        && body['support_email'] !== null
+        && !isString(body['support_email'])) {
+        fieldErrors['support_email'] = 'must be a non-empty string or null';
+      }
+      if (body['agentic_commerce_enabled'] !== undefined
+        && typeof body['agentic_commerce_enabled'] !== 'boolean') {
+        fieldErrors['agentic_commerce_enabled'] = 'must be a boolean';
+      }
+      if (Object.keys(fieldErrors).length > 0) {
+        throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+          details: { fields: fieldErrors },
+          retryable: false,
+        });
+      }
+
+      const sql = getSql();
+      const tenantId = request.commerceTenantId;
+      const merchantId = request.params.merchantId;
+      const hasLegalName = Object.prototype.hasOwnProperty.call(body, 'legal_name');
+      const hasDisplayName = Object.prototype.hasOwnProperty.call(body, 'display_name');
+      const hasCategoryPreset = Object.prototype.hasOwnProperty.call(body, 'category_preset');
+      const hasDefaultCurrency = Object.prototype.hasOwnProperty.call(body, 'default_currency');
+      const hasCountryCode = Object.prototype.hasOwnProperty.call(body, 'country_code');
+      const hasSupportEmail = Object.prototype.hasOwnProperty.call(body, 'support_email');
+      const hasAgenticCommerce = Object.prototype.hasOwnProperty.call(body, 'agentic_commerce_enabled');
+      const patchLegalName = hasLegalName ? body['legal_name'] as string : null;
+      const patchDisplayName = hasDisplayName ? body['display_name'] as string : null;
+      const patchCategoryPreset = hasCategoryPreset ? body['category_preset'] as string : null;
+      const patchDefaultCurrency = hasDefaultCurrency ? body['default_currency'] as string : null;
+      const patchCountryCode = hasCountryCode ? body['country_code'] as string : null;
+      const patchSupportEmail = hasSupportEmail ? body['support_email'] as string | null : null;
+      const patchAgenticCommerce = hasAgenticCommerce ? body['agentic_commerce_enabled'] as boolean : null;
+
+      const result = await sql.begin(async (_tx) => {
+        const tx = _tx as unknown as TxSql;
+        const rows = await tx<Record<string, unknown>[]>`
+          UPDATE commerce_merchants
+             SET legal_name = CASE WHEN ${hasLegalName}::boolean THEN ${patchLegalName}::text ELSE legal_name END,
+                 display_name = CASE WHEN ${hasDisplayName}::boolean THEN ${patchDisplayName}::text ELSE display_name END,
+                 category_preset = CASE WHEN ${hasCategoryPreset}::boolean THEN ${patchCategoryPreset}::text ELSE category_preset END,
+                 default_currency = CASE WHEN ${hasDefaultCurrency}::boolean THEN ${patchDefaultCurrency}::text ELSE default_currency END,
+                 country_code = CASE WHEN ${hasCountryCode}::boolean THEN ${patchCountryCode}::text ELSE country_code END,
+                 support_email = CASE WHEN ${hasSupportEmail}::boolean THEN ${patchSupportEmail}::text ELSE support_email END,
+                 agentic_commerce_enabled = CASE WHEN ${hasAgenticCommerce}::boolean THEN ${patchAgenticCommerce}::boolean ELSE agentic_commerce_enabled END,
+                 updated_at = NOW()
+           WHERE id = ${merchantId}
+             AND tenant_id = ${tenantId}
+           RETURNING id, tenant_id, legal_name, display_name, category_preset,
+                     verification_status, environment, agentic_commerce_enabled,
+                     default_currency, country_code, support_email,
+                     disabled_at, created_at, updated_at
+        `;
+        const merchant = rows[0];
+        if (!merchant) return null;
+        const audit = await appendCommerceAudit(tx as unknown as Sql, {
+          tenantId,
+          merchantId,
+          eventType: 'merchant.updated',
+          resourceType: 'merchant',
+          resourceId: merchantId,
+          requestId: request.id,
+          metadata: { changed_fields: changedFields },
+        });
+        return { merchant, auditEventId: audit.id };
+      });
+      if (!result) {
+        throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
+      }
+      return reply.status(200).send({ data: result.merchant, audit_event_id: result.auditEventId });
+    },
+  );
+
+  // ----------------------------------------------------------------------
   // POST /agents — operator only; trust_status server-controlled (M1 hardening)
   // ----------------------------------------------------------------------
   app.post<{ Body: AgentCreateBody }>('/agents', async (request, reply) => {
@@ -471,6 +640,113 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
   });
 
   // ----------------------------------------------------------------------
+  // GET /agents — tenant-bound list. Operator callers list tenant agents;
+  // merchant callers may request their own merchant scope. CommerceAgents
+  // are tenant-scoped in the current schema, so merchant_id is verified as
+  // tenant-owned but is not treated as an exclusive join.
+  // ----------------------------------------------------------------------
+  app.get<{ Querystring: AgentListQuery }>('/agents', async (request, reply) => {
+    const caller = request.commerceCaller;
+    if (caller.kind === 'service') {
+      throw new CommerceHttpError(403, 'caller_not_authorized',
+        'CommerceAgent listing requires operator, merchant, or the agent itself');
+    }
+
+    const fieldErrors: Record<string, string> = {};
+    const limit = request.query.limit === undefined ? 25 : asInt(request.query.limit);
+    if (limit === null || limit < 1 || limit > 100) {
+      fieldErrors['limit'] = 'must be an integer between 1 and 100';
+    }
+    const trustStatus = request.query.trust_status ?? null;
+    if (trustStatus !== null && !AGENT_TRUST_STATUSES.has(trustStatus)) {
+      fieldErrors['trust_status'] = 'must be one of: pending, trusted, suspended, disabled';
+    }
+    const status = request.query.status ?? null;
+    if (status !== null && !AGENT_STATUSES.has(status)) {
+      fieldErrors['status'] = 'must be one of: active, disabled';
+    }
+    if (request.query.cursor !== undefined && typeof request.query.cursor !== 'string') {
+      fieldErrors['cursor'] = 'must be a string';
+    }
+
+    let merchantId = request.query.merchant_id ?? null;
+    if (caller.kind === 'merchant') {
+      if (merchantId !== null && merchantId !== caller.merchantId) {
+        throw new CommerceHttpError(403, 'merchant_scope_violation',
+          'Merchant callers may only list CommerceAgents for their own merchant scope');
+      }
+      merchantId = caller.merchantId;
+    }
+    if (caller.kind === 'agent' && merchantId !== null) {
+      throw new CommerceHttpError(403, 'caller_not_authorized',
+        'CommerceAgent callers may only list their own agent record');
+    }
+    if (Object.keys(fieldErrors).length > 0) {
+      throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed',
+        { details: { fields: fieldErrors }, retryable: false });
+    }
+
+    let cursorCreated: string | null = null;
+    let cursorId: string | null = null;
+    if (request.query.cursor) {
+      try {
+        const decoded = Buffer.from(request.query.cursor, 'base64url').toString('utf8');
+        const [created, id] = decoded.split('|');
+        if (created && id) { cursorCreated = created; cursorId = id; }
+      } catch { /* ignore malformed cursor */ }
+    }
+
+    const sql = getSql();
+    const tenantId = request.commerceTenantId;
+    if (merchantId !== null) {
+      const merchantRows = await sql<{ id: string }[]>`
+        SELECT id FROM commerce_merchants
+         WHERE id = ${merchantId}
+           AND tenant_id = ${tenantId}
+         LIMIT 1
+      `;
+      if (!merchantRows[0]) {
+        throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
+      }
+    }
+
+    const selfAgentId = caller.kind === 'agent' ? caller.agentId : null;
+    const rows = await sql<Record<string, unknown>[]>`
+      SELECT id, tenant_id, display_name, agent_type,
+             public_key_jwk, trust_status,
+             CASE WHEN disabled_at IS NULL THEN 'active' ELSE 'disabled' END AS status,
+             disabled_at, created_at, updated_at
+        FROM commerce_agents
+       WHERE tenant_id = ${tenantId}
+         AND (${selfAgentId}::text IS NULL OR id = ${selfAgentId})
+         AND (${trustStatus}::text IS NULL OR trust_status = ${trustStatus})
+         AND (
+           ${status}::text IS NULL
+           OR (${status}::text = 'active' AND disabled_at IS NULL)
+           OR (${status}::text = 'disabled' AND disabled_at IS NOT NULL)
+         )
+         AND (
+           ${cursorCreated}::timestamptz IS NULL
+           OR (created_at, id) < (${cursorCreated}::timestamptz, ${cursorId}::text)
+         )
+       ORDER BY created_at DESC, id DESC
+       LIMIT ${(limit ?? 25) + 1}
+    `;
+    let nextCursor: string | null = null;
+    const safeLimit = limit ?? 25;
+    if (rows.length > safeLimit) {
+      const last = rows[safeLimit - 1];
+      if (last) {
+        const createdVal = last['created_at'];
+        const createdIso = createdVal instanceof Date ? createdVal.toISOString() : String(createdVal);
+        nextCursor = Buffer.from(`${createdIso}|${last['id'] as string}`, 'utf8').toString('base64url');
+      }
+      rows.length = safeLimit;
+    }
+    return reply.status(200).send({ items: rows, next_cursor: nextCursor });
+  });
+
+  // ----------------------------------------------------------------------
   // GET /agents/:agentId — operator OR the agent reading own record.
   // Merchant denied.
   // ----------------------------------------------------------------------
@@ -491,6 +767,112 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
     }
     return reply.status(200).send({ data: rows[0] });
   });
+
+  // ----------------------------------------------------------------------
+  // PATCH /agents/:agentId — operator only. Agent self-updates are denied
+  // so an agent cannot self-elevate trust/status.
+  // ----------------------------------------------------------------------
+  app.patch<{ Params: { agentId: string }; Body: AgentPatchBody }>(
+    '/agents/:agentId',
+    async (request, reply) => {
+      requireOperator(request);
+      if (request.body !== undefined && !isPlainObject(request.body)) {
+        throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+          details: { fields: { body: 'must be a JSON object' } },
+          retryable: false,
+        });
+      }
+
+      const body = (request.body ?? {}) as Record<string, unknown>;
+      const fieldErrors: Record<string, string> = {};
+      const changedFields = validatePatchKeys(body, AGENT_PATCH_FIELDS, fieldErrors);
+      if (changedFields.length === 0 && Object.keys(fieldErrors).length === 0) {
+        fieldErrors['body'] = 'at least one mutable field is required';
+      }
+      if (body['display_name'] !== undefined && !isString(body['display_name'])) {
+        fieldErrors['display_name'] = 'must be a non-empty string';
+      }
+      if (body['trust_status'] !== undefined
+        && (typeof body['trust_status'] !== 'string' || !AGENT_TRUST_STATUSES.has(body['trust_status']))) {
+        fieldErrors['trust_status'] = 'must be one of: pending, trusted, suspended, disabled';
+      }
+      if (body['status'] !== undefined
+        && (typeof body['status'] !== 'string' || !AGENT_STATUSES.has(body['status']))) {
+        fieldErrors['status'] = 'must be one of: active, disabled';
+      }
+      if (Object.keys(fieldErrors).length > 0) {
+        throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+          details: { fields: fieldErrors },
+          retryable: false,
+        });
+      }
+
+      const hasDisplayName = Object.prototype.hasOwnProperty.call(body, 'display_name');
+      const hasTrustStatus = Object.prototype.hasOwnProperty.call(body, 'trust_status');
+      const hasStatus = Object.prototype.hasOwnProperty.call(body, 'status');
+      const targetTrustStatus = hasTrustStatus ? body['trust_status'] as string : null;
+      const targetStatus = hasStatus ? body['status'] as string : null;
+      const patchDisplayName = hasDisplayName ? body['display_name'] as string : null;
+
+      const sql = getSql();
+      const tenantId = request.commerceTenantId;
+      const agentId = request.params.agentId;
+      const result = await sql.begin(async (_tx) => {
+        const tx = _tx as unknown as TxSql;
+        const existingRows = await tx<Array<{ id: string; disabled_at: string | Date | null }>>`
+          SELECT id, disabled_at
+            FROM commerce_agents
+           WHERE id = ${agentId}
+             AND tenant_id = ${tenantId}
+           LIMIT 1
+        `;
+        const existing = existingRows[0];
+        if (!existing) return null;
+        const wouldBeDisabled = targetStatus === 'disabled'
+          || (targetStatus === null && existing.disabled_at !== null);
+        if (targetTrustStatus === 'trusted' && wouldBeDisabled) {
+          throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+            details: { fields: { trust_status: 'disabled agents cannot be marked trusted' } },
+            retryable: false,
+          });
+        }
+
+        const rows = await tx<Record<string, unknown>[]>`
+          UPDATE commerce_agents
+             SET display_name = CASE WHEN ${hasDisplayName}::boolean THEN ${patchDisplayName}::text ELSE display_name END,
+                 trust_status = CASE WHEN ${hasTrustStatus}::boolean THEN ${targetTrustStatus}::text ELSE trust_status END,
+                 disabled_at = CASE
+                   WHEN ${hasStatus}::boolean AND ${targetStatus}::text = 'disabled' THEN NOW()
+                   WHEN ${hasStatus}::boolean AND ${targetStatus}::text = 'active' THEN NULL::timestamptz
+                   ELSE disabled_at
+                 END,
+                 updated_at = NOW()
+           WHERE id = ${agentId}
+             AND tenant_id = ${tenantId}
+           RETURNING id, tenant_id, display_name, agent_type,
+                     public_key_jwk, trust_status,
+                     CASE WHEN disabled_at IS NULL THEN 'active' ELSE 'disabled' END AS status,
+                     disabled_at, created_at, updated_at
+        `;
+        const agent = rows[0];
+        if (!agent) return null;
+        const audit = await appendCommerceAudit(tx as unknown as Sql, {
+          tenantId,
+          agentId,
+          eventType: 'agent.updated',
+          resourceType: 'commerce_agent',
+          resourceId: agentId,
+          requestId: request.id,
+          metadata: { changed_fields: changedFields },
+        });
+        return { agent, auditEventId: audit.id };
+      });
+      if (!result) {
+        throw new CommerceHttpError(404, 'agent_not_found', 'Agent not found in this tenant');
+      }
+      return reply.status(200).send({ data: result.agent, audit_event_id: result.auditEventId });
+    },
+  );
 
   // ----------------------------------------------------------------------
   // POST /catalog/products — operator only

--- a/apps/auth-service/tests/commerce-merchant-agent-m12a.test.ts
+++ b/apps/auth-service/tests/commerce-merchant-agent-m12a.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { authHeader, buildTestApp, sqlMock } from './helpers.js';
+import { seedCommerceContext, TEST_COMMERCE_TENANT_ID } from './commerce-helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const openapiPath = join(__dirname, '..', '..', '..', 'docs', 'api', 'grantex-commerce-v1.openapi.yaml');
+const MERCHANT_TOKEN = 'grtx_sk_sandbox_abcd1234abcd1234abcd1234abcd1234';
+const AGENT_TOKEN = 'grtx_agent_M12AXXXXXXXXXXXXXXXXXXXXXXXX';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+function seedMerchantCaller(merchantId = 'mch_M12A'): void {
+  sqlMock.mockResolvedValueOnce([{
+    id: 'mkey_M12A',
+    tenant_id: TEST_COMMERCE_TENANT_ID,
+    merchant_id: merchantId,
+    environment: 'sandbox',
+    tenant_status: 'active',
+  }]);
+  // resolveMerchantApiKey performs a best-effort last_used_at update.
+  sqlMock.mockResolvedValueOnce([]);
+}
+
+function seedAgentCaller(agentId = 'cag_M12A'): void {
+  sqlMock.mockResolvedValueOnce([{
+    id: agentId,
+    tenant_id: TEST_COMMERCE_TENANT_ID,
+    trust_status: 'trusted',
+    public_key_jwk: null,
+    api_key_hash: 'sha256:test',
+    tenant_status: 'active',
+  }]);
+}
+
+function merchantRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'mch_M12A',
+    tenant_id: TEST_COMMERCE_TENANT_ID,
+    legal_name: 'Acme Electronics Pvt Ltd',
+    display_name: 'Acme Electronics',
+    category_preset: 'electronics_appliances',
+    verification_status: 'unverified',
+    environment: 'sandbox',
+    agentic_commerce_enabled: true,
+    default_currency: 'INR',
+    country_code: 'IN',
+    support_email: 'support@acme.example',
+    disabled_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function agentRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'cag_M12A',
+    tenant_id: TEST_COMMERCE_TENANT_ID,
+    display_name: 'Acme Sales Agent',
+    agent_type: 'sales',
+    public_key_jwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' },
+    trust_status: 'trusted',
+    status: 'active',
+    disabled_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function sqlText(call: unknown[]): string {
+  return Array.isArray(call[0]) ? (call[0] as string[]).join(' ') : '';
+}
+
+function findSqlCall(pattern: RegExp): unknown[] | undefined {
+  return sqlMock.mock.calls.find((call) => pattern.test(sqlText(call)));
+}
+
+function findAuditCall(eventType: string): unknown[] | undefined {
+  return sqlMock.mock.calls.find((call) => {
+    return /INSERT INTO commerce_audit_events/i.test(sqlText(call))
+      && call.slice(1).includes(eventType);
+  });
+}
+
+describe('M12A PATCH /v1/commerce/merchants/:merchantId', () => {
+  it('updates allowlisted merchant fields and writes merchant.updated audit metadata', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([merchantRow({ display_name: 'Acme Updated' })]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_MERCHANT_UPDATED', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/commerce/merchants/mch_M12A',
+      headers: authHeader(),
+      payload: { display_name: 'Acme Updated', agentic_commerce_enabled: true },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { id: string; display_name: string }; audit_event_id: string }>();
+    expect(body.data.id).toBe('mch_M12A');
+    expect(body.data.display_name).toBe('Acme Updated');
+    expect(body.audit_event_id).toBe('caud_MERCHANT_UPDATED');
+
+    const auditCall = findAuditCall('merchant.updated');
+    expect(auditCall).toBeDefined();
+    const metadata = auditCall?.find((value) => typeof value === 'string' && value.includes('changed_fields')) as string;
+    expect(metadata).toContain('display_name');
+    expect(metadata).toContain('agentic_commerce_enabled');
+    expect(metadata).not.toContain('Acme Updated');
+  });
+
+  it('rejects unknown, immutable, and sensitive merchant patch keys', async () => {
+    seedCommerceContext();
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/commerce/merchants/mch_M12A',
+      headers: authHeader(),
+      payload: {
+        tenant_id: 'cten_OTHER',
+        environment: 'live',
+        provider_account_refs: { plural: 'x' },
+      },
+    });
+
+    expect(res.statusCode).toBe(422);
+    const fields = res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields;
+    expect(fields).toHaveProperty('tenant_id');
+    expect(fields).toHaveProperty('environment');
+    expect(fields).toHaveProperty('provider_account_refs');
+  });
+
+  it('returns non-enumerating 404 when merchant is absent or outside the tenant', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/commerce/merchants/mch_OTHER_TENANT',
+      headers: authHeader(),
+      payload: { display_name: 'Nope' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('merchant_not_found');
+  });
+
+  it('denies CommerceAgent callers on merchant update', async () => {
+    seedAgentCaller();
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/commerce/merchants/mch_M12A',
+      headers: { authorization: `Bearer ${AGENT_TOKEN}` },
+      payload: { display_name: 'Agent Cannot Change Merchant' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('caller_not_authorized');
+  });
+});
+
+describe('M12A GET /v1/commerce/agents', () => {
+  it('lists tenant CommerceAgents for operators without selecting secret-bearing fields', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([agentRow()]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/agents?trust_status=trusted&status=active&limit=10',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ items: Array<{ id: string; api_key_hash?: string }>; next_cursor: string | null }>();
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0]!.id).toBe('cag_M12A');
+    expect(JSON.stringify(body)).not.toContain('api_key_hash');
+    expect(JSON.stringify(body)).not.toContain('provider_credential');
+    expect(body.next_cursor).toBeNull();
+
+    const listCall = findSqlCall(/FROM commerce_agents[\s\S]*ORDER BY created_at DESC/i);
+    expect(listCall).toBeDefined();
+    expect(sqlText(listCall!)).not.toMatch(/api_key_hash|private_key|provider_credential/i);
+  });
+
+  it('allows a merchant caller to list only its verified own merchant scope', async () => {
+    seedMerchantCaller('mch_M12A');
+    sqlMock.mockResolvedValueOnce([{ id: 'mch_M12A' }]);
+    sqlMock.mockResolvedValueOnce([agentRow()]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/agents?merchant_id=mch_M12A',
+      headers: { authorization: `Bearer ${MERCHANT_TOKEN}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ items: Array<{ id: string }> }>().items[0]!.id).toBe('cag_M12A');
+  });
+
+  it('rejects a merchant caller listing another merchant scope', async () => {
+    seedMerchantCaller('mch_M12A');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/agents?merchant_id=mch_OTHER',
+      headers: { authorization: `Bearer ${MERCHANT_TOKEN}` },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('merchant_scope_violation');
+  });
+});
+
+describe('M12A PATCH /v1/commerce/agents/:agentId', () => {
+  it('updates allowlisted agent status, trust_status, and display_name with audit', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([{ id: 'cag_M12A', disabled_at: null }]);
+    sqlMock.mockResolvedValueOnce([agentRow({ display_name: 'Trusted Sales Agent', trust_status: 'trusted' })]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_AGENT_UPDATED', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/commerce/agents/cag_M12A',
+      headers: authHeader(),
+      payload: { display_name: 'Trusted Sales Agent', trust_status: 'trusted', status: 'active' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { id: string; trust_status: string; status: string }; audit_event_id: string }>();
+    expect(body.data.id).toBe('cag_M12A');
+    expect(body.data.trust_status).toBe('trusted');
+    expect(body.data.status).toBe('active');
+    expect(body.audit_event_id).toBe('caud_AGENT_UPDATED');
+
+    const auditCall = findAuditCall('agent.updated');
+    expect(auditCall).toBeDefined();
+    const metadata = auditCall?.find((value) => typeof value === 'string' && value.includes('changed_fields')) as string;
+    expect(metadata).toContain('display_name');
+    expect(metadata).toContain('trust_status');
+    expect(metadata).toContain('status');
+    expect(metadata).not.toContain('Trusted Sales Agent');
+  });
+
+  it('rejects unknown, immutable, and sensitive agent patch keys', async () => {
+    seedCommerceContext();
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/commerce/agents/cag_M12A',
+      headers: authHeader(),
+      payload: {
+        tenant_id: TEST_COMMERCE_TENANT_ID,
+        merchant_id: 'mch_M12A',
+        api_key_hash: 'sha256:do-not-accept',
+        public_key_jwk: { kty: 'oct', k: 'secret' },
+      },
+    });
+
+    expect(res.statusCode).toBe(422);
+    const fields = res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields;
+    expect(fields).toHaveProperty('tenant_id');
+    expect(fields).toHaveProperty('merchant_id');
+    expect(fields).toHaveProperty('api_key_hash');
+    expect(fields).toHaveProperty('public_key_jwk');
+  });
+
+  it('prevents CommerceAgent self-elevation of trust/status', async () => {
+    seedAgentCaller('cag_M12A');
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/commerce/agents/cag_M12A',
+      headers: { authorization: `Bearer ${AGENT_TOKEN}` },
+      payload: { trust_status: 'trusted', status: 'active' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('operator_required');
+  });
+
+  it('returns 404 when the agent is absent or outside the tenant', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/commerce/agents/cag_OTHER_TENANT',
+      headers: authHeader(),
+      payload: { status: 'disabled' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('agent_not_found');
+  });
+});
+
+describe('M12A OpenAPI drift guard', () => {
+  function pathBlock(path: string): string {
+    const content = readFileSync(openapiPath, 'utf8');
+    const start = content.indexOf(`  ${path}:`);
+    expect(start, `OpenAPI must declare ${path}`).toBeGreaterThan(-1);
+    const after = content.slice(start + path.length + 3);
+    const next = after.search(/\n {2}\/[A-Za-z0-9{]/);
+    return next === -1 ? after : after.slice(0, next);
+  }
+
+  it('marks merchant update and CommerceAgent list/update as implemented', () => {
+    expect(pathBlock('/v1/commerce/merchants/{merchant_id}'))
+      .toMatch(/patch:[\s\S]*operationId:\s*updateMerchant[\s\S]*x-implemented:\s*true/);
+    expect(pathBlock('/v1/commerce/agents'))
+      .toMatch(/get:[\s\S]*operationId:\s*listAgents[\s\S]*x-implemented:\s*true/);
+    expect(pathBlock('/v1/commerce/agents/{agent_id}'))
+      .toMatch(/patch:[\s\S]*operationId:\s*updateAgent[\s\S]*x-implemented:\s*true/);
+  });
+});

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -134,6 +134,23 @@ components:
         country_code: { type: string, default: IN }
         support_email: { type: string, nullable: true }
 
+    UpdateMerchantRequest:
+      type: object
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        legal_name: { type: string }
+        display_name: { type: string }
+        category_preset: { type: string, enum: [electronics_appliances] }
+        default_currency: { type: string, pattern: "^[A-Z]{3}$" }
+        country_code: { type: string, pattern: "^[A-Z]{2}$" }
+        support_email: { type: string, nullable: true }
+        agentic_commerce_enabled: { type: boolean }
+      description: >-
+        Mutable merchant fields only. Tenant, ownership, environment,
+        provider account references, audit fields, created_at, and updated_at
+        are immutable on this endpoint.
+
     Agent:
       type: object
       properties:
@@ -143,6 +160,7 @@ components:
         agent_type: { type: string }
         public_key_jwk: { type: object, additionalProperties: true, nullable: true }
         trust_status: { type: string, enum: [pending, trusted, suspended, disabled] }
+        status: { type: string, enum: [active, disabled] }
         disabled_at: { type: string, format: date-time, nullable: true }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
@@ -159,7 +177,21 @@ components:
         Note: trust_status is server-controlled. New agents are always
         created in 'pending'. The field accepts 'pending' (no-op) for
         forward compatibility but rejects any other value with 422. Trust
-        changes will land on a future admin/operator endpoint (M2+).
+        changes are handled by the operator-only updateAgent endpoint.
+
+    UpdateAgentRequest:
+      type: object
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        display_name: { type: string }
+        status: { type: string, enum: [active, disabled] }
+        trust_status: { type: string, enum: [pending, trusted, suspended, disabled] }
+      description: >-
+        Operator-only mutable CommerceAgent fields. API key hashes, public key
+        material, tenant_id, merchant_id, audit fields, provider credentials,
+        and created_at/updated_at are immutable here. Key rotation requires a
+        separate explicit rotation contract.
 
     Variant:
       type: object
@@ -874,10 +906,29 @@ paths:
     patch:
       tags: [Merchants]
       summary: Update merchant (mutable fields only)
-      x-implemented: false
+      operationId: updateMerchant
+      x-implemented: true
       x-milestone: M2
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/UpdateMerchantRequest" }
       responses:
-        "501": { description: Not implemented in M1 }
+        "200":
+          description: Updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/Merchant" }
+                  audit_event_id: { type: string }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Operator or owning merchant caller required; CommerceAgent callers are denied }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "422": { $ref: "#/components/responses/ValidationFailed" }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
 
   /v1/commerce/merchants/{merchant_id}/disable-agentic-commerce:
     parameters:
@@ -931,10 +982,39 @@ paths:
     get:
       tags: [Commerce Agents]
       summary: List CommerceAgents
-      x-implemented: false
+      description: >-
+        Lists tenant-bound CommerceAgents without API key hashes or private
+        key/provider credential material. Operator callers list tenant agents.
+        Merchant callers may request their own merchant scope; the current
+        CommerceAgent schema is tenant-scoped, so merchant_id is verified for
+        tenant ownership and does not expose a secret-bearing merchant-agent
+        join. CommerceAgent callers list only their own agent record.
+      operationId: listAgents
+      x-implemented: true
       x-milestone: M2
+      parameters:
+        - { in: query, name: merchant_id, required: false, schema: { type: string } }
+        - { in: query, name: status, required: false, schema: { type: string, enum: [active, disabled] } }
+        - { in: query, name: trust_status, required: false, schema: { type: string, enum: [pending, trusted, suspended, disabled] } }
+        - { in: query, name: limit, required: false, schema: { type: integer, minimum: 1, maximum: 100, default: 25 } }
+        - { in: query, name: cursor, required: false, schema: { type: string } }
       responses:
-        "501": { description: Not implemented in M1 }
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items: { $ref: "#/components/schemas/Agent" }
+                  next_cursor: { type: string, nullable: true }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Caller is outside the allowed tenant/merchant/agent scope }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "422": { $ref: "#/components/responses/ValidationFailed" }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
 
   /v1/commerce/agents/{agent_id}:
     parameters:
@@ -960,10 +1040,29 @@ paths:
     patch:
       tags: [Commerce Agents]
       summary: Update agent
-      x-implemented: false
+      operationId: updateAgent
+      x-implemented: true
       x-milestone: M2
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/UpdateAgentRequest" }
       responses:
-        "501": { description: Not implemented in M1 }
+        "200":
+          description: Updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/Agent" }
+                  audit_event_id: { type: string }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Operator caller required; CommerceAgents cannot self-elevate status or trust }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "422": { $ref: "#/components/responses/ValidationFailed" }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
 
   /v1/commerce/catalog/products:
     post:

--- a/docs/commerce-v1-pilot-readiness.validate.mjs
+++ b/docs/commerce-v1-pilot-readiness.validate.mjs
@@ -319,9 +319,6 @@ for (const required of [
 }
 
 const expectedFalseImplementedRoutes = [
-  'PATCH /v1/commerce/merchants/{merchant_id}',
-  'GET /v1/commerce/agents',
-  'PATCH /v1/commerce/agents/{agent_id}',
   'GET /v1/commerce/catalog/products',
   'POST /v1/commerce/catalog/products/bulk',
   'PATCH /v1/commerce/catalog/products/{product_id}',

--- a/docs/reports/commerce-v1-contract-completeness-gap-report.md
+++ b/docs/reports/commerce-v1-contract-completeness-gap-report.md
@@ -1,6 +1,6 @@
 # Commerce V1 Contract Completeness Gap Report
 
-Status: M12 gap analysis and safe static guards only. This pass did not deploy, merge, create cloud resources, change production config, enable production Commerce V1, enable live payments, enable live Plural, touch production secrets, or commit local-only artifacts.
+Status: M12 gap analysis plus M12A merchant/agent API completion. This pass did not deploy, merge, create cloud resources, change production config, enable production Commerce V1, enable live payments, enable live Plural, touch production secrets, or commit local-only artifacts.
 
 ## Classification Key
 
@@ -15,7 +15,7 @@ Status: M12 gap analysis and safe static guards only. This pass did not deploy, 
 | Area | Status | Assessment |
 | --- | --- | --- |
 | Core consent, passport, mock payment, checkout, webhook, reconciliation, audit path | `done` | Strong internal sandbox core after the M8 mock-provider `authorized` fix. |
-| Merchant/agent mutable control-plane APIs | `not-started` | OpenAPI still marks list/update gaps as `x-implemented: false`; routes are absent. |
+| Merchant/agent mutable control-plane APIs | `done` | M12A implements tenant-bound merchant update plus CommerceAgent list/update with allowlisted fields, no secret disclosure, audit, OpenAPI, and focused tests. |
 | Product list/update/bulk/CSV | `not-started` | Product create/get/archive/search exist, but list/update/bulk and CSV ingestion are missing. |
 | Inbound merchant webhook source APIs | `not-started` | All source management and inbound merchant webhook endpoints remain `x-implemented: false`. |
 | Portal merchant control plane | `partial` | Payments, audit, passports, settings, playground, and ops views exist; onboarding/catalog/CSV/webhook-source/policy/publish controls do not. |
@@ -29,9 +29,9 @@ Status: M12 gap analysis and safe static guards only. This pass did not deploy, 
 
 | Contract item | Status | Current evidence | Required next slice |
 | --- | --- | --- | --- |
-| `PATCH /v1/commerce/merchants/{merchant_id}` | `not-started` | OpenAPI `x-implemented: false`; `commerce.ts` has create/get only. | M12A mutable merchant allowlist with audit and tenant boundary tests. |
-| `GET /v1/commerce/agents` | `not-started` | OpenAPI `x-implemented: false`; `commerce.ts` has create/get by id only. | M12A scoped list endpoint with operator filters and no secret fields. |
-| `PATCH /v1/commerce/agents/{agent_id}` | `not-started` | OpenAPI `x-implemented: false`; trust/status update path absent. | M12A mutable agent allowlist, trust/status controls, audit. |
+| `PATCH /v1/commerce/merchants/{merchant_id}` | `done` | M12A route is implemented with operator/own-merchant auth, tenant filter, mutable allowlist, field validation, and `merchant.updated` audit. | Hosted staging evidence after infrastructure exists. |
+| `GET /v1/commerce/agents` | `done` | M12A route lists tenant-bound CommerceAgents for operators, verifies merchant caller scope, supports status/trust_status/limit/cursor filters, and excludes API key hashes/private/provider credentials. | Hosted staging evidence after infrastructure exists. |
+| `PATCH /v1/commerce/agents/{agent_id}` | `done` | M12A route is operator-only, rejects agent self-elevation, validates status/trust_status/display_name, filters by tenant, and writes `agent.updated` audit. | Hosted staging evidence after infrastructure exists. |
 | `GET /v1/commerce/catalog/products` | `not-started` | OpenAPI `x-implemented: false`; only get-by-id and search exist. | M12B paginated list with merchant/agent/operator scoping. |
 | `PATCH /v1/commerce/catalog/products/{product_id}` | `not-started` | OpenAPI `x-implemented: false`; only create/get/archive exist. | M12B mutable product/variant allowlist with price-change safety. |
 | `POST /v1/commerce/catalog/products/bulk` | `not-started` | OpenAPI `x-implemented: false`; no route. | M12B bulk ingest with per-row validation and audit. |
@@ -50,9 +50,6 @@ Status: M12 gap analysis and safe static guards only. This pass did not deploy, 
 
 The validator pins this current set so the gap report cannot silently drift:
 
-- `PATCH /v1/commerce/merchants/{merchant_id}`
-- `GET /v1/commerce/agents`
-- `PATCH /v1/commerce/agents/{agent_id}`
 - `GET /v1/commerce/catalog/products`
 - `POST /v1/commerce/catalog/products/bulk`
 - `PATCH /v1/commerce/catalog/products/{product_id}`
@@ -95,6 +92,13 @@ The validator pins this current set so the gap report cannot silently drift:
 - Added this gap report.
 - Added validator coverage that reads the report, extracts current OpenAPI `x-implemented: false` routes, and fails if the report or pinned inventory drifts.
 - Did not implement broad API families, portal redesign, Plural integration, or hosted run mode.
+
+## Safe Fixes Made In M12A
+
+- Implemented `PATCH /v1/commerce/merchants/{merchant_id}` with mutable-field allowlist, tenant-bound update, non-enumerating 404 for missing/cross-tenant merchants, and `merchant.updated` audit metadata containing changed field names only.
+- Implemented `GET /v1/commerce/agents` with tenant-bound listing, operator/merchant/agent caller scoping, status/trust filters, cursor pagination, and no API key hash, private key, provider credential, bearer token, or secret output.
+- Implemented `PATCH /v1/commerce/agents/{agent_id}` as operator-only with mutable-field allowlist, trust/status validation, self-elevation denial by caller matrix, tenant-bound update, and `agent.updated` audit metadata containing changed field names only.
+- Updated OpenAPI to mark the three M12A operations `x-implemented: true`; product, CSV, webhook-source, inbound webhook, portal, failed replay, emergency re-enable, and Plural work remain out of scope.
 
 ## Exact Future Implementation Prompts
 


### PR DESCRIPTION
## Scope

M12A Grantex auth-service/API contract only. This PR implements:

- `PATCH /v1/commerce/merchants/{merchant_id}`
- `GET /v1/commerce/agents`
- `PATCH /v1/commerce/agents/{agent_id}`

No product, CSV, webhook-source, portal, Plural, deploy, cloud, production config, live-payment, or live-Plural work is included.

## Implementation

- Adds mutable allowlist validation for merchant updates and agent updates.
- Keeps all lookups and updates tenant-bound.
- Allows operator merchant updates and owning merchant self-updates; CommerceAgent callers are denied merchant update.
- Adds tenant-bound CommerceAgent list with `status`, `trust_status`, `limit`, and `cursor` filters.
- Lets merchant callers list only their verified own merchant scope. The current CommerceAgent schema is tenant-scoped, so `merchant_id` is verified for tenant ownership and no secret-bearing merchant-agent join is exposed.
- Makes CommerceAgent update operator-only so agents cannot self-elevate trust/status.
- Adds `merchant.updated` and `agent.updated` audit events with changed field names only.
- Updates OpenAPI `x-implemented: true` markers and request/response schemas for the three M12A operations.
- Updates the M12 gap report and readiness validator false-route inventory.

## Validation

Passed locally:

- `npm run typecheck`
- `npm test -- commerce-merchant-agent-m12a.test.ts`
- `npm test -- commerce`
- `npm test`
- `node docs/commerce-v1-pilot-readiness.validate.mjs`
- `git diff --check`

`git diff --check` emitted only local CRLF conversion warnings, with no whitespace errors.

## Safety

- No deploy was performed.
- No merge was performed.
- No cloud resources were created.
- No production config was changed.
- Production Commerce V1 was not enabled.
- Live payments and live Plural were not enabled.
- No production secrets were touched.
- `.tmp/`, synthetic env files, local-only reports, bearer-token artifacts, passports, idempotency keys, provider credentials, and secrets were not committed.