### PR TITLE
docs(commerce): record c2f smoke evidence

### DIFF
--- a/docs/reports/commerce-v1-option-a-smoke-evidence.md
+++ b/docs/reports/commerce-v1-option-a-smoke-evidence.md
@@ -1,10 +1,10 @@
 # Commerce V1 Option A Smoke Evidence
 
-Status: C2E approved smoke evidence captured from a temporary Option A smoke service. This report is scrubbed and contains no bearer token values, passports, idempotency key values, webhook secrets, provider credentials, raw payloads, DB/Redis URLs, private keys, or secret values.
+Status: C2F approved smoke evidence captured from a temporary Option A smoke service. This report is scrubbed and contains no bearer token values, passports, idempotency key values, webhook secrets, provider credentials, raw payloads, DB/Redis URLs, private keys, or secret values.
 
-Generated at: 2026-05-16T15:12:37.892Z
+Generated at: 2026-05-16T17:09:09.274Z
 
-Target host: grantex-auth-smoke-876335597959.us-central1.run.app
+Target host: grantex-auth-smoke-dd4mtrt2gq-uc.a.run.app
 
 Provider: mock
 
@@ -17,8 +17,8 @@ Variable names used: GRANTEX_COMMERCE_BASE_URL, GRANTEX_BASE_URL, AGENTICORG_COM
 Synthetic IDs:
 - Merchant: mch_staging_electronics_pilot
 - Agent: cag_staging_agenticorg_sales
-- Product: cprd_01KRRN1K5HSQV7MGEDP8PD54Z2
-- Variant: cvar_01KRRN1K5TB1MQ10GJJB91H2YT
+- Product: cprd_01KRRW5GHPGK90F3CD7TH1X5C6
+- Variant: cvar_01KRRW5GHY3M38WKMDXKD1MHKR
 
 ## Summary
 
@@ -27,30 +27,34 @@ Synthetic IDs:
 - Failed-safe: 6
 - Skipped: 0
 
+## C2F Payment-Intent Check
+
+The positive payment intent path passed against the temporary smoke service with provider `mock`, Commerce live mode false, live payments false, and live Plural false.
+
 ## Case Results
 
 | Case | Status | HTTP | Latency ms | Error code | Synthetic refs |
 | --- | --- | ---: | ---: | --- | --- |
-| health | passed | 200 | 454 |  |  |
-| jwks | passed | 200 | 321 |  |  |
-| commerce_well_known | passed | 200 | 296 |  |  |
+| health | passed | 200 | 389 |  |  |
+| jwks | passed | 200 | 331 |  |  |
+| commerce_well_known | passed | 200 | 290 |  |  |
 | mcp_initialize | passed | 200 | 303 |  |  |
-| mcp_tools_list | passed | 200 | 302 |  |  |
-| merchant_profile | passed | 200 | 295 |  | merchant_id=mch_staging_electronics_pilot |
-| catalog_search | passed | 200 | 335 |  | merchant_id=mch_staging_electronics_pilot |
-| catalog_get_item | passed | 200 | 328 |  | product_id=cprd_01KRRN1K5HSQV7MGEDP8PD54Z2 |
-| inventory_check | passed | 200 | 310 |  | variant_id=cvar_01KRRN1K5TB1MQ10GJJB91H2YT |
-| cart_create | passed | 200 | 465 |  | cart_id=ccart_01KRRNH8M8ZKWMRMDD5PN658BE |
-| consent_request | passed | 201 | 356 |  | consent_request_id=IPLGk3vA0Utxt3DI6ADo1ubBavQP2yLd |
-| consent_exchange | failed-safe | 409 | 319 | consent_not_granted |  |
-| payment_intent_create | passed | 200 | 416 |  | payment_intent_id=cpi_01KRRNH9P3Y50WGAETGSHKDNHA |
-| checkout_create | passed | 200 | 381 |  | payment_intent_id=cpi_01KRRNH9P3Y50WGAETGSHKDNHA |
-| payment_status | passed | 200 | 325 |  | payment_intent_id=cpi_01KRRNH9P3Y50WGAETGSHKDNHA |
-| missing_consent_refusal | failed-safe | 200 | 309 | validation_failed |  |
-| amount_cap_breach_refusal | failed-safe | 200 | 319 | cart_not_payable |  |
-| revoked_passport_refusal | failed-safe | 200 | 347 | cart_not_payable |  |
-| expired_passport_refusal | failed-safe | 200 | 308 | cart_not_payable |  |
-| denied_consent_refusal | failed-safe | 403 | 303 | consent_denied |  |
+| mcp_tools_list | passed | 200 | 292 |  |  |
+| merchant_profile | passed | 200 | 311 |  | merchant_id=mch_staging_electronics_pilot |
+| catalog_search | passed | 200 | 318 |  | merchant_id=mch_staging_electronics_pilot |
+| catalog_get_item | passed | 200 | 306 |  | product_id=cprd_01KRRW5GHPGK90F3CD7TH1X5C6 |
+| inventory_check | passed | 200 | 301 |  | variant_id=cvar_01KRRW5GHY3M38WKMDXKD1MHKR |
+| cart_create | passed | 200 | 436 |  | cart_id=ccart_01KRRW6M9EGNR30KWDR303R8KK |
+| consent_request | passed | 201 | 320 |  | consent_request_id=gmAMG7jQMeASLr2IUymZAXF3yyqNnLJP |
+| consent_exchange | failed-safe | 409 | 312 | consent_not_granted |  |
+| payment_intent_create | passed | 200 | 361 |  | payment_intent_id=cpi_01KRRW6N8F3HET2ANSB55RY1PS |
+| checkout_create | passed | 200 | 350 |  | payment_intent_id=cpi_01KRRW6N8F3HET2ANSB55RY1PS |
+| payment_status | passed | 200 | 302 |  | payment_intent_id=cpi_01KRRW6N8F3HET2ANSB55RY1PS |
+| missing_consent_refusal | failed-safe | 200 | 305 | validation_failed |  |
+| amount_cap_breach_refusal | failed-safe | 200 | 300 | cart_not_payable |  |
+| revoked_passport_refusal | failed-safe | 200 | 313 | cart_not_payable |  |
+| expired_passport_refusal | failed-safe | 200 | 322 | cart_not_payable |  |
+| denied_consent_refusal | failed-safe | 403 | 305 | consent_denied |  |
 
 ## Cleanup Status
 
@@ -59,20 +63,11 @@ Cleanup completed after evidence capture.
 Deleted temporary Cloud Run service: grantex-auth-smoke
 Deleted temporary Cloud SQL instance: grantex-commerce-smoke-pg
 Deleted temporary Redis instance: grantex-commerce-smoke-redis
-
-Deleted temporary smoke resources:
-- Smoke secrets: grantex-smoke-* only
-- Smoke image tag: auth-service-smoke:42f602bbecb1358794e8743dd4b162d92fe3cdc2
+Deleted temporary smoke secrets: grantex-smoke-* only
+Deleted temporary smoke image tag: auth-service-smoke:81003bae4ce32b98e847c7f1ab536945079eb96a
 
 Verified temporary smoke Cloud Run, Cloud SQL, Redis, and smoke secrets absent after cleanup.
-
-Production resources verified present and untouched after cleanup:
-- Cloud Run service: grantex-auth
-- Cloud SQL instance: grantex-pg16
-- Redis instance: grantex-redis
-
 Verified production resources still present: grantex-auth, grantex-pg16, grantex-redis.
-
 Production Commerce V1, live payment, and live Plural flags were not changed by this run.
 
 ## Redaction


### PR DESCRIPTION
## Summary
- Records C2F Option A smoke evidence from the temporary Grantex smoke service.
- Captures the C2F payment-intent check with mock provider and live flags disabled.
- Adds cleanup and production-safety verification for the temporary smoke resources.

## Evidence
- Grantex: 14 passed, 0 failed, 6 failed-safe, 0 skipped.
- Smoke resources were deleted after evidence capture.
- Production resources were verified present and production Commerce/live flags were not changed.

## Validation
- `node docs/commerce-v1-pilot-readiness.validate.mjs`
- `git diff --check`
- Focused secret scan on `docs/reports/commerce-v1-option-a-smoke-evidence.md`