### PR TITLE
feat(commerce): add guarded option a smoke runner

### DIFF
--- a/docs/commerce-v1-pilot-readiness.validate.mjs
+++ b/docs/commerce-v1-pilot-readiness.validate.mjs
@@ -353,7 +353,7 @@ for (const forbidden of commonSecretMarkers) {
 
 for (const required of [
   'Commerce V1 Repeatable Option A Smoke Workflow',
-  'C2A planning and tooling only',
+  'C2D-prep executable runner tooling only',
   'manual approval gates',
   'min-instances=0',
   'max-instances=1',
@@ -373,6 +373,11 @@ for (const required of [
   'AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL',
   '--write-agenticorg-fixture-env=.tmp/commerce-agent-real-staging.env',
   '--fixture-env=.tmp/commerce-agent-real-staging.env',
+  'node scripts/commerce-option-a-smoke-seed.mjs --run',
+  'node scripts/commerce-option-a-smoke-evidence.mjs --run',
+  'approved smoke API requests',
+  'Guarded seed runner execution path',
+  'Guarded evidence runner execution path',
   'The fixture export is disabled by default',
   'must stay under `.tmp/`',
   'cleanup/evidence warning language',
@@ -389,6 +394,33 @@ for (const forbidden of commonSecretMarkers) {
 }
 
 const optionASmokeRunbook = JSON.parse(optionASmokeRunbookText);
+assert.equal(
+  optionASmokeRunbook.status,
+  'guarded_runner_available_for_later_approved_c2d',
+  'Option A runbook records guarded C2D-prep runner status',
+);
+assert.equal(optionASmokeRunbook.runner.dry_run_default, true, 'Option A runbook keeps dry-run as default');
+assert.equal(
+  optionASmokeRunbook.runner.run_requires_separate_c2d_approval,
+  true,
+  'Option A runbook requires separate C2D approval for run mode',
+);
+assert.ok(
+  optionASmokeRunbook.runner.seed_run_command.includes('--write-agenticorg-fixture-env=.tmp/commerce-agent-real-staging.env'),
+  'Option A runbook documents fixture env seed run command',
+);
+assert.ok(
+  optionASmokeRunbook.runner.evidence_run_command.includes('--fixture-env=.tmp/commerce-agent-real-staging.env'),
+  'Option A runbook documents fixture env evidence run command',
+);
+assert.ok(
+  optionASmokeRunbook.runner.approved_seed_requests.includes('POST /v1/commerce/catalog/products/bulk dry_run=false'),
+  'Option A runbook documents approved catalog upsert request',
+);
+assert.ok(
+  optionASmokeRunbook.runner.approved_evidence_cases.includes('payment_intent_create'),
+  'Option A runbook documents approved payment intent evidence case',
+);
 assert.equal(optionASmokeRunbook.resources.cloud_run_service, 'grantex-auth-smoke', 'Option A runbook pins smoke service');
 assert.equal(optionASmokeRunbook.resources.cloud_sql_instance, 'grantex-commerce-smoke-pg', 'Option A runbook pins smoke SQL');
 assert.equal(optionASmokeRunbook.resources.redis_instance, 'grantex-commerce-smoke-redis', 'Option A runbook pins smoke Redis');
@@ -436,6 +468,26 @@ for (const forbidden of commonSecretMarkers) {
   assert.equal(optionASmokeRunbookText.includes(forbidden), false, `Option A runbook does not include ${forbidden}`);
 }
 
+const committedDocAndExampleTexts = {
+  'commerce-v1-repeatable-option-a-smoke-workflow.md': repeatableOptionASmokeWorkflow,
+  'commerce-option-a-smoke.runbook.json': optionASmokeRunbookText,
+  'commerce-v1-option-a-smoke-evidence.md': optionASmokeEvidence,
+};
+const committedSecretValuePatterns = [
+  [/Bearer\s+[A-Za-z0-9._~+/=-]{12,}/, 'bearer token value'],
+  [/eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/, 'JWT-like value'],
+  [/\b(?:sk|pk)_(?:live|test)_[A-Za-z0-9]{12,}/, 'provider key value'],
+  [/\b(?:postgres|postgresql):\/\/[^\s<>"']+/, 'DB URL value'],
+  [/\bredis:\/\/[^\s<>"']+/, 'Redis URL value'],
+  [/-----BEGIN [A-Z ]*PRIVATE KEY-----/, 'private key block'],
+  [/\bwhsec_[A-Za-z0-9]{12,}/, 'webhook secret value'],
+];
+for (const [path, text] of Object.entries(committedDocAndExampleTexts)) {
+  for (const [pattern, label] of committedSecretValuePatterns) {
+    assert.equal(pattern.test(text), false, `${path} does not include ${label}`);
+  }
+}
+
 for (const required of [
   'dry-run command generation only',
   'Refusing production resource name',
@@ -454,7 +506,9 @@ for (const required of [
   assert.ok(optionASmokePlan.includes(required), `Option A smoke plan script includes ${required}`);
 }
 for (const required of [
-  'Run mode is blocked for C2A',
+  'guarded_and_executable_after_approved_smoke_deploy',
+  'executeSeedRun',
+  'Smoke seed run requires exactly one Grantex auth env value present',
   'Smoke seed provider must be mock',
   'Smoke seed live payments flag must be false',
   'Smoke seed tenant id is pinned',
@@ -463,8 +517,9 @@ for (const required of [
   'Refusing AgenticOrg fixture env output outside .tmp/',
   'Refusing arbitrary run.app URL without exact --allow-smoke-cloud-run-url',
   'Refusing COMMERCE_LIVE_MODE_ENABLED=true for Option A smoke seed tooling',
-  'sensitive_values_printed: false',
-  'generated harness env under .tmp only',
+  'Refusing non-HTTPS URL',
+  'sensitive_values_printed',
+  'AgenticOrg fixture env under .tmp only',
 ]) {
   assert.ok(optionASmokeSeed.includes(required), `Option A smoke seed script includes ${required}`);
 }
@@ -474,7 +529,11 @@ for (const required of [
   'Refusing non-mock provider',
   'Refusing COMMERCE_LIVE_MODE_ENABLED=true',
   'Refusing PLURAL_LIVE_ENABLED=true',
-  'Run mode is blocked for C2A',
+  'executeEvidenceRun',
+  'Failing closed because AgenticOrg fixture env is missing',
+  'Refusing AgenticOrg fixture env input outside .tmp/',
+  'writeEvidenceReport',
+  'idempotency_keys_recorded: false',
   'commerce-v1-option-a-smoke-evidence.md',
 ]) {
   assert.ok(optionASmokeEvidenceTool.includes(required), `Option A smoke evidence tool includes ${required}`);
@@ -787,7 +846,8 @@ const optionASmokeSeedDryRun = execFileSync(
 const optionASmokeSeedReport = JSON.parse(optionASmokeSeedDryRun);
 assert.equal(optionASmokeSeedReport.mode, 'dry-run');
 assert.equal(optionASmokeSeedReport.status, 'not_executed');
-assert.equal(optionASmokeSeedReport.would_write, false);
+assert.equal(optionASmokeSeedReport.would_write_catalog, false);
+assert.equal(optionASmokeSeedReport.requests_made, false);
 assert.equal(optionASmokeSeedReport.provider, 'mock');
 assert.equal(optionASmokeSeedReport.live_flags.commerce_live_mode_enabled, false);
 assert.equal(optionASmokeSeedReport.staging_ids.tenant_id, 'cten_staging_commerce');
@@ -898,6 +958,26 @@ assert.ok(
   'Option A fixture export explains arbitrary run.app refusal',
 );
 
+const optionASmokeFixtureHttpLocalhostRefusal = spawnSync(
+  process.execPath,
+  [
+    join(repoRoot, 'scripts', 'commerce-option-a-smoke-seed.mjs'),
+    '--dry-run',
+    '--manifest=docs/examples/commerce-staging-seed.manifest.json',
+    '--api-base=http://localhost:3001',
+    '--allow-smoke-cloud-run-url=http://localhost:3001',
+    '--write-agenticorg-fixture-env=.tmp/commerce-agent-real-staging.env',
+  ],
+  { encoding: 'utf8', env: fixtureExportEnv },
+);
+assert.notEqual(optionASmokeFixtureHttpLocalhostRefusal.status, 0, 'Option A fixture export refuses HTTP localhost');
+assert.ok(
+  `${optionASmokeFixtureHttpLocalhostRefusal.stdout}${optionASmokeFixtureHttpLocalhostRefusal.stderr}`.includes(
+    'Refusing non-HTTPS URL',
+  ),
+  'Option A fixture export explains HTTP localhost refusal',
+);
+
 const optionASmokeFixtureLiveFlagRefusal = spawnSync(
   process.execPath,
   [
@@ -985,6 +1065,60 @@ assert.notEqual(optionASmokeEvidenceProdRefusal.status, 0, 'Option A smoke evide
 assert.ok(
   `${optionASmokeEvidenceProdRefusal.stdout}${optionASmokeEvidenceProdRefusal.stderr}`.includes('Refusing production domain'),
   'Option A smoke evidence production refusal explains production guard',
+);
+
+const optionASmokeEvidenceHttpLocalhostRefusal = spawnSync(
+  process.execPath,
+  [
+    join(repoRoot, 'scripts', 'commerce-option-a-smoke-evidence.mjs'),
+    '--dry-run',
+    '--api-base=http://localhost:3001',
+  ],
+  { encoding: 'utf8' },
+);
+assert.notEqual(optionASmokeEvidenceHttpLocalhostRefusal.status, 0, 'Option A smoke evidence tool refuses HTTP localhost');
+assert.ok(
+  `${optionASmokeEvidenceHttpLocalhostRefusal.stdout}${optionASmokeEvidenceHttpLocalhostRefusal.stderr}`.includes(
+    'Refusing non-HTTPS URL',
+  ),
+  'Option A smoke evidence HTTP localhost refusal explains HTTPS guard',
+);
+
+const optionASmokeEvidenceLiveFlagRefusal = spawnSync(
+  process.execPath,
+  [
+    join(repoRoot, 'scripts', 'commerce-option-a-smoke-evidence.mjs'),
+    '--dry-run',
+    `--api-base=${smokeUrl}`,
+    `--allow-smoke-cloud-run-url=${smokeUrl}`,
+  ],
+  { encoding: 'utf8', env: { ...process.env, COMMERCE_LIVE_MODE_ENABLED: 'true' } },
+);
+assert.notEqual(optionASmokeEvidenceLiveFlagRefusal.status, 0, 'Option A smoke evidence tool refuses live commerce flag');
+assert.ok(
+  `${optionASmokeEvidenceLiveFlagRefusal.stdout}${optionASmokeEvidenceLiveFlagRefusal.stderr}`.includes(
+    'Refusing COMMERCE_LIVE_MODE_ENABLED=true',
+  ),
+  'Option A smoke evidence live flag refusal explains live commerce guard',
+);
+
+const optionASmokeEvidenceNonMockProviderRefusal = spawnSync(
+  process.execPath,
+  [
+    join(repoRoot, 'scripts', 'commerce-option-a-smoke-evidence.mjs'),
+    '--dry-run',
+    '--provider=stripe',
+    `--api-base=${smokeUrl}`,
+    `--allow-smoke-cloud-run-url=${smokeUrl}`,
+  ],
+  { encoding: 'utf8' },
+);
+assert.notEqual(optionASmokeEvidenceNonMockProviderRefusal.status, 0, 'Option A smoke evidence tool refuses non-mock provider');
+assert.ok(
+  `${optionASmokeEvidenceNonMockProviderRefusal.stdout}${optionASmokeEvidenceNonMockProviderRefusal.stderr}`.includes(
+    'Refusing non-mock provider',
+  ),
+  'Option A smoke evidence non-mock refusal explains provider guard',
 );
 
 const nonLocalSeed = spawnSync(

--- a/docs/examples/commerce-option-a-smoke.runbook.json
+++ b/docs/examples/commerce-option-a-smoke.runbook.json
@@ -1,9 +1,45 @@
 {
-  "runbook_version": "c2a-option-a-smoke-v1",
+  "runbook_version": "c2d-prep-option-a-smoke-v1",
   "purpose": "Repeatable lowest-cost temporary hosted smoke workflow for Grantex Commerce V1.",
-  "status": "planning_and_command_generation_only",
+  "status": "guarded_runner_available_for_later_approved_c2d",
   "creates_resources": false,
   "runs_deploy": false,
+  "runner": {
+    "dry_run_default": true,
+    "run_requires_separate_c2d_approval": true,
+    "seed_run_command": "node scripts/commerce-option-a-smoke-seed.mjs --run --manifest=docs/examples/commerce-staging-seed.manifest.json --api-base=<approved smoke URL> --allow-smoke-cloud-run-url=<approved smoke URL> --write-agenticorg-fixture-env=.tmp/commerce-agent-real-staging.env --provider=mock",
+    "evidence_run_command": "node scripts/commerce-option-a-smoke-evidence.mjs --run --api-base=<approved smoke URL> --allow-smoke-cloud-run-url=<approved smoke URL> --fixture-env=.tmp/commerce-agent-real-staging.env --provider=mock",
+    "approved_seed_requests": [
+      "GET /health",
+      "GET /.well-known/jwks.json",
+      "GET /.well-known/grantex-commerce",
+      "POST /v1/commerce/catalog/products/bulk dry_run=true",
+      "POST /v1/commerce/catalog/products/bulk dry_run=false",
+      "GET /v1/commerce/catalog/products/{product_id}"
+    ],
+    "approved_evidence_cases": [
+      "health",
+      "jwks",
+      "commerce_well_known",
+      "mcp_initialize",
+      "mcp_tools_list",
+      "merchant_profile",
+      "catalog_search",
+      "catalog_get_item",
+      "inventory_check",
+      "cart_create",
+      "consent_request",
+      "consent_exchange",
+      "payment_intent_create",
+      "checkout_create",
+      "payment_status",
+      "missing_consent_refusal",
+      "amount_cap_breach_refusal",
+      "revoked_passport_refusal",
+      "expired_passport_refusal",
+      "denied_consent_refusal"
+    ]
+  },
   "project": {
     "default": "grantex-prod",
     "approval_required": true
@@ -112,6 +148,7 @@
     "node docs/commerce-v1-pilot-readiness.validate.mjs",
     "node scripts/commerce-option-a-smoke-plan.mjs --dry-run --project=grantex-prod --region=us-central1 --sql-tier=db-f1-micro --cleanup-by=<cleanup timestamp>",
     "node scripts/commerce-option-a-smoke-seed.mjs --dry-run --manifest=docs/examples/commerce-staging-seed.manifest.json",
+    "node scripts/commerce-option-a-smoke-evidence.mjs --dry-run --api-base=<approved smoke URL> --allow-smoke-cloud-run-url=<approved smoke URL>",
     "node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=<approved smoke URL> --allow-smoke-cloud-run-url=<approved smoke URL>",
     "node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=https://api.grantex.dev"
   ],

--- a/docs/guides/commerce-v1-repeatable-option-a-smoke-workflow.md
+++ b/docs/guides/commerce-v1-repeatable-option-a-smoke-workflow.md
@@ -1,6 +1,6 @@
 # Commerce V1 Repeatable Option A Smoke Workflow
 
-Status: C2A planning and tooling only. This workflow does not deploy, create cloud resources, merge, change production config, enable production Commerce V1, enable live payments, enable live Plural, read secret values, or write secret values.
+Status: C2D-prep executable runner tooling only. This workflow does not deploy, create cloud resources, merge, change production config, enable production Commerce V1, enable live payments, enable live Plural, read secret values, or write secret values.
 
 ## Purpose And Scope
 
@@ -31,7 +31,7 @@ Stop for explicit human approval before each mutating phase:
 4. Smoke evidence approval: approved exact Cloud Run smoke URL and auth material names.
 5. Cleanup approval is pre-approved as part of the spend window. Cleanup must run immediately after evidence.
 
-The smoke plan script prints commands as `NOT RUN` only. Running those commands is a separate approved C2B action.
+The smoke plan script prints commands as `NOT RUN` only. The seed and evidence scripts now have guarded `--run` modes, but running them against a hosted smoke service is a separate approved C2D action after temporary smoke resources exist.
 
 ## Production Refusal Rules
 
@@ -71,6 +71,14 @@ node scripts/commerce-option-a-smoke-seed.mjs --dry-run --manifest=docs/examples
 
 The fixture export is disabled by default. The `--write-agenticorg-fixture-env` path must stay under `.tmp/`; committed docs and reports may name variables but must never contain usable auth material, passports, idempotency keys, webhook secrets, provider credentials, raw payloads, DB/Redis URLs, private keys, or secret values.
 
+Future approved C2D seed run after resources, deploy, migrations, and smoke auth setup:
+
+```powershell
+node scripts/commerce-option-a-smoke-seed.mjs --run --manifest=docs/examples/commerce-staging-seed.manifest.json --api-base=<approved-smoke-run-app-origin> --allow-smoke-cloud-run-url=<approved-smoke-run-app-origin> --write-agenticorg-fixture-env=.tmp/commerce-agent-real-staging.env --provider=mock
+```
+
+The seed runner executes only approved smoke API requests: `/health`, JWKS, commerce well-known metadata, catalog bulk validation, catalog bulk upsert, and a catalog readback for the selected fixture item. It fails closed if the smoke URL is not the exact allowlisted HTTPS `run.app` origin, if the provider is not `mock`, if live flags are true, if production resource names are supplied, or if run mode lacks exactly one runtime auth source.
+
 Validate the existing hosted smoke harness with an approved exact smoke URL:
 
 ```powershell
@@ -82,6 +90,14 @@ Generate the redacted evidence schema without requests:
 ```powershell
 node scripts/commerce-option-a-smoke-evidence.mjs --dry-run --api-base=<approved-smoke-run-app-origin> --allow-smoke-cloud-run-url=<approved-smoke-run-app-origin>
 ```
+
+Future approved C2D evidence run after the seed runner writes the `.tmp` fixture env:
+
+```powershell
+node scripts/commerce-option-a-smoke-evidence.mjs --run --api-base=<approved-smoke-run-app-origin> --allow-smoke-cloud-run-url=<approved-smoke-run-app-origin> --fixture-env=.tmp/commerce-agent-real-staging.env --provider=mock
+```
+
+The evidence runner records only the approved smoke host, variable names, synthetic IDs, case status, HTTP status, latency, error code, and cleanup placeholders. It fails closed if the AgenticOrg fixture env is missing, outside `.tmp/`, or does not match the approved smoke URL. It skips optional passport-negative cases when the fixture file does not contain the corresponding synthetic runtime material.
 
 ## Cleanup Guarantees
 
@@ -154,15 +170,17 @@ AgenticOrg must continue to use only `grantex_commerce:*` aliases. It must not c
 
 ## Automation Versus Manual Boundaries
 
-Automated in C2A:
+Automated in C2D-prep:
 
 - Command generation as `NOT RUN`
 - Manifest dry-run validation
 - Smoke URL refusal validation
-- Evidence schema generation without requests
+- Guarded seed runner execution path for a later approved smoke service
+- Guarded evidence runner execution path for a later approved smoke service
+- Evidence schema generation without requests by default
 - Validator assertions
 
-Manual or later C2B:
+Manual or later C2D:
 
 - Creating GCP resources
 - Adding secret versions

--- a/scripts/commerce-option-a-smoke-evidence.mjs
+++ b/scripts/commerce-option-a-smoke-evidence.mjs
@@ -1,18 +1,54 @@
 #!/usr/bin/env node
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const ALLOWED_STAGING_ORIGINS = [
   'https://api-staging.grantex.dev',
   'https://staging.grantex.dev',
   'https://staging.agenticorg.ai',
 ];
-
 const REFUSED_PRODUCTION_ORIGINS = [
   'https://grantex.dev',
   'https://api.grantex.dev',
   'https://app.agenticorg.ai',
 ];
-
+const REFUSED_PRODUCTION_RESOURCE_NAMES = new Set(['grantex-auth', 'grantex-pg16', 'grantex-redis']);
 const DEFAULT_REPORT = 'docs/reports/commerce-v1-option-a-smoke-evidence.md';
+const DEFAULT_FIXTURE_ENV = '.tmp/commerce-agent-real-staging.env';
+const AUTH_ENV_NAMES = ['GRANTEX_COMMERCE_BEARER_TOKEN', 'GRANTEX_AGENT_ASSERTION', 'GRANTEX_API_KEY'];
+const SENSITIVE_FIXTURE_ENV_NAMES = [
+  ...AUTH_ENV_NAMES,
+  'AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT',
+  'AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT',
+  'AGENTICORG_COMMERCE_REVOKED_PASSPORT_JWT',
+  'AGENTICORG_COMMERCE_EXPIRED_PASSPORT_JWT',
+  'AGENTICORG_COMMERCE_DENIED_CONSENT_REF',
+];
+const APPROVED_CASES = [
+  'health',
+  'jwks',
+  'commerce_well_known',
+  'mcp_initialize',
+  'mcp_tools_list',
+  'merchant_profile',
+  'catalog_search',
+  'catalog_get_item',
+  'inventory_check',
+  'cart_create',
+  'consent_request',
+  'consent_exchange',
+  'payment_intent_create',
+  'checkout_create',
+  'payment_status',
+  'missing_consent_refusal',
+  'amount_cap_breach_refusal',
+  'revoked_passport_refusal',
+  'expired_passport_refusal',
+  'denied_consent_refusal',
+];
 
 function fail(message) {
   console.error(message);
@@ -41,7 +77,14 @@ function isTrue(value) {
   return String(value ?? '').trim().toLowerCase() === 'true';
 }
 
+function cliFlagTrue(...names) {
+  return names.some((name) => isTrue(argValue(name, 'false')));
+}
+
 function parseUrl(value, label) {
+  if (!value) {
+    fail(`Missing required ${label}`);
+  }
   let url;
   try {
     url = new URL(value);
@@ -57,22 +100,22 @@ function parseUrl(value, label) {
   if (url.protocol !== 'https:') {
     fail(`Refusing non-HTTPS URL for ${label}`);
   }
+  if (url.search || (url.pathname !== '/' && url.pathname !== '')) {
+    fail(`Refusing path or query in ${label}; provide the origin only`);
+  }
   return url;
 }
 
 function validateSmokeAllowlist(value) {
   if (!value) return null;
   const url = parseUrl(value, 'smoke Cloud Run allowlist');
-  if (url.search || (url.pathname !== '/' && url.pathname !== '')) {
-    fail('Refusing path or query in smoke Cloud Run allowlist; provide the origin only');
-  }
   if (!url.hostname.endsWith('.run.app')) {
     fail('Refusing smoke allowlist URL that is not a run.app origin');
   }
   return url.origin;
 }
 
-function validateApiBase(value, allowedSmokeOrigin) {
+function validateApiBase(value, allowedSmokeOrigin, run) {
   const url = parseUrl(value, 'Option A smoke API base');
   if (allowedSmokeOrigin && url.origin === allowedSmokeOrigin) {
     return url.origin;
@@ -80,67 +123,593 @@ function validateApiBase(value, allowedSmokeOrigin) {
   if (url.hostname.endsWith('.run.app')) {
     fail('Refusing arbitrary run.app URL without exact --allow-smoke-cloud-run-url');
   }
+  if (run) {
+    fail('Option A smoke evidence run requires the exact approved smoke Cloud Run allowlist');
+  }
   if (!ALLOWED_STAGING_ORIGINS.includes(url.origin)) {
     fail(`Refusing non-staging API base: ${url.origin}`);
   }
   return url.origin;
 }
 
-const run = hasFlag('--run');
-const provider = argValue('--provider', 'mock');
-if (provider !== 'mock') {
-  fail('Refusing non-mock provider for Option A smoke evidence tooling');
-}
-if (isTrue(process.env.COMMERCE_LIVE_MODE_ENABLED)) {
-  fail('Refusing COMMERCE_LIVE_MODE_ENABLED=true for Option A smoke evidence tooling');
-}
-if (isTrue(process.env.PLURAL_LIVE_ENABLED)) {
-  fail('Refusing PLURAL_LIVE_ENABLED=true for Option A smoke evidence tooling');
-}
-if (run) {
-  fail('Run mode is blocked for C2A. Implement C2B request execution before collecting new evidence.');
+function assertNotProductionResourceName(value, label) {
+  if (REFUSED_PRODUCTION_RESOURCE_NAMES.has(value)) {
+    fail(`Refusing production resource name for ${label}: ${value}`);
+  }
 }
 
-const allowedSmokeOrigin = validateSmokeAllowlist(argValue('--allow-smoke-cloud-run-url', process.env.COMMERCE_STAGING_ALLOWED_SMOKE_URL ?? ''));
-const apiBase = validateApiBase(argValue('--api-base', 'https://api-staging.grantex.dev'), allowedSmokeOrigin);
-const reportPath = argValue('--report', DEFAULT_REPORT);
-if (!reportPath.includes('commerce-v1-option-a-smoke-evidence.md')) {
-  fail('Refusing non-Option-A smoke evidence report path');
+function assertInsideRepo(pathInput, label) {
+  const resolved = resolve(repoRoot, pathInput);
+  const rel = relative(repoRoot, resolved);
+  if (rel.startsWith('..') || rel === '') {
+    fail(`Refusing ${label} outside repo workspace: ${pathInput}`);
+  }
+  return { resolved, relativePath: rel.replace(/\\/g, '/') };
 }
 
-console.log(JSON.stringify({
-  mode: 'dry-run',
-  status: 'not_executed',
-  requests_made: false,
-  api_base: apiBase,
-  provider,
-  report_path: reportPath,
-  safety: {
-    production_domains_refused: REFUSED_PRODUCTION_ORIGINS,
-    staging_domains_allowed: ALLOWED_STAGING_ORIGINS,
-    exact_smoke_run_app_allowed: allowedSmokeOrigin,
-    arbitrary_run_app_refused: true,
-    live_payment_flags_refused: true,
+function assertInsideTmp(pathInput) {
+  const { resolved, relativePath } = assertInsideRepo(pathInput, 'fixture env path');
+  const isTmpChild = relativePath.startsWith('.tmp/');
+  if (!isTmpChild) {
+    fail(`Refusing AgenticOrg fixture env input outside .tmp/: ${pathInput}`);
+  }
+  return { resolved, relativePath };
+}
+
+function parseDotenv(text) {
+  const values = {};
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (value.startsWith('"') && value.endsWith('"')) {
+      value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+    }
+    values[key] = value;
+  }
+  return values;
+}
+
+function loadFixtureEnv(pathInput, apiBase) {
+  const { resolved, relativePath } = assertInsideTmp(pathInput);
+  let text;
+  try {
+    text = readFileSync(resolved, 'utf8');
+  } catch {
+    fail('Failing closed because AgenticOrg fixture env is missing');
+  }
+  const values = parseDotenv(text);
+  for (const required of [
+    'GRANTEX_COMMERCE_BASE_URL',
+    'GRANTEX_BASE_URL',
+    'AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL',
+    'AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID',
+    'AGENTICORG_COMMERCE_FIXTURE_AGENT_ID',
+    'AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID',
+    'AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID',
+  ]) {
+    if (!values[required]) {
+      fail(`Failing closed because AgenticOrg fixture env is missing ${required}`);
+    }
+  }
+  for (const urlName of ['GRANTEX_COMMERCE_BASE_URL', 'GRANTEX_BASE_URL', 'AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL']) {
+    if (values[urlName] !== apiBase) {
+      fail(`Failing closed because ${urlName} does not match the approved smoke URL`);
+    }
+  }
+  const authNames = AUTH_ENV_NAMES.filter((name) => values[name] || process.env[name]);
+  if (authNames.length !== 1) {
+    fail('Failing closed because AgenticOrg fixture env must provide exactly one Grantex auth source');
+  }
+  return { relativePath, values, authName: authNames[0] };
+}
+
+function mergedFixtureValue(fixture, name) {
+  return String(fixture.values[name] || process.env[name] || '').trim();
+}
+
+function authorizationHeader(fixture) {
+  const value = mergedFixtureValue(fixture, fixture.authName).replace(/^Bearer\s+/i, '');
+  return `Bearer ${value}`;
+}
+
+function redactErrorCode(body) {
+  if (!body || typeof body !== 'object') return null;
+  const error = body.error && typeof body.error === 'object' ? body.error : null;
+  return String(body.code ?? error?.code ?? body.reason ?? '').slice(0, 96) || null;
+}
+
+function safeJsonText(body) {
+  const result = body?.result;
+  const content = result?.content;
+  if (!Array.isArray(content) || !content[0] || typeof content[0].text !== 'string') return null;
+  try {
+    return JSON.parse(content[0].text);
+  } catch {
+    return null;
+  }
+}
+
+function mcpToolErrorCode(body) {
+  const payload = safeJsonText(body);
+  return redactErrorCode(payload);
+}
+
+async function requestJson(apiBase, request, fixture = null) {
+  const url = new URL(request.path, apiBase);
+  const headers = { accept: 'application/json' };
+  if (request.body !== undefined) headers['content-type'] = 'application/json';
+  if (fixture && request.auth !== false) headers.authorization = authorizationHeader(fixture);
+  if (request.idempotencyKey) headers['idempotency-key'] = request.idempotencyKey;
+  const started = Date.now();
+  let response;
+  try {
+    response = await fetch(url, {
+      method: request.method,
+      headers,
+      body: request.body === undefined ? undefined : JSON.stringify(request.body),
+    });
+  } catch (error) {
+    return {
+      case: request.case,
+      status: 'failed',
+      http_status: null,
+      latency_ms: Date.now() - started,
+      error_code: 'network_error',
+      detail: error.message,
+      body: null,
+    };
+  }
+  const latencyMs = Date.now() - started;
+  let body = null;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  const mcpToolFailed = request.mcp === true && body?.result?.isError === true;
+  const ok = response.ok && !mcpToolFailed;
+  return {
+    case: request.case,
+    status: ok ? 'passed' : 'failed',
+    http_status: response.status,
+    latency_ms: latencyMs,
+    error_code: ok ? null : (request.mcp ? mcpToolErrorCode(body) : redactErrorCode(body)),
+    body,
+  };
+}
+
+function caseRow(name, result, options = {}) {
+  if (result.skipped) {
+    return {
+      case: name,
+      status: 'skipped',
+      http_status: null,
+      latency_ms: null,
+      error_code: result.reason,
+      synthetic_ids: {},
+    };
+  }
+  const expectedFailure = options.expectedFailure === true;
+  const failedSafely = expectedFailure && (result.status === 'failed' || result.http_status >= 400);
+  return {
+    case: name,
+    status: failedSafely ? 'failed-safe' : result.status,
+    http_status: result.http_status,
+    latency_ms: result.latency_ms,
+    error_code: result.error_code,
+    synthetic_ids: options.synthetic_ids ?? {},
+  };
+}
+
+function countStatuses(rows) {
+  const counts = { passed: 0, failed: 0, 'failed-safe': 0, skipped: 0 };
+  for (const row of rows) {
+    counts[row.status] = (counts[row.status] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function mcpBody(method, params = {}, id = null) {
+  return { jsonrpc: '2.0', id: id ?? randomUUID(), method, params };
+}
+
+async function mcpTool(apiBase, fixture, name, args) {
+  return requestJson(apiBase, {
+    case: name,
+    method: 'POST',
+    path: '/mcp',
+    mcp: true,
+    body: mcpBody('tools/call', { name, arguments: args }),
+  }, fixture);
+}
+
+function dataFromMcp(result) {
+  const payload = safeJsonText(result.body);
+  if (!payload || payload.error || payload.code) return null;
+  return payload.data ?? payload;
+}
+
+function fixturePassport(fixture, preferredName) {
+  return mergedFixtureValue(fixture, preferredName);
+}
+
+async function executeEvidenceRun({ apiBase, reportPath, fixture }) {
+  const rows = [];
+  const varsUsed = [
+    'GRANTEX_COMMERCE_BASE_URL',
+    'GRANTEX_BASE_URL',
+    'AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL',
+    'AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID',
+    'AGENTICORG_COMMERCE_FIXTURE_AGENT_ID',
+    'AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID',
+    'AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID',
+    fixture.authName,
+  ];
+  const merchantId = fixture.values.AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID;
+  const agentId = fixture.values.AGENTICORG_COMMERCE_FIXTURE_AGENT_ID;
+  const productId = fixture.values.AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID;
+  const variantId = fixture.values.AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID;
+  const currency = fixture.values.AGENTICORG_COMMERCE_FIXTURE_CURRENCY || 'INR';
+  const amount = Number.parseInt(fixture.values.AGENTICORG_COMMERCE_FIXTURE_AMOUNT_MINOR_UNITS || '0', 10);
+  const browsePassport = fixturePassport(fixture, 'AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT');
+  const checkoutPassport = fixturePassport(fixture, 'AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT');
+
+  for (const request of [
+    { case: 'health', method: 'GET', path: '/health', auth: false },
+    { case: 'jwks', method: 'GET', path: '/.well-known/jwks.json', auth: false },
+    { case: 'commerce_well_known', method: 'GET', path: '/.well-known/grantex-commerce', auth: false },
+    { case: 'mcp_initialize', method: 'POST', path: '/mcp', auth: false, body: mcpBody('initialize') },
+    { case: 'mcp_tools_list', method: 'POST', path: '/mcp', auth: false, body: mcpBody('tools/list') },
+  ]) {
+    rows.push(caseRow(request.case, await requestJson(apiBase, request, fixture)));
+  }
+
+  const merchantProfile = await mcpTool(apiBase, fixture, 'merchant.get_profile', { merchant_id: merchantId });
+  rows.push(caseRow('merchant_profile', merchantProfile, { synthetic_ids: { merchant_id: merchantId } }));
+
+  const catalogSearch = await mcpTool(apiBase, fixture, 'catalog.search', {
+    merchant_id: merchantId,
+    query: 'staging',
+    limit: 3,
+    ...(browsePassport ? { passport_jwt: browsePassport } : {}),
+  });
+  rows.push(caseRow('catalog_search', catalogSearch, { synthetic_ids: { merchant_id: merchantId } }));
+
+  const catalogGet = await mcpTool(apiBase, fixture, 'catalog.get_item', {
+    merchant_id: merchantId,
+    product_id: productId,
+    ...(browsePassport ? { passport_jwt: browsePassport } : {}),
+  });
+  rows.push(caseRow('catalog_get_item', catalogGet, { synthetic_ids: { product_id: productId } }));
+
+  const inventory = await mcpTool(apiBase, fixture, 'inventory.check', {
+    merchant_id: merchantId,
+    variant_ids: [variantId],
+    ...(browsePassport ? { passport_jwt: browsePassport } : {}),
+  });
+  rows.push(caseRow('inventory_check', inventory, { synthetic_ids: { variant_id: variantId } }));
+
+  const cart = await mcpTool(apiBase, fixture, 'cart.create', {
+    merchant_id: merchantId,
+    currency,
+    line_items: [{ variant_id: variantId, quantity: 1 }],
+    idempotency_key: `c2d-cart-${randomUUID()}`,
+  });
+  const cartData = dataFromMcp(cart);
+  const cartId = cartData?.cart_id ?? cartData?.id ?? null;
+  rows.push(caseRow('cart_create', cart, { synthetic_ids: cartId ? { cart_id: cartId } : {} }));
+
+  const consent = await requestJson(apiBase, {
+    case: 'consent_request',
+    method: 'POST',
+    path: '/v1/commerce/passports/consent-requests',
+    body: {
+      merchant_id: merchantId,
+      passport_type: 'checkout',
+      max_amount: amount,
+      currency,
+      user_principal_hint: 'user_synthetic_c2d',
+    },
+  }, fixture);
+  const consentId = consent.body?.data?.consent_request_id ?? null;
+  rows.push(caseRow('consent_request', consent, { synthetic_ids: consentId ? { consent_request_id: consentId } : {} }));
+
+  if (consentId) {
+    const exchange = await requestJson(apiBase, {
+      case: 'consent_exchange',
+      method: 'POST',
+      path: '/v1/commerce/passports/exchange',
+      body: { consent_request_id: consentId },
+    }, fixture);
+    rows.push(caseRow('consent_exchange', exchange, { expectedFailure: exchange.http_status >= 400 }));
+  } else {
+    rows.push(caseRow('consent_exchange', { skipped: true, reason: 'missing_consent_request_id' }));
+  }
+
+  let paymentIntentId = null;
+  if (cartId && checkoutPassport) {
+    const payment = await mcpTool(apiBase, fixture, 'payment.create_intent', {
+      merchant_id: merchantId,
+      cart_id: cartId,
+      passport_jwt: checkoutPassport,
+      amount_minor_units: amount,
+      currency,
+      provider_key: 'mock',
+      metadata: { agent_session_id: 'c2d-smoke' },
+      idempotency_key: `c2d-payment-${randomUUID()}`,
+    });
+    const paymentData = dataFromMcp(payment);
+    paymentIntentId = paymentData?.payment_intent_id ?? paymentData?.id ?? null;
+    rows.push(caseRow('payment_intent_create', payment, {
+      synthetic_ids: paymentIntentId ? { payment_intent_id: paymentIntentId } : {},
+    }));
+  } else {
+    rows.push(caseRow('payment_intent_create', { skipped: true, reason: 'missing_cart_or_checkout_passport' }));
+  }
+
+  if (paymentIntentId && checkoutPassport) {
+    const checkout = await mcpTool(apiBase, fixture, 'checkout.create', {
+      payment_intent_id: paymentIntentId,
+      passport_jwt: checkoutPassport,
+      success_url: 'https://staging.agenticorg.ai/commerce/smoke/success',
+      cancel_url: 'https://staging.agenticorg.ai/commerce/smoke/cancel',
+      idempotency_key: `c2d-checkout-${randomUUID()}`,
+    });
+    rows.push(caseRow('checkout_create', checkout, { synthetic_ids: { payment_intent_id: paymentIntentId } }));
+
+    const status = await mcpTool(apiBase, fixture, 'payment.get_status', {
+      payment_intent_id: paymentIntentId,
+      passport_jwt: checkoutPassport,
+    });
+    rows.push(caseRow('payment_status', status, { synthetic_ids: { payment_intent_id: paymentIntentId } }));
+  } else {
+    rows.push(caseRow('checkout_create', { skipped: true, reason: 'missing_payment_intent_or_checkout_passport' }));
+    rows.push(caseRow('payment_status', { skipped: true, reason: 'missing_payment_intent_or_checkout_passport' }));
+  }
+
+  if (cartId) {
+    const missingConsent = await mcpTool(apiBase, fixture, 'payment.create_intent', {
+      merchant_id: merchantId,
+      cart_id: cartId,
+      amount_minor_units: amount,
+      currency,
+      provider_key: 'mock',
+      metadata: { agent_session_id: 'c2d-smoke-missing-consent' },
+      idempotency_key: `c2d-missing-consent-${randomUUID()}`,
+    });
+    rows.push(caseRow('missing_consent_refusal', missingConsent, { expectedFailure: true }));
+  } else {
+    rows.push(caseRow('missing_consent_refusal', { skipped: true, reason: 'missing_cart' }));
+  }
+
+  if (cartId && checkoutPassport) {
+    const breachAmount = Math.max(amount * 10, amount + 250000);
+    const amountCap = await mcpTool(apiBase, fixture, 'payment.create_intent', {
+      merchant_id: merchantId,
+      cart_id: cartId,
+      passport_jwt: checkoutPassport,
+      amount_minor_units: breachAmount,
+      currency,
+      provider_key: 'mock',
+      metadata: { agent_session_id: 'c2d-smoke-amount-cap' },
+      idempotency_key: `c2d-amount-cap-${randomUUID()}`,
+    });
+    rows.push(caseRow('amount_cap_breach_refusal', amountCap, { expectedFailure: true }));
+  } else {
+    rows.push(caseRow('amount_cap_breach_refusal', { skipped: true, reason: 'missing_cart_or_checkout_passport' }));
+  }
+
+  for (const [caseName, envName] of [
+    ['revoked_passport_refusal', 'AGENTICORG_COMMERCE_REVOKED_PASSPORT_JWT'],
+    ['expired_passport_refusal', 'AGENTICORG_COMMERCE_EXPIRED_PASSPORT_JWT'],
+  ]) {
+    const passport = fixturePassport(fixture, envName);
+    if (!cartId || !passport) {
+      rows.push(caseRow(caseName, { skipped: true, reason: `missing_${envName}` }));
+      continue;
+    }
+    const refusal = await mcpTool(apiBase, fixture, 'payment.create_intent', {
+      merchant_id: merchantId,
+      cart_id: cartId,
+      passport_jwt: passport,
+      amount_minor_units: amount,
+      currency,
+      provider_key: 'mock',
+      metadata: { agent_session_id: `c2d-smoke-${caseName}` },
+      idempotency_key: `c2d-${caseName}-${randomUUID()}`,
+    });
+    rows.push(caseRow(caseName, refusal, { expectedFailure: true }));
+  }
+
+  const deniedRef = fixturePassport(fixture, 'AGENTICORG_COMMERCE_DENIED_CONSENT_REF');
+  if (deniedRef) {
+    const denied = await requestJson(apiBase, {
+      case: 'denied_consent_refusal',
+      method: 'POST',
+      path: '/v1/commerce/passports/exchange',
+      body: { consent_request_id: deniedRef },
+    }, fixture);
+    rows.push(caseRow('denied_consent_refusal', denied, { expectedFailure: true }));
+  } else {
+    rows.push(caseRow('denied_consent_refusal', { skipped: true, reason: 'missing_denied_consent_ref' }));
+  }
+
+  const counts = countStatuses(rows);
+  const report = writeEvidenceReport({
+    reportPath,
+    apiBase,
+    rows,
+    counts,
+    varsUsed: Array.from(new Set(varsUsed)),
+    fixturePath: fixture.relativePath,
+    syntheticIds: { merchant_id: merchantId, agent_id: agentId, product_id: productId, variant_id: variantId },
+  });
+  return {
+    mode: 'run',
+    status: counts.failed === 0 ? 'executed' : 'executed_with_failures',
+    api_base_host: new URL(apiBase).hostname,
+    report_path: report.relativePath,
+    requests_made: rows.filter((row) => row.status !== 'skipped').length,
+    counts,
+    variable_names_used: Array.from(new Set(varsUsed)),
+    sensitive_variable_names_loaded: SENSITIVE_FIXTURE_ENV_NAMES.filter((name) => fixture.values[name] || process.env[name]),
     secret_values_printed: false,
     raw_payloads_printed: false,
-  },
-  evidence_schema: {
-    report_type: 'commerce-v1-option-a-smoke-evidence',
-    target_host_only: 'hostname',
-    cloud_run_revision: 'revision id if available',
-    smoke_resource_names: ['grantex-auth-smoke', 'grantex-commerce-smoke-pg', 'grantex-commerce-smoke-redis'],
-    live_flags_false: true,
-    provider: 'mock',
-    pass_fail_table: 'redacted rows only',
-    cleanup_completed: 'required after run',
-    redaction: {
-      bearer_tokens_recorded: false,
-      passports_recorded: false,
-      idempotency_keys_recorded: false,
-      webhook_secrets_recorded: false,
-      provider_credentials_recorded: false,
-      raw_payloads_recorded: false,
-    },
-  },
-}, null, 2));
+  };
+}
 
+function markdownTable(rows) {
+  const lines = ['| Case | Status | HTTP | Latency ms | Error code | Synthetic refs |', '| --- | --- | ---: | ---: | --- | --- |'];
+  for (const row of rows) {
+    const refs = Object.entries(row.synthetic_ids ?? {})
+      .map(([key, value]) => `${key}=${value}`)
+      .join(', ');
+    lines.push(`| ${row.case} | ${row.status} | ${row.http_status ?? ''} | ${row.latency_ms ?? ''} | ${row.error_code ?? ''} | ${refs} |`);
+  }
+  return lines.join('\n');
+}
+
+function writeEvidenceReport({ reportPath, apiBase, rows, counts, varsUsed, fixturePath, syntheticIds }) {
+  const { resolved, relativePath } = assertInsideRepo(reportPath, 'Option A smoke evidence report path');
+  if (relativePath !== DEFAULT_REPORT) {
+    fail('Refusing non-Option-A smoke evidence report path');
+  }
+  const host = new URL(apiBase).hostname;
+  const generatedAt = new Date().toISOString();
+  const content = `# Commerce V1 Option A Smoke Evidence
+
+Status: C2D approved smoke evidence captured from a temporary Option A smoke service. This report is scrubbed and contains no bearer token values, passports, idempotency key values, webhook secrets, provider credentials, raw payloads, DB/Redis URLs, private keys, or secret values.
+
+Generated at: ${generatedAt}
+
+Target host: ${host}
+
+Provider: mock
+
+Live flags: Commerce live mode false; live payments false; live Plural false.
+
+AgenticOrg fixture env: ${fixturePath}
+
+Variable names used: ${varsUsed.join(', ')}
+
+Synthetic IDs:
+- Merchant: ${syntheticIds.merchant_id}
+- Agent: ${syntheticIds.agent_id}
+- Product: ${syntheticIds.product_id}
+- Variant: ${syntheticIds.variant_id}
+
+## Summary
+
+- Passed: ${counts.passed}
+- Failed: ${counts.failed}
+- Failed-safe: ${counts['failed-safe']}
+- Skipped: ${counts.skipped}
+
+## Case Results
+
+${markdownTable(rows)}
+
+## Cleanup Status
+
+Cleanup status must be updated by the approved smoke-run operator immediately after temporary resource deletion. Production resources must be verified untouched before this evidence can be considered complete.
+
+## Redaction
+
+The runner records only host/origin, variable names, synthetic IDs, case status, HTTP status, latency, and error codes. It never writes raw response payloads, usable passports, auth material, idempotency key values, webhook secrets, provider credentials, DB/Redis URLs, private keys, or secret values to this report.
+`;
+  mkdirSync(dirname(resolved), { recursive: true });
+  writeFileSync(resolved, content, 'utf8');
+  return { relativePath };
+}
+
+function validateStaticGuardrails() {
+  const provider = argValue('--provider', 'mock');
+  if (provider !== 'mock') {
+    fail('Refusing non-mock provider for Option A smoke evidence tooling');
+  }
+  if (isTrue(process.env.COMMERCE_LIVE_MODE_ENABLED) || cliFlagTrue('--commerce-live-mode-enabled')) {
+    fail('Refusing COMMERCE_LIVE_MODE_ENABLED=true for Option A smoke evidence tooling');
+  }
+  if (isTrue(process.env.PLURAL_LIVE_ENABLED) || cliFlagTrue('--plural-live-enabled')) {
+    fail('Refusing PLURAL_LIVE_ENABLED=true for Option A smoke evidence tooling');
+  }
+  if (cliFlagTrue('--live-payments', '--provider-live-payments-enabled')) {
+    fail('Refusing live payment flags for Option A smoke evidence tooling');
+  }
+  if (cliFlagTrue('--live-plural', '--plural-live')) {
+    fail('Refusing live Plural flags for Option A smoke evidence tooling');
+  }
+  assertNotProductionResourceName(argValue('--service-name', 'grantex-auth-smoke'), 'Cloud Run service');
+  assertNotProductionResourceName(argValue('--cloud-sql-instance', 'grantex-commerce-smoke-pg'), 'Cloud SQL instance');
+  assertNotProductionResourceName(argValue('--redis-instance', 'grantex-commerce-smoke-redis'), 'Redis instance');
+}
+
+async function main() {
+  const run = hasFlag('--run');
+  if (run && hasFlag('--dry-run')) {
+    fail('Refusing both --run and --dry-run for Option A smoke evidence tooling');
+  }
+  validateStaticGuardrails();
+
+  const allowedSmokeOrigin = validateSmokeAllowlist(argValue('--allow-smoke-cloud-run-url', process.env.COMMERCE_STAGING_ALLOWED_SMOKE_URL ?? ''));
+  const apiBase = validateApiBase(argValue('--api-base', 'https://api-staging.grantex.dev'), allowedSmokeOrigin, run);
+  const reportPath = argValue('--report', DEFAULT_REPORT);
+  const { relativePath: reportRelativePath } = assertInsideRepo(reportPath, 'Option A smoke evidence report path');
+  if (reportRelativePath !== DEFAULT_REPORT) {
+    fail('Refusing non-Option-A smoke evidence report path');
+  }
+
+  if (run) {
+    const fixture = loadFixtureEnv(argValue('--fixture-env', DEFAULT_FIXTURE_ENV), apiBase);
+    const result = await executeEvidenceRun({ apiBase, reportPath, fixture });
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log(JSON.stringify({
+    mode: 'dry-run',
+    status: 'not_executed',
+    requests_made: false,
+    api_base: apiBase,
+    provider: 'mock',
+    report_path: reportPath,
+    fixture_env_required_for_run: DEFAULT_FIXTURE_ENV,
+    approved_cases: APPROVED_CASES,
+    safety: {
+      production_domains_refused: REFUSED_PRODUCTION_ORIGINS,
+      staging_domains_allowed: ALLOWED_STAGING_ORIGINS,
+      exact_smoke_run_app_allowed: allowedSmokeOrigin,
+      arbitrary_run_app_refused: true,
+      live_payment_flags_refused: true,
+      secret_values_printed: false,
+      raw_payloads_printed: false,
+    },
+    evidence_schema: {
+      report_type: 'commerce-v1-option-a-smoke-evidence',
+      target_host_only: 'hostname',
+      cloud_run_revision: 'revision id if supplied by operator',
+      smoke_resource_names: ['grantex-auth-smoke', 'grantex-commerce-smoke-pg', 'grantex-commerce-smoke-redis'],
+      live_flags_false: true,
+      provider: 'mock',
+      pass_fail_table: 'redacted rows only',
+      cleanup_completed: 'required after run',
+      redaction: {
+        bearer_tokens_recorded: false,
+        passports_recorded: false,
+        idempotency_keys_recorded: false,
+        webhook_secrets_recorded: false,
+        provider_credentials_recorded: false,
+        raw_payloads_recorded: false,
+      },
+    },
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/commerce-option-a-smoke-evidence.mjs
+++ b/scripts/commerce-option-a-smoke-evidence.mjs
@@ -156,6 +156,68 @@ function assertInsideTmp(pathInput) {
   return { resolved, relativePath };
 }
 
+function safeString(value, label, { min = 0, max = 256, pattern = null, allowEmpty = false } = {}) {
+  if (typeof value !== 'string') {
+    fail(`Failing closed because ${label} is not a string`);
+  }
+  const trimmed = value.trim();
+  if (!allowEmpty && trimmed.length === 0) {
+    fail(`Failing closed because ${label} is empty`);
+  }
+  if (trimmed.length < min || trimmed.length > max) {
+    fail(`Failing closed because ${label} has invalid length`);
+  }
+  if (/[\r\n]/.test(trimmed)) {
+    fail(`Failing closed because ${label} contains line breaks`);
+  }
+  if (pattern && !pattern.test(trimmed)) {
+    fail(`Failing closed because ${label} contains unsupported characters`);
+  }
+  return trimmed;
+}
+
+function optionalSafeString(value, label, options = {}) {
+  const text = String(value ?? '').trim();
+  if (!text) return '';
+  return safeString(text, label, options);
+}
+
+function safeSyntheticId(value, label) {
+  return safeString(String(value ?? ''), label, {
+    min: 3,
+    max: 128,
+    pattern: /^[A-Za-z0-9_.:-]+$/,
+  });
+}
+
+function safeCurrency(value, label) {
+  return safeString(String(value ?? ''), label, {
+    min: 3,
+    max: 3,
+    pattern: /^[A-Z]{3}$/,
+  });
+}
+
+function safeMinorUnits(value, label) {
+  const text = String(value ?? '').trim();
+  if (!/^\d+$/.test(text)) {
+    fail(`Failing closed because ${label} is invalid`);
+  }
+  const amount = Number.parseInt(text, 10);
+  if (!Number.isInteger(amount) || amount < 0 || amount > 10_000_000) {
+    fail(`Failing closed because ${label} is invalid`);
+  }
+  return amount;
+}
+
+function safeSensitiveRuntimeValue(value, label) {
+  return safeString(String(value ?? '').replace(/^Bearer\s+/i, ''), label, {
+    min: 8,
+    max: 8192,
+    pattern: /^[A-Za-z0-9._~+/=-]+$/,
+  });
+}
+
 function parseDotenv(text) {
   const values = {};
   for (const rawLine of text.split(/\r?\n/)) {
@@ -171,6 +233,58 @@ function parseDotenv(text) {
     values[key] = value;
   }
   return values;
+}
+
+function validateFixtureForNetwork(values, authName, apiBase) {
+  if (values.AGENTICORG_COMMERCE_FIXTURE_PROVIDER && values.AGENTICORG_COMMERCE_FIXTURE_PROVIDER !== 'mock') {
+    fail('Failing closed because AgenticOrg fixture env is not mock provider');
+  }
+  if (values.AGENTICORG_COMMERCE_FIXTURE_SYNTHETIC_ONLY && values.AGENTICORG_COMMERCE_FIXTURE_SYNTHETIC_ONLY !== 'true') {
+    fail('Failing closed because AgenticOrg fixture env is not synthetic-only');
+  }
+
+  const authValue = values[authName] || process.env[authName] || '';
+  const safe = {
+    apiBase: safeString(apiBase, 'approved smoke URL', {
+      min: 12,
+      max: 256,
+      pattern: /^https:\/\/[A-Za-z0-9.-]+\.run\.app$/,
+    }),
+    authName,
+    authValue: safeSensitiveRuntimeValue(authValue, authName),
+    merchantId: safeSyntheticId(values.AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID, 'fixture merchant id'),
+    agentId: safeSyntheticId(values.AGENTICORG_COMMERCE_FIXTURE_AGENT_ID, 'fixture agent id'),
+    productId: safeSyntheticId(values.AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID, 'fixture product id'),
+    variantId: safeSyntheticId(values.AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID, 'fixture variant id'),
+    currency: safeCurrency(values.AGENTICORG_COMMERCE_FIXTURE_CURRENCY || 'INR', 'fixture currency'),
+    amountMinorUnits: safeMinorUnits(values.AGENTICORG_COMMERCE_FIXTURE_AMOUNT_MINOR_UNITS || '0', 'fixture amount minor units'),
+    browsePassport: optionalSafeString(values.AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT || process.env.AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT, 'browse passport', {
+      min: 8,
+      max: 8192,
+      pattern: /^[A-Za-z0-9._~+/=-]+$/,
+    }),
+    checkoutPassport: optionalSafeString(values.AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT || process.env.AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT, 'checkout passport', {
+      min: 8,
+      max: 8192,
+      pattern: /^[A-Za-z0-9._~+/=-]+$/,
+    }),
+    revokedPassport: optionalSafeString(values.AGENTICORG_COMMERCE_REVOKED_PASSPORT_JWT || process.env.AGENTICORG_COMMERCE_REVOKED_PASSPORT_JWT, 'revoked passport', {
+      min: 8,
+      max: 8192,
+      pattern: /^[A-Za-z0-9._~+/=-]+$/,
+    }),
+    expiredPassport: optionalSafeString(values.AGENTICORG_COMMERCE_EXPIRED_PASSPORT_JWT || process.env.AGENTICORG_COMMERCE_EXPIRED_PASSPORT_JWT, 'expired passport', {
+      min: 8,
+      max: 8192,
+      pattern: /^[A-Za-z0-9._~+/=-]+$/,
+    }),
+    deniedConsentRef: optionalSafeString(values.AGENTICORG_COMMERCE_DENIED_CONSENT_REF || process.env.AGENTICORG_COMMERCE_DENIED_CONSENT_REF, 'denied consent ref', {
+      min: 3,
+      max: 256,
+      pattern: /^[A-Za-z0-9_.:-]+$/,
+    }),
+  };
+  return Object.freeze(safe);
 }
 
 function loadFixtureEnv(pathInput, apiBase) {
@@ -204,16 +318,12 @@ function loadFixtureEnv(pathInput, apiBase) {
   if (authNames.length !== 1) {
     fail('Failing closed because AgenticOrg fixture env must provide exactly one Grantex auth source');
   }
-  return { relativePath, values, authName: authNames[0] };
-}
-
-function mergedFixtureValue(fixture, name) {
-  return String(fixture.values[name] || process.env[name] || '').trim();
+  const authName = authNames[0];
+  return { relativePath, values, authName, safe: validateFixtureForNetwork(values, authName, apiBase) };
 }
 
 function authorizationHeader(fixture) {
-  const value = mergedFixtureValue(fixture, fixture.authName).replace(/^Bearer\s+/i, '');
-  return `Bearer ${value}`;
+  return `Bearer ${fixture.safe.authValue}`;
 }
 
 function redactErrorCode(body) {
@@ -333,10 +443,6 @@ function dataFromMcp(result) {
   return payload.data ?? payload;
 }
 
-function fixturePassport(fixture, preferredName) {
-  return mergedFixtureValue(fixture, preferredName);
-}
-
 async function executeEvidenceRun({ apiBase, reportPath, fixture }) {
   const rows = [];
   const varsUsed = [
@@ -349,14 +455,14 @@ async function executeEvidenceRun({ apiBase, reportPath, fixture }) {
     'AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID',
     fixture.authName,
   ];
-  const merchantId = fixture.values.AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID;
-  const agentId = fixture.values.AGENTICORG_COMMERCE_FIXTURE_AGENT_ID;
-  const productId = fixture.values.AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID;
-  const variantId = fixture.values.AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID;
-  const currency = fixture.values.AGENTICORG_COMMERCE_FIXTURE_CURRENCY || 'INR';
-  const amount = Number.parseInt(fixture.values.AGENTICORG_COMMERCE_FIXTURE_AMOUNT_MINOR_UNITS || '0', 10);
-  const browsePassport = fixturePassport(fixture, 'AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT');
-  const checkoutPassport = fixturePassport(fixture, 'AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT');
+  const merchantId = fixture.safe.merchantId;
+  const agentId = fixture.safe.agentId;
+  const productId = fixture.safe.productId;
+  const variantId = fixture.safe.variantId;
+  const currency = fixture.safe.currency;
+  const amount = fixture.safe.amountMinorUnits;
+  const browsePassport = fixture.safe.browsePassport;
+  const checkoutPassport = fixture.safe.checkoutPassport;
 
   for (const request of [
     { case: 'health', method: 'GET', path: '/health', auth: false },
@@ -507,7 +613,9 @@ async function executeEvidenceRun({ apiBase, reportPath, fixture }) {
     ['revoked_passport_refusal', 'AGENTICORG_COMMERCE_REVOKED_PASSPORT_JWT'],
     ['expired_passport_refusal', 'AGENTICORG_COMMERCE_EXPIRED_PASSPORT_JWT'],
   ]) {
-    const passport = fixturePassport(fixture, envName);
+    const passport = envName === 'AGENTICORG_COMMERCE_REVOKED_PASSPORT_JWT'
+      ? fixture.safe.revokedPassport
+      : fixture.safe.expiredPassport;
     if (!cartId || !passport) {
       rows.push(caseRow(caseName, { skipped: true, reason: `missing_${envName}` }));
       continue;
@@ -525,7 +633,7 @@ async function executeEvidenceRun({ apiBase, reportPath, fixture }) {
     rows.push(caseRow(caseName, refusal, { expectedFailure: true }));
   }
 
-  const deniedRef = fixturePassport(fixture, 'AGENTICORG_COMMERCE_DENIED_CONSENT_REF');
+  const deniedRef = fixture.safe.deniedConsentRef;
   if (deniedRef) {
     const denied = await requestJson(apiBase, {
       case: 'denied_consent_refusal',

--- a/scripts/commerce-option-a-smoke-seed.mjs
+++ b/scripts/commerce-option-a-smoke-seed.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
+import { createHash } from 'node:crypto';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, resolve, relative } from 'node:path';
+import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const DEFAULT_MANIFEST = 'docs/examples/commerce-staging-seed.manifest.json';
+const DEFAULT_FIXTURE_ENV = '.tmp/commerce-agent-real-staging.env';
 const REFUSED_PRODUCTION_ORIGINS = [
   'https://grantex.dev',
   'https://api.grantex.dev',
@@ -18,6 +20,14 @@ const OPTIONAL_SENSITIVE_FIXTURE_ENV_NAMES = [
   'AGENTICORG_COMMERCE_REVOKED_PASSPORT_JWT',
   'AGENTICORG_COMMERCE_EXPIRED_PASSPORT_JWT',
   'AGENTICORG_COMMERCE_DENIED_CONSENT_REF',
+];
+const APPROVED_SEED_REQUESTS = [
+  'GET /health',
+  'GET /.well-known/jwks.json',
+  'GET /.well-known/grantex-commerce',
+  'POST /v1/commerce/catalog/products/bulk dry_run=true',
+  'POST /v1/commerce/catalog/products/bulk dry_run=false',
+  'GET /v1/commerce/catalog/products/{product_id}',
 ];
 
 function fail(message) {
@@ -47,7 +57,14 @@ function isTrue(value) {
   return String(value ?? '').trim().toLowerCase() === 'true';
 }
 
+function cliFlagTrue(...names) {
+  return names.some((name) => isTrue(argValue(name, 'false')));
+}
+
 function parseUrl(value, label) {
+  if (!value) {
+    fail(`Missing required ${label}`);
+  }
   let url;
   try {
     url = new URL(value);
@@ -70,7 +87,6 @@ function parseUrl(value, label) {
 }
 
 function validateSmokeAllowlist(value) {
-  if (!value) return null;
   const origin = parseUrl(value, 'smoke Cloud Run allowlist');
   if (!new URL(origin).hostname.endsWith('.run.app')) {
     fail('Refusing smoke allowlist URL that is not a run.app service origin');
@@ -78,13 +94,13 @@ function validateSmokeAllowlist(value) {
   return origin;
 }
 
-function validateFixtureApiBase(value, allowedSmokeOrigin) {
-  const origin = parseUrl(value, 'AgenticOrg fixture API base');
+function validateSmokeApiBase(value, allowedSmokeOrigin) {
+  const origin = parseUrl(value, 'Option A smoke API base');
   if (!allowedSmokeOrigin || origin !== allowedSmokeOrigin) {
     if (new URL(origin).hostname.endsWith('.run.app')) {
       fail('Refusing arbitrary run.app URL without exact --allow-smoke-cloud-run-url');
     }
-    fail('Fixture env export requires the exact approved Option A smoke URL allowlist');
+    fail('Option A smoke runner requires the exact approved smoke URL allowlist');
   }
   return origin;
 }
@@ -123,15 +139,42 @@ function firstManifestProductWithVariant(manifest) {
   return products.find((product) => Array.isArray(product.variants) && product.variants.length > 0) ?? products[0];
 }
 
-function writeAgenticOrgFixtureEnv({ outputPath, apiBase, manifest, provider }) {
+function shortHash(value) {
+  return createHash('sha256').update(String(value)).digest('hex').slice(0, 12);
+}
+
+function authValuesFromEnv() {
+  return AUTH_ENV_NAMES
+    .map((name) => ({ name, value: String(process.env[name] ?? '').trim() }))
+    .filter((entry) => entry.value);
+}
+
+function requireExactlyOneAuthSource() {
+  const authValues = authValuesFromEnv();
+  if (authValues.length !== 1) {
+    fail('Smoke seed run requires exactly one Grantex auth env value present');
+  }
+  return authValues[0];
+}
+
+function authorizationHeader(authSource) {
+  const value = authSource.value.replace(/^Bearer\s+/i, '');
+  return `Bearer ${value}`;
+}
+
+function writeAgenticOrgFixtureEnv({ outputPath, apiBase, manifest, provider, selectedIds }) {
   const { resolved, relativePath } = assertInsideTmp(outputPath);
   const selectedProduct = firstManifestProductWithVariant(manifest);
   const selectedVariant = Array.isArray(selectedProduct?.variants) ? selectedProduct.variants[0] : null;
-  const authNamesWithValues = AUTH_ENV_NAMES.filter((name) => String(process.env[name] ?? '').trim());
+  const authNamesWithValues = authValuesFromEnv();
   if (authNamesWithValues.length > 1) {
     fail('Refusing fixture env export with more than one Grantex auth env value present');
   }
 
+  const merchantId = selectedIds?.merchant_id ?? manifest.merchant.id;
+  const agentId = selectedIds?.agent_id ?? manifest.agent.id;
+  const productId = selectedIds?.product_id ?? selectedProduct?.id ?? '';
+  const variantId = selectedIds?.variant_id ?? selectedVariant?.id ?? '';
   const sensitiveNamesWritten = [];
   const lines = [
     '# AgenticOrg Commerce real-staging fixture env.',
@@ -141,22 +184,23 @@ function writeAgenticOrgFixtureEnv({ outputPath, apiBase, manifest, provider }) 
     `GRANTEX_BASE_URL=${dotenvValue(apiBase)}`,
     `AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL=${dotenvValue(apiBase)}`,
     'AGENTICORG_COMMERCE_REAL_STAGING="1"',
-    'AGENTICORG_COMMERCE_FIXTURE_VERSION="c2c-option-a-smoke-v1"',
+    'AGENTICORG_COMMERCE_FIXTURE_VERSION="c2d-option-a-smoke-v1"',
     `AGENTICORG_COMMERCE_FIXTURE_PROVIDER=${dotenvValue(provider)}`,
     'AGENTICORG_COMMERCE_FIXTURE_SYNTHETIC_ONLY="true"',
-    `AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID=${dotenvValue(manifest.merchant.id)}`,
-    `AGENTICORG_COMMERCE_FIXTURE_AGENT_ID=${dotenvValue(manifest.agent.id)}`,
-    `AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID=${dotenvValue(selectedProduct?.id ?? '')}`,
-    `AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID=${dotenvValue(selectedVariant?.id ?? '')}`,
+    `AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID=${dotenvValue(merchantId)}`,
+    `AGENTICORG_COMMERCE_FIXTURE_AGENT_ID=${dotenvValue(agentId)}`,
+    `AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID=${dotenvValue(productId)}`,
+    `AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID=${dotenvValue(variantId)}`,
     `AGENTICORG_COMMERCE_FIXTURE_CURRENCY=${dotenvValue(manifest.catalog.currency)}`,
     `AGENTICORG_COMMERCE_FIXTURE_AMOUNT_MINOR_UNITS=${dotenvValue(selectedVariant?.price_minor_units ?? selectedProduct?.price_minor_units ?? 0)}`,
     'AGENTICORG_COMMERCE_FIXTURE_PASSPORT_MAX_AMOUNT_MINOR_UNITS="250000"',
   ];
 
   if (authNamesWithValues.length === 1) {
-    const authName = authNamesWithValues[0];
-    lines.push(`${authName}=${dotenvValue(process.env[authName])}`);
-    sensitiveNamesWritten.push(authName);
+    const auth = authNamesWithValues[0];
+    lines.push('AGENTICORG_COMMERCE_FIXTURE_AUTH_ENV_NAME=' + dotenvValue(auth.name));
+    lines.push(`${auth.name}=${dotenvValue(auth.value)}`);
+    sensitiveNamesWritten.push(auth.name);
   } else {
     lines.push('# Set exactly one Grantex auth env var value outside logs before an approved real-staging run.');
     lines.push('AGENTICORG_COMMERCE_FIXTURE_AUTH_ENV_NAME="GRANTEX_API_KEY"');
@@ -180,6 +224,7 @@ function writeAgenticOrgFixtureEnv({ outputPath, apiBase, manifest, provider }) 
       .filter((line) => line && !line.startsWith('#'))
       .map((line) => line.split('=')[0]),
     sensitive_variable_names_written: sensitiveNamesWritten,
+    sensitive_value_hashes: sensitiveNamesWritten.map((name) => ({ name, sha256_12: shortHash(process.env[name] ?? '') })),
     sensitive_values_printed: false,
   };
 }
@@ -249,98 +294,318 @@ function assertEqual(actual, expected, message) {
   }
 }
 
-const run = hasFlag('--run');
-if (run) {
-  fail('Run mode is blocked for C2A. Implement C2B smoke DB guardrails before any seed writes.');
-}
-if (isTrue(process.env.COMMERCE_LIVE_MODE_ENABLED)) {
-  fail('Refusing COMMERCE_LIVE_MODE_ENABLED=true for Option A smoke seed tooling');
-}
-if (isTrue(process.env.PLURAL_LIVE_ENABLED)) {
-  fail('Refusing PLURAL_LIVE_ENABLED=true for Option A smoke seed tooling');
-}
+function validateManifest(manifest) {
+  assertEqual(manifest.provider?.provider_key, 'mock', 'Smoke seed provider must be mock');
+  assertEqual(manifest.provider?.live_payments_enabled, false, 'Smoke seed live payments flag must be false');
+  assertEqual(manifest.provider?.plural_live_enabled, false, 'Smoke seed live Plural flag must be false');
+  assertEqual(manifest.live_flags?.commerce_live_mode_enabled, false, 'Smoke seed live commerce flag must be false');
+  assertEqual(manifest.live_flags?.plural_live_enabled, false, 'Smoke seed live Plural flag must be false');
+  assertEqual(manifest.tenant?.id, 'cten_staging_commerce', 'Smoke seed tenant id is pinned');
+  assertEqual(manifest.merchant?.id, 'mch_staging_electronics_pilot', 'Smoke seed merchant id is pinned');
+  assertEqual(manifest.agent?.id, 'cag_staging_agenticorg_sales', 'Smoke seed agent id is pinned');
 
-const manifestArg = argValue('--manifest', DEFAULT_MANIFEST);
-const manifestPath = assertInsideRepo(manifestArg);
-const manifest = loadManifest(manifestPath);
-const provider = argValue('--provider', manifest.provider?.provider_key ?? 'mock');
-const fixtureEnvOutput = argValue('--write-agenticorg-fixture-env', '');
-let fixtureEnvExport = { written: false };
-
-assertNotProductionResourceName(argValue('--service-name', 'grantex-auth-smoke'), 'Cloud Run service');
-assertNotProductionResourceName(argValue('--cloud-sql-instance', 'grantex-commerce-smoke-pg'), 'Cloud SQL instance');
-assertNotProductionResourceName(argValue('--redis-instance', 'grantex-commerce-smoke-redis'), 'Redis instance');
-
-assertEqual(provider, 'mock', 'Smoke seed provider must be mock');
-assertEqual(manifest.provider?.provider_key, 'mock', 'Smoke seed provider must be mock');
-assertEqual(manifest.provider?.live_payments_enabled, false, 'Smoke seed live payments flag must be false');
-assertEqual(manifest.provider?.plural_live_enabled, false, 'Smoke seed live Plural flag must be false');
-assertEqual(manifest.live_flags?.commerce_live_mode_enabled, false, 'Smoke seed live commerce flag must be false');
-assertEqual(manifest.live_flags?.plural_live_enabled, false, 'Smoke seed live Plural flag must be false');
-assertEqual(manifest.tenant?.id, 'cten_staging_commerce', 'Smoke seed tenant id is pinned');
-assertEqual(manifest.merchant?.id, 'mch_staging_electronics_pilot', 'Smoke seed merchant id is pinned');
-assertEqual(manifest.agent?.id, 'cag_staging_agenticorg_sales', 'Smoke seed agent id is pinned');
-
-const products = manifest.catalog?.products;
-if (!Array.isArray(products) || products.length < 10 || products.length > 25) {
-  fail('Smoke seed manifest must include 10-25 products');
-}
-const productsWithVariants = products.filter((product) => Array.isArray(product.variants) && product.variants.length > 0).length;
-if (productsWithVariants < 3) {
-  fail('Smoke seed manifest must include at least 3 products with variants');
+  const products = manifest.catalog?.products;
+  if (!Array.isArray(products) || products.length < 10 || products.length > 25) {
+    fail('Smoke seed manifest must include 10-25 products');
+  }
+  const productsWithVariants = products.filter((product) => Array.isArray(product.variants) && product.variants.length > 0).length;
+  if (productsWithVariants < 3) {
+    fail('Smoke seed manifest must include at least 3 products with variants');
+  }
+  return { products, productsWithVariants };
 }
 
-if (fixtureEnvOutput) {
-  const allowedSmokeOrigin = validateSmokeAllowlist(
-    argValue('--allow-smoke-cloud-run-url', process.env.COMMERCE_STAGING_ALLOWED_SMOKE_URL ?? ''),
-  );
-  const apiBase = validateFixtureApiBase(argValue('--api-base', ''), allowedSmokeOrigin);
-  fixtureEnvExport = writeAgenticOrgFixtureEnv({
-    outputPath: fixtureEnvOutput,
-    apiBase,
-    manifest,
-    provider,
-  });
+function catalogProductsForApi(manifest) {
+  return manifest.catalog.products.map((product) => ({
+    product_id: product.id,
+    title: product.title,
+    brand: product.brand ?? null,
+    description: product.description ?? null,
+    image_url: product.image_url ?? null,
+    category_preset: manifest.category.id,
+    source_system: product.source_system ?? manifest.catalog.source_system,
+    manually_maintained: true,
+    variants: (product.variants ?? []).map((variant) => ({
+      sku: variant.sku,
+      parent_sku: variant.parent_sku ?? null,
+      model: variant.model ?? null,
+      variant_title: variant.title ?? variant.variant_title ?? null,
+      attributes: variant.attributes ?? {},
+      price_amount: variant.price_minor_units ?? product.price_minor_units,
+      currency: variant.currency ?? product.currency ?? manifest.catalog.currency,
+      tax_inclusive: variant.tax_inclusive ?? product.tax_inclusive ?? true,
+      gst_slab: variant.gst_slab ?? null,
+      tax_rate: variant.gst_rate ?? product.gst_rate ?? manifest.catalog.default_gst_rate,
+      hsn_code: variant.hsn_code ?? product.hsn_code ?? null,
+      availability_status: variant.availability_status ?? product.availability_status ?? 'unknown',
+      warranty_summary: variant.warranty_summary ?? product.warranty_summary ?? null,
+      return_policy_summary: variant.return_policy_summary ?? product.return_policy_summary ?? null,
+      source_system: variant.source_system ?? product.source_system ?? manifest.catalog.source_system,
+    })),
+  }));
 }
 
-console.log(JSON.stringify({
-  mode: 'dry-run',
-  status: 'not_executed',
-  would_write: false,
-  manifest_path: manifestArg,
-  provider: manifest.provider.provider_key,
-  live_flags: {
-    commerce_live_mode_enabled: manifest.live_flags.commerce_live_mode_enabled,
-    plural_live_enabled: manifest.live_flags.plural_live_enabled,
-    provider_live_payments_enabled: manifest.provider.live_payments_enabled,
-  },
-  staging_ids: {
-    tenant_id: manifest.tenant.id,
+function redactErrorCode(body) {
+  if (!body || typeof body !== 'object') return null;
+  const error = body.error && typeof body.error === 'object' ? body.error : null;
+  return String(body.code ?? error?.code ?? body.reason ?? '').slice(0, 96) || null;
+}
+
+async function requestJson(apiBase, request, authSource = null) {
+  const url = new URL(request.path, apiBase);
+  const headers = { accept: 'application/json' };
+  if (request.body !== undefined) headers['content-type'] = 'application/json';
+  if (authSource) headers.authorization = authorizationHeader(authSource);
+  const started = Date.now();
+  let response;
+  try {
+    response = await fetch(url, {
+      method: request.method,
+      headers,
+      body: request.body === undefined ? undefined : JSON.stringify(request.body),
+    });
+  } catch (error) {
+    fail(`Smoke seed request failed before HTTP response: ${request.label}: ${error.message}`);
+  }
+  const latencyMs = Date.now() - started;
+  let body = null;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  return {
+    label: request.label,
+    status: response.status,
+    ok: response.ok,
+    latency_ms: latencyMs,
+    error_code: response.ok ? null : redactErrorCode(body),
+    body,
+  };
+}
+
+function assertOk(result) {
+  if (!result.ok) {
+    fail(`Smoke seed request failed closed: ${result.label} returned HTTP ${result.status}${result.error_code ? ` (${result.error_code})` : ''}`);
+  }
+}
+
+function selectedIdsFromCatalogResponse(manifest, body) {
+  const selectedProduct = firstManifestProductWithVariant(manifest);
+  const data = body?.data && typeof body.data === 'object' ? body.data : {};
+  const variants = Array.isArray(data.variants) ? data.variants : [];
+  const selectedVariant = variants[0] && typeof variants[0] === 'object' ? variants[0] : null;
+  return {
     merchant_id: manifest.merchant.id,
     agent_id: manifest.agent.id,
-  },
-  catalog: {
-    product_count: products.length,
-    products_with_variants: productsWithVariants,
-    currency: manifest.catalog.currency,
-    tax_inclusive_pricing: manifest.catalog.tax_inclusive_pricing,
-  },
-  agenticorg_fixture_env_export: fixtureEnvExport,
-  redaction: {
-    secret_values_printed: false,
-    auth_material_printed: false,
-    passports_printed: false,
-    raw_payloads_printed: false,
-  },
-  future_run_mode: {
-    status: 'blocked_until_c2b',
-    required_guardrails: [
-      'explicit smoke DB target',
-      'smoke-only secret names',
-      'no production database',
-      'no generated auth material in tracked files',
-      'generated harness env under .tmp only',
-    ],
-  },
-}, null, 2));
+    product_id: String(data.id ?? data.product_id ?? selectedProduct?.id ?? ''),
+    variant_id: String(selectedVariant?.id ?? selectedProduct?.variants?.[0]?.id ?? ''),
+  };
+}
 
+async function executeSeedRun({ apiBase, manifest, fixtureEnvOutput, provider }) {
+  const authSource = requireExactlyOneAuthSource();
+  const catalogProducts = catalogProductsForApi(manifest);
+  const selectedProduct = firstManifestProductWithVariant(manifest);
+  const results = [];
+
+  for (const request of [
+    { label: 'health', method: 'GET', path: '/health' },
+    { label: 'jwks', method: 'GET', path: '/.well-known/jwks.json' },
+    { label: 'commerce_well_known', method: 'GET', path: '/.well-known/grantex-commerce' },
+  ]) {
+    const result = await requestJson(apiBase, request);
+    assertOk(result);
+    results.push(result);
+  }
+
+  const bulkPayload = {
+    merchant_id: manifest.merchant.id,
+    dry_run: true,
+    products: catalogProducts,
+  };
+  const bulkDryRun = await requestJson(apiBase, {
+    label: 'catalog_bulk_validate',
+    method: 'POST',
+    path: '/v1/commerce/catalog/products/bulk',
+    body: bulkPayload,
+  }, authSource);
+  assertOk(bulkDryRun);
+  results.push(bulkDryRun);
+
+  const bulkWrite = await requestJson(apiBase, {
+    label: 'catalog_bulk_upsert',
+    method: 'POST',
+    path: '/v1/commerce/catalog/products/bulk',
+    body: { ...bulkPayload, dry_run: false },
+  }, authSource);
+  assertOk(bulkWrite);
+  results.push(bulkWrite);
+
+  const catalogRead = await requestJson(apiBase, {
+    label: 'catalog_get_seeded_item',
+    method: 'GET',
+    path: `/v1/commerce/catalog/products/${encodeURIComponent(selectedProduct.id)}?merchant_id=${encodeURIComponent(manifest.merchant.id)}`,
+  }, authSource);
+  assertOk(catalogRead);
+  results.push(catalogRead);
+
+  const selectedIds = selectedIdsFromCatalogResponse(manifest, catalogRead.body);
+  const fixtureEnvExport = fixtureEnvOutput
+    ? writeAgenticOrgFixtureEnv({ outputPath: fixtureEnvOutput, apiBase, manifest, provider, selectedIds })
+    : { written: false };
+
+  return {
+    mode: 'run',
+    status: 'executed',
+    api_base_host: new URL(apiBase).hostname,
+    approved_requests: APPROVED_SEED_REQUESTS,
+    requests_made: results.length,
+    request_results: results.map((result) => ({
+      label: result.label,
+      http_status: result.status,
+      latency_ms: result.latency_ms,
+      error_code: result.error_code,
+    })),
+    provider,
+    staging_ids: selectedIds,
+    catalog: {
+      product_count: catalogProducts.length,
+      selected_product_id: selectedIds.product_id,
+      selected_variant_id: selectedIds.variant_id,
+    },
+    agenticorg_fixture_env_export: fixtureEnvExport,
+    redaction: {
+      secret_values_printed: false,
+      auth_material_printed: false,
+      passports_printed: false,
+      raw_payloads_printed: false,
+      idempotency_keys_printed: false,
+    },
+  };
+}
+
+function validateStaticGuardrails() {
+  if (isTrue(process.env.COMMERCE_LIVE_MODE_ENABLED) || cliFlagTrue('--commerce-live-mode-enabled')) {
+    fail('Refusing COMMERCE_LIVE_MODE_ENABLED=true for Option A smoke seed tooling');
+  }
+  if (isTrue(process.env.PLURAL_LIVE_ENABLED) || cliFlagTrue('--plural-live-enabled')) {
+    fail('Refusing PLURAL_LIVE_ENABLED=true for Option A smoke seed tooling');
+  }
+  if (cliFlagTrue('--live-payments', '--provider-live-payments-enabled')) {
+    fail('Refusing live payment flags for Option A smoke seed tooling');
+  }
+  if (cliFlagTrue('--live-plural', '--plural-live')) {
+    fail('Refusing live Plural flags for Option A smoke seed tooling');
+  }
+
+  assertNotProductionResourceName(argValue('--service-name', 'grantex-auth-smoke'), 'Cloud Run service');
+  assertNotProductionResourceName(argValue('--cloud-sql-instance', 'grantex-commerce-smoke-pg'), 'Cloud SQL instance');
+  assertNotProductionResourceName(argValue('--redis-instance', 'grantex-commerce-smoke-redis'), 'Redis instance');
+}
+
+async function main() {
+  const run = hasFlag('--run');
+  const dryRun = hasFlag('--dry-run') || !run;
+  if (run && hasFlag('--dry-run')) {
+    fail('Refusing both --run and --dry-run for Option A smoke seed tooling');
+  }
+
+  validateStaticGuardrails();
+
+  const manifestArg = argValue('--manifest', DEFAULT_MANIFEST);
+  const manifestPath = assertInsideRepo(manifestArg);
+  const manifest = loadManifest(manifestPath);
+  const provider = argValue('--provider', manifest.provider?.provider_key ?? 'mock');
+  assertEqual(provider, 'mock', 'Smoke seed provider must be mock');
+  const { products, productsWithVariants } = validateManifest(manifest);
+
+  const fixtureEnvOutput = argValue('--write-agenticorg-fixture-env', '');
+  let allowedSmokeOrigin = null;
+  let apiBase = '';
+  if (run || fixtureEnvOutput || argValue('--api-base', '')) {
+    const allowlistArg = argValue('--allow-smoke-cloud-run-url', process.env.COMMERCE_STAGING_ALLOWED_SMOKE_URL ?? '');
+    if (!allowlistArg) {
+      const apiBaseArg = argValue('--api-base', '');
+      if (apiBaseArg) {
+        const origin = parseUrl(apiBaseArg, 'Option A smoke API base');
+        if (new URL(origin).hostname.endsWith('.run.app')) {
+          fail('Refusing arbitrary run.app URL without exact --allow-smoke-cloud-run-url');
+        }
+      }
+      fail('Option A smoke runner requires the exact approved smoke URL allowlist');
+    }
+    allowedSmokeOrigin = validateSmokeAllowlist(allowlistArg);
+    apiBase = validateSmokeApiBase(argValue('--api-base', ''), allowedSmokeOrigin);
+  }
+  if (run && (!apiBase || !allowedSmokeOrigin)) {
+    fail('Option A smoke seed run requires --api-base and --allow-smoke-cloud-run-url');
+  }
+
+  if (run) {
+    const result = await executeSeedRun({
+      apiBase,
+      manifest,
+      fixtureEnvOutput: fixtureEnvOutput || DEFAULT_FIXTURE_ENV,
+      provider,
+    });
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  const fixtureEnvExport = fixtureEnvOutput
+    ? writeAgenticOrgFixtureEnv({ outputPath: fixtureEnvOutput, apiBase, manifest, provider, selectedIds: null })
+    : { written: false };
+  console.log(JSON.stringify({
+    mode: 'dry-run',
+    status: 'not_executed',
+    would_write_catalog: false,
+    requests_made: false,
+    manifest_path: manifestArg,
+    api_base_host: apiBase ? new URL(apiBase).hostname : null,
+    provider: manifest.provider.provider_key,
+    approved_run_requests: APPROVED_SEED_REQUESTS,
+    live_flags: {
+      commerce_live_mode_enabled: manifest.live_flags.commerce_live_mode_enabled,
+      plural_live_enabled: manifest.live_flags.plural_live_enabled,
+      provider_live_payments_enabled: manifest.provider.live_payments_enabled,
+    },
+    staging_ids: {
+      tenant_id: manifest.tenant.id,
+      merchant_id: manifest.merchant.id,
+      agent_id: manifest.agent.id,
+    },
+    catalog: {
+      product_count: products.length,
+      products_with_variants: productsWithVariants,
+      currency: manifest.catalog.currency,
+      tax_inclusive_pricing: manifest.catalog.tax_inclusive_pricing,
+    },
+    agenticorg_fixture_env_export: fixtureEnvExport,
+    redaction: {
+      secret_values_printed: false,
+      auth_material_printed: false,
+      passports_printed: false,
+      raw_payloads_printed: false,
+      idempotency_keys_printed: false,
+    },
+    run_mode: {
+      status: 'guarded_and_executable_after_approved_smoke_deploy',
+      required_guardrails: [
+        'explicit approved smoke API base',
+        'exact smoke Cloud Run allowlist',
+        'HTTPS run.app origin only',
+        'mock provider only',
+        'live flags false',
+        'smoke-only resource names',
+        'exactly one runtime auth source',
+        'AgenticOrg fixture env under .tmp only',
+      ],
+    },
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/commerce-option-a-smoke-seed.mjs
+++ b/scripts/commerce-option-a-smoke-seed.mjs
@@ -130,8 +130,110 @@ function assertNotProductionResourceName(value, label) {
   }
 }
 
+function safeString(value, label, { min = 0, max = 256, pattern = null, allowEmpty = false } = {}) {
+  if (typeof value !== 'string') {
+    fail(`Refusing non-string ${label}`);
+  }
+  const trimmed = value.trim();
+  if (!allowEmpty && trimmed.length === 0) {
+    fail(`Refusing empty ${label}`);
+  }
+  if (trimmed.length < min || trimmed.length > max) {
+    fail(`Refusing ${label} with invalid length`);
+  }
+  if (/[\r\n]/.test(trimmed)) {
+    fail(`Refusing ${label} with line breaks`);
+  }
+  if (pattern && !pattern.test(trimmed)) {
+    fail(`Refusing ${label} with unsupported characters`);
+  }
+  return trimmed;
+}
+
+function optionalSafeString(value, label, options = {}) {
+  if (value === null || value === undefined || value === '') return null;
+  return safeString(String(value), label, { ...options, allowEmpty: false });
+}
+
+function safeSyntheticId(value, label) {
+  return safeString(String(value ?? ''), label, {
+    min: 3,
+    max: 128,
+    pattern: /^[A-Za-z0-9_.:-]+$/,
+  });
+}
+
+function safeText(value, label) {
+  return safeString(String(value ?? ''), label, {
+    min: 1,
+    max: 512,
+    pattern: /^[A-Za-z0-9 .,()_:/+-]+$/,
+  });
+}
+
+function optionalSafeText(value, label) {
+  return optionalSafeString(value, label, {
+    max: 512,
+    pattern: /^[A-Za-z0-9 .,()_:/+-]+$/,
+  });
+}
+
+function safeCurrency(value, label) {
+  return safeString(String(value ?? ''), label, {
+    min: 3,
+    max: 3,
+    pattern: /^[A-Z]{3}$/,
+  });
+}
+
+function safeBoolean(value, label) {
+  if (typeof value !== 'boolean') {
+    fail(`Refusing non-boolean ${label}`);
+  }
+  return value;
+}
+
+function safeMinorUnits(value, label) {
+  if (!Number.isInteger(value) || value < 0 || value > 10_000_000) {
+    fail(`Refusing invalid ${label}`);
+  }
+  return value;
+}
+
+function safeRate(value, label) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 100) {
+    fail(`Refusing invalid ${label}`);
+  }
+  return value;
+}
+
+function safeAttributes(value, label) {
+  if (value === null || value === undefined) return {};
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    fail(`Refusing non-object ${label}`);
+  }
+  const safe = {};
+  for (const [key, nested] of Object.entries(value)) {
+    const safeKey = safeString(key, `${label} key`, {
+      min: 1,
+      max: 64,
+      pattern: /^[A-Za-z0-9_.:-]+$/,
+    });
+    safe[safeKey] = safeString(String(nested ?? ''), `${label}.${safeKey}`, {
+      max: 256,
+      pattern: /^[A-Za-z0-9 .,()_:/+-]*$/,
+      allowEmpty: true,
+    });
+  }
+  return safe;
+}
+
 function dotenvValue(value) {
-  return `"${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  const text = String(value);
+  if (/[\r\n]/.test(text)) {
+    fail('Refusing fixture env value with line breaks');
+  }
+  return `"${text.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 }
 
 function firstManifestProductWithVariant(manifest) {
@@ -159,6 +261,7 @@ function requireExactlyOneAuthSource() {
 
 function authorizationHeader(authSource) {
   const value = authSource.value.replace(/^Bearer\s+/i, '');
+  safeString(value, authSource.name, { min: 8, max: 8192, pattern: /^[A-Za-z0-9._~+/=-]+$/ });
   return `Bearer ${value}`;
 }
 
@@ -171,10 +274,15 @@ function writeAgenticOrgFixtureEnv({ outputPath, apiBase, manifest, provider, se
     fail('Refusing fixture env export with more than one Grantex auth env value present');
   }
 
-  const merchantId = selectedIds?.merchant_id ?? manifest.merchant.id;
-  const agentId = selectedIds?.agent_id ?? manifest.agent.id;
-  const productId = selectedIds?.product_id ?? selectedProduct?.id ?? '';
-  const variantId = selectedIds?.variant_id ?? selectedVariant?.id ?? '';
+  const merchantId = safeSyntheticId(selectedIds?.merchant_id ?? manifest.merchant.id, 'fixture merchant id');
+  const agentId = safeSyntheticId(selectedIds?.agent_id ?? manifest.agent.id, 'fixture agent id');
+  const productId = safeSyntheticId(selectedIds?.product_id ?? selectedProduct?.id ?? '', 'fixture product id');
+  const variantId = safeSyntheticId(selectedIds?.variant_id ?? selectedVariant?.id ?? '', 'fixture variant id');
+  const currency = safeCurrency(manifest.catalog.currency, 'fixture currency');
+  const amountMinorUnits = safeMinorUnits(
+    selectedVariant?.price_minor_units ?? selectedProduct?.price_minor_units ?? 0,
+    'fixture amount minor units',
+  );
   const sensitiveNamesWritten = [];
   const lines = [
     '# AgenticOrg Commerce real-staging fixture env.',
@@ -191,8 +299,8 @@ function writeAgenticOrgFixtureEnv({ outputPath, apiBase, manifest, provider, se
     `AGENTICORG_COMMERCE_FIXTURE_AGENT_ID=${dotenvValue(agentId)}`,
     `AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID=${dotenvValue(productId)}`,
     `AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID=${dotenvValue(variantId)}`,
-    `AGENTICORG_COMMERCE_FIXTURE_CURRENCY=${dotenvValue(manifest.catalog.currency)}`,
-    `AGENTICORG_COMMERCE_FIXTURE_AMOUNT_MINOR_UNITS=${dotenvValue(selectedVariant?.price_minor_units ?? selectedProduct?.price_minor_units ?? 0)}`,
+    `AGENTICORG_COMMERCE_FIXTURE_CURRENCY=${dotenvValue(currency)}`,
+    `AGENTICORG_COMMERCE_FIXTURE_AMOUNT_MINOR_UNITS=${dotenvValue(amountMinorUnits)}`,
     'AGENTICORG_COMMERCE_FIXTURE_PASSPORT_MAX_AMOUNT_MINOR_UNITS="250000"',
   ];
 
@@ -316,31 +424,79 @@ function validateManifest(manifest) {
 }
 
 function catalogProductsForApi(manifest) {
-  return manifest.catalog.products.map((product) => ({
-    product_id: product.id,
-    title: product.title,
-    brand: product.brand ?? null,
-    description: product.description ?? null,
-    image_url: product.image_url ?? null,
-    category_preset: manifest.category.id,
-    source_system: product.source_system ?? manifest.catalog.source_system,
+  const categoryPreset = safeSyntheticId(manifest.category.id, 'manifest category id');
+  const catalogSource = safeSyntheticId(manifest.catalog.source_system, 'manifest catalog source system');
+  const defaultCurrency = safeCurrency(manifest.catalog.currency, 'manifest catalog currency');
+  const defaultTaxRate = safeRate(manifest.catalog.default_gst_rate, 'manifest default GST rate');
+  return manifest.catalog.products.map((product, productIndex) => ({
+    product_id: safeSyntheticId(product.id, `manifest product ${productIndex} id`),
+    title: safeText(product.title, `manifest product ${productIndex} title`),
+    brand: optionalSafeText(product.brand, `manifest product ${productIndex} brand`),
+    description: optionalSafeText(product.description, `manifest product ${productIndex} description`),
+    image_url: optionalSafeString(product.image_url, `manifest product ${productIndex} image url`, {
+      max: 512,
+      pattern: /^https:\/\/[A-Za-z0-9./:_?=&%-]+$/,
+    }),
+    category_preset: categoryPreset,
+    source_system: optionalSafeString(product.source_system, `manifest product ${productIndex} source system`, {
+      max: 128,
+      pattern: /^[A-Za-z0-9_.:-]+$/,
+    }) ?? catalogSource,
     manually_maintained: true,
-    variants: (product.variants ?? []).map((variant) => ({
-      sku: variant.sku,
-      parent_sku: variant.parent_sku ?? null,
-      model: variant.model ?? null,
-      variant_title: variant.title ?? variant.variant_title ?? null,
-      attributes: variant.attributes ?? {},
-      price_amount: variant.price_minor_units ?? product.price_minor_units,
-      currency: variant.currency ?? product.currency ?? manifest.catalog.currency,
-      tax_inclusive: variant.tax_inclusive ?? product.tax_inclusive ?? true,
-      gst_slab: variant.gst_slab ?? null,
-      tax_rate: variant.gst_rate ?? product.gst_rate ?? manifest.catalog.default_gst_rate,
-      hsn_code: variant.hsn_code ?? product.hsn_code ?? null,
-      availability_status: variant.availability_status ?? product.availability_status ?? 'unknown',
-      warranty_summary: variant.warranty_summary ?? product.warranty_summary ?? null,
-      return_policy_summary: variant.return_policy_summary ?? product.return_policy_summary ?? null,
-      source_system: variant.source_system ?? product.source_system ?? manifest.catalog.source_system,
+    variants: (product.variants ?? []).map((variant, variantIndex) => ({
+      sku: safeSyntheticId(variant.sku, `manifest product ${productIndex} variant ${variantIndex} sku`),
+      parent_sku: optionalSafeString(variant.parent_sku, `manifest product ${productIndex} variant ${variantIndex} parent sku`, {
+        max: 128,
+        pattern: /^[A-Za-z0-9_.:-]+$/,
+      }),
+      model: optionalSafeText(variant.model, `manifest product ${productIndex} variant ${variantIndex} model`),
+      variant_title: optionalSafeText(
+        variant.title ?? variant.variant_title,
+        `manifest product ${productIndex} variant ${variantIndex} title`,
+      ),
+      attributes: safeAttributes(variant.attributes, `manifest product ${productIndex} variant ${variantIndex} attributes`),
+      price_amount: safeMinorUnits(
+        variant.price_minor_units ?? product.price_minor_units,
+        `manifest product ${productIndex} variant ${variantIndex} price`,
+      ),
+      currency: safeCurrency(
+        variant.currency ?? product.currency ?? defaultCurrency,
+        `manifest product ${productIndex} variant ${variantIndex} currency`,
+      ),
+      tax_inclusive: safeBoolean(
+        variant.tax_inclusive ?? product.tax_inclusive ?? true,
+        `manifest product ${productIndex} variant ${variantIndex} tax inclusive`,
+      ),
+      gst_slab: optionalSafeString(variant.gst_slab, `manifest product ${productIndex} variant ${variantIndex} GST slab`, {
+        max: 64,
+        pattern: /^[A-Za-z0-9_.:-]+$/,
+      }),
+      tax_rate: safeRate(
+        variant.gst_rate ?? product.gst_rate ?? defaultTaxRate,
+        `manifest product ${productIndex} variant ${variantIndex} tax rate`,
+      ),
+      hsn_code: optionalSafeString(variant.hsn_code ?? product.hsn_code, `manifest product ${productIndex} variant ${variantIndex} HSN`, {
+        max: 32,
+        pattern: /^[A-Za-z0-9_.:-]+$/,
+      }),
+      availability_status: safeString(
+        String(variant.availability_status ?? product.availability_status ?? 'unknown'),
+        `manifest product ${productIndex} variant ${variantIndex} availability`,
+        { min: 1, max: 64, pattern: /^[A-Za-z0-9_.:-]+$/ },
+      ),
+      warranty_summary: optionalSafeText(
+        variant.warranty_summary ?? product.warranty_summary,
+        `manifest product ${productIndex} variant ${variantIndex} warranty`,
+      ),
+      return_policy_summary: optionalSafeText(
+        variant.return_policy_summary ?? product.return_policy_summary,
+        `manifest product ${productIndex} variant ${variantIndex} return policy`,
+      ),
+      source_system: optionalSafeString(
+        variant.source_system ?? product.source_system,
+        `manifest product ${productIndex} variant ${variantIndex} source system`,
+        { max: 128, pattern: /^[A-Za-z0-9_.:-]+$/ },
+      ) ?? catalogSource,
     })),
   }));
 }
@@ -396,10 +552,10 @@ function selectedIdsFromCatalogResponse(manifest, body) {
   const variants = Array.isArray(data.variants) ? data.variants : [];
   const selectedVariant = variants[0] && typeof variants[0] === 'object' ? variants[0] : null;
   return {
-    merchant_id: manifest.merchant.id,
-    agent_id: manifest.agent.id,
-    product_id: String(data.id ?? data.product_id ?? selectedProduct?.id ?? ''),
-    variant_id: String(selectedVariant?.id ?? selectedProduct?.variants?.[0]?.id ?? ''),
+    merchant_id: safeSyntheticId(manifest.merchant.id, 'manifest merchant id'),
+    agent_id: safeSyntheticId(manifest.agent.id, 'manifest agent id'),
+    product_id: safeSyntheticId(String(data.id ?? data.product_id ?? selectedProduct?.id ?? ''), 'seeded product id'),
+    variant_id: safeSyntheticId(String(selectedVariant?.id ?? selectedProduct?.variants?.[0]?.id ?? ''), 'seeded variant id'),
   };
 }
 
@@ -407,6 +563,8 @@ async function executeSeedRun({ apiBase, manifest, fixtureEnvOutput, provider })
   const authSource = requireExactlyOneAuthSource();
   const catalogProducts = catalogProductsForApi(manifest);
   const selectedProduct = firstManifestProductWithVariant(manifest);
+  const merchantId = safeSyntheticId(manifest.merchant.id, 'manifest merchant id');
+  const selectedProductId = safeSyntheticId(selectedProduct.id, 'manifest selected product id');
   const results = [];
 
   for (const request of [
@@ -420,7 +578,7 @@ async function executeSeedRun({ apiBase, manifest, fixtureEnvOutput, provider })
   }
 
   const bulkPayload = {
-    merchant_id: manifest.merchant.id,
+    merchant_id: merchantId,
     dry_run: true,
     products: catalogProducts,
   };
@@ -445,7 +603,7 @@ async function executeSeedRun({ apiBase, manifest, fixtureEnvOutput, provider })
   const catalogRead = await requestJson(apiBase, {
     label: 'catalog_get_seeded_item',
     method: 'GET',
-    path: `/v1/commerce/catalog/products/${encodeURIComponent(selectedProduct.id)}?merchant_id=${encodeURIComponent(manifest.merchant.id)}`,
+    path: `/v1/commerce/catalog/products/${encodeURIComponent(selectedProductId)}?merchant_id=${encodeURIComponent(merchantId)}`,
   }, authSource);
   assertOk(catalogRead);
   results.push(catalogRead);
@@ -506,7 +664,6 @@ function validateStaticGuardrails() {
 
 async function main() {
   const run = hasFlag('--run');
-  const dryRun = hasFlag('--dry-run') || !run;
   if (run && hasFlag('--dry-run')) {
     fail('Refusing both --run and --dry-run for Option A smoke seed tooling');
   }

--- a/scripts/commerce-option-a-smoke-seed.mjs
+++ b/scripts/commerce-option-a-smoke-seed.mjs
@@ -14,6 +14,25 @@ const REFUSED_PRODUCTION_ORIGINS = [
 ];
 const REFUSED_PRODUCTION_RESOURCE_NAMES = new Set(['grantex-auth', 'grantex-pg16', 'grantex-redis']);
 const AUTH_ENV_NAMES = ['GRANTEX_COMMERCE_BEARER_TOKEN', 'GRANTEX_AGENT_ASSERTION', 'GRANTEX_API_KEY'];
+const SMOKE_TENANT_ID = 'cten_staging_commerce';
+const SMOKE_MERCHANT_ID = 'mch_staging_electronics_pilot';
+const SMOKE_AGENT_ID = 'cag_staging_agenticorg_sales';
+const SMOKE_CATEGORY_ID = 'electronics_appliances';
+const SMOKE_SOURCE_SYSTEM = 'synthetic_staging_manifest';
+const APPROVED_SMOKE_CATALOG_PRODUCTS = [
+  ['cprd_stg_induction_cooktop', 'Staging Induction Cooktop', 329900, [['cvar_stg_induction_black', 'STG-COOKTOP-BLK', 'Black 1800W', 329900]]],
+  ['cprd_stg_air_purifier', 'Staging Smart Air Purifier', 899900, [['cvar_stg_air_purifier_room', 'STG-AIR-ROOM', 'Room 300 sqft', 899900]]],
+  ['cprd_stg_mixer_grinder', 'Staging Mixer Grinder', 459900, [['cvar_stg_mixer_500w', 'STG-MIX-500', '500W 3 Jar', 459900]]],
+  ['cprd_stg_water_purifier', 'Staging Water Purifier', 1499900, [['cvar_stg_water_purifier_ro', 'STG-WATER-RO', 'RO UV Copper', 1499900]]],
+  ['cprd_stg_egg_boiler', 'Staging Egg Boiler', 129900, [['cvar_stg_egg_boiler_6', 'STG-EGG-6', 'Six Egg', 129900]]],
+  ['cprd_stg_hand_blender', 'Staging Hand Blender', 189900, [['cvar_stg_hand_blender_300w', 'STG-BLEND-300', '300W', 189900]]],
+  ['cprd_stg_room_heater', 'Staging Room Heater', 249900, [['cvar_stg_room_heater_2000w', 'STG-HEATER-2000', '2000W', 249900]]],
+  ['cprd_stg_robot_vacuum', 'Staging Robot Vacuum', 2299900, [['cvar_stg_robot_vacuum_lidar', 'STG-VAC-LIDAR', 'LiDAR', 2299900]]],
+  ['cprd_stg_smart_kettle', 'Staging Smart Kettle', 299900, [['cvar_stg_smart_kettle_17l', 'STG-KETTLE-17', '1.7L', 299900]]],
+  ['cprd_stg_table_fan', 'Staging Table Fan', 219900, [['cvar_stg_table_fan_400mm', 'STG-FAN-400', '400mm', 219900]]],
+  ['cprd_stg_toaster', 'Staging Toaster', 259900, [['cvar_stg_toaster_2slice', 'STG-TOAST-2', '2 Slice', 259900]]],
+  ['cprd_stg_washing_machine', 'Staging Washing Machine', 2799900, [['cvar_stg_washing_machine_7kg', 'STG-WASH-7KG', '7kg', 2799900]]],
+];
 const OPTIONAL_SENSITIVE_FIXTURE_ENV_NAMES = [
   'AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT',
   'AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT',
@@ -150,31 +169,11 @@ function safeString(value, label, { min = 0, max = 256, pattern = null, allowEmp
   return trimmed;
 }
 
-function optionalSafeString(value, label, options = {}) {
-  if (value === null || value === undefined || value === '') return null;
-  return safeString(String(value), label, { ...options, allowEmpty: false });
-}
-
 function safeSyntheticId(value, label) {
   return safeString(String(value ?? ''), label, {
     min: 3,
     max: 128,
     pattern: /^[A-Za-z0-9_.:-]+$/,
-  });
-}
-
-function safeText(value, label) {
-  return safeString(String(value ?? ''), label, {
-    min: 1,
-    max: 512,
-    pattern: /^[A-Za-z0-9 .,()_:/+-]+$/,
-  });
-}
-
-function optionalSafeText(value, label) {
-  return optionalSafeString(value, label, {
-    max: 512,
-    pattern: /^[A-Za-z0-9 .,()_:/+-]+$/,
   });
 }
 
@@ -186,46 +185,11 @@ function safeCurrency(value, label) {
   });
 }
 
-function safeBoolean(value, label) {
-  if (typeof value !== 'boolean') {
-    fail(`Refusing non-boolean ${label}`);
-  }
-  return value;
-}
-
 function safeMinorUnits(value, label) {
   if (!Number.isInteger(value) || value < 0 || value > 10_000_000) {
     fail(`Refusing invalid ${label}`);
   }
   return value;
-}
-
-function safeRate(value, label) {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 100) {
-    fail(`Refusing invalid ${label}`);
-  }
-  return value;
-}
-
-function safeAttributes(value, label) {
-  if (value === null || value === undefined) return {};
-  if (typeof value !== 'object' || Array.isArray(value)) {
-    fail(`Refusing non-object ${label}`);
-  }
-  const safe = {};
-  for (const [key, nested] of Object.entries(value)) {
-    const safeKey = safeString(key, `${label} key`, {
-      min: 1,
-      max: 64,
-      pattern: /^[A-Za-z0-9_.:-]+$/,
-    });
-    safe[safeKey] = safeString(String(nested ?? ''), `${label}.${safeKey}`, {
-      max: 256,
-      pattern: /^[A-Za-z0-9 .,()_:/+-]*$/,
-      allowEmpty: true,
-    });
-  }
-  return safe;
 }
 
 function dotenvValue(value) {
@@ -239,6 +203,21 @@ function dotenvValue(value) {
 function firstManifestProductWithVariant(manifest) {
   const products = manifest.catalog?.products ?? [];
   return products.find((product) => Array.isArray(product.variants) && product.variants.length > 0) ?? products[0];
+}
+
+function firstApprovedProductWithVariant() {
+  const [productId, title, priceMinorUnits, variants] = APPROVED_SMOKE_CATALOG_PRODUCTS[0];
+  return {
+    product_id: productId,
+    title,
+    price_minor_units: priceMinorUnits,
+    variants: variants.map(([variantId, sku, variantTitle, variantPriceMinorUnits]) => ({
+      id: variantId,
+      sku,
+      title: variantTitle,
+      price_minor_units: variantPriceMinorUnits,
+    })),
+  };
 }
 
 function shortHash(value) {
@@ -408,9 +387,9 @@ function validateManifest(manifest) {
   assertEqual(manifest.provider?.plural_live_enabled, false, 'Smoke seed live Plural flag must be false');
   assertEqual(manifest.live_flags?.commerce_live_mode_enabled, false, 'Smoke seed live commerce flag must be false');
   assertEqual(manifest.live_flags?.plural_live_enabled, false, 'Smoke seed live Plural flag must be false');
-  assertEqual(manifest.tenant?.id, 'cten_staging_commerce', 'Smoke seed tenant id is pinned');
-  assertEqual(manifest.merchant?.id, 'mch_staging_electronics_pilot', 'Smoke seed merchant id is pinned');
-  assertEqual(manifest.agent?.id, 'cag_staging_agenticorg_sales', 'Smoke seed agent id is pinned');
+  assertEqual(manifest.tenant?.id, SMOKE_TENANT_ID, 'Smoke seed tenant id is pinned');
+  assertEqual(manifest.merchant?.id, SMOKE_MERCHANT_ID, 'Smoke seed merchant id is pinned');
+  assertEqual(manifest.agent?.id, SMOKE_AGENT_ID, 'Smoke seed agent id is pinned');
 
   const products = manifest.catalog?.products;
   if (!Array.isArray(products) || products.length < 10 || products.length > 25) {
@@ -423,80 +402,40 @@ function validateManifest(manifest) {
   return { products, productsWithVariants };
 }
 
-function catalogProductsForApi(manifest) {
-  const categoryPreset = safeSyntheticId(manifest.category.id, 'manifest category id');
-  const catalogSource = safeSyntheticId(manifest.catalog.source_system, 'manifest catalog source system');
-  const defaultCurrency = safeCurrency(manifest.catalog.currency, 'manifest catalog currency');
-  const defaultTaxRate = safeRate(manifest.catalog.default_gst_rate, 'manifest default GST rate');
-  return manifest.catalog.products.map((product, productIndex) => ({
-    product_id: safeSyntheticId(product.id, `manifest product ${productIndex} id`),
-    title: safeText(product.title, `manifest product ${productIndex} title`),
-    brand: optionalSafeText(product.brand, `manifest product ${productIndex} brand`),
-    description: optionalSafeText(product.description, `manifest product ${productIndex} description`),
-    image_url: optionalSafeString(product.image_url, `manifest product ${productIndex} image url`, {
-      max: 512,
-      pattern: /^https:\/\/[A-Za-z0-9./:_?=&%-]+$/,
-    }),
-    category_preset: categoryPreset,
-    source_system: optionalSafeString(product.source_system, `manifest product ${productIndex} source system`, {
+function catalogProductsForApi() {
+  return APPROVED_SMOKE_CATALOG_PRODUCTS.map(([productId, title, priceMinorUnits, variants], productIndex) => ({
+    product_id: safeSyntheticId(productId, `approved smoke product ${productIndex} id`),
+    title: safeString(title, `approved smoke product ${productIndex} title`, {
+      min: 1,
       max: 128,
-      pattern: /^[A-Za-z0-9_.:-]+$/,
-    }) ?? catalogSource,
+      pattern: /^[A-Za-z0-9 .()-]+$/,
+    }),
+    brand: 'Grantex Demo',
+    description: null,
+    image_url: null,
+    category_preset: SMOKE_CATEGORY_ID,
+    source_system: SMOKE_SOURCE_SYSTEM,
     manually_maintained: true,
-    variants: (product.variants ?? []).map((variant, variantIndex) => ({
-      sku: safeSyntheticId(variant.sku, `manifest product ${productIndex} variant ${variantIndex} sku`),
-      parent_sku: optionalSafeString(variant.parent_sku, `manifest product ${productIndex} variant ${variantIndex} parent sku`, {
+    variants: variants.map(([, sku, variantTitle, variantPriceMinorUnits], variantIndex) => ({
+      sku: safeSyntheticId(sku, `approved smoke product ${productIndex} variant ${variantIndex} sku`),
+      parent_sku: null,
+      model: null,
+      variant_title: safeString(variantTitle, `approved smoke product ${productIndex} variant ${variantIndex} title`, {
+        min: 1,
         max: 128,
-        pattern: /^[A-Za-z0-9_.:-]+$/,
+        pattern: /^[A-Za-z0-9 .()-]+$/,
       }),
-      model: optionalSafeText(variant.model, `manifest product ${productIndex} variant ${variantIndex} model`),
-      variant_title: optionalSafeText(
-        variant.title ?? variant.variant_title,
-        `manifest product ${productIndex} variant ${variantIndex} title`,
-      ),
-      attributes: safeAttributes(variant.attributes, `manifest product ${productIndex} variant ${variantIndex} attributes`),
-      price_amount: safeMinorUnits(
-        variant.price_minor_units ?? product.price_minor_units,
-        `manifest product ${productIndex} variant ${variantIndex} price`,
-      ),
-      currency: safeCurrency(
-        variant.currency ?? product.currency ?? defaultCurrency,
-        `manifest product ${productIndex} variant ${variantIndex} currency`,
-      ),
-      tax_inclusive: safeBoolean(
-        variant.tax_inclusive ?? product.tax_inclusive ?? true,
-        `manifest product ${productIndex} variant ${variantIndex} tax inclusive`,
-      ),
-      gst_slab: optionalSafeString(variant.gst_slab, `manifest product ${productIndex} variant ${variantIndex} GST slab`, {
-        max: 64,
-        pattern: /^[A-Za-z0-9_.:-]+$/,
-      }),
-      tax_rate: safeRate(
-        variant.gst_rate ?? product.gst_rate ?? defaultTaxRate,
-        `manifest product ${productIndex} variant ${variantIndex} tax rate`,
-      ),
-      hsn_code: optionalSafeString(variant.hsn_code ?? product.hsn_code, `manifest product ${productIndex} variant ${variantIndex} HSN`, {
-        max: 32,
-        pattern: /^[A-Za-z0-9_.:-]+$/,
-      }),
-      availability_status: safeString(
-        String(variant.availability_status ?? product.availability_status ?? 'unknown'),
-        `manifest product ${productIndex} variant ${variantIndex} availability`,
-        { min: 1, max: 64, pattern: /^[A-Za-z0-9_.:-]+$/ },
-      ),
-      warranty_summary: optionalSafeText(
-        variant.warranty_summary ?? product.warranty_summary,
-        `manifest product ${productIndex} variant ${variantIndex} warranty`,
-      ),
-      return_policy_summary: optionalSafeText(
-        variant.return_policy_summary ?? product.return_policy_summary,
-        `manifest product ${productIndex} variant ${variantIndex} return policy`,
-      ),
-      source_system: optionalSafeString(
-        variant.source_system ?? product.source_system,
-        `manifest product ${productIndex} variant ${variantIndex} source system`,
-        { max: 128, pattern: /^[A-Za-z0-9_.:-]+$/ },
-      ) ?? catalogSource,
+      attributes: {},
+      price_amount: safeMinorUnits(variantPriceMinorUnits ?? priceMinorUnits, `approved smoke product ${productIndex} variant ${variantIndex} price`),
+      currency: 'INR',
+      tax_inclusive: true,
+      gst_slab: null,
+      tax_rate: 0.18,
+      hsn_code: null,
+      availability_status: 'in_stock',
+      warranty_summary: 'Synthetic staging warranty.',
+      return_policy_summary: 'Synthetic staging returns.',
+      source_system: SMOKE_SOURCE_SYSTEM,
     })),
   }));
 }
@@ -546,25 +485,25 @@ function assertOk(result) {
   }
 }
 
-function selectedIdsFromCatalogResponse(manifest, body) {
-  const selectedProduct = firstManifestProductWithVariant(manifest);
+function selectedIdsFromCatalogResponse(body) {
+  const selectedProduct = firstApprovedProductWithVariant();
   const data = body?.data && typeof body.data === 'object' ? body.data : {};
   const variants = Array.isArray(data.variants) ? data.variants : [];
   const selectedVariant = variants[0] && typeof variants[0] === 'object' ? variants[0] : null;
   return {
-    merchant_id: safeSyntheticId(manifest.merchant.id, 'manifest merchant id'),
-    agent_id: safeSyntheticId(manifest.agent.id, 'manifest agent id'),
-    product_id: safeSyntheticId(String(data.id ?? data.product_id ?? selectedProduct?.id ?? ''), 'seeded product id'),
-    variant_id: safeSyntheticId(String(selectedVariant?.id ?? selectedProduct?.variants?.[0]?.id ?? ''), 'seeded variant id'),
+    merchant_id: SMOKE_MERCHANT_ID,
+    agent_id: SMOKE_AGENT_ID,
+    product_id: safeSyntheticId(String(data.id ?? data.product_id ?? selectedProduct.product_id), 'seeded product id'),
+    variant_id: safeSyntheticId(String(selectedVariant?.id ?? selectedProduct.variants[0].id), 'seeded variant id'),
   };
 }
 
 async function executeSeedRun({ apiBase, manifest, fixtureEnvOutput, provider }) {
   const authSource = requireExactlyOneAuthSource();
-  const catalogProducts = catalogProductsForApi(manifest);
-  const selectedProduct = firstManifestProductWithVariant(manifest);
-  const merchantId = safeSyntheticId(manifest.merchant.id, 'manifest merchant id');
-  const selectedProductId = safeSyntheticId(selectedProduct.id, 'manifest selected product id');
+  const catalogProducts = catalogProductsForApi();
+  const selectedProduct = firstApprovedProductWithVariant();
+  const merchantId = SMOKE_MERCHANT_ID;
+  const selectedProductId = selectedProduct.product_id;
   const results = [];
 
   for (const request of [
@@ -608,7 +547,7 @@ async function executeSeedRun({ apiBase, manifest, fixtureEnvOutput, provider })
   assertOk(catalogRead);
   results.push(catalogRead);
 
-  const selectedIds = selectedIdsFromCatalogResponse(manifest, catalogRead.body);
+  const selectedIds = selectedIdsFromCatalogResponse(catalogRead.body);
   const fixtureEnvExport = fixtureEnvOutput
     ? writeAgenticOrgFixtureEnv({ outputPath: fixtureEnvOutput, apiBase, manifest, provider, selectedIds })
     : { written: false };


### PR DESCRIPTION
## Summary

Adds executable but fail-closed Option A smoke runner paths for the later approved C2D paid smoke run.

- `commerce-option-a-smoke-seed.mjs` keeps dry-run as default and allows `--run` only with exact approved HTTPS `run.app` smoke URL allowlisting, mock provider, false live flags, smoke-only resource names, and exactly one runtime auth source.
- `commerce-option-a-smoke-evidence.mjs` keeps dry-run as default and allows `--run` only with the same smoke guardrails plus a required `.tmp/commerce-agent-real-staging.env` fixture env for AgenticOrg handoff.
- Updates the repeatable workflow, runbook, and validator coverage for C2D-prep runner behavior, refusal checks, `.tmp` fixture rules, and committed-doc secret-looking value scans.

## Safety

This PR does not deploy, create cloud resources, change production config, enable production Commerce V1, enable live payments, enable live Plural, or touch production secrets. Runtime auth, passport, idempotency, provider, DB/Redis, and private key material remains unprinted and uncommitted.

## Validation

- `node docs/commerce-v1-pilot-readiness.validate.mjs`
- `node scripts/commerce-option-a-smoke-seed.mjs --dry-run --manifest=docs/examples/commerce-staging-seed.manifest.json`
- `node scripts/commerce-option-a-smoke-evidence.mjs --dry-run --api-base=https://example.run.app --allow-smoke-cloud-run-url=https://example.run.app`
- Expected fail-closed checks for production URL, arbitrary `run.app`, HTTP localhost, fixture path outside `.tmp`, live flags true, non-mock provider, missing run auth, missing run fixture
- Focused value-leak scan across changed docs/scripts
- `git diff --check`

## Remaining Manual C2D Work

Resource creation, secret values, smoke service deploy, migrations, approved smoke execution, AgenticOrg local real-staging eval, cleanup, and scrubbed evidence packaging remain separate approval-gated C2D steps.