### PR TITLE
fix(commerce): clean up security alerts

### DIFF
--- a/apps/auth-service/src/routes/commerce-cart-payment.ts
+++ b/apps/auth-service/src/routes/commerce-cart-payment.ts
@@ -833,10 +833,10 @@ export async function commerceCartPaymentRoutes(app: FastifyInstance): Promise<v
     commerceCriticalFlowTotal.labels('cart.create', 'success', '').inc();
     request.log.info(commerceLogContext({
       requestId: request.id,
-      tenantId,
-      merchantId,
-      agentId: caller.agentId,
-      cartId,
+      tenantId: tenantId.replace(/[\r\n\t]/g, '_'),
+      merchantId: merchantId.replace(/[\r\n\t]/g, '_'),
+      agentId: caller.agentId?.replace(/[\r\n\t]/g, '_'),
+      cartId: cartId.replace(/[\r\n\t]/g, '_'),
       idempotencyKeyHash: idempotency.keyHash,
       status: 'draft',
     }), 'commerce.cart.created');
@@ -1079,12 +1079,12 @@ export async function commerceCartPaymentRoutes(app: FastifyInstance): Promise<v
         ).inc();
         request.log.warn(commerceLogContext({
           requestId: request.id,
-          tenantId,
-          merchantId,
-          agentId: caller.agentId,
-          cartId: cart.id,
-          providerKey,
-          errorCode: err.normalized.code,
+          tenantId: tenantId.replace(/[\r\n\t]/g, '_'),
+          merchantId: merchantId.replace(/[\r\n\t]/g, '_'),
+          agentId: caller.agentId?.replace(/[\r\n\t]/g, '_'),
+          cartId: cart.id.replace(/[\r\n\t]/g, '_'),
+          providerKey: providerKey.replace(/[\r\n\t]/g, '_'),
+          errorCode: err.normalized.code.replace(/[\r\n\t]/g, '_'),
           idempotencyKeyHash: idempotency.keyHash,
         }), 'commerce.payment_intent.provider_error');
         throw new CommerceHttpError(503, err.normalized.code, err.normalized.message, {
@@ -1202,18 +1202,18 @@ export async function commerceCartPaymentRoutes(app: FastifyInstance): Promise<v
     commerceCriticalFlowTotal.labels('payment_intent.create', 'success', '').inc();
     request.log.info(commerceLogContext({
       requestId: request.id,
-      tenantId,
-      merchantId,
-      agentId: caller.agentId,
-      cartId: cart.id,
-      paymentIntentId,
-      providerKey,
-      providerPaymentIdRef: hashedReference(providerResult.provider_payment_id, 'provider_payment'),
-      passportJti: passport.jti,
-      policyVersion: policy.version,
-      decisionId,
+      tenantId: tenantId.replace(/[\r\n\t]/g, '_'),
+      merchantId: merchantId.replace(/[\r\n\t]/g, '_'),
+      agentId: caller.agentId?.replace(/[\r\n\t]/g, '_'),
+      cartId: cart.id.replace(/[\r\n\t]/g, '_'),
+      paymentIntentId: paymentIntentId.replace(/[\r\n\t]/g, '_'),
+      providerKey: providerKey.replace(/[\r\n\t]/g, '_'),
+      providerPaymentIdRef: hashedReference(providerResult.provider_payment_id.replace(/[\r\n\t]/g, '_'), 'provider_payment'),
+      passportJtiRef: hashedReference(passport.jti.replace(/[\r\n\t]/g, '_')),
+      policyVersion: policy.version.replace(/[\r\n\t]/g, '_'),
+      decisionId: decisionId.replace(/[\r\n\t]/g, '_'),
       idempotencyKeyHash: idempotency.keyHash,
-      status: providerResult.status,
+      status: providerResult.status.replace(/[\r\n\t]/g, '_'),
     }), 'commerce.payment_intent.created');
 
     return reply.status(201).send(responseBody);

--- a/apps/auth-service/src/routes/commerce-ops.ts
+++ b/apps/auth-service/src/routes/commerce-ops.ts
@@ -454,8 +454,10 @@ export async function commerceOpsRoutes(app: FastifyInstance): Promise<void> {
       }
       const body = (request.body ?? {}) as Record<string, unknown>;
       const fieldErrors: Record<string, string> = {};
-      for (const key of Object.keys(body)) {
-        if (key !== 'reason' && key !== 'dry_run') fieldErrors[key] = 'field is unsupported';
+      const unsupportedFields = Object.keys(body).filter((key) => key !== 'reason' && key !== 'dry_run');
+      if (unsupportedFields.length > 0) {
+        fieldErrors['unsupported_fields'] =
+          `unsupported fields: ${unsupportedFields.map((key) => key.replace(/[\r\n\t]/g, '_')).join(', ')}`;
       }
       if (!nonEmptyString(body['reason'])) fieldErrors['reason'] = 'required non-empty string';
       if (body['dry_run'] !== undefined && typeof body['dry_run'] !== 'boolean') {

--- a/apps/auth-service/src/routes/commerce-policy.ts
+++ b/apps/auth-service/src/routes/commerce-policy.ts
@@ -598,10 +598,11 @@ export async function commercePolicyRoutes(app: FastifyInstance): Promise<void> 
       requireOperator(request);
       const body = (request.body ?? {}) as Record<string, unknown>;
       const fieldErrors: Record<string, string> = {};
-      for (const key of Object.keys(body)) {
-        if (!['reason', 'reviewed_policy_id', 'incident_reference', 'confirm_reenable'].includes(key)) {
-          fieldErrors[key] = 'field is unsupported';
-        }
+      const supportedFields = new Set(['reason', 'reviewed_policy_id', 'incident_reference', 'confirm_reenable']);
+      const unsupportedFields = Object.keys(body).filter((key) => !supportedFields.has(key));
+      if (unsupportedFields.length > 0) {
+        fieldErrors['unsupported_fields'] =
+          `unsupported fields: ${unsupportedFields.map((key) => key.replace(/[\r\n\t]/g, '_')).join(', ')}`;
       }
       if (!isString(body['reason'])) fieldErrors['reason'] = 'required non-empty string';
       if (!isString(body['reviewed_policy_id'])) {

--- a/apps/auth-service/src/routes/commerce-webhook-sources.ts
+++ b/apps/auth-service/src/routes/commerce-webhook-sources.ts
@@ -249,10 +249,10 @@ export async function commerceWebhookSourceRoutes(app: FastifyInstance): Promise
     const sourceKey = validateSourceKey(request.params.source_key, fieldErrors);
     const merchantId = merchantIdForWebhookSourceWrite(request, request.query.merchant_id);
     const changedFields = Object.keys(body);
-    for (const key of changedFields) {
-      if (!WEBHOOK_SOURCE_PATCH_FIELDS.has(key)) {
-        fieldErrors[key] = 'field is immutable or unsupported';
-      }
+    const unsupportedFields = changedFields.filter((key) => !WEBHOOK_SOURCE_PATCH_FIELDS.has(key));
+    if (unsupportedFields.length > 0) {
+      fieldErrors['unsupported_fields'] =
+        `immutable or unsupported fields: ${unsupportedFields.map((key) => key.replace(/[\r\n\t]/g, '_')).join(', ')}`;
     }
     const mutableFields = changedFields.filter((key) => WEBHOOK_SOURCE_PATCH_FIELDS.has(key));
     if (mutableFields.length === 0 && Object.keys(fieldErrors).length === 0) {

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -226,10 +226,10 @@ function validatePatchKeys(
   fieldErrors: Record<string, string>,
 ): string[] {
   const changedFields = Object.keys(body);
-  for (const key of changedFields) {
-    if (!allowed.has(key)) {
-      fieldErrors[key] = 'field is immutable or unsupported';
-    }
+  const unsupportedFields = changedFields.filter((key) => !allowed.has(key));
+  if (unsupportedFields.length > 0) {
+    fieldErrors['unsupported_fields'] =
+      `immutable or unsupported fields: ${unsupportedFields.map((key) => key.replace(/[\r\n\t]/g, '_')).join(', ')}`;
   }
   return changedFields.filter((key) => allowed.has(key));
 }

--- a/apps/auth-service/tests/commerce-catalog-m12b.test.ts
+++ b/apps/auth-service/tests/commerce-catalog-m12b.test.ts
@@ -264,10 +264,10 @@ describe('M12B PATCH /v1/commerce/catalog/products/:productId', () => {
 
     expect(res.statusCode).toBe(422);
     const fields = res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields;
-    expect(fields).toHaveProperty('id');
-    expect(fields).toHaveProperty('tenant_id');
-    expect(fields).toHaveProperty('merchant_id');
-    expect(fields).toHaveProperty('provider_payment_id');
+    expect(fields.unsupported_fields).toContain('id');
+    expect(fields.unsupported_fields).toContain('tenant_id');
+    expect(fields.unsupported_fields).toContain('merchant_id');
+    expect(fields.unsupported_fields).toContain('provider_payment_id');
   });
 
   it('rejects invalid price and currency patches', async () => {

--- a/apps/auth-service/tests/commerce-hardening.test.ts
+++ b/apps/auth-service/tests/commerce-hardening.test.ts
@@ -87,6 +87,16 @@ describe('Commerce M6A observability hardening', () => {
     expect(serialized).not.toMatch(/[\r\n\t]/);
   });
 
+  it('pre-sanitizes cart and payment route log values before structured logging', () => {
+    const cartPayment = readRoute('commerce-cart-payment.ts');
+
+    expect(cartPayment).toContain("merchantId: merchantId.replace(/[\\r\\n\\t]/g, '_')");
+    expect(cartPayment).toContain("cartId: cartId.replace(/[\\r\\n\\t]/g, '_')");
+    expect(cartPayment).toContain("providerKey: providerKey.replace(/[\\r\\n\\t]/g, '_')");
+    expect(cartPayment).toContain("providerPaymentIdRef: hashedReference(providerResult.provider_payment_id.replace(/[\\r\\n\\t]/g, '_'), 'provider_payment')");
+    expect(cartPayment).toContain("passportJtiRef: hashedReference(passport.jti.replace(/[\\r\\n\\t]/g, '_'))");
+  });
+
   it('mock provider metadata stores idempotency hash only, not plaintext prefixes', async () => {
     const rawIdempotencyKey = 'idem_SECRET_PREFIX_SHOULD_NOT_LEAK';
     const result = await new MockPaymentProvider().createPaymentIntent({

--- a/apps/auth-service/tests/commerce-m14-replay-reenable.test.ts
+++ b/apps/auth-service/tests/commerce-m14-replay-reenable.test.ts
@@ -242,6 +242,22 @@ describe('M14 provider webhook replay', () => {
     expect(flattenedSqlCalls()).not.toContain('UPDATE commerce_payment_intents');
   });
 
+  it('rejects replay request unsupported fields under a constant validation key', async () => {
+    seedCommerceContext();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/v1/commerce/ops/provider-webhook-events/${WEBHOOK_EVENT}/replay`,
+      headers: authHeader(),
+      payload: { reason: 'ops_review', signature: 'do-not-accept' },
+    });
+
+    expect(res.statusCode).toBe(422);
+    const fields = res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields;
+    expect(Object.keys(fields)).not.toContain('signature');
+    expect(fields.unsupported_fields).toContain('signature');
+  });
+
   it('replays a valid failed provider webhook through the payment state machine', async () => {
     seedCommerceContext();
     sqlMock.mockResolvedValueOnce([replayRow()]);
@@ -338,6 +354,26 @@ describe('M14 emergency re-enable', () => {
     expect(res.statusCode).toBe(422);
     expect(res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields)
       .toHaveProperty('confirm_reenable');
+  });
+
+  it('rejects re-enable unsupported fields under a constant validation key', async () => {
+    seedCommerceContext();
+    const res = await app.inject({
+      method: 'POST',
+      url: `/v1/commerce/merchants/${MERCHANT}/enable-agentic-commerce`,
+      headers: authHeader(),
+      payload: {
+        reason: 'review',
+        reviewed_policy_id: POLICY_ID,
+        confirm_reenable: true,
+        secret: 'do-not-accept',
+      },
+    });
+
+    expect(res.statusCode).toBe(422);
+    const fields = res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields;
+    expect(Object.keys(fields)).not.toContain('secret');
+    expect(fields.unsupported_fields).toContain('secret');
   });
 
   it('rejects invalid reviewed policy evidence', async () => {

--- a/apps/auth-service/tests/commerce-merchant-agent-m12a.test.ts
+++ b/apps/auth-service/tests/commerce-merchant-agent-m12a.test.ts
@@ -134,9 +134,9 @@ describe('M12A PATCH /v1/commerce/merchants/:merchantId', () => {
 
     expect(res.statusCode).toBe(422);
     const fields = res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields;
-    expect(fields).toHaveProperty('tenant_id');
-    expect(fields).toHaveProperty('environment');
-    expect(fields).toHaveProperty('provider_account_refs');
+    expect(fields.unsupported_fields).toContain('tenant_id');
+    expect(fields.unsupported_fields).toContain('environment');
+    expect(fields.unsupported_fields).toContain('provider_account_refs');
   });
 
   it('returns non-enumerating 404 when merchant is absent or outside the tenant', async () => {
@@ -269,10 +269,10 @@ describe('M12A PATCH /v1/commerce/agents/:agentId', () => {
 
     expect(res.statusCode).toBe(422);
     const fields = res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields;
-    expect(fields).toHaveProperty('tenant_id');
-    expect(fields).toHaveProperty('merchant_id');
-    expect(fields).toHaveProperty('api_key_hash');
-    expect(fields).toHaveProperty('public_key_jwk');
+    expect(fields.unsupported_fields).toContain('tenant_id');
+    expect(fields.unsupported_fields).toContain('merchant_id');
+    expect(fields.unsupported_fields).toContain('api_key_hash');
+    expect(fields.unsupported_fields).toContain('public_key_jwk');
   });
 
   it('prevents CommerceAgent self-elevation of trust/status', async () => {

--- a/apps/auth-service/tests/commerce-merchant-webhooks-m12c.test.ts
+++ b/apps/auth-service/tests/commerce-merchant-webhooks-m12c.test.ts
@@ -231,11 +231,11 @@ describe('M12C webhook source management APIs', () => {
 
     expect(res.statusCode).toBe(422);
     const fields = res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields;
-    expect(fields).toHaveProperty('merchant_id');
-    expect(fields).toHaveProperty('source_key');
-    expect(fields).toHaveProperty('secret');
-    expect(fields).toHaveProperty('secret_hash');
-    expect(fields).toHaveProperty('created_at');
+    expect(fields.unsupported_fields).toContain('merchant_id');
+    expect(fields.unsupported_fields).toContain('source_key');
+    expect(fields.unsupported_fields).toContain('secret');
+    expect(fields.unsupported_fields).toContain('secret_hash');
+    expect(fields.unsupported_fields).toContain('created_at');
   });
 
   it('rotates a source secret once and never exposes previous material', async () => {

--- a/packages/langchain/package-lock.json
+++ b/packages/langchain/package-lock.json
@@ -756,14 +756,13 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.20.tgz",
-      "integrity": "sha512-ULhLM8RswvQDXufLtNtvclHrWCBx8Cb5UPI6lAZC+8Dq59iHsVPz/3Ac9khWNm1VIvChRsuykixD/WrmzuuA3Q==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.1.tgz",
+      "integrity": "sha512-Wjk90UjNoY5cBHMlNAC/eZx5clI8jnjBOBW8uJu8+MWBtx0QesNjsUiLtjI+I3UnrpxFFpDqGXcnhBjH654Mqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "p-queue": "6.6.2",
-        "uuid": "10.0.0"
+        "p-queue": "6.6.2"
       },
       "peerDependencies": {
         "@opentelemetry/api": "*",

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -31,7 +31,7 @@
   },
   "overrides": {
     "esbuild": ">=0.25.0",
-    "langsmith": ">=0.4.6"
+    "langsmith": ">=0.6.0"
   },
   "devDependencies": {
     "@grantex/sdk": "file:../sdk-ts",


### PR DESCRIPTION
## Scope

C0 security cleanup only. No deploy, production config change, Commerce V1 enablement, live payments, or live Plural changes.

## CodeQL alert fixes

- `js/log-injection` in `apps/auth-service/src/routes/commerce-cart-payment.ts`: pre-sanitizes request/provider-derived log values before structured commerce logging.
- `js/remote-property-injection` in Commerce patch/replay/re-enable validators: replaces untrusted dynamic validation error keys with constant `unsupported_fields` and sanitized field-name summaries.

## Dependabot fix

- Updates `packages/langchain` `langsmith` override to `>=0.6.0` and lockfile resolution to `0.7.1` for Dependabot alert #176.
- Inspected existing Dependabot PR #330; this PR supersedes it with the same vulnerable package remediated past the advisory floor.

## Validation

- `apps/auth-service`: `npm run typecheck` passed.
- `apps/auth-service`: `npm test -- commerce-hardening.test.ts commerce-merchant-agent-m12a.test.ts commerce-catalog-m12b.test.ts commerce-merchant-webhooks-m12c.test.ts commerce-m14-replay-reenable.test.ts` passed: 70 tests.
- `apps/auth-service`: `npm test -- commerce` passed: 31 files, 434 tests.
- `apps/auth-service`: `npm test` passed: 107 files, 1461 tests.
- `packages/langchain`: `npm ci` completed with 0 vulnerabilities reported.
- `packages/sdk-ts`: `npm ci` and `npm run build` passed so the local SDK dependency is available for package typecheck.
- `packages/langchain`: `npm run typecheck` passed.
- `packages/langchain`: `npm test` passed: 3 files, 20 tests.
- Repo root: `node docs/commerce-v1-pilot-readiness.validate.mjs` passed.
- Repo root: `git diff --check` passed.

Note: a direct `npm audit --audit-level=high` retry returned an npm registry audit endpoint error, but install/ci audit output for the affected package reported 0 vulnerabilities after the lock update.

## Safety

- No `.tmp` or local report artifacts committed.
- No secrets, bearer tokens, passports, idempotency keys, webhook secrets, provider credentials, or raw payloads added.
- No production config or live payment/Plural flags changed.