### PR TITLE
docs(commerce): record c2g smoke evidence

### DIFF
--- a/docs/reports/commerce-v1-option-a-smoke-evidence.md
+++ b/docs/reports/commerce-v1-option-a-smoke-evidence.md
@@ -1,8 +1,8 @@
 # Commerce V1 Option A Smoke Evidence
 
-Status: C2F approved smoke evidence captured from a temporary Option A smoke service. This report is scrubbed and contains no bearer token values, passports, idempotency key values, webhook secrets, provider credentials, raw payloads, DB/Redis URLs, private keys, or secret values.
+Status: C2G approved smoke evidence captured from a temporary Option A smoke service. This report is scrubbed and contains no bearer token values, passports, consent runtime material, idempotency key values, webhook secrets, provider credentials, raw payloads, DB/Redis URLs, private keys, or secret values.
 
-Generated at: 2026-05-16T17:09:09.274Z
+Generated at: 2026-05-17T05:54:50.986Z
 
 Target host: grantex-auth-smoke-dd4mtrt2gq-uc.a.run.app
 
@@ -17,8 +17,8 @@ Variable names used: GRANTEX_COMMERCE_BASE_URL, GRANTEX_BASE_URL, AGENTICORG_COM
 Synthetic IDs:
 - Merchant: mch_staging_electronics_pilot
 - Agent: cag_staging_agenticorg_sales
-- Product: cprd_01KRRW5GHPGK90F3CD7TH1X5C6
-- Variant: cvar_01KRRW5GHY3M38WKMDXKD1MHKR
+- Product: cprd_01KRT7Y4ZFHB6FE2Z4PDHP3H3K
+- Variant: cvar_01KRT7Y4ZJNS9KQ3NT1HA0AX6D
 
 ## Summary
 
@@ -27,34 +27,30 @@ Synthetic IDs:
 - Failed-safe: 6
 - Skipped: 0
 
-## C2F Payment-Intent Check
-
-The positive payment intent path passed against the temporary smoke service with provider `mock`, Commerce live mode false, live payments false, and live Plural false.
-
 ## Case Results
 
 | Case | Status | HTTP | Latency ms | Error code | Synthetic refs |
 | --- | --- | ---: | ---: | --- | --- |
-| health | passed | 200 | 389 |  |  |
-| jwks | passed | 200 | 331 |  |  |
-| commerce_well_known | passed | 200 | 290 |  |  |
-| mcp_initialize | passed | 200 | 303 |  |  |
-| mcp_tools_list | passed | 200 | 292 |  |  |
-| merchant_profile | passed | 200 | 311 |  | merchant_id=mch_staging_electronics_pilot |
-| catalog_search | passed | 200 | 318 |  | merchant_id=mch_staging_electronics_pilot |
-| catalog_get_item | passed | 200 | 306 |  | product_id=cprd_01KRRW5GHPGK90F3CD7TH1X5C6 |
-| inventory_check | passed | 200 | 301 |  | variant_id=cvar_01KRRW5GHY3M38WKMDXKD1MHKR |
-| cart_create | passed | 200 | 436 |  | cart_id=ccart_01KRRW6M9EGNR30KWDR303R8KK |
-| consent_request | passed | 201 | 320 |  | consent_request_id=gmAMG7jQMeASLr2IUymZAXF3yyqNnLJP |
-| consent_exchange | failed-safe | 409 | 312 | consent_not_granted |  |
-| payment_intent_create | passed | 200 | 361 |  | payment_intent_id=cpi_01KRRW6N8F3HET2ANSB55RY1PS |
-| checkout_create | passed | 200 | 350 |  | payment_intent_id=cpi_01KRRW6N8F3HET2ANSB55RY1PS |
-| payment_status | passed | 200 | 302 |  | payment_intent_id=cpi_01KRRW6N8F3HET2ANSB55RY1PS |
-| missing_consent_refusal | failed-safe | 200 | 305 | validation_failed |  |
-| amount_cap_breach_refusal | failed-safe | 200 | 300 | cart_not_payable |  |
-| revoked_passport_refusal | failed-safe | 200 | 313 | cart_not_payable |  |
-| expired_passport_refusal | failed-safe | 200 | 322 | cart_not_payable |  |
-| denied_consent_refusal | failed-safe | 403 | 305 | consent_denied |  |
+| health | passed | 200 | 516 |  |  |
+| jwks | passed | 200 | 345 |  |  |
+| commerce_well_known | passed | 200 | 293 |  |  |
+| mcp_initialize | passed | 200 | 294 |  |  |
+| mcp_tools_list | passed | 200 | 288 |  |  |
+| merchant_profile | passed | 200 | 300 |  | merchant_id=mch_staging_electronics_pilot |
+| catalog_search | passed | 200 | 323 |  | merchant_id=mch_staging_electronics_pilot |
+| catalog_get_item | passed | 200 | 303 |  | product_id=cprd_01KRT7Y4ZFHB6FE2Z4PDHP3H3K |
+| inventory_check | passed | 200 | 303 |  | variant_id=cvar_01KRT7Y4ZJNS9KQ3NT1HA0AX6D |
+| cart_create | passed | 200 | 427 |  | cart_id=ccart_01KRT80PTS3BA236ZWA1RW1DZR |
+| consent_request | passed | 201 | 322 |  | consent_request_id=redacted |
+| consent_exchange | failed-safe | 409 | 297 | consent_not_granted |  |
+| payment_intent_create | passed | 200 | 356 |  | payment_intent_id=cpi_01KRT80QSDDAASHJMHNHDJHG7H |
+| checkout_create | passed | 200 | 341 |  | payment_intent_id=cpi_01KRT80QSDDAASHJMHNHDJHG7H |
+| payment_status | passed | 200 | 299 |  | payment_intent_id=cpi_01KRT80QSDDAASHJMHNHDJHG7H |
+| missing_consent_refusal | failed-safe | 200 | 298 | validation_failed |  |
+| amount_cap_breach_refusal | failed-safe | 200 | 303 | cart_not_payable |  |
+| revoked_passport_refusal | failed-safe | 200 | 326 | cart_not_payable |  |
+| expired_passport_refusal | failed-safe | 200 | 302 | cart_not_payable |  |
+| denied_consent_refusal | failed-safe | 403 | 312 | consent_denied |  |
 
 ## Cleanup Status
 
@@ -64,9 +60,10 @@ Deleted temporary Cloud Run service: grantex-auth-smoke
 Deleted temporary Cloud SQL instance: grantex-commerce-smoke-pg
 Deleted temporary Redis instance: grantex-commerce-smoke-redis
 Deleted temporary smoke secrets: grantex-smoke-* only
-Deleted temporary smoke image tag: auth-service-smoke:81003bae4ce32b98e847c7f1ab536945079eb96a
+Deleted temporary smoke image tag: auth-service-smoke:a664af2d4cae7c50cf6567205c4986ddb54805a1
 
 Verified temporary smoke Cloud Run, Cloud SQL, Redis, and smoke secrets absent after cleanup.
+Verified temporary smoke image tag absent after cleanup.
 Verified production resources still present: grantex-auth, grantex-pg16, grantex-redis.
 Production Commerce V1, live payment, and live Plural flags were not changed by this run.
 


### PR DESCRIPTION
## Summary
- Records C2G Option A smoke evidence from the temporary Grantex smoke service.
- Captures the scrubbed 14 passed / 0 failed / 6 failed-safe / 0 skipped result.
- Records cleanup completion and production resource safety verification.

## Validation
- `node docs/commerce-v1-pilot-readiness.validate.mjs`
- `git diff --check`
- Focused evidence secret scan: passed

Draft only; do not merge until review.