### PR TITLE
fix(portal): ErrorBoundary 'Go to Dashboard' uses /dashboard/ with trailing slash

### DIFF
--- a/apps/portal/src/components/ErrorBoundary.tsx
+++ b/apps/portal/src/components/ErrorBoundary.tsx
@@ -45,7 +45,7 @@ export class ErrorBoundary extends Component<Props, State> {
               </Button>
               <Button
                 size="sm"
-                onClick={() => { window.location.href = '/dashboard'; }}
+                onClick={() => { window.location.href = '/dashboard/'; }}
               >
                 Go to Dashboard
               </Button>

--- a/apps/portal/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/apps/portal/src/components/__tests__/ErrorBoundary.test.tsx
@@ -62,6 +62,36 @@ describe('ErrorBoundary', () => {
     expect(screen.getByRole('button', { name: 'Go to Dashboard' })).toBeInTheDocument();
   });
 
+  it('navigates to /dashboard/ (with trailing slash) when Go to Dashboard is clicked', async () => {
+    // Vite serves the portal under base: '/dashboard/' — without the trailing
+    // slash, Vite shows an educational warning page instead of the SPA.
+    const user = userEvent.setup();
+    const hrefSetter = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        get href() { return ''; },
+        set href(v: string) { hrefSetter(v); },
+      },
+    });
+
+    try {
+      render(
+        <ErrorBoundary>
+          <ThrowError shouldThrow={true} />
+        </ErrorBoundary>,
+      );
+      await user.click(screen.getByRole('button', { name: 'Go to Dashboard' }));
+      expect(hrefSetter).toHaveBeenCalledWith('/dashboard/');
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
   it('resets error state when Try Again is clicked', async () => {
     const user = userEvent.setup();
 


### PR DESCRIPTION
## Summary

- `ErrorBoundary.tsx` recovery button now navigates to `/dashboard/` (with trailing slash) instead of `/dashboard`
- Vite is configured with `base: '/dashboard/'`, so the old URL lands the user on Vite's "did you mean /dashboard/" warning page instead of the SPA
- Adds a regression test asserting the navigation target

Fixes #371.

## Test plan

- [x] `npm run typecheck` passes (if TypeScript changed) — clean
- [x] `npm test` passes (if TypeScript changed) — `npx vitest run ErrorBoundary` → 9/9 passing (8 existing + 1 new)
- [ ] `pytest` passes (if Python changed) — N/A
- [ ] `go test ./...` passes (if Go changed) — N/A
- [x] Manual testing (describe below)

**Manual verification:**
1. `cd apps/portal && npm run dev`
2. Trigger ErrorBoundary (e.g. visit any page that throws, or use `/dashboard/bundles` while #369 is open)
3. Click "Go to Dashboard"
   - Before: lands on Vite's "did you mean /dashboard/" educational page
   - After: lands on the dashboard, SPA loads

## Scope

One-character fix to the URL string + one new test. Class component (required for `componentDidCatch`), so swapping to `useNavigate` would require a wrapper HOC — out of scope for this fix.

## Related issues

Fixes #371