### PR TITLE
fix(commerce): add read-only discovery gate

### DIFF
--- a/apps/auth-service/src/config.ts
+++ b/apps/auth-service/src/config.ts
@@ -1,4 +1,8 @@
 import 'dotenv/config';
+import {
+  commercePublicDiscoveryMerchantAllowlist,
+  isCommercePublicDiscoveryEnabled,
+} from './lib/commerce/public-discovery.js';
 
 function required(name: string): string {
   const val = process.env[name];
@@ -94,6 +98,8 @@ export const config = {
   // be provisioned via the explicit endpoints planned for M2.
   // ---------------------------------------------------------------------
   commerceV1Enabled: process.env['COMMERCE_V1_ENABLED'] === 'true',
+  commercePublicDiscoveryEnabled: isCommercePublicDiscoveryEnabled(),
+  commercePublicDiscoveryMerchantAllowlist: commercePublicDiscoveryMerchantAllowlist(),
   commerceSandboxEnabled: process.env['COMMERCE_SANDBOX_ENABLED'] !== 'false',
   commerceAllowAutoTenant: process.env['COMMERCE_ALLOW_AUTO_TENANT'] === 'true',
   pluralSandboxEnabled: process.env['PLURAL_SANDBOX_ENABLED'] === 'true',

--- a/apps/auth-service/src/lib/commerce/public-discovery.ts
+++ b/apps/auth-service/src/lib/commerce/public-discovery.ts
@@ -1,0 +1,22 @@
+export const COMMERCE_PUBLIC_DISCOVERY_ENABLED_ENV = 'COMMERCE_PUBLIC_DISCOVERY_ENABLED';
+export const COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST_ENV = 'COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST';
+
+const EXPLICIT_TRUE_VALUES = new Set(['1', 'true', 'yes', 'on', 'enabled']);
+
+export function isExplicitSafeTrue(value: string | undefined): boolean {
+  return EXPLICIT_TRUE_VALUES.has((value ?? '').trim().toLowerCase());
+}
+
+export function isCommercePublicDiscoveryEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isExplicitSafeTrue(env[COMMERCE_PUBLIC_DISCOVERY_ENABLED_ENV]);
+}
+
+export function commercePublicDiscoveryMerchantAllowlist(env: NodeJS.ProcessEnv = process.env): string[] {
+  const seen = new Set<string>();
+  const raw = env[COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST_ENV] ?? '';
+  for (const item of raw.split(',')) {
+    const merchantId = item.trim();
+    if (merchantId.length > 0) seen.add(merchantId);
+  }
+  return [...seen];
+}

--- a/apps/auth-service/src/routes/commerce-well-known.ts
+++ b/apps/auth-service/src/routes/commerce-well-known.ts
@@ -53,6 +53,8 @@ export async function commerceWellKnownRoutes(app: FastifyInstance): Promise<voi
     '/.well-known/grantex-commerce',
     { config: { skipAuth: true, rateLimit: { max: 60, timeWindow: '1 minute' } } },
     async (request, reply) => {
+      reply.header('Cache-Control', 'no-store');
+      reply.header('Pragma', 'no-cache');
       const commerceV1Enabled = isCommerceV1Enabled();
       const publicDiscoveryEnabled = isCommercePublicDiscoveryEnabled();
       if (!commerceV1Enabled && !publicDiscoveryEnabled) {
@@ -77,8 +79,6 @@ export async function commerceWellKnownRoutes(app: FastifyInstance): Promise<voi
           'Multiple commerce merchants are available; pass ?merchant_id=...');
       }
 
-      reply.header('Cache-Control', 'no-store');
-      reply.header('Pragma', 'no-cache');
       return reply.status(200).send({
         version: 'grantex-commerce-v1',
         merchant: result.profile,

--- a/apps/auth-service/src/routes/commerce-well-known.ts
+++ b/apps/auth-service/src/routes/commerce-well-known.ts
@@ -3,6 +3,10 @@ import { config } from '../config.js';
 import { getSql } from '../db/client.js';
 import { commerceErrorHandler, CommerceHttpError } from '../lib/commerce/errors.js';
 import {
+  commercePublicDiscoveryMerchantAllowlist,
+  isCommercePublicDiscoveryEnabled,
+} from '../lib/commerce/public-discovery.js';
+import {
   readMerchantPublishingProfile,
   V1_COMMERCE_REQUIRED_SCOPES,
   V1_COMMERCE_TOOLS,
@@ -16,6 +20,32 @@ function publicUrl(path: string): string {
   return new URL(path, config.publicBaseUrl).toString();
 }
 
+function resolvePublicDiscoveryMerchantId(requestedMerchantId: string | null): string {
+  const allowlist = commercePublicDiscoveryMerchantAllowlist();
+  if (allowlist.length === 0) {
+    throw new CommerceHttpError(503, 'commerce_public_discovery_allowlist_required',
+      'Commerce public discovery requires an allowlisted merchant', { retryable: false });
+  }
+  if (!requestedMerchantId && allowlist.length > 1) {
+    throw new CommerceHttpError(422, 'merchant_selector_required',
+      'Multiple commerce merchants are available; pass ?merchant_id=...');
+  }
+  const merchantId = requestedMerchantId ?? allowlist[0];
+  if (!merchantId || !allowlist.includes(merchantId)) {
+    throw new CommerceHttpError(404, 'merchant_not_found',
+      'Merchant publishing profile was not found');
+  }
+  return merchantId;
+}
+
+function assertPublicDiscoveryLiveFlagsDisabled(): void {
+  if (process.env['COMMERCE_LIVE_MODE_ENABLED'] === 'true' || process.env['PLURAL_LIVE_ENABLED'] === 'true') {
+    throw new CommerceHttpError(503, 'commerce_public_discovery_live_flags_forbidden',
+      'Commerce public discovery requires live payment and live Plural flags to remain disabled',
+      { retryable: false });
+  }
+}
+
 export async function commerceWellKnownRoutes(app: FastifyInstance): Promise<void> {
   app.setErrorHandler(commerceErrorHandler);
 
@@ -23,13 +53,20 @@ export async function commerceWellKnownRoutes(app: FastifyInstance): Promise<voi
     '/.well-known/grantex-commerce',
     { config: { skipAuth: true, rateLimit: { max: 60, timeWindow: '1 minute' } } },
     async (request, reply) => {
-      if (!isCommerceV1Enabled()) {
+      const commerceV1Enabled = isCommerceV1Enabled();
+      const publicDiscoveryEnabled = isCommercePublicDiscoveryEnabled();
+      if (!commerceV1Enabled && !publicDiscoveryEnabled) {
         throw new CommerceHttpError(503, 'commerce_disabled',
           'Grantex Commerce V1 is not enabled in this environment', { retryable: false });
       }
-      const merchantId = typeof request.query.merchant_id === 'string' && request.query.merchant_id.length > 0
+      const requestedMerchantId = typeof request.query.merchant_id === 'string' && request.query.merchant_id.length > 0
         ? request.query.merchant_id
         : null;
+      let merchantId = requestedMerchantId;
+      if (publicDiscoveryEnabled) {
+        assertPublicDiscoveryLiveFlagsDisabled();
+        merchantId = resolvePublicDiscoveryMerchantId(requestedMerchantId);
+      }
       const result = await readMerchantPublishingProfile(getSql(), { merchantId });
       if (result.kind === 'not_found') {
         throw new CommerceHttpError(404, 'merchant_not_found',
@@ -40,6 +77,8 @@ export async function commerceWellKnownRoutes(app: FastifyInstance): Promise<voi
           'Multiple commerce merchants are available; pass ?merchant_id=...');
       }
 
+      reply.header('Cache-Control', 'no-store');
+      reply.header('Pragma', 'no-cache');
       return reply.status(200).send({
         version: 'grantex-commerce-v1',
         merchant: result.profile,
@@ -61,6 +100,23 @@ export async function commerceWellKnownRoutes(app: FastifyInstance): Promise<voi
           base_url: publicUrl('/v1/commerce'),
         },
         capabilities: result.profile.capabilities,
+        discovery_posture: {
+          mode: publicDiscoveryEnabled ? 'public_read_only_discovery' : 'commerce_v1_runtime_discovery',
+          read_only_discovery_only: publicDiscoveryEnabled && !commerceV1Enabled,
+          commerce_v1_runtime_enabled: commerceV1Enabled,
+          checkout_payment_creation_enabled_by_discovery_gate: false,
+          live_payments_enabled: false,
+          live_plural_enabled: false,
+          provider_credentials_exposed: false,
+          readiness_claim: 'none',
+          certification_claim: 'none',
+          notes: [
+            'COMMERCE_PUBLIC_DISCOVERY_ENABLED publishes metadata only.',
+            'Checkout and payment creation require separate Commerce V1 runtime approval.',
+            'Live payments and live Plural remain disabled by this discovery gate.',
+            'This profile makes no production-readiness or certification claim.',
+          ],
+        },
       });
     },
   );

--- a/apps/auth-service/tests/commerce-feature-flags.test.ts
+++ b/apps/auth-service/tests/commerce-feature-flags.test.ts
@@ -68,6 +68,10 @@ describe('Commerce flags exposed on config', () => {
   it('config.commerceV1Enabled is true in test env', async () => {
     const { config } = await import('../src/config.js');
     expect(config.commerceV1Enabled).toBe(true);
+    expect(config).toHaveProperty('commercePublicDiscoveryEnabled');
+    expect(config.commercePublicDiscoveryEnabled).toBe(false);
+    expect(config).toHaveProperty('commercePublicDiscoveryMerchantAllowlist');
+    expect(config.commercePublicDiscoveryMerchantAllowlist).toEqual([]);
     expect(config).toHaveProperty('pluralSandboxEnabled');
     expect(config).toHaveProperty('pluralLiveEnabled');
     expect(config).toHaveProperty('commerceLiveModeEnabled');

--- a/apps/auth-service/tests/commerce-publishing-catalog.test.ts
+++ b/apps/auth-service/tests/commerce-publishing-catalog.test.ts
@@ -93,6 +93,8 @@ describe('GET /.well-known/grantex-commerce', () => {
     });
 
     expect(res.statusCode).toBe(503);
+    expect(res.headers['cache-control']).toBe('no-store');
+    expect(res.headers['pragma']).toBe('no-cache');
     expect(res.json<{ error: { code: string } }>().error.code).toBe('commerce_disabled');
   });
 
@@ -126,21 +128,26 @@ describe('GET /.well-known/grantex-commerce', () => {
       .toBe('commerce_public_discovery_allowlist_required');
   });
 
-  it('fails closed when public discovery is enabled with live flags true', async () => {
-    vi.stubEnv('COMMERCE_V1_ENABLED', '');
-    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_ENABLED', 'true');
-    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST', MERCHANT);
-    vi.stubEnv('PLURAL_LIVE_ENABLED', 'true');
+  it.each(['COMMERCE_LIVE_MODE_ENABLED', 'PLURAL_LIVE_ENABLED'])(
+    'fails closed when public discovery is enabled with %s=true',
+    async (liveFlag) => {
+      vi.stubEnv('COMMERCE_V1_ENABLED', '');
+      vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_ENABLED', 'true');
+      vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST', MERCHANT);
+      vi.stubEnv(liveFlag, 'true');
 
-    const res = await app.inject({
-      method: 'GET',
-      url: '/.well-known/grantex-commerce?merchant_id=mch_M5A',
-    });
+      const res = await app.inject({
+        method: 'GET',
+        url: '/.well-known/grantex-commerce?merchant_id=mch_M5A',
+      });
 
-    expect(res.statusCode).toBe(503);
-    expect(res.json<{ error: { code: string } }>().error.code)
-      .toBe('commerce_public_discovery_live_flags_forbidden');
-  });
+      expect(res.statusCode).toBe(503);
+      expect(res.headers['cache-control']).toBe('no-store');
+      expect(res.headers['pragma']).toBe('no-cache');
+      expect(res.json<{ error: { code: string } }>().error.code)
+        .toBe('commerce_public_discovery_live_flags_forbidden');
+    },
+  );
 
   it('fails closed when the requested merchant is not allowlisted', async () => {
     vi.stubEnv('COMMERCE_V1_ENABLED', '');
@@ -170,6 +177,7 @@ describe('GET /.well-known/grantex-commerce', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.headers['cache-control']).toBe('no-store');
+    expect(res.headers['pragma']).toBe('no-cache');
     const body = res.json<{
       merchant: { merchant_id: string };
       discovery_posture: {

--- a/apps/auth-service/tests/commerce-publishing-catalog.test.ts
+++ b/apps/auth-service/tests/commerce-publishing-catalog.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { authHeader, buildTestApp, sqlMock } from './helpers.js';
+import { authHeader, buildTestApp, seedAuth, sqlMock } from './helpers.js';
 import { seedCommerceContext, TEST_COMMERCE_TENANT_ID } from './commerce-helpers.js';
 
 const TEST_DIR = dirname(fileURLToPath(import.meta.url));
@@ -26,6 +26,7 @@ const V1_TOOLS = [
 
 let app: FastifyInstance;
 beforeAll(async () => { app = await buildTestApp(); });
+afterEach(() => { vi.unstubAllEnvs(); });
 
 function merchantProfile(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -82,6 +83,150 @@ function openApiBlock(path: string): string {
 }
 
 describe('GET /.well-known/grantex-commerce', () => {
+  it('fails closed when both Commerce V1 and public discovery are disabled', async () => {
+    vi.stubEnv('COMMERCE_V1_ENABLED', '');
+    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_ENABLED', '');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/.well-known/grantex-commerce?merchant_id=mch_M5A',
+    });
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('commerce_disabled');
+  });
+
+  it('treats empty or invalid public discovery values as disabled', async () => {
+    vi.stubEnv('COMMERCE_V1_ENABLED', '');
+    for (const value of ['', 'false', 'enabled-but-unsafe']) {
+      vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_ENABLED', value);
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/.well-known/grantex-commerce?merchant_id=mch_M5A',
+      });
+
+      expect(res.statusCode).toBe(503);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe('commerce_disabled');
+    }
+  });
+
+  it('requires an allowlisted merchant when public read-only discovery is enabled', async () => {
+    vi.stubEnv('COMMERCE_V1_ENABLED', '');
+    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_ENABLED', 'true');
+    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST', '');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/.well-known/grantex-commerce?merchant_id=mch_M5A',
+    });
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json<{ error: { code: string } }>().error.code)
+      .toBe('commerce_public_discovery_allowlist_required');
+  });
+
+  it('fails closed when public discovery is enabled with live flags true', async () => {
+    vi.stubEnv('COMMERCE_V1_ENABLED', '');
+    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_ENABLED', 'true');
+    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST', MERCHANT);
+    vi.stubEnv('PLURAL_LIVE_ENABLED', 'true');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/.well-known/grantex-commerce?merchant_id=mch_M5A',
+    });
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json<{ error: { code: string } }>().error.code)
+      .toBe('commerce_public_discovery_live_flags_forbidden');
+  });
+
+  it('fails closed when the requested merchant is not allowlisted', async () => {
+    vi.stubEnv('COMMERCE_V1_ENABLED', '');
+    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_ENABLED', 'enabled');
+    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST', OTHER_MERCHANT);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/.well-known/grantex-commerce?merchant_id=mch_M5A',
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('merchant_not_found');
+    expect(sqlMock).not.toHaveBeenCalled();
+  });
+
+  it('returns read-only discovery through the public gate without Commerce V1 runtime enabled', async () => {
+    vi.stubEnv('COMMERCE_V1_ENABLED', '');
+    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_ENABLED', 'true');
+    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST', MERCHANT);
+    sqlMock.mockResolvedValueOnce([merchantProfile()]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/.well-known/grantex-commerce?merchant_id=mch_M5A',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['cache-control']).toBe('no-store');
+    const body = res.json<{
+      merchant: { merchant_id: string };
+      discovery_posture: {
+        mode: string;
+        read_only_discovery_only: boolean;
+        commerce_v1_runtime_enabled: boolean;
+        checkout_payment_creation_enabled_by_discovery_gate: boolean;
+        live_payments_enabled: boolean;
+        live_plural_enabled: boolean;
+        provider_credentials_exposed: boolean;
+        readiness_claim: string;
+        certification_claim: string;
+      };
+    }>();
+    expect(body.merchant.merchant_id).toBe(MERCHANT);
+    expect(body.discovery_posture).toMatchObject({
+      mode: 'public_read_only_discovery',
+      read_only_discovery_only: true,
+      commerce_v1_runtime_enabled: false,
+      checkout_payment_creation_enabled_by_discovery_gate: false,
+      live_payments_enabled: false,
+      live_plural_enabled: false,
+      provider_credentials_exposed: false,
+      readiness_claim: 'none',
+      certification_claim: 'none',
+    });
+  });
+
+  it('uses the single allowlisted merchant when no selector is supplied', async () => {
+    vi.stubEnv('COMMERCE_V1_ENABLED', '');
+    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_ENABLED', '1');
+    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST', ` ${MERCHANT} `);
+    sqlMock.mockResolvedValueOnce([merchantProfile()]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/.well-known/grantex-commerce',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(sqlMock.mock.calls.flat()).toContain(MERCHANT);
+  });
+
+  it('requires a selector when multiple public discovery merchants are allowlisted', async () => {
+    vi.stubEnv('COMMERCE_V1_ENABLED', '');
+    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_ENABLED', 'yes');
+    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST', `${MERCHANT},${OTHER_MERCHANT}`);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/.well-known/grantex-commerce',
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('merchant_selector_required');
+  });
+
   it('returns the public merchant publishing profile', async () => {
     sqlMock.mockResolvedValueOnce([merchantProfile()]);
 
@@ -119,9 +264,11 @@ describe('GET /.well-known/grantex-commerce', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    const body = JSON.stringify(res.json());
+    const parsed = res.json<{ discovery_posture: { certification_claim: string; readiness_claim: string } }>();
+    const body = JSON.stringify(parsed);
     expect(body).not.toMatch(/\b(UCP|ACP|AP2|MPP|A2A)\b/);
-    expect(body).not.toMatch(/certif/i);
+    expect(parsed.discovery_posture.certification_claim).toBe('none');
+    expect(parsed.discovery_posture.readiness_claim).toBe('none');
   });
 
   it('lists streamable_http MCP transport and all V1 tools', async () => {
@@ -137,6 +284,54 @@ describe('GET /.well-known/grantex-commerce', () => {
     expect(body.mcp.transport).toBe('streamable_http');
     expect(body.mcp.url).toContain('/mcp');
     expect(body.supported_tools).toEqual(V1_TOOLS);
+  });
+
+  it('does not let the public discovery gate enable MCP or Commerce runtime routes', async () => {
+    vi.stubEnv('COMMERCE_V1_ENABLED', '');
+    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_ENABLED', 'true');
+    vi.stubEnv('COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST', MERCHANT);
+
+    const mcpList = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      headers: { 'content-type': 'application/json' },
+      payload: { jsonrpc: '2.0', id: 'm5a', method: 'tools/list' },
+    });
+    expect(mcpList.statusCode).toBe(503);
+    expect(mcpList.json<{ error: { data: { error: { code: string } } } }>().error.data.error.code)
+      .toBe('commerce_disabled');
+
+    const mcpCall = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      headers: { 'content-type': 'application/json' },
+      payload: {
+        jsonrpc: '2.0',
+        id: 'm5a',
+        method: 'tools/call',
+        params: { name: 'merchant.get_profile', arguments: { merchant_id: MERCHANT } },
+      },
+    });
+    expect(mcpCall.statusCode).toBe(503);
+
+    seedAuth();
+    const merchantRoute = await app.inject({
+      method: 'GET',
+      url: `/v1/commerce/merchants/${MERCHANT}`,
+      headers: authHeader(),
+    });
+    expect(merchantRoute.statusCode).toBe(503);
+    expect(merchantRoute.json<{ error: { code: string } }>().error.code).toBe('commerce_disabled');
+
+    seedAuth();
+    const cartRoute = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/carts',
+      headers: authHeader(),
+      payload: { merchant_id: MERCHANT, currency: 'INR', line_items: [], idempotency_key: 'idem_test' },
+    });
+    expect(cartRoute.statusCode).toBe(503);
+    expect(cartRoute.json<{ error: { code: string } }>().error.code).toBe('commerce_disabled');
   });
 
   it('keeps the commerce well-known profile rate limited outside the JWKS allowlist', async () => {
@@ -297,6 +492,12 @@ describe('M5A OpenAPI contract', () => {
     expect(wellKnown).toMatch(/operationId:\s*getGrantexCommerceProfile/);
     expect(wellKnown).toMatch(/x-implemented:\s*true/);
     expect(wellKnown).toContain('streamable_http');
+    const content = readFileSync(OPENAPI_PATH, 'utf8');
+    expect(content).toContain('discovery_posture');
+    expect(content).toContain('public_read_only_discovery');
+    expect(content).toContain('checkout_payment_creation_enabled_by_discovery_gate');
+    expect(content).toContain('live_payments_enabled');
+    expect(content).toContain('live_plural_enabled');
 
     const search = openApiBlock('/v1/commerce/catalog/search:');
     expect(search).toMatch(/operationId:\s*searchCommerceCatalog/);

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -19,7 +19,9 @@ info:
     foundation. M5B implements the
     `/mcp` JSON-RPC HTTP tool endpoint. M5C adds a static sandbox
     playground client for the commerce MCP surface. M6A adds operator-only
-    commerce operations health and baseline hardening runbooks.
+    commerce operations health and baseline hardening runbooks. C5C adds a
+    narrow read-only discovery gate for the well-known profile without
+    enabling broader Commerce V1 runtime routes.
 servers:
   - url: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
     description: Production (Cloud Run)
@@ -79,7 +81,7 @@ components:
         application/json:
           schema: { $ref: "#/components/schemas/Error" }
     CommerceDisabled:
-      description: COMMERCE_V1_ENABLED is not set in this environment
+      description: Commerce V1 runtime or read-only public discovery is not enabled or not allowlisted
       content:
         application/json:
           schema: { $ref: "#/components/schemas/Error" }
@@ -276,6 +278,7 @@ components:
         - mcp
         - native_rest
         - capabilities
+        - discovery_posture
       properties:
         version: { type: string, example: grantex-commerce-v1 }
         merchant: { $ref: "#/components/schemas/MerchantPublishingProfile" }
@@ -321,6 +324,33 @@ components:
         capabilities:
           type: array
           items: { type: string }
+        discovery_posture:
+          type: object
+          required:
+            - mode
+            - read_only_discovery_only
+            - commerce_v1_runtime_enabled
+            - checkout_payment_creation_enabled_by_discovery_gate
+            - live_payments_enabled
+            - live_plural_enabled
+            - provider_credentials_exposed
+            - readiness_claim
+            - certification_claim
+          properties:
+            mode:
+              type: string
+              enum: [public_read_only_discovery, commerce_v1_runtime_discovery]
+            read_only_discovery_only: { type: boolean }
+            commerce_v1_runtime_enabled: { type: boolean }
+            checkout_payment_creation_enabled_by_discovery_gate: { type: boolean }
+            live_payments_enabled: { type: boolean }
+            live_plural_enabled: { type: boolean }
+            provider_credentials_exposed: { type: boolean }
+            readiness_claim: { type: string, enum: [none] }
+            certification_claim: { type: string, enum: [none] }
+            notes:
+              type: array
+              items: { type: string }
 
     CatalogSearchRequest:
       type: object
@@ -3082,7 +3112,7 @@ paths:
     get:
       tags: [Well-Known]
       summary: Merchant publishing profile for Grantex Commerce V1
-      description: Publishes streamable_http MCP transport metadata and native REST entry points without asserting external compliance status.
+      description: Publishes streamable_http MCP transport metadata and native REST entry points without asserting external compliance status. COMMERCE_PUBLIC_DISCOVERY_ENABLED can expose this read-only metadata with an allowlisted merchant without enabling MCP tool calls, cart creation, checkout creation, payment intent creation, live payments, or live Plural.
       operationId: getGrantexCommerceProfile
       x-implemented: true
       x-milestone: M5

--- a/docs/commerce-v1-pilot-readiness.validate.mjs
+++ b/docs/commerce-v1-pilot-readiness.validate.mjs
@@ -22,6 +22,10 @@ const repeatableOptionASmokeWorkflow = readFileSync(
 const hostedStagingE2ETemplate = readFileSync(join(docsDir, 'reports', 'commerce-v1-hosted-staging-e2e.template.md'), 'utf8');
 const optionASmokeEvidence = readFileSync(join(docsDir, 'reports', 'commerce-v1-option-a-smoke-evidence.md'), 'utf8');
 const contractGapReport = readFileSync(join(docsDir, 'reports', 'commerce-v1-contract-completeness-gap-report.md'), 'utf8');
+const readOnlyDiscoveryProposal = readFileSync(
+  join(docsDir, 'reports', 'commerce-v1-read-only-production-discovery-proposal.md'),
+  'utf8',
+);
 const optionASmokeRunbookText = readFileSync(join(docsDir, 'examples', 'commerce-option-a-smoke.runbook.json'), 'utf8');
 const harness = readFileSync(join(repoRoot, 'scripts', 'commerce-pilot-load-harness.mjs'), 'utf8');
 const stagingE2EHarness = readFileSync(join(repoRoot, 'scripts', 'commerce-staging-e2e-harness.mjs'), 'utf8');
@@ -99,6 +103,41 @@ for (const required of [
   'docker compose up --build',
 ]) {
   assert.ok(guide.includes(required), `operations guide includes ${required}`);
+}
+
+for (const required of [
+  'COMMERCE_PUBLIC_DISCOVERY_ENABLED',
+  'COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST',
+  'controls only',
+  'GET /.well-known/grantex-commerce',
+  'does not enable `/mcp`',
+  'does not enable `/mcp`, MCP',
+  'No allowlist must fail closed',
+  'A requested merchant outside the allowlist must fail closed',
+  'read-only metadata only',
+  'checkout/payment creation is not enabled by the gate',
+  'live payments are',
+  'disabled, live Plural is disabled',
+  'live Plural is disabled',
+  'no readiness or certification claim',
+  'AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED',
+]) {
+  assert.ok(readOnlyDiscoveryProposal.includes(required), `read-only discovery proposal includes ${required}`);
+}
+for (const forbidden of [
+  'COMMERCE_PUBLIC_DISCOVERY_ENABLED=true',
+  'COMMERCE_V1_ENABLED=true',
+  'COMMERCE_LIVE_MODE_ENABLED=true',
+  'PLURAL_LIVE_ENABLED=true',
+  joinText('sk', '_live_'),
+  joinText('pk', '_live_'),
+  joinText('Bearer', ' '),
+]) {
+  assert.equal(
+    readOnlyDiscoveryProposal.includes(forbidden),
+    false,
+    `read-only discovery proposal does not include ${forbidden}`,
+  );
 }
 
 assert.ok(openapi.includes('/v1/commerce/ops/provider-webhook-events:'), 'OpenAPI documents provider webhook event listing');
@@ -1193,6 +1232,7 @@ assert.equal(/[^\u0000-\u007F]/.test(repeatableOptionASmokeWorkflow), false, 're
 assert.equal(/[^\u0000-\u007F]/.test(hostedStagingE2ETemplate), false, 'hosted staging E2E template stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(optionASmokeEvidence), false, 'Option A smoke evidence stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(contractGapReport), false, 'contract gap report stays ASCII-only');
+assert.equal(/[^\u0000-\u007F]/.test(readOnlyDiscoveryProposal), false, 'read-only discovery proposal stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(optionASmokeRunbookText), false, 'Option A smoke runbook stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(harness), false, 'load harness stays ASCII-only');
 assert.equal(/[^\u0000-\u007F]/.test(stagingE2EHarness), false, 'hosted staging E2E harness stays ASCII-only');

--- a/docs/reports/commerce-v1-read-only-production-discovery-proposal.md
+++ b/docs/reports/commerce-v1-read-only-production-discovery-proposal.md
@@ -167,6 +167,27 @@ Recommended topology for a future C5B implementation:
 8. Keep AgenticOrg public commerce discovery hidden until Grantex read-only
    discovery passes a read-only smoke.
 
+## C5C Implementation Requirements
+
+The future implementation must keep these gate boundaries explicit:
+
+- `COMMERCE_PUBLIC_DISCOVERY_ENABLED` controls only
+  `GET /.well-known/grantex-commerce`.
+- `COMMERCE_PUBLIC_DISCOVERY_ENABLED` does not enable `/mcp`, MCP
+  `tools/list`, MCP `tools/call`, cart creation, checkout creation, payment
+  intent creation, payment status mutation, provider webhooks, merchant
+  webhooks, reconciliation workers, live payments, or live Plural.
+- `COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST` is required when the public
+  read-only discovery gate is enabled.
+- No allowlist must fail closed.
+- A requested merchant outside the allowlist must fail closed.
+- The discovery payload must state that the gate is read-only metadata only,
+  checkout/payment creation is not enabled by the gate, live payments are
+  disabled, live Plural is disabled, and no readiness or certification claim is
+  made.
+- AgenticOrg `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED` remains disabled
+  until Grantex read-only discovery is approved and smoke-tested.
+
 ## Merchant Scoping Proposal
 
 No production merchant is approved by this planning task.


### PR DESCRIPTION
## Summary
- Adds fail-closed `COMMERCE_PUBLIC_DISCOVERY_ENABLED` and `COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST` handling for `GET /.well-known/grantex-commerce`.
- Keeps `COMMERCE_V1_ENABLED` as the broader Commerce V1 runtime gate; MCP and `/v1/commerce` runtime routes remain disabled when only the public discovery gate is enabled.
- Adds read-only discovery posture fields to the well-known payload and OpenAPI schema.
- Updates C5B proposal/validator coverage for gate boundaries, no-go conditions, allowlist behavior, and payload posture.

## Safety
- No deploy, cloud resources, production config, secrets, Commerce V1 runtime enablement, AgenticOrg public discovery enablement, checkout/payment creation, live payments, or live Plural changes.
- Public discovery gate defaults disabled unless explicitly set to a safe true value.
- Public discovery requires an allowlisted merchant and fails closed if live Commerce or live Plural flags are true.

## Validation
- `npm test -- --run tests/commerce-publishing-catalog.test.ts tests/commerce-feature-flags.test.ts tests/commerce-mcp.test.ts tests/commerce-hardening.test.ts tests/commerce-openapi.test.ts` from `apps/auth-service`
- `npm run typecheck` from `apps/auth-service`
- `node docs/commerce-v1-pilot-readiness.validate.mjs`
- Focused secret/value scan on changed files
- Focused overclaim scan on changed files; only negative/no-go wording and test assertions mention blocked claims
- `git diff --check`

Draft PR for review only.