### PR TITLE
docs(commerce): add repeatable option a smoke workflow

### DIFF
--- a/docs/commerce-v1-pilot-readiness.validate.mjs
+++ b/docs/commerce-v1-pilot-readiness.validate.mjs
@@ -15,11 +15,19 @@ const hostedStagingPlan = readFileSync(join(docsDir, 'guides', 'commerce-v1-host
 const stagingDataSetup = readFileSync(join(docsDir, 'guides', 'commerce-v1-staging-data-setup.md'), 'utf8');
 const hostedStagingE2E = readFileSync(join(docsDir, 'guides', 'commerce-v1-hosted-staging-e2e.md'), 'utf8');
 const optionASmokeSetup = readFileSync(join(docsDir, 'guides', 'commerce-v1-option-a-smoke-setup.md'), 'utf8');
+const repeatableOptionASmokeWorkflow = readFileSync(
+  join(docsDir, 'guides', 'commerce-v1-repeatable-option-a-smoke-workflow.md'),
+  'utf8',
+);
 const hostedStagingE2ETemplate = readFileSync(join(docsDir, 'reports', 'commerce-v1-hosted-staging-e2e.template.md'), 'utf8');
 const optionASmokeEvidence = readFileSync(join(docsDir, 'reports', 'commerce-v1-option-a-smoke-evidence.md'), 'utf8');
 const contractGapReport = readFileSync(join(docsDir, 'reports', 'commerce-v1-contract-completeness-gap-report.md'), 'utf8');
+const optionASmokeRunbookText = readFileSync(join(docsDir, 'examples', 'commerce-option-a-smoke.runbook.json'), 'utf8');
 const harness = readFileSync(join(repoRoot, 'scripts', 'commerce-pilot-load-harness.mjs'), 'utf8');
 const stagingE2EHarness = readFileSync(join(repoRoot, 'scripts', 'commerce-staging-e2e-harness.mjs'), 'utf8');
+const optionASmokePlan = readFileSync(join(repoRoot, 'scripts', 'commerce-option-a-smoke-plan.mjs'), 'utf8');
+const optionASmokeSeed = readFileSync(join(repoRoot, 'scripts', 'commerce-option-a-smoke-seed.mjs'), 'utf8');
+const optionASmokeEvidenceTool = readFileSync(join(repoRoot, 'scripts', 'commerce-option-a-smoke-evidence.mjs'), 'utf8');
 const seed = readFileSync(join(repoRoot, 'scripts', 'commerce-pilot-seed-local.mjs'), 'utf8');
 
 function extractFalseImplementedRoutes(openapiText) {
@@ -323,6 +331,108 @@ for (const forbidden of [
 }
 
 for (const required of [
+  'Commerce V1 Repeatable Option A Smoke Workflow',
+  'C2A planning and tooling only',
+  'manual approval gates',
+  'min-instances=0',
+  'max-instances=1',
+  'grantex-auth-smoke',
+  'grantex-commerce-smoke-pg',
+  'grantex-commerce-smoke-redis',
+  'Mock provider only',
+  'COMMERCE_LIVE_MODE_ENABLED=true',
+  'PLURAL_LIVE_ENABLED=true',
+  'Cleanup Guarantees',
+  'more than 24 hours',
+  '--allow-long-cleanup-window',
+  'AgenticOrg Local Real-Staging Eval Fit',
+  'AGENTICORG_COMMERCE_REAL_STAGING',
+  'GRANTEX_COMMERCE_BASE_URL',
+  'GRANTEX_BASE_URL',
+  'AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL',
+  'No hosted AgenticOrg deploy',
+]) {
+  assert.ok(repeatableOptionASmokeWorkflow.includes(required), `repeatable Option A workflow includes ${required}`);
+}
+for (const forbidden of [
+  'sk_live_',
+  'pk_live_',
+  'Bearer ',
+  'passport.jwt',
+  'idempotency-key:',
+  'mock-webhook-secret',
+]) {
+  assert.equal(
+    repeatableOptionASmokeWorkflow.includes(forbidden),
+    false,
+    `repeatable Option A workflow does not include ${forbidden}`,
+  );
+}
+
+const optionASmokeRunbook = JSON.parse(optionASmokeRunbookText);
+assert.equal(optionASmokeRunbook.resources.cloud_run_service, 'grantex-auth-smoke', 'Option A runbook pins smoke service');
+assert.equal(optionASmokeRunbook.resources.cloud_sql_instance, 'grantex-commerce-smoke-pg', 'Option A runbook pins smoke SQL');
+assert.equal(optionASmokeRunbook.resources.redis_instance, 'grantex-commerce-smoke-redis', 'Option A runbook pins smoke Redis');
+assert.equal(optionASmokeRunbook.resources.min_instances, 0, 'Option A runbook documents min instances 0');
+assert.equal(optionASmokeRunbook.resources.max_instances, 1, 'Option A runbook documents max instances 1');
+assert.equal(optionASmokeRunbook.provider.required, 'mock', 'Option A runbook requires mock provider');
+assert.equal(optionASmokeRunbook.provider.live_payments_enabled, false, 'Option A runbook blocks live payments');
+assert.equal(optionASmokeRunbook.provider.plural_live_enabled, false, 'Option A runbook blocks live Plural');
+assert.ok(
+  optionASmokeRunbook.refused_resource_names.includes('grantex-auth')
+    && optionASmokeRunbook.refused_resource_names.includes('grantex-pg16')
+    && optionASmokeRunbook.refused_resource_names.includes('grantex-redis'),
+  'Option A runbook documents production resource name refusals',
+);
+assert.ok(
+  optionASmokeRunbook.secret_names_only.every((name) => name.startsWith('grantex-smoke-')),
+  'Option A runbook lists smoke secret names only',
+);
+assert.equal(optionASmokeRunbook.redaction.secret_values_included, false, 'Option A runbook excludes secret values');
+for (const forbidden of ['sk_live_', 'pk_live_', 'Bearer ', 'passport.jwt', 'idempotency-key:', 'mock-webhook-secret']) {
+  assert.equal(optionASmokeRunbookText.includes(forbidden), false, `Option A runbook does not include ${forbidden}`);
+}
+
+for (const required of [
+  'dry-run command generation only',
+  'Refusing production resource name',
+  'Refusing production URL',
+  'Refusing non-mock provider',
+  'min-instances=0',
+  'max-instances=1',
+  'Refusing cleanup window more than 24 hours',
+  'create_cloud_sql',
+  'create_redis',
+  'create_smoke_secret_names',
+  'deploy_smoke_service',
+  'agenticorg_local_real_staging_eval',
+  '# NOT RUN',
+]) {
+  assert.ok(optionASmokePlan.includes(required), `Option A smoke plan script includes ${required}`);
+}
+for (const required of [
+  'Run mode is blocked for C2A',
+  'Smoke seed provider must be mock',
+  'Smoke seed live payments flag must be false',
+  'Smoke seed tenant id is pinned',
+  'Smoke seed manifest must include 10-25 products',
+  'generated harness env under .tmp only',
+]) {
+  assert.ok(optionASmokeSeed.includes(required), `Option A smoke seed script includes ${required}`);
+}
+for (const required of [
+  'Refusing production domain',
+  'Refusing arbitrary run.app URL without exact --allow-smoke-cloud-run-url',
+  'Refusing non-mock provider',
+  'Refusing COMMERCE_LIVE_MODE_ENABLED=true',
+  'Refusing PLURAL_LIVE_ENABLED=true',
+  'Run mode is blocked for C2A',
+  'commerce-v1-option-a-smoke-evidence.md',
+]) {
+  assert.ok(optionASmokeEvidenceTool.includes(required), `Option A smoke evidence tool includes ${required}`);
+}
+
+for (const required of [
   'Commerce V1 Option A Smoke Evidence',
   'Passed checks | 22',
   'Failed checks | 0',
@@ -572,6 +682,139 @@ assert.ok(
   'hosted staging E2E run.app refusal explains the smoke allowlist guard',
 );
 
+const nearCleanup = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+const optionASmokePlanDryRun = execFileSync(
+  process.execPath,
+  [
+    join(repoRoot, 'scripts', 'commerce-option-a-smoke-plan.mjs'),
+    '--dry-run',
+    '--project=grantex-prod',
+    '--region=us-central1',
+    '--sql-tier=db-f1-micro',
+    `--cleanup-by=${nearCleanup}`,
+  ],
+  { encoding: 'utf8' },
+);
+const optionASmokePlanReport = JSON.parse(optionASmokePlanDryRun);
+assert.equal(optionASmokePlanReport.mode, 'dry-run');
+assert.equal(optionASmokePlanReport.status, 'not_executed');
+assert.equal(optionASmokePlanReport.creates_resources, false);
+assert.equal(optionASmokePlanReport.deploys, false);
+assert.equal(optionASmokePlanReport.service_name, 'grantex-auth-smoke');
+assert.equal(optionASmokePlanReport.cloud_sql_instance, 'grantex-commerce-smoke-pg');
+assert.equal(optionASmokePlanReport.redis_instance, 'grantex-commerce-smoke-redis');
+assert.equal(optionASmokePlanReport.provider, 'mock');
+assert.equal(optionASmokePlanReport.min_instances, 0);
+assert.equal(optionASmokePlanReport.max_instances, 1);
+assert.ok(
+  optionASmokePlanReport.commands.every((entry) => entry.command.startsWith('# NOT RUN')),
+  'Option A smoke planner prints commands as NOT RUN',
+);
+
+const optionASmokeLongCleanupRefusal = spawnSync(
+  process.execPath,
+  [
+    join(repoRoot, 'scripts', 'commerce-option-a-smoke-plan.mjs'),
+    '--dry-run',
+    '--project=grantex-prod',
+    '--region=us-central1',
+    '--sql-tier=db-f1-micro',
+    '--cleanup-by=2099-01-01T00:00:00+05:30',
+  ],
+  { encoding: 'utf8' },
+);
+assert.notEqual(optionASmokeLongCleanupRefusal.status, 0, 'Option A smoke planner refuses long cleanup windows');
+assert.ok(
+  `${optionASmokeLongCleanupRefusal.stdout}${optionASmokeLongCleanupRefusal.stderr}`.includes('Refusing cleanup window more than 24 hours'),
+  'Option A smoke planner explains long cleanup window refusal',
+);
+
+const optionASmokeProdNameRefusal = spawnSync(
+  process.execPath,
+  [
+    join(repoRoot, 'scripts', 'commerce-option-a-smoke-plan.mjs'),
+    '--dry-run',
+    '--project=grantex-prod',
+    '--region=us-central1',
+    '--sql-tier=db-f1-micro',
+    `--cleanup-by=${nearCleanup}`,
+    '--service-name=grantex-auth',
+  ],
+  { encoding: 'utf8' },
+);
+assert.notEqual(optionASmokeProdNameRefusal.status, 0, 'Option A smoke planner refuses production service name');
+assert.ok(
+  `${optionASmokeProdNameRefusal.stdout}${optionASmokeProdNameRefusal.stderr}`.includes('Refusing production resource name'),
+  'Option A smoke planner explains production resource name refusal',
+);
+
+const optionASmokeSeedDryRun = execFileSync(
+  process.execPath,
+  [
+    join(repoRoot, 'scripts', 'commerce-option-a-smoke-seed.mjs'),
+    '--dry-run',
+    '--manifest=docs/examples/commerce-staging-seed.manifest.json',
+  ],
+  { encoding: 'utf8' },
+);
+const optionASmokeSeedReport = JSON.parse(optionASmokeSeedDryRun);
+assert.equal(optionASmokeSeedReport.mode, 'dry-run');
+assert.equal(optionASmokeSeedReport.status, 'not_executed');
+assert.equal(optionASmokeSeedReport.would_write, false);
+assert.equal(optionASmokeSeedReport.provider, 'mock');
+assert.equal(optionASmokeSeedReport.live_flags.commerce_live_mode_enabled, false);
+assert.equal(optionASmokeSeedReport.staging_ids.tenant_id, 'cten_staging_commerce');
+assert.ok(optionASmokeSeedReport.catalog.product_count >= 10);
+assert.ok(optionASmokeSeedReport.catalog.products_with_variants >= 3);
+
+const optionASmokeEvidenceDryRun = execFileSync(
+  process.execPath,
+  [
+    join(repoRoot, 'scripts', 'commerce-option-a-smoke-evidence.mjs'),
+    '--dry-run',
+    `--api-base=${smokeUrl}`,
+    `--allow-smoke-cloud-run-url=${smokeUrl}`,
+  ],
+  { encoding: 'utf8' },
+);
+const optionASmokeEvidenceDryRunReport = JSON.parse(optionASmokeEvidenceDryRun);
+assert.equal(optionASmokeEvidenceDryRunReport.mode, 'dry-run');
+assert.equal(optionASmokeEvidenceDryRunReport.status, 'not_executed');
+assert.equal(optionASmokeEvidenceDryRunReport.requests_made, false);
+assert.equal(optionASmokeEvidenceDryRunReport.api_base, smokeUrl);
+assert.equal(optionASmokeEvidenceDryRunReport.provider, 'mock');
+assert.equal(optionASmokeEvidenceDryRunReport.safety.exact_smoke_run_app_allowed, smokeUrl);
+
+const optionASmokeEvidenceRunAppRefusal = spawnSync(
+  process.execPath,
+  [
+    join(repoRoot, 'scripts', 'commerce-option-a-smoke-evidence.mjs'),
+    '--dry-run',
+    `--api-base=${smokeUrl}`,
+  ],
+  { encoding: 'utf8' },
+);
+assert.notEqual(optionASmokeEvidenceRunAppRefusal.status, 0, 'Option A smoke evidence tool refuses arbitrary run.app');
+assert.ok(
+  `${optionASmokeEvidenceRunAppRefusal.stdout}${optionASmokeEvidenceRunAppRefusal.stderr}`.includes('Refusing arbitrary run.app URL'),
+  'Option A smoke evidence run.app refusal explains exact allowlist guard',
+);
+
+const optionASmokeEvidenceProdRefusal = spawnSync(
+  process.execPath,
+  [
+    join(repoRoot, 'scripts', 'commerce-option-a-smoke-evidence.mjs'),
+    '--dry-run',
+    '--api-base=https://api.grantex.dev',
+  ],
+  { encoding: 'utf8' },
+);
+assert.notEqual(optionASmokeEvidenceProdRefusal.status, 0, 'Option A smoke evidence tool refuses production API base');
+assert.ok(
+  `${optionASmokeEvidenceProdRefusal.stdout}${optionASmokeEvidenceProdRefusal.stderr}`.includes('Refusing production domain'),
+  'Option A smoke evidence production refusal explains production guard',
+);
+
 const nonLocalSeed = spawnSync(
   process.execPath,
   [
@@ -640,11 +883,16 @@ assert.equal(/[^\u0000-\u007F]/.test(hostedStagingPlan), false, 'hosted staging 
 assert.equal(/[^\u0000-\u007F]/.test(stagingDataSetup), false, 'staging data setup guide stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(hostedStagingE2E), false, 'hosted staging E2E guide stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(optionASmokeSetup), false, 'Option A smoke setup guide stays ASCII-only');
+assert.equal(/[^\u0000-\u007F]/.test(repeatableOptionASmokeWorkflow), false, 'repeatable Option A smoke workflow stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(hostedStagingE2ETemplate), false, 'hosted staging E2E template stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(optionASmokeEvidence), false, 'Option A smoke evidence stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(contractGapReport), false, 'contract gap report stays ASCII-only');
+assert.equal(/[^\u0000-\u007F]/.test(optionASmokeRunbookText), false, 'Option A smoke runbook stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(harness), false, 'load harness stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(stagingE2EHarness), false, 'hosted staging E2E harness stays ASCII-only');
+assert.equal(/[^\u0000-\u007F]/.test(optionASmokePlan), false, 'Option A smoke plan script stays ASCII-only');
+assert.equal(/[^\u0000-\u007F]/.test(optionASmokeSeed), false, 'Option A smoke seed script stays ASCII-only');
+assert.equal(/[^\u0000-\u007F]/.test(optionASmokeEvidenceTool), false, 'Option A smoke evidence tool stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(seed), false, 'local seed script stays ASCII-only');
 
 console.log('commerce-v1 pilot readiness validation passed');

--- a/docs/examples/commerce-option-a-smoke.runbook.json
+++ b/docs/examples/commerce-option-a-smoke.runbook.json
@@ -1,0 +1,109 @@
+{
+  "runbook_version": "c2a-option-a-smoke-v1",
+  "purpose": "Repeatable lowest-cost temporary hosted smoke workflow for Grantex Commerce V1.",
+  "status": "planning_and_command_generation_only",
+  "creates_resources": false,
+  "runs_deploy": false,
+  "project": {
+    "default": "grantex-prod",
+    "approval_required": true
+  },
+  "region": {
+    "default": "us-central1",
+    "approval_required": true
+  },
+  "resources": {
+    "cloud_run_service": "grantex-auth-smoke",
+    "cloud_sql_instance": "grantex-commerce-smoke-pg",
+    "cloud_sql_database": "grantex_commerce_smoke",
+    "cloud_sql_user": "grantex_commerce_smoke_app",
+    "redis_instance": "grantex-commerce-smoke-redis",
+    "sql_tier_default": "db-f1-micro",
+    "redis_tier": "basic",
+    "redis_size_gb": 1,
+    "min_instances": 0,
+    "max_instances": 1
+  },
+  "cleanup": {
+    "cleanup_by": "<required ISO-8601 timestamp>",
+    "max_window_hours": 24,
+    "allow_long_cleanup_window_flag": "--allow-long-cleanup-window",
+    "delete_cloud_run_service": true,
+    "delete_cloud_sql_instance": true,
+    "delete_redis_instance": true,
+    "delete_smoke_secret_names": true,
+    "delete_smoke_image_tags_if_safe": true
+  },
+  "provider": {
+    "required": "mock",
+    "live_payments_enabled": false,
+    "plural_live_enabled": false,
+    "plural_sandbox_enabled": false
+  },
+  "secret_names_only": [
+    "grantex-smoke-database-url",
+    "grantex-smoke-redis-url",
+    "grantex-smoke-admin-api-key",
+    "grantex-smoke-vault-encryption-key",
+    "grantex-smoke-rsa-private-key",
+    "grantex-smoke-sso-state-secret",
+    "grantex-smoke-metrics-api-key",
+    "grantex-smoke-mock-payment-webhook-secret",
+    "grantex-smoke-commerce-passport-signing-key"
+  ],
+  "allowed_url_rules": {
+    "custom_staging_domains": [
+      "https://api-staging.grantex.dev",
+      "https://staging.grantex.dev",
+      "https://staging.agenticorg.ai"
+    ],
+    "option_a_smoke_run_app": "exact approved run.app origin only with allowlist flag",
+    "localhost": "local dry-run comparison only"
+  },
+  "refused_url_rules": [
+    "https://grantex.dev",
+    "https://api.grantex.dev",
+    "https://app.agenticorg.ai",
+    "credentialed URLs",
+    "arbitrary run.app URLs",
+    "non-HTTPS URLs outside local dry-run comparison"
+  ],
+  "refused_resource_names": [
+    "grantex-auth",
+    "grantex-pg16",
+    "grantex-redis"
+  ],
+  "validation_commands": [
+    "node docs/commerce-v1-pilot-readiness.validate.mjs",
+    "node scripts/commerce-option-a-smoke-plan.mjs --dry-run --project=grantex-prod --region=us-central1 --sql-tier=db-f1-micro --cleanup-by=<cleanup timestamp>",
+    "node scripts/commerce-option-a-smoke-seed.mjs --dry-run --manifest=docs/examples/commerce-staging-seed.manifest.json",
+    "node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=<approved smoke URL> --allow-smoke-cloud-run-url=<approved smoke URL>",
+    "node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=https://api.grantex.dev"
+  ],
+  "cleanup_commands": [
+    "gcloud run services delete grantex-auth-smoke --project=<project> --region=<region> --quiet",
+    "gcloud redis instances delete grantex-commerce-smoke-redis --project=<project> --region=<region> --quiet",
+    "gcloud sql instances delete grantex-commerce-smoke-pg --project=<project> --quiet",
+    "gcloud secrets delete <grantex-smoke-secret-name> --project=<project> --quiet"
+  ],
+  "agenticorg_local_real_staging": {
+    "hosted_agenticorg_required": false,
+    "env_names_only": [
+      "GRANTEX_COMMERCE_BASE_URL",
+      "GRANTEX_BASE_URL",
+      "AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL",
+      "AGENTICORG_COMMERCE_REAL_STAGING",
+      "GRANTEX_COMMERCE_BEARER_TOKEN",
+      "GRANTEX_AGENT_ASSERTION",
+      "GRANTEX_API_KEY"
+    ],
+    "command": "python demos/commerce_sales_agent_demo.py --mode=real-staging --grantex-base <approved smoke URL> --allow-smoke-cloud-run-url <approved smoke URL>"
+  },
+  "redaction": {
+    "secret_values_included": false,
+    "tokens_included": false,
+    "passports_included": false,
+    "provider_credentials_included": false,
+    "raw_payloads_included": false
+  }
+}

--- a/docs/guides/commerce-v1-option-a-smoke-setup.md
+++ b/docs/guides/commerce-v1-option-a-smoke-setup.md
@@ -282,9 +282,11 @@ Run mode must remain fail-closed until a reviewed implementation exists and the 
 # NOT RUN
 $env:GRANTEX_COMMERCE_BASE_URL=$env:SMOKE_URL
 $env:GRANTEX_BASE_URL=$env:SMOKE_URL
-$env:AGENTICORG_BASE_URL='http://localhost:3000'
-python demos/commerce_sales_agent_demo.py --mode=hosted-staging
-python -m pytest tests/evals/test_commerce_sales_agent_evals.py -q --hosted-staging
+$env:AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL=$env:SMOKE_URL
+$env:AGENTICORG_COMMERCE_REAL_STAGING='1'
+# Set exactly one Grantex auth env var securely outside logs.
+python demos/commerce_sales_agent_demo.py --mode=real-staging --grantex-base $env:SMOKE_URL --allow-smoke-cloud-run-url $env:SMOKE_URL --evidence-report docs/reports/commerce-agent-real-staging-evidence.md
+python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q
 ```
 
 Use only approved local AgenticOrg auth material. Do not print or commit bearer tokens, passports, idempotency keys, provider credentials, webhook secrets, raw payloads, or secret values.

--- a/docs/guides/commerce-v1-repeatable-option-a-smoke-workflow.md
+++ b/docs/guides/commerce-v1-repeatable-option-a-smoke-workflow.md
@@ -1,0 +1,155 @@
+# Commerce V1 Repeatable Option A Smoke Workflow
+
+Status: C2A planning and tooling only. This workflow does not deploy, create cloud resources, merge, change production config, enable production Commerce V1, enable live payments, enable live Plural, read secret values, or write secret values.
+
+## Purpose And Scope
+
+This guide turns the successful one-off Option A smoke into a repeatable, approval-gated workflow with manual approval gates. Option A is the cheapest temporary hosted smoke path for Grantex Commerce V1. It proves the hosted Grantex API mock-provider commerce path over HTTPS while using isolated smoke resources that are deleted immediately after evidence capture.
+
+Option A is not full hosted staging. It does not create custom DNS, Firebase portal staging, hosted AgenticOrg staging, production-like scaling, Plural sandbox, or live payment evidence.
+
+## Cheapest Temporary Topology
+
+| Component | Option A choice | Cost control |
+| --- | --- | --- |
+| Host project | Existing approved GCP project | Avoids new project setup |
+| API runtime | Separate Cloud Run service `grantex-auth-smoke` | `min-instances=0`, `max-instances=1` |
+| API URL | Direct approved Cloud Run `run.app` URL | No custom DNS |
+| Database | Temporary tiny Cloud SQL Postgres `grantex-commerce-smoke-pg` | Delete after evidence |
+| Redis | Temporary Basic 1GB Redis `grantex-commerce-smoke-redis` | Delete after evidence |
+| Provider | `mock` only | No live payment provider |
+| Portal | Local or skipped | No Firebase deploy |
+| AgenticOrg | Local real-staging eval against approved smoke URL | No hosted AgenticOrg deploy |
+
+## Manual Approval Gates
+
+Stop for explicit human approval before each mutating phase:
+
+1. Resource creation approval: project, region, SQL tier, Redis cost, cleanup deadline, and resource names.
+2. Secret creation approval: smoke secret names only, with values supplied outside logs, files, PRs, and chat.
+3. Smoke deploy approval: approved commit SHA and service name `grantex-auth-smoke`.
+4. Smoke evidence approval: approved exact Cloud Run smoke URL and auth material names.
+5. Cleanup approval is pre-approved as part of the spend window. Cleanup must run immediately after evidence.
+
+The smoke plan script prints commands as `NOT RUN` only. Running those commands is a separate approved C2B action.
+
+## Production Refusal Rules
+
+Option A tooling must refuse:
+
+- Cloud Run service name `grantex-auth`
+- Cloud SQL instance `grantex-pg16`
+- Redis instance `grantex-redis`
+- Production URL `https://grantex.dev`
+- Production API URL `https://api.grantex.dev`
+- Production AgenticOrg URL `https://app.agenticorg.ai`
+- Credentialed URLs
+- Arbitrary `run.app` URLs unless the exact smoke URL is allowlisted
+- `COMMERCE_LIVE_MODE_ENABLED=true`
+- `PLURAL_LIVE_ENABLED=true`
+- Non-mock providers
+
+## Command Sequence
+
+Generate the command plan:
+
+```powershell
+node scripts/commerce-option-a-smoke-plan.mjs --dry-run --project=grantex-prod --region=us-central1 --sql-tier=db-f1-micro --cleanup-by="2026-05-15T23:59:00+05:30"
+```
+
+Validate the seed manifest without writes:
+
+```powershell
+node scripts/commerce-option-a-smoke-seed.mjs --dry-run --manifest=docs/examples/commerce-staging-seed.manifest.json
+```
+
+Validate the existing hosted smoke harness with an approved exact smoke URL:
+
+```powershell
+node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=<approved-smoke-run-app-origin> --allow-smoke-cloud-run-url=<approved-smoke-run-app-origin>
+```
+
+Generate the redacted evidence schema without requests:
+
+```powershell
+node scripts/commerce-option-a-smoke-evidence.mjs --dry-run --api-base=<approved-smoke-run-app-origin> --allow-smoke-cloud-run-url=<approved-smoke-run-app-origin>
+```
+
+## Cleanup Guarantees
+
+Cleanup is part of the approved smoke window, not optional follow-up work. The command plan must include deletion commands for:
+
+- Cloud Run service `grantex-auth-smoke`
+- Redis instance `grantex-commerce-smoke-redis`
+- Cloud SQL instance `grantex-commerce-smoke-pg`
+- Smoke secret names matching `grantex-smoke-*`
+- Smoke image tags if they are not referenced by any active service
+
+The plan script refuses cleanup windows more than 24 hours in the future unless `--allow-long-cleanup-window` is explicitly passed.
+
+## Cost Controls
+
+- Keep Cloud Run `min-instances=0`.
+- Keep Cloud Run `max-instances=1`.
+- Use the approved cheapest SQL tier, such as `db-f1-micro` when available.
+- Use temporary Basic Redis 1GB only because the current auth-service requires `REDIS_URL`.
+- Do not configure custom DNS.
+- Do not deploy Firebase portal.
+- Do not deploy hosted AgenticOrg.
+- Delete Cloud SQL and Redis immediately after evidence.
+
+## Safety Controls
+
+- Use smoke resources only.
+- Use smoke secret names only.
+- Do not read or print secret values.
+- Do not write generated tokens, passports, idempotency keys, webhook secrets, provider credentials, raw payloads, or secret values to tracked files.
+- Write any future generated harness env material only under `.tmp/` and keep it untracked.
+- Mock provider only.
+- Keep mock provider only.
+- Keep `COMMERCE_LIVE_MODE_ENABLED=false`.
+- Keep `PLURAL_LIVE_ENABLED=false`.
+- Keep `PLURAL_SANDBOX_ENABLED=false` unless a future approved sandbox contract changes that.
+
+## AgenticOrg Local Real-Staging Eval Fit
+
+After the Grantex smoke URL exists and the Grantex smoke flow passes, AgenticOrg can run locally against that same approved smoke URL. This does not require hosted AgenticOrg staging.
+
+Required env names only:
+
+```powershell
+$env:GRANTEX_COMMERCE_BASE_URL='<approved-smoke-run-app-origin>'
+$env:GRANTEX_BASE_URL='<approved-smoke-run-app-origin>'
+$env:AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL='<approved-smoke-run-app-origin>'
+$env:AGENTICORG_COMMERCE_REAL_STAGING='1'
+# Set exactly one of GRANTEX_COMMERCE_BEARER_TOKEN, GRANTEX_AGENT_ASSERTION, or GRANTEX_API_KEY outside logs.
+```
+
+Run plan after approval:
+
+```powershell
+python demos/commerce_sales_agent_demo.py --mode=real-staging --grantex-base '<approved-smoke-run-app-origin>' --allow-smoke-cloud-run-url '<approved-smoke-run-app-origin>' --evidence-report docs/reports/commerce-agent-real-staging-evidence.md
+python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q
+```
+
+AgenticOrg must continue to use only `grantex_commerce:*` aliases. It must not call Stripe, Plural, Pine, or provider credential paths for commerce.
+
+## Automation Versus Manual Boundaries
+
+Automated in C2A:
+
+- Command generation as `NOT RUN`
+- Manifest dry-run validation
+- Smoke URL refusal validation
+- Evidence schema generation without requests
+- Validator assertions
+
+Manual or later C2B:
+
+- Creating GCP resources
+- Adding secret versions
+- Deploying `grantex-auth-smoke`
+- Running migrations or seed writes
+- Running hosted smoke requests
+- Running AgenticOrg real-staging eval against an approved smoke URL
+- Cleanup command execution

--- a/scripts/commerce-option-a-smoke-evidence.mjs
+++ b/scripts/commerce-option-a-smoke-evidence.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+const ALLOWED_STAGING_ORIGINS = [
+  'https://api-staging.grantex.dev',
+  'https://staging.grantex.dev',
+  'https://staging.agenticorg.ai',
+];
+
+const REFUSED_PRODUCTION_ORIGINS = [
+  'https://grantex.dev',
+  'https://api.grantex.dev',
+  'https://app.agenticorg.ai',
+];
+
+const DEFAULT_REPORT = 'docs/reports/commerce-v1-option-a-smoke-evidence.md';
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function argValue(name, fallback = '') {
+  const prefix = `${name}=`;
+  for (let index = 2; index < process.argv.length; index += 1) {
+    const arg = process.argv[index];
+    if (arg === name && process.argv[index + 1] && !process.argv[index + 1].startsWith('--')) {
+      return process.argv[index + 1];
+    }
+    if (arg.startsWith(prefix)) {
+      return arg.slice(prefix.length);
+    }
+  }
+  return fallback;
+}
+
+function hasFlag(name) {
+  return process.argv.includes(name);
+}
+
+function isTrue(value) {
+  return String(value ?? '').trim().toLowerCase() === 'true';
+}
+
+function parseUrl(value, label) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    fail(`Refusing invalid ${label}: ${value}`);
+  }
+  if (url.username || url.password) {
+    fail(`Refusing credentialed URL for ${label}`);
+  }
+  if (REFUSED_PRODUCTION_ORIGINS.includes(url.origin)) {
+    fail(`Refusing production domain for ${label}: ${url.origin}`);
+  }
+  if (url.protocol !== 'https:') {
+    fail(`Refusing non-HTTPS URL for ${label}`);
+  }
+  return url;
+}
+
+function validateSmokeAllowlist(value) {
+  if (!value) return null;
+  const url = parseUrl(value, 'smoke Cloud Run allowlist');
+  if (url.search || (url.pathname !== '/' && url.pathname !== '')) {
+    fail('Refusing path or query in smoke Cloud Run allowlist; provide the origin only');
+  }
+  if (!url.hostname.endsWith('.run.app')) {
+    fail('Refusing smoke allowlist URL that is not a run.app origin');
+  }
+  return url.origin;
+}
+
+function validateApiBase(value, allowedSmokeOrigin) {
+  const url = parseUrl(value, 'Option A smoke API base');
+  if (allowedSmokeOrigin && url.origin === allowedSmokeOrigin) {
+    return url.origin;
+  }
+  if (url.hostname.endsWith('.run.app')) {
+    fail('Refusing arbitrary run.app URL without exact --allow-smoke-cloud-run-url');
+  }
+  if (!ALLOWED_STAGING_ORIGINS.includes(url.origin)) {
+    fail(`Refusing non-staging API base: ${url.origin}`);
+  }
+  return url.origin;
+}
+
+const run = hasFlag('--run');
+const provider = argValue('--provider', 'mock');
+if (provider !== 'mock') {
+  fail('Refusing non-mock provider for Option A smoke evidence tooling');
+}
+if (isTrue(process.env.COMMERCE_LIVE_MODE_ENABLED)) {
+  fail('Refusing COMMERCE_LIVE_MODE_ENABLED=true for Option A smoke evidence tooling');
+}
+if (isTrue(process.env.PLURAL_LIVE_ENABLED)) {
+  fail('Refusing PLURAL_LIVE_ENABLED=true for Option A smoke evidence tooling');
+}
+if (run) {
+  fail('Run mode is blocked for C2A. Implement C2B request execution before collecting new evidence.');
+}
+
+const allowedSmokeOrigin = validateSmokeAllowlist(argValue('--allow-smoke-cloud-run-url', process.env.COMMERCE_STAGING_ALLOWED_SMOKE_URL ?? ''));
+const apiBase = validateApiBase(argValue('--api-base', 'https://api-staging.grantex.dev'), allowedSmokeOrigin);
+const reportPath = argValue('--report', DEFAULT_REPORT);
+if (!reportPath.includes('commerce-v1-option-a-smoke-evidence.md')) {
+  fail('Refusing non-Option-A smoke evidence report path');
+}
+
+console.log(JSON.stringify({
+  mode: 'dry-run',
+  status: 'not_executed',
+  requests_made: false,
+  api_base: apiBase,
+  provider,
+  report_path: reportPath,
+  safety: {
+    production_domains_refused: REFUSED_PRODUCTION_ORIGINS,
+    staging_domains_allowed: ALLOWED_STAGING_ORIGINS,
+    exact_smoke_run_app_allowed: allowedSmokeOrigin,
+    arbitrary_run_app_refused: true,
+    live_payment_flags_refused: true,
+    secret_values_printed: false,
+    raw_payloads_printed: false,
+  },
+  evidence_schema: {
+    report_type: 'commerce-v1-option-a-smoke-evidence',
+    target_host_only: 'hostname',
+    cloud_run_revision: 'revision id if available',
+    smoke_resource_names: ['grantex-auth-smoke', 'grantex-commerce-smoke-pg', 'grantex-commerce-smoke-redis'],
+    live_flags_false: true,
+    provider: 'mock',
+    pass_fail_table: 'redacted rows only',
+    cleanup_completed: 'required after run',
+    redaction: {
+      bearer_tokens_recorded: false,
+      passports_recorded: false,
+      idempotency_keys_recorded: false,
+      webhook_secrets_recorded: false,
+      provider_credentials_recorded: false,
+      raw_payloads_recorded: false,
+    },
+  },
+}, null, 2));
+

--- a/scripts/commerce-option-a-smoke-plan.mjs
+++ b/scripts/commerce-option-a-smoke-plan.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+
+const DEFAULTS = {
+  serviceName: 'grantex-auth-smoke',
+  sqlInstance: 'grantex-commerce-smoke-pg',
+  sqlDatabase: 'grantex_commerce_smoke',
+  sqlUser: 'grantex_commerce_smoke_app',
+  redisInstance: 'grantex-commerce-smoke-redis',
+  artifactRepo: 'grantex-images',
+  provider: 'mock',
+  minInstances: 0,
+  maxInstances: 1,
+};
+
+const REFUSED_RESOURCE_NAMES = new Set(['grantex-auth', 'grantex-pg16', 'grantex-redis']);
+const REFUSED_PRODUCTION_ORIGINS = new Set([
+  'https://grantex.dev',
+  'https://api.grantex.dev',
+  'https://app.agenticorg.ai',
+]);
+
+const SECRET_NAMES = [
+  'grantex-smoke-database-url',
+  'grantex-smoke-redis-url',
+  'grantex-smoke-admin-api-key',
+  'grantex-smoke-vault-encryption-key',
+  'grantex-smoke-rsa-private-key',
+  'grantex-smoke-sso-state-secret',
+  'grantex-smoke-metrics-api-key',
+  'grantex-smoke-mock-payment-webhook-secret',
+  'grantex-smoke-commerce-passport-signing-key',
+];
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function argValue(name, fallback = '') {
+  const prefix = `${name}=`;
+  for (let index = 2; index < process.argv.length; index += 1) {
+    const arg = process.argv[index];
+    if (arg === name && process.argv[index + 1] && !process.argv[index + 1].startsWith('--')) {
+      return process.argv[index + 1];
+    }
+    if (arg.startsWith(prefix)) {
+      return arg.slice(prefix.length);
+    }
+  }
+  return fallback;
+}
+
+function hasFlag(name) {
+  return process.argv.includes(name);
+}
+
+function requireArg(name) {
+  const value = argValue(name);
+  if (!value.trim()) {
+    fail(`Missing required argument ${name}`);
+  }
+  return value.trim();
+}
+
+function validateResourceName(value, label) {
+  if (!/^[a-z][a-z0-9-]{2,62}$/.test(value)) {
+    fail(`Refusing invalid ${label}: ${value}`);
+  }
+  if (REFUSED_RESOURCE_NAMES.has(value)) {
+    fail(`Refusing production resource name for ${label}: ${value}`);
+  }
+  return value;
+}
+
+function validateUrlIfPresent(value, label) {
+  if (!value) return null;
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    fail(`Refusing invalid ${label}: ${value}`);
+  }
+  if (url.username || url.password) {
+    fail(`Refusing credentialed ${label}`);
+  }
+  if (REFUSED_PRODUCTION_ORIGINS.has(url.origin)) {
+    fail(`Refusing production URL for ${label}: ${url.origin}`);
+  }
+  if (url.protocol !== 'https:') {
+    fail(`Refusing non-HTTPS ${label}`);
+  }
+  return url.origin;
+}
+
+function validateCleanupWindow(cleanupBy, allowLongWindow) {
+  const cleanupDate = new Date(cleanupBy);
+  if (Number.isNaN(cleanupDate.getTime())) {
+    fail(`Refusing invalid --cleanup-by timestamp: ${cleanupBy}`);
+  }
+  const maxMs = 24 * 60 * 60 * 1000;
+  if (cleanupDate.getTime() - Date.now() > maxMs && !allowLongWindow) {
+    fail('Refusing cleanup window more than 24 hours in the future without --allow-long-cleanup-window');
+  }
+  return cleanupDate.toISOString();
+}
+
+function notRun(command) {
+  return `# NOT RUN\n${command}`;
+}
+
+const dryRun = hasFlag('--dry-run') || !hasFlag('--run');
+if (hasFlag('--run')) {
+  fail('This planner is dry-run command generation only. It never creates resources or deploys.');
+}
+
+const project = requireArg('--project');
+const region = requireArg('--region');
+const sqlTier = requireArg('--sql-tier');
+const cleanupBy = validateCleanupWindow(requireArg('--cleanup-by'), hasFlag('--allow-long-cleanup-window'));
+const provider = argValue('--provider', DEFAULTS.provider);
+if (provider !== 'mock') {
+  fail('Refusing non-mock provider for Option A smoke planning');
+}
+
+const serviceName = validateResourceName(argValue('--service-name', DEFAULTS.serviceName), 'Cloud Run service');
+const sqlInstance = validateResourceName(argValue('--sql-instance', DEFAULTS.sqlInstance), 'Cloud SQL instance');
+const redisInstance = validateResourceName(argValue('--redis-instance', DEFAULTS.redisInstance), 'Redis instance');
+const maxInstances = Number(argValue('--max-instances', String(DEFAULTS.maxInstances)));
+if (maxInstances !== 1) {
+  fail('Refusing Option A smoke plan unless --max-instances=1');
+}
+const smokeUrl = validateUrlIfPresent(argValue('--smoke-url', ''), 'smoke URL') ?? '<approved-smoke-run-app-origin>';
+const image = `${region}-docker.pkg.dev/${project}/${DEFAULTS.artifactRepo}/auth-service-smoke:<approved-commit-sha>`;
+
+const secretCreateCommands = SECRET_NAMES.map(
+  (name) => `gcloud secrets create ${name} --project=${project} --replication-policy=automatic`,
+);
+const secretDeleteCommands = SECRET_NAMES.map((name) => `gcloud secrets delete ${name} --project=${project} --quiet`);
+
+const commands = [
+  {
+    phase: 'create_cloud_sql',
+    command: notRun([
+      `gcloud sql instances create ${sqlInstance}`,
+      `  --project=${project}`,
+      `  --region=${region}`,
+      '  --database-version=POSTGRES_16',
+      `  --tier=${sqlTier}`,
+      '  --storage-type=HDD',
+      '  --storage-size=10GB',
+      '  --availability-type=zonal',
+      '  --no-deletion-protection',
+    ].join(' \\\n')),
+  },
+  {
+    phase: 'create_database_and_user',
+    command: notRun([
+      `gcloud sql databases create ${DEFAULTS.sqlDatabase} --project=${project} --instance=${sqlInstance}`,
+      `gcloud sql users create ${DEFAULTS.sqlUser} --project=${project} --instance=${sqlInstance} --password=<smoke-db-password-provided-outside-logs>`,
+    ].join('\n')),
+  },
+  {
+    phase: 'create_redis',
+    command: notRun([
+      `gcloud redis instances create ${redisInstance}`,
+      `  --project=${project}`,
+      `  --region=${region}`,
+      '  --size=1',
+      '  --tier=basic',
+      '  --redis-version=redis_7_0',
+    ].join(' \\\n')),
+  },
+  {
+    phase: 'create_smoke_secret_names',
+    command: notRun(secretCreateCommands.join('\n')),
+  },
+  {
+    phase: 'build_smoke_image',
+    command: notRun(`gcloud builds submit apps/auth-service --project=${project} --tag=${image}`),
+  },
+  {
+    phase: 'deploy_smoke_service',
+    command: notRun([
+      `gcloud run deploy ${serviceName}`,
+      `  --project=${project}`,
+      `  --region=${region}`,
+      `  --image=${image}`,
+      '  --min-instances=0',
+      '  --max-instances=1',
+      '  --cpu=1',
+      '  --memory=512Mi',
+      '  --concurrency=20',
+      '  --no-allow-unauthenticated',
+      '  --set-env-vars=NODE_ENV=staging,COMMERCE_V1_ENABLED=true,COMMERCE_SANDBOX_ENABLED=true,COMMERCE_ALLOW_AUTO_TENANT=false,COMMERCE_LOCAL_LOAD_TEST=false,COMMERCE_LIVE_MODE_ENABLED=false,PLURAL_SANDBOX_ENABLED=false,PLURAL_LIVE_ENABLED=false,COMMERCE_RECONCILIATION_WORKER_ENABLED=false,METRICS_ENABLED=true,METRICS_REQUIRE_AUTH=true,SSO_ALLOW_INSECURE_URLS=false,WEBHOOK_ALLOW_INSECURE_URLS=false,LDAP_TLS_REJECT_UNAUTHORIZED=true,AUTO_GENERATE_KEYS=false',
+      '  --set-secrets=DATABASE_URL=grantex-smoke-database-url:latest,REDIS_URL=grantex-smoke-redis-url:latest,ADMIN_API_KEY=grantex-smoke-admin-api-key:latest,VAULT_ENCRYPTION_KEY=grantex-smoke-vault-encryption-key:latest,RSA_PRIVATE_KEY=grantex-smoke-rsa-private-key:latest,SSO_STATE_SECRET=grantex-smoke-sso-state-secret:latest,METRICS_API_KEY=grantex-smoke-metrics-api-key:latest,MOCK_PAYMENT_WEBHOOK_SECRET=grantex-smoke-mock-payment-webhook-secret:latest',
+    ].join(' \\\n')),
+  },
+  {
+    phase: 'smoke_harness_dry_run',
+    command: notRun(`node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=${smokeUrl} --allow-smoke-cloud-run-url=${smokeUrl}`),
+  },
+  {
+    phase: 'smoke_evidence_run_placeholder',
+    command: notRun(`node scripts/commerce-option-a-smoke-evidence.mjs --dry-run --api-base=${smokeUrl} --allow-smoke-cloud-run-url=${smokeUrl}`),
+  },
+  {
+    phase: 'agenticorg_local_real_staging_eval',
+    command: notRun([
+      '$env:GRANTEX_COMMERCE_BASE_URL=\'<approved-smoke-run-app-origin>\'',
+      '$env:GRANTEX_BASE_URL=\'<approved-smoke-run-app-origin>\'',
+      '$env:AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL=\'<approved-smoke-run-app-origin>\'',
+      '$env:AGENTICORG_COMMERCE_REAL_STAGING=\'1\'',
+      '# Set exactly one Grantex auth env var securely outside logs.',
+      'python demos/commerce_sales_agent_demo.py --mode=real-staging --grantex-base \'<approved-smoke-run-app-origin>\' --allow-smoke-cloud-run-url \'<approved-smoke-run-app-origin>\' --evidence-report docs/reports/commerce-agent-real-staging-evidence.md',
+      'python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q',
+    ].join('\n')),
+  },
+  {
+    phase: 'cleanup',
+    command: notRun([
+      `gcloud run services delete ${serviceName} --project=${project} --region=${region} --quiet`,
+      `gcloud redis instances delete ${redisInstance} --project=${project} --region=${region} --quiet`,
+      `gcloud sql instances delete ${sqlInstance} --project=${project} --quiet`,
+      secretDeleteCommands.join('\n'),
+      `gcloud artifacts docker images delete ${image} --project=${project} --quiet`,
+    ].join('\n')),
+  },
+];
+
+console.log(JSON.stringify({
+  mode: dryRun ? 'dry-run' : 'run',
+  status: 'not_executed',
+  creates_resources: false,
+  deploys: false,
+  project,
+  region,
+  service_name: serviceName,
+  cloud_sql_instance: sqlInstance,
+  cloud_sql_tier: sqlTier,
+  redis_instance: redisInstance,
+  provider,
+  min_instances: DEFAULTS.minInstances,
+  max_instances: maxInstances,
+  cleanup_by: cleanupBy,
+  cleanup_window_guard_hours: 24,
+  secret_names: SECRET_NAMES,
+  refused_resource_names: [...REFUSED_RESOURCE_NAMES],
+  refused_production_origins: [...REFUSED_PRODUCTION_ORIGINS],
+  commands,
+}, null, 2));
+

--- a/scripts/commerce-option-a-smoke-seed.mjs
+++ b/scripts/commerce-option-a-smoke-seed.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { dirname, resolve, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_MANIFEST = 'docs/examples/commerce-staging-seed.manifest.json';
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function argValue(name, fallback = '') {
+  const prefix = `${name}=`;
+  for (let index = 2; index < process.argv.length; index += 1) {
+    const arg = process.argv[index];
+    if (arg === name && process.argv[index + 1] && !process.argv[index + 1].startsWith('--')) {
+      return process.argv[index + 1];
+    }
+    if (arg.startsWith(prefix)) {
+      return arg.slice(prefix.length);
+    }
+  }
+  return fallback;
+}
+
+function hasFlag(name) {
+  return process.argv.includes(name);
+}
+
+function assertInsideRepo(pathInput) {
+  const resolved = resolve(repoRoot, pathInput);
+  const rel = relative(repoRoot, resolved);
+  if (rel.startsWith('..') || rel === '') {
+    fail(`Refusing manifest path outside repo workspace: ${pathInput}`);
+  }
+  return resolved;
+}
+
+function assertNoForbiddenSecrets(value, path = 'manifest') {
+  const forbiddenKeyFragments = [
+    'api_key',
+    'bearer',
+    'credential_payload',
+    'credential_ref',
+    'idempotency',
+    'private_key',
+    'raw_passport',
+    'secret',
+    'token',
+    'webhook_secret',
+  ];
+  const forbiddenValueFragments = [
+    'Bearer ',
+    'sk_live_',
+    'pk_live_',
+    '-----BEGIN',
+    'passport.jwt',
+    'idempotency-key:',
+    'mock-webhook-secret',
+    'postgres://',
+    'redis://',
+  ];
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoForbiddenSecrets(item, `${path}[${index}]`));
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, nested] of Object.entries(value)) {
+      const lowered = key.toLowerCase();
+      if (forbiddenKeyFragments.some((fragment) => lowered.includes(fragment))) {
+        fail(`Refusing secret-like key in smoke seed manifest at ${path}.${key}`);
+      }
+      assertNoForbiddenSecrets(nested, `${path}.${key}`);
+    }
+    return;
+  }
+  if (typeof value === 'string') {
+    for (const forbidden of forbiddenValueFragments) {
+      if (value.includes(forbidden)) {
+        fail(`Refusing secret-like value in smoke seed manifest at ${path}`);
+      }
+    }
+  }
+}
+
+function loadManifest(manifestPath) {
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch (error) {
+    fail(`Unable to read smoke seed manifest: ${error.message}`);
+  }
+  assertNoForbiddenSecrets(parsed);
+  return parsed;
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    fail(`${message}; expected ${expected}, got ${actual}`);
+  }
+}
+
+const run = hasFlag('--run');
+if (run) {
+  fail('Run mode is blocked for C2A. Implement C2B smoke DB guardrails before any seed writes.');
+}
+
+const manifestArg = argValue('--manifest', DEFAULT_MANIFEST);
+const manifestPath = assertInsideRepo(manifestArg);
+const manifest = loadManifest(manifestPath);
+
+assertEqual(manifest.provider?.provider_key, 'mock', 'Smoke seed provider must be mock');
+assertEqual(manifest.provider?.live_payments_enabled, false, 'Smoke seed live payments flag must be false');
+assertEqual(manifest.provider?.plural_live_enabled, false, 'Smoke seed live Plural flag must be false');
+assertEqual(manifest.live_flags?.commerce_live_mode_enabled, false, 'Smoke seed live commerce flag must be false');
+assertEqual(manifest.live_flags?.plural_live_enabled, false, 'Smoke seed live Plural flag must be false');
+assertEqual(manifest.tenant?.id, 'cten_staging_commerce', 'Smoke seed tenant id is pinned');
+assertEqual(manifest.merchant?.id, 'mch_staging_electronics_pilot', 'Smoke seed merchant id is pinned');
+assertEqual(manifest.agent?.id, 'cag_staging_agenticorg_sales', 'Smoke seed agent id is pinned');
+
+const products = manifest.catalog?.products;
+if (!Array.isArray(products) || products.length < 10 || products.length > 25) {
+  fail('Smoke seed manifest must include 10-25 products');
+}
+const productsWithVariants = products.filter((product) => Array.isArray(product.variants) && product.variants.length > 0).length;
+if (productsWithVariants < 3) {
+  fail('Smoke seed manifest must include at least 3 products with variants');
+}
+
+console.log(JSON.stringify({
+  mode: 'dry-run',
+  status: 'not_executed',
+  would_write: false,
+  manifest_path: manifestArg,
+  provider: manifest.provider.provider_key,
+  live_flags: {
+    commerce_live_mode_enabled: manifest.live_flags.commerce_live_mode_enabled,
+    plural_live_enabled: manifest.live_flags.plural_live_enabled,
+    provider_live_payments_enabled: manifest.provider.live_payments_enabled,
+  },
+  staging_ids: {
+    tenant_id: manifest.tenant.id,
+    merchant_id: manifest.merchant.id,
+    agent_id: manifest.agent.id,
+  },
+  catalog: {
+    product_count: products.length,
+    products_with_variants: productsWithVariants,
+    currency: manifest.catalog.currency,
+    tax_inclusive_pricing: manifest.catalog.tax_inclusive_pricing,
+  },
+  redaction: {
+    secret_values_printed: false,
+    auth_material_printed: false,
+    passports_printed: false,
+    raw_payloads_printed: false,
+  },
+  future_run_mode: {
+    status: 'blocked_until_c2b',
+    required_guardrails: [
+      'explicit smoke DB target',
+      'smoke-only secret names',
+      'no production database',
+      'no generated auth material in tracked files',
+      'generated harness env under .tmp only',
+    ],
+  },
+}, null, 2));
+


### PR DESCRIPTION
## Scope

C2A repeatable Option A smoke workflow prep only. This is docs/tooling/validator work; it does not deploy, create cloud resources, change production config, enable production Commerce V1, enable live payments, or enable live Plural.

## Changes

- Add a repeatable Option A smoke workflow guide.
- Add a smoke runbook JSON with resource names, URL rules, cleanup rules, and secret names only.
- Add dry-run-only command generation for the cheapest temporary smoke setup.
- Add dry-run-only seed manifest validation.
- Add dry-run-only Option A evidence schema/refusal tooling.
- Update pilot readiness validation and the prior Option A guide to use the C1 real-staging AgenticOrg command shape.

## Guardrails

- Commands are printed as `NOT RUN` only.
- Production resource names are refused: `grantex-auth`, `grantex-pg16`, `grantex-redis`.
- Production URLs are refused: `https://grantex.dev`, `https://api.grantex.dev`, `https://app.agenticorg.ai`.
- Cleanup windows over 24 hours are refused unless explicitly overridden.
- Mock provider only, min instances 0, max instances 1.
- No secret values, tokens, passports, provider credentials, webhook secrets, idempotency keys, or raw payloads are committed.

## Validation

- `node docs/commerce-v1-pilot-readiness.validate.mjs` passed.
- `node scripts/commerce-option-a-smoke-plan.mjs --dry-run --project=grantex-prod --region=us-central1 --sql-tier=db-f1-micro --cleanup-by="2026-05-15T23:59:00+05:30"` passed.
- Long cleanup-window refusal failed closed as expected.
- `node scripts/commerce-option-a-smoke-seed.mjs --dry-run --manifest=docs/examples/commerce-staging-seed.manifest.json` passed.
- Exact smoke URL harness dry-run passed.
- Arbitrary `run.app` refusal failed closed as expected.
- Production URL refusal failed closed as expected.
- `git diff --check` passed.