### PR TITLE
docs(commerce): expand agentic commerce education

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,36 @@
 
 </div>
 
+## Agentic Commerce V1
+
+Grantex Commerce V1 is the consent, Commerce Passport, policy, audit, and payment-control layer for agentic checkout. It lets commerce agents discover merchant catalog data, create carts, request user consent, receive a scoped Commerce Passport, and create provider-neutral payment intents without giving the agent direct access to payment providers.
+
+> Production Commerce V1 discovery is currently disabled/fail-closed. Production live checkout, live payments, and live Plural are not enabled.
+
+```mermaid
+flowchart LR
+  user[User] --> agent[AgenticOrg Commerce Sales Agent]
+  agent --> gx[Grantex Commerce REST/MCP]
+  gx --> consent[Consent and Passport]
+  gx --> policy[Policy, amount caps, audit]
+  gx --> catalog[Catalog, cart, inventory]
+  gx --> provider[Provider-neutral payment intent]
+  provider --> mock[Mock provider verified in smoke]
+  provider -. blocked .-> plural[Future live Plural gate]
+```
+
+| Area | Current posture |
+| --- | --- |
+| Internal sandbox | Implemented for synthetic catalog, consent, passport, cart, payment, webhook, and audit flows. |
+| Temporary Option A smoke | Verified with mock provider and cleaned-up smoke resources. |
+| AgenticOrg real-staging handoff | Verified through Grantex-only tools with redacted fixture handling. |
+| Hosted AgenticOrg discovery | Verified in temporary API-only hosted smoke. |
+| Production read-only discovery | Grantex production Commerce V1 discovery remains disabled/fail-closed. |
+| Live checkout/payments | Blocked pending legal, compliance, security, operations, and provider approvals. |
+| Live Plural | Blocked; mock provider only in current evidence. |
+
+Start with the [Commerce V1 overview](docs/guides/commerce-v1-overview.mdx), then use the [developer guide](docs/guides/commerce-v1-developer-guide.mdx), [merchant/operator guide](docs/guides/commerce-v1-merchant-operator-guide.mdx), [operations guide](docs/guides/commerce-v1-operations.mdx), and [repeatable Option A smoke workflow](docs/guides/commerce-v1-repeatable-option-a-smoke-workflow.md). Reference evidence lives in [Option A smoke evidence](docs/reports/commerce-v1-option-a-smoke-evidence.md) and [production discovery readiness](docs/reports/commerce-v1-production-discovery-readiness.md). The public education page is `web/commerce.html`.
+
 ## What's New in v2.5
 
 - **@grantex/gemma**: Day-zero Gemma 4 integration — offline consent bundles,

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -71,6 +71,18 @@
             ]
           },
           {
+            "group": "Agentic Commerce V1",
+            "pages": [
+              "guides/commerce-v1-overview",
+              "guides/commerce-v1-developer-guide",
+              "guides/commerce-v1-merchant-operator-guide",
+              "guides/commerce-v1-operations",
+              "guides/commerce-v1-repeatable-option-a-smoke-workflow",
+              "guides/commerce-v1-option-a-smoke-setup",
+              "guides/commerce-v1-hosted-staging-e2e"
+            ]
+          },
+          {
             "group": "Compliance",
             "pages": [
               "features/dpdp-compliance",

--- a/docs/guides/commerce-v1-developer-guide.mdx
+++ b/docs/guides/commerce-v1-developer-guide.mdx
@@ -1,0 +1,140 @@
+---
+title: Commerce V1 Developer Guide
+description: Grantex Commerce REST/MCP model, consent/passport sequence, idempotency, webhooks, sandbox usage, and current blockers.
+---
+
+# Commerce V1 Developer Guide
+
+This guide explains how developers should reason about the Grantex Commerce V1
+contract. It is safe documentation only. It does not enable production Commerce
+V1, live payments, live Plural, or production discovery.
+
+## API And MCP Surface
+
+Developers should use the OpenAPI contract in
+`docs/api/grantex-commerce-v1.openapi.yaml` plus the MCP tool surface exposed by
+the Commerce service. The current AgenticOrg integration uses these Grantex-only
+aliases:
+
+| Area | Tool or API responsibility |
+| --- | --- |
+| Merchant profile | Fetch merchant policy and status metadata. |
+| Catalog search | Search grounded merchant products. |
+| Catalog get item | Retrieve a specific product or variant. |
+| Inventory check | Confirm availability before cart or checkout. |
+| Cart create | Create a cart draft from grounded catalog IDs. |
+| Consent request | Ask for the user permission required for checkout. |
+| Consent exchange | Exchange granted consent for a Commerce Passport when a granted consent fixture exists. |
+| Payment intent | Create a provider-neutral payment intent with passport and policy checks. |
+| Checkout create | Create a checkout handoff through Grantex. |
+| Payment status | Poll Grantex payment status, not a provider directly. |
+
+## Auth And Caller Model
+
+Commerce callers are modeled as agents operating for a tenant, merchant, and
+user. A caller must be authenticated through an approved Grantex auth source in
+runtime configuration. Auth material is runtime-sensitive and must not be
+committed or printed.
+
+The important IDs are not equivalent:
+
+| Identifier | Purpose |
+| --- | --- |
+| Tenant ID | Owns isolation and policy boundaries. |
+| Merchant ID | Owns catalog, provider configuration status, and merchant policy. |
+| Agent ID | Identifies the delegated agent allowed to use commerce tools. |
+| User/principal | The person whose consent controls checkout. |
+| Commerce Passport | Scoped, usable runtime material created after approved consent or smoke fixture export. |
+
+Synthetic tenant, merchant, user, product, and variant IDs may appear in evidence
+when they are non-production fixtures. Usable passports, bearer tokens,
+idempotency key values, secrets, and provider credentials remain sensitive.
+
+## Consent-First Checkout Sequence
+
+```mermaid
+sequenceDiagram
+  participant A as Agent
+  participant G as Grantex
+  A->>G: merchant.get_profile
+  A->>G: catalog.search
+  A->>G: catalog.get_item
+  A->>G: inventory.check
+  A->>G: cart.create
+  A->>G: consent.request
+  G-->>A: consent request ID or blocker
+  A->>G: consent.exchange when consent is granted
+  G-->>A: Commerce Passport or fail-safe error
+  A->>G: payment.create_intent with allowed fields only
+  A->>G: checkout.create
+  A->>G: payment.get_status
+```
+
+During fixture-backed smoke runs, AgenticOrg may already have a checkout passport
+exported by the Grantex smoke runner. In that case, AgenticOrg evidence treats
+`consent_exchange` as skipped only when the blocker is exactly
+`preexported_checkout_passport_without_granted_consent_fixture`.
+
+## Payment Intent Shape
+
+Payment intent calls must send only fields supported by the Grantex Commerce
+contract. Local fixture guardrail data, such as amount cap metadata used by
+AgenticOrg preflight checks, must not be forwarded to Grantex as arbitrary
+top-level request fields.
+
+Keep idempotency values out of docs and logs. Evidence may record that an
+idempotency mechanism was used, but never the value.
+
+## Webhooks And Replay
+
+Grantex owns provider webhook ingestion, verification, replay controls, and
+reconciliation status. Current smoke evidence uses the mock-provider path only.
+Failed webhook replay is an operator-only capability and remains mock-provider
+only until the live provider contract and signature behavior are approved.
+
+Replay safety rules:
+
+- do not log raw provider payloads;
+- do not store or expose webhook secrets in documentation;
+- preserve original signature metadata only in protected runtime storage;
+- replay only through operator-approved controls;
+- treat live provider replay as blocked until provider/legal/ops gates pass.
+
+## Error Handling
+
+Commerce clients should treat validation and policy failures as explicit
+outcomes, not retry storms. Important classes include:
+
+| Class | Expected handling |
+| --- | --- |
+| `validation_failed` | Fix request shape or unsupported field usage. |
+| `consent_not_granted` | Do not proceed without granted consent or an approved checkout passport fixture. |
+| `consent_denied` | Stop the checkout path. |
+| Amount-cap or policy breach | Fail safely before payment/provider work. |
+| Disabled merchant or untrusted agent | Stop and surface an operator-safe blocker. |
+
+## Sandbox And Mock Provider
+
+Use mock-provider/internal sandbox flows for development. Production Commerce V1,
+live payments, and live Plural are disabled. Approved temporary Option A smoke
+uses isolated Cloud Run, Cloud SQL, Redis, smoke secrets, and mock provider
+resources that are deleted immediately after evidence capture.
+
+Developers should use:
+
+- `docs/guides/commerce-v1-repeatable-option-a-smoke-workflow.md` for the
+  approval-gated smoke path;
+- `docs/examples/commerce-option-a-smoke.runbook.json` for runbook fields;
+- `docs/reports/commerce-v1-option-a-smoke-evidence.md` for scrubbed evidence;
+- `docs/reports/commerce-v1-production-discovery-readiness.md` for current
+  production discovery posture.
+
+## Blocked Until Future Approval
+
+- Production Commerce V1 discovery enablement.
+- External pilot readiness claims.
+- Production checkout or live payment execution.
+- Live Plural or live provider credentials.
+- Direct provider calls from AgenticOrg commerce.
+- Public docs that imply AP2, UCP, ACP, Plural, payment-provider, or external
+  pilot certification.

--- a/docs/guides/commerce-v1-merchant-operator-guide.mdx
+++ b/docs/guides/commerce-v1-merchant-operator-guide.mdx
@@ -1,0 +1,121 @@
+---
+title: Commerce V1 Merchant And Operator Guide
+description: Merchant onboarding, catalog, policy, audit, webhook, emergency control, and production no-go guidance for Grantex Commerce V1.
+---
+
+# Commerce V1 Merchant And Operator Guide
+
+This guide is for merchant, support, security, and operations teams. It explains
+what Grantex Commerce V1 can support in internal sandbox and temporary smoke
+runs today, and what remains blocked before any production or live-payment use.
+
+## Operating Principle
+
+Agents may help users find products and prepare checkout, but Grantex controls
+the commercial boundary:
+
+- merchant status and catalog grounding;
+- consent request and Commerce Passport issuance;
+- amount caps and merchant policy;
+- provider-neutral payment intent creation;
+- webhook ingestion, replay controls, and reconciliation;
+- audit records for review and incident response.
+
+AgenticOrg commerce does not call Stripe, Plural, Pine, or provider credential
+paths directly.
+
+## Merchant Onboarding Checklist
+
+| Step | Current guidance |
+| --- | --- |
+| Tenant and merchant registration | Use synthetic fixtures for sandbox and smoke evidence. Production onboarding requires human approval. |
+| Catalog import | Use approved catalog schemas and product/variant IDs. Keep raw supplier or provider payload dumps out of evidence. |
+| Agent trust | Register or allow only approved agent IDs. Untrusted agents must fail safely. |
+| Policy activation | Configure amount caps, allowed scopes, merchant status, and checkout controls. |
+| Provider status | Mock provider only for current evidence. Live provider credentials remain blocked. |
+| Audit review | Confirm consent, passport, cart, payment intent, and webhook metadata are observable without secret values. |
+
+## Catalog And Inventory
+
+Catalog and inventory grounding is the first safety step. Agents must not invent
+products, variants, prices, or availability. Operator checks should verify:
+
+- catalog search returns merchant-owned products;
+- item retrieval uses exact product and variant IDs;
+- inventory checks pass the required browse passport when policy requires it;
+- cart creation uses grounded variant IDs and quantities;
+- evidence records synthetic IDs only when they are safe fixture identifiers.
+
+## Consent, Passport, And Amount Caps
+
+Consent-first checkout is mandatory. A Commerce Passport is scoped runtime
+material and must remain out of docs, logs, PRs, chat, and evidence reports.
+
+Operators should verify:
+
+- consent scopes match the supported Grantex schema;
+- payment amount is less than or equal to the passport cap before positive
+  payment work proceeds;
+- amount-cap breach is preserved as a fail-safe negative case;
+- missing, revoked, expired, or denied passport cases stop before provider work;
+- `consent_exchange` skip evidence uses the stable blocker code when a
+  pre-exported checkout passport fixture is used without granted consent
+  fixture material.
+
+## Webhook And Replay Safety
+
+Provider webhook handling is owned by Grantex. Current evidence covers the mock
+provider path only. For any future live provider review:
+
+- record secret names by name only, never values;
+- avoid raw payload dumps in evidence;
+- keep replay operator-only;
+- verify signature handling with provider-approved material;
+- confirm replay cannot change production state without explicit approval.
+
+## Emergency Disable And Re-Enable
+
+Emergency controls must prefer fail-closed behavior:
+
+1. Disable Commerce V1 discovery or keep it disabled.
+2. Disable merchant checkout policy.
+3. Remove or gate commerce agent discovery.
+4. Stop temporary smoke resources and delete temporary smoke secrets.
+5. Verify production `grantex-auth`, `grantex-pg16`, and `grantex-redis` remain
+   unchanged after smoke runs.
+6. Re-enable only through a reviewed proposal, with rollback and secret-scan
+   evidence.
+
+## Internal Sandbox Checklist
+
+- Use mock provider only.
+- Use synthetic tenant, merchant, agent, product, and variant IDs.
+- Keep usable auth material and passports under `.tmp/` during approved local
+  handoff runs.
+- Record only hosts, case status, HTTP status, latency, error/blocker codes,
+  synthetic IDs, variable names, and redacted hashes.
+- Confirm cleanup of temporary Cloud Run, Cloud SQL, Redis, smoke secrets, and
+  image tags after hosted smoke.
+
+## Production No-Go Checklist
+
+Do not proceed to production discovery, checkout, live payments, live Plural, or
+external pilot claims if any of these are true:
+
+- Grantex production Commerce V1 discovery has not been explicitly approved.
+- AgenticOrg commerce discovery is not gated or reviewed against the approved
+  Grantex production discovery payload.
+- Provider/live-payment/live Plural signoff is missing.
+- Legal, compliance, security, operations, and product approvals are incomplete.
+- The rollback plan is missing.
+- Evidence includes secrets, raw payloads, passports/JWTs, DB/Redis URLs,
+  provider credentials, private keys, or idempotency key values.
+
+## Evidence Links
+
+- Option A smoke: `docs/reports/commerce-v1-option-a-smoke-evidence.md`
+- Production discovery readiness:
+  `docs/reports/commerce-v1-production-discovery-readiness.md`
+- Repeatable workflow:
+  `docs/guides/commerce-v1-repeatable-option-a-smoke-workflow.md`
+- Operations guide: `docs/guides/commerce-v1-operations.mdx`

--- a/docs/guides/commerce-v1-operations.mdx
+++ b/docs/guides/commerce-v1-operations.mdx
@@ -382,6 +382,9 @@ Safe replay rules:
 - Dry-run with `{ "reason": "...", "dry_run": true }` before real replay when investigating.
 - Real replay requires a non-empty reason, uses the payment state machine, and must not double-transition
   payments that already reached the target terminal state.
+- Production non-mock replay remains blocked with
+  `webhook_failed_event_list_and_replay_api_contract_deferred` until provider API and signature
+  contracts are explicitly approved.
 - Responses, logs, audit metadata, and portal UI must never include raw payloads, raw signatures,
   encrypted payload material, webhook secrets, provider credentials, bearer tokens, passports, or
   plaintext idempotency keys.

--- a/docs/guides/commerce-v1-overview.mdx
+++ b/docs/guides/commerce-v1-overview.mdx
@@ -1,0 +1,118 @@
+---
+title: Commerce V1 Overview
+description: Start here for Grantex Agentic Commerce architecture, readiness, safety gates, and audience-specific paths.
+---
+
+# Commerce V1 Overview
+
+Grantex Commerce V1 is the control plane for agentic commerce. It keeps consent,
+Commerce Passports, merchant policy, amount caps, audit, catalog grounding,
+webhook replay safety, and payment-provider boundaries inside Grantex while
+agents interact through approved REST and MCP surfaces.
+
+This is a documentation and education page. It does not enable production
+Commerce V1, live payments, live Plural, or production discovery.
+
+## Current Posture
+
+| Capability | Status | Evidence or gate |
+| --- | --- | --- |
+| Local/internal sandbox | Implemented | Synthetic catalog, cart, consent, passport, payment, webhook, and audit flows. |
+| Temporary Grantex Option A smoke | Verified | `docs/reports/commerce-v1-option-a-smoke-evidence.md` records 14 passed, 0 failed, 6 failed-safe, 0 skipped. |
+| AgenticOrg real-staging handoff | Verified externally | AgenticOrg evidence records Grantex-only tools and redacted fixture handling. |
+| Hosted AgenticOrg API-only discovery | Verified externally | AgenticOrg C3 evidence records hosted MCP/A2A discovery against temporary Grantex smoke. |
+| Grantex production Commerce V1 discovery | Disabled/fail-closed | `docs/reports/commerce-v1-production-discovery-readiness.md`. |
+| Production checkout/live payments | Blocked | Requires legal, compliance, security, operations, provider, rollback, and human approval gates. |
+| Live Plural | Blocked | Mock provider only in current smoke evidence. |
+
+## Start Here
+
+| Audience | Path |
+| --- | --- |
+| Developers integrating with Grantex Commerce APIs/MCP | Read this overview, then `docs/guides/commerce-v1-developer-guide.mdx` and `docs/api/grantex-commerce-v1.openapi.yaml`. |
+| Merchants and operators | Read `docs/guides/commerce-v1-merchant-operator-guide.mdx`, then `docs/guides/commerce-v1-operations.mdx`. |
+| AgenticOrg integration owners | Read this page, the AgenticOrg commerce docs, and the Option A smoke workflow. |
+| Reviewers assessing readiness | Read the smoke evidence and production discovery readiness report before any enablement proposal. |
+| End users | Use the plain-language consent flow below: agents can prepare a purchase, but Grantex controls what may proceed and records what happened. |
+
+## Architecture
+
+```mermaid
+flowchart LR
+  buyer[End user] --> agent[Commerce agent]
+  agent --> tools[AgenticOrg Grantex-only commerce tools]
+  tools --> api[Grantex Commerce REST/MCP]
+  api --> catalog[Catalog and inventory]
+  api --> consent[Consent request]
+  consent --> passport[Commerce Passport]
+  api --> policy[Policy and amount caps]
+  policy --> audit[Audit and observability]
+  api --> payment[Provider-neutral payment intent]
+  payment --> mock[Mock provider evidence]
+  payment -. future gate .-> live[Live provider / Plural]
+```
+
+The important boundary is that the agent does not own payment-provider access.
+AgenticOrg uses `grantex_commerce:*` tools. Grantex owns provider abstraction,
+policy enforcement, audit, webhook replay safety, and any future live-provider
+enablement.
+
+## Consent And Commerce Passport Lifecycle
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant A as Commerce Agent
+  participant G as Grantex
+  participant P as Provider Adapter
+  A->>G: Search catalog and check inventory
+  A->>G: Create cart draft
+  A->>G: Request consent with supported scopes
+  G-->>U: Consent UI / approval challenge
+  U-->>G: Approve or deny
+  G-->>A: Commerce Passport if approved
+  A->>G: Create payment intent with passport
+  G->>G: Enforce merchant policy and amount cap
+  G->>P: Mock-provider payment path in current evidence
+  A->>G: Create checkout and poll payment status
+```
+
+The Commerce Passport is scoped runtime material. It may be used during approved
+smoke runs, but it must never appear in committed docs, PR bodies, logs, raw
+payload dumps, or chat.
+
+## Readiness Gate Ladder
+
+```mermaid
+flowchart TB
+  local[Local tests and internal sandbox] --> optionA[Temporary Grantex Option A smoke]
+  optionA --> real[Local AgenticOrg real-staging eval]
+  real --> hosted[Temporary hosted AgenticOrg API smoke]
+  hosted --> prodReadOnly[Read-only production discovery proposal]
+  prodReadOnly --> external[External sandbox pilot proposal]
+  external --> live[Live payment and live Plural gate]
+```
+
+Each gate is separate. Passing a temporary smoke run does not imply production
+discovery, production checkout, live payments, live Plural, external pilot
+readiness, or provider certification.
+
+## Allowed And Blocked
+
+| Allowed now | Blocked now |
+| --- | --- |
+| Local mock demo and internal sandbox work. | Production Commerce V1 discovery enablement. |
+| Approved temporary Option A smoke resources. | Production checkout or payment execution. |
+| Mock-provider evidence with scrubbed reports. | Live Plural or live provider credentials. |
+| AgenticOrg Grantex-only commerce tools. | Direct Stripe, Plural, Pine, or provider credential paths from AgenticOrg commerce. |
+| Public JWKS references as verification metadata. | Raw passports, bearer tokens, idempotency key values, secrets, DB/Redis URLs, or raw payloads in docs/evidence. |
+
+## Related Documents
+
+- `docs/guides/commerce-v1-developer-guide.mdx`
+- `docs/guides/commerce-v1-merchant-operator-guide.mdx`
+- `docs/guides/commerce-v1-operations.mdx`
+- `docs/guides/commerce-v1-repeatable-option-a-smoke-workflow.md`
+- `docs/reports/commerce-v1-option-a-smoke-evidence.md`
+- `docs/reports/commerce-v1-production-discovery-readiness.md`
+- `docs/api/grantex-commerce-v1.openapi.yaml`

--- a/web/commerce.html
+++ b/web/commerce.html
@@ -1,0 +1,249 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Grantex Agentic Commerce V1</title>
+  <meta name="description" content="Plain-language education for Grantex Agentic Commerce V1 consent, Commerce Passport, policy, audit, and payment-control flows." />
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #132018;
+      --muted: #50645a;
+      --line: #d8e4dc;
+      --paper: #f7faf7;
+      --white: #ffffff;
+      --green: #267a4a;
+      --blue: #255f8e;
+      --amber: #9a651f;
+      --red: #a43f31;
+      --shadow: 0 18px 55px rgba(19, 32, 24, 0.11);
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--ink);
+      background: var(--paper);
+      line-height: 1.6;
+    }
+    a { color: var(--blue); }
+    header, section { padding: 64px 24px; }
+    .wrap { max-width: 1120px; margin: 0 auto; }
+    .topbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 18px 24px;
+      border-bottom: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.9);
+      position: sticky;
+      top: 0;
+      z-index: 2;
+      backdrop-filter: blur(14px);
+    }
+    .brand { font-weight: 800; color: var(--ink); text-decoration: none; letter-spacing: 0; }
+    .nav { display: flex; gap: 18px; font-size: 14px; }
+    .nav a { color: var(--muted); text-decoration: none; }
+    .hero {
+      background: linear-gradient(135deg, #ffffff 0%, #eef6f1 55%, #f7efe4 100%);
+      border-bottom: 1px solid var(--line);
+    }
+    .hero-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
+      gap: 42px;
+      align-items: center;
+    }
+    .eyebrow { color: var(--green); font-weight: 800; text-transform: uppercase; font-size: 13px; }
+    h1 { font-size: clamp(36px, 5vw, 64px); line-height: 1.02; margin: 12px 0 18px; letter-spacing: 0; }
+    h2 { font-size: clamp(26px, 3vw, 40px); line-height: 1.14; margin: 0 0 18px; letter-spacing: 0; }
+    h3 { margin: 0 0 8px; font-size: 19px; letter-spacing: 0; }
+    p { margin: 0 0 16px; color: var(--muted); }
+    .badges { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 26px; }
+    .badge { border: 1px solid var(--line); background: var(--white); border-radius: 999px; padding: 8px 12px; font-size: 13px; font-weight: 700; }
+    .badge.blocked { color: var(--red); border-color: #efc8c1; }
+    .badge.review { color: var(--amber); border-color: #edd9b7; }
+    .badge.ready { color: var(--green); border-color: #b8dbc6; }
+    .panel {
+      background: var(--white);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+      padding: 26px;
+    }
+    .flow { display: grid; gap: 12px; }
+    .step {
+      display: grid;
+      grid-template-columns: 34px 1fr;
+      gap: 12px;
+      align-items: start;
+      padding: 14px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fbfdfb;
+    }
+    .num {
+      width: 34px;
+      height: 34px;
+      border-radius: 50%;
+      background: var(--green);
+      color: white;
+      display: grid;
+      place-items: center;
+      font-weight: 800;
+    }
+    .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+    .grid-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+    .card {
+      background: var(--white);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 22px;
+    }
+    .status-table { width: 100%; border-collapse: collapse; background: var(--white); border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+    .status-table th, .status-table td { text-align: left; padding: 14px; border-bottom: 1px solid var(--line); vertical-align: top; }
+    .status-table th { background: #eef6f1; font-size: 13px; text-transform: uppercase; color: var(--muted); }
+    .ladder {
+      display: grid;
+      grid-template-columns: repeat(6, 1fr);
+      gap: 10px;
+      margin-top: 22px;
+    }
+    .rung {
+      min-height: 110px;
+      padding: 14px;
+      border-radius: 8px;
+      border: 1px solid var(--line);
+      background: var(--white);
+      font-weight: 800;
+      font-size: 14px;
+    }
+    .rung span { display: block; margin-top: 8px; color: var(--muted); font-weight: 500; font-size: 13px; }
+    .allowed { border-top: 4px solid var(--green); }
+    .blocked-line { border-top: 4px solid var(--red); }
+    .review-line { border-top: 4px solid var(--amber); }
+    .cta { background: #132018; color: white; }
+    .cta p, .cta a { color: #d8e4dc; }
+    footer { padding: 28px 24px; border-top: 1px solid var(--line); color: var(--muted); background: var(--white); }
+    @media (max-width: 880px) {
+      .hero-grid, .grid-3, .grid-2, .ladder { grid-template-columns: 1fr; }
+      .nav { display: none; }
+      header, section { padding: 44px 18px; }
+    }
+  </style>
+</head>
+<body>
+  <nav class="topbar">
+    <a class="brand" href="/">Grantex</a>
+    <div class="nav">
+      <a href="#workflow">Workflow</a>
+      <a href="#readiness">Readiness</a>
+      <a href="#audiences">Audience paths</a>
+      <a href="https://docs.grantex.dev/guides/commerce-v1-overview">Docs</a>
+    </div>
+  </nav>
+
+  <header class="hero">
+    <div class="wrap hero-grid">
+      <div>
+        <div class="eyebrow">Agentic Commerce V1</div>
+        <h1>Consent-first checkout control for commerce agents.</h1>
+        <p>
+          Grantex keeps consent, Commerce Passports, merchant policy, amount caps,
+          audit, and provider boundaries in one control layer while agents use
+          approved catalog, cart, consent, and payment-intent tools.
+        </p>
+        <div class="badges">
+          <span class="badge ready">Internal sandbox ready</span>
+          <span class="badge ready">Hosted smoke verified</span>
+          <span class="badge review">Production discovery disabled</span>
+          <span class="badge blocked">Live payments blocked</span>
+          <span class="badge blocked">Live Plural blocked</span>
+        </div>
+      </div>
+      <div class="panel" aria-label="Agentic checkout flow">
+        <div class="flow">
+          <div class="step"><div class="num">1</div><div><h3>Ground the cart</h3><p>Agents search catalog, retrieve items, and check inventory through Grantex.</p></div></div>
+          <div class="step"><div class="num">2</div><div><h3>Ask for consent</h3><p>Grantex creates a consent request and only approved scope proceeds.</p></div></div>
+          <div class="step"><div class="num">3</div><div><h3>Issue a passport</h3><p>The Commerce Passport carries policy and amount limits as sensitive runtime material.</p></div></div>
+          <div class="step"><div class="num">4</div><div><h3>Control payment</h3><p>Payment intents and checkout handoff stay provider-neutral and audit-visible.</p></div></div>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <section id="workflow">
+    <div class="wrap">
+      <h2>Why Grantex sits between agents and payment providers</h2>
+      <div class="grid-3">
+        <div class="card">
+          <h3>Consent boundary</h3>
+          <p>Agents can prepare a purchase, but Grantex controls whether the requested action matches user consent and merchant policy.</p>
+        </div>
+        <div class="card">
+          <h3>Policy boundary</h3>
+          <p>Amount caps, merchant status, trusted agent checks, and passport state are enforced before payment-affecting work proceeds.</p>
+        </div>
+        <div class="card">
+          <h3>Provider boundary</h3>
+          <p>AgenticOrg commerce does not call Stripe, Plural, Pine, or provider credentials directly. Grantex owns the provider abstraction.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="readiness">
+    <div class="wrap">
+      <h2>Readiness is staged, not implied</h2>
+      <table class="status-table">
+        <thead><tr><th>Layer</th><th>Status</th><th>Meaning</th></tr></thead>
+        <tbody>
+          <tr><td>Internal sandbox</td><td>Ready</td><td>Synthetic data and mock-provider paths exist for controlled validation.</td></tr>
+          <tr><td>Temporary smoke</td><td>Verified</td><td>Option A and hosted AgenticOrg smoke evidence used temporary resources and scrubbed reports.</td></tr>
+          <tr><td>Production discovery</td><td>Disabled/fail-closed</td><td>Read-only discovery requires a later approved proposal.</td></tr>
+          <tr><td>Live checkout/payments</td><td>Blocked</td><td>Legal, compliance, security, operations, and provider gates remain required.</td></tr>
+          <tr><td>Live Plural</td><td>Blocked</td><td>No current evidence enables live Plural or live provider credentials.</td></tr>
+        </tbody>
+      </table>
+      <div class="ladder" aria-label="Readiness gate ladder">
+        <div class="rung allowed">Local tests<span>Internal sandbox</span></div>
+        <div class="rung allowed">Option A smoke<span>Temporary Grantex service</span></div>
+        <div class="rung allowed">AgenticOrg eval<span>Grantex-only path</span></div>
+        <div class="rung allowed">Hosted API smoke<span>MCP/A2A discovery</span></div>
+        <div class="rung review-line">Read-only discovery<span>Human proposal required</span></div>
+        <div class="rung blocked-line">Live payments<span>Blocked</span></div>
+      </div>
+    </div>
+  </section>
+
+  <section id="audiences">
+    <div class="wrap">
+      <h2>Start paths</h2>
+      <div class="grid-2">
+        <div class="card"><h3>Developers</h3><p>Use the Commerce V1 developer guide and OpenAPI contract. Treat all auth, passport, idempotency, and provider material as runtime-sensitive.</p></div>
+        <div class="card"><h3>Merchants and operators</h3><p>Use the operator guide for catalog, policy, audit, webhook, emergency disable, and no-go checks.</p></div>
+        <div class="card"><h3>Agent builders</h3><p>Use Grantex Commerce REST/MCP only. AgenticOrg uses `grantex_commerce:*` tools and no direct provider credential path.</p></div>
+        <div class="card"><h3>End users</h3><p>The agent may help prepare a cart, but consent and policy checks determine whether checkout can proceed.</p></div>
+      </div>
+    </div>
+  </section>
+
+  <section class="cta">
+    <div class="wrap">
+      <h2>Use this page as education, not enablement.</h2>
+      <p>
+        Production Commerce V1 discovery, live checkout, live payments, live Plural,
+        external pilot readiness, and provider certification remain blocked until
+        explicit human gates approve them.
+      </p>
+      <p><a href="https://docs.grantex.dev/guides/commerce-v1-overview">Read the Commerce V1 docs</a></p>
+    </div>
+  </section>
+
+  <footer>
+    <div class="wrap">No secrets, passports, tokens, raw payloads, provider credentials, or live payment material are included on this page.</div>
+  </footer>
+</body>
+</html>

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -25,6 +25,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://grantex.dev/commerce</loc>
+    <lastmod>2026-05-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://grantex.dev/for/langchain</loc>
     <lastmod>2026-04-07</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
## Summary
- Add Agentic Commerce V1 README coverage, docs navigation, developer guide, merchant/operator guide, and overview.
- Add a static Commerce education page and sitemap entry.
- Preserve current safety posture: production Commerce V1 discovery disabled/fail-closed, live payments blocked, live Plural blocked, mock-provider smoke evidence only.

## Validation
- `node docs/commerce-v1-pilot-readiness.validate.mjs`
- `node docs/commerce-v1-hardening.validate.mjs`
- `node web/commerce-playground.validate.mjs`
- `git diff --check`
- Focused staged added-line secret scan: clean

No deploy, cloud resource, production config, secret, Commerce V1, live payment, or live Plural action was performed.