### PR TITLE
docs(commerce): prepare option a smoke setup

### DIFF
--- a/docs/commerce-v1-pilot-readiness.validate.mjs
+++ b/docs/commerce-v1-pilot-readiness.validate.mjs
@@ -14,6 +14,7 @@ const loadReport = readFileSync(join(docsDir, 'reports', 'commerce-v1-local-pilo
 const hostedStagingPlan = readFileSync(join(docsDir, 'guides', 'commerce-v1-hosted-staging-plan.md'), 'utf8');
 const stagingDataSetup = readFileSync(join(docsDir, 'guides', 'commerce-v1-staging-data-setup.md'), 'utf8');
 const hostedStagingE2E = readFileSync(join(docsDir, 'guides', 'commerce-v1-hosted-staging-e2e.md'), 'utf8');
+const optionASmokeSetup = readFileSync(join(docsDir, 'guides', 'commerce-v1-option-a-smoke-setup.md'), 'utf8');
 const hostedStagingE2ETemplate = readFileSync(join(docsDir, 'reports', 'commerce-v1-hosted-staging-e2e.template.md'), 'utf8');
 const contractGapReport = readFileSync(join(docsDir, 'reports', 'commerce-v1-contract-completeness-gap-report.md'), 'utf8');
 const harness = readFileSync(join(repoRoot, 'scripts', 'commerce-pilot-load-harness.mjs'), 'utf8');
@@ -277,6 +278,44 @@ for (const required of [
 }
 
 for (const required of [
+  'Commerce V1 Option A Smoke Setup',
+  'temporary hosted smoke path',
+  'Direct Cloud Run URLs are allowed only for Option A smoke',
+  'No custom DNS',
+  'No hosted AgenticOrg',
+  'No Firebase deploy',
+  'min-instances=0',
+  'max-instances=1',
+  'Mock provider only',
+  'No production database',
+  'No production Redis',
+  'No production secrets',
+  'Delete temporary Redis',
+  'Delete temporary Cloud SQL',
+  'Commands Proposed But Not Run',
+  'Cleanup Commands Proposed But Not Run',
+  'COMMERCE_LIVE_MODE_ENABLED=false',
+  'PLURAL_LIVE_ENABLED=false',
+  'grantex-auth-smoke',
+  'grantex-commerce-smoke-pg',
+  'grantex-commerce-smoke-redis',
+  '--allow-smoke-cloud-run-url',
+  'COMMERCE_STAGING_ALLOWED_SMOKE_URL',
+]) {
+  assert.ok(optionASmokeSetup.includes(required), `Option A smoke setup guide includes ${required}`);
+}
+for (const forbidden of [
+  'sk_live_',
+  'pk_live_',
+  'Bearer ',
+  'passport.jwt',
+  'idempotency-key:',
+  'mock-webhook-secret',
+]) {
+  assert.equal(optionASmokeSetup.includes(forbidden), false, `Option A smoke setup guide does not include ${forbidden}`);
+}
+
+for (const required of [
   'https://api-staging.grantex.dev',
   'https://staging.grantex.dev',
   'https://staging.agenticorg.ai',
@@ -291,6 +330,10 @@ for (const required of [
   'Refusing PLURAL_LIVE_ENABLED=true',
   'Refusing non-mock provider',
   'Run mode is intentionally disabled for M11 dry-run-only harness',
+  '--allow-smoke-cloud-run-url',
+  'COMMERCE_STAGING_ALLOWED_SMOKE_URL',
+  'smoke_cloud_run_origin_allowed',
+  'Refusing smoke Cloud Run allowlist URL that is not a run.app service origin',
 ]) {
   assert.ok(stagingE2EHarness.includes(required), `hosted staging E2E harness includes ${required}`);
 }
@@ -447,6 +490,39 @@ assert.ok(
   'hosted staging E2E production refusal explains the safety guard',
 );
 
+const smokeUrl = 'https://grantex-auth-smoke-abc123-uc.a.run.app';
+const stagingE2ESmokeDryRun = execFileSync(
+  process.execPath,
+  [
+    join(repoRoot, 'scripts', 'commerce-staging-e2e-harness.mjs'),
+    '--dry-run',
+    `--api-base=${smokeUrl}`,
+    `--allow-smoke-cloud-run-url=${smokeUrl}`,
+  ],
+  { encoding: 'utf8' },
+);
+const stagingE2ESmokeReport = JSON.parse(stagingE2ESmokeDryRun);
+assert.equal(stagingE2ESmokeReport.mode, 'dry-run');
+assert.equal(stagingE2ESmokeReport.status, 'not_executed');
+assert.equal(stagingE2ESmokeReport.targets.api_base, smokeUrl);
+assert.equal(stagingE2ESmokeReport.safety.smoke_cloud_run_origin_allowed, smokeUrl);
+assert.equal(stagingE2ESmokeReport.safety.no_requests_made, true);
+
+const stagingE2ESmokeNoAllowlist = spawnSync(
+  process.execPath,
+  [
+    join(repoRoot, 'scripts', 'commerce-staging-e2e-harness.mjs'),
+    '--dry-run',
+    `--api-base=${smokeUrl}`,
+  ],
+  { encoding: 'utf8' },
+);
+assert.notEqual(stagingE2ESmokeNoAllowlist.status, 0, 'hosted staging E2E harness refuses arbitrary run.app without allowlist');
+assert.ok(
+  `${stagingE2ESmokeNoAllowlist.stdout}${stagingE2ESmokeNoAllowlist.stderr}`.includes('Refusing non-staging Grantex API base'),
+  'hosted staging E2E run.app refusal explains the smoke allowlist guard',
+);
+
 const nonLocalSeed = spawnSync(
   process.execPath,
   [
@@ -514,6 +590,7 @@ assert.equal(/[^\u0000-\u007F]/.test(loadReport), false, 'pilot load report stay
 assert.equal(/[^\u0000-\u007F]/.test(hostedStagingPlan), false, 'hosted staging plan stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(stagingDataSetup), false, 'staging data setup guide stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(hostedStagingE2E), false, 'hosted staging E2E guide stays ASCII-only');
+assert.equal(/[^\u0000-\u007F]/.test(optionASmokeSetup), false, 'Option A smoke setup guide stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(hostedStagingE2ETemplate), false, 'hosted staging E2E template stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(contractGapReport), false, 'contract gap report stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(harness), false, 'load harness stays ASCII-only');

--- a/docs/guides/commerce-v1-option-a-smoke-setup.md
+++ b/docs/guides/commerce-v1-option-a-smoke-setup.md
@@ -1,0 +1,359 @@
+# Commerce V1 Option A Smoke Setup
+
+Status: preparation only. This document does not deploy, create cloud resources, merge branches, change production config, enable production Commerce V1, enable live payments, enable live Plural, read secret values, or write secret values.
+
+## Purpose
+
+Option A is the cheapest temporary hosted smoke path for Grantex Commerce V1. It is not full staging. It exists only to prove that the hosted Grantex API can run the Commerce V1 mock-provider path over HTTPS with isolated staging data stores and staging-only secrets.
+
+## Cheapest Temporary Topology
+
+| Component | Option A choice | Cost control |
+| --- | --- | --- |
+| GCP host project | Existing `grantex-prod` project as host only | Avoids new project setup cost and time |
+| API runtime | Separate Cloud Run service `grantex-auth-smoke` | `min-instances=0`, `max-instances=1` |
+| API URL | Direct Cloud Run `https://...run.app` URL | No custom DNS or certificate setup |
+| Database | Temporary tiny Cloud SQL Postgres | Delete immediately after evidence |
+| Redis | Temporary Basic 1GB Redis | Required because auth-service needs `REDIS_URL` |
+| Provider | `mock` only | No live payment provider |
+| Portal | Local portal against hosted API or skipped | No Firebase deploy |
+| AgenticOrg | Local AgenticOrg demo/eval against hosted Grantex | No hosted AgenticOrg services |
+| Evidence | Redacted local report after approved run | No raw payloads or secrets |
+
+## Why Direct Cloud Run URL Is Allowed For First Smoke
+
+Direct Cloud Run URLs are allowed only for Option A smoke because the goal is a temporary hosted API check, not browser-domain parity. The harness must allow exactly one explicitly approved `run.app` origin with `--allow-smoke-cloud-run-url` or `COMMERCE_STAGING_ALLOWED_SMOKE_URL`. Arbitrary `run.app` URLs remain refused.
+
+This keeps production refusal intact while avoiding the cost and setup time of custom DNS for the first smoke.
+
+## What Option A Proves
+
+- Grantex auth-service can start in a hosted runtime with Commerce V1 enabled only on the smoke service.
+- Hosted HTTPS API health, JWKS, commerce well-known, MCP, catalog, inventory, cart, consent, passport, payment intent, checkout, mock webhook, reconciliation, audit, provider webhook replay, and emergency re-enable paths can be exercised against isolated smoke data stores.
+- Mock-provider payment and checkout paths stay sandbox-only.
+- The staging harness still refuses production domains and live flags.
+- AgenticOrg connector/demo code can point locally at a hosted Grantex Commerce API.
+
+## What Option A Does Not Prove
+
+- Custom DNS behavior for `api-staging.grantex.dev`.
+- Browser origin behavior for `staging.grantex.dev`.
+- FIDO RP ID or origin behavior on the final staging domain.
+- Full hosted portal behavior through Firebase Hosting.
+- Hosted AgenticOrg Cloud Run runtime, MCP discovery, or A2A discovery at `staging.agenticorg.ai`.
+- Production-like scale, HA, failover, or long-lived operational posture.
+- Plural sandbox or live payment behavior.
+
+## Required Project And Region Placeholders
+
+Use these defaults only after explicit approval:
+
+```text
+GCP_PROJECT_ID=grantex-prod
+GCP_REGION=us-central1
+ARTIFACT_REPO=grantex-images
+CLOUD_RUN_SERVICE=grantex-auth-smoke
+CLOUD_SQL_INSTANCE=grantex-commerce-smoke-pg
+CLOUD_SQL_DATABASE=grantex_commerce_smoke
+CLOUD_SQL_USER=grantex_commerce_smoke_app
+REDIS_INSTANCE=grantex-commerce-smoke-redis
+```
+
+## Exact Non-Secret Environment Variables
+
+Set these only on `grantex-auth-smoke`:
+
+```text
+NODE_ENV=staging
+PUBLIC_BASE_URL=<approved smoke Cloud Run URL>
+JWT_ISSUER=<approved smoke Cloud Run URL>
+DID_WEB_DOMAIN=<approved smoke Cloud Run host only>
+FIDO_RP_ID=<approved smoke Cloud Run host only>
+FIDO_ORIGIN=<approved smoke Cloud Run URL>
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:4173
+COMMERCE_V1_ENABLED=true
+COMMERCE_SANDBOX_ENABLED=true
+COMMERCE_ALLOW_AUTO_TENANT=false
+COMMERCE_LOCAL_LOAD_TEST=false
+COMMERCE_LIVE_MODE_ENABLED=false
+PLURAL_SANDBOX_ENABLED=false
+PLURAL_LIVE_ENABLED=false
+COMMERCE_RECONCILIATION_WORKER_ENABLED=false
+COMMERCE_RECONCILIATION_INTERVAL_MS=300000
+COMMERCE_RECONCILIATION_LIMIT=50
+METRICS_ENABLED=true
+METRICS_REQUIRE_AUTH=true
+SSO_ALLOW_INSECURE_URLS=false
+WEBHOOK_ALLOW_INSECURE_URLS=false
+LDAP_TLS_REJECT_UNAUTHORIZED=true
+AUTO_GENERATE_KEYS=false
+```
+
+Do not set production domain values on this service.
+
+## Required Secrets By Name Only
+
+Create staging-only smoke secret names. Do not reuse production secret versions.
+
+- `grantex-smoke-database-url`
+- `grantex-smoke-redis-url`
+- `grantex-smoke-admin-api-key`
+- `grantex-smoke-vault-encryption-key`
+- `grantex-smoke-rsa-private-key`
+- `grantex-smoke-sso-state-secret`
+- `grantex-smoke-metrics-api-key`
+- `grantex-smoke-mock-payment-webhook-secret`
+- `grantex-smoke-commerce-passport-signing-key`
+
+Optional only if the smoke run needs the path:
+
+- `grantex-smoke-ed25519-private-key`
+- `grantex-smoke-resend-api-key`
+
+## Commands Proposed But Not Run
+
+Every command in this section is a proposed command. Do not run these until the user explicitly approves the final command list.
+
+### Preflight Names
+
+```powershell
+# NOT RUN
+$env:GCP_PROJECT_ID='grantex-prod'
+$env:GCP_REGION='us-central1'
+$env:CLOUD_RUN_SERVICE='grantex-auth-smoke'
+$env:CLOUD_SQL_INSTANCE='grantex-commerce-smoke-pg'
+$env:CLOUD_SQL_DATABASE='grantex_commerce_smoke'
+$env:CLOUD_SQL_USER='grantex_commerce_smoke_app'
+$env:REDIS_INSTANCE='grantex-commerce-smoke-redis'
+```
+
+### Create Tiny Temporary Cloud SQL
+
+```powershell
+# NOT RUN
+gcloud sql instances create $env:CLOUD_SQL_INSTANCE `
+  --project=$env:GCP_PROJECT_ID `
+  --region=$env:GCP_REGION `
+  --database-version=POSTGRES_16 `
+  --tier=db-f1-micro `
+  --storage-type=HDD `
+  --storage-size=10GB `
+  --availability-type=zonal `
+  --backup-start-time=03:00 `
+  --no-deletion-protection
+
+# NOT RUN
+gcloud sql databases create $env:CLOUD_SQL_DATABASE `
+  --project=$env:GCP_PROJECT_ID `
+  --instance=$env:CLOUD_SQL_INSTANCE
+
+# NOT RUN
+gcloud sql users create $env:CLOUD_SQL_USER `
+  --project=$env:GCP_PROJECT_ID `
+  --instance=$env:CLOUD_SQL_INSTANCE `
+  --password=<generate-smoke-password-outside-repo>
+```
+
+If `db-f1-micro` is unavailable in the selected region or edition, choose the cheapest approved PostgreSQL tier available in the Google Cloud console before running.
+
+### Create Temporary Basic Redis
+
+```powershell
+# NOT RUN
+gcloud redis instances create $env:REDIS_INSTANCE `
+  --project=$env:GCP_PROJECT_ID `
+  --region=$env:GCP_REGION `
+  --size=1 `
+  --tier=basic `
+  --redis-version=redis_7_0
+```
+
+Redis is included because the current auth-service startup requires `REDIS_URL`. Omitting it would require code changes and would weaken smoke evidence for revocation, rate-limit, usage, and commerce event paths.
+
+### Create Staging-Only Secret Names
+
+```powershell
+# NOT RUN
+gcloud secrets create grantex-smoke-database-url --project=$env:GCP_PROJECT_ID --replication-policy=automatic
+gcloud secrets create grantex-smoke-redis-url --project=$env:GCP_PROJECT_ID --replication-policy=automatic
+gcloud secrets create grantex-smoke-admin-api-key --project=$env:GCP_PROJECT_ID --replication-policy=automatic
+gcloud secrets create grantex-smoke-vault-encryption-key --project=$env:GCP_PROJECT_ID --replication-policy=automatic
+gcloud secrets create grantex-smoke-rsa-private-key --project=$env:GCP_PROJECT_ID --replication-policy=automatic
+gcloud secrets create grantex-smoke-sso-state-secret --project=$env:GCP_PROJECT_ID --replication-policy=automatic
+gcloud secrets create grantex-smoke-metrics-api-key --project=$env:GCP_PROJECT_ID --replication-policy=automatic
+gcloud secrets create grantex-smoke-mock-payment-webhook-secret --project=$env:GCP_PROJECT_ID --replication-policy=automatic
+gcloud secrets create grantex-smoke-commerce-passport-signing-key --project=$env:GCP_PROJECT_ID --replication-policy=automatic
+```
+
+Secret versions must be added only from secure local files or console entry. Do not paste values into docs, shell history, PRs, reports, or chat.
+
+### Build And Deploy Separate Cloud Run Service
+
+```powershell
+# NOT RUN
+gcloud builds submit apps/auth-service `
+  --project=$env:GCP_PROJECT_ID `
+  --tag=us-central1-docker.pkg.dev/grantex-prod/grantex-images/auth-service-smoke:<approved-commit-sha>
+
+# NOT RUN
+gcloud run deploy $env:CLOUD_RUN_SERVICE `
+  --project=$env:GCP_PROJECT_ID `
+  --region=$env:GCP_REGION `
+  --image=us-central1-docker.pkg.dev/grantex-prod/grantex-images/auth-service-smoke:<approved-commit-sha> `
+  --min-instances=0 `
+  --max-instances=1 `
+  --cpu=1 `
+  --memory=512Mi `
+  --concurrency=20 `
+  --no-allow-unauthenticated `
+  --set-env-vars=NODE_ENV=staging,COMMERCE_V1_ENABLED=true,COMMERCE_SANDBOX_ENABLED=true,COMMERCE_ALLOW_AUTO_TENANT=false,COMMERCE_LOCAL_LOAD_TEST=false,COMMERCE_LIVE_MODE_ENABLED=false,PLURAL_SANDBOX_ENABLED=false,PLURAL_LIVE_ENABLED=false,COMMERCE_RECONCILIATION_WORKER_ENABLED=false,METRICS_ENABLED=true,METRICS_REQUIRE_AUTH=true,SSO_ALLOW_INSECURE_URLS=false,WEBHOOK_ALLOW_INSECURE_URLS=false,LDAP_TLS_REJECT_UNAUTHORIZED=true,AUTO_GENERATE_KEYS=false `
+  --set-secrets=DATABASE_URL=grantex-smoke-database-url:latest,REDIS_URL=grantex-smoke-redis-url:latest,ADMIN_API_KEY=grantex-smoke-admin-api-key:latest,VAULT_ENCRYPTION_KEY=grantex-smoke-vault-encryption-key:latest,RSA_PRIVATE_KEY=grantex-smoke-rsa-private-key:latest,SSO_STATE_SECRET=grantex-smoke-sso-state-secret:latest,METRICS_API_KEY=grantex-smoke-metrics-api-key:latest,MOCK_PAYMENT_WEBHOOK_SECRET=grantex-smoke-mock-payment-webhook-secret:latest
+```
+
+If the smoke service must be reachable by the local harness without an identity token, use a restricted temporary invoker setup approved separately. Do not make production services public.
+
+### Get Direct Cloud Run URL
+
+```powershell
+# NOT RUN
+$env:SMOKE_URL = gcloud run services describe $env:CLOUD_RUN_SERVICE `
+  --project=$env:GCP_PROJECT_ID `
+  --region=$env:GCP_REGION `
+  --format='value(status.url)'
+```
+
+### Update URL-Dependent Env Vars
+
+```powershell
+# NOT RUN
+$smokeHost = ([uri]$env:SMOKE_URL).Host
+
+# NOT RUN
+gcloud run services update $env:CLOUD_RUN_SERVICE `
+  --project=$env:GCP_PROJECT_ID `
+  --region=$env:GCP_REGION `
+  --set-env-vars=PUBLIC_BASE_URL=$env:SMOKE_URL,JWT_ISSUER=$env:SMOKE_URL,DID_WEB_DOMAIN=$smokeHost,FIDO_RP_ID=$smokeHost,FIDO_ORIGIN=$env:SMOKE_URL,CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:4173
+```
+
+### Run Migrations And Seed
+
+Prefer app startup migrations only if the current service already runs them safely. If a separate migration command is required, run it as a one-off Cloud Run job or service command using the same smoke image, smoke DB, and smoke secrets only.
+
+```powershell
+# NOT RUN
+node scripts/commerce-staging-seed-plan.mjs --dry-run --manifest=docs/examples/commerce-staging-seed.manifest.json
+
+# NOT RUN
+node scripts/commerce-staging-seed.mjs --run --api-base=$env:SMOKE_URL --manifest=docs/examples/commerce-staging-seed.manifest.json
+```
+
+If the executable hosted seed script is not implemented yet, stop and implement it as a separate guarded change before seeding.
+
+### Harness Dry-Run With Explicit Smoke URL
+
+```powershell
+# NOT RUN
+node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=$env:SMOKE_URL --allow-smoke-cloud-run-url=$env:SMOKE_URL
+```
+
+### Hosted Smoke After Approval
+
+```powershell
+# NOT RUN
+node scripts/commerce-staging-e2e-harness.mjs --run --api-base=$env:SMOKE_URL --allow-smoke-cloud-run-url=$env:SMOKE_URL --report=docs/reports/commerce-v1-hosted-staging-e2e.md
+```
+
+Run mode must remain fail-closed until a reviewed implementation exists and the required smoke env names are present.
+
+### Local AgenticOrg Against Hosted Grantex
+
+```powershell
+# NOT RUN
+$env:GRANTEX_COMMERCE_BASE_URL=$env:SMOKE_URL
+$env:GRANTEX_BASE_URL=$env:SMOKE_URL
+$env:AGENTICORG_BASE_URL='http://localhost:3000'
+python demos/commerce_sales_agent_demo.py --mode=hosted-staging
+python -m pytest tests/evals/test_commerce_sales_agent_evals.py -q --hosted-staging
+```
+
+Use only approved local AgenticOrg auth material. Do not print or commit bearer tokens, passports, idempotency keys, provider credentials, webhook secrets, raw payloads, or secret values.
+
+## Evidence Report Command Plan
+
+Create a redacted report only after real smoke checks run:
+
+```powershell
+# NOT RUN
+node scripts/commerce-staging-e2e-harness.mjs --run --api-base=$env:SMOKE_URL --allow-smoke-cloud-run-url=$env:SMOKE_URL --report=docs/reports/commerce-v1-hosted-staging-e2e.md
+```
+
+The report must include only hostnames, request counts, status codes, redacted request IDs, pass/fail rows, blockers, and no-live-payment confirmation. It must not include secret values, bearer tokens, raw passports, idempotency keys, provider credentials, webhook secrets, encrypted payload material, or raw webhook payloads.
+
+## Cleanup Commands Proposed But Not Run
+
+```powershell
+# NOT RUN
+gcloud run services delete $env:CLOUD_RUN_SERVICE `
+  --project=$env:GCP_PROJECT_ID `
+  --region=$env:GCP_REGION `
+  --quiet
+
+# NOT RUN
+gcloud redis instances delete $env:REDIS_INSTANCE `
+  --project=$env:GCP_PROJECT_ID `
+  --region=$env:GCP_REGION `
+  --quiet
+
+# NOT RUN
+gcloud sql instances delete $env:CLOUD_SQL_INSTANCE `
+  --project=$env:GCP_PROJECT_ID `
+  --quiet
+
+# NOT RUN
+gcloud secrets delete grantex-smoke-database-url --project=$env:GCP_PROJECT_ID --quiet
+gcloud secrets delete grantex-smoke-redis-url --project=$env:GCP_PROJECT_ID --quiet
+gcloud secrets delete grantex-smoke-admin-api-key --project=$env:GCP_PROJECT_ID --quiet
+gcloud secrets delete grantex-smoke-vault-encryption-key --project=$env:GCP_PROJECT_ID --quiet
+gcloud secrets delete grantex-smoke-rsa-private-key --project=$env:GCP_PROJECT_ID --quiet
+gcloud secrets delete grantex-smoke-sso-state-secret --project=$env:GCP_PROJECT_ID --quiet
+gcloud secrets delete grantex-smoke-metrics-api-key --project=$env:GCP_PROJECT_ID --quiet
+gcloud secrets delete grantex-smoke-mock-payment-webhook-secret --project=$env:GCP_PROJECT_ID --quiet
+gcloud secrets delete grantex-smoke-commerce-passport-signing-key --project=$env:GCP_PROJECT_ID --quiet
+
+# NOT RUN
+gcloud artifacts docker images delete us-central1-docker.pkg.dev/grantex-prod/grantex-images/auth-service-smoke:<approved-commit-sha> `
+  --project=$env:GCP_PROJECT_ID `
+  --quiet
+```
+
+## Safety Controls
+
+- Use a separate Cloud Run service; never update `grantex-auth`.
+- Use a separate temporary database; never write to `grantex-pg16` or any production-shaped database.
+- Use a separate temporary Redis instance; never write to `grantex-redis`.
+- Use separate smoke secret names; never mount production secret versions.
+- No production database.
+- No production Redis.
+- No production secrets.
+- Mock provider only.
+- Keep `COMMERCE_LIVE_MODE_ENABLED=false`.
+- Keep `PLURAL_LIVE_ENABLED=false`.
+- Keep `PLURAL_SANDBOX_ENABLED=false` until external Plural sandbox contract is confirmed.
+- Use mock provider only.
+- Keep Cloud Run `min-instances=0` and `max-instances=1` for the smoke service.
+- Do not configure custom DNS in Option A.
+- Do not deploy Firebase portal in Option A.
+- Do not deploy hosted AgenticOrg in Option A.
+- Delete smoke DB and Redis immediately after evidence collection unless the user approves a longer retention window.
+
+## Rollback Plan
+
+Rollback is deletion, not traffic migration:
+
+1. Stop any running smoke harness.
+2. Delete `grantex-auth-smoke`.
+3. Delete temporary Redis.
+4. Delete temporary Cloud SQL.
+5. Delete smoke-only secrets.
+6. Delete smoke image tags if they are no longer needed.
+7. Confirm production services, production DB, production Redis, production secrets, live payment flags, and live Plural settings were untouched.

--- a/scripts/commerce-staging-e2e-harness.mjs
+++ b/scripts/commerce-staging-e2e-harness.mjs
@@ -102,14 +102,18 @@ function isLocalhost(url) {
   return ['localhost', '127.0.0.1', '::1', '[::1]'].includes(url.hostname);
 }
 
-function validateUrl(input, label, dryRun, allowLocalhost) {
+function parseUrl(input, label) {
   let url;
   try {
     url = new URL(input);
   } catch {
     fail(`Refusing invalid ${label}: ${input}`);
   }
+  return url;
+}
 
+function validateUrl(input, label, dryRun, allowLocalhost, allowedSmokeOrigin) {
+  const url = parseUrl(input, label);
   if (url.username || url.password) {
     fail(`Refusing credentialed URL for ${label}`);
   }
@@ -139,10 +143,38 @@ function validateUrl(input, label, dryRun, allowLocalhost) {
     fail(`Refusing non-HTTPS staging URL for ${label}`);
   }
 
+  if (allowedSmokeOrigin && url.origin === allowedSmokeOrigin) {
+    return url.origin;
+  }
+
   if (!ALLOWED_STAGING_ORIGINS.includes(url.origin)) {
     fail(`Refusing non-staging ${label}: ${url.origin}`);
   }
 
+  return url.origin;
+}
+
+function validateSmokeCloudRunUrl(input) {
+  if (!input) return null;
+  const url = parseUrl(input, 'smoke Cloud Run URL');
+  if (url.username || url.password) {
+    fail('Refusing credentialed URL for smoke Cloud Run allowlist');
+  }
+  if (url.search) {
+    fail('Refusing query string in smoke Cloud Run allowlist URL');
+  }
+  if (url.pathname !== '/' && url.pathname !== '') {
+    fail('Refusing path in smoke Cloud Run allowlist URL; provide the service origin only');
+  }
+  if (REFUSED_PRODUCTION_ORIGINS.includes(url.origin)) {
+    fail(`Refusing production domain for smoke Cloud Run allowlist: ${url.origin}`);
+  }
+  if (url.protocol !== 'https:') {
+    fail('Refusing non-HTTPS smoke Cloud Run allowlist URL');
+  }
+  if (!url.hostname.endsWith('.run.app')) {
+    fail('Refusing smoke Cloud Run allowlist URL that is not a run.app service origin');
+  }
   return url.origin;
 }
 
@@ -243,6 +275,9 @@ const portalBase = argValue('--portal-base', DEFAULT_PORTAL_BASE);
 const agenticorgBase = argValue('--agenticorg-base', DEFAULT_AGENTICORG_BASE);
 const manifestPath = argValue('--manifest', DEFAULT_MANIFEST);
 const reportPath = argValue('--report', DEFAULT_REPORT);
+const allowedSmokeOrigin = validateSmokeCloudRunUrl(
+  argValue('--allow-smoke-cloud-run-url', process.env.COMMERCE_STAGING_ALLOWED_SMOKE_URL ?? ''),
+);
 
 if (provider !== 'mock') {
   fail('Refusing non-mock provider; future --allow-provider-sandbox mode is not implemented');
@@ -257,9 +292,9 @@ if (reportPath.includes('.tmp') || !reportPath.includes('hosted-staging-e2e')) {
   fail('Refusing non-staging or local-only report path');
 }
 
-const normalizedApiBase = validateUrl(apiBase, 'Grantex API base', dryRun, allowLocalhost);
-const normalizedPortalBase = validateUrl(portalBase, 'Grantex portal base', dryRun, allowLocalhost);
-const normalizedAgenticOrgBase = validateUrl(agenticorgBase, 'AgenticOrg base', dryRun, allowLocalhost);
+const normalizedApiBase = validateUrl(apiBase, 'Grantex API base', dryRun, allowLocalhost, allowedSmokeOrigin);
+const normalizedPortalBase = validateUrl(portalBase, 'Grantex portal base', dryRun, allowLocalhost, allowedSmokeOrigin);
+const normalizedAgenticOrgBase = validateUrl(agenticorgBase, 'AgenticOrg base', dryRun, allowLocalhost, allowedSmokeOrigin);
 const manifestSummary = loadManifest(manifestPath);
 
 const output = {
@@ -269,6 +304,7 @@ const output = {
     no_requests_made: true,
     production_domains_refused: REFUSED_PRODUCTION_ORIGINS,
     staging_domains_allowed: ALLOWED_STAGING_ORIGINS,
+    smoke_cloud_run_origin_allowed: allowedSmokeOrigin,
     non_mock_provider_refused: true,
     live_payment_flags_refused: true,
     secret_values_printed: false,


### PR DESCRIPTION
## Scope

Option A preparation only. This PR does not deploy, create cloud resources, merge, change production config, enable production Commerce V1, enable live payments, enable live Plural, read secret values, or write secret values.

## What Changed

- Added `docs/guides/commerce-v1-option-a-smoke-setup.md` with the cheapest temporary hosted Grantex API smoke topology.
- Updated `scripts/commerce-staging-e2e-harness.mjs` with an opt-in exact Cloud Run smoke URL allowlist:
  - `--allow-smoke-cloud-run-url=https://...run.app`
  - `COMMERCE_STAGING_ALLOWED_SMOKE_URL=https://...run.app`
- Updated `docs/commerce-v1-pilot-readiness.validate.mjs` to guard the Option A doc and harness behavior.

## Harness Safety

- Production domains remain refused: `https://grantex.dev`, `https://api.grantex.dev`, `https://app.agenticorg.ai`.
- Existing staging domains remain allowed.
- Arbitrary `run.app` URLs remain refused unless the exact origin is supplied through the smoke allowlist.
- Credentialed URLs, query-string credential material, non-HTTPS URLs, non-mock providers, `COMMERCE_LIVE_MODE_ENABLED=true`, and `PLURAL_LIVE_ENABLED=true` remain refused.
- `--run` remains fail-closed; this PR only prepares dry-run planning for the future smoke URL.

## Option A Plan

- Separate Cloud Run service: `grantex-auth-smoke`.
- Direct Cloud Run URL for first smoke; no custom DNS in this pass.
- Temporary tiny Cloud SQL Postgres and Basic 1GB Redis, deleted after evidence.
- Mock provider only.
- No hosted AgenticOrg; local AgenticOrg demo/eval points at hosted Grantex smoke URL.
- No Firebase portal deploy.
- Commands are documented as `NOT RUN` only.

## Validation

- `node docs/commerce-v1-pilot-readiness.validate.mjs` - pass
- `node scripts/commerce-staging-e2e-harness.mjs --dry-run` - pass
- `node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=https://grantex-auth-smoke-abc123-uc.a.run.app --allow-smoke-cloud-run-url=https://grantex-auth-smoke-abc123-uc.a.run.app` - pass
- `node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=https://grantex-auth-smoke-abc123-uc.a.run.app` - expected fail closed
- `node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=https://api.grantex.dev` - expected fail closed
- `git diff --check` - pass

## Safety Confirmations

- `.tmp`, local-only reports, bearer tokens, passports, idempotency keys, provider credentials, webhook secrets, raw payloads, and secret values were not committed.
- No production DB/Redis, production secrets, production service config, live payment flags, or live Plural settings were touched.
- No cloud resource was created.