### PR TITLE
fix(commerce): qualify webhook replay payload hash

### DIFF
--- a/apps/auth-service/src/routes/commerce-ops.ts
+++ b/apps/auth-service/src/routes/commerce-ops.ts
@@ -408,10 +408,10 @@ export async function commerceOpsRoutes(app: FastifyInstance): Promise<void> {
       const sql = getSql();
       const rows = await sql<WebhookEventRow[]>`
         SELECT e.id, e.tenant_id, e.provider_key, e.merchant_id, e.payment_intent_id,
-               provider_payment_id, provider_event_id, provider_event_type,
-               signature_validation_status, replay_status, processing_status,
-               payload_hash, error_code, error_message, attempt_count,
-               replay_count, last_replayed_at,
+               e.provider_payment_id, e.provider_event_id, e.provider_event_type,
+               e.signature_validation_status, e.replay_status, e.processing_status,
+               e.payload_hash, e.error_code, e.error_message, e.attempt_count,
+               e.replay_count, e.last_replayed_at,
                (p.webhook_event_id IS NOT NULL) AS has_replay_payload,
                e.received_at, e.processed_at, e.updated_at
           FROM commerce_provider_webhook_events e

--- a/apps/auth-service/tests/commerce-m14-replay-reenable.test.ts
+++ b/apps/auth-service/tests/commerce-m14-replay-reenable.test.ts
@@ -205,6 +205,25 @@ describe('M14 provider webhook replay', () => {
     expect(res.body).not.toContain(MOCK_WEBHOOK_SECRET);
   });
 
+  it('qualifies replay availability payload hash to avoid joined-table ambiguity', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([replayRow()]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/ops/provider-webhook-events?merchant_id=mch_M14&processing_status=failed',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const calls = flattenedSqlCalls();
+    expect(calls).toContain('e.payload_hash');
+    expect(calls).not.toMatch(/[^.]payload_hash, e\.error_code/);
+    expect(res.body).not.toContain('encrypted_payload');
+    expect(res.body).not.toContain('safe_headers_json');
+    expect(res.body).not.toContain(MOCK_WEBHOOK_SECRET);
+  });
+
   it('supports replay dry-run with a required reason', async () => {
     seedCommerceContext();
     sqlMock.mockResolvedValueOnce([replayRow()]);


### PR DESCRIPTION
## Scope

M14.1 fix only. This PR qualifies provider webhook replay event listing columns so the joined replay-payload table cannot make `payload_hash` ambiguous.

## Root Cause

The provider webhook replay dry-run smoke path first lists failed provider webhook events. That query joins `commerce_provider_webhook_events e` with `commerce_provider_webhook_event_payloads p`, and both tables contain `payload_hash`. The listing SELECT used unqualified event columns, causing Postgres to fail with an ambiguous `payload_hash` reference.

## Changes

- Qualify provider webhook event listing columns with the `e.` table alias.
- Add a focused M14 regression proving replay availability listing uses `e.payload_hash` and does not expose encrypted payload, safe header metadata, webhook secrets, or signing material.

## Validation

Local validation on the clean M14.1 branch:

- `npm run typecheck` from `apps/auth-service` passed.
- `npm test -- commerce-m14-replay-reenable.test.ts` passed.
- `npm test -- commerce-provider-webhook.test.ts` passed.
- `npm test -- commerce` passed.
- `node docs/commerce-v1-pilot-readiness.validate.mjs` passed.
- `git diff --check` passed.

Smoke evidence after applying the same fix onto the approved Option A smoke build source:

- Existing service only: `grantex-auth-smoke`.
- New smoke revision: `grantex-auth-smoke-00006-bld`.
- Replay dry-run returned safe metadata with HTTP 200.
- Evidence report recorded 22 passed, 0 failed, 9 skipped, no blockers.

## Safety

- No production service/config changed.
- No production DB/Redis used.
- No live payment or live Plural enablement.
- No raw payloads, encrypted payloads, signatures, tokens, passports, provider credentials, webhook secrets, or secret values committed.
- `.tmp` and local evidence artifacts remain uncommitted.