### PR TITLE
fix(commerce): use static payment log entries

### DIFF
--- a/apps/auth-service/src/routes/commerce-cart-payment.ts
+++ b/apps/auth-service/src/routes/commerce-cart-payment.ts
@@ -831,15 +831,7 @@ export async function commerceCartPaymentRoutes(app: FastifyInstance): Promise<v
     });
 
     commerceCriticalFlowTotal.labels('cart.create', 'success', '').inc();
-    request.log.info(commerceLogContext({
-      requestId: request.id,
-      tenantId: tenantId.replace(/[\r\n\t]/g, '_'),
-      merchantId: merchantId.replace(/[\r\n\t]/g, '_'),
-      agentId: caller.agentId?.replace(/[\r\n\t]/g, '_'),
-      cartId: cartId.replace(/[\r\n\t]/g, '_'),
-      idempotencyKeyHash: idempotency.keyHash,
-      status: 'draft',
-    }), 'commerce.cart.created');
+    request.log.info({ flow: 'cart.create', status: 'draft' }, 'commerce.cart.created');
 
     return reply.status(201).send(responseBody);
     },
@@ -1077,16 +1069,8 @@ export async function commerceCartPaymentRoutes(app: FastifyInstance): Promise<v
           'provider_error',
           err.normalized.code,
         ).inc();
-        request.log.warn(commerceLogContext({
-          requestId: request.id,
-          tenantId: tenantId.replace(/[\r\n\t]/g, '_'),
-          merchantId: merchantId.replace(/[\r\n\t]/g, '_'),
-          agentId: caller.agentId?.replace(/[\r\n\t]/g, '_'),
-          cartId: cart.id.replace(/[\r\n\t]/g, '_'),
-          providerKey: providerKey.replace(/[\r\n\t]/g, '_'),
-          errorCode: err.normalized.code.replace(/[\r\n\t]/g, '_'),
-          idempotencyKeyHash: idempotency.keyHash,
-        }), 'commerce.payment_intent.provider_error');
+        request.log.warn({ flow: 'payment_intent.create', status: 'provider_error' },
+          'commerce.payment_intent.provider_error');
         throw new CommerceHttpError(503, err.normalized.code, err.normalized.message, {
           retryable: err.normalized.retryable,
           details: {
@@ -1200,21 +1184,8 @@ export async function commerceCartPaymentRoutes(app: FastifyInstance): Promise<v
     });
 
     commerceCriticalFlowTotal.labels('payment_intent.create', 'success', '').inc();
-    request.log.info(commerceLogContext({
-      requestId: request.id,
-      tenantId: tenantId.replace(/[\r\n\t]/g, '_'),
-      merchantId: merchantId.replace(/[\r\n\t]/g, '_'),
-      agentId: caller.agentId?.replace(/[\r\n\t]/g, '_'),
-      cartId: cart.id.replace(/[\r\n\t]/g, '_'),
-      paymentIntentId: paymentIntentId.replace(/[\r\n\t]/g, '_'),
-      providerKey: providerKey.replace(/[\r\n\t]/g, '_'),
-      providerPaymentIdRef: hashedReference(providerResult.provider_payment_id.replace(/[\r\n\t]/g, '_'), 'provider_payment'),
-      passportJtiRef: hashedReference(passport.jti.replace(/[\r\n\t]/g, '_')),
-      policyVersion: policy.version.replace(/[\r\n\t]/g, '_'),
-      decisionId: decisionId.replace(/[\r\n\t]/g, '_'),
-      idempotencyKeyHash: idempotency.keyHash,
-      status: providerResult.status.replace(/[\r\n\t]/g, '_'),
-    }), 'commerce.payment_intent.created');
+    request.log.info({ flow: 'payment_intent.create', status: 'created' },
+      'commerce.payment_intent.created');
 
     return reply.status(201).send(responseBody);
     },

--- a/apps/auth-service/tests/commerce-hardening.test.ts
+++ b/apps/auth-service/tests/commerce-hardening.test.ts
@@ -87,14 +87,20 @@ describe('Commerce M6A observability hardening', () => {
     expect(serialized).not.toMatch(/[\r\n\t]/);
   });
 
-  it('pre-sanitizes cart and payment route log values before structured logging', () => {
+  it('keeps CodeQL-sensitive cart and payment route log entries static', () => {
     const cartPayment = readRoute('commerce-cart-payment.ts');
 
-    expect(cartPayment).toContain("merchantId: merchantId.replace(/[\\r\\n\\t]/g, '_')");
-    expect(cartPayment).toContain("cartId: cartId.replace(/[\\r\\n\\t]/g, '_')");
-    expect(cartPayment).toContain("providerKey: providerKey.replace(/[\\r\\n\\t]/g, '_')");
-    expect(cartPayment).toContain("providerPaymentIdRef: hashedReference(providerResult.provider_payment_id.replace(/[\\r\\n\\t]/g, '_'), 'provider_payment')");
-    expect(cartPayment).toContain("passportJtiRef: hashedReference(passport.jti.replace(/[\\r\\n\\t]/g, '_'))");
+    expect(cartPayment).toContain(
+      "request.log.info({ flow: 'cart.create', status: 'draft' }, 'commerce.cart.created');",
+    );
+    expect(cartPayment).toContain(
+      "request.log.warn({ flow: 'payment_intent.create', status: 'provider_error' },",
+    );
+    expect(cartPayment).toContain(
+      "request.log.info({ flow: 'payment_intent.create', status: 'created' },",
+    );
+    expect(cartPayment).not.toContain("merchantId: merchantId.replace(/[\\r\\n\\t]/g, '_')");
+    expect(cartPayment).not.toContain("providerPaymentIdRef: hashedReference(providerResult.provider_payment_id");
   });
 
   it('mock provider metadata stores idempotency hash only, not plaintext prefixes', async () => {


### PR DESCRIPTION
## Scope

C0.1 only. This narrowly addresses the remaining CodeQL `js/log-injection` alerts in `apps/auth-service/src/routes/commerce-cart-payment.ts`.

## Fix

- Alert #252: `commerce.cart.created` now logs only static structured fields.
- Alert #253: `commerce.payment_intent.provider_error` now logs only static structured fields.
- Alert #254: `commerce.payment_intent.created` now logs only static structured fields.

Request, provider, passport, idempotency, and payment identifiers remain available through audit records and response metadata where appropriate, but are no longer passed into these three CodeQL-sensitive logger sinks.

## Validation

- `apps/auth-service`: `npm run typecheck` passed.
- `apps/auth-service`: `npm test -- commerce-hardening.test.ts` passed: 14 tests.
- `apps/auth-service`: `npm test -- commerce` passed: 31 files, 434 tests.
- `apps/auth-service`: `npm test` passed: 107 files, 1461 tests.
- Repo root: `node docs/commerce-v1-pilot-readiness.validate.mjs` passed.
- Repo root: `git diff --check` passed.

## Safety

- No deploy, production config change, Commerce V1 enablement, live payment change, or live Plural change.
- No `.tmp`, local reports, secrets, bearer tokens, passports, idempotency keys, webhook secrets, provider credentials, or raw payloads committed.