### PR TITLE
Add Strands Agents SDK integration

### DIFF
--- a/packages/strands-py/pyproject.toml
+++ b/packages/strands-py/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "grantex-strands"
+version = "0.1.0"
+description = "Grantex scope enforcement for Strands Agents SDK"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+dependencies = [
+    "strands-agents>=0.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/grantex_strands"]

--- a/packages/strands-py/src/grantex_strands/__init__.py
+++ b/packages/strands-py/src/grantex_strands/__init__.py
@@ -1,0 +1,11 @@
+"""Grantex integration for Strands Agents SDK."""
+
+from ._tool import create_grantex_tool, get_tool_scopes
+from ._errors import GrantexStrandsError, ScopeViolationError
+
+__all__ = [
+    "create_grantex_tool",
+    "get_tool_scopes",
+    "GrantexStrandsError",
+    "ScopeViolationError",
+]

--- a/packages/strands-py/src/grantex_strands/_errors.py
+++ b/packages/strands-py/src/grantex_strands/_errors.py
@@ -1,0 +1,19 @@
+"""Error classes for grantex-strands."""
+
+from __future__ import annotations
+
+
+class GrantexStrandsError(Exception):
+    """Base exception for all grantex-strands errors."""
+
+
+class ScopeViolationError(GrantexStrandsError):
+    """Raised when a required scope is missing from the grant token."""
+
+    def __init__(self, required_scope: str, granted_scopes: list[str]) -> None:
+        self.required_scope = required_scope
+        self.granted_scopes = granted_scopes
+        super().__init__(
+            f"Grant token is missing required scope '{required_scope}'. "
+            f"Granted scopes: {granted_scopes}"
+        )

--- a/packages/strands-py/src/grantex_strands/_jwt.py
+++ b/packages/strands-py/src/grantex_strands/_jwt.py
@@ -1,0 +1,27 @@
+"""JWT payload decoding — offline, no signature verification."""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, Dict
+
+
+def _b64url_decode(data: str) -> bytes:
+    padding = 4 - len(data) % 4
+    if padding != 4:
+        data += "=" * padding
+    return base64.urlsafe_b64decode(data)
+
+
+def decode_jwt_payload(token: str) -> Dict[str, Any]:
+    """Decode the payload of a JWT without verifying the signature.
+
+    This is intentionally an offline operation — the token must already
+    have been verified (e.g. by Grantex) before being passed here.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise ValueError("Invalid JWT: expected 3 parts separated by '.'")
+    payload_bytes = _b64url_decode(parts[1])
+    return json.loads(payload_bytes.decode("utf-8"))  # type: ignore[no-any-return]

--- a/packages/strands-py/src/grantex_strands/_tool.py
+++ b/packages/strands-py/src/grantex_strands/_tool.py
@@ -1,0 +1,126 @@
+"""Strands SDK tool with Grantex scope enforcement."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from ._jwt import decode_jwt_payload
+from ._errors import ScopeViolationError
+
+
+def create_grantex_tool(
+    *,
+    name: str,
+    description: str,
+    grant_token: str,
+    required_scope: str,
+    func: Callable[..., str],
+    client: Any = None,
+    connector: str | None = None,
+    online: bool = False,
+) -> Any:
+    """Create a Strands-compatible tool with Grantex scope enforcement.
+
+    Supports two modes:
+
+    **Offline (default):** Decodes the JWT payload and checks the ``scp``
+    claim directly. Fast, no network required. Cannot detect token
+    revocation or verify signatures.
+
+    **Online (online=True):** Uses ``client.enforce()`` which verifies the
+    token signature via JWKS and checks scopes against the loaded manifest.
+    Requires a ``Grantex`` client instance and a ``connector`` name.
+
+    The scope check happens at **creation time** — if the token doesn't
+    have the required scope, PermissionError is raised immediately.
+
+    Example (offline)::
+
+        tool = create_grantex_tool(
+            name="get_balance",
+            description="Get account balance.",
+            grant_token=token,
+            required_scope="balance:read",
+            func=lambda account_id: f"Balance: $1000",
+        )
+
+    Example (online)::
+
+        tool = create_grantex_tool(
+            name="get_balance",
+            description="Get account balance.",
+            grant_token=token,
+            required_scope="tool:banking:read",
+            func=lambda account_id: f"Balance: $1000",
+            client=grantex_client,
+            connector="banking",
+            online=True,
+        )
+
+    Args:
+        name: Tool name.
+        description: Tool description.
+        grant_token: The Grantex grant token (JWT).
+        required_scope: Scope required to use this tool.
+        func: The function to execute when the tool is called.
+        client: Grantex client instance (required for online mode).
+        connector: Connector name for manifest lookup (required for online mode).
+        online: If True, use client.enforce() for signature + scope verification.
+
+    Raises:
+        PermissionError: if the grant token does not contain the required scope.
+        ValueError: if the grant token cannot be decoded (offline) or if
+                    client/connector are missing (online).
+    """
+    from strands import tool as strands_tool  # type: ignore[import-not-found]
+
+    if online:
+        # Online mode: use client.enforce() for full verification
+        if client is None:
+            raise ValueError("online=True requires a 'client' (Grantex instance)")
+        if connector is None:
+            raise ValueError("online=True requires a 'connector' name")
+
+        result = client.enforce(grant_token, connector, name)
+        allowed = result.allowed if hasattr(result, "allowed") else result.get("allowed")
+        if not allowed:
+            reason = result.reason if hasattr(result, "reason") else result.get("reason", "")
+            raise PermissionError(
+                f"Grant token scope check failed for tool '{name}' on "
+                f"connector '{connector}': {reason}"
+            )
+    else:
+        # Offline mode: decode JWT and check scp claim directly
+        try:
+            payload = decode_jwt_payload(grant_token)
+        except Exception as exc:
+            raise ValueError(f"Could not decode grant_token: {exc}") from exc
+
+        scopes: list[str] = payload.get("scp", [])
+        if required_scope not in scopes:
+            raise PermissionError(
+                f"Grant token is missing required scope '{required_scope}'. "
+                f"Granted scopes: {scopes}"
+            )
+
+    # Wrap func so the Strands decorator sees a proper function
+    def _wrapper(**kwargs: Any) -> str:
+        return func(**kwargs)
+
+    _wrapper.__name__ = name
+    _wrapper.__doc__ = description
+
+    return strands_tool(_wrapper)
+
+
+def get_tool_scopes(grant_token: str) -> list[str]:
+    """Extract the scopes list from a grant token (offline, no verification).
+
+    Returns an empty list if the token cannot be decoded or has no scp claim.
+    """
+    try:
+        payload = decode_jwt_payload(grant_token)
+        scp = payload.get("scp", [])
+        return scp if isinstance(scp, list) else []
+    except Exception:
+        return []

--- a/packages/strands-py/tests/conftest.py
+++ b/packages/strands-py/tests/conftest.py
@@ -1,0 +1,68 @@
+"""Test fixtures — stub the strands module so tests run without strands installed."""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import types
+from typing import Any
+
+
+# ─── Strands stub ────────────────────────────────────────────────────────────
+
+class _StrandsTool:
+    """Minimal Strands tool stub that mimics the strands @tool interface."""
+
+    def __init__(self, func: Any) -> None:
+        self._func = func
+        self.name = getattr(func, "__name__", "unknown")
+        self.description = getattr(func, "__doc__", "") or ""
+
+    def __call__(self, **kwargs: Any) -> str:
+        return self._func(**kwargs)
+
+    def run(self, **kwargs: Any) -> str:
+        return self._func(**kwargs)
+
+
+def _tool_decorator(func: Any) -> _StrandsTool:
+    return _StrandsTool(func)
+
+
+_strands_mod = types.ModuleType("strands")
+_strands_mod.tool = _tool_decorator  # type: ignore[attr-defined]
+_strands_mod.Tool = _StrandsTool  # type: ignore[attr-defined]
+
+sys.modules.setdefault("strands", _strands_mod)
+
+
+# ─── JWT helpers ─────────────────────────────────────────────────────────────
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def make_grant_token(scopes: list[str], extra: dict[str, Any] | None = None) -> str:
+    """Build a fake (unsigned) JWT with the given scp claim."""
+    header = _b64url(json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
+    payload_data: dict[str, Any] = {
+        "iss": "https://api.grantex.dev",
+        "sub": "user_01",
+        "agt": "did:grantex:ag_01",
+        "dev": "dev_01",
+        "scp": scopes,
+        "iat": 1700000000,
+        "exp": 9999999999,
+        "jti": "tok_01",
+        "grnt": "grnt_01",
+    }
+    if extra:
+        payload_data.update(extra)
+    payload = _b64url(json.dumps(payload_data).encode())
+    return f"{header}.{payload}.fakesignature"
+
+
+# Pre-built tokens for tests
+TOKEN_WITH_SCOPES = make_grant_token(["data:read", "data:write"])
+TOKEN_WITH_READ = make_grant_token(["data:read"])

--- a/packages/strands-py/tests/test_tool.py
+++ b/packages/strands-py/tests/test_tool.py
@@ -1,0 +1,108 @@
+"""Tests for grantex_strands — scope enforcement on Strands tools."""
+
+from __future__ import annotations
+
+import pytest
+
+from conftest import TOKEN_WITH_SCOPES, TOKEN_WITH_READ, make_grant_token
+from grantex_strands import create_grantex_tool, get_tool_scopes
+
+
+# ─── Tool creation and scope enforcement ─────────────────────────────────────
+
+
+def test_create_tool_returns_strands_tool_instance() -> None:
+    tool = create_grantex_tool(
+        name="my_tool",
+        description="Does something.",
+        grant_token=TOKEN_WITH_READ,
+        required_scope="data:read",
+        func=lambda: "ok",
+    )
+    # Should be callable (Strands tools are callable)
+    assert callable(tool)
+    assert tool.name == "my_tool"
+    assert tool.description == "Does something."
+
+
+def test_create_tool_raises_permission_error_for_missing_scope() -> None:
+    with pytest.raises(PermissionError, match="missing required scope 'admin:all'"):
+        create_grantex_tool(
+            name="admin_tool",
+            description="Admin action.",
+            grant_token=TOKEN_WITH_READ,
+            required_scope="admin:all",
+            func=lambda: "ok",
+        )
+
+
+def test_create_tool_raises_for_invalid_jwt() -> None:
+    with pytest.raises(ValueError, match="Could not decode grant_token"):
+        create_grantex_tool(
+            name="bad_tool",
+            description="Bad token.",
+            grant_token="not.a.valid-jwt-payload",
+            required_scope="data:read",
+            func=lambda: "ok",
+        )
+
+
+def test_tool_run_delegates_to_func() -> None:
+    calls: list[dict[str, str]] = []
+
+    def my_func(url: str = "") -> str:
+        calls.append({"url": url})
+        return f"fetched:{url}"
+
+    tool = create_grantex_tool(
+        name="fetch",
+        description="Fetch a URL.",
+        grant_token=TOKEN_WITH_SCOPES,
+        required_scope="data:read",
+        func=my_func,
+    )
+
+    result = tool(url="https://example.com")
+    assert result == "fetched:https://example.com"
+    assert calls == [{"url": "https://example.com"}]
+
+
+def test_write_scope_allows_write_tool() -> None:
+    tool = create_grantex_tool(
+        name="write_tool",
+        description="Writes data.",
+        grant_token=TOKEN_WITH_SCOPES,  # has data:write
+        required_scope="data:write",
+        func=lambda: "written",
+    )
+    assert tool() == "written"
+
+
+def test_read_scope_denies_write_tool() -> None:
+    with pytest.raises(PermissionError, match="missing required scope 'data:write'"):
+        create_grantex_tool(
+            name="write_tool",
+            description="Writes data.",
+            grant_token=TOKEN_WITH_READ,  # only has data:read
+            required_scope="data:write",
+            func=lambda: "written",
+        )
+
+
+# ─── get_tool_scopes ─────────────────────────────────────────────────────────
+
+
+def test_get_tool_scopes_returns_scp_list() -> None:
+    scopes = get_tool_scopes(TOKEN_WITH_SCOPES)
+    assert scopes == ["data:read", "data:write"]
+
+
+def test_get_tool_scopes_empty_token() -> None:
+    token = make_grant_token([])
+    scopes = get_tool_scopes(token)
+    assert scopes == []
+
+
+def test_get_tool_scopes_invalid_token() -> None:
+    scopes = get_tool_scopes("garbage")
+    assert scopes == []


### PR DESCRIPTION
## What
Adds packages/strands-py — Grantex scope enforcement for AWS Strands Agents SDK.

## How it works
create_grantex_tool() wraps a Strands tool function with scope enforcement at creation time.
Supports offline (JWT decode) and online (client.enforce()) modes.

## Testing
- 9 unit tests passing
- E2E validated against local auth service (sandbox mode)
- Comparison with baseline documented

## Pattern
Same API and test structure as packages/crewai, packages/openai-agents, packages/google-adk.