### PR TITLE
test: align production e2e with hardened P0 posture

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Portal features (full API surface)
         env:
           E2E_BASE_URL: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
+          # /metrics requires Bearer-token auth in production. The value
+          # must match the auth-service's METRICS_API_KEY env var (kept in
+          # GCP Secret Manager and mirrored as a GitHub repo secret of the
+          # same name). See tests/e2e/portal-features.test.ts metrics test
+          # and apps/auth-service/src/routes/metrics.ts for the contract.
+          METRICS_API_KEY: ${{ secrets.METRICS_API_KEY }}
         run: npx vitest run --testTimeout=120000 tests/e2e/portal-features.test.ts
 
       - name: Scope enforcement

--- a/tests/e2e/dpdp.test.ts
+++ b/tests/e2e/dpdp.test.ts
@@ -286,7 +286,11 @@ describe('E2E: DPDP Grievances', () => {
     expect(grievance.grievanceId).toBeDefined();
     expect(typeof grievance.grievanceId).toBe('string');
     expect(grievance.referenceNumber).toBeDefined();
-    expect(grievance.referenceNumber).toMatch(/^GRV-\d{4}-\d{5}$/);
+    // Grievance references are crypto-strong ULID-suffixed since the
+    // P0-19 hardening (apps/auth-service/src/lib/ids.ts::newGrievanceReference).
+    // Mirrors the unit-test regex in apps/auth-service/tests/dpdp.test.ts:714.
+    // Crockford base32 alphabet excludes I, L, O, U → [0-9A-HJKMNP-TV-Z].
+    expect(grievance.referenceNumber).toMatch(/^GRV-\d{4}-[0-9A-HJKMNP-TV-Z]{26}$/);
     expect(grievance.type).toBe('data-breach');
     expect(grievance.status).toBe('submitted');
     expect(grievance.expectedResolutionBy).toBeDefined();

--- a/tests/e2e/portal-features.test.ts
+++ b/tests/e2e/portal-features.test.ts
@@ -441,8 +441,31 @@ describe('Well-Known Endpoints', () => {
   });
 
   it('serves Prometheus metrics', async () => {
-    const res = await fetch(`${BASE_URL}/metrics`);
+    // /metrics is gated by Bearer-token auth in production
+    // (apps/auth-service/src/routes/metrics.ts:7-26 + config.ts:48-49).
+    // The CI workflow MUST forward METRICS_API_KEY (same value as the
+    // auth-service's env var) when E2E_BASE_URL points at a deployed
+    // environment. Local runs against http://localhost can leave it
+    // unset because METRICS_REQUIRE_AUTH defaults to false there.
+    const metricsKey = process.env['METRICS_API_KEY'];
+    const isLocal = /^https?:\/\/(localhost|127\.0\.0\.1)(:|\/|$)/.test(BASE_URL);
+    if (!metricsKey && !isLocal) {
+      throw new Error(
+        'METRICS_API_KEY env var is required for the /metrics e2e check against a non-local '
+          + 'BASE_URL. The production auth-service requires Bearer-token auth on /metrics; see '
+          + 'apps/auth-service/src/routes/metrics.ts. Add the secret to the workflow step that '
+          + 'runs portal-features.test.ts.',
+      );
+    }
+    const headers: Record<string, string> = {};
+    if (metricsKey) headers['Authorization'] = `Bearer ${metricsKey}`;
+    const res = await fetch(`${BASE_URL}/metrics`, { headers });
     expect(res.status).toBe(200);
+    const contentType = res.headers.get('content-type') ?? '';
+    expect(contentType).toMatch(/text\/plain/);
+    const body = await res.text();
+    // Prometheus exposition format: at least one HELP/TYPE comment or metric line.
+    expect(body).toMatch(/^# HELP |^# TYPE |^[a-zA-Z_][a-zA-Z0-9_]*(\{|\s)/m);
   });
 });
 

--- a/tests/e2e/sso.test.ts
+++ b/tests/e2e/sso.test.ts
@@ -140,7 +140,7 @@ describe('E2E: SSO LDAP Connection', () => {
     const conn = await grantex.sso.createConnection({
       name: 'test-ldap',
       protocol: 'ldap',
-      ldapUrl: 'ldap://ldap.example.com:389',
+      ldapUrl: 'ldaps://ldap.example.com:636',
       ldapBindDn: 'cn=admin,dc=example,dc=com',
       ldapBindPassword: 'admin-password',
       ldapSearchBase: 'ou=users,dc=example,dc=com',
@@ -152,7 +152,7 @@ describe('E2E: SSO LDAP Connection', () => {
 
     expect(conn.name).toBe('test-ldap');
     expect(conn.protocol).toBe('ldap');
-    expect(conn.ldapUrl).toBe('ldap://ldap.example.com:389');
+    expect(conn.ldapUrl).toBe('ldaps://ldap.example.com:636');
     expect(conn.ldapBindDn).toBe('cn=admin,dc=example,dc=com');
     expect(conn.ldapSearchBase).toBe('ou=users,dc=example,dc=com');
     expect(conn.ldapTlsEnabled).toBe(false);
@@ -203,7 +203,11 @@ describe('E2E: SSO Validation', () => {
       grantex.sso.createConnection({
         name: 'incomplete-ldap',
         protocol: 'ldap',
-        ldapUrl: 'ldap://example.com',
+        // ldaps:// is required by the production validator
+        // (apps/auth-service/src/routes/sso.ts:114). Using LDAPS here so
+        // the test exercises its declared missing-fields rejection path
+        // instead of tripping on the insecure-URL gate.
+        ldapUrl: 'ldaps://example.com',
         // Missing ldapBindDn, ldapBindPassword, ldapSearchBase
       } as any),
     ).rejects.toThrow();


### PR DESCRIPTION
## Summary

Realigns three `tests/e2e/*` assertions with the hardened production posture introduced by the P0 remediation in PR #376. **No production code is changed** and **no security posture is loosened** — no workflow bypass flag, no env override.

### Failure 1 — `Well-Known Endpoints > serves Prometheus metrics` (fixed in `78dc440`)

`/metrics` is intentionally auth-protected in production:

- `apps/auth-service/src/routes/metrics.ts:7-26` returns `401` unless `Authorization: Bearer ${config.metricsApiKey}` matches via `crypto.timingSafeEqual`.
- `apps/auth-service/src/config.ts:48-49` reads `METRICS_API_KEY` + `METRICS_REQUIRE_AUTH`; line 133 refuses to start when require-auth is on without a key.

The old e2e fetched `/metrics` unauthenticated and expected `200` — correct only for local-dev where `METRICS_REQUIRE_AUTH` defaults to `false`. The test now reads `METRICS_API_KEY` from env, sends `Authorization: Bearer ${key}`, asserts `200` + `text/plain` + a Prometheus-format body, and throws a clear actionable error if the env var is missing against a non-local `BASE_URL`. The token is never logged. The `Portal features` step in `.github/workflows/e2e.yml` now forwards `${{ secrets.METRICS_API_KEY }}` — only that step, no others.

### Failure 2 — `DPDP Grievances > files a grievance` (fixed in `7f7f74e`)

DPDP grievance references were enumerable 5-digit `Math.random` IDs (`GRV-YYYY-NNNNN`) — a privacy hazard in the DPDP module. P0-19 replaced the generator with ULID-suffixed crypto-strong references in `apps/auth-service/src/lib/ids.ts::newGrievanceReference`:

```ts
export const newGrievanceReference = (): string =>
  \`GRV-\${new Date().getUTCFullYear()}-\${ulid()}\`;
```

Unit tests at `apps/auth-service/tests/dpdp.test.ts:714` were updated to `/^GRV-\d{4}-[0-9A-HJKMNP-TV-Z]{26}$/` (Crockford base32 ULID alphabet, 26 chars). The e2e test at `tests/e2e/dpdp.test.ts:289` still pinned the legacy 5-digit regex and was missed. This PR mirrors the unit-test regex exactly.

### Failure 3 — `SSO LDAP Connection > creates an LDAP connection` (fixed in `1761dcb`)

The production validator rejects plain `ldap://` URLs:

- `apps/auth-service/src/routes/sso.ts:114` — `'ldapUrl: Insecure LDAP URLs are disabled; use LDAPS or enable SSO_ALLOW_INSECURE_URLS'`.
- `apps/auth-service/src/config.ts:52` — `allowInsecureSsoUrls` is a single env flag default-off.

The e2e test used `ldap://ldap.example.com:389`. Fix uses canonical `ldaps://ldap.example.com:636` in the happy-path create + matching assertion. The "rejects LDAP connection without required fields" case at `tests/e2e/sso.test.ts:206` was also updated to `ldaps://example.com` so the test exercises its declared missing-fields rejection path instead of tripping on the insecure-URL gate. **`SSO_ALLOW_INSECURE_URLS` was NOT set in the workflow** — the e2e fixtures match the hardened production posture instead.

### What this PR explicitly does NOT do

- Does **not** modify `apps/auth-service/src/routes/metrics.ts`.
- Does **not** modify `apps/auth-service/src/config.ts`.
- Does **not** modify `apps/auth-service/src/lib/ids.ts` or restore `GRV-YYYY-NNNNN`.
- Does **not** modify `apps/auth-service/src/routes/sso.ts` or `apps/auth-service/src/lib/ldap.ts`.
- Does **not** add `SSO_ALLOW_INSECURE_URLS=true` to any workflow step or env.
- Does **not** add `skipAuth: true` to any production route.

### Required GitHub secret

A repo-level secret named `METRICS_API_KEY` must exist with the same value the deployed auth-service sees in production. **Confirmed present.**

## Test plan

- [x] Local typecheck of changed test files — clean
- [x] `.github/workflows/e2e.yml` YAML syntax — parses cleanly
- [x] `git diff --check` — clean across all three commits
- [x] `rg "ldap://" tests/e2e` returns no matches after the SSO fix
- [x] e2e run 26353642576 — proved metrics fix works (Portal features step passed)
- [x] e2e run 26353763840 — proved DPDP fix works (DPDP compliance + 10 later steps passed); surfaced SSO drift
- [ ] e2e re-validation after `1761dcb` — green pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)