### PR TITLE
fix: close enterprise readiness P0 blockers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,278 @@
+# Dependabot configuration — closes brutal-review item H-32.
+#
+# Recent merge history (#373, #375 for qs and express) shows GitHub's
+# default ecosystem detection HAS been picking up some npm directories,
+# but it is not exhaustive: until this file exists nothing was scheduled
+# for python, go, terraform, or github-actions itself. The list below
+# mirrors every real manifest under packages/, apps/, and examples/
+# (`.tmp/` is .gitignored and excluded by definition).
+
+version: 2
+updates:
+  # ─── GitHub Actions workflows themselves ────────────────────────────
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+
+  # ─── npm — root + every app + every Node package + the TS example ───
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: [dependencies, npm]
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+
+  - package-ecosystem: npm
+    directory: /apps/auth-service
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: [dependencies, npm, auth-service]
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+
+  - package-ecosystem: npm
+    directory: /apps/mpp-demo-service
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, mpp-demo-service]
+
+  - package-ecosystem: npm
+    directory: /apps/portal
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: [dependencies, npm, portal]
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+
+  - package-ecosystem: npm
+    directory: /packages/sdk-ts
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: [dependencies, npm, sdk-ts]
+
+  - package-ecosystem: npm
+    directory: /packages/anthropic
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, anthropic]
+
+  - package-ecosystem: npm
+    directory: /packages/dpdp
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, dpdp]
+
+  - package-ecosystem: npm
+    directory: /packages/x402
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, x402]
+
+  - package-ecosystem: npm
+    directory: /packages/cli
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, cli]
+
+  - package-ecosystem: npm
+    directory: /packages/mcp
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, mcp]
+
+  - package-ecosystem: npm
+    directory: /packages/mcp-auth
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, mcp-auth]
+
+  - package-ecosystem: npm
+    directory: /packages/langchain
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, langchain]
+
+  - package-ecosystem: npm
+    directory: /packages/autogen
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, autogen]
+
+  - package-ecosystem: npm
+    directory: /packages/vercel-ai
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, vercel-ai]
+
+  - package-ecosystem: npm
+    directory: /packages/express
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, express]
+
+  - package-ecosystem: npm
+    directory: /packages/gateway
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, gateway]
+
+  - package-ecosystem: npm
+    directory: /packages/adapters
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, adapters]
+
+  - package-ecosystem: npm
+    directory: /packages/destinations
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, destinations]
+
+  - package-ecosystem: npm
+    directory: /packages/conformance
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, conformance]
+
+  - package-ecosystem: npm
+    directory: /packages/gemma
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, gemma]
+
+  - package-ecosystem: npm
+    directory: /packages/mpp
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, mpp]
+
+  - package-ecosystem: npm
+    directory: /packages/a2a
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, a2a]
+
+  - package-ecosystem: npm
+    directory: /examples/quickstart-ts
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, npm, examples]
+
+  # ─── pip — every Python package directory with pyproject.toml ───────
+  - package-ecosystem: pip
+    directory: /packages/sdk-py
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: [dependencies, python, sdk-py]
+
+  - package-ecosystem: pip
+    directory: /packages/fastapi
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, python, fastapi]
+
+  - package-ecosystem: pip
+    directory: /packages/crewai
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, python, crewai]
+
+  - package-ecosystem: pip
+    directory: /packages/openai-agents
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, python, openai-agents]
+
+  - package-ecosystem: pip
+    directory: /packages/google-adk
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, python, google-adk]
+
+  - package-ecosystem: pip
+    directory: /packages/a2a-py
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, python, a2a-py]
+
+  - package-ecosystem: pip
+    directory: /packages/gemma-py
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, python, gemma-py]
+
+  - package-ecosystem: pip
+    directory: /packages/strands-py
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, python, strands-py]
+
+  # ─── gomod — Go SDK, Terraform provider, Go quickstart example ──────
+  - package-ecosystem: gomod
+    directory: /packages/go-sdk
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: [dependencies, go, sdk-go]
+
+  - package-ecosystem: gomod
+    directory: /packages/terraform-provider-grantex
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: [dependencies, go, terraform-provider]
+
+  - package-ecosystem: gomod
+    directory: /examples/quickstart-go
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, go, examples]
+
+  # ─── terraform — providers/modules referenced in the example HCL ────
+  - package-ecosystem: terraform
+    directory: /packages/terraform-provider-grantex/examples
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: [dependencies, terraform]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,3 +219,27 @@ jobs:
         run: npm run typecheck
       - name: Build
         run: npm run build
+
+  # ─── Examples: quickstart-ts ─────────────────────────────────────────────
+  #
+  # The README's "Try in 30 seconds" snippet uses this example. The CHECK
+  # IT here is intentionally network-free: we install deps and typecheck
+  # against the published SDK shape, but never call `npm start` (which
+  # would attempt to reach a running Grantex API). The auditor's P0-15
+  # complaint was that the example had a stale ^0.1.1 pin against an
+  # 0.3.x SDK; this job catches the same drift in future SDK bumps.
+  quickstart-ts:
+    name: Example — quickstart-ts
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: examples/quickstart-ts
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+      - name: Install (resolves @grantex/sdk against the public registry)
+        run: npm install --no-audit --no-fund
+      - name: Typecheck (no network calls)
+        run: npx tsc --noEmit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,156 @@
 name: Release
 
+# A tag push must not produce a public GitHub Release until the critical
+# verification gates below pass. The preflight job exists inside this
+# workflow (rather than depending on the separate `CI` workflow) because
+# `needs:` cannot reach across workflows — `workflow_run` is not a safe
+# gate, since a failing CI run does not prevent a release tag from
+# triggering this workflow on its own.
+
 on:
   push:
     tags:
       - 'v*'
 
+# Default to read-only. The release job re-elevates to `contents: write`
+# explicitly so any new jobs added later inherit the safe default.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  release:
+  # ─── Preflight: critical verification that gates the release ───────────
+  preflight:
+    name: Preflight (critical verification)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: TypeScript SDK — install + typecheck + test
+        working-directory: packages/sdk-ts
+        run: |
+          npm ci
+          npm run typecheck
+          npm test
+
+      - name: TypeScript SDK — build (consumed by Anthropic adapter)
+        working-directory: packages/sdk-ts
+        run: npm run build
+
+      - name: Anthropic adapter — install + typecheck + test
+        working-directory: packages/anthropic
+        run: |
+          npm ci
+          npm run typecheck
+          npm test
+
+      - name: Auth service — install + typecheck
+        working-directory: apps/auth-service
+        run: |
+          npm ci
+          npm run typecheck
+
+      - name: Auth service — focused DPDP / multi-tenancy / admin tests
+        working-directory: apps/auth-service
+        run: |
+          npx vitest run \
+            tests/dpdp.test.ts \
+            tests/security-multi-tenancy.test.ts \
+            tests/admin.test.ts \
+            tests/commerce-tenant-provisioning.test.ts \
+            tests/commerce-caller-resolver.test.ts \
+            tests/commerce-finding-fixes.test.ts
+
+      - name: P0-23 — Commerce live-mode guard placeholder
+        # See scripts/check-live-mode-guard.mjs. Until the central
+        # live-mode-guard module lands, this step only documents intent
+        # and never fails. Once the guard exists, the script will be
+        # promoted to a real check that fails CI on regressions.
+        run: node scripts/check-live-mode-guard.mjs
+
+  # ─── Build release artifact + checksum ────────────────────────────────
+  release:
+    name: Create GitHub Release
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # `id-token: write` is requested here so a follow-up SLSA generator
+      # job (see TODO below) can mint an OIDC token without an extra
+      # permissions change.
+      id-token: write
+    outputs:
+      artifact-name: ${{ steps.archive.outputs.artifact-name }}
+      artifact-sha256: ${{ steps.archive.outputs.artifact-sha256 }}
+      slsa-subjects: ${{ steps.archive.outputs.slsa-subjects }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # SLSA provenance needs the full history for repro-checks.
+          fetch-depth: 0
+
+      - name: Build source archive + SHA-256 checksum
+        id: archive
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          name="grantex-${version}-src.tar.gz"
+          mkdir -p dist
+          git archive --format=tar.gz --prefix="grantex-${version}/" \
+            -o "dist/${name}" HEAD
+          ( cd dist && sha256sum "${name}" | tee "${name}.sha256" )
+          # base64-encoded `sha256(file)  filename` line — the canonical
+          # input shape for slsa-framework/slsa-github-generator's
+          # generator_generic_slsa3.yml `base64-subjects` field.
+          subjects=$(sha256sum "dist/${name}" | base64 -w0)
+          {
+            echo "artifact-name=${name}"
+            echo "artifact-sha256=$(sha256sum "dist/${name}" | awk '{print $1}')"
+            echo "slsa-subjects=${subjects}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact for provenance job
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
+          files: |
+            dist/grantex-*-src.tar.gz
+            dist/grantex-*-src.tar.gz.sha256
+
+  # ─── SLSA L3 build provenance ─────────────────────────────────────────
+  #
+  # The reusable workflow below produces a signed in-toto provenance
+  # attestation for the release artifact and uploads it to the GitHub
+  # Release. The `base64-subjects` input is the base64-encoded line from
+  # `sha256sum` over the release archive (already produced above).
+  #
+  # NOTE — VERSION PIN REQUIRED BEFORE FIRST USE:
+  #   Confirm the latest stable tag of slsa-framework/slsa-github-generator
+  #   at https://github.com/slsa-framework/slsa-github-generator/releases
+  #   and replace `vX.Y.Z` below with that pinned tag (NOT a moving ref
+  #   like `@main` — pinning is a SLSA L3 requirement). Until then this
+  #   job is intentionally disabled so that the release workflow does not
+  #   reference an unverified third-party version.
+  #
+  # provenance:
+  #   needs: [release]
+  #   permissions:
+  #     actions: read
+  #     id-token: write
+  #     contents: write
+  #   uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@vX.Y.Z
+  #   with:
+  #     base64-subjects: ${{ needs.release.outputs.slsa-subjects }}
+  #     upload-assets: true

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ __pycache__/
 # Build outputs
 dist/
 build/
+.tmp/
 
 # Firebase
 .firebase/

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,41 @@
-* @mishrasanjeev
-packages/sdk-ts/ @mishrasanjeev
-packages/sdk-py/ @mishrasanjeev
-apps/auth-service/ @mishrasanjeev
-docs/ @mishrasanjeev
-SPEC.md @mishrasanjeev
+# CODEOWNERS — bus-factor remediation per brutal-review item P0-9.
+#
+# IMPORTANT — provisioning prerequisite:
+#   The team @grantex/maintainers MUST be created in the GitHub
+#   organisation hosting this repository and populated with at least
+#   one human reviewer in addition to @mishrasanjeev BEFORE the
+#   branch-protection rule on `main` is set to require approval from
+#   this file's listed owners.
+#
+#   If the team does not exist yet, GitHub silently ignores its
+#   entries here and falls back to @mishrasanjeev as the sole
+#   required reviewer — i.e. the bus-factor is unchanged. Create the
+#   team at:
+#     https://docs.github.com/en/organizations/organizing-members-into-teams/creating-a-team
+#
+# Pattern: every path requires BOTH a team review and the @mishrasanjeev
+# individual fallback. GitHub requires at least one approver from the
+# listed owners; once the team has more than one human member, the
+# single-point-of-failure review constraint is broken without any
+# further change to this file.
+
+* @grantex/maintainers @mishrasanjeev
+
+# Area ownership — same dual-owner pattern. Specific entries override
+# the catch-all above, so each must list both the team and the
+# individual fallback.
+packages/sdk-ts/                                        @grantex/maintainers @mishrasanjeev
+packages/sdk-py/                                        @grantex/maintainers @mishrasanjeev
+apps/auth-service/                                      @grantex/maintainers @mishrasanjeev
+docs/                                                   @grantex/maintainers @mishrasanjeev
+SPEC.md                                                 @grantex/maintainers @mishrasanjeev
+
+# Security- and release-sensitive paths — same review requirements,
+# called out explicitly so a future branch-protection rule that
+# requires team review on these specifically is unambiguous.
+SECURITY.md                                             @grantex/maintainers @mishrasanjeev
+docs/compliance/                                        @grantex/maintainers @mishrasanjeev
+apps/auth-service/src/lib/commerce/live-mode-guard.ts   @grantex/maintainers @mishrasanjeev
+scripts/check-live-mode-guard.mjs                       @grantex/maintainers @mishrasanjeev
+.github/workflows/release.yml                           @grantex/maintainers @mishrasanjeev
+.github/dependabot.yml                                  @grantex/maintainers @mishrasanjeev

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,61 @@
+# Grantex Compatibility Matrix
+
+Last updated: 2026-05-24
+
+This repository currently uses package-specific versions. The public README should not be read as a monorepo-wide `v2.5` release. Until a release tool such as Changesets or Nx enforces this automatically, use this matrix to choose compatible packages.
+
+## Canonical Release Signals
+
+| Surface | Current value | Notes |
+| --- | --- | --- |
+| Repository changelog | v0.3.8 | Latest top-level release entry in `CHANGELOG.md`. |
+| TypeScript SDK | @grantex/sdk 0.3.8 | Primary TypeScript client package. |
+| Python SDK | grantex 0.3.9 | Primary Python client package. |
+| OpenAPI | 0.1.3 | Needs reconciliation with SDK versions. |
+| MCP Auth | @grantex/mcp-auth 2.0.1 | Independently versioned package. |
+
+## Package Versions
+
+The repository contains 28 packages under `packages/` (matching the README "28 packages" claim). Each row maps a directory to the published artifact name and the version recorded in its manifest at the time of writing.
+
+| # | Directory | Published name | Version | Status |
+| ---: | --- | --- | ---: | --- |
+| 1 | `packages/sdk-ts` | @grantex/sdk | 0.3.8 | Primary SDK (TypeScript) |
+| 2 | `packages/sdk-py` | grantex | 0.3.9 | Primary SDK (Python) |
+| 3 | `packages/go-sdk` | github.com/mishrasanjeev/grantex-go | Go module (1.26.1) | Primary SDK (Go) |
+| 4 | `packages/cli` | @grantex/cli | 0.2.4 | Tooling |
+| 5 | `packages/mcp-auth` | @grantex/mcp-auth | 2.0.1 | Independently versioned |
+| 6 | `packages/mcp` | @grantex/mcp | 0.1.9 | Adapter |
+| 7 | `packages/langchain` | @grantex/langchain | 0.1.6 | Adapter |
+| 8 | `packages/autogen` | @grantex/autogen | 0.1.5 | Adapter |
+| 9 | `packages/vercel-ai` | @grantex/vercel-ai | 0.1.5 | Adapter |
+| 10 | `packages/anthropic` | @grantex/anthropic | 0.1.0 | Adapter |
+| 11 | `packages/crewai` | grantex-crewai | 0.1.4 | Adapter |
+| 12 | `packages/openai-agents` | grantex-openai-agents | 0.1.3 | Adapter |
+| 13 | `packages/google-adk` | grantex-adk | 0.1.3 | Adapter |
+| 14 | `packages/strands-py` | grantex-strands | 0.1.0 | Adapter |
+| 15 | `packages/express` | @grantex/express | 0.1.4 | Middleware |
+| 16 | `packages/fastapi` | grantex-fastapi | 0.1.4 | Middleware |
+| 17 | `packages/gateway` | @grantex/gateway | 0.1.4 | Gateway |
+| 18 | `packages/conformance` | @grantex/conformance | 0.1.7 | Test suite |
+| 19 | `packages/adapters` | @grantex/adapters | 0.1.4 | Service adapters |
+| 20 | `packages/destinations` | @grantex/destinations | 0.1.2 | Event destinations |
+| 21 | `packages/dpdp` | @grantex/dpdp | 0.1.0 | Compliance controls |
+| 22 | `packages/gemma` | @grantex/gemma | 0.1.0 | Offline authorization (TS) |
+| 23 | `packages/gemma-py` | grantex-gemma | 0.1.0 | Offline authorization (Python) |
+| 24 | `packages/a2a` | @grantex/a2a | 0.1.2 | A2A bridge (TS) |
+| 25 | `packages/a2a-py` | grantex-a2a | 0.1.2 | A2A bridge (Python) |
+| 26 | `packages/mpp` | @grantex/mpp | 0.1.1 | MPP support |
+| 27 | `packages/x402` | @grantex/x402 | 0.1.1 | x402 support |
+| 28 | `packages/terraform-provider-grantex` | terraform-provider-grantex | Go module (1.21) | Terraform provider |
+
+## Installation Guidance
+
+Use the latest published primary SDK for your language, then choose adapter versions from the same date range in this matrix. Do not mix this repository's package versions with marketing release labels until a single release process is in place.
+
+## Required Follow-Up
+
+- Pick independent versioning or lockstep versioning and document it permanently.
+- Add CI that fails when README, OpenAPI, changelog, and package versions drift without an update to this matrix.
+- Reconcile OpenAPI `info.version` with the supported SDK release line.
+- Align `packages/go-sdk` (Go 1.26.1) and `packages/terraform-provider-grantex` (Go 1.21) on the same Go toolchain.

--- a/README.md
+++ b/README.md
@@ -11,17 +11,15 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Spec Version](https://img.shields.io/badge/spec-v1.0--final-green)](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md)
 [![IETF Draft](https://img.shields.io/badge/IETF-draft--mishra--oauth--agent--grants-blue)](https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/)
-[![SOC 2 Type I](https://img.shields.io/badge/SOC%202-Type%20I%20Certified-brightgreen)](https://docs.grantex.dev/security)
 [![CI](https://img.shields.io/github/actions/workflow/status/mishrasanjeev/grantex/ci.yml?branch=main&label=CI)](https://github.com/mishrasanjeev/grantex/actions/workflows/ci.yml)
-[![4,147 Tests — 100%](https://img.shields.io/badge/tests-4%2C147%20passing%20%7C%20100%25-brightgreen)](https://github.com/mishrasanjeev/grantex/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@grantex/sdk)](https://www.npmjs.com/package/@grantex/sdk)
 [![PyPI](https://img.shields.io/pypi/v/grantex)](https://pypi.org/project/grantex/)
 [![npm downloads](https://img.shields.io/npm/dm/@grantex/sdk?label=npm%20downloads)](https://www.npmjs.com/package/@grantex/sdk)
 [![GitHub Stars](https://img.shields.io/github/stars/mishrasanjeev/grantex?style=social)](https://github.com/mishrasanjeev/grantex)
 [![Docs](https://img.shields.io/badge/docs-grantex.dev-3fb950)](https://grantex.dev/docs)
 [![MCP Server](https://img.shields.io/badge/MCP-Server-blue)](https://www.npmjs.com/package/@grantex/mcp)
-[![DPDP Compliant](https://img.shields.io/badge/DPDP-Compliant-green)](https://grantex.dev/dpdp)
-[![EU AI Act Ready](https://img.shields.io/badge/EU_AI_Act-Ready-blue)](https://grantex.dev/dpdp)
+[![DPDP Mapping](https://img.shields.io/badge/DPDP-control%20mapping-informational)](https://grantex.dev/dpdp)
+[![EU AI Act Mapping](https://img.shields.io/badge/EU_AI_Act-control%20mapping-informational)](https://grantex.dev/dpdp)
 
 <br/>
 
@@ -35,11 +33,11 @@
 
 </div>
 
-## Agentic Commerce V1
+## Agentic Commerce V1 (closed beta)
 
-Grantex Commerce V1 is the consent, Commerce Passport, policy, audit, and payment-control layer for agentic checkout. It lets commerce agents discover merchant catalog data, create carts, request user consent, receive a scoped Commerce Passport, and create provider-neutral payment intents without giving the agent direct access to payment providers.
+Grantex Commerce V1 is the closed-beta consent, Commerce Passport, policy, audit, and payment-control layer for agentic checkout. It lets commerce agents use sandbox catalog data, create carts, request user consent, receive a scoped Commerce Passport, and exercise mock provider payment intents without giving the agent direct access to payment providers.
 
-> Production Commerce V1 discovery is currently disabled/fail-closed. Production live checkout, live payments, and live Plural are not enabled.
+> Production Commerce V1 discovery is disabled/fail-closed. Live checkout, live payments, and live Plural are not enabled. Public demos and playgrounds are mock-provider only until legal, compliance, security, operations, and provider approvals are complete.
 
 ```mermaid
 flowchart LR
@@ -59,19 +57,19 @@ flowchart LR
 | Temporary Option A smoke | Verified with mock provider and cleaned-up smoke resources. |
 | AgenticOrg real-staging handoff | Verified through Grantex-only tools with redacted fixture handling. |
 | Hosted AgenticOrg discovery | Verified in temporary API-only hosted smoke. |
-| Production read-only discovery | Grantex production Commerce V1 discovery remains disabled/fail-closed. |
+| Production read-only discovery | Disabled/fail-closed. |
 | Live checkout/payments | Blocked pending legal, compliance, security, operations, and provider approvals. |
 | Live Plural | Blocked; mock provider only in current evidence. |
 
-Start with the [Commerce V1 overview](docs/guides/commerce-v1-overview.mdx), then use the [developer guide](docs/guides/commerce-v1-developer-guide.mdx), [merchant/operator guide](docs/guides/commerce-v1-merchant-operator-guide.mdx), [operations guide](docs/guides/commerce-v1-operations.mdx), and [repeatable Option A smoke workflow](docs/guides/commerce-v1-repeatable-option-a-smoke-workflow.md). Reference evidence lives in [Option A smoke evidence](docs/reports/commerce-v1-option-a-smoke-evidence.md) and [production discovery readiness](docs/reports/commerce-v1-production-discovery-readiness.md). The public education page is `web/commerce.html`.
+Start with the [Commerce V1 overview](docs/guides/commerce-v1-overview.mdx), then use the [developer guide](docs/guides/commerce-v1-developer-guide.mdx), [merchant/operator guide](docs/guides/commerce-v1-merchant-operator-guide.mdx), and [operations guide](docs/guides/commerce-v1-operations.mdx). The public education page is `web/commerce.html`.
 
-## What's New in v2.5
+## Current Development Snapshot
 
-- **@grantex/gemma**: Day-zero Gemma 4 integration — offline consent bundles,
-  < 5ms verification on Raspberry Pi, Google ADK adapter
-- **MCP Auth Server v2.0 GA**: OAuth 2.1 + PKCE for any MCP server,
-  managed + self-hosted modes, Bronze/Silver/Gold certification program
-- **@grantex/dpdp**: DPDP Act 2023 & EU AI Act compliance module
+The latest repository changelog currently tops out at v0.3.8. Package versions are being reconciled across SDKs and adapters; use [COMPATIBILITY.md](COMPATIBILITY.md) as the current source of truth for package-specific versions.
+
+- **@grantex/gemma**: Offline consent bundles and on-device verification examples
+- **MCP Auth Server**: OAuth 2.1 + PKCE for MCP servers, managed and self-hosted modes
+- **@grantex/dpdp**: DPDP Act 2023 and EU AI Act control mappings
 - **Trust Registry**: Public DID verification registry — `grantex.dev/registry`
 - **`grantex verify`**: Token inspection CLI — no account needed
 - **Anomaly Detection**: 10 built-in rules, Slack/PagerDuty/Datadog integration
@@ -105,7 +103,7 @@ go get github.com/mishrasanjeev/grantex-go  # Go
 npm install -g @grantex/cli     # CLI
 ```
 
-> **28 packages** across TypeScript, Python, and Go. Integrations for **Anthropic SDK, LangChain, OpenAI Agents SDK, Google ADK, Strands Agents SDK, CrewAI, Vercel AI, AutoGen, MCP, Express.js, FastAPI**, and **Terraform**. 4,147 tests (100% pass rate). Fully self-hostable. Apache 2.0.
+> **28 packages** across TypeScript, Python, and Go. Integrations for **Anthropic SDK, LangChain, OpenAI Agents SDK, Google ADK, Strands Agents SDK, CrewAI, Vercel AI, AutoGen, MCP, Express.js, FastAPI**, and **Terraform**. The latest changelog reports 3,536 tests across 28 packages; GitHub Actions is the source of truth for current pass/fail status. Fully self-hostable. Apache 2.0.
 
 ---
 
@@ -1137,7 +1135,7 @@ bundles = client.policies.bundles()
 
 ## DPDP Act 2023 Compliance
 
-Full DPDP Act 2023 compliance built in — structured consent records, purpose limitation, data principal rights (access, erasure, grievance), and audit-ready exports. Available in all SDKs and the CLI.
+DPDP Act 2023 support includes structured consent records, purpose limitation, data principal rights workflows (access, erasure, grievance), and audit-ready exports. Available in all SDKs and the CLI. This is a technical control mapping, not a legal certification.
 
 ```typescript
 // Register a consent notice
@@ -1310,7 +1308,7 @@ Grantex is built as an **open protocol**, not a closed SaaS product. Here's why 
 
 **Offline-verifiable.** Services verify tokens using published JWKS — zero runtime dependency on Grantex infrastructure. Your agent works even if our servers are down.
 
-**Compliance-ready.** The EU AI Act, GDPR, and emerging US AI regulations will mandate auditable agent actions. Grantex gives you that on day one.
+**Compliance-oriented controls.** The EU AI Act, GDPR, and emerging US AI regulations will mandate auditable agent actions. Grantex provides technical controls that can support those programs from day one.
 
 ---
 
@@ -1617,7 +1615,7 @@ All milestones through v1.0 are complete. See [ROADMAP.md](https://github.com/mi
 | **v0.1 — Foundation** | Protocol spec, TypeScript & Python SDKs, auth service, consent UI, audit trail, multi-agent delegation, sandbox mode | ✅ Complete |
 | **v0.2 — Integrations** | LangChain, AutoGen, webhooks, Stripe billing, CLI | ✅ Complete |
 | **v0.3 — Enterprise** | CrewAI, Vercel AI, compliance exports, policy engine, SCIM/SSO, anomaly detection | ✅ Complete |
-| **v1.0 — Stable Protocol** | Protocol spec finalized (v1.0), security audit, SOC2, standards submission | ✅ Complete |
+| **v1.0 — Stable Protocol** | Protocol spec finalized (v1.0), security audit, SOC 2 readiness mapping, standards submission | ✅ Complete |
 | **v2.0 — Platform** | MCP Auth Server, Credential Vault, 7 new adapters, webhook delivery log, examples | ✅ Complete |
 | **v2.1 — Enterprise Scale** | Event streaming, budget controls, observability, Terraform provider, gateway, conformance | ✅ Complete |
 | **v2.2 — Ecosystem** | OPA/Cedar policy backends, A2A protocol bridge, usage metering, custom domains, policy-as-code | ✅ Complete |
@@ -1648,7 +1646,7 @@ Read [CONTRIBUTING.md](https://github.com/mishrasanjeev/grantex/blob/main/CONTRI
 | **NIST AI RMF** | Govern 1.1, Map 5.1, Measure 2.5 — NCCoE public comment filed |
 | **IETF** | Internet-Draft submitted to OAuth Working Group ([draft-mishra-oauth-agent-grants-01](https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/)) |
 | **AuthZEN** | Conformance mapped |
-| **SOC 2** | Type I certification completed |
+| **SOC 2** | Readiness control mapping published; formal third-party attestation not published |
 | **Protocol Spec** | [v1.0 Final](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md) — frozen, open, Apache 2.0 |
 
 Full compliance matrix: [docs.grantex.dev/guides/compliance-matrix](https://docs.grantex.dev/guides/compliance-matrix)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,7 +42,7 @@
 ### v1.0 Stable Protocol
 - [x] Protocol specification finalized and frozen
 - [x] Independent security audit (Vestige Security Labs)
-- [x] SOC2 Type I certification (Thornfield Assurance Partners)
+- [x] SOC 2 readiness control mapping published (formal third-party attestation not published)
 - [x] On-premise enterprise deployment option
 - [x] IETF Internet-Draft submission
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,18 +46,38 @@ Include in your report:
 - Steps to reproduce or a minimal proof-of-concept
 - Any suggested mitigations you have identified
 
-Encrypt sensitive reports with our PGP key (available at `https://grantex.dev/.well-known/security.asc`).
+### Encrypted reports
+
+If a report contains exploit code, customer data, or other material you do not
+want to send in cleartext, request our PGP key by emailing
+`security@grantex.dev` with the subject **"PGP key request"** and we will reply
+with the current public key and its fingerprint within one business day. The
+fingerprint will also be posted at `https://grantex.dev/.well-known/security.asc`
+**(URL provisioning is TBD — until it is published, email is the source of
+truth).** Do not assume any key you find on a public key server is ours unless
+the fingerprint matches what we emailed you.
 
 ### Response SLA
 
-| Stage                      | Target                          |
-|----------------------------|---------------------------------|
-| Acknowledgement            | 48 hours                        |
-| Substantive response       | 5 business days                 |
-| Patch (Critical / High)    | 7 days from confirmation        |
-| Patch (Medium / Low)       | 30 days from confirmation       |
+Acknowledgement and substantive-response windows apply to every report.
+Remediation targets depend on the assessed severity using the CVSS v3.1
+qualitative scale:
 
-We will keep you informed of progress throughout the remediation process.
+| Stage                       | Target                                       |
+|-----------------------------|----------------------------------------------|
+| Acknowledgement of receipt  | Within **48 hours** (business hours, IST/UTC)|
+| Substantive triage response | Within **5 business days**                   |
+| Remediation — **Critical**  | Patch shipped within **7 calendar days** of confirmation; coordinated disclosure once patched |
+| Remediation — **High**      | Patch shipped within **14 calendar days** of confirmation |
+| Remediation — **Medium**    | Patch shipped within **30 calendar days** of confirmation |
+| Remediation — **Low**       | Patch shipped within **90 calendar days** of confirmation, or in the next regularly scheduled release |
+| Status updates              | Every **7 calendar days** while remediation is open |
+
+Severity is assigned by the Grantex security responder based on CVSS v3.1
+exploitability, scope, and impact. We will share our reasoning with the
+reporter and adjust on substantive feedback. If the issue is in a third-party
+dependency, the calendar starts when the upstream patch (or a Grantex
+mitigation) is available.
 
 ---
 
@@ -107,6 +127,36 @@ We will not pursue legal action against researchers who act in good faith and fo
 
 ---
 
-## Bug Bounty
+## Recognition (no monetary bug bounty)
 
-We do not currently operate a formal bug bounty programme. We recognize impactful reports publicly in release notes and on our [Hall of Thanks](https://grantex.dev/security/thanks).
+Grantex does **not** currently operate a paid bug bounty programme. We are an
+open-source project and a small commercial team; a formal monetary programme
+is on the roadmap but is not in place today, and we will not invent one.
+
+What we do offer:
+
+- **Hall of Thanks** — researchers who report a valid vulnerability and follow
+  this policy are credited by name (or anonymously, on request) at
+  `https://grantex.dev/security/thanks` and in the release notes for the
+  fix. **The page is provisioning-pending; until it is live we will keep an
+  internal list and migrate it once the page ships.** TBD.
+- **CVE assignment** — for qualifying issues we will request a CVE via the
+  GitHub CNA and credit you in it.
+- **Swag** — Grantex stickers / shirt, on request, when shipping logistics
+  allow.
+
+If you are reporting to us under a third-party VDP platform (e.g. HackerOne,
+Bugcrowd) on behalf of one of our customers: please also send a copy to
+`security@grantex.dev` so we can triage in parallel.
+
+---
+
+## Related procurement / compliance documents
+
+- [Data Processing Addendum (template)](docs/compliance/dpa.md)
+- [Sub-processor disclosure](docs/compliance/sub-processors.md)
+- [Data residency statement](docs/compliance/data-residency.md)
+- [Privacy Policy (draft)](docs/compliance/privacy-policy.md)
+- [Terms of Service (draft)](docs/compliance/terms-of-service.md)
+- [Cookie Policy (draft)](docs/compliance/cookie-policy.md)
+- [SOC 2 readiness control mapping](docs/soc2-type1/report.md) — not a third-party attestation; see the file's own warning block.

--- a/apps/auth-service/src/lib/commerce/live-mode-guard.ts
+++ b/apps/auth-service/src/lib/commerce/live-mode-guard.ts
@@ -1,0 +1,170 @@
+/**
+ * P0-23 — central Commerce live-mode guard.
+ *
+ * Every commerce handler that can create or advance live payment-provider
+ * state must call {@link ensureCommerceLiveMode} as the first side-effect
+ * gate. Read-only routes, sandbox-only routes, and the mock provider do
+ * NOT need this gate — passing `environment: 'sandbox'` or
+ * `providerKey: 'mock'` always resolves to allowed.
+ *
+ * The guard is fail-closed by default: live commerce side effects are
+ * blocked unless `COMMERCE_LIVE_MODE_ENABLED=true` is explicitly set in
+ * the deployment environment, and `PLURAL_LIVE_ENABLED=true` is also set
+ * for Plural-specific live flows. This mirrors the existing scattered
+ * env checks that were previously duplicated across
+ *   - apps/auth-service/src/routes/commerce-cart-payment.ts
+ *   - apps/auth-service/src/routes/commerce-provider-credentials.ts
+ *   - apps/auth-service/src/routes/commerce-well-known.ts
+ *   - apps/auth-service/src/lib/commerce/payment-providers/plural.ts
+ *
+ * Stable error contract (envelope shape comes from
+ * {@link CommerceHttpError} → commerceErrorEnvelope):
+ *   status 403
+ *   code   'commerce_live_mode_disabled' | 'plural_live_disabled'
+ *   retryable=false
+ *   details.reason = one of the LiveModeBlockReason values
+ *
+ * Callers must NOT catch and translate this error — let it bubble to
+ * the commerce error handler, which renders the spec §16 envelope.
+ */
+
+import { CommerceHttpError } from './errors.js';
+import type { CommerceEnvironment, ProviderKey } from './payment-providers/index.js';
+
+export type LiveModeBlockReason =
+  | 'live_mode_disabled'
+  | 'plural_live_disabled'
+  | 'plural_sandbox_disabled';
+
+export interface LiveModeStatus {
+  /** COMMERCE_LIVE_MODE_ENABLED — master switch for any live commerce side effects. */
+  liveModeEnabled: boolean;
+  /** PLURAL_LIVE_ENABLED — Plural-specific live-mode authorization. */
+  pluralLiveEnabled: boolean;
+  /** PLURAL_SANDBOX_ENABLED — Plural sandbox enablement (separate from mock). */
+  pluralSandboxEnabled: boolean;
+}
+
+export interface LiveModeRequest {
+  /**
+   * Environment of the resource the handler is about to touch. `sandbox`
+   * is always allowed by the guard. Omit only for handlers that do not
+   * yet know the environment (caller should fall back to fail-closed
+   * before any side effect).
+   */
+  environment?: CommerceEnvironment;
+  /**
+   * Payment provider the handler is dispatching to. `mock` is always
+   * allowed by the guard (it has no real money flow). `plural` requires
+   * the provider-specific flag in addition to the master switch.
+   */
+  providerKey?: ProviderKey;
+}
+
+/**
+ * Read the env flags ONCE per call. Tests use `vi.stubEnv` between
+ * cases, so we resolve the values lazily rather than caching them at
+ * module load.
+ */
+export function getCommerceLiveModeStatus(): LiveModeStatus {
+  return {
+    liveModeEnabled: process.env['COMMERCE_LIVE_MODE_ENABLED'] === 'true',
+    pluralLiveEnabled: process.env['PLURAL_LIVE_ENABLED'] === 'true',
+    pluralSandboxEnabled: process.env['PLURAL_SANDBOX_ENABLED'] === 'true',
+  };
+}
+
+/**
+ * True iff the request would cause a live commerce side effect that
+ * requires the guard's permission. The mock provider never causes a
+ * real side effect, so it short-circuits to `false` regardless of the
+ * environment label. Plural always needs the guard.
+ */
+export function isLiveCommerceSideEffect(req: LiveModeRequest): boolean {
+  if (req.providerKey === 'mock') return false;
+  if (req.providerKey === 'plural') return true;
+  return req.environment === 'live';
+}
+
+/**
+ * Throw a structured 403 if the requested commerce side effect is not
+ * authorized in this deployment. Returns void on success.
+ *
+ * Decision matrix (preserves the historical per-handler behaviour the
+ * existing test suite asserts):
+ *
+ *   provider=mock,  any environment      → allowed (mock has no real side effect)
+ *   provider=plural, environment=live    → requires COMMERCE_LIVE_MODE_ENABLED
+ *                                          AND PLURAL_LIVE_ENABLED
+ *   provider=plural, environment=sandbox → requires PLURAL_SANDBOX_ENABLED
+ *   provider undefined, env=live         → requires COMMERCE_LIVE_MODE_ENABLED
+ *   provider undefined, env=sandbox      → allowed
+ *   provider undefined, env undefined    → defaults to live → master flag required
+ */
+export function ensureCommerceLiveMode(req: LiveModeRequest = {}): void {
+  const status = getCommerceLiveModeStatus();
+  const providerKey = req.providerKey;
+  const environment: CommerceEnvironment = req.environment ?? 'live';
+
+  // Mock provider — no real money flow, always permitted.
+  if (providerKey === 'mock') return;
+
+  if (providerKey === 'plural') {
+    if (environment === 'sandbox') {
+      if (!status.pluralSandboxEnabled) {
+        throw new CommerceHttpError(
+          403,
+          'plural_live_disabled',
+          'Plural sandbox is disabled pending integration confirmation',
+          {
+            retryable: false,
+            details: {
+              reason: 'plural_sandbox_disabled' satisfies LiveModeBlockReason,
+              remediation: 'Set PLURAL_SANDBOX_ENABLED=true after integration sign-off.',
+              provider_key: 'plural',
+            },
+          },
+        );
+      }
+      return;
+    }
+    // environment === 'live'
+    if (!status.liveModeEnabled || !status.pluralLiveEnabled) {
+      throw new CommerceHttpError(
+        403,
+        'plural_live_disabled',
+        'Plural live mode is disabled pending legal, partner, and production '
+          + 'readiness review',
+        {
+          retryable: false,
+          details: {
+            reason: 'plural_live_disabled' satisfies LiveModeBlockReason,
+            remediation: 'Set both COMMERCE_LIVE_MODE_ENABLED=true and '
+              + 'PLURAL_LIVE_ENABLED=true after Plural production sign-off.',
+            provider_key: 'plural',
+          },
+        },
+      );
+    }
+    return;
+  }
+
+  // No provider specified: gate solely on the master switch.
+  if (environment === 'sandbox') return;
+  if (!status.liveModeEnabled) {
+    throw new CommerceHttpError(
+      403,
+      'commerce_live_mode_disabled',
+      'Live commerce side effects are disabled pending legal, compliance, '
+        + 'security, operations, and provider approvals',
+      {
+        retryable: false,
+        details: {
+          reason: 'live_mode_disabled' satisfies LiveModeBlockReason,
+          remediation: 'Set COMMERCE_LIVE_MODE_ENABLED=true after the readiness gate is signed off.',
+          ...(providerKey !== undefined ? { provider_key: providerKey } : {}),
+        },
+      },
+    );
+  }
+}

--- a/apps/auth-service/src/lib/ids.ts
+++ b/apps/auth-service/src/lib/ids.ts
@@ -34,6 +34,15 @@ export const newConsentRecordId = (): string => `crec_${ulid()}`;
 export const newNoticeId = (): string => `notice_${ulid()}`;
 export const newGrievanceId = (): string => `grv_${ulid()}`;
 export const newExportId = (): string => `exp_${ulid()}`;
+
+// Externally exposed DPDP reference numbers / request IDs.
+// These travel back to the data principal and appear in audit logs, so they
+// must be non-enumerable. ULID gives 26 Crockford-base32 chars (~125 bits of
+// entropy + monotonic time prefix) while still being short and copy-friendly.
+export const newGrievanceReference = (): string =>
+  `GRV-${new Date().getUTCFullYear()}-${ulid()}`;
+export const newErasureRequestId = (): string =>
+  `ER-${new Date().getUTCFullYear()}-${ulid()}`;
 export const newRegistryAgentId = (): string => `ragent_${ulid()}`;
 export const newAnomalyRuleId = (): string => `arule_${ulid()}`;
 export const newAnomalyChannelId = (): string => `achan_${ulid()}`;

--- a/apps/auth-service/src/routes/commerce-cart-payment.ts
+++ b/apps/auth-service/src/routes/commerce-cart-payment.ts
@@ -30,6 +30,7 @@ import {
   type CommerceEnvironment,
   type ProviderKey,
 } from '../lib/commerce/payment-providers/index.js';
+import { ensureCommerceLiveMode } from '../lib/commerce/live-mode-guard.js';
 import {
   assertPaymentStatusTransition,
   type CommercePaymentStatus,
@@ -1039,6 +1040,13 @@ export async function commerceCartPaymentRoutes(app: FastifyInstance): Promise<v
       });
     }
 
+    // P0-23 — central live-mode gate. Fails closed when live commerce
+    // side effects are not authorized for this deployment. Runs after
+    // policy/passport so the caller still gets the most specific reason
+    // for any deny, but before any provider call that could create
+    // off-platform state.
+    ensureCommerceLiveMode({ environment: merchant.environment, providerKey });
+
     const paymentIntentId = newCommercePaymentIntentId();
     const provider = getPaymentProvider(providerKey);
     let providerResult: {
@@ -1246,6 +1254,14 @@ export async function commerceCartPaymentRoutes(app: FastifyInstance): Promise<v
         throw new CommerceHttpError(409, 'payment_intent_missing_policy_evidence',
           'Checkout links require stored passport and policy decision evidence', { retryable: false });
       }
+
+      // P0-23 — fail-closed live-mode gate. Creating a checkout link
+      // hands control to the live provider, so the deployment must be
+      // authorized for live commerce side effects on this provider.
+      ensureCommerceLiveMode({
+        environment: paymentIntent.provider_environment,
+        providerKey: paymentIntent.provider,
+      });
 
       const policy = await loadActivePolicy(sql, tenantId, paymentIntent.merchant_id);
       if (!policy) {
@@ -1565,6 +1581,14 @@ export async function commerceCartPaymentRoutes(app: FastifyInstance): Promise<v
       throw new CommerceHttpError(404, 'payment_intent_not_found',
         'Payment intent not found in this tenant');
     }
+
+    // P0-23 — reconciliation pulls fresh status from the live provider
+    // and may transition payment state. Gate it on the same live-mode
+    // switch that protected the original intent creation.
+    ensureCommerceLiveMode({
+      environment: paymentIntent.provider_environment,
+      providerKey: paymentIntent.provider,
+    });
 
     const result = await reconcilePaymentIntent(sql, paymentIntent, {
       requestId: request.id,

--- a/apps/auth-service/src/routes/commerce-provider-credentials.ts
+++ b/apps/auth-service/src/routes/commerce-provider-credentials.ts
@@ -13,6 +13,7 @@ import {
   type NormalizedProviderError,
   type ProviderKey,
 } from '../lib/commerce/payment-providers/index.js';
+import { ensureCommerceLiveMode } from '../lib/commerce/live-mode-guard.js';
 import type { CommerceCaller } from '../lib/commerce/caller.js';
 
 type Sql = ReturnType<typeof postgres>;
@@ -118,19 +119,14 @@ function credentialRef(
   return `cref_${sha256hex(`${providerKey}:${environment}:${stableJson(payload)}`).slice(0, 32)}`;
 }
 
+// P0-23 — replaced by ensureCommerceLiveMode in lib/commerce/live-mode-guard.ts.
+// The wrapper is kept solely so the existing call sites read naturally; new
+// code should call ensureCommerceLiveMode directly.
 function assertProviderModeAllowed(
   providerKey: ProviderKey,
   environment: CommerceEnvironment,
 ): void {
-  if (providerKey === 'plural' && environment === 'live') {
-    const liveAllowed = process.env['COMMERCE_LIVE_MODE_ENABLED'] === 'true'
-      && process.env['PLURAL_LIVE_ENABLED'] === 'true';
-    if (!liveAllowed) {
-      throw new CommerceHttpError(403, 'plural_live_disabled',
-        'Plural live mode is disabled pending legal, partner, and production readiness review',
-        { retryable: false });
-    }
-  }
+  ensureCommerceLiveMode({ providerKey, environment });
 }
 
 function sanitizeCredential(row: CredentialRow): Record<string, unknown> {
@@ -305,6 +301,18 @@ export async function commerceProviderCredentialRoutes(app: FastifyInstance): Pr
       }
       requireCredentialManager(request, existing.merchant_id);
 
+      // P0-23 — rotating a credential or flipping status on a LIVE
+      // provider credential touches live-mode authorization state, so
+      // it must be gated by the same flag as credential creation.
+      // Disabling is intentionally permitted in any mode so operators
+      // can always lock down a leaked credential.
+      if (!disable) {
+        ensureCommerceLiveMode({
+          providerKey: existing.provider_key,
+          environment: existing.environment,
+        });
+      }
+
       const nextPayload = hasPayload ? body.credential_payload as Record<string, unknown> : null;
       const nextRef = nextPayload ? credentialRef(existing.provider_key, existing.environment, nextPayload) : existing.credential_ref;
       const nextEncrypted = nextPayload ? encrypt(stableJson(nextPayload)) : null;
@@ -380,6 +388,13 @@ export async function commerceProviderCredentialRoutes(app: FastifyInstance): Pr
         throw new CommerceHttpError(409, 'provider_credential_disabled',
           'Disabled provider credentials cannot be validated');
       }
+
+      // P0-23 — validation hits the live provider, so it requires the
+      // same live-mode authorization as creation/rotation.
+      ensureCommerceLiveMode({
+        providerKey: existing.provider_key,
+        environment: existing.environment,
+      });
 
       const provider = getPaymentProvider(existing.provider_key);
       const validation = await provider.validateCredentials({

--- a/apps/auth-service/src/routes/commerce-provider-webhooks.ts
+++ b/apps/auth-service/src/routes/commerce-provider-webhooks.ts
@@ -15,6 +15,7 @@ import {
   isPaymentProviderError,
   type ProviderKey,
 } from '../lib/commerce/payment-providers/index.js';
+import { ensureCommerceLiveMode } from '../lib/commerce/live-mode-guard.js';
 import {
   assertPaymentStatusTransition,
   type CommercePaymentStatus,
@@ -444,6 +445,14 @@ export async function commerceProviderWebhookRoutes(app: FastifyInstance): Promi
           'Provider webhook route is not registered for this provider', { retryable: false });
       }
       const providerKey = providerKeyParam;
+      // P0-23 — incoming provider webhooks advance payment state for
+      // their issuing provider. Gate on the same live-mode flag used
+      // by the outbound provider calls so that, for example, a Plural
+      // event arriving at a deployment without PLURAL_LIVE_ENABLED is
+      // rejected before any state transition runs. The environment is
+      // not on the URL; pass providerKey alone — mock is permitted in
+      // every deployment, plural falls under the plural-specific gate.
+      ensureCommerceLiveMode({ providerKey });
       const receivedAt = new Date().toISOString();
       const rawBody = requestBodyToRaw(request.body);
       const payloadHash = sha256hex(rawBody);

--- a/apps/auth-service/src/routes/dpdp.ts
+++ b/apps/auth-service/src/routes/dpdp.ts
@@ -1,7 +1,14 @@
 import { createHash } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import { getSql } from '../db/client.js';
-import { newConsentRecordId, newNoticeId, newGrievanceId, newExportId } from '../lib/ids.js';
+import {
+  newConsentRecordId,
+  newNoticeId,
+  newGrievanceId,
+  newExportId,
+  newGrievanceReference,
+  newErasureRequestId,
+} from '../lib/ids.js';
 import { signWithEd25519 } from '../lib/crypto.js';
 import { emitEvent } from '../lib/events.js';
 
@@ -54,12 +61,6 @@ interface CreateExportBody {
 
 function sha256(input: string): string {
   return createHash('sha256').update(input).digest('hex');
-}
-
-function generateGrievanceRef(): string {
-  const year = new Date().getFullYear();
-  const seq = String(Math.floor(Math.random() * 99999) + 1).padStart(5, '0');
-  return `GRV-${year}-${seq}`;
 }
 
 // ── Routes ─────────────────────────────────────────────────────────────────
@@ -387,7 +388,7 @@ export async function dpdpRoutes(app: FastifyInstance): Promise<void> {
 
       const sql = getSql();
       const id = newGrievanceId();
-      const referenceNumber = generateGrievanceRef();
+      const referenceNumber = newGrievanceReference();
       const expectedResolutionBy = new Date(Date.now() + 7 * 86400_000); // 7 days
 
       await sql`
@@ -737,7 +738,7 @@ export async function dpdpRoutes(app: FastifyInstance): Promise<void> {
       }
 
       const erasedAt = new Date();
-      const requestId = `ER-${erasedAt.getFullYear()}-${String(Math.floor(Math.random() * 99999) + 1).padStart(5, '0')}`;
+      const requestId = newErasureRequestId();
 
       // Mark all consent records as erased
       const ids = records.map((r) => r['id'] as string);

--- a/apps/auth-service/tests/admin.test.ts
+++ b/apps/auth-service/tests/admin.test.ts
@@ -4,7 +4,11 @@ import type { FastifyInstance } from 'fastify';
 // The admin key must be set BEFORE config.ts is evaluated.
 // vi.hoisted runs before all imports.
 const ADMIN_KEY = vi.hoisted(() => {
-  const key = 'test-admin-key-secret';
+  // Avoid hardcoded literal credentials in the test source. The key is
+  // regenerated for every test run and only lives in this process's memory.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { randomBytes } = require('node:crypto') as typeof import('node:crypto');
+  const key = randomBytes(32).toString('hex');
   process.env['ADMIN_API_KEY'] = key;
   return key;
 });

--- a/apps/auth-service/tests/commerce-caller-resolver.test.ts
+++ b/apps/auth-service/tests/commerce-caller-resolver.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 import { generateKeyPair, exportJWK, SignJWT, type KeyLike, type JWK, type JWTPayload } from 'jose';
-import { authHeader, sqlMock, mockRedis, TEST_DEVELOPER, buildTestApp } from './helpers.js';
+import { authHeader, sqlMock, mockRedis, TEST_DEVELOPER, TEST_ADMIN_API_KEY, buildTestApp } from './helpers.js';
 import { TEST_COMMERCE_TENANT_ID } from './commerce-helpers.js';
 
 let app: FastifyInstance;
@@ -110,8 +110,9 @@ describe('Commerce caller resolver — token-shape detection', () => {
   });
 
   it('platform admin key falls through to operator with isPlatformAdmin=true', async () => {
-    // The vitest config sets ADMIN_API_KEY='test-admin-key-secret'.
-    // The admin token isn't in `developers`; loadDeveloperByApiKey returns [].
+    // The vitest config generates a per-run ADMIN_API_KEY and exposes it as
+    // TEST_ADMIN_API_KEY. The admin token isn't in `developers`;
+    // loadDeveloperByApiKey returns [].
     sqlMock.mockResolvedValueOnce([]);  // developer lookup empty (admin only)
 
     // Hit a route the admin caller can use without a tenant (the
@@ -124,7 +125,7 @@ describe('Commerce caller resolver — token-shape detection', () => {
 
     const res = await app.inject({
       method: 'POST', url: '/v1/commerce/tenants',
-      headers: { authorization: 'Bearer test-admin-key-secret' },
+      headers: { authorization: `Bearer ${TEST_ADMIN_API_KEY}` },
       payload: { display_name: 'New Tenant' },
     });
     expect(res.statusCode).toBe(201);

--- a/apps/auth-service/tests/commerce-cart-payment.test.ts
+++ b/apps/auth-service/tests/commerce-cart-payment.test.ts
@@ -649,9 +649,18 @@ describe('Commerce payment intent APIs', () => {
       headers: { ...agentHeader(), 'idempotency-key': 'pay-key-blocked-provider' },
       payload: await paymentPayload({ provider_key: 'plural' }),
     });
-    expect(blocked.statusCode).toBe(503);
-    expect(blocked.json<{ error: { code: string; details?: { provider_error_code?: string } } }>().error)
-      .toMatchObject({ code: 'provider_validation_failed' });
+    // P0-23: the central live-mode guard now intercepts before the
+    // provider stub runs, returning a stable 403 envelope rather than
+    // the legacy 503 from plural's blockedError(). The guard is the
+    // outer gate; the stub stays the inner gate for when flags ARE set.
+    expect(blocked.statusCode).toBe(403);
+    // The test merchant fixture is environment='sandbox'; the guard
+    // returns the stable 'plural_live_disabled' code with a sandbox-
+    // specific `reason` so callers can distinguish the two paths.
+    expect(blocked.json<{ error: { code: string; details?: { reason?: string } } }>().error)
+      .toMatchObject({ code: 'plural_live_disabled' });
+    expect(blocked.json<{ error: { details?: { reason?: string } } }>().error.details?.reason)
+      .toBe('plural_sandbox_disabled');
   });
 
   it('lists and reads payment intents through tenant-scoped queries', async () => {
@@ -825,8 +834,6 @@ describe('Commerce checkout link API', () => {
   it('returns explicit safe provider error while configured provider remains blocked', async () => {
     seedAgentAuth();
     sqlMock.mockResolvedValueOnce([paymentIntentRow({ status: 'authorized', provider: 'plural' })]);
-    primeCheckoutSecurity();
-    sqlMock.mockResolvedValueOnce([]);
 
     const res = await app.inject({
       method: 'POST',
@@ -835,14 +842,14 @@ describe('Commerce checkout link API', () => {
       payload: await checkoutPayload(),
     });
 
-    expect(res.statusCode).toBe(503);
-    const body = res.json<{ error: { code: string; details?: { provider_error_code?: string; safe_metadata?: Record<string, unknown> } } }>();
-    expect(body.error.code).toBe('provider_validation_failed');
-    expect(body.error.details?.provider_error_code).toMatch(/plural_/);
-    expect(body.error.details?.safe_metadata).toMatchObject({
-      api_contract_confirmed: false,
-      webhook_signature_confirmed: false,
-    });
+    // P0-23: the central live-mode guard intercepts before the provider
+    // stub. The body asserts the new stable contract.
+    expect(res.statusCode).toBe(403);
+    const body = res.json<{ error: { code: string; details?: { reason?: string; provider_key?: string } } }>();
+    expect(body.error.code).toBe('plural_live_disabled');
+    // Test payment intent fixture is sandbox-environment.
+    expect(body.error.details?.reason).toBe('plural_sandbox_disabled');
+    expect(body.error.details?.provider_key).toBe('plural');
   });
 });
 

--- a/apps/auth-service/tests/commerce-finding-fixes.test.ts
+++ b/apps/auth-service/tests/commerce-finding-fixes.test.ts
@@ -7,7 +7,7 @@ import type { FastifyInstance } from 'fastify';
 import {
   generateKeyPair, exportJWK, SignJWT, type KeyLike, type JWK,
 } from 'jose';
-import { sqlMock, mockRedis, buildTestApp, authHeader, TEST_DEVELOPER } from './helpers.js';
+import { sqlMock, mockRedis, buildTestApp, authHeader, TEST_DEVELOPER, TEST_ADMIN_API_KEY } from './helpers.js';
 import { signPrincipalSessionToken } from '../src/lib/crypto.js';
 import { seedCommerceContext, TEST_COMMERCE_TENANT_ID } from './commerce-helpers.js';
 import {
@@ -733,7 +733,7 @@ describe('Finding 3 (round 2) — disabled tenant blocks merchant/agent/consent/
     sqlMock.mockResolvedValueOnce([{ id: 'caud_T', occurred_at: new Date().toISOString() }]);
     const res = await app.inject({
       method: 'POST', url: '/v1/commerce/tenants',
-      headers: { authorization: 'Bearer test-admin-key-secret' },
+      headers: { authorization: `Bearer ${TEST_ADMIN_API_KEY}` },
       payload: { display_name: 'X' },
     });
     expect(res.statusCode).toBe(201);

--- a/apps/auth-service/tests/commerce-live-mode-guard.test.ts
+++ b/apps/auth-service/tests/commerce-live-mode-guard.test.ts
@@ -1,0 +1,161 @@
+/**
+ * P0-23 — central Commerce live-mode guard.
+ *
+ * Verifies the unit-level decision matrix (sandbox/live × mock/plural)
+ * and asserts that every payment-touching route file actually imports
+ * the guard. The latter check mirrors what
+ * `scripts/check-live-mode-guard.mjs` enforces in the release preflight;
+ * keeping it as a vitest spec means a missed guard call is caught by
+ * the package test job too, not only by the release pipeline.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  ensureCommerceLiveMode,
+  getCommerceLiveModeStatus,
+  isLiveCommerceSideEffect,
+} from '../src/lib/commerce/live-mode-guard.js';
+import { CommerceHttpError } from '../src/lib/commerce/errors.js';
+
+// vitest.config.ts does NOT set COMMERCE_LIVE_MODE_ENABLED, so the
+// default state across this suite is fail-closed (the production
+// posture documented in README.md:42).
+
+describe('ensureCommerceLiveMode — decision matrix', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('passes through sandbox + mock (the default playground flow)', () => {
+    expect(() =>
+      ensureCommerceLiveMode({ environment: 'sandbox', providerKey: 'mock' }),
+    ).not.toThrow();
+  });
+
+  it('passes through sandbox + no provider key', () => {
+    expect(() => ensureCommerceLiveMode({ environment: 'sandbox' })).not.toThrow();
+  });
+
+  it('passes live + mock regardless of master switch (mock has no real side effect)', () => {
+    vi.stubEnv('COMMERCE_LIVE_MODE_ENABLED', '');
+    expect(() =>
+      ensureCommerceLiveMode({ environment: 'live', providerKey: 'mock' }),
+    ).not.toThrow();
+  });
+
+  it('rejects live + unspecified provider when COMMERCE_LIVE_MODE_ENABLED is unset', () => {
+    vi.stubEnv('COMMERCE_LIVE_MODE_ENABLED', '');
+    let captured: unknown;
+    try {
+      ensureCommerceLiveMode({ environment: 'live' });
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(CommerceHttpError);
+    const err = captured as CommerceHttpError;
+    expect(err.statusCode).toBe(403);
+    expect(err.code).toBe('commerce_live_mode_disabled');
+    expect(err.options.retryable).toBe(false);
+    expect(err.options.details).toMatchObject({ reason: 'live_mode_disabled' });
+  });
+
+  it('rejects live + plural when only the master flag is set', () => {
+    vi.stubEnv('COMMERCE_LIVE_MODE_ENABLED', 'true');
+    vi.stubEnv('PLURAL_LIVE_ENABLED', '');
+    let captured: unknown;
+    try {
+      ensureCommerceLiveMode({ environment: 'live', providerKey: 'plural' });
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(CommerceHttpError);
+    const err = captured as CommerceHttpError;
+    expect(err.statusCode).toBe(403);
+    expect(err.code).toBe('plural_live_disabled');
+    expect(err.options.details).toMatchObject({
+      reason: 'plural_live_disabled',
+      provider_key: 'plural',
+    });
+  });
+
+  it('passes live + plural when both flags are explicitly set', () => {
+    vi.stubEnv('COMMERCE_LIVE_MODE_ENABLED', 'true');
+    vi.stubEnv('PLURAL_LIVE_ENABLED', 'true');
+    expect(() =>
+      ensureCommerceLiveMode({ environment: 'live', providerKey: 'plural' }),
+    ).not.toThrow();
+  });
+
+  it('treats an unspecified environment as live (fail-closed)', () => {
+    vi.stubEnv('COMMERCE_LIVE_MODE_ENABLED', '');
+    expect(() => ensureCommerceLiveMode({})).toThrow(CommerceHttpError);
+  });
+
+  it('rejects sandbox + plural unless PLURAL_SANDBOX_ENABLED is set', () => {
+    vi.stubEnv('PLURAL_SANDBOX_ENABLED', '');
+    let captured: unknown;
+    try {
+      ensureCommerceLiveMode({ environment: 'sandbox', providerKey: 'plural' });
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(CommerceHttpError);
+    const err = captured as CommerceHttpError;
+    expect(err.statusCode).toBe(403);
+    expect(err.code).toBe('plural_live_disabled');
+    expect(err.options.details).toMatchObject({ reason: 'plural_sandbox_disabled' });
+  });
+
+  it('passes sandbox + plural when PLURAL_SANDBOX_ENABLED is set', () => {
+    vi.stubEnv('PLURAL_SANDBOX_ENABLED', 'true');
+    expect(() =>
+      ensureCommerceLiveMode({ environment: 'sandbox', providerKey: 'plural' }),
+    ).not.toThrow();
+  });
+});
+
+describe('getCommerceLiveModeStatus / isLiveCommerceSideEffect', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('reflects current env flags on every call (not cached)', () => {
+    vi.stubEnv('COMMERCE_LIVE_MODE_ENABLED', '');
+    expect(getCommerceLiveModeStatus().liveModeEnabled).toBe(false);
+    vi.stubEnv('COMMERCE_LIVE_MODE_ENABLED', 'true');
+    expect(getCommerceLiveModeStatus().liveModeEnabled).toBe(true);
+  });
+
+  it('classifies live and plural requests as side-effecting', () => {
+    expect(isLiveCommerceSideEffect({ environment: 'sandbox', providerKey: 'mock' })).toBe(false);
+    expect(isLiveCommerceSideEffect({ environment: 'sandbox' })).toBe(false);
+    // Mock never has a real side effect, even with environment=live.
+    expect(isLiveCommerceSideEffect({ environment: 'live', providerKey: 'mock' })).toBe(false);
+    expect(isLiveCommerceSideEffect({ environment: 'sandbox', providerKey: 'plural' })).toBe(true);
+    expect(isLiveCommerceSideEffect({ environment: 'live', providerKey: 'plural' })).toBe(true);
+    expect(isLiveCommerceSideEffect({ environment: 'live' })).toBe(true);
+  });
+});
+
+// The inventory below mirrors scripts/check-live-mode-guard.mjs. If a
+// new route file starts touching live provider state, add it here AND
+// to the script so both gates fire on regressions.
+const ROUTES_THAT_MUST_REFERENCE_GUARD = [
+  'apps/auth-service/src/routes/commerce-cart-payment.ts',
+  'apps/auth-service/src/routes/commerce-provider-credentials.ts',
+  'apps/auth-service/src/routes/commerce-provider-webhooks.ts',
+];
+
+describe('static inventory: payment-touching routes import the guard', () => {
+  for (const rel of ROUTES_THAT_MUST_REFERENCE_GUARD) {
+    it(`${rel} imports live-mode-guard`, () => {
+      // The test process runs with cwd = apps/auth-service (vitest.config
+      // is rooted there), so walk back up to the repo root.
+      const abs = join(process.cwd(), '..', '..', rel);
+      const src = readFileSync(abs, 'utf-8');
+      expect(src).toMatch(/from '\.\.\/lib\/commerce\/live-mode-guard\.js'/);
+      expect(src).toMatch(/ensureCommerceLiveMode\s*\(/);
+    });
+  }
+});

--- a/apps/auth-service/tests/commerce-no-plural-leak.test.ts
+++ b/apps/auth-service/tests/commerce-no-plural-leak.test.ts
@@ -62,8 +62,20 @@ describe('Plural neutrality — core commerce models carry no Plural-specific id
   });
 
   it('lib/commerce/* modules have no "plural" outside of comments', () => {
+    // Exempted directories / files:
+    //   - payment-providers/  (the original carve-out: provider adapters
+    //     and their stubs live here).
+    //   - live-mode-guard.ts (P0-23): the central live-mode authorization
+    //     module is the single source of truth for the COMMERCE_LIVE_MODE
+    //     / PLURAL_LIVE / PLURAL_SANDBOX flag matrix. It must reference
+    //     Plural by name because it implements the provider-specific
+    //     branch that the rest of the code base no longer needs to know
+    //     about (the routes call ensureCommerceLiveMode({ providerKey })
+    //     and stay provider-agnostic).
+    const exemptBasenames = new Set(['live-mode-guard.ts']);
     const files = gather(join(root, 'lib', 'commerce'), ['.ts'])
-      .filter((f) => !f.split(/[\\/]/).includes('payment-providers'));
+      .filter((f) => !f.split(/[\\/]/).includes('payment-providers'))
+      .filter((f) => !exemptBasenames.has(f.split(/[\\/]/).pop()!));
     expect(files.length).toBeGreaterThan(0);
     for (const f of files) {
       const content = stripTsComments(readFileSync(f, 'utf8'));

--- a/apps/auth-service/tests/commerce-payment-foundations.test.ts
+++ b/apps/auth-service/tests/commerce-payment-foundations.test.ts
@@ -245,24 +245,12 @@ describe('Provider credential APIs', () => {
     expect(res.body).not.toContain(RAW_SECRET);
   });
 
-  it('validates plural credentials as explicitly blocked when API details are absent', async () => {
+  it('plural credential validation is blocked by the central live-mode guard before any provider call', async () => {
     seedCommerceContext();
     sqlMock.mockResolvedValueOnce([credentialRow({
       provider_key: 'plural',
       encrypted_secret_blob: 'ciphertext',
     })]);
-    sqlMock.mockResolvedValueOnce([credentialRow({
-      provider_key: 'plural',
-      status: 'invalid',
-      last_validation_error: {
-        code: 'provider_validation_failed',
-        provider_key: 'plural',
-        retryable: false,
-        provider_error_code: 'plural_sandbox_blocked',
-      },
-      last_validated_at: new Date().toISOString(),
-    })]);
-    sqlMock.mockResolvedValueOnce([{ id: 'caud_PLURAL_VALIDATE', occurred_at: new Date().toISOString() }]);
 
     const res = await app.inject({
       method: 'POST',
@@ -270,11 +258,18 @@ describe('Provider credential APIs', () => {
       headers: authHeader(),
     });
 
-    expect(res.statusCode).toBe(200);
-    const body = res.json<{ data: { status: string; validation: { valid: boolean; error: { provider_error_code: string } } } }>();
-    expect(body.data.status).toBe('invalid');
-    expect(body.data.validation.valid).toBe(false);
-    expect(body.data.validation.error.provider_error_code).toMatch(/plural_/);
+    // P0-23: with PLURAL_SANDBOX_ENABLED unset (the default in
+    // vitest.config.ts), the guard rejects before the credential is
+    // ever validated against the provider stub. The stable contract
+    // — code, reason, provider_key — is the surface partners can rely
+    // on, rather than the provider-stub's normalized 503 payload.
+    expect(res.statusCode).toBe(403);
+    const body = res.json<{ error: { code: string; details?: { reason?: string; provider_key?: string } } }>();
+    expect(body.error.code).toBe('plural_live_disabled');
+    expect(body.error.details?.reason).toBe('plural_sandbox_disabled');
+    expect(body.error.details?.provider_key).toBe('plural');
+    // Provider was never called: only the credential lookup SQL ran.
+    expect(res.body).not.toContain('ciphertext');
   });
 });
 

--- a/apps/auth-service/tests/commerce-payment-reconciliation.test.ts
+++ b/apps/auth-service/tests/commerce-payment-reconciliation.test.ts
@@ -232,13 +232,12 @@ describe('Commerce payment reconciliation', () => {
     expect(sqlCallCount(/SET status =/i)).toBe(0);
   });
 
-  it('provider blocked error is stored safely and does not transition', async () => {
+  it('central live-mode guard blocks reconcile for plural before any provider call', async () => {
     seedCommerceContext();
     sqlMock.mockResolvedValueOnce([paymentIntentRow({
       provider: 'plural',
       provider_payment_id: `plural_pay_${PAYMENT_INTENT}`,
     })]);
-    sqlMock.mockResolvedValueOnce([]);
 
     const res = await app.inject({
       method: 'POST',
@@ -246,14 +245,24 @@ describe('Commerce payment reconciliation', () => {
       headers: authHeader(),
     });
 
-    expect(res.statusCode).toBe(503);
-    expect(res.json<{ error: { code: string; details: { provider_key: string; provider_error_code: string } } }>().error)
+    // P0-23: the central guard intercepts BEFORE reconcilePaymentIntent
+    // runs, so no provider call happens, no transition runs, and no
+    // last_reconciliation_error is persisted (the guard predates the
+    // reconciliation pipeline entirely).
+    expect(res.statusCode).toBe(403);
+    // The test fixture's payment intent is sandbox-environment, so the
+    // guard reports the sandbox-specific reason behind the stable code.
+    expect(res.json<{ error: { code: string; details?: { reason?: string; provider_key?: string } } }>().error)
       .toMatchObject({
-        code: 'provider_validation_failed',
-        details: { provider_key: 'plural', provider_error_code: 'plural_sandbox_blocked' },
+        code: 'plural_live_disabled',
+        details: { reason: 'plural_sandbox_disabled', provider_key: 'plural' },
       });
-    expect(flattenedSqlCalls()).toContain('last_reconciliation_error');
     expect(sqlCallCount(/SET status =/i)).toBe(0);
+    // `last_reconciliation_error` is in the SELECT column list of the
+    // intent lookup, so it appears once in the captured SQL. The proof
+    // that no reconciliation transition ran is the absence of any
+    // statement that WRITES to that column.
+    expect(sqlCallCount(/SET\s+[^;]*last_reconciliation_error/i)).toBe(0);
   });
 
   it('manual reconcile enforces tenant and caller boundary', async () => {

--- a/apps/auth-service/tests/commerce-provider-webhook.test.ts
+++ b/apps/auth-service/tests/commerce-provider-webhook.test.ts
@@ -260,7 +260,7 @@ describe('Commerce provider webhook route', () => {
     expect(sqlCallCount(/UPDATE commerce_payment_intents/i)).toBe(0);
   });
 
-  it('plural provider webhook returns explicit blocked configuration error', async () => {
+  it('plural provider webhook is blocked by the central live-mode guard before any provider call', async () => {
     const payload = webhookPayload({ event_id: 'evt_PLURAL', status: 'paid' });
     const res = await app.inject({
       method: 'POST',
@@ -268,14 +268,14 @@ describe('Commerce provider webhook route', () => {
       payload,
     });
 
-    expect(res.statusCode).toBe(503);
-    expect(res.json<{ error: { code: string; details: { provider_error_code: string; safe_metadata: Record<string, unknown> } } }>().error)
+    // P0-23: with both PLURAL flags unset (default in vitest.config.ts),
+    // the guard rejects before provider.handleWebhook runs. No SQL ran,
+    // no audit row was written.
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string; details?: { reason?: string; provider_key?: string } } }>().error)
       .toMatchObject({
-        code: 'provider_validation_failed',
-        details: {
-          provider_error_code: 'plural_webhook_signature_unconfirmed',
-          safe_metadata: { webhook_signature_confirmed: false },
-        },
+        code: 'plural_live_disabled',
+        details: { reason: 'plural_live_disabled', provider_key: 'plural' },
       });
     expect(sqlMock).not.toHaveBeenCalled();
   });

--- a/apps/auth-service/tests/commerce-tenant-provisioning.test.ts
+++ b/apps/auth-service/tests/commerce-tenant-provisioning.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import type { FastifyInstance } from 'fastify';
-import { sqlMock, buildTestApp, TEST_DEVELOPER, authHeader } from './helpers.js';
+import { sqlMock, buildTestApp, TEST_DEVELOPER, TEST_ADMIN_API_KEY, authHeader } from './helpers.js';
 import { TEST_COMMERCE_TENANT_ID, seedCommerceContext } from './commerce-helpers.js';
 
 let app: FastifyInstance;
 beforeAll(async () => { app = await buildTestApp(); });
 
-const adminAuth = { authorization: 'Bearer test-admin-key-secret' };
+const adminAuth = { authorization: `Bearer ${TEST_ADMIN_API_KEY}` };
 
 describe('POST /v1/commerce/tenants — admin only (Decision C)', () => {
   it('admin caller creates a tenant', async () => {

--- a/apps/auth-service/tests/dpdp.test.ts
+++ b/apps/auth-service/tests/dpdp.test.ts
@@ -543,7 +543,8 @@ describe('POST /v1/dpdp/data-principals/:principalId/erasure', () => {
 
     expect(res.statusCode).toBe(201);
     const body = res.json();
-    expect(body.requestId).toMatch(/^ER-\d{4}-\d{5}$/);
+    // ULID-suffixed, non-enumerable. Crockford base32 excludes I, L, O, U.
+    expect(body.requestId).toMatch(/^ER-\d{4}-[0-9A-HJKMNP-TV-Z]{26}$/);
     expect(body.dataPrincipalId).toBe('user_123');
     expect(body.status).toBe('completed');
     expect(body.recordsErased).toBe(2);
@@ -570,6 +571,34 @@ describe('POST /v1/dpdp/data-principals/:principalId/erasure', () => {
 
     expect(res.statusCode).toBe(404);
     expect(res.json().code).toBe('NOT_FOUND');
+  });
+
+  it('returns non-predictable, non-enumerable erasure request IDs on successive calls', async () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 5; i++) {
+      seedAuth();
+      sqlMock.mockResolvedValueOnce([{ id: 'crec_1', grant_id: null }]); // records lookup
+      sqlMock.mockResolvedValueOnce([]); // mark erased
+      sqlMock.mockResolvedValueOnce([]); // anonymize audit
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/dpdp/data-principals/user_predictable_test/erasure',
+        headers: authHeader(),
+      });
+      expect(res.statusCode).toBe(201);
+      ids.add(res.json().requestId as string);
+    }
+    expect(ids.size).toBe(5);
+    const arr = [...ids];
+    for (let i = 0; i < arr.length; i++) {
+      for (let j = i + 1; j < arr.length; j++) {
+        const a = arr[i]!.slice(-26);
+        const b = arr[j]!.slice(-26);
+        let n = 0;
+        while (n < a.length && a[n] === b[n]) n++;
+        expect(n).toBeLessThanOrEqual(20);
+      }
+    }
   });
 
   it('handles records with no associated grants', async () => {
@@ -681,9 +710,48 @@ describe('POST /v1/dpdp/grievances', () => {
     expect(res.statusCode).toBe(202);
     const body = res.json();
     expect(body.grievanceId).toMatch(/^grv_/);
-    expect(body.referenceNumber).toMatch(/^GRV-\d{4}-\d{5}$/);
+    // ULID-suffixed, non-enumerable.
+    expect(body.referenceNumber).toMatch(/^GRV-\d{4}-[0-9A-HJKMNP-TV-Z]{26}$/);
     expect(body.status).toBe('submitted');
     expect(body.expectedResolutionBy).toBeDefined();
+  });
+
+  it('returns non-predictable, non-enumerable grievance references on successive calls', async () => {
+    const refs = new Set<string>();
+    for (let i = 0; i < 5; i++) {
+      seedAuth();
+      sqlMock.mockResolvedValueOnce([]); // insert
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/dpdp/grievances',
+        headers: authHeader(),
+        payload: {
+          dataPrincipalId: 'user_123',
+          type: 'data-erasure',
+          description: 'Please delete my data',
+        },
+      });
+      expect(res.statusCode).toBe(202);
+      refs.add(res.json().referenceNumber as string);
+    }
+    expect(refs.size).toBe(5);
+    // No reference should differ from any other by a single decimal increment
+    // (which would betray a sequential / Math.random() generator).
+    const arr = [...refs];
+    for (let i = 0; i < arr.length; i++) {
+      for (let j = i + 1; j < arr.length; j++) {
+        const a = arr[i]!.slice(-26);
+        const b = arr[j]!.slice(-26);
+        const sharedPrefixLen = (() => {
+          let n = 0;
+          while (n < a.length && a[n] === b[n]) n++;
+          return n;
+        })();
+        // ULID's 10-char timestamp prefix can match; the 16-char random tail
+        // must not collide on more than a couple of leading chars by chance.
+        expect(sharedPrefixLen).toBeLessThanOrEqual(20);
+      }
+    }
   });
 
   it('returns 400 for missing fields', async () => {

--- a/apps/auth-service/tests/helpers.ts
+++ b/apps/auth-service/tests/helpers.ts
@@ -13,6 +13,12 @@ export { sqlMock, mockRedis };
 // Seed data
 // ------------------------------------------------------------------
 export const TEST_API_KEY = 'test-api-key-1234';
+
+// Resolved at module load — vitest.config.ts generates a per-run ADMIN_API_KEY
+// via crypto.randomBytes() and exports it through the env block. Tests that
+// need to call admin-gated endpoints should use this constant rather than a
+// hardcoded literal.
+export const TEST_ADMIN_API_KEY = process.env['ADMIN_API_KEY'] ?? '';
 export const TEST_DEVELOPER = { id: 'dev_TEST', name: 'Test Developer', mode: 'live' };
 export const TEST_SANDBOX_DEVELOPER = { ...TEST_DEVELOPER, mode: 'sandbox' };
 

--- a/apps/auth-service/tests/security-multi-tenancy.test.ts
+++ b/apps/auth-service/tests/security-multi-tenancy.test.ts
@@ -13,6 +13,7 @@ import {
   TEST_DEVELOPER,
   TEST_AGENT,
 } from './helpers.js';
+import { seedCommerceContext } from './commerce-helpers.js';
 import type { FastifyInstance } from 'fastify';
 import { signGrantToken } from '../src/lib/crypto.js';
 
@@ -304,6 +305,95 @@ describe('Multi-tenancy isolation', () => {
     // The data returned is only for developer A — no cross-org data
     expect(body.agents.total).toBe(3);
     expect(body.plan).toBe('pro');
+  });
+
+  // ── Commerce tenants ────────────────────────────────────────────────────
+  //
+  // The commerce-tenants routes are gated by an operator caller and a
+  // hybrid authorization model: admin sees all tenants; an operator only
+  // sees rows joined to their entry in commerce_tenant_operators. These
+  // tests prove Developer A cannot enumerate or mutate Developer B's
+  // commerce tenants.
+
+  it('non-admin operator listing commerce tenants only sees its own', async () => {
+    seedCommerceContext();
+    // Owner-scoped JOIN returns just A's tenant. If the route forgot the
+    // developer_id filter and returned all tenants, we'd see foreign rows.
+    sqlMock.mockResolvedValueOnce([
+      {
+        id: 'cten_DEV_A_OWNED', display_name: 'A Org', status: 'active',
+        metadata: {}, created_at: new Date(), updated_at: new Date(),
+      },
+    ]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/tenants',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ items: Array<{ id: string }> }>();
+    expect(body.items.map((t) => t.id)).toEqual(['cten_DEV_A_OWNED']);
+    expect(body.items.every((t) => t.id !== 'cten_DEV_B_OWNED')).toBe(true);
+
+    // Defence-in-depth: confirm the SQL the route ran is the owner-scoped
+    // JOIN keyed on the caller's developer_id, not the admin-only SELECT.
+    const ownerScopedCall = sqlMock.mock.calls.find((c) => {
+      const tpl = c[0] as unknown;
+      return Array.isArray(tpl)
+        && tpl.some((s) =>
+          typeof s === 'string'
+          && /commerce_tenant_operators/i.test(s)
+          && /op\.developer_id\s*=/i.test(s));
+    });
+    expect(ownerScopedCall).toBeDefined();
+    expect(ownerScopedCall!.slice(1)).toContain(TEST_DEVELOPER.id);
+  });
+
+  it('org A cannot create commerce tenant without admin key (403 admin_required)', async () => {
+    seedCommerceContext();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/tenants',
+      headers: authHeader(),
+      payload: { display_name: 'Hostile Takeover' },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('admin_required');
+  });
+
+  it('org A cannot patch a commerce tenant it does not own (403 tenant_owner_required)', async () => {
+    seedCommerceContext();
+    // Ownership check (operator → tenant) returns empty: dev A is not
+    // listed in commerce_tenant_operators for cten_DEV_B_OWNED.
+    sqlMock.mockResolvedValueOnce([]);
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/commerce/tenants/cten_DEV_B_OWNED',
+      headers: authHeader(),
+      payload: { display_name: 'Renamed by A' },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('tenant_owner_required');
+  });
+
+  it('org A cannot bind another developer to a tenant it does not own (403 tenant_owner_required)', async () => {
+    seedCommerceContext();
+    // Ownership check returns empty for cten_DEV_B_OWNED.
+    sqlMock.mockResolvedValueOnce([]);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/developer-tenants',
+      headers: authHeader(),
+      payload: {
+        developer_id: 'dev_OTHER',
+        tenant_id: 'cten_DEV_B_OWNED',
+        is_default: true,
+      },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('tenant_owner_required');
   });
 
   // ── Authorize scoping ──────────────────────────────────────────────────

--- a/apps/auth-service/vitest.config.ts
+++ b/apps/auth-service/vitest.config.ts
@@ -1,4 +1,11 @@
+import { randomBytes } from 'node:crypto';
 import { defineConfig } from 'vitest/config';
+
+// Fresh per test process. The literal that used to live here ('test-admin-key-secret')
+// was a hardcoded credential that would surface in CI logs on any test-output dump.
+// Tests that need the value should read it from process.env['ADMIN_API_KEY'] or import
+// TEST_ADMIN_API_KEY from tests/helpers.ts.
+const generatedAdminApiKey = randomBytes(32).toString('hex');
 
 export default defineConfig({
   test: {
@@ -26,7 +33,7 @@ export default defineConfig({
       STRIPE_PRICE_PRO: 'price_pro_fake',
       STRIPE_PRICE_ENTERPRISE: 'price_enterprise_fake',
       VAULT_ENCRYPTION_KEY: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-      ADMIN_API_KEY: 'test-admin-key-secret',
+      ADMIN_API_KEY: generatedAdminApiKey,
       // Grantex Commerce M1 — flag is checked at request time so tests can
       // toggle it via vi.stubEnv. The feature-flag test stubs it back off.
       COMMERCE_V1_ENABLED: 'true',

--- a/apps/mpp-demo-service/src/index.ts
+++ b/apps/mpp-demo-service/src/index.ts
@@ -7,12 +7,41 @@ const app = express();
 app.use(express.json());
 app.use(rateLimit({ windowMs: 60_000, max: 100 }));
 
-// Enable CORS for demo UI
-app.use((_req, res, next) => {
-  res.header('Access-Control-Allow-Origin', '*');
-  res.header('Access-Control-Allow-Headers', 'Authorization, X-Grantex-Passport, Content-Type');
-  res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-  if (_req.method === 'OPTIONS') {
+// CORS — explicit allowlist, not wildcard.
+//
+// Origins come from MPP_DEMO_CORS_ALLOWED_ORIGINS (comma-separated). When
+// the env var is unset we fall back to the local dev origins the demo UI
+// is served from. Production deployments must set the env var explicitly;
+// anything not in the list is rejected at the preflight stage.
+const DEFAULT_DEV_ORIGINS = [
+  'http://localhost:5173',
+  'http://localhost:3000',
+  'http://127.0.0.1:5173',
+  'http://127.0.0.1:3000',
+];
+
+const ALLOWED_ORIGINS: ReadonlySet<string> = new Set(
+  (process.env['MPP_DEMO_CORS_ALLOWED_ORIGINS'] ?? DEFAULT_DEV_ORIGINS.join(','))
+    .split(',')
+    .map((o) => o.trim())
+    .filter((o) => o.length > 0),
+);
+
+app.use((req, res, next) => {
+  const origin = req.headers.origin;
+  if (typeof origin === 'string' && ALLOWED_ORIGINS.has(origin)) {
+    res.header('Access-Control-Allow-Origin', origin);
+    res.header('Vary', 'Origin');
+    res.header('Access-Control-Allow-Headers', 'Authorization, X-Grantex-Passport, Content-Type');
+    res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  }
+  if (req.method === 'OPTIONS') {
+    // Reject preflights from disallowed origins so misconfigured callers
+    // see a clear error instead of a silent same-origin failure later.
+    if (typeof origin !== 'string' || !ALLOWED_ORIGINS.has(origin)) {
+      res.status(403).json({ error: 'cors_origin_not_allowed' });
+      return;
+    }
     res.sendStatus(204);
     return;
   }

--- a/apps/mpp-demo/index.html
+++ b/apps/mpp-demo/index.html
@@ -248,8 +248,7 @@
 
   <script>
     // ── Config ──────────────────────────────────────────────────────────────
-    const AUTH_API = window.location.hostname === 'localhost'
-      ? 'http://localhost:3001' : 'https://api.grantex.dev';
+    const AUTH_API = 'https://api.grantex.dev';
 
     // ── State ──────────────────────────────────────────────────────────────
     const spendTotals = { inference: 0, compute: 0, data: 0 };

--- a/apps/portal/src/pages/__tests__/RegistryOrgDetail.test.tsx
+++ b/apps/portal/src/pages/__tests__/RegistryOrgDetail.test.tsx
@@ -62,9 +62,9 @@ describe('RegistryOrgDetail', () => {
   it('shows compliance section', async () => {
     r();
     await waitFor(() => expect(screen.getByText('Compliance')).toBeInTheDocument());
-    expect(screen.getByText('SOC 2 Type II')).toBeInTheDocument();
-    expect(screen.getByText('DPDP Compliant')).toBeInTheDocument();
-    expect(screen.getByText('GDPR Compliant')).toBeInTheDocument();
+    expect(screen.getByText('SOC 2 evidence submitted')).toBeInTheDocument();
+    expect(screen.getByText('DPDP mapping')).toBeInTheDocument();
+    expect(screen.getByText('GDPR mapping')).toBeInTheDocument();
   });
 
   it('shows contact info', async () => {

--- a/apps/portal/src/pages/registry/RegistryOrgDetail.tsx
+++ b/apps/portal/src/pages/registry/RegistryOrgDetail.tsx
@@ -148,9 +148,9 @@ export function RegistryOrgDetail() {
         <Card>
           <h2 className="text-sm font-semibold text-gx-text mb-4">Compliance</h2>
           <div className="space-y-3">
-            <ComplianceRow label="SOC 2 Type II" passed={org.compliance.soc2} />
-            <ComplianceRow label="DPDP Compliant" passed={org.compliance.dpdp} />
-            <ComplianceRow label="GDPR Compliant" passed={org.compliance.gdpr} />
+            <ComplianceRow label="SOC 2 evidence submitted" passed={org.compliance.soc2} />
+            <ComplianceRow label="DPDP mapping" passed={org.compliance.dpdp} />
+            <ComplianceRow label="GDPR mapping" passed={org.compliance.gdpr} />
           </div>
         </Card>
 

--- a/docs/blog/from-copilot-to-autonomous-agents.mdx
+++ b/docs/blog/from-copilot-to-autonomous-agents.mdx
@@ -101,7 +101,7 @@ When the auditor asks "what did this agent do?", you have an answer that cannot 
 
 ## The Standard Is Here
 
-Grantex implements all five properties as an open protocol. Apache 2.0 licensed. IETF Internet-Draft submitted. SOC 2 Type I certified. SDKs for TypeScript, Python, and Go. Integrations with every major agent framework.
+Grantex implements all five properties as an open protocol. Apache 2.0 licensed. IETF Internet-Draft submitted. SOC 2 readiness control mapping published; formal third-party attestation is not published. SDKs for TypeScript, Python, and Go. Integrations with major agent frameworks.
 
 The shift from copilot to autonomous agent happened fast. Authorization needs to catch up.
 

--- a/docs/blog/owasp-agentic-top-10-compliance.mdx
+++ b/docs/blog/owasp-agentic-top-10-compliance.mdx
@@ -156,6 +156,6 @@ The compliance requirements are clear. The protocol exists. The window to be pro
 ## Learn More
 
 - [Compliance Evidence Pack API](/api-reference/compliance/generate-compliance-evidence-pack) — export grants, tokens, and audit entries for auditors
-- [SOC 2 Type I Report](/security/soc2-report) — our own certification
+- [SOC 2 readiness control mapping](/security/soc2-report) — control mapping; not third-party certification
 - [IETF Internet-Draft](/community/ietf-draft) — the open standard submission
 - [NIST AI RMF Comment](/community/nist-comment) — our public comment to NIST

--- a/docs/commerce-v1-pilot-readiness.validate.mjs
+++ b/docs/commerce-v1-pilot-readiness.validate.mjs
@@ -19,11 +19,14 @@ const repeatableOptionASmokeWorkflow = readFileSync(
   join(docsDir, 'guides', 'commerce-v1-repeatable-option-a-smoke-workflow.md'),
   'utf8',
 );
-const hostedStagingE2ETemplate = readFileSync(join(docsDir, 'reports', 'commerce-v1-hosted-staging-e2e.template.md'), 'utf8');
-const optionASmokeEvidence = readFileSync(join(docsDir, 'reports', 'commerce-v1-option-a-smoke-evidence.md'), 'utf8');
-const contractGapReport = readFileSync(join(docsDir, 'reports', 'commerce-v1-contract-completeness-gap-report.md'), 'utf8');
+// Internal commerce-v1 reports moved from docs/reports/ to
+// docs/internal/commerce-v1/ on 2026-05-24 per brutal-review P0-5.
+const internalCommerceV1Dir = join(docsDir, 'internal', 'commerce-v1');
+const hostedStagingE2ETemplate = readFileSync(join(internalCommerceV1Dir, 'commerce-v1-hosted-staging-e2e.template.md'), 'utf8');
+const optionASmokeEvidence = readFileSync(join(internalCommerceV1Dir, 'commerce-v1-option-a-smoke-evidence.md'), 'utf8');
+const contractGapReport = readFileSync(join(internalCommerceV1Dir, 'commerce-v1-contract-completeness-gap-report.md'), 'utf8');
 const readOnlyDiscoveryProposal = readFileSync(
-  join(docsDir, 'reports', 'commerce-v1-read-only-production-discovery-proposal.md'),
+  join(internalCommerceV1Dir, 'commerce-v1-read-only-production-discovery-proposal.md'),
   'utf8',
 );
 const optionASmokeRunbookText = readFileSync(join(docsDir, 'examples', 'commerce-option-a-smoke.runbook.json'), 'utf8');
@@ -348,7 +351,7 @@ for (const required of [
   'stale inventory',
   'unsupported EMI/discount/warranty claim',
   'invalid webhook signature',
-  'docs/reports/commerce-v1-hosted-staging-e2e.md',
+  'docs/internal/commerce-v1/commerce-v1-hosted-staging-e2e.md',
 ]) {
   assert.ok(hostedStagingE2E.includes(required), `hosted staging E2E guide includes ${required}`);
 }
@@ -614,7 +617,7 @@ for (const required of [
   'https://api.grantex.dev',
   'https://app.agenticorg.ai',
   "const dryRun = boolArg('--dry-run') || !run;",
-  'docs/reports/commerce-v1-hosted-staging-e2e.md',
+  'docs/internal/commerce-v1/commerce-v1-hosted-staging-e2e.md',
   'Refusing production domain',
   'Refusing credentialed URL',
   'Refusing COMMERCE_LIVE_MODE_ENABLED=true',
@@ -754,7 +757,7 @@ assert.equal(stagingE2EReport.status, 'not_executed');
 assert.equal(stagingE2EReport.safety.no_requests_made, true);
 assert.equal(stagingE2EReport.targets.api_base, 'https://api-staging.grantex.dev');
 assert.equal(stagingE2EReport.targets.agenticorg_base, 'https://staging.agenticorg.ai');
-assert.equal(stagingE2EReport.report_path, 'docs/reports/commerce-v1-hosted-staging-e2e.md');
+assert.equal(stagingE2EReport.report_path, 'docs/internal/commerce-v1/commerce-v1-hosted-staging-e2e.md');
 assert.equal(stagingE2EReport.manifest.provider, 'mock');
 assert.ok(stagingE2EReport.positive_checks.includes('checkout create'));
 assert.ok(stagingE2EReport.negative_checks.includes('invalid webhook signature'));

--- a/docs/compliance/cookie-policy.md
+++ b/docs/compliance/cookie-policy.md
@@ -1,0 +1,50 @@
+# Cookie Policy (Draft)
+
+**Status:** Draft. Subject to legal review.
+**Last reviewed:** 2026-05-24
+**Applies to:** the marketing site (`grantex.dev`), the documentation site (`docs.grantex.dev`), and the developer portal (`grantex.dev/dashboard`).
+
+This page describes the cookies and similar storage mechanisms used by the public Grantex sites today, based on what is wired up in this repository. **Self-hosted Grantex deployments serve the marketing site only if the operator publishes it; the analytics cookie below is in the source under the maintainers' GA ID and is easy to remove for a fork.**
+
+## Categories in use
+
+### Strictly necessary
+
+These are required to operate the developer portal and consent UI. They cannot be disabled.
+
+| Name | Purpose | Set by | Duration |
+|---|---|---|---|
+| `__session` | Developer-portal authenticated session | `apps/portal` | Session |
+| `csrf` | CSRF double-submit token on consent and portal forms | auth-service consent challenge route | Session |
+
+No third-party cookies are set by the auth-service or the developer portal.
+
+### Analytics
+
+The marketing site only uses Google Analytics for aggregate traffic data, which we use to decide where to invest in docs and integrations.
+
+| Name | Purpose | Set by | Duration |
+|---|---|---|---|
+| `_ga`, `_gid`, `_ga_*` | Google Analytics aggregate site traffic | Google Analytics (GA4 property `G-DNXYVLS5NY`) | Up to 2 years |
+
+You can opt out of Google Analytics by using a browser extension such as the official Google Analytics Opt-out, by enabling Do Not Track, or by blocking the `googletagmanager.com` and `google-analytics.com` domains in your browser. The marketing site does not currently surface a per-visitor banner-style consent prompt. **TBD:** a CMP-style consent banner is on the follow-up list for the EU launch — see `docs/reports/enterprise-readiness-brutal-review-2026-05-24.md` item H-3 (legal-link work).
+
+### Marketing / advertising
+
+None. Grantex does not currently run third-party ad pixels (no Facebook Pixel, no LinkedIn Insight Tag, no Google Ads tag) and does not retarget visitors.
+
+### Session replay or behavioural recording
+
+None. No session-replay tooling (FullStory, Hotjar, LogRocket) is referenced anywhere in the repo.
+
+## Local / session storage
+
+The interactive playgrounds (`web/commerce-playground.html`, `web/x402-playground/`, `web/mpp-demo/`) use `localStorage` to remember the API base URL, sample payloads, and form values you typed. Nothing is sent off-device beyond what you explicitly submit through the UI.
+
+## How to clear
+
+Use your browser's standard "Clear site data" controls for `grantex.dev` and `docs.grantex.dev`. Clearing site data signs you out of the portal and resets the playgrounds to defaults.
+
+## Contact
+
+Cookie or tracking questions: `security@grantex.dev`.

--- a/docs/compliance/data-residency.md
+++ b/docs/compliance/data-residency.md
@@ -1,0 +1,60 @@
+# Data Residency Statement
+
+**Status:** Current public disclosure. Subject to legal review. Not a certification document.
+**Last reviewed:** 2026-05-24
+
+This page describes where Grantex stores and processes customer data on the **hosted** offering (`api.grantex.dev`), and the residency choices available to operators running their **own** Grantex deployment.
+
+## Hosted Grantex (`api.grantex.dev`) — single region today
+
+All production-grade data for the hosted service is currently pinned to **Google Cloud `us-central1` (Council Bluffs, Iowa, USA)**. This is sourced from `deploy/gcp/setup.sh`:
+
+```
+REGION="us-central1"
+SQL_INSTANCE="grantex-pg16"       → us-central1
+REDIS_INSTANCE="grantex-redis"    → us-central1
+AR_REPO="grantex-images"          → us-central1
+CR_SERVICE="grantex-auth"         → us-central1
+```
+
+| Data class | Storage location | Notes |
+|---|---|---|
+| Agents, grants, audit, commerce records | Cloud SQL PostgreSQL, `us-central1` | Encrypted at rest by GCP (AES-256). Backups stored in the same region. |
+| Rate-limit + idempotency state | Memorystore Redis, `us-central1` | TTL-bound, no long-lived PII. |
+| Container images | Artifact Registry, `us-central1` | Build artifacts only. |
+| Runtime secrets | Secret Manager, `us-central1` | Vault encryption key, JWT signing keys. |
+| Marketing site (`grantex.dev`) | Firebase Hosting | Global CDN edge (Google anycast); origin in US. |
+| DNS records | Cloud DNS | Global anycast. |
+
+**Cross-border transfers.** Operating the hosted service from `us-central1` means that requests originating outside the United States cross a border at request time. Customer payloads are not replicated to other regions by Grantex.
+
+## EU / India / multi-region availability
+
+A multi-region offering (EU and India) is on the public roadmap (`ROADMAP.md`, item "Managed Cloud"). **It is not available today.** Until then:
+
+- Customers with EU data-residency obligations under GDPR should evaluate the self-hosting option below.
+- Customers with DPDP Act (India) "significant data fiduciary" obligations may require self-hosting to keep data within India. See `docs/compliance/dpdp-act-2023.mdx` for the technical control mapping.
+
+## Self-hosted Grantex — operator-chosen residency
+
+Grantex is Apache 2.0 and ships with a Helm chart (`deploy/helm/grantex/`) and Docker Compose stack (`docker-compose.prod.yml`). When you self-host, **the data never leaves the infrastructure you control** — Grantex maintainers receive no telemetry from your deployment by default.
+
+Operator-controlled residency knobs:
+
+- **Compute** — anywhere your Kubernetes cluster or container host runs.
+- **PostgreSQL** — point `DATABASE_URL` at any Postgres 14+ instance in your region of choice.
+- **Redis** — point `REDIS_URL` at any Redis 6+ instance in your region of choice.
+- **Object storage destination** (optional audit export) — choose any S3-compatible bucket region.
+- **OpenTelemetry sink** (optional) — point `OTEL_EXPORTER_OTLP_ENDPOINT` at a collector in your region.
+
+See `docs/self-hosting.md` for the full operator runbook.
+
+## Backup, retention, and deletion
+
+- **Backups:** WAL-archive backups recommended per the Cloud SQL default policy on hosted; operator-defined on self-hosted. A formal backup/restore runbook is **TBD** as a follow-up doc.
+- **Retention:** audit-log retention is operator-configurable; defaults documented in `apps/auth-service/src/config.ts`.
+- **Deletion:** DPDP erasure flow (`/v1/dpdp/data-principals/:id/erasure`) and consent withdrawal flows are implemented in `apps/auth-service/src/routes/dpdp.ts`. Deletion propagates to the consent record, the associated grant, and audit-entry anonymization.
+
+## Contact
+
+Residency or transfer questions: `security@grantex.dev`.

--- a/docs/compliance/dpa.md
+++ b/docs/compliance/dpa.md
@@ -1,0 +1,98 @@
+# Data Processing Addendum (Template)
+
+**Status:** Draft template. Subject to legal review. **Not a legally executed agreement and not legal advice.**
+**Last reviewed:** 2026-05-24
+
+This template forms the basis of the Data Processing Addendum that Grantex offers to customers of the hosted service. It is published so procurement teams can review the terms before requesting a signed copy. The signed copy that the parties execute will be a PDF derived from this template, countersigned by both parties; this Markdown file does not constitute that signed agreement.
+
+Customers requiring a signed DPA should email `security@grantex.dev` with their legal counter-party details.
+
+---
+
+## 1. Parties
+
+- **Processor:** Grantex maintainers (the entity operating `api.grantex.dev`; legal entity name **TBD** pending company formation / counsel review).
+- **Controller:** the customer organization identified in the executed cover sheet.
+
+This addendum supplements the Apache 2.0 license of the open-source software and any commercial agreement covering the hosted service. In a conflict, the executed cover sheet governs.
+
+## 2. Subject matter and duration
+
+The Processor processes personal data on behalf of the Controller solely to deliver the Grantex Delegated Authorization Platform hosted service. Processing continues for the term of the underlying agreement and during any wind-down period defined in Section 10 (Return or Deletion).
+
+## 3. Nature and purpose of processing
+
+- Issuing, verifying, and revoking agent grant tokens.
+- Recording consent records and audit entries linked to data principals.
+- Operating the supporting administrative, support, and security functions of the platform.
+
+## 4. Categories of personal data
+
+| Category | Examples |
+|---|---|
+| Account / developer | Email, name, organization, hashed API key |
+| End-user / data principal | Principal identifier supplied by the Controller (typically a pseudonymous ID), optional WebAuthn credential references |
+| Authorization events | Scope strings, timestamps, agent DIDs, IP addresses captured for rate limiting |
+| Audit metadata | Action, status, request ID, hashed references to third-party identifiers |
+| Optional compliance | DPDP consent records, grievance references, erasure request IDs |
+
+Grantex does **not** request payment-card data, government identifiers, or special-category personal data. Customers must not transmit such data to the platform.
+
+## 5. Categories of data subjects
+
+- The Controller's developers and administrators.
+- The Controller's end users (data principals) whose authorization is brokered by Grantex.
+- Authorized agents acting on behalf of those end users.
+
+## 6. Sub-processors
+
+A current list is maintained at [docs/compliance/sub-processors.md](./sub-processors.md). The Processor will provide at least 30 days' notice (via CHANGELOG and the developer portal) before engaging a new production sub-processor; the Controller may object in writing within that window, in which case the parties will discuss an alternative arrangement in good faith.
+
+## 7. Technical and organisational measures
+
+The Processor maintains the following safeguards, summarised here and described in detail in `docs/security/` and `SECURITY.md`:
+
+- **Encryption in transit** — TLS 1.2+ enforced on all public endpoints.
+- **Encryption at rest** — provider-native (Cloud SQL, Memorystore, Secret Manager) plus an application-level vault key for sensitive fields.
+- **Key management** — JWT signing keys and the vault encryption key live in Google Secret Manager and are rotatable without redeploy.
+- **Access controls** — least-privilege IAM on infrastructure; CODEOWNERS-gated reviews on the source; CI-required status checks on `main`.
+- **Multi-tenancy isolation** — every row is developer-scoped and proven by `tests/security-multi-tenancy.test.ts`.
+- **Vulnerability management** — published disclosure policy and SLA in `SECURITY.md`; weekly Dependabot updates configured in `.github/dependabot.yml`.
+- **Live commerce side-effects fail closed** — central guard in `apps/auth-service/src/lib/commerce/live-mode-guard.ts`.
+
+## 8. Confidentiality
+
+Personnel with access to personal data are bound by confidentiality obligations and receive security training appropriate to their role.
+
+## 9. Breach notification
+
+The Processor will notify the Controller **without undue delay and in any event within 72 hours** of becoming aware of a personal-data breach affecting the Controller's data. The notification will include: nature of the breach, categories and approximate number of data subjects and records affected, likely consequences, and measures taken or proposed.
+
+## 10. Return or deletion of data
+
+On termination of the underlying agreement, the Controller may, within 30 days, request:
+
+- **Export** — a JSON export of all personal data the Processor holds about the Controller's tenants; or
+- **Deletion** — irreversible deletion of that data and a written confirmation.
+
+The DPDP erasure endpoint (`POST /v1/dpdp/data-principals/:id/erasure`, see `apps/auth-service/src/routes/dpdp.ts`) is available throughout the term for per-principal deletion.
+
+## 11. International transfers
+
+The Processor relies on the European Commission's Standard Contractual Clauses (Module Two: Controller-to-Processor) for any transfer of EEA-origin personal data outside the EEA, plus the UK International Data Transfer Addendum and the Swiss FDPIC adequacy mechanism as applicable. Today, all hosted processing occurs in `us-central1`; see [data-residency.md](./data-residency.md).
+
+## 12. Audits
+
+The Controller may request, no more than once per year and on at least 60 days' notice, evidence of the Processor's compliance with this Addendum. The Processor will respond with the most recent SOC 2 attestation **when available** (status today: SOC 2 readiness control mapping published in `docs/security/soc2-report.mdx`; formal third-party attestation pending). On-site audits are by mutual written agreement.
+
+## 13. Liability
+
+Liability under this Addendum is subject to the limits in the underlying commercial agreement. Open-source self-hosted use is governed solely by the Apache 2.0 license.
+
+## 14. Governing law
+
+The governing law and venue are those specified in the executed cover sheet. The template defaults to Delaware, United States, pending company-formation decisions.
+
+## 15. Signature block
+
+This template becomes binding only when both parties sign the executed cover sheet that incorporates these terms by reference. **The Markdown file alone is not a signed agreement.**

--- a/docs/compliance/privacy-policy.md
+++ b/docs/compliance/privacy-policy.md
@@ -1,0 +1,83 @@
+# Privacy Policy (Draft)
+
+**Status:** Draft. Subject to legal review. **Not a legally executed privacy notice and not legal advice.**
+**Last reviewed:** 2026-05-24
+**Applies to:** the hosted Grantex services at `grantex.dev`, `api.grantex.dev`, and `docs.grantex.dev`.
+
+This draft is published so customers and end users can review Grantex's privacy practices before a counsel-reviewed version is countersigned and published.
+
+## 1. Who we are
+
+Grantex is an open protocol and a hosted developer service operated by the Grantex maintainers (the legal entity name and registered office are **TBD** pending company formation). For privacy questions or to exercise the rights below, contact `security@grantex.dev`.
+
+## 2. What we collect and why
+
+### As a developer using the hosted service
+
+- **Account data** — name, email, organization, password hash, hashed API key. Used to authenticate you and to operate the service.
+- **Usage and billing data** — request counts, error counts, plan tier, Stripe customer ID if billing is enabled. Used for billing and capacity planning.
+- **Operational logs** — request ID, timestamp, source IP, route, status code, latency. Used for security monitoring and debugging. Retained per the schedule below.
+
+### As an end user (data principal) whose agent uses Grantex
+
+- **Principal identifier** — the opaque identifier your developer assigned you (typically pseudonymous).
+- **Authorization events** — what scopes you granted, to which agent, when, and when you revoked them. This is the core audit trail Grantex exists to provide.
+- **Optional WebAuthn credential references** — only if your developer turned on FIDO/WebAuthn.
+- **DPDP consent records, grievance references, erasure request IDs** — only if your developer is using the DPDP compliance features.
+
+We do **not** ask you for payment-card data, government identifiers, biometrics, location, or contacts.
+
+## 3. Legal bases (GDPR-equivalent)
+
+- **Contract** — to deliver the service the developer agreed to.
+- **Legitimate interest** — to keep the service secure (rate limiting, anomaly detection, audit).
+- **Consent** — for any optional cookies that go beyond strictly necessary (see [Cookie Policy](./cookie-policy.md)).
+- **Legal obligation** — to respond to lawful requests from regulators.
+
+## 4. How long we keep it
+
+| Category | Retention |
+|---|---|
+| Account data | For the life of the account; deleted within 30 days of account closure. |
+| Authorization audit trail | Operator-configurable; default 365 days on the hosted service. |
+| Operational logs | 30 days. |
+| Backups | 30 days, rolling. |
+| DPDP / GDPR erasure records | Indefinitely, anonymized — required as proof the erasure occurred. |
+
+## 5. Sub-processors and international transfers
+
+We use a small number of third-party services to operate the hosted offering. The full list and locations are in [sub-processors.md](./sub-processors.md). Hosted processing occurs in the US (`us-central1`); see [data-residency.md](./data-residency.md). For EEA / UK / Swiss transfers we rely on Standard Contractual Clauses; see [dpa.md](./dpa.md).
+
+## 6. Your rights
+
+Depending on where you live, you have some or all of the following rights:
+
+- **Access** — request a copy of the data we hold about you.
+- **Rectification** — correct inaccurate data.
+- **Erasure** — ask us to delete your data. For agent-authorization records this is implemented programmatically via `POST /v1/dpdp/data-principals/:principalId/erasure` (see `apps/auth-service/src/routes/dpdp.ts`); your developer can also trigger this on your behalf.
+- **Portability** — receive your data in JSON.
+- **Restriction** and **objection** to certain processing.
+- **Withdrawal of consent** at any time, with no effect on lawfulness of earlier processing.
+- **Lodge a complaint** with your local supervisory authority (e.g., EU DPA, the UK ICO, the Indian DPB).
+
+Exercise any of these by emailing `security@grantex.dev`. We aim to respond within 30 days.
+
+## 7. Children
+
+Grantex is a developer infrastructure service. We do not knowingly collect personal data from children under 13 (or the equivalent age of digital consent in your jurisdiction). If you believe we have, please contact us and we will delete it.
+
+## 8. Cookies and tracking
+
+The marketing site (`grantex.dev`) uses Google Analytics for aggregate traffic statistics. The developer portal and API use only strictly necessary cookies (session, CSRF). Full details in the [Cookie Policy](./cookie-policy.md).
+
+## 9. Security
+
+How we protect data is described in `SECURITY.md` and the [DPA template](./dpa.md), Section 7. To report a vulnerability, see `SECURITY.md`.
+
+## 10. Changes
+
+Material changes to this policy will be announced via the public CHANGELOG and the developer portal at least 30 days before they take effect. The `Last reviewed` date at the top of this file is the authoritative version marker.
+
+## 11. Contact
+
+`security@grantex.dev`

--- a/docs/compliance/sub-processors.md
+++ b/docs/compliance/sub-processors.md
@@ -1,0 +1,54 @@
+# Sub-processor Disclosure
+
+**Status:** Current public disclosure. Subject to legal review. Not a certification document.
+**Last reviewed:** 2026-05-24
+
+This list enumerates the third-party services Grantex's maintainers use to operate the public hosted endpoints (`api.grantex.dev`, `grantex.dev`, `docs.grantex.dev`) and the SaaS tooling that supports the project. **Self-hosted Grantex deployments do not transit any of these sub-processors unless the operator opts in** — the open-source release runs entirely on infrastructure of the operator's choosing.
+
+Every entry below is derived from artifacts inside this repository (deploy scripts, Helm charts, Docker Compose files, GitHub workflows, package dependencies). Items the repository does not evidence are marked **TBD**.
+
+## Production runtime sub-processors (hosted Grantex)
+
+| Sub-processor | Service | Purpose | Data categories | Location | Evidence |
+|---|---|---|---|---|---|
+| Google LLC | Google Cloud Run | Stateless auth-service compute | All API request/response payloads | `us-central1` (US) | `deploy/gcp/setup.sh` (`run.googleapis.com`, `CR_SERVICE="grantex-auth"`) |
+| Google LLC | Google Cloud SQL for PostgreSQL 16 | Primary datastore — agents, grants, audit, commerce state | All persisted application data | `us-central1` (US) | `deploy/gcp/setup.sh` (`sqladmin.googleapis.com`, `SQL_INSTANCE="grantex-pg16"`) |
+| Google LLC | Google Memorystore for Redis | Rate-limit counters, idempotency keys, short-lived caches | Request metadata; no PII at rest beyond TTL | `us-central1` (US) | `deploy/gcp/setup.sh` (`redis.googleapis.com`, `REDIS_INSTANCE="grantex-redis"`) |
+| Google LLC | Google Artifact Registry | Container image hosting for auth-service builds | Build artifacts, no customer data | `us-central1` (US) | `deploy/gcp/setup.sh` (`artifactregistry.googleapis.com`, `AR_REPO="grantex-images"`) |
+| Google LLC | Google Secret Manager | Runtime secrets for `api.grantex.dev` | Vault encryption key, signing keys, third-party API keys | `us-central1` (US) | `deploy/gcp/setup.sh` (`secretmanager.googleapis.com`) |
+| Google LLC | Google Cloud DNS | DNS hosting for `grantex.dev` zone | DNS records only | Global (Google anycast) | `deploy/gcp/dns.sh`, `deploy/gcp/setup.sh` (`dns.googleapis.com`) |
+| Google LLC | Firebase Hosting | Static marketing site (`grantex.dev`, `web/`) | No PII; CDN access logs only | Google CDN, global | `firebase.json` |
+| GitHub, Inc. (Microsoft) | GitHub | Source control, issue tracking, GitHub Actions CI/CD, GitHub Security Advisories | Code, build artifacts, vulnerability reports | US (GitHub-managed) | `.github/workflows/*.yml`, project hosted at `github.com/mishrasanjeev/grantex` |
+
+## Optional sub-processors (only when feature-flagged on)
+
+The following providers are integrated in code but **disabled by default**; operators must explicitly enable them with the listed environment variables.
+
+| Sub-processor | Service | Purpose | Enabled by | Evidence |
+|---|---|---|---|---|
+| Stripe, Inc. | Stripe | Subscription billing for paid plans | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_*` | `docker-compose.yml:59-63`, `apps/auth-service/src/config.ts` |
+| Anthropic, PBC | Datadog (when configured as anomaly destination) | Anomaly alerting and metric forwarding | `ANOMALY_DESTINATIONS` env containing `datadog` (operator-supplied API key) | README anomaly section; `packages/destinations` Datadog adapter |
+| Amazon Web Services, Inc. | AWS S3 | Audit log export destination (immutable archive) | `AUDIT_DESTINATIONS` containing `s3` | `packages/destinations/package-lock.json` (`@aws-sdk/client-s3`) |
+| Google LLC | Google BigQuery | Audit log export destination (analytics) | `AUDIT_DESTINATIONS` containing `bigquery` | `packages/destinations/package-lock.json` (`@google-cloud/bigquery`) |
+| Apache Kafka operators | Kafka (operator-managed) | Audit/event streaming | `AUDIT_DESTINATIONS` containing `kafka` | `packages/destinations/package-lock.json` (`kafkajs`) |
+| Cloud Native Computing Foundation | OpenTelemetry collector (operator-managed sink) | Traces/metrics export | `OTEL_EXPORTER_OTLP_ENDPOINT` | `apps/auth-service/src/config.ts:51`, `deploy/helm/grantex/values.yaml:114-119` |
+
+## Notably *not* in use today
+
+- **No transactional email provider configured.** TBD if SendGrid / Postmark / AWS SES is wired in for verification emails before public signup launch.
+- **No SMS provider configured.**
+- **No CRM, analytics, or session-replay tooling** (e.g., Segment, Mixpanel, FullStory) is referenced in the runtime code paths.
+- **No third-party customer-support tool** is integrated into the hosted product.
+- **No live payment processor.** Plural is a *planned* integration that is currently fail-closed in code (`COMMERCE_LIVE_MODE_ENABLED` / `PLURAL_LIVE_ENABLED` default to off — see `apps/auth-service/src/lib/commerce/live-mode-guard.ts`).
+
+## Change process
+
+Adding a new sub-processor requires:
+
+1. A PR that updates this file with the row, evidence path, and data categories.
+2. A corresponding entry in the GitHub release notes for the version that introduces the dependency.
+3. Existing customers receive at least 30 days' notice via the public CHANGELOG and a banner in the developer portal before the new processor begins receiving production data.
+
+## Contact
+
+Procurement and DPA questions: `security@grantex.dev` (see `SECURITY.md` for the canonical contact).

--- a/docs/compliance/terms-of-service.md
+++ b/docs/compliance/terms-of-service.md
@@ -1,0 +1,83 @@
+# Terms of Service (Draft)
+
+**Status:** Draft. Subject to legal review. **Not a legally executed agreement and not legal advice.**
+**Last reviewed:** 2026-05-24
+**Applies to:** the hosted Grantex services at `grantex.dev` and `api.grantex.dev`.
+
+The open-source Grantex software is licensed separately under the Apache License 2.0 (see `LICENSE`); these Terms govern only your use of the hosted service operated by the Grantex maintainers.
+
+## 1. Acceptance
+
+By creating an account, calling the hosted API with credentials issued by the service, or otherwise using the hosted service, you agree to these Terms. If you are agreeing on behalf of an organization, you represent that you have authority to bind that organization.
+
+## 2. The service
+
+Grantex provides a delegated authorization service for AI agents: agent registration, scoped authorization, grant-token issuance and verification, audit logging, and the supporting consent UI. Detailed behavior is described in the protocol specification (`SPEC.md`) and the public API reference (`docs.grantex.dev/api-reference`).
+
+## 3. Your account
+
+- You must keep your API keys, signing keys, and admin credentials confidential.
+- You are responsible for activity that occurs under your account, including activity by any agent or end user you have authorized.
+- You must not use the service to violate any applicable law or to enable a third party to do so.
+
+## 4. Acceptable use
+
+You may not, and may not permit your agents or end users to:
+
+- Reverse engineer, decompile, or attempt to derive the signing keys of the hosted service.
+- Use the service to facilitate fraud, theft, harassment, or other unlawful activity.
+- Probe, scan, or stress-test the service except via published load-test endpoints with prior coordination.
+- Send personal data the service is not designed to handle (see [Privacy Policy](./privacy-policy.md), Section 2 — no payment-card data, no special-category personal data).
+- Circumvent rate limits, billing meters, or the central live-mode guard.
+
+We may suspend or terminate access for material breach, with notice where reasonable.
+
+## 5. Fees
+
+If your plan is paid, fees are described in your order form or at `grantex.dev/pricing` (pricing page **TBD**). Fees are billed through Stripe (see [Sub-processors](./sub-processors.md)). Unpaid invoices may result in service suspension after notice.
+
+## 6. Beta and early-access features
+
+Features labelled "beta", "preview", "closed beta", or "experimental" are provided **as-is** with no service-level commitments. Today this includes Commerce V1 (`README.md` section "Agentic Commerce V1 (closed beta)"), the Trust Registry, and the SOC 2 readiness mapping.
+
+## 7. Service level
+
+Target availability for the production hosted service is **99.5%** monthly, measured at the auth-service `/health` endpoint, excluding scheduled maintenance announced at least 48 hours in advance. A formal SLA with credits is **TBD**.
+
+## 8. Data ownership and processing
+
+You retain ownership of all data you submit. The service processes that data only as described in the [Privacy Policy](./privacy-policy.md) and the [DPA template](./dpa.md). For self-hosted Grantex you control all data; these Terms do not apply.
+
+## 9. Confidentiality
+
+Each party will protect the other's non-public information with at least the same degree of care it uses for its own (and no less than a reasonable degree of care). Public artifacts — the spec, the open-source code, documentation, and published metrics — are not confidential.
+
+## 10. Intellectual property
+
+- The open-source software is yours to use under the Apache 2.0 license.
+- The "Grantex" name, logo, and the hosted-service branding remain ours.
+- Feedback you provide may be used to improve the service without obligation, but Grantex will not publicly attribute negative feedback to you without consent.
+
+## 11. Warranties and disclaimers
+
+The hosted service is provided **as-is** and **as-available**, without warranties of any kind, express or implied, including merchantability, fitness for a particular purpose, and non-infringement. Some jurisdictions do not allow the exclusion of implied warranties; in those jurisdictions the exclusions apply to the maximum extent permitted by law.
+
+## 12. Limitation of liability
+
+To the maximum extent permitted by law, neither party will be liable to the other for indirect, incidental, special, consequential, or punitive damages, or for loss of profits, revenue, goodwill, or data, arising out of these Terms. Each party's total liability is capped at the fees you paid in the 12 months preceding the event giving rise to the claim. These limits do not apply to either party's indemnity obligations or to your payment obligations.
+
+## 13. Termination
+
+Either party may terminate for material breach uncured 30 days after written notice. Sections 8 (Data), 11 (Disclaimers), 12 (Liability), 14 (Governing law) survive termination. On termination, the data return-or-delete process in the [DPA](./dpa.md), Section 10 applies.
+
+## 14. Governing law and disputes
+
+The governing law and venue are those specified in your executed order form. The template default is Delaware, United States. Either party may seek injunctive relief in any court of competent jurisdiction.
+
+## 15. Changes
+
+We may revise these Terms; material changes will be announced at least 30 days in advance via the public CHANGELOG and the developer portal. Continued use after the effective date constitutes acceptance.
+
+## 16. Contact
+
+`security@grantex.dev`

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -76,10 +76,7 @@
               "guides/commerce-v1-overview",
               "guides/commerce-v1-developer-guide",
               "guides/commerce-v1-merchant-operator-guide",
-              "guides/commerce-v1-operations",
-              "guides/commerce-v1-repeatable-option-a-smoke-workflow",
-              "guides/commerce-v1-option-a-smoke-setup",
-              "guides/commerce-v1-hosted-staging-e2e"
+              "guides/commerce-v1-operations"
             ]
           },
           {
@@ -87,7 +84,13 @@
             "pages": [
               "features/dpdp-compliance",
               "compliance/dpdp-act-2023",
-              "compliance/eu-ai-act"
+              "compliance/eu-ai-act",
+              "compliance/sub-processors",
+              "compliance/data-residency",
+              "compliance/dpa",
+              "compliance/privacy-policy",
+              "compliance/terms-of-service",
+              "compliance/cookie-policy"
             ]
           },
           {

--- a/docs/guides/commerce-v1-developer-guide.mdx
+++ b/docs/guides/commerce-v1-developer-guide.mdx
@@ -125,9 +125,11 @@ Developers should use:
 - `docs/guides/commerce-v1-repeatable-option-a-smoke-workflow.md` for the
   approval-gated smoke path;
 - `docs/examples/commerce-option-a-smoke.runbook.json` for runbook fields;
-- `docs/reports/commerce-v1-option-a-smoke-evidence.md` for scrubbed evidence;
-- `docs/reports/commerce-v1-production-discovery-readiness.md` for current
-  production discovery posture.
+- the internal Option A smoke evidence record (operator-internal,
+  kept in `docs/internal/commerce-v1/` and available to authorized
+  reviewers via `security@grantex.dev`);
+- the internal production-discovery readiness record (same access
+  path) for the current posture.
 
 ## Blocked Until Future Approval
 

--- a/docs/guides/commerce-v1-hosted-staging-e2e.md
+++ b/docs/guides/commerce-v1-hosted-staging-e2e.md
@@ -189,7 +189,7 @@ The third command is a refusal check and must fail before any network request.
 Later hosted staging execution, after M9/M10 prerequisites and a reviewed implementation of run mode:
 
 ```powershell
-node scripts/commerce-staging-e2e-harness.mjs --run --api-base=https://api-staging.grantex.dev --agenticorg-base=https://staging.agenticorg.ai --manifest=docs/examples/commerce-staging-seed.manifest.json --report=docs/reports/commerce-v1-hosted-staging-e2e.md
+node scripts/commerce-staging-e2e-harness.mjs --run --api-base=https://api-staging.grantex.dev --agenticorg-base=https://staging.agenticorg.ai --manifest=docs/examples/commerce-staging-seed.manifest.json --report=docs/internal/commerce-v1/commerce-v1-hosted-staging-e2e.md
 ```
 
 AgenticOrg later real-staging handoff commands:

--- a/docs/guides/commerce-v1-merchant-operator-guide.mdx
+++ b/docs/guides/commerce-v1-merchant-operator-guide.mdx
@@ -113,9 +113,10 @@ external pilot claims if any of these are true:
 
 ## Evidence Links
 
-- Option A smoke: `docs/reports/commerce-v1-option-a-smoke-evidence.md`
-- Production discovery readiness:
-  `docs/reports/commerce-v1-production-discovery-readiness.md`
+- Option A smoke evidence: operator-internal artifact, available to
+  authorized reviewers via `security@grantex.dev`.
+- Production discovery readiness: operator-internal artifact, same
+  access path.
 - Repeatable workflow:
   `docs/guides/commerce-v1-repeatable-option-a-smoke-workflow.md`
 - Operations guide: `docs/guides/commerce-v1-operations.mdx`

--- a/docs/guides/commerce-v1-operations.mdx
+++ b/docs/guides/commerce-v1-operations.mdx
@@ -75,7 +75,9 @@ M7B dashboard status:
 
 - Health checks are measured from the API.
 - SLA target cards are visible as target indicators; measured local load evidence is recorded in
-  `docs/reports/commerce-v1-local-pilot-load.md`.
+  the internal local-pilot-load report (operator-internal artifact in
+  `docs/internal/commerce-v1/`, available to authorized reviewers via
+  `security@grantex.dev`).
 - Live Plural readiness is marked `blocked`.
 - Failed provider webhook replay is operator-only and mock-provider-only until the Plural contract is confirmed.
   Replay is available only for future failed events with valid original signatures and encrypted replay material.
@@ -129,7 +131,7 @@ Measured run command:
 ```bash
 node scripts/commerce-pilot-load-harness.mjs --run \
   --env-file=.tmp/commerce-pilot-load.env \
-  --report=docs/reports/commerce-v1-local-pilot-load.md
+  --report=docs/internal/commerce-v1/commerce-v1-local-pilot-load.md
 ```
 
 Optional target subset for staged local checks:
@@ -161,7 +163,7 @@ For the full M7B target run, seed at least:
 
 The measured report includes request count, success count, error count, p50, p95, max latency,
 per-target pass/fail, and duplicate webhook transition evidence. The report location is
-`docs/reports/commerce-v1-local-pilot-load.md`.
+`docs/internal/commerce-v1/commerce-v1-local-pilot-load.md`.
 
 Do not use production credentials, real provider credentials, live payment mode, or real Plural calls
 with this harness.
@@ -251,7 +253,7 @@ M7C internal-sandbox signoff status:
 | Dry-run harness validation | Passing | `node scripts/commerce-pilot-load-harness.mjs --dry-run` |
 | Non-local URL refusal | Passing | Harness refuses production-like base URLs before network calls |
 | Local sandbox seed path | Available | `node scripts/commerce-pilot-seed-local.mjs --run --migrate --env-output=.tmp/commerce-pilot-load.env` |
-| Measured local load report | Passing | `docs/reports/commerce-v1-local-pilot-load.md` records localhost/mock run results: payment intent create 100/100 p95 16.53 ms, catalog search 500/500 p95 5.41 ms, mock provider webhook 52/52 p95 20.45 ms, duplicate transitions 0 |
+| Measured local load report | Passing | `docs/internal/commerce-v1/commerce-v1-local-pilot-load.md` records localhost/mock run results: payment intent create 100/100 p95 16.53 ms, catalog search 500/500 p95 5.41 ms, mock provider webhook 52/52 p95 20.45 ms, duplicate transitions 0 |
 | Internal sandbox recommendation | Ready for internal sandbox only | External/live pilot remains blocked |
 
 ## Not-Ready-If Checklist

--- a/docs/guides/commerce-v1-option-a-smoke-setup.md
+++ b/docs/guides/commerce-v1-option-a-smoke-setup.md
@@ -8,7 +8,7 @@ Option A is the cheapest temporary hosted smoke path for Grantex Commerce V1. It
 
 ## Execution Outcome
 
-Option A hosted smoke was executed after explicit approval and is now complete. The redacted evidence report is `docs/reports/commerce-v1-option-a-smoke-evidence.md`.
+Option A hosted smoke was executed after explicit approval and is now complete. The redacted evidence report is `docs/internal/commerce-v1/commerce-v1-option-a-smoke-evidence.md`.
 
 - Final smoke evidence recorded 22 passed checks, 0 failed checks, and 9 skipped negative checks.
 - Health, JWKS, commerce well-known, MCP initialize/tools/list, catalog, inventory, cart, consent, passport exchange, mock payment intent, checkout, mock provider webhooks, duplicate webhook idempotency, manual reconciliation, audit timeline, provider webhook replay dry-run, and emergency re-enable negative check passed.
@@ -271,7 +271,7 @@ node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=$env:SMOKE_UR
 
 ```powershell
 # NOT RUN
-node scripts/commerce-staging-e2e-harness.mjs --run --api-base=$env:SMOKE_URL --allow-smoke-cloud-run-url=$env:SMOKE_URL --report=docs/reports/commerce-v1-hosted-staging-e2e.md
+node scripts/commerce-staging-e2e-harness.mjs --run --api-base=$env:SMOKE_URL --allow-smoke-cloud-run-url=$env:SMOKE_URL --report=docs/internal/commerce-v1/commerce-v1-hosted-staging-e2e.md
 ```
 
 Run mode must remain fail-closed until a reviewed implementation exists and the required smoke env names are present.
@@ -297,7 +297,7 @@ Create a redacted report only after real smoke checks run:
 
 ```powershell
 # NOT RUN
-node scripts/commerce-staging-e2e-harness.mjs --run --api-base=$env:SMOKE_URL --allow-smoke-cloud-run-url=$env:SMOKE_URL --report=docs/reports/commerce-v1-hosted-staging-e2e.md
+node scripts/commerce-staging-e2e-harness.mjs --run --api-base=$env:SMOKE_URL --allow-smoke-cloud-run-url=$env:SMOKE_URL --report=docs/internal/commerce-v1/commerce-v1-hosted-staging-e2e.md
 ```
 
 The report must include only hostnames, request counts, status codes, redacted request IDs, pass/fail rows, blockers, and no-live-payment confirmation. It must not include secret values, bearer tokens, raw passports, idempotency keys, provider credentials, webhook secrets, encrypted payload material, or raw webhook payloads.

--- a/docs/guides/commerce-v1-overview.mdx
+++ b/docs/guides/commerce-v1-overview.mdx
@@ -18,10 +18,10 @@ Commerce V1, live payments, live Plural, or production discovery.
 | Capability | Status | Evidence or gate |
 | --- | --- | --- |
 | Local/internal sandbox | Implemented | Synthetic catalog, cart, consent, passport, payment, webhook, and audit flows. |
-| Temporary Grantex Option A smoke | Verified | `docs/reports/commerce-v1-option-a-smoke-evidence.md` records 14 passed, 0 failed, 6 failed-safe, 0 skipped. |
+| Temporary Grantex Option A smoke | Verified | internal evidence record (operator-internal, available on request) records 14 passed, 0 failed, 6 failed-safe, 0 skipped. |
 | AgenticOrg real-staging handoff | Verified externally | AgenticOrg evidence records Grantex-only tools and redacted fixture handling. |
 | Hosted AgenticOrg API-only discovery | Verified externally | AgenticOrg C3 evidence records hosted MCP/A2A discovery against temporary Grantex smoke. |
-| Grantex production Commerce V1 discovery | Disabled/fail-closed | `docs/reports/commerce-v1-production-discovery-readiness.md`. |
+| Grantex production Commerce V1 discovery | Disabled/fail-closed | internal production-discovery readiness record (operator-internal, available on request). |
 | Production checkout/live payments | Blocked | Requires legal, compliance, security, operations, provider, rollback, and human approval gates. |
 | Live Plural | Blocked | Mock provider only in current smoke evidence. |
 
@@ -113,6 +113,9 @@ readiness, or provider certification.
 - `docs/guides/commerce-v1-merchant-operator-guide.mdx`
 - `docs/guides/commerce-v1-operations.mdx`
 - `docs/guides/commerce-v1-repeatable-option-a-smoke-workflow.md`
-- `docs/reports/commerce-v1-option-a-smoke-evidence.md`
-- `docs/reports/commerce-v1-production-discovery-readiness.md`
 - `docs/api/grantex-commerce-v1.openapi.yaml`
+
+Internal Option A smoke evidence and production-discovery readiness
+records are operator-internal artifacts kept in `docs/internal/commerce-v1/`
+and are available to authorized reviewers on request via
+`security@grantex.dev`.

--- a/docs/guides/commerce-v1-staging-data-setup.md
+++ b/docs/guides/commerce-v1-staging-data-setup.md
@@ -145,7 +145,7 @@ Expected command shape:
 
 ```bash
 node scripts/commerce-staging-e2e-harness.mjs --dry-run --api-base=https://api-staging.grantex.dev --merchant-id=mch_staging_electronics_pilot --agent-id=cag_staging_agenticorg_sales
-node scripts/commerce-staging-e2e-harness.mjs --run --api-base=https://api-staging.grantex.dev --merchant-id=mch_staging_electronics_pilot --agent-id=cag_staging_agenticorg_sales --report=docs/reports/commerce-v1-hosted-staging-e2e.md
+node scripts/commerce-staging-e2e-harness.mjs --run --api-base=https://api-staging.grantex.dev --merchant-id=mch_staging_electronics_pilot --agent-id=cag_staging_agenticorg_sales --report=docs/internal/commerce-v1/commerce-v1-hosted-staging-e2e.md
 ```
 
 Smoke coverage should include:

--- a/docs/guides/compliance-matrix.mdx
+++ b/docs/guides/compliance-matrix.mdx
@@ -74,9 +74,9 @@ The evidence pack includes:
 - Policy snapshots
 - Anomaly detection findings
 
-## Certifications
+## Evidence And Standards Mappings
 
-- **SOC 2 Type I** — certified. [View report](/security/soc2-report)
+- **SOC 2** — readiness control mapping published; formal third-party attestation is not published. [View mapping](/security/soc2-report)
 - **IETF Internet-Draft** — submitted. [View submission](/community/ietf-draft)
 - **NIST AI RMF** — public comment submitted. [View comment](/community/nist-comment)
 - **OpenID AuthZEN** — conformance mapping complete. [View mapping](/community/authzen-mapping)

--- a/docs/internal/commerce-v1/commerce-v1-contract-completeness-gap-report.md
+++ b/docs/internal/commerce-v1/commerce-v1-contract-completeness-gap-report.md
@@ -1,3 +1,11 @@
+> **Internal artifact — not public marketing or compliance evidence.**
+> This file was relocated from `docs/reports/` to `docs/internal/commerce-v1/`
+> on 2026-05-24 to mark it as operator-internal documentation. It is
+> excluded from the public Mintlify navigation (`docs/docs.json`). Do
+> not link this file from any public marketing page or external sales
+> material. See `docs/reports/enterprise-readiness-brutal-review-2026-05-24.md`
+> item P0-5 for the audit context.
+
 # Commerce V1 Contract Completeness Gap Report
 
 Status: M12 gap analysis plus M12A/M12B/M12C/M12D, M14, M14.1, and Option A hosted smoke evidence. Option A was a temporary approved smoke run only; its resources were deleted after evidence capture. This pass did not merge, change production config, enable production Commerce V1, enable live payments, enable live Plural, touch production secrets, or commit local-only artifacts.
@@ -140,7 +148,7 @@ The validator pins this current set so the gap report cannot silently drift:
 
 ## Option A Hosted Smoke Evidence
 
-- Redacted evidence report: `docs/reports/commerce-v1-option-a-smoke-evidence.md`.
+- Redacted evidence report: `docs/internal/commerce-v1/commerce-v1-option-a-smoke-evidence.md`.
 - Final result: 22 passed checks, 0 failed checks, and 9 skipped negative checks.
 - Passed checks covered health, JWKS, commerce well-known, MCP initialize/tools/list, catalog search/get item, inventory check, cart create, consent request, passport exchange, payment intent, checkout, mock paid/failed/expired webhooks, duplicate webhook idempotency, manual reconciliation, audit timeline, invalid webhook signature refusal, missing consent refusal, provider webhook replay dry-run, and emergency re-enable negative check.
 - Temporary resources were cleaned up after evidence capture: `grantex-auth-smoke`, `grantex-commerce-smoke-pg`, `grantex-commerce-smoke-redis`, `grantex-smoke-*` secrets, and smoke image tags.

--- a/docs/internal/commerce-v1/commerce-v1-hosted-staging-e2e.template.md
+++ b/docs/internal/commerce-v1/commerce-v1-hosted-staging-e2e.template.md
@@ -1,3 +1,11 @@
+> **Internal artifact — not public marketing or compliance evidence.**
+> This file was relocated from `docs/reports/` to `docs/internal/commerce-v1/`
+> on 2026-05-24 to mark it as operator-internal documentation. It is
+> excluded from the public Mintlify navigation (`docs/docs.json`). Do
+> not link this file from any public marketing page or external sales
+> material. See `docs/reports/enterprise-readiness-brutal-review-2026-05-24.md`
+> item P0-5 for the audit context.
+
 # Commerce V1 Hosted Staging E2E Evidence Template
 
 Status: template only. Do not record bearer tokens, raw passports, idempotency keys, provider credentials, webhook secret values, private keys, or production data.

--- a/docs/internal/commerce-v1/commerce-v1-local-pilot-load.md
+++ b/docs/internal/commerce-v1/commerce-v1-local-pilot-load.md
@@ -1,3 +1,11 @@
+> **Internal artifact — not public marketing or compliance evidence.**
+> This file was relocated from `docs/reports/` to `docs/internal/commerce-v1/`
+> on 2026-05-24 to mark it as operator-internal documentation. It is
+> excluded from the public Mintlify navigation (`docs/docs.json`). Do
+> not link this file from any public marketing page or external sales
+> material. See `docs/reports/enterprise-readiness-brutal-review-2026-05-24.md`
+> item P0-5 for the audit context.
+
 # Commerce V1 Local Pilot Load Report
 
 Generated at: 2026-05-13T03:45:16.810Z

--- a/docs/internal/commerce-v1/commerce-v1-local-workstation-prod-candidate.md
+++ b/docs/internal/commerce-v1/commerce-v1-local-workstation-prod-candidate.md
@@ -1,0 +1,188 @@
+> **Internal artifact — not public marketing or compliance evidence.**
+> This file was relocated from `docs/reports/` to `docs/internal/commerce-v1/`
+> on 2026-05-24 to mark it as operator-internal documentation. It is
+> excluded from the public Mintlify navigation (`docs/docs.json`). Do
+> not link this file from any public marketing page or external sales
+> material. See `docs/reports/enterprise-readiness-brutal-review-2026-05-24.md`
+> item P0-5 for the audit context.
+
+# Commerce V1 Local Workstation Prod-Candidate E2E
+
+Run date: 2026-05-13
+
+Scope: local workstation validation for Grantex Commerce V1 and AgenticOrg Commerce Sales Agent.
+No hosted staging was used. No production configuration was changed. No deployment was performed.
+Live payments and live Plural remained disabled.
+
+## Position
+
+This report replaces the hosted-staging execution path only for the current cost posture. It does
+not provide the isolation or production-like coverage of hosted staging. Treat it as the strongest
+available local workstation gate before a controlled production rollout.
+
+Production rollout remains blocked for live payments and live Plural. Any production rollout should
+keep Commerce V1 disabled or tightly gated until production config, rollback, and human approval
+checks are completed.
+
+## Local Environment
+
+Grantex local stack:
+
+- API: `http://localhost:3001`
+- Postgres: local Docker Compose
+- Redis: local Docker Compose
+- `COMMERCE_V1_ENABLED=true`
+- `COMMERCE_LOCAL_LOAD_TEST=true`
+- `COMMERCE_LIVE_MODE_ENABLED=false`
+- `PLURAL_LIVE_ENABLED=false`
+- Provider: `mock`
+- Tenant: `cten_internal_sandbox`
+- Merchant: `mch_internal_sandbox_pilot`
+- Agent: `cag_internal_sandbox_pilot`
+
+AgenticOrg local validation:
+
+- Deterministic eval/demo harness
+- Live-local connector smoke against Grantex localhost
+- Tool path: `grantex_commerce` connector to Grantex MCP/REST only
+- No direct Stripe, Plural, Pine, or provider credential path
+
+## Issue Found And Fixed
+
+The live-local AgenticOrg connector path exposed a real checkout handoff gap:
+
+- `payment.create_intent` succeeded through Grantex.
+- `checkout.create` rejected the fresh payment intent with
+  `invalid_payment_status_transition`.
+- Root cause: the mock provider returned payment intent status `created`, while checkout creation
+  correctly requires an `authorized` intent before moving to `checkout_created` and
+  `payment_pending`.
+
+Focused fix:
+
+- `MockPaymentProvider.createPaymentIntent` now returns `authorized` with raw status
+  `mock_authorized`.
+- Tests were updated to expect the mock provider to produce checkout-ready internal-sandbox intents.
+- Live provider code, production config, live Plural, and provider credentials were not changed.
+
+## Grantex Smoke
+
+| Check | Result |
+| --- | --- |
+| Docker Compose local stack | Pass |
+| `GET http://localhost:3001/health` | Pass: database and Redis `ok` |
+| `GET http://localhost:3001/.well-known/jwks.json` | Pass |
+| `GET http://localhost:3001/.well-known/grantex-commerce?merchant_id=mch_internal_sandbox_pilot` | Pass |
+| Commerce profile environment | Pass: `sandbox` |
+| Commerce profile live payment exposure | Pass: no live payment enablement |
+
+## Grantex E2E Load Harness
+
+Command:
+
+```powershell
+node scripts/commerce-pilot-load-harness.mjs --run --env-file=.tmp/commerce-pilot-load.env --report=.tmp/commerce-v1-local-workstation-e2e-load.md
+```
+
+Result:
+
+| Target | Requests | Success | Errors | p95 | Target | Result |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| Payment intent create | 100 | 100 | 0 | 14.58 ms | 500 ms | Pass |
+| Catalog search | 500 | 500 | 0 | 5.41 ms | 300 ms | Pass |
+| Mock provider webhook | 52 | 52 | 0 | 13.26 ms | 500 ms | Pass |
+
+Webhook duplicate evidence:
+
+- Duplicate payment transition count: 0
+- Processed payment intent count: 51
+- Duplicate probe first status: `processed`
+- Duplicate probe second status: `duplicate`
+
+## AgenticOrg Live-Local Connector E2E
+
+The AgenticOrg connector was run against live local Grantex using synthetic `.tmp` seed inputs.
+Secrets, passports, bearer tokens, idempotency keys, and raw payment data were not printed.
+
+| Step | Result |
+| --- | --- |
+| Connector health | Pass: `healthy` |
+| Merchant profile | Pass |
+| Catalog search | Pass: 1 local sandbox item |
+| Cart draft creation | Pass |
+| Payment intent creation | Pass |
+| Checkout handoff | Pass |
+| Payment status polling | Pass: `payment_pending` |
+| Provider | `mock` only |
+| Tool path | AgenticOrg `grantex_commerce` connector to local Grantex MCP/REST only |
+
+## Command Results
+
+Grantex:
+
+- `npm run typecheck` from `apps/auth-service`: passed.
+- `npm test -- commerce` from `apps/auth-service`: 27 files, 377 tests passed.
+- `npm test` from `apps/auth-service`: 103 files, 1404 tests passed.
+- `npm run typecheck` from `apps/portal`: passed.
+- `npm test` from `apps/portal`: 96 files, 906 tests passed; expected test error-boundary console output appeared.
+- `npm run build` from `apps/portal`: passed with existing Vite chunk-size warning.
+- `node docs/commerce-v1-hardening.validate.mjs`: passed.
+- `node web/commerce-playground.validate.mjs`: passed.
+- `node docs/commerce-v1-pilot-readiness.validate.mjs`: passed.
+- `node scripts/commerce-pilot-load-harness.mjs --dry-run`: passed.
+- `git diff --check`: passed with line-ending warnings only.
+
+AgenticOrg:
+
+- `python -m ruff check ...`: passed.
+- `python -m pytest ... -q --no-cov`: 47 tests passed; one pytest cache warning.
+- `python -m mypy --follow-imports=skip ...`: passed.
+- `python -m compileall ...`: passed.
+- `python demos/commerce_sales_agent_demo.py`: passed.
+
+## Negative Coverage
+
+| Scenario | Coverage |
+| --- | --- |
+| Missing consent | AgenticOrg eval/demo refusal |
+| Denied consent | AgenticOrg eval/guardrail refusal |
+| Amount cap breach | AgenticOrg eval/guardrail refusal |
+| Stale or unknown inventory | AgenticOrg cautious response |
+| Disabled merchant / policy denial | Grantex tests and AgenticOrg guardrails |
+| Revoked or expired passport | Grantex commerce tests |
+| Unsupported EMI/discount/offer/warranty | AgenticOrg refusal |
+| Direct provider path | AgenticOrg static regression confirms no Stripe/Plural/Pine commerce path |
+| Duplicate webhook transition | Local Grantex harness confirms no duplicate payment transition |
+
+## Limitations
+
+- No hosted staging pair exists.
+- AgenticOrg API was not running on `localhost:8000`, so HTTP discovery endpoints were not tested
+  locally through a live AgenticOrg API server.
+- AgenticOrg behavior was covered through deterministic eval/demo tests plus a live-local connector
+  smoke into Grantex.
+- Local workstation testing does not validate cloud IAM, Secret Manager bindings, Cloud Run runtime
+  settings, production DNS, production CORS, production logging sinks, production rollback, or
+  real external customer traffic.
+
+## Direct-To-Prod Not-Ready-If
+
+Do not proceed to production rollout if any of the following is true:
+
+- The mock-provider `authorized` checkout fix is not committed and deployed.
+- Production Commerce V1 would be enabled without explicit human approval.
+- `COMMERCE_LIVE_MODE_ENABLED` would be set to `true`.
+- `PLURAL_LIVE_ENABLED` would be set to `true`.
+- Live Plural/provider credentials would be mounted for commerce.
+- Production rollback revision and commands are not confirmed.
+- Production smoke plan does not exclude real payment creation.
+- Legal/compliance/payment/ops review gates are not explicitly accepted or deferred.
+
+## Recommendation
+
+Local workstation E2E is green after the mock checkout-state fix.
+
+Recommended next step is a controlled production deployment only if Commerce V1 remains disabled or
+internally gated in production, live payment mode remains disabled, and live Plural remains disabled.
+External sandbox pilot and live payments are still not ready without the human review gates and
+provider/legal/ops approvals.

--- a/docs/internal/commerce-v1/commerce-v1-merchant-approval-artifact-checklist.md
+++ b/docs/internal/commerce-v1/commerce-v1-merchant-approval-artifact-checklist.md
@@ -1,3 +1,11 @@
+> **Internal artifact — not public marketing or compliance evidence.**
+> This file was relocated from `docs/reports/` to `docs/internal/commerce-v1/`
+> on 2026-05-24 to mark it as operator-internal documentation. It is
+> excluded from the public Mintlify navigation (`docs/docs.json`). Do
+> not link this file from any public marketing page or external sales
+> material. See `docs/reports/enterprise-readiness-brutal-review-2026-05-24.md`
+> item P0-5 for the audit context.
+
 # Grantex Commerce V1 Merchant Approval Artifact Checklist
 
 Status: planning checklist only

--- a/docs/internal/commerce-v1/commerce-v1-merchant-approval-intake-status.md
+++ b/docs/internal/commerce-v1/commerce-v1-merchant-approval-intake-status.md
@@ -1,3 +1,11 @@
+> **Internal artifact — not public marketing or compliance evidence.**
+> This file was relocated from `docs/reports/` to `docs/internal/commerce-v1/`
+> on 2026-05-24 to mark it as operator-internal documentation. It is
+> excluded from the public Mintlify navigation (`docs/docs.json`). Do
+> not link this file from any public marketing page or external sales
+> material. See `docs/reports/enterprise-readiness-brutal-review-2026-05-24.md`
+> item P0-5 for the audit context.
+
 # Grantex Commerce V1 Merchant Approval Intake Status
 
 Status: current intake status record

--- a/docs/internal/commerce-v1/commerce-v1-merchant-artifact-collection-readiness.md
+++ b/docs/internal/commerce-v1/commerce-v1-merchant-artifact-collection-readiness.md
@@ -1,3 +1,11 @@
+> **Internal artifact — not public marketing or compliance evidence.**
+> This file was relocated from `docs/reports/` to `docs/internal/commerce-v1/`
+> on 2026-05-24 to mark it as operator-internal documentation. It is
+> excluded from the public Mintlify navigation (`docs/docs.json`). Do
+> not link this file from any public marketing page or external sales
+> material. See `docs/reports/enterprise-readiness-brutal-review-2026-05-24.md`
+> item P0-5 for the audit context.
+
 # Grantex Commerce V1 Merchant Artifact Collection Readiness
 
 Status: planning packet only

--- a/docs/internal/commerce-v1/commerce-v1-named-merchant-discovery-approval-package.md
+++ b/docs/internal/commerce-v1/commerce-v1-named-merchant-discovery-approval-package.md
@@ -1,3 +1,11 @@
+> **Internal artifact — not public marketing or compliance evidence.**
+> This file was relocated from `docs/reports/` to `docs/internal/commerce-v1/`
+> on 2026-05-24 to mark it as operator-internal documentation. It is
+> excluded from the public Mintlify navigation (`docs/docs.json`). Do
+> not link this file from any public marketing page or external sales
+> material. See `docs/reports/enterprise-readiness-brutal-review-2026-05-24.md`
+> item P0-5 for the audit context.
+
 # Grantex Commerce V1 Named Merchant Discovery Approval Package
 
 Status: planning template only

--- a/docs/internal/commerce-v1/commerce-v1-option-a-smoke-evidence.md
+++ b/docs/internal/commerce-v1/commerce-v1-option-a-smoke-evidence.md
@@ -1,3 +1,11 @@
+> **Internal artifact — not public marketing or compliance evidence.**
+> This file was relocated from `docs/reports/` to `docs/internal/commerce-v1/`
+> on 2026-05-24 to mark it as operator-internal documentation. It is
+> excluded from the public Mintlify navigation (`docs/docs.json`). Do
+> not link this file from any public marketing page or external sales
+> material. See `docs/reports/enterprise-readiness-brutal-review-2026-05-24.md`
+> item P0-5 for the audit context.
+
 # Commerce V1 Option A Smoke Evidence
 
 Status: C2G approved smoke evidence captured from a temporary Option A smoke service. This report is scrubbed and contains no bearer token values, passports, consent runtime material, idempotency key values, webhook secrets, provider credentials, raw payloads, DB/Redis URLs, private keys, or secret values.

--- a/docs/internal/commerce-v1/commerce-v1-production-discovery-readiness.md
+++ b/docs/internal/commerce-v1/commerce-v1-production-discovery-readiness.md
@@ -1,3 +1,11 @@
+> **Internal artifact — not public marketing or compliance evidence.**
+> This file was relocated from `docs/reports/` to `docs/internal/commerce-v1/`
+> on 2026-05-24 to mark it as operator-internal documentation. It is
+> excluded from the public Mintlify navigation (`docs/docs.json`). Do
+> not link this file from any public marketing page or external sales
+> material. See `docs/reports/enterprise-readiness-brutal-review-2026-05-24.md`
+> item P0-5 for the audit context.
+
 # Commerce V1 Production Discovery Readiness
 
 - Assessment date: 2026-05-17T14:58:09+05:30

--- a/docs/internal/commerce-v1/commerce-v1-read-only-discovery-rollout-plan.md
+++ b/docs/internal/commerce-v1/commerce-v1-read-only-discovery-rollout-plan.md
@@ -1,3 +1,11 @@
+> **Internal artifact — not public marketing or compliance evidence.**
+> This file was relocated from `docs/reports/` to `docs/internal/commerce-v1/`
+> on 2026-05-24 to mark it as operator-internal documentation. It is
+> excluded from the public Mintlify navigation (`docs/docs.json`). Do
+> not link this file from any public marketing page or external sales
+> material. See `docs/reports/enterprise-readiness-brutal-review-2026-05-24.md`
+> item P0-5 for the audit context.
+
 # Grantex Commerce V1 Read-Only Discovery Rollout Plan
 
 Status: planning package only

--- a/docs/internal/commerce-v1/commerce-v1-read-only-production-discovery-proposal.md
+++ b/docs/internal/commerce-v1/commerce-v1-read-only-production-discovery-proposal.md
@@ -1,3 +1,11 @@
+> **Internal artifact — not public marketing or compliance evidence.**
+> This file was relocated from `docs/reports/` to `docs/internal/commerce-v1/`
+> on 2026-05-24 to mark it as operator-internal documentation. It is
+> excluded from the public Mintlify navigation (`docs/docs.json`). Do
+> not link this file from any public marketing page or external sales
+> material. See `docs/reports/enterprise-readiness-brutal-review-2026-05-24.md`
+> item P0-5 for the audit context.
+
 # Grantex Commerce V1 Read-Only Production Discovery Proposal
 
 Status: planning proposal only

--- a/docs/internal/commerce-v1/commerce-v1-staging-readiness.md
+++ b/docs/internal/commerce-v1/commerce-v1-staging-readiness.md
@@ -1,0 +1,168 @@
+> **Internal artifact — not public marketing or compliance evidence.**
+> This file was relocated from `docs/reports/` to `docs/internal/commerce-v1/`
+> on 2026-05-24 to mark it as operator-internal documentation. It is
+> excluded from the public Mintlify navigation (`docs/docs.json`). Do
+> not link this file from any public marketing page or external sales
+> material. See `docs/reports/enterprise-readiness-brutal-review-2026-05-24.md`
+> item P0-5 for the audit context.
+
+# Commerce V1 Staging/Internal-Sandbox Readiness Run
+
+Run date: 2026-05-13
+
+Scope: Option A readiness execution for Grantex Commerce V1 and AgenticOrg Commerce Sales Agent.
+Production Commerce V1 remains disabled. No production config was changed. No production deploy was
+performed. Live payments and live Plural remained disabled.
+
+## Environment Availability
+
+| System | Environment | Status | Notes |
+| --- | --- | --- | --- |
+| Grantex hosted staging | GCP/GitHub | Not available | GCP inventory showed only `grantex-prod` with Cloud Run service `grantex-auth`. GitHub has `staging - docs`, which is docs-only and not a Commerce API staging runtime. |
+| Grantex local internal sandbox | Docker Compose | Available | `auth-service`, `postgres`, and `redis` were running locally. `http://localhost:3001/health` returned healthy. |
+| AgenticOrg hosted staging | GCP/GitHub | Not available for this run | GitHub has a `staging` environment, but the visible Cloud Run services were production-named app services in `perfect-period-305406`. No separate staging API URL was identified. |
+| AgenticOrg local API | Docker/localhost | Not running | No local AgenticOrg API responded on port 8000. AgenticOrg validation used the mocked Commerce Sales Agent eval/demo harness. |
+
+## Config Values Used
+
+Secrets, bearer tokens, Commerce Passports, provider credentials, and idempotency keys are excluded
+from this report.
+
+Grantex local internal sandbox:
+
+- API base URL: `http://localhost:3001`
+- Database: local Docker Postgres
+- Redis: local Docker Redis
+- `COMMERCE_V1_ENABLED=true`
+- `COMMERCE_ALLOW_AUTO_TENANT=true`
+- `COMMERCE_LOCAL_LOAD_TEST=true`
+- `COMMERCE_LIVE_MODE_ENABLED=false`
+- `PLURAL_SANDBOX_ENABLED=true`
+- `PLURAL_LIVE_ENABLED=false`
+- Provider: `mock`
+- Tenant: `cten_internal_sandbox`
+- Merchant: `mch_internal_sandbox_pilot`
+- Agent: `cag_internal_sandbox_pilot`
+
+AgenticOrg internal sandbox:
+
+- Runtime: mocked eval/demo harness
+- Commerce tool prefix: `grantex_commerce:*`
+- No direct Stripe, Plural, Pine, or provider credential path allowed for commerce
+- No live Grantex, Docker, API keys, or provider runtime required for the AgenticOrg mocked checks
+
+## Smoke Results
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| Grantex health | Pass | `GET http://localhost:3001/health` returned `200` with database and Redis `ok`. |
+| Grantex JWKS | Pass | `GET http://localhost:3001/.well-known/jwks.json` returned `200`. |
+| Grantex commerce profile | Pass | `GET http://localhost:3001/.well-known/grantex-commerce?merchant_id=mch_internal_sandbox_pilot` returned `200`, `version=grantex-commerce-v1`, `environment=sandbox`. |
+| Commerce profile overclaim/secret scan | Pass | No external certification marker or secret marker was detected in the local commerce profile response. |
+| Static playground | Pass | `node web/commerce-playground.validate.mjs` passed. |
+| Commerce hardening docs | Pass | `node docs/commerce-v1-hardening.validate.mjs` passed. |
+| Commerce pilot readiness docs | Pass | `node docs/commerce-v1-pilot-readiness.validate.mjs` passed. |
+| Local load harness dry-run | Pass | `node scripts/commerce-pilot-load-harness.mjs --dry-run` passed. |
+| AgenticOrg health | Blocked | No non-production AgenticOrg API endpoint was available. Production endpoint was not used for this staging run. |
+| AgenticOrg MCP/A2A discovery | Covered by static tests | Focused tests confirmed `commerce_sales_agent` default tools are `grantex_commerce:*` only. |
+
+## E2E Results
+
+Grantex local synthetic seed:
+
+- Command: `node scripts/commerce-pilot-seed-local.mjs --run --migrate --database-url=postgres://grantex:grantex@localhost:5432/grantex --env-output=.tmp/commerce-pilot-load.env`
+- Result: pass
+- Seeded 100 synthetic carts and 51 pending mock provider payment references.
+- Live Plural remained disabled.
+- Provider key: `mock`
+
+Grantex local measured harness:
+
+- Command: `node scripts/commerce-pilot-load-harness.mjs --run --env-file=.tmp/commerce-pilot-load.env --report=.tmp/commerce-v1-staging-readiness-load.md`
+- Result: pass
+
+| Target | Requests | Success | Errors | p95 | Target | Result |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| Payment intent create | 100 | 100 | 0 | 14.36 ms | 500 ms | Pass |
+| Catalog search | 500 | 500 | 0 | 5.36 ms | 300 ms | Pass |
+| Mock provider webhook | 52 | 52 | 0 | 13.40 ms | 500 ms | Pass |
+
+Mock webhook duplicate transition evidence:
+
+- Duplicate payment transition count: 0
+- Processed payment intent count: 51
+- Duplicate probe first status: `processed`
+- Duplicate probe second status: `duplicate`
+
+AgenticOrg mocked demo:
+
+- Command: `python demos/commerce_sales_agent_demo.py`
+- Result: pass
+- Covered product discovery, product Q&A, inventory check, cart draft, consent request, passport
+  exchange, payment intent, checkout handoff, and payment status polling through
+  `grantex_commerce:*` tool aliases.
+- Demo safety summary reported no direct provider calls, no provider credential handling, internal
+  sandbox only, and user-controlled final payment confirmation.
+
+## Negative Test Results
+
+| Negative check | Result | Evidence |
+| --- | --- | --- |
+| Denied consent | Pass | Covered by Grantex commerce tests and AgenticOrg eval/guardrail tests. |
+| Missing consent | Pass | AgenticOrg eval/demo refused checkout/payment without granted consent/passport. |
+| Amount cap breach | Pass | AgenticOrg eval/guardrail tests refused over-cap payment requests. |
+| Stale inventory | Pass | AgenticOrg eval/demo produced cautious response without availability guarantee. |
+| Unknown inventory | Pass | AgenticOrg eval/demo produced cautious response without availability guarantee. |
+| Disabled merchant / policy denial | Pass | Grantex commerce tests and AgenticOrg eval/guardrail tests cover refusal behavior. |
+| Revoked/expired passport | Pass | Grantex focused commerce tests cover passport revocation/expiry behavior. |
+| Unsupported EMI/discount/offer claim | Pass | AgenticOrg eval/demo refused unsupported commerce claims. |
+| Direct provider path unavailable | Pass | AgenticOrg no-provider-call regression confirmed commerce code/default tools avoid Stripe, Plural, Pine, and provider credential paths. |
+
+Focused command results:
+
+- `npm test -- commerce` from `apps/auth-service`: 27 files, 377 tests passed.
+- `npm run typecheck` from `apps/auth-service`: passed.
+- `npm run typecheck` from `apps/portal`: passed.
+- `npm test -- commerce` from `apps/portal`: 2 files, 19 tests passed.
+- `npm run build` from `apps/portal`: passed with the existing Vite chunk-size warning.
+- `python -m pytest tests/unit/test_grantex_commerce_connector.py tests/unit/test_commerce_sales_agent_guardrails.py tests/regression/test_commerce_sales_agent_no_provider_calls.py tests/evals/test_commerce_sales_agent_evals.py tests/evals/test_commerce_sales_agent_demo.py tests/unit/test_commerce_agent_production_readiness_doc.py -q --no-cov`: 47 tests passed.
+- `python -m ruff check connectors/commerce core/commerce core/langgraph/agents/commerce_sales_agent.py tests/unit/test_grantex_commerce_connector.py tests/unit/test_commerce_sales_agent_guardrails.py tests/regression/test_commerce_sales_agent_no_provider_calls.py tests/evals/test_commerce_sales_agent_evals.py tests/evals/test_commerce_sales_agent_demo.py demos/commerce_sales_agent_demo.py tests/unit/test_commerce_agent_production_readiness_doc.py`: passed.
+
+## Blockers
+
+- No hosted Grantex Commerce staging API is available.
+- No hosted AgenticOrg staging Commerce Sales Agent API was identified.
+- No local AgenticOrg API was running for HTTP `/health`, MCP, or A2A discovery checks.
+- This run cannot qualify as an external sandbox pilot gate because it used local Grantex and mocked
+  AgenticOrg execution, not an isolated hosted staging pair.
+- Human review gates remain open: security, payments, legal/compliance, operations, product, and
+  partner/customer success.
+- Live payment mode and live Plural remain blocked.
+
+## Hosted Staging Setup Plan
+
+1. Create or identify a non-production Grantex project/service, for example `grantex-staging`.
+2. Deploy Grantex auth-service to a staging Cloud Run service with:
+   - `COMMERCE_V1_ENABLED=true`
+   - `COMMERCE_LIVE_MODE_ENABLED=false`
+   - `PLURAL_LIVE_ENABLED=false`
+   - mock or approved sandbox provider only
+3. Provision staging Postgres, Redis, and secrets separate from production.
+4. Seed synthetic Commerce V1 tenant, merchant, agent, catalog, policies, passports, carts, and mock
+   provider payment references.
+5. Publish a staging-only `/.well-known/grantex-commerce` profile.
+6. Create or identify a non-production AgenticOrg API service.
+7. Point staging AgenticOrg commerce config to the Grantex staging base URL.
+8. Verify AgenticOrg MCP/A2A staging discovery exposes only `grantex_commerce:*` tools for
+   `commerce_sales_agent`.
+9. Re-run this checklist against hosted staging URLs.
+10. Keep production Commerce V1 disabled until production discovery gates are approved.
+
+## Recommendation
+
+Needs fixes/setup before external sandbox pilot.
+
+The local/internal-sandbox implementation evidence is strong and all focused local/mocked checks
+passed. However, there is no hosted staging pair available for Grantex plus AgenticOrg, so external
+sandbox pilot readiness remains blocked until hosted staging is provisioned and this checklist is
+rerun against those non-production services.

--- a/docs/reports/enterprise-readiness-brutal-review-2026-05-24.md
+++ b/docs/reports/enterprise-readiness-brutal-review-2026-05-24.md
@@ -1,0 +1,331 @@
+# Grantex — Brutal Enterprise-Readiness Review & Fix Plan
+
+**Date:** 2026-05-24
+**Reviewer:** Multi-agent audit across landing pages, docs, README/root, SDKs, core services, deploy/security
+**Verdict:** **NOT ENTERPRISE-READY.** Strong technical bones, but the marketing surface, version story, and compliance evidence are not in a state any enterprise procurement team would accept. ~190 distinct findings across six surfaces. **23 hard blockers** must be resolved before any enterprise outreach.
+
+---
+
+## Executive Summary
+
+| Surface | Critical | High | Medium | Low | Verdict |
+|---|---:|---:|---:|---:|---|
+| Landing pages & web UI | 5 | 10 | 10 | 15 | Demo-grade, not enterprise |
+| Docs & MDX guides | ~10 | 5 | 8 | 12 | Broken nav + version chaos + missing buyer pages |
+| README & root markdowns | 6 | 8 | 8 | 4 | Marketing contradicts code reality |
+| SDKs & API packages | 13 | 18 | 15 | 6 | Version Tower of Babel; stubs in shipped adapters |
+| Core services / apps | 5 | 12 | 18 | 12 | Solid base, weak guardrails, scattered kill switches |
+| Deploy / CI / security | 0 | 3 | 6 | 5 | Best-rated surface; compliance evidence is the gap |
+| **TOTAL** | **~39** | **56** | **65** | **54** | **Beta-grade across the board** |
+
+**Single biggest red flag:** the public marketing claims (`SOC 2 Type I Certified`, `EU AI Act Ready`, `DPDP Compliant`, `4,147 tests`, `v2.5`, `Production`) contradict what the repository actually proves — the SOC 2 report self-identifies as *“fictional CPA firm created for illustrative purposes”* (`docs/soc2-type1/report.md:393`), the CHANGELOG tops out at `v0.3.8` with `3,536` tests, OpenAPI is at `0.1.3`, and Commerce V1 production discovery is explicitly disabled/fail-closed (`README.md:42`). Shipping this combination is fraud-adjacent in B2B procurement.
+
+---
+
+## P0 — HARD BLOCKERS (must fix before any enterprise call)
+
+These are claims-vs-reality, legal-risk, or broken-critical-path items. **Do not run another sales motion until these are resolved.**
+
+### P0-1. Pull the “SOC 2 Type I Certified” badge OR publish a real attestation
+- **Where:** `README.md:14`, `docs/guides/compliance-matrix.mdx:79`, `docs/soc2-type1/report.md:393`
+- **Why:** The committed “report” explicitly says it’s a fictional CPA firm for illustration. The badge is a false statement of fact and will be flagged in any vendor security questionnaire.
+- **Fix:** Either (a) remove the badge and the “SOC 2 Type I” language sitewide and replace with “SOC 2 Type I in progress, target Q3 2026” with a real auditor named, OR (b) commission and publish a real Type I report with auditor letter + attestation date + scope boundaries, gated behind an NDA download form.
+- **Owner:** Founder + Legal • **Effort:** 1 day (remove) / 8–12 weeks (real audit)
+
+### P0-2. Pull the “EU AI Act Ready” and “DPDP Compliant” badges OR cite evidence
+- **Where:** `README.md:23-24`, `docs/compliance/eu-ai-act.mdx:13-14` (which itself disclaims “not legal advice”)
+- **Why:** Compliance badges in the README without a legal opinion, certification body, or named DPO are misleading.
+- **Fix:** Replace with “DPDP & EU AI Act mapping (see compliance matrix)” linking to an honest gap analysis. If you want a hard claim, get a written legal opinion from named counsel and link it from the badge.
+- **Owner:** Legal • **Effort:** 1 day to soften / 4–6 weeks for opinion letter
+
+### P0-3. Fix the version Tower of Babel
+- **Where:** `README.md:68` (v2.5) vs `CHANGELOG.md:7` (v0.3.8) vs `docs/openapi.yaml:4` (0.1.3) vs `packages/sdk-ts/package.json:3` (0.3.8) vs `packages/sdk-py/pyproject.toml:7` (0.3.9) vs `packages/mcp-auth/package.json:3` (2.0.1) vs all framework adapters (0.1.0)
+- **Why:** A buyer cannot tell what version of anything they are installing or whether adapters are compatible with the SDK.
+- **Fix:** Single source of truth for version. Either:
+  - **(Recommended)** Adopt Changesets/Lerna/Nx. Bump every package to the same `1.0.0` for a real GA, drop “v2.5” language from README until the repo can back it.
+  - Or: keep independent versioning but publish a `COMPATIBILITY.md` matrix and CI-enforced range constraints between adapters and SDK.
+- **Owner:** Eng lead • **Effort:** 3–5 days
+
+### P0-4. Fix the test-count claim
+- **Where:** `README.md:16` and `README.md:108` say “4,147 tests — 100%”. CHANGELOG.md:24 says 3,536. Adapter tests are largely mocked (`packages/crewai/tests/conftest.py:17-28` mocks CrewAI entirely with `raise NotImplementedError`; `packages/conformance/src/suites/agents.ts:35,75` skips for “Plan limit reached”).
+- **Fix:** Update README to the real number from CI’s latest green run, link the badge to a status page that scrapes the actual workflow, and remove the “100%” qualifier or make it dynamic. Delete the CrewAI mock fixture and write at least one real round-trip test, or remove `crewai` from the “28 packages” list.
+- **Owner:** Eng • **Effort:** 1 day for badge, 3 days for CrewAI
+
+### P0-5. Reconcile Commerce V1 marketing vs reality
+- **Where:** `README.md:38-66` (prominent feature) vs `README.md:42` (“Production Commerce V1 discovery is currently disabled/fail-closed”) vs `docs/reports/commerce-v1-production-discovery-readiness.md:27` (“disabled/unavailable”) vs `docs/reports/commerce-v1-merchant-approval-artifact-checklist.md:22-34` (all placeholders `<MERCHANT_ID_PENDING_APPROVAL>`)
+- **Why:** README leads with Commerce V1 as a flagship feature. The same README admits it is fail-closed. The docs say it is not provisioned. Marketing posts (`LAUNCH_POSTS.md`) say “live in production.” Three independent stories from the same project.
+- **Fix:**
+  1. Move the Commerce V1 section in README from #2 to an “Early access (closed beta)” section near the bottom, with one paragraph and a “Request access” CTA.
+  2. Move `docs/reports/commerce-v1-*` (13 files of internal testing artifacts) out of the public docs nav into `docs/internal/commerce-v1/` and add `<frontmatter>internal: true</frontmatter>`. Audit `docs.json` to drop them.
+  3. Rewrite `web/commerce.html` and `web/commerce-playground.html` headers to read “Closed beta — mock provider only.”
+  4. Update `LAUNCH_POSTS.md`, `DEVTO_ARTICLE.md`, `tweet-gemma.md`, `twitterposts.md` to match.
+- **Owner:** Founder + Eng • **Effort:** 2 days
+
+### P0-6. Resolve broken docs.json nav (Mintlify 404s)
+- **Where:** `docs/docs.json:81-82` references three `.mdx` files that exist only as `.md`:
+  - `guides/commerce-v1-option-a-smoke-setup`
+  - `guides/commerce-v1-hosted-staging-e2e`
+  - `guides/commerce-v1-repeatable-option-a-smoke-workflow`
+- **Fix:** Either rename the files to `.mdx` (and add frontmatter), or remove from nav. Audit the rest of `docs.json` for ghost entries (e.g., `community/ietf-draft`, `community/nist-comment`, `community/authzen-mapping` are stubs).
+- **Owner:** Docs • **Effort:** 2 hours
+
+### P0-7. Remove `.tmp/` directory (untracked, 500 MB+ of CI checkouts)
+- **Where:** `.tmp/pr324-ci/`, `.tmp/pr324-ci2/`, `.tmp/issue313-ci/`
+- **Why:** Bloats the repo, includes full `node_modules` + `.git` from old branches.
+- **Fix:** `rm -rf .tmp` and add `.tmp/` to `.gitignore`. Decide whether the new untracked `docs/reports/commerce-v1-local-workstation-prod-candidate.md` and `docs/reports/commerce-v1-staging-readiness.md` should be committed, archived, or deleted.
+- **Owner:** Eng • **Effort:** 30 minutes
+
+### P0-8. Localhost / placeholder leaks on public marketing pages
+- **Where:**
+  - `web/commerce-playground.html:460` — default API endpoint hardcoded to `http://localhost:3001`
+  - `web/mpp-demo/index.html:265-266` — `window.location.hostname === 'localhost'` branching
+  - `web/index.html:1646`, `web/mcp.html:959,982,1164` — `your-mcp-server.example.com`, `user@example.com` in code samples
+  - `web/dpdp.html:1240-1268` — `rajesh.kumar@example.com`, `priya.sharma@example.com` as fixture data on the public compliance page
+  - `web/registry.html:92-98` — duplicate GA blocks, second one hardcoded to `G-XXXXXXXXXX`
+- **Fix:** Replace localhost defaults with `https://api.grantex.dev`; collapse the GA duplicate; replace fixture emails with `***@***.com`-style redactions or remove the section.
+- **Owner:** Web • **Effort:** 1 day
+
+### P0-9. CODEOWNERS bus-factor = 1
+- **Where:** `CODEOWNERS` — every path owned by `@mishrasanjeev` only
+- **Why:** One reviewer for the entire codebase blocks PRs the moment the maintainer is unavailable, and is a procurement-questionnaire fail (“how do you ensure no single individual can push to production?”).
+- **Fix:** Add at least one co-owner per major area (or a `@grantex/maintainers` team). If no co-owner exists yet, hire one or make it an explicit ROADMAP item.
+- **Owner:** Founder • **Effort:** 1 hour (config) / weeks (people)
+
+### P0-10. CI not gated on release
+- **Where:** `.github/workflows/release.yml:1-21` — release job runs on tag push with no `needs:` dependency on CI suite.
+- **Fix:** Add `needs: [auth-service, sdk-ts, sdk-py, conformance, ...]` to the release job. Add SLSA provenance via `slsa-framework/slsa-github-generator`. Verify branch protection on `main` requires all CI checks before merge.
+- **Owner:** Eng • **Effort:** 2 hours
+
+### P0-11. No DPA / sub-processor list (procurement blocker)
+- **Where:** Missing — no `docs/compliance/dpa.md`, no `docs/compliance/sub-processors.md`
+- **Fix:** Publish:
+  - Sub-processor list (GCP Cloud Run, Cloud SQL, Artifact Registry, Datadog, Stripe — confirmed in `deploy/`)
+  - GDPR DPA template (signable PDF + markdown)
+  - Data-residency statement (where is `api.grantex.dev` hosted? Single region or multi?)
+- **Owner:** Legal • **Effort:** 1–2 weeks
+
+### P0-12. No SECURITY.md teeth
+- **Where:** `SECURITY.md:49` says PGP key at `grantex.dev/.well-known/security.asc` (untested URL, no fingerprint published); `SECURITY.md:110-112` confirms no bug bounty
+- **Fix:** Either stand up the PGP key with a published fingerprint or remove the line. Publish a vulnerability-disclosure SLA (e.g., acknowledge within 72h, fix within 90d). If you can’t do a bounty, link to a Hall of Fame at minimum.
+- **Owner:** Security • **Effort:** 1 day
+
+### P0-13. Anthropic adapter does unsafe JWT decode
+- **Where:** `packages/anthropic/src/tool.ts:59` calls `decodeJwtPayload(grantToken)` without signature verification before checking scopes
+- **Why:** A forged token with the right `scp` claim passes the adapter’s scope check. Critical for any partner who trusts the Anthropic adapter as their enforcement point.
+- **Fix:** Replace with `verifyGrantToken()`. Add a unit test that a tampered token is rejected. Audit the other framework adapters for the same pattern.
+- **Owner:** Eng • **Effort:** 1 day
+
+### P0-14. PERMISSIVE mode warns to stdout in production code path
+- **Where:** `packages/sdk-ts/src/client.ts:362` — `console.warn('[grantex] PERMISSIVE MODE…')` leaks scope-denial reason
+- **Fix:** Route through a structured logger with level/throttle, or gate behind `NODE_ENV !== 'production'`.
+- **Owner:** Eng • **Effort:** 2 hours
+
+### P0-15. `examples/quickstart-ts` pinned to `@grantex/sdk@^0.1.1` while SDK is 0.3.8
+- **Where:** `examples/quickstart-ts/package.json:9`. Also `examples/quickstart-ts/src/index.ts` appears missing.
+- **Why:** Every developer following the README’s “Try in 30 seconds” experiences a broken install. This is the single highest-traffic developer touchpoint.
+- **Fix:** Update version pin, restore the missing entrypoint, run `npm install && npm run start` in CI on every PR.
+- **Owner:** DX • **Effort:** 4 hours
+
+### P0-16. README “28 packages”, “Day-zero Gemma 4” — validate or rewrite
+- **Where:** `README.md:108` and `README.md:70-71`
+- **Fix:** Run a script that lists `packages/*/package.json`, count and verify the assertion. For Gemma: link to actual release notes, benchmark numbers, or remove the “< 5ms verification on Raspberry Pi” line until you can cite a public benchmark file.
+- **Owner:** Eng + Marketing • **Effort:** 1 day
+
+### P0-17. No legal links on any landing page
+- **Where:** `web/index.html` footer (line ~2650), `web/commerce.html`, all other web/*.html
+- **Why:** GDPR / CCPA / EU cookie law non-compliance. Required before any EU enterprise will sign.
+- **Fix:** Add Privacy Policy, Terms of Service, DPA, Cookie Policy, Sub-Processor List, Impressum (for DE), and a Cookie banner. Publish all four documents.
+- **Owner:** Legal + Web • **Effort:** 1 week
+
+### P0-18. Multi-tenancy boundary test gap for `commerce_tenants`
+- **Where:** `apps/auth-service/tests/security-multi-tenancy.test.ts` tests agent isolation between orgs but **no test that Dev A cannot enumerate Dev B’s commerce tenants**.
+- **Fix:** Add explicit test. Also verify `apps/auth-service/src/routes/commerce-tenants.ts:40` `isPlatformAdmin` semantics — does “operator” mean `ADMIN_API_KEY` or any dev key?
+- **Owner:** Eng • **Effort:** 1 day
+
+### P0-19. Predictable request IDs in DPDP flow (privacy concern)
+- **Where:** `apps/auth-service/src/routes/dpdp.ts:61` and `:740` use `Math.floor(Math.random() * 99999)` for grievance/erasure request IDs.
+- **Why:** Sequential/guessable IDs enable enumeration of other principals’ DPDP requests — itself a privacy violation in the DPDP module.
+- **Fix:** Use `crypto.randomUUID()`. Grep the codebase for `Math.random` and replace everywhere it touches IDs/tokens.
+- **Owner:** Eng • **Effort:** 4 hours
+
+### P0-20. Admin API key in test config
+- **Where:** `apps/auth-service/vitest.config.ts:29` — `ADMIN_API_KEY: 'test-admin-key-secret'`
+- **Fix:** Move to env-only, generate per-run, never log. Audit `tests/**` for the same pattern.
+- **Owner:** Eng • **Effort:** 2 hours
+
+### P0-21. Demo service has `Access-Control-Allow-Origin: *`
+- **Where:** `apps/mpp-demo-service/src/index.ts:11-14`. Also `firebase.json:60-66` allows `*` on `public/contexts/**`.
+- **Fix:** Lock to known origins. If you keep a “public demo,” put it behind its own subdomain and rate-limit aggressively.
+- **Owner:** Eng • **Effort:** 2 hours
+
+### P0-22. No rate limit on `/v1/signup`, `/v1/token`, `/v1/authorize`
+- **Where:** `apps/auth-service/src/routes/` — only `mpp-demo-service:8` shows rateLimit usage. Security audit (`docs/security-audit.md:145-160` GXT-003) acknowledges this but defers to “v1.1 roadmap.”
+- **Fix:** Add `@fastify/rate-limit` to all unauthenticated endpoints **before** any GA claim. 10/min per IP on signup, 60/min per API key on token issuance.
+- **Owner:** Eng • **Effort:** 1 day
+
+### P0-23. Central kill switch for Commerce live mode
+- **Where:** `apps/auth-service/src/routes/commerce-cart-payment.ts:65` checks `COMMERCE_LIVE_MODE_ENABLED` / `PLURAL_LIVE_ENABLED` — but no inventory of every payment path, no integration test that confirms the flag actually blocks live payments end-to-end.
+- **Fix:**
+  1. Create `apps/auth-service/src/lib/commerce/live-mode-guard.ts` — a single function that every payment-touching handler must call as the first line.
+  2. Add a CI grep that fails any new handler in `commerce-*` routes that doesn’t reference the guard.
+  3. Add an explicit E2E test: `LIVE_MODE_ENABLED=false` + payment attempt → 403 with structured error.
+- **Owner:** Eng • **Effort:** 2 days
+
+---
+
+## P1 — HIGH (fix in next 2–4 weeks)
+
+### Marketing & docs
+- **H-1** Stray planning docs at root: `agentic-org-scope-enforcement-fix.md` (1202 lines), `grantex-tool-manifest-and-enforcer.md` (1365 lines) — move to `docs/internal/` or delete.
+- **H-2** ROADMAP last updated March 2026 (today: 2026-05-24). Refresh. Items dated past today still listed as planned. `ROADMAP.md:119`.
+- **H-3** Add 7 enterprise buyer pages: SLA, Support Tiers, Pricing, Data Residency, BYOK, Audit Log Retention, Incident Response Runbook.
+- **H-4** Single canonical API URL. `quickstart.mdx:20` says `https://api.grantex.dev`; `openapi.yaml:29` says `https://grantex-auth-dd4mtrt2gq-uc.a.run.app` (Cloud Run internal); `api-reference/introduction.mdx:12` echoes the Cloud Run URL. Pick one. Set up `api.grantex.dev` as a stable alias if not already.
+- **H-5** Bump `docs/openapi.yaml:4` from `0.1.3` to whatever matches the SDK; add standardized error schema across every operation; fix missing `operationId`s; link Postman collection + environment from `docs.json` (currently orphaned).
+- **H-6** Consolidate contact emails. `CODE_OF_CONDUCT.md:11` says `sanjeev@grantex.dev`; `SECURITY.md:39` says `security@grantex.dev`. Pick canonical aliases and use them.
+- **H-7** Tweets/launch posts at root (`tweet-gemma.md`, `twitterposts.md`, `DEVTO_ARTICLE.md`, `LAUNCH_POSTS.md`) should be in `docs/marketing/` or deleted; they currently clutter the repo root.
+- **H-8** `LICENSE` line 170 says “Copyright 2026” — change to `2024-2026`.
+- **H-9** CONTRIBUTING.md missing DCO/CLA mention. Add DCO requirement (`Signed-off-by:` on commits) — enterprise-OSS table stakes.
+- **H-10** Mobile responsiveness gaps in interactive playgrounds (`mpp-demo`, `x402-playground`, `commerce-playground`) — desktop-first layouts break below 640px.
+- **H-11** Missing apple-touch-icon, web-manifest, theme-color, OG image variants. All HTML files use `/favicon.svg` only.
+- **H-12** Dashboard wiring opaque: `web/dashboard/index.html` loads compiled React (`index-DgO4FPua.js`) — what endpoints does it hit? Is `apps/portal` what produced it? Document and add a CI step that confirms a fresh build matches the deployed asset hashes.
+- **H-13** Mintlify config not gated in CI. Add a CI step that runs `mintlify dev` (or the equivalent build) and fails on broken links / missing files.
+
+### SDKs & integrations
+- **H-14** Go version mismatch: `packages/go-sdk/go.mod:3` says Go 1.26.1 while `packages/terraform-provider-grantex/go.mod:3` says Go 1.21. Align.
+- **H-15** mcp-auth at `2.0.1` vs everything else at `0.x`. Either justify the major bump in CHANGELOG or downversion to the rest of the monorepo.
+- **H-16** Cross-SDK parity test: add a single conformance script that exercises `agents.register / authorize / tokens.exchange / verifyGrantToken` against the same fixture in TS, Python, and Go. Run in CI on every PR.
+- **H-17** `packages/conformance/src/suites/agents.ts:35,75` skips agent CRUD tests for “Plan limit reached.” Either remove the plan limit in the test fixture or fail the suite — skipping silently is the worst option.
+- **H-18** Hardcoded HS256 secret in `packages/mcp-auth/tests/security.test.ts:11,31`. Generate per-test or load from env.
+- **H-19** `packages/sdk-py/src/grantex/_verify.py` either missing or not exported (offline verification claim in README needs proof at this path).
+- **H-20** Manifests in `packages/sdk-py/src/grantex/manifests/` (60+ hardcoded files) need a codegen path tied to OpenAPI, or they will drift forever.
+- **H-21** No retry / exponential backoff in HTTP clients (`packages/mcp-auth/src/endpoints/token.ts:78-89`). No rate-limit-header parsing in `packages/sdk-ts/src/client.ts`. No circuit breaker.
+- **H-22** Webhook signature verification exists (`packages/sdk-ts/src/webhook.ts`) but not documented in README or per-adapter README. Apps will skip it.
+- **H-23** Terraform provider has 5 resources, 2 data sources, no README, no acceptance tests. Either flesh out to production grade or label it experimental in README and remove from “Integrations” marketing.
+
+### Core / apps
+- **H-24** Vault encryption key validation is lazy (`apps/auth-service/src/lib/vault-crypto.ts` decrypts without validating IV length first) — produce a clear 422 instead of 500 on malformed input. Validate the env key at startup, not at first decrypt.
+- **H-25** No pagination on admin list endpoints (`apps/auth-service/src/routes/commerce-tenants.ts:85-93` hardcodes LIMIT 100).
+- **H-26** Audit-log writes unbounded (`appendCommerceAudit` in every cart-payment path) — add throttling/aggregation or risk audit DoS.
+- **H-27** Sync `crypto.generateKeyPair` in `apps/auth-service/src/lib/commerce/passport-keys.ts:162-175` — no timeout; switch to async with timeout.
+- **H-28** DPDP erasure requests not idempotent (`apps/auth-service/src/routes/dpdp.ts:740`) — generate request ID server-side keyed off principal+timestamp; accept client `Idempotency-Key`.
+- **H-29** No HSTS header found in Fastify config. Add `strict-transport-security` middleware with `max-age=63072000; includeSubDomains; preload`.
+- **H-30** Tenant auto-provisioning (`apps/auth-service/src/lib/commerce/tenant.ts:57-59`) correctly gated by `NODE_ENV !== production`, but no rate limit if accidentally flipped. Add rate limit + alarm.
+- **H-31** CSRF protection on commerce consent challenge form: tests reference a CSRF cookie/payload (`apps/auth-service/tests/commerce-consent-challenge.test.ts:69,116,161`) but no double-submit validation visible in handlers — verify and document.
+
+### Deploy / CI
+- **H-32** `.github/dependabot.yml` missing entirely. Dependabot PRs *are* arriving (recent commits show qs, express bumps) but there’s no config — they’re coming from GitHub’s default ecosystem detection, which is not exhaustive. Add explicit config for npm, pip, go, github-actions, terraform.
+- **H-33** `docker-compose.prod.yml` postgres/redis have no resource limits (lines 2-39); auth-service does (lines 86-88). Add limits to DB and cache too.
+- **H-34** `docker-compose.yml` exposes 5432, 6379, hardcoded `VAULT_ENCRYPTION_KEY: 000102030405...`. Add a banner: “DEV ONLY — DO NOT USE IN PROD.” Comment out port bindings on prod compose or bind to `127.0.0.1` only.
+- **H-35** Helm `values.yaml:79-85` accepts `rsaPrivateKey: ""` inline. Document loudly that only `existingSecret` should be used in prod; add a Helm `NOTES.txt` warning.
+
+---
+
+## P2 — MEDIUM (fix in next quarter)
+
+### Visible-but-not-blocking polish
+- **M-1** Add loading/error states in all interactive playgrounds (`commerce-playground.html`, `mpp-demo/index.html`, `x402-playground/index.html`). Currently silent on API failure.
+- **M-2** `web/for/index.html` and `web/vs/index.html` populate meta tags via JS — Slack/Twitter unfurl bots won’t see them. Server-render or pre-render the metadata.
+- **M-3** No `prefers-reduced-motion`, missing alt text, no aria-labels on icon buttons. WCAG 2.1 AA work.
+- **M-4** Robots.txt allows playground/demo pages to index — thin-content SEO penalty. Disallow `/playground/`, `/mpp-demo/`, `/x402-playground/`, `/commerce-playground.html`.
+- **M-5** Stale `local-development.mdx:19-20` lists dev API keys in cleartext (acceptable for local-only, but bad pattern — at least note they’re local-only and rotated).
+- **M-6** `SPEC.md:3` says “v1.0 rev 3, Feb 2026” while git tags show only `v1.0`. Either tag `v1.0.3` or stop using “rev N.”
+- **M-7** `discord-welcome.md` exists at root but no Discord link in README/SECURITY — clarify whether community Discord exists and is moderated.
+- **M-8** Blog has `blog/grantex-v2-2.mdx` but no `v2-5.mdx` despite the “What’s New in v2.5” README banner.
+- **M-9** Commerce V1 reports (`docs/reports/commerce-v1-*` — 13 files) are internal test artifacts publicly readable. Add `<frontmatter>internal: true</frontmatter>` and exclude from sitemap.
+- **M-10** No type stubs (`.pyi`) for Python SDK — `mypy --strict` likely fails.
+- **M-11** CLI commands have no `--dry-run` for destructive ops (`grantex revoke`, `grantex agents delete`).
+- **M-12** Error message style inconsistent across SDKs (`GrantexTokenError` in TS, generic `Exception` likely in Py, undefined in Go).
+- **M-13** Examples don’t live in `docs/examples/`; the repo has both `examples/` (root) and `docs/examples/` — pick one.
+- **M-14** No SLO / SLA docs for self-hosted (RPO 1h, RTO 4h, durability targets).
+- **M-15** OpenTelemetry is in dependencies but no observability guide. Create `docs/guides/observability.mdx` with OTLP endpoint config + Datadog/Grafana recipes.
+- **M-16** SPDX license headers missing from `packages/*/src/**`, `apps/*/src/**` source files. Run `addlicense -l apache -c "Grantex Contributors" .`
+- **M-17** Backup / DR runbook missing for self-hosted (`docs/self-hosting.md`). Add WAL archiving recipe, Redis RDB strategy, pg_basebackup example.
+- **M-18** `vitest.config.ts:10` E2E uses `singleFork: true` — sequential, slow CI. Investigate parallel-safe rewrite.
+
+### Internal hygiene
+- **M-19** Logging policy: structured logs only, no `console.log/warn` in production code paths.
+- **M-20** No automated check that OpenAPI endpoints have SDK coverage (or vice versa). Build one.
+- **M-21** Scope strings accepted as freeform; no enum/registry. Add a `ScopeRegistry` and validate.
+- **M-22** No `getRateLimit()` parser in SDK clients — apps can’t self-throttle.
+- **M-23** Audit-log filter routes (`apps/auth-service/src/routes/audit.ts`) — verify SQL parameterization on date/type filters.
+- **M-24** Session token rotation on privilege escalation (sandbox→live) not enforced.
+- **M-25** Policy backend fallback paths (OPA, Cedar) not test-covered.
+- **M-26** No audit event emitted on API key rotation — investigators can’t reconstruct.
+- **M-27** Webhook delivery worker retry/backoff policy not visible in code or docs.
+
+---
+
+## P3 — LOW (cleanup / nice-to-have)
+
+- **L-1** Test count badge in README should be auto-generated from the latest green CI run, not hardcoded.
+- **L-2** Consistent code-block styling across all landing pages (some have copy buttons, some don’t).
+- **L-3** Add `dns-prefetch` for Google Fonts, OG images.
+- **L-4** Service worker / offline support for playgrounds.
+- **L-5** Multiple OG image variants for LinkedIn/Twitter/Discord.
+- **L-6** `dependency-review.yml:27-34` whitelist may be too tight — explicit deny-list for AGPL is friendlier.
+- **L-7** Add a `VERSION` file at repo root for tooling consistency.
+- **L-8** Document monorepo structure in CONTRIBUTING.md — explain why root `package.json` is 6 lines.
+- **L-9** `examples/vercel-ai-chatbot:30`, `examples/quickstart-ts:21` default `GRANTEX_API_KEY` to `'sandbox-api-key-local'`. Either remove defaults or add a stern comment.
+- **L-10** Audit `git log` for any committed secrets that need `git filter-repo` + key rotation.
+- **L-11** Add an `OWNERS.md` per package directory listing the maintainer + on-call rotation.
+- **L-12** Stripe webhook secret rotation runbook not documented.
+
+---
+
+## Suggested Fix Sequencing (8-week plan)
+
+**Week 1 — Stop the bleeding (P0)**
+- Remove false compliance badges OR commission real audit (P0-1, P0-2).
+- Delete `.tmp/`, fix `docs.json` 404s, replace localhost defaults in web (P0-7, P0-6, P0-8).
+- Fix unsafe JWT decode in Anthropic adapter and console.warn leak (P0-13, P0-14).
+- Pull “v2.5” language and “4,147 tests” claim down to the truth (P0-3, P0-4).
+- Soften Commerce V1 marketing posture; move reports out of public nav (P0-5).
+
+**Week 2 — Procurement basics**
+- DPA, sub-processor list, data-residency page (P0-11).
+- SECURITY.md PGP key + disclosure SLA (P0-12).
+- Privacy/Terms/Cookie/DPA links in web footer (P0-17).
+- Add CODEOWNERS co-owner or remove single-owner risk publicly (P0-9).
+
+**Week 3 — Code guardrails**
+- Rate limits on auth endpoints (P0-22).
+- Central live-mode guard + CI grep + integration test (P0-23).
+- Replace `Math.random` for IDs (P0-19).
+- Multi-tenancy boundary test for commerce_tenants (P0-18).
+- Remove admin API key from vitest config (P0-20), lock down demo CORS (P0-21).
+- Fix `examples/quickstart-ts` (P0-15).
+- Release workflow CI-gated + SLSA provenance (P0-10).
+
+**Weeks 4–6 — Version reconciliation + buyer pages**
+- Adopt Changesets, bump everything to `1.0.0` or publish COMPATIBILITY.md (P0-3).
+- 7 new enterprise pages (SLA, Pricing, Support, Data Residency, BYOK, Audit Retention, IR Runbook) (H-3).
+- OpenAPI parity + Mintlify CI gate (H-5, H-13).
+- Cross-SDK parity test in CI (H-16).
+- Backup/DR + observability guides (M-15, M-17).
+
+**Weeks 7–8 — Polish**
+- All H-tier remaining items.
+- Pick highest-value M-tier items by stakeholder request.
+- Final dry-run with an external buyer simulating procurement.
+
+---
+
+## What is *actually* working (don't break these)
+
+- Cryptographic foundations: JWKS, RS256, JWT verification path in `packages/sdk-ts/src/verify.ts:82-94` is solid.
+- Multi-tenant agent isolation (`apps/auth-service/tests/security-multi-tenancy.test.ts`) — tested.
+- Encryption at rest for sensitive secrets (passport keys, merchant credentials).
+- Dependabot PRs landing weekly (qs, express recent bumps).
+- Design system across landing pages (consistent dark theme, JSON-LD, canonical tags).
+- 222-line CI workflow with real coverage across packages.
+- Apache 2.0 LICENSE is clean; no copyleft contamination in deps.
+- Helm chart + docker-compose.prod.yml exist and follow basic security patterns (the gaps above are real but the foundation is right).
+- Vestige third-party security audit (`docs/security-audit.md`) — having it at all puts you ahead of most pre-Series A vendors.
+
+---
+
+## Bottom Line
+
+This repository is **further along than 90% of seed-stage open-source protocols**. It is also **misrepresented as enterprise-ready in ways that will lose deals and risk legal exposure**. Fixing the 23 P0 items is roughly two weeks of focused engineering plus parallel legal/compliance work. Until those are done, do not pitch this to a Fortune 500 procurement team. After those are done, this becomes a credible enterprise story.
+
+The single highest-leverage action: **pick a version, ship a real GA, align every package + the README + the OpenAPI + the badges to that version, and stop using marketing language the code can’t back up.** Everything else flows from that.

--- a/docs/security/soc2-report.mdx
+++ b/docs/security/soc2-report.mdx
@@ -1,24 +1,25 @@
 ---
-title: "SOC 2 Type I Report"
-sidebarTitle: "SOC 2 Report"
-description: "SOC 2 Type I examination report for the Grantex Delegated Authorization Platform."
+title: "SOC 2 Readiness Control Mapping"
+sidebarTitle: "SOC 2 Readiness"
+description: "Internal SOC 2 readiness control mapping for the Grantex Delegated Authorization Platform."
 ---
 
 | Field | Detail |
 |-------|--------|
-| **Prepared by** | Thornfield Assurance Partners LLP |
-| **Examination date** | As of February 20, 2026 |
-| **Report date** | February 28, 2026 |
+| **Prepared by** | Grantex maintainers |
+| **Readiness snapshot date** | February 20, 2026 |
+| **Publication date** | February 28, 2026 |
 | **Trust Service Categories** | Security (CC), Availability (A), Confidentiality (C) |
 | **Classification** | Public |
-| **Report type** | SOC 2 Type I |
+| **Report type** | Internal readiness control mapping; not a SOC 2 Type I attestation |
 
-## Opinion
+<Warning>
+  This page is not an independent CPA attestation and should not be represented as SOC 2 certification. It is a public control mapping intended to help reviewers understand the evidence Grantex maintains while formal audit work is pending.
+</Warning>
 
-In our opinion, in all material respects:
+## Readiness Position
 
-1. The description fairly presents the System as of February 20, 2026.
-2. The controls stated in the description were suitably designed to provide reasonable assurance that the trust service criteria for **Security**, **Availability**, and **Confidentiality** would be achieved.
+This document summarizes controls that map to SOC 2 Security, Availability, and Confidentiality criteria. It does not express an auditor opinion on control design or operating effectiveness.
 
 ## System Description
 
@@ -90,8 +91,8 @@ Grantex provides a Delegated Authorization Platform — an open, model-neutral p
 
 ## Findings Summary
 
-All findings from the third-party security assessment (Vestige Security Labs) were remediated before the examination date, except GXT-003 (rate limiting), which was subsequently addressed in v0.1.3. No findings affect the suitability of design conclusion.
+The readiness mapping tracks findings from the referenced third-party security assessment. Open findings must be treated as remediation work, not as exceptions approved by a SOC 2 auditor.
 
 ---
 
-*Thornfield Assurance Partners LLP, New York. February 28, 2026. The full report is maintained at [github.com/mishrasanjeev/grantex/blob/main/docs/soc2-type1/report.md](https://github.com/mishrasanjeev/grantex/blob/main/docs/soc2-type1/report.md).*
+*This public readiness mapping is maintained at [github.com/mishrasanjeev/grantex/blob/main/docs/soc2-type1/report.md](https://github.com/mishrasanjeev/grantex/blob/main/docs/soc2-type1/report.md).*

--- a/docs/soc2-type1/report.md
+++ b/docs/soc2-type1/report.md
@@ -1,46 +1,34 @@
-# SOC 2 Type I Examination Report
+# SOC 2 Readiness Control Mapping
 ## Grantex Delegated Authorization Platform
 
 | Field | Detail |
 |-------|--------|
-| **Prepared by** | Thornfield Assurance Partners LLP |
-| **Examination date** | As of February 20, 2026 |
-| **Report date** | February 28, 2026 |
+| **Prepared by** | Grantex maintainers |
+| **Readiness snapshot date** | February 20, 2026 |
+| **Publication date** | February 28, 2026 |
 | **Trust Service Categories** | Security (CC) · Availability (A) · Confidentiality (C) |
 | **Classification** | Public |
-| **Report type** | SOC 2 Type I |
+| **Report type** | Internal readiness control mapping; not a SOC 2 Type I attestation |
 
 ---
 
-## Part I — Independent Service Auditor's Report
+> This document is not an independent CPA attestation and must not be represented as SOC 2 certification. It is a public readiness mapping that describes controls and evidence Grantex maintains while formal audit work is pending.
 
-To the Management of Grantex:
+## Part I — Readiness Position
 
-We have examined Grantex's description of its Delegated Authorization Platform (the "System") for the period ending February 20, 2026, and the suitability of the design of the controls included in the description to achieve the related trust service criteria set forth in the AICPA's _TSP Section 100, 2017 Trust Services Criteria for Security, Availability, and Confidentiality_.
+This document summarizes Grantex's description of its Delegated Authorization Platform (the "System") and the controls mapped to the AICPA's _TSP Section 100, 2017 Trust Services Criteria for Security, Availability, and Confidentiality_.
 
 **Management's Responsibility**
 
 Grantex's management is responsible for (1) preparing the description of the System and the accompanying assertion, (2) the completeness, accuracy, and method of presentation of both, (3) providing the services covered by the description, (4) specifying the trust service criteria to be applied, and (5) designing, implementing, and operating controls to achieve the stated trust service criteria.
 
-**Service Auditor's Responsibility**
-
-Our responsibility is to express an opinion on the fairness of the presentation of the description and on the suitability of the design of the controls to achieve the related trust service criteria, based on our examination. We conducted our examination in accordance with attestation standards established by the AICPA. We believe the evidence we obtained is sufficient and appropriate to provide a reasonable basis for our opinion.
-
 **Inherent Limitations**
 
 The description is prepared to meet the common needs of a broad range of users and may not include every aspect of the system that each user may consider important. Because of their nature, controls may not prevent or detect all misstatements or unauthorized access to user data. Additionally, the projection of any conclusions about the suitability of controls to achieve the trust service criteria to future periods is subject to the risk that changes in the environment or operations may alter their suitability.
 
-**Opinion**
+**Readiness Statement**
 
-In our opinion, in all material respects:
-
-1. The description fairly presents the System as of February 20, 2026.
-2. The controls stated in the description were suitably designed to provide reasonable assurance that the trust service criteria for **Security**, **Availability**, and **Confidentiality** would be achieved as of February 20, 2026, if the controls operated effectively throughout the period.
-
-**Thornfield Assurance Partners LLP**
-Certified Public Accountants
-New York, New York
-February 28, 2026
+This is a control mapping, not an auditor opinion. It does not conclude that controls were suitably designed, operating effectively, or SOC 2 certified.
 
 ---
 
@@ -110,7 +98,7 @@ The System boundary encompasses the `auth-service`, the PostgreSQL database, and
 
 ### 2.5 Subservice Organizations
 
-The System relies on the following subservice organizations. Controls at these organizations are excluded from the scope of this examination (carve-out method):
+The System relies on the following subservice organizations. Controls at these organizations are excluded from this readiness mapping:
 
 | Subservice | Service Provided |
 |------------|-----------------|
@@ -119,13 +107,13 @@ The System relies on the following subservice organizations. Controls at these o
 
 ---
 
-## Part III — Management's Assertion
+## Part III — Management's Readiness Statement
 
 To the Users of This Report:
 
-We have prepared the description of Grantex's Delegated Authorization Platform as of February 20, 2026, and have designed and implemented controls within the System to provide reasonable assurance that the trust service criteria for **Security**, **Availability**, and **Confidentiality** are achieved.
+We have prepared the description of Grantex's Delegated Authorization Platform as of February 20, 2026, and mapped implemented controls within the System to the trust service criteria for **Security**, **Availability**, and **Confidentiality**.
 
-The description fairly presents the System and the controls are suitably designed to achieve the stated trust service criteria as of February 20, 2026.
+This readiness statement is not an independent attestation and does not certify control design or operating effectiveness.
 
 **Grantex Management**
 February 28, 2026
@@ -386,8 +374,8 @@ The following controls are the responsibility of user entities (Developers using
 
 *Source: Vestige Security Labs, Third-Party Security Assessment, February 21, 2026.*
 
-No findings from the security assessment affect the suitability of design conclusion expressed in Part I of this report. The one open finding (GXT-003) relates to rate limiting and does not affect the authorization, revocation, or audit integrity controls that are the basis of the Security, Availability, and Confidentiality trust service criteria opinions.
+Open findings from the security assessment are remediation items for the readiness program. They must not be treated as approved exceptions by a SOC 2 auditor.
 
 ---
 
-*This report is released under a public disclosure classification and may be freely redistributed. Thornfield Assurance Partners LLP is a fictional CPA firm created for illustrative purposes. This document represents a good-faith implementation of SOC 2 Type I report conventions for the Grantex open-source project.*
+*This readiness mapping is released under a public disclosure classification and may be freely redistributed. It is not a SOC 2 Type I report, does not rely on a CPA firm, and must not be presented as certification.*

--- a/examples/quickstart-ts/package.json
+++ b/examples/quickstart-ts/package.json
@@ -6,7 +6,7 @@
     "start": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@grantex/sdk": "^0.1.1"
+    "@grantex/sdk": "^0.3.8"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/quickstart-ts/src/index.ts
+++ b/examples/quickstart-ts/src/index.ts
@@ -66,7 +66,9 @@ async function main(): Promise<void> {
   // ── 5. Log an audit entry ──────────────────────────────────────────
   const entry = await grantex.audit.log({
     agentId: agent.id,
+    agentDid: agent.did,
     grantId: token.grantId,
+    principalId: verified.principalId,
     action: 'calendar.read',
     status: 'success',
     metadata: { query: 'today', results: 3 },

--- a/packages/anthropic/README.md
+++ b/packages/anthropic/README.md
@@ -27,6 +27,7 @@ const readFileTool = createGrantexTool({
     required: ['path'],
   },
   grantToken: process.env.GRANT_TOKEN!,
+  jwksUri: 'https://api.grantex.dev/.well-known/jwks.json',
   requiredScope: 'file:read',
   execute: async ({ path }) => fs.readFile(path as string, 'utf-8'),
 });
@@ -47,11 +48,11 @@ for (const block of response.content) {
 
 ## Features
 
-- **`createGrantexTool()`** — Wrap any Anthropic tool definition with offline scope enforcement
+- **`createGrantexTool()`** — Wrap any Anthropic tool definition with JWKS token verification and scope enforcement
 - **`GrantexToolRegistry`** — Manage multiple tools and dispatch `tool_use` blocks by name
 - **`withAuditLogging()`** — Wrap tools to automatically log success/failure to the Grantex audit trail
 - **`handleToolCall()`** — Execute a tool from a `tool_use` block with audit logging in one step
-- **`getGrantScopes()`** — Decode scopes from a grant token offline
+- **`getGrantScopes()`** — Decode scopes from a grant token for diagnostics without signature verification
 
 ## Documentation
 

--- a/packages/anthropic/src/tool.ts
+++ b/packages/anthropic/src/tool.ts
@@ -1,3 +1,4 @@
+import { verifyGrantToken, type VerifyGrantTokenOptions } from '@grantex/sdk';
 import { decodeJwtPayload } from './_jwt.js';
 import {
   GrantexScopeError,
@@ -6,13 +7,14 @@ import {
   type AnthropicToolDefinition,
 } from './types.js';
 
+const DEFAULT_JWKS_URI = 'https://api.grantex.dev/.well-known/jwks.json';
+
 /**
  * Create a Grantex-authorized tool in Anthropic SDK format.
  *
- * The scope check is performed offline by reading the `scp` claim from the
- * grant token JWT — no network call is made. If the agent does not hold
- * `requiredScope`, `execute()` throws {@link GrantexScopeError} before
- * calling the implementation.
+ * The grant token is verified against Grantex JWKS before its `scp` claim is
+ * trusted. If the agent does not hold `requiredScope`, `execute()` throws
+ * {@link GrantexScopeError} before calling the implementation.
  *
  * @example
  * ```ts
@@ -56,10 +58,8 @@ export function createGrantexTool<T extends Record<string, unknown>>(
   return {
     definition,
     async execute(args: T): Promise<unknown> {
-      const payload = decodeJwtPayload(grantToken);
-      const scopes = Array.isArray(payload['scp'])
-        ? (payload['scp'] as string[])
-        : [];
+      const grant = await verifyGrantToken(grantToken, buildVerifyOptions(options));
+      const scopes = grant.scopes;
 
       if (!scopes.includes(requiredScope)) {
         throw new GrantexScopeError(requiredScope, scopes);
@@ -73,9 +73,21 @@ export function createGrantexTool<T extends Record<string, unknown>>(
 /**
  * Return the scopes embedded in a Grantex grant token.
  *
- * Purely offline — no network call, no signature check.
+ * Purely offline for diagnostics only: no network call, no signature check.
  */
 export function getGrantScopes(grantToken: string): string[] {
   const payload = decodeJwtPayload(grantToken);
   return Array.isArray(payload['scp']) ? (payload['scp'] as string[]) : [];
+}
+
+function buildVerifyOptions<T extends Record<string, unknown>>(
+  options: CreateGrantexToolOptions<T>,
+): VerifyGrantTokenOptions {
+  return {
+    jwksUri: options.jwksUri ?? DEFAULT_JWKS_URI,
+    ...(options.issuer !== undefined ? { issuer: options.issuer } : {}),
+    ...(options.issuerDid !== undefined ? { issuerDid: options.issuerDid } : {}),
+    ...(options.audience !== undefined ? { audience: options.audience } : {}),
+    ...(options.clockTolerance !== undefined ? { clockTolerance: options.clockTolerance } : {}),
+  };
 }

--- a/packages/anthropic/src/types.ts
+++ b/packages/anthropic/src/types.ts
@@ -48,6 +48,16 @@ export interface CreateGrantexToolOptions<T extends Record<string, unknown>> {
   inputSchema: AnthropicInputSchema;
   /** Grantex grant token obtained from the token exchange. */
   grantToken: string;
+  /** JWKS URL used to verify the grant token. Defaults to https://api.grantex.dev/.well-known/jwks.json. */
+  jwksUri?: string;
+  /** Expected JWT issuer when it differs from the JWKS origin. */
+  issuer?: string;
+  /** did:web issuer used to derive the JWKS URL. */
+  issuerDid?: string;
+  /** Expected JWT audience. */
+  audience?: string;
+  /** Clock tolerance in seconds for token verification. */
+  clockTolerance?: number;
   /** Scope the agent must hold to invoke this tool (e.g. `'file:read'`). */
   requiredScope: string;
   /** The tool implementation. Receives typed args, returns any JSON-serialisable value. */
@@ -58,14 +68,14 @@ export interface CreateGrantexToolOptions<T extends Record<string, unknown>> {
  * A Grantex-authorized tool in Anthropic SDK format.
  *
  * - `definition` — pass this to the `tools` array of `client.messages.create()`
- * - `execute(args)` — call when handling a `tool_use` block; enforces scope offline
+ * - `execute(args)` — call when handling a `tool_use` block; verifies the token, then enforces scope
  */
 export interface GrantexTool<T extends Record<string, unknown>> {
   /** Anthropic tool definition for passing to the model. */
   readonly definition: AnthropicToolDefinition;
   /**
    * Execute the tool with the given arguments.
-   * Verifies the required scope offline before calling the implementation.
+   * Verifies the grant token and required scope before calling the implementation.
    * @throws {GrantexScopeError} if the agent does not hold the required scope.
    */
   execute(args: T): Promise<unknown>;

--- a/packages/anthropic/tests/integration.test.ts
+++ b/packages/anthropic/tests/integration.test.ts
@@ -11,7 +11,7 @@
  * Uses realistic Grantex JWT claim structures (not minimal fakes).
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import {
   createGrantexTool,
   getGrantScopes,
@@ -20,7 +20,11 @@ import {
   GrantexToolRegistry,
   GrantexScopeError,
 } from '../src/index.js';
-import type { Grantex } from '@grantex/sdk';
+import { verifyGrantToken, type Grantex, type VerifiedGrant } from '@grantex/sdk';
+
+vi.mock('@grantex/sdk', () => ({
+  verifyGrantToken: vi.fn(),
+}));
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -56,6 +60,28 @@ function makeRealisticToken(overrides: Record<string, unknown> = {}): string {
   return `${b64Header}.${b64Payload}.${fakeSig}`;
 }
 
+function scopesFromToken(token: string): string[] {
+  const parts = token.split('.');
+  if (parts.length !== 3 || !parts[1]) {
+    throw new Error('invalid JWT format');
+  }
+  const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf-8')) as Record<string, unknown>;
+  return Array.isArray(payload['scp']) ? (payload['scp'] as string[]) : [];
+}
+
+function makeGrant(scopes: string[]): VerifiedGrant {
+  return {
+    tokenId: 'tok_integration_01',
+    grantId: 'grnt_integration_01',
+    principalId: 'user_abc123',
+    agentDid: 'did:grantex:ag_tool_demo',
+    developerId: 'dev_xyz789',
+    scopes,
+    issuedAt: Math.floor(Date.now() / 1000),
+    expiresAt: Math.floor(Date.now() / 1000) + 3600,
+  };
+}
+
 function makeClient(): { client: Grantex; logCalls: unknown[] } {
   const logCalls: unknown[] = [];
   const client = {
@@ -79,6 +105,14 @@ describe('Integration: full developer workflow', () => {
     grantId: 'grnt_integration_01',
     principalId: 'user_abc123',
   };
+
+  beforeEach(() => {
+    vi.mocked(verifyGrantToken).mockImplementation(async (token) => makeGrant(scopesFromToken(token)));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
 
   it('end-to-end: create → register → execute → audit', async () => {
     // Step 1: Create tools

--- a/packages/anthropic/tests/tool.test.ts
+++ b/packages/anthropic/tests/tool.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { verifyGrantToken, type VerifiedGrant } from '@grantex/sdk';
 import { createGrantexTool, getGrantScopes } from '../src/tool.js';
 import { GrantexScopeError } from '../src/types.js';
+
+vi.mock('@grantex/sdk', () => ({
+  verifyGrantToken: vi.fn(),
+}));
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -34,9 +39,39 @@ const INPUT_SCHEMA: import('../src/types.js').AnthropicInputSchema = {
   required: ['path'],
 };
 
+function scopesFromToken(token: string): string[] {
+  const parts = token.split('.');
+  if (parts.length !== 3 || !parts[1]) {
+    throw new Error('invalid JWT format');
+  }
+  const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf-8')) as Record<string, unknown>;
+  return Array.isArray(payload['scp']) ? (payload['scp'] as string[]) : [];
+}
+
+function makeGrant(scopes: string[]): VerifiedGrant {
+  return {
+    tokenId: 'tok_01',
+    grantId: 'grnt_01',
+    principalId: 'user_01',
+    agentDid: 'did:grantex:ag_01',
+    developerId: 'dev_01',
+    scopes,
+    issuedAt: 1,
+    expiresAt: 9999999999,
+  };
+}
+
 // ─── createGrantexTool ────────────────────────────────────────────────────────
 
 describe('createGrantexTool', () => {
+  beforeEach(() => {
+    vi.mocked(verifyGrantToken).mockImplementation(async (token) => makeGrant(scopesFromToken(token)));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('executes when agent holds the required scope', async () => {
     const fn = vi.fn().mockResolvedValue('file contents');
     const tool = createGrantexTool({
@@ -52,6 +87,49 @@ describe('createGrantexTool', () => {
 
     expect(result).toBe('file contents');
     expect(fn).toHaveBeenCalledWith({ path: '/tmp/config.json' });
+    expect(verifyGrantToken).toHaveBeenCalledWith(TOKEN_WITH_SCOPES, {
+      jwksUri: 'https://api.grantex.dev/.well-known/jwks.json',
+    });
+  });
+
+  it('passes custom token verification options', async () => {
+    const tool = createGrantexTool({
+      name: 'read_file',
+      description: 'Read a file',
+      inputSchema: INPUT_SCHEMA,
+      grantToken: TOKEN_WITH_SCOPES,
+      jwksUri: 'https://issuer.example/.well-known/jwks.json',
+      issuer: 'https://issuer.example',
+      audience: 'anthropic-tools',
+      clockTolerance: 5,
+      requiredScope: 'file:read',
+      execute: vi.fn().mockResolvedValue('ok'),
+    });
+
+    await tool.execute({ path: '/tmp/config.json' });
+
+    expect(verifyGrantToken).toHaveBeenCalledWith(TOKEN_WITH_SCOPES, {
+      jwksUri: 'https://issuer.example/.well-known/jwks.json',
+      issuer: 'https://issuer.example',
+      audience: 'anthropic-tools',
+      clockTolerance: 5,
+    });
+  });
+
+  it('rejects forged tokens even when they contain the required scope', async () => {
+    vi.mocked(verifyGrantToken).mockRejectedValueOnce(new Error('invalid signature'));
+    const fn = vi.fn();
+    const tool = createGrantexTool({
+      name: 'read_file',
+      description: 'Read a file',
+      inputSchema: INPUT_SCHEMA,
+      grantToken: TOKEN_WITH_SCOPES,
+      requiredScope: 'file:read',
+      execute: fn,
+    });
+
+    await expect(tool.execute({ path: '/tmp/config.json' })).rejects.toThrow('invalid signature');
+    expect(fn).not.toHaveBeenCalled();
   });
 
   it('throws GrantexScopeError when agent lacks the required scope', async () => {

--- a/packages/dpdp/README.md
+++ b/packages/dpdp/README.md
@@ -405,7 +405,7 @@ Check the status of a filed grievance.
 
 #### `generateReferenceNumber(): string`
 
-Generate a grievance reference number in format `GRV-YYYY-NNNNN`.
+Generate a grievance reference number in format `GRV-YYYY-XXXXXXXXXXXXXXXX`, where the suffix is 16 lowercase hex characters drawn from a cryptographically strong source (64 bits of entropy). The older 5-digit format was enumerable and has been removed.
 
 #### `calculateExpectedResolution(fromDate?: Date): Date`
 

--- a/packages/dpdp/src/data-principal/grievance.ts
+++ b/packages/dpdp/src/data-principal/grievance.ts
@@ -6,6 +6,7 @@
  * a reasonable period (7 days per implementation).
  */
 
+import { randomBytes } from 'node:crypto';
 import type { Grievance, FileGrievanceParams } from '../types.js';
 import { GrievanceError } from '../errors.js';
 
@@ -15,15 +16,20 @@ const GRIEVANCE_RESOLUTION_DAYS = 7;
 /**
  * Generate a grievance reference number.
  *
- * Format: `GRV-YYYY-NNNNN` where YYYY is the current year and NNNNN
- * is a zero-padded random 5-digit number.
+ * Format: `GRV-YYYY-XXXXXXXXXXXXXXXX` where YYYY is the current year
+ * and XXXXXXXXXXXXXXXX is 16 lowercase hex characters (64 bits) drawn
+ * from a cryptographically strong random source.
+ *
+ * The older `GRV-YYYY-NNNNN` 5-digit format was enumerable — a third
+ * party could iterate through ~100 000 references and probe the API
+ * for other data principals' grievances. 64 bits of entropy puts the
+ * collision and guessing probability beyond practical reach while
+ * keeping the reference short enough to read over the phone.
  */
 export function generateReferenceNumber(): string {
   const year = new Date().getFullYear();
-  const seq = Math.floor(Math.random() * 100_000)
-    .toString()
-    .padStart(5, '0');
-  return `GRV-${year}-${seq}`;
+  const suffix = randomBytes(8).toString('hex');
+  return `GRV-${year}-${suffix}`;
 }
 
 /**

--- a/packages/dpdp/tests/grievance.test.ts
+++ b/packages/dpdp/tests/grievance.test.ts
@@ -32,7 +32,7 @@ describe('grievance', () => {
             type: 'unauthorized_processing',
             description: 'Data processed without consent',
             status: 'submitted',
-            referenceNumber: 'GRV-2026-00042',
+            referenceNumber: 'GRV-2026-deadbeefcafef00d',
             expectedResolutionBy,
           }),
       }),
@@ -48,7 +48,7 @@ describe('grievance', () => {
     const grievance = await fileGrievance(params, 'test-key', 'https://api.test.local');
 
     expect(grievance.grievanceId).toBe('grv_001');
-    expect(grievance.referenceNumber).toMatch(/^GRV-\d{4}-\d{5}$/);
+    expect(grievance.referenceNumber).toMatch(/^GRV-\d{4}-[0-9a-f]{16}$/);
     expect(grievance.status).toBe('submitted');
   });
 
@@ -62,11 +62,40 @@ describe('grievance', () => {
 
   it('generates valid reference number format', () => {
     const ref = generateReferenceNumber();
-    expect(ref).toMatch(/^GRV-\d{4}-\d{5}$/);
+    // Crypto-strong 64-bit suffix, lowercase hex.
+    expect(ref).toMatch(/^GRV-\d{4}-[0-9a-f]{16}$/);
 
     // Year should be current
     const year = new Date().getFullYear().toString();
     expect(ref).toContain(year);
+  });
+
+  it('generates unique, non-sequential references across repeated calls', () => {
+    const refs = Array.from({ length: 200 }, () => generateReferenceNumber());
+    // All distinct
+    expect(new Set(refs).size).toBe(refs.length);
+    // No two suffixes share a long common prefix — sequential / Math.random
+    // generators tend to produce close-by values when called in rapid
+    // succession.
+    const suffixes = refs.map((r) => r.slice(-16));
+    for (let i = 0; i < suffixes.length; i++) {
+      for (let j = i + 1; j < suffixes.length; j++) {
+        const a = suffixes[i]!;
+        const b = suffixes[j]!;
+        let n = 0;
+        while (n < a.length && a[n] === b[n]) n++;
+        // 16 hex chars = 64 bits; a chance collision of >8 leading chars
+        // across 200 calls would be vanishingly unlikely with real entropy.
+        expect(n).toBeLessThanOrEqual(8);
+      }
+    }
+  });
+
+  it('does not return any of the legacy 5-digit references', () => {
+    for (let i = 0; i < 50; i++) {
+      const ref = generateReferenceNumber();
+      expect(ref).not.toMatch(/^GRV-\d{4}-\d{5}$/);
+    }
   });
 
   it('rejects grievance without required fields', async () => {

--- a/packages/sdk-ts/src/client.ts
+++ b/packages/sdk-ts/src/client.ts
@@ -359,7 +359,9 @@ export class Grantex {
 
   #applyEnforceMode(result: EnforceResult): EnforceResult {
     if (!result.allowed && this.#enforceMode === 'permissive') {
-      console.warn(`[grantex] PERMISSIVE MODE — would deny: ${result.reason} (connector=${result.connector}, tool=${result.tool})`);
+      if (process.env['NODE_ENV'] !== 'production') {
+        console.warn(`[grantex] PERMISSIVE MODE — would deny: ${result.reason} (connector=${result.connector}, tool=${result.tool})`);
+      }
       return { ...result, allowed: true };
     }
     return result;

--- a/packages/sdk-ts/tests/enforce.test.ts
+++ b/packages/sdk-ts/tests/enforce.test.ts
@@ -688,6 +688,19 @@ describe('enforce()', () => {
       warn.mockRestore();
     });
 
+    it('allows denied results in permissive mode without console warning in production', async () => {
+      vi.mocked(verifyGrantToken).mockResolvedValue(makeGrant({ scopes: ['tool:salesforce:read'] }));
+      vi.stubGlobal('fetch', makeFetch(200, {}));
+      vi.stubEnv('NODE_ENV', 'production');
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const gx = new Grantex({ apiKey: 'k', enforceMode: 'permissive' } as any);
+      gx.loadManifest(new ToolManifest({ connector: 'salesforce', tools: { create_lead: Permission.WRITE } }));
+      const result = await gx.enforce({ grantToken: 'tok', connector: 'salesforce', tool: 'create_lead' });
+      expect(result.allowed).toBe(true);
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
     it('strict mode denies normally (default)', async () => {
       vi.mocked(verifyGrantToken).mockResolvedValue(makeGrant({ scopes: ['tool:salesforce:read'] }));
       vi.stubGlobal('fetch', makeFetch(200, {}));

--- a/packages/x402/src/agent.ts
+++ b/packages/x402/src/agent.ts
@@ -9,6 +9,7 @@
  * 5. Retries the request with payment proof + GDT
  */
 
+import { randomBytes } from 'node:crypto';
 import { getAuditLog } from './audit.js';
 import type { X402AgentConfig, X402FetchOptions, X402PaymentDetails } from './types.js';
 
@@ -180,11 +181,25 @@ export function x402AgentFetch(config: X402AgentConfig = {}) {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Generate `length` lowercase hex characters from a cryptographically
+ * strong source. Used by the default stub payment handler to mint a
+ * 64-character `txHash` that ships inside the base64-encoded payment
+ * proof. Even for the stub, weak `Math.random()` was a hazard:
+ *
+ *   - The proof string travels over the wire and is persisted to audit
+ *     logs that may key off `txHash` for idempotency / replay detection.
+ *   - Two parallel callers could collide and mask each other in those
+ *     audit/idempotency tables.
+ *
+ * `length` must be even (one hex char per nibble, two per byte).
+ */
 function randomHex(length: number): string {
-  const chars = '0123456789abcdef';
-  let result = '';
-  for (let i = 0; i < length; i++) {
-    result += chars[Math.floor(Math.random() * 16)];
+  if (length < 0 || !Number.isInteger(length)) {
+    throw new RangeError('randomHex length must be a non-negative integer');
   }
-  return result;
+  if (length === 0) return '';
+  // Round byte count up; slice back down so odd lengths still work.
+  const byteCount = Math.ceil(length / 2);
+  return randomBytes(byteCount).toString('hex').slice(0, length);
 }

--- a/packages/x402/tests/agent.test.ts
+++ b/packages/x402/tests/agent.test.ts
@@ -142,5 +142,36 @@ describe('x402 Agent', () => {
       expect(decoded.chain).toBe('base');
       expect(decoded.amount).toBe(0.001);
     });
+
+    it('stub payment handler emits unique 64-hex txHash values per call', async () => {
+      const seen = new Set<string>();
+      for (let i = 0; i < 25; i++) {
+        mockFetch.mockResolvedValueOnce(
+          new Response(null, {
+            status: 402,
+            headers: {
+              [HEADERS.PAYMENT_AMOUNT]: '0.001',
+              [HEADERS.PAYMENT_CURRENCY]: 'USDC',
+              [HEADERS.PAYMENT_RECIPIENT]: '0xrecipient',
+              [HEADERS.PAYMENT_CHAIN]: 'base',
+            },
+          }),
+        );
+        mockFetch.mockResolvedValueOnce(new Response('OK', { status: 200 }));
+
+        const agent = createX402Agent({ gdt: 'test-gdt' });
+        await agent.fetch('https://api.example.com/data');
+
+        const retryHeaders = mockFetch.mock.calls[mockFetch.mock.calls.length - 1]![1]!.headers as Headers;
+        const proof = retryHeaders.get(HEADERS.PAYMENT_PROOF)!;
+        const decoded = JSON.parse(Buffer.from(proof, 'base64url').toString());
+        expect(decoded.txHash).toMatch(/^0x[0-9a-f]{64}$/);
+        seen.add(decoded.txHash);
+      }
+      // All 25 calls produce distinct txHashes — Math.random with a
+      // restart-per-call PRNG state could repeat; crypto.randomBytes
+      // makes that vanishingly unlikely.
+      expect(seen.size).toBe(25);
+    });
   });
 });

--- a/scripts/check-live-mode-guard.mjs
+++ b/scripts/check-live-mode-guard.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * P0-23 — hard gate for the central Commerce live-mode guard.
+ *
+ * Verifies two invariants and exits 1 on any violation, so that the
+ * release-preflight job (and any future CI integration) fails the
+ * pipeline when a payment-touching route forgets to call the guard:
+ *
+ *   1. apps/auth-service/src/lib/commerce/live-mode-guard.ts exists
+ *      and exports ensureCommerceLiveMode.
+ *   2. Every file in PAYMENT_TOUCHING_ROUTES below
+ *      - imports from '../lib/commerce/live-mode-guard.js', and
+ *      - actually calls ensureCommerceLiveMode(...).
+ *
+ * Read-only / admin / setup routes are deliberately NOT in the inventory
+ * to avoid false positives. Adding a new payment-touching route requires
+ * a one-line addition here AND to
+ * apps/auth-service/tests/commerce-live-mode-guard.test.ts — the test
+ * mirrors this list so an in-package regression is caught even when the
+ * release pipeline does not run.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = process.cwd();
+const here = dirname(fileURLToPath(import.meta.url));
+
+const GUARD_PATH = join(
+  repoRoot,
+  'apps',
+  'auth-service',
+  'src',
+  'lib',
+  'commerce',
+  'live-mode-guard.ts',
+);
+
+// Files that handle inbound requests which can create or advance live
+// payment-provider state. Read-only/admin/setup routes are excluded.
+const PAYMENT_TOUCHING_ROUTES = [
+  'apps/auth-service/src/routes/commerce-cart-payment.ts',
+  'apps/auth-service/src/routes/commerce-provider-credentials.ts',
+  'apps/auth-service/src/routes/commerce-provider-webhooks.ts',
+];
+
+const REQUIRED_IMPORT_RE = /from\s+['"]\.\.\/lib\/commerce\/live-mode-guard\.js['"]/;
+const REQUIRED_CALL_RE = /ensureCommerceLiveMode\s*\(/;
+
+let failed = false;
+function fail(msg) {
+  failed = true;
+  console.error(`[live-mode-guard] ${msg}`);
+}
+
+// 1. Guard module must exist and export the expected symbol.
+if (!existsSync(GUARD_PATH)) {
+  fail(`expected guard module at ${GUARD_PATH} — module is missing.`);
+} else {
+  const guardSrc = readFileSync(GUARD_PATH, 'utf-8');
+  if (!/export\s+function\s+ensureCommerceLiveMode\b/.test(guardSrc)) {
+    fail(`${GUARD_PATH} does not export ensureCommerceLiveMode.`);
+  } else {
+    console.log(`[live-mode-guard] guard module OK: ${GUARD_PATH}`);
+  }
+}
+
+// 2. Every payment-touching route must import the guard AND call it.
+for (const rel of PAYMENT_TOUCHING_ROUTES) {
+  const abs = join(repoRoot, rel);
+  if (!existsSync(abs)) {
+    fail(`inventory references ${rel} but the file does not exist; ` +
+      `either remove the entry from PAYMENT_TOUCHING_ROUTES or restore the file.`);
+    continue;
+  }
+  const src = readFileSync(abs, 'utf-8');
+  const hasImport = REQUIRED_IMPORT_RE.test(src);
+  const hasCall = REQUIRED_CALL_RE.test(src);
+  if (!hasImport) {
+    fail(`${rel} does not import ensureCommerceLiveMode from ` +
+      `'../lib/commerce/live-mode-guard.js'.`);
+  }
+  if (!hasCall) {
+    fail(`${rel} does not call ensureCommerceLiveMode(...). ` +
+      `Every handler that can create or advance live payment-provider state ` +
+      `must call the central guard before any side effect.`);
+  }
+  if (hasImport && hasCall) {
+    console.log(`[live-mode-guard] ${rel} OK`);
+  }
+}
+
+if (failed) {
+  console.error('');
+  console.error('[live-mode-guard] FAIL — release blocked until the gaps above are closed.');
+  console.error(
+    '[live-mode-guard] Reference: docs/reports/' +
+      'enterprise-readiness-brutal-review-2026-05-24.md item P0-23.',
+  );
+  process.exit(1);
+}
+console.log('[live-mode-guard] PASS — all payment-touching routes reference the central guard.');
+// Touch `here` so a no-op import does not get pruned by linters.
+void here;

--- a/web/commerce-playground.html
+++ b/web/commerce-playground.html
@@ -457,7 +457,7 @@
         <div class="panel-body">
           <div class="field">
             <label for="api-base">API base URL</label>
-            <input id="api-base" autocomplete="off" spellcheck="false" value="http://localhost:3001">
+            <input id="api-base" autocomplete="off" spellcheck="false" value="https://api.grantex.dev">
           </div>
           <div class="field">
             <label for="merchant-id">Merchant ID</label>
@@ -940,5 +940,14 @@
     renderToolButtons();
     loadExample();
   </script>
+  <footer style="margin-top:2rem;padding:1rem;text-align:center;font-size:0.85em;color:#888;border-top:1px solid #2a2a2a;">
+    <a href="https://docs.grantex.dev/compliance/privacy-policy" style="color:#888;">Privacy</a> &middot;
+    <a href="https://docs.grantex.dev/compliance/terms-of-service" style="color:#888;">Terms</a> &middot;
+    <a href="https://docs.grantex.dev/compliance/dpa" style="color:#888;">DPA</a> &middot;
+    <a href="https://docs.grantex.dev/compliance/cookie-policy" style="color:#888;">Cookies</a> &middot;
+    <a href="https://docs.grantex.dev/compliance/sub-processors" style="color:#888;">Sub-processors</a> &middot;
+    <a href="https://docs.grantex.dev/compliance/data-residency" style="color:#888;">Data Residency</a> &middot;
+    <a href="https://github.com/mishrasanjeev/grantex/blob/main/SECURITY.md" style="color:#888;">Security</a>
+  </footer>
 </body>
 </html>

--- a/web/commerce.html
+++ b/web/commerce.html
@@ -243,7 +243,18 @@
   </section>
 
   <footer>
-    <div class="wrap">No secrets, passports, tokens, raw payloads, provider credentials, or live payment material are included on this page.</div>
+    <div class="wrap">
+      <p style="margin:0 0 0.75em 0;">No secrets, passports, tokens, raw payloads, provider credentials, or live payment material are included on this page.</p>
+      <p style="margin:0;font-size:0.9em;">
+        <a href="https://docs.grantex.dev/compliance/privacy-policy">Privacy</a> &middot;
+        <a href="https://docs.grantex.dev/compliance/terms-of-service">Terms</a> &middot;
+        <a href="https://docs.grantex.dev/compliance/dpa">DPA</a> &middot;
+        <a href="https://docs.grantex.dev/compliance/cookie-policy">Cookies</a> &middot;
+        <a href="https://docs.grantex.dev/compliance/sub-processors">Sub-processors</a> &middot;
+        <a href="https://docs.grantex.dev/compliance/data-residency">Data Residency</a> &middot;
+        <a href="https://github.com/mishrasanjeev/grantex/blob/main/SECURITY.md">Security</a>
+      </p>
+    </div>
   </footer>
 </body>
 </html>

--- a/web/dpdp.html
+++ b/web/dpdp.html
@@ -1237,35 +1237,35 @@
           <tbody>
             <tr>
               <td class="agent">calendar-assistant</td>
-              <td>rajesh.kumar@example.com</td>
+              <td>r***@***.com</td>
               <td style="font-family:var(--mono);font-size:11px;">calendar:read, calendar:write</td>
               <td><span class="dash-badge active">Active</span></td>
               <td style="font-family:var(--mono);font-size:11px;">2026-04-01</td>
             </tr>
             <tr>
               <td class="agent">email-summarizer</td>
-              <td>priya.sharma@example.com</td>
+              <td>p***@***.com</td>
               <td style="font-family:var(--mono);font-size:11px;">email:read</td>
               <td><span class="dash-badge active">Active</span></td>
               <td style="font-family:var(--mono);font-size:11px;">2026-03-28</td>
             </tr>
             <tr>
               <td class="agent">doc-analyzer</td>
-              <td>amit.patel@example.com</td>
+              <td>a***@***.com</td>
               <td style="font-family:var(--mono);font-size:11px;">files:read, files:analyze</td>
               <td><span class="dash-badge withdrawn">Withdrawn</span></td>
               <td style="font-family:var(--mono);font-size:11px;">2026-03-15</td>
             </tr>
             <tr>
               <td class="agent">hr-assistant</td>
-              <td>deepa.nair@example.com</td>
+              <td>d***@***.com</td>
               <td style="font-family:var(--mono);font-size:11px;">employee:read, payroll:view</td>
               <td><span class="dash-badge active">Active</span></td>
               <td style="font-family:var(--mono);font-size:11px;">2026-03-10</td>
             </tr>
             <tr>
               <td class="agent">travel-planner</td>
-              <td>vikram.singh@example.com</td>
+              <td>v***@***.com</td>
               <td style="font-family:var(--mono);font-size:11px;">calendar:read, travel:book</td>
               <td><span class="dash-badge expired">Expired</span></td>
               <td style="font-family:var(--mono);font-size:11px;">2026-02-20</td>
@@ -1669,6 +1669,15 @@
         <li><a href="https://pypi.org/project/grantex/">PyPI</a></li>
         <li><a href="https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/">IETF Draft</a></li>
         <li><a href="https://github.com/mishrasanjeev/grantex/blob/main/LICENSE">Apache 2.0</a></li>
+      </ul>
+      <ul class="footer-links" aria-label="Legal and procurement">
+        <li><a href="https://docs.grantex.dev/compliance/privacy-policy">Privacy</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/terms-of-service">Terms</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/dpa">DPA</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/cookie-policy">Cookies</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/sub-processors">Sub-processors</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/data-residency">Data Residency</a></li>
+        <li><a href="https://github.com/mishrasanjeev/grantex/blob/main/SECURITY.md">Security</a></li>
       </ul>
       <span class="footer-copy">&copy; 2026 Grantex</span>
     </div>

--- a/web/index.html
+++ b/web/index.html
@@ -1012,18 +1012,18 @@
     </div>
     <div class="badge-row">
       <span class="badge"><span class="dot"></span> IETF I-D</span>
-      <span class="badge"><span class="dot"></span> SOC 2 Type I</span>
+      <span class="badge"><span class="dot"></span> SOC 2 readiness mapping</span>
       <span class="badge"><span class="dot"></span> Apache 2.0</span>
       <span class="badge"><span class="dot"></span> v1.0</span>
     </div>
   </div>
 </section>
 
-<!-- ── What's New in v2.5 ─────────────────────────────────────────────────── -->
+<!-- ── Current Development Snapshot ───────────────────────────────────────── -->
 <section id="whats-new" style="padding:48px 0;border-bottom:1px solid var(--border);">
   <div class="container">
-    <div class="section-label">What's new</div>
-    <h2 class="section-title" style="font-size:clamp(24px,4vw,36px);">Grantex v2.5 — April 2026</h2>
+    <div class="section-label">Current snapshot</div>
+    <h2 class="section-title" style="font-size:clamp(24px,4vw,36px);">Recent Grantex capabilities</h2>
     <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px;margin-top:32px;">
 
       <a href="/gemma" style="text-decoration:none;display:block;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:24px;transition:border-color .2s;" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
@@ -1031,15 +1031,15 @@
           <span style="background:#3fb950;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">NEW</span>
           <span style="color:var(--text);font-weight:600;">@grantex/gemma</span>
         </div>
-        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">Day-zero Gemma 4 integration — offline consent bundles, &lt;5ms verification on Raspberry Pi, Google ADK adapter.</p>
+        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">Offline consent bundles and on-device verification examples for Gemma agents.</p>
       </a>
 
       <a href="/mcp" style="text-decoration:none;display:block;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:24px;transition:border-color .2s;" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
         <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
-          <span style="background:#3fb950;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">GA</span>
+          <span style="background:#3fb950;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">PKG</span>
           <span style="color:var(--text);font-weight:600;">MCP Auth Server v2.0.1</span>
         </div>
-        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">OAuth 2.1 + PKCE for any MCP server. Managed + self-hosted. Bronze/Silver/Gold certification program.</p>
+        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">OAuth 2.1 + PKCE for MCP servers, with managed and self-hosted modes.</p>
       </a>
 
       <a href="/dpdp" style="text-decoration:none;display:block;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:24px;transition:border-color .2s;" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
@@ -1047,7 +1047,7 @@
           <span style="background:#3fb950;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">NEW</span>
           <span style="color:var(--text);font-weight:600;">@grantex/dpdp</span>
         </div>
-        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">DPDP Act 2023 &amp; EU AI Act compliance. Structured consent records, purpose limitation, audit-ready exports.</p>
+        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">DPDP Act 2023 and EU AI Act control mappings, structured consent records, purpose limitation, and audit-ready exports.</p>
       </a>
 
       <a href="/registry" style="text-decoration:none;display:block;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:24px;transition:border-color .2s;" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
@@ -1055,7 +1055,7 @@
           <span style="background:#58a6ff;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">LAUNCH</span>
           <span style="color:var(--text);font-weight:600;">Trust Registry</span>
         </div>
-        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">Public DID-based directory of verified AI agent publishers. DNS verification, SOC 2 badges, embeddable widget.</p>
+        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">Public DID-based directory of verified AI agent publishers, DNS verification, and embeddable widgets.</p>
       </a>
 
       <a href="/anomaly" style="text-decoration:none;display:block;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:24px;transition:border-color .2s;" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
@@ -1643,7 +1643,7 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
 <span class="cm"># All commands support --json for AI agent / script use</span>
 
 <span class="cm"># 1. Request authorization (sandbox auto-approves)</span>
-<span class="id">grantex</span> <span class="id">authorize</span> <span class="op">--</span><span class="id">agent</span> <span class="str">ag_01J...</span> <span class="op">--</span><span class="id">principal</span> <span class="str">user@example.com</span> \
+<span class="id">grantex</span> <span class="id">authorize</span> <span class="op">--</span><span class="id">agent</span> <span class="str">ag_01J...</span> <span class="op">--</span><span class="id">principal</span> <span class="str">user_123</span> \
   <span class="op">--</span><span class="id">scopes</span> <span class="str">calendar:read,email:send</span>
 
 <span class="cm"># 2. Exchange the code for a grant token</span>
@@ -2340,13 +2340,13 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
         <div class="auditor">Vestige Security Labs</div>
       </div>
       <div class="trust-card">
-        <div class="trust-label">SOC 2 Type I</div>
-        <h3>SOC 2 Type I Certified</h3>
+        <div class="trust-label">SOC 2 readiness</div>
+        <h3>Control Mapping Published</h3>
         <p>
-          Controls for Security, Availability, and Confidentiality trust service
-          criteria reviewed and attested by an independent CPA firm.
+          Controls for Security, Availability, and Confidentiality are mapped
+          to SOC 2 criteria. Formal third-party attestation is not published.
         </p>
-        <div class="auditor">Thornfield Assurance Partners</div>
+        <div class="auditor">Internal readiness mapping</div>
       </div>
       <div class="trust-card">
         <div class="trust-label">Open Standard</div>
@@ -2363,13 +2363,12 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
       </div>
       <div class="trust-card">
         <div class="trust-label">Testing</div>
-        <h3>4,147 Tests &mdash; 100% Pass Rate</h3>
+        <h3>3,536 Tests Reported In Changelog</h3>
         <p>
-          Every feature tested end-to-end across 27 packages in TypeScript, Python,
-          and Go. Rate limiting, transactions, retry logic, scope enforcement,
-          WebAuthn, VCs, SSO, DPDP &mdash; all verified.
+          The repository changelog reports 3,536 tests across 28 packages.
+          GitHub Actions is the source of truth for current pass/fail status.
         </p>
-        <div class="auditor">27 packages &middot; TypeScript, Python, Go</div>
+        <div class="auditor">28 packages &middot; TypeScript, Python, Go</div>
       </div>
     </div>
   </div>
@@ -2646,6 +2645,15 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
         <li><a href="/anomaly">Anomaly</a></li>
         <li><a href="https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/">IETF Draft</a></li>
         <li><a href="https://github.com/mishrasanjeev/grantex/blob/main/LICENSE">Apache 2.0</a></li>
+      </ul>
+      <ul class="footer-links" aria-label="Legal and procurement">
+        <li><a href="https://docs.grantex.dev/compliance/privacy-policy">Privacy</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/terms-of-service">Terms</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/dpa">DPA</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/cookie-policy">Cookies</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/sub-processors">Sub-processors</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/data-residency">Data Residency</a></li>
+        <li><a href="https://github.com/mishrasanjeev/grantex/blob/main/SECURITY.md">Security</a></li>
       </ul>
       <span class="footer-copy">&copy; 2026 Grantex</span>
     </div>

--- a/web/llms-full.txt
+++ b/web/llms-full.txt
@@ -13,8 +13,8 @@ Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, hum
 - IETF Draft: https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/
 - License: Apache 2.0
 - Protocol Version: 1.0 (Final, frozen)
-- Tests: 3,604 passing (100% pass rate across 28 packages)
-- SOC 2 Type I certified
+- Tests: latest changelog reports 3,536 tests across 28 packages; GitHub Actions is the source of truth for pass/fail status
+- SOC 2: readiness control mapping published; formal third-party attestation is not published
 - Production: Cloud Run at https://grantex-auth-dd4mtrt2gq-uc.a.run.app
 
 ---
@@ -356,8 +356,8 @@ White-label consent UI and API endpoints. DNS TXT verification.
 ### Anomaly Detection
 Runtime behavioral monitoring for agent activity. Detects deviations from established baselines.
 
-### DPDP Act Compliance (India Digital Personal Data Protection Act, 2023)
-Full lifecycle compliance for AI agent data processing under India's DPDP Act.
+### DPDP Act Control Mapping (India Digital Personal Data Protection Act, 2023)
+Technical controls for AI agent data processing workflows under India's DPDP Act. This is not a legal certification.
 
 #### Consent Management
 - `POST /v1/dpdp/consent-records` — Create a consent record linking a Grantex grant to a data principal with explicit purpose limitation. Each record is cryptographically signed (Ed25519) and includes a SHA-256 hash of the consent notice shown to the user.
@@ -519,7 +519,7 @@ MCP Auth is specific to the Model Context Protocol. Grantex works across all fra
 - SD-JWT (IETF draft-ietf-oauth-selective-disclosure-jwt)
 - OAuth 2.1 + PKCE (RFC 7636)
 - JWT (RFC 7519), JWS (RFC 7515), JWKS (RFC 7517)
-- SOC 2 Type I certified
+- SOC 2 readiness control mapping published; formal third-party attestation is not published
 
 ---
 

--- a/web/llms.txt
+++ b/web/llms.txt
@@ -37,10 +37,10 @@ Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, hum
 - FastAPI middleware: `pip install grantex-fastapi`
 - Reverse-proxy gateway: `npm install @grantex/gateway`
 
-## Key Packages (New in v2.5)
+## Key Packages
 - @grantex/gemma: Offline authorization for Gemma 4 on-device agents
 - @grantex/mcp-auth: OAuth 2.1 auth server for MCP servers
-- @grantex/dpdp: DPDP Act 2023 + EU AI Act compliance module
+- @grantex/dpdp: DPDP Act 2023 + EU AI Act control mappings
 
 ## Key Features
 
@@ -76,7 +76,7 @@ Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, hum
 - OWASP Agentic Top 10 (Dec 2025): ASI-01 (goal hijacking), ASI-03 (identity abuse), ASI-05 (privilege escalation), ASI-10 (rogue agents)
 - EU AI Act (binding Aug 2026): Art. 9 (risk management), Art. 13 (transparency), Art. 14 (human oversight)
 - NIST AI RMF + EO 14110: Govern 1.1 (accountability), Map 5.1 (attribution), Measure 2.5 (audit trails)
-- SOC 2 Type I certified
+- SOC 2 readiness control mapping published; formal third-party attestation is not published
 - Full compliance matrix: https://docs.grantex.dev/guides/compliance-matrix
 
 ## Scope Enforcement (v0.3.7)
@@ -118,7 +118,7 @@ Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, hum
 - Config validation on startup (exits if required vars missing)
 - Structured JSON logging via pino (zero console.log remaining)
 - Webhook retry with 20% jitter (prevents thundering herd)
-- 3,604 tests across 28 packages — 100% pass rate
+- Latest changelog reports 3,536 tests across 28 packages; GitHub Actions is the source of truth for pass/fail status
 - Zero known vulnerabilities (npm audit, pip-audit, govulncheck all clean)
 
 ## SDK Parity

--- a/web/mcp.html
+++ b/web/mcp.html
@@ -956,7 +956,7 @@
   <span class="id">grantex</span>,
   <span class="id">agentId</span>: <span class="str">'ag_your_mcp_server'</span>,
   <span class="id">scopes</span>:  [<span class="str">'tools:read'</span>, <span class="str">'tools:execute'</span>, <span class="str">'resources:read'</span>],
-  <span class="id">issuer</span>:  <span class="str">'https://your-mcp-server.example.com'</span>,
+  <span class="id">issuer</span>:  <span class="str">'https://mcp.yourcompany.com'</span>,
 });
 
 <span class="kw">await</span> <span class="id">authServer</span>.<span class="fn">listen</span>({ <span class="id">port</span>: <span class="id">3001</span> });</pre>
@@ -979,7 +979,7 @@
 
 <span class="cm">// Protect all MCP tool routes</span>
 <span class="id">app</span>.<span class="fn">use</span>(<span class="str">'/mcp'</span>, <span class="fn">requireMcpAuth</span>({
-  <span class="id">issuer</span>: <span class="str">'https://your-mcp-server.example.com'</span>,
+  <span class="id">issuer</span>: <span class="str">'https://mcp.yourcompany.com'</span>,
   <span class="id">scopes</span>: [<span class="str">'tools:execute'</span>],
 }));
 
@@ -1161,7 +1161,7 @@
   }),
   <span class="id">agentId</span>: <span class="str">'ag_your_server'</span>,
   <span class="id">scopes</span>:  [<span class="str">'tools:read'</span>, <span class="str">'tools:execute'</span>],
-  <span class="id">issuer</span>:  <span class="str">'https://your-domain.example.com'</span>,
+  <span class="id">issuer</span>:  <span class="str">'https://mcp.yourcompany.com'</span>,
 });</pre>
         </div>
       </div>
@@ -1297,6 +1297,15 @@
         <li><a href="https://pypi.org/project/grantex/">PyPI</a></li>
         <li><a href="https://www.npmjs.com/package/@grantex/mcp-auth">npm</a></li>
         <li><a href="https://github.com/mishrasanjeev/grantex/blob/main/LICENSE">Apache 2.0</a></li>
+      </ul>
+      <ul class="footer-links" aria-label="Legal and procurement">
+        <li><a href="https://docs.grantex.dev/compliance/privacy-policy">Privacy</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/terms-of-service">Terms</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/dpa">DPA</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/cookie-policy">Cookies</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/sub-processors">Sub-processors</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/data-residency">Data Residency</a></li>
+        <li><a href="https://github.com/mishrasanjeev/grantex/blob/main/SECURITY.md">Security</a></li>
       </ul>
       <span class="footer-copy">&copy; 2026 Grantex</span>
     </div>

--- a/web/mpp-demo/index.html
+++ b/web/mpp-demo/index.html
@@ -262,8 +262,7 @@
 
   <script>
     // ── Config ──────────────────────────────────────────────────────────────
-    const AUTH_API = window.location.hostname === 'localhost'
-      ? 'http://localhost:3001' : 'https://api.grantex.dev';
+    const AUTH_API = 'https://api.grantex.dev';
 
     // ── State ──────────────────────────────────────────────────────────────
     const spendTotals = { inference: 0, compute: 0, data: 0 };
@@ -555,5 +554,14 @@
       return ts + rand;
     }
   </script>
+  <footer style="margin-top:2rem;padding:1rem;text-align:center;font-size:0.85em;color:#888;border-top:1px solid #2a2a2a;">
+    <a href="https://docs.grantex.dev/compliance/privacy-policy" style="color:#888;">Privacy</a> &middot;
+    <a href="https://docs.grantex.dev/compliance/terms-of-service" style="color:#888;">Terms</a> &middot;
+    <a href="https://docs.grantex.dev/compliance/dpa" style="color:#888;">DPA</a> &middot;
+    <a href="https://docs.grantex.dev/compliance/cookie-policy" style="color:#888;">Cookies</a> &middot;
+    <a href="https://docs.grantex.dev/compliance/sub-processors" style="color:#888;">Sub-processors</a> &middot;
+    <a href="https://docs.grantex.dev/compliance/data-residency" style="color:#888;">Data Residency</a> &middot;
+    <a href="https://github.com/mishrasanjeev/grantex/blob/main/SECURITY.md" style="color:#888;">Security</a>
+  </footer>
 </body>
 </html>

--- a/web/og-image-placeholder.svg
+++ b/web/og-image-placeholder.svg
@@ -46,10 +46,10 @@
   <circle cx="123" cy="453" r="5" fill="#3fb950"/>
   <text x="136" y="458" font-family="'JetBrains Mono', monospace" font-size="13" fill="#8b949e">IETF I-D</text>
 
-  <!-- SOC 2 Type I -->
+  <!-- SOC 2 mapping -->
   <rect x="256" y="436" width="152" height="34" rx="17" fill="#161b22" stroke="#30363d" stroke-width="1"/>
   <circle cx="279" cy="453" r="5" fill="#3fb950"/>
-  <text x="292" y="458" font-family="'JetBrains Mono', monospace" font-size="13" fill="#8b949e">SOC 2 Type I</text>
+  <text x="292" y="458" font-family="'JetBrains Mono', monospace" font-size="13" fill="#8b949e">SOC 2 mapping</text>
 
   <!-- Apache 2.0 -->
   <rect x="424" y="436" width="146" height="34" rx="17" fill="#161b22" stroke="#30363d" stroke-width="1"/>

--- a/web/ph-gallery.html
+++ b/web/ph-gallery.html
@@ -864,7 +864,7 @@
         </div>
         <div class="trust-pill">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M6.5 12L2 7.5L3.4 6.1L6.5 9.2L12.6 3.1L14 4.5L6.5 12Z" fill="#3fb950"/></svg>
-          <span style="color:var(--green)">SOC 2 Type I</span>
+          <span style="color:var(--green)">SOC 2 mapping</span>
         </div>
         <div class="trust-pill">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6" stroke="#3fb950" stroke-width="1.5" fill="none"/><path d="M5.5 8H10.5M8 5.5V10.5" stroke="#3fb950" stroke-width="1.5"/></svg>

--- a/web/registry.html
+++ b/web/registry.html
@@ -88,15 +88,6 @@
   }
   </script>
 
-  <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-XXXXXXXXXX');
-  </script>
-
   <style>
     /* ── Design tokens ─────────────────────────────────────────────────────── */
     :root {
@@ -1090,6 +1081,15 @@ orgs = gx.registry.<span class="fn">search</span>(q=<span class="str">"acme"</sp
         <li><a href="https://pypi.org/project/grantex/">PyPI</a></li>
         <li><a href="https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/">IETF Draft</a></li>
         <li><a href="https://github.com/mishrasanjeev/grantex/blob/main/LICENSE">Apache 2.0</a></li>
+      </ul>
+      <ul class="footer-links" aria-label="Legal and procurement">
+        <li><a href="https://docs.grantex.dev/compliance/privacy-policy">Privacy</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/terms-of-service">Terms</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/dpa">DPA</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/cookie-policy">Cookies</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/sub-processors">Sub-processors</a></li>
+        <li><a href="https://docs.grantex.dev/compliance/data-residency">Data Residency</a></li>
+        <li><a href="https://github.com/mishrasanjeev/grantex/blob/main/SECURITY.md">Security</a></li>
       </ul>
       <span class="footer-copy">&copy; 2026 Grantex</span>
     </div>

--- a/web/report/state-of-agent-security-2026.html
+++ b/web/report/state-of-agent-security-2026.html
@@ -419,7 +419,7 @@
 
   <h3>How Grantex addresses these gaps</h3>
   <p><a href="https://github.com/mishrasanjeev/grantex">Grantex</a> is an open protocol (Apache 2.0) that implements all six primitives as a standard. It provides signed JWT grant tokens with scoped claims, per-agent DIDs, user consent flows with optional FIDO2/WebAuthn passkeys, granular revocation with cascade, immutable audit trails, and delegation chains with depth limits and scope narrowing.</p>
-  <p>The protocol has an <a href="https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/">IETF Internet-Draft</a> submitted to the OAuth Working Group, a NIST NCCoE public comment filed, and SOC 2 Type I certification completed. SDKs are available for TypeScript, Python, and Go, with integrations for LangChain, CrewAI, OpenAI Agents SDK, Vercel AI, Google ADK, AutoGen, MCP, Express.js, FastAPI, and Terraform.</p>
+  <p>The protocol has an <a href="https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/">IETF Internet-Draft</a> submitted to the OAuth Working Group, a NIST NCCoE public comment filed, and a SOC 2 readiness control mapping published. Formal third-party SOC 2 attestation is not published. SDKs are available for TypeScript, Python, and Go, with integrations for LangChain, CrewAI, OpenAI Agents SDK, Vercel AI, Google ADK, AutoGen, MCP, Express.js, FastAPI, and Terraform.</p>
 
   <div style="margin: 3rem 0; text-align: center;">
     <a href="https://github.com/mishrasanjeev/grantex" class="cta">View on GitHub</a>


### PR DESCRIPTION
## Summary

Closes all 23 P0 hard blockers from `docs/reports/enterprise-readiness-brutal-review-2026-05-24.md`.

- Removes unsupported compliance, version, Commerce V1, and test-count claims (badges, README, docs, web copy, ROADMAP, portal labels).
- Adds compatibility matrix, six procurement docs (DPA / sub-processors / data-residency / privacy / terms / cookies), legal footer links on 7 web pages, and a severity-keyed security SLA.
- Hardens JWT verification (Anthropic adapter), random IDs (DPDP grievance + erasure + x402 stub txHash), CORS (mpp-demo-service allowlist), admin test secret generation, and adds a central Commerce live-mode guard (`apps/auth-service/src/lib/commerce/live-mode-guard.ts`) called from every payment-touching route.
- Adds release-workflow preflight (gates the GH release on focused SDK + Anthropic + auth-service tests + the live-mode-guard check), Dependabot config (36 update streams across npm/pip/gomod/terraform/github-actions), CODEOWNERS dual-owner pattern with `@grantex/maintainers`, and a quickstart-ts CI job.
- Moves 13 internal Commerce V1 reports out of public docs nav into `docs/internal/commerce-v1/` with internal-artifact notices; deletes `.tmp/` and ignores it.

## Test plan

- [x] `node scripts/check-live-mode-guard.mjs` — PASS in source repo AND in fresh clone of this commit.
- [x] docs nav existence check — 346/346 entries resolve.
- [x] `packages/sdk-ts` vitest — 404/404 pass.
- [x] `packages/anthropic` vitest — 44/44 pass (includes new "rejects forged tokens" case).
- [x] `packages/dpdp` vitest — 106/106 pass (includes new non-predictability cases).
- [x] `packages/x402` `agent.test.ts` — 7/7 pass (includes new unique-txHash case).
- [x] `apps/auth-service` full vitest — 1,491/1,491 pass.
- [x] Fresh-clone audit at this SHA — every static check + the four test suites above run green from `npm ci` against a clean clone with no working-tree leftovers.
- [x] `rg` unsupported-claim sweep (`SOC 2 Type I certified`, `Thornfield`, `DPDP Compliant`, `EU AI Act Ready`, `4,147`, `What's New in v2.5`, `Production Commerce V1 discovery is currently`) — only matches inside the audit artifact itself.
- [ ] CI (this PR) — green check pending.

## External activation items (documented honestly in `HEAD`, not blockers to merging)

- Create `@grantex/maintainers` team in the GitHub org so the new CODEOWNERS dual-review pattern is non-trivial (`CODEOWNERS:1-21` carries the prereq comment).
- Enable branch protection on `main` to require all CI checks + reviews.
- Pin the SLSA generator tag in `.github/workflows/release.yml:148` and uncomment the `provenance` job.
- Replace `docs/soc2-type1/report.md` (currently "Readiness Control Mapping") with a real CPA-issued Type I report when available.
- Counsel review of `docs/compliance/*.md` drafts.
- Publish `/.well-known/security.asc` and `/security/thanks` (both marked TBD in `SECURITY.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)