### PR TITLE
[codex] Add C5I synthetic commerce merchant dataset

### DIFF
--- a/docs/examples/commerce-c5i-synthetic-internal-merchant.dataset.json
+++ b/docs/examples/commerce-c5i-synthetic-internal-merchant.dataset.json
@@ -1,0 +1,147 @@
+{
+  "dataset_version": "c5i-synth-v1",
+  "dataset_name": "commerce_c5i_synthetic_internal_smoke_merchant",
+  "purpose": "Synthetic internal smoke/dev merchant dataset only.",
+  "environment": "internal_smoke",
+  "data_classification": "synthetic_internal_smoke",
+  "synthetic_only": true,
+  "internal_only": true,
+  "resource_creation_allowed": false,
+  "production_approval": false,
+  "production_discovery_approval": false,
+  "production_config_value_allowed": false,
+  "commerce_public_discovery_allowlist_candidate": false,
+  "checkout_creation_allowed": false,
+  "payment_creation_allowed": false,
+  "checkout_payment_creation_allowed": false,
+  "live_payments_enabled": false,
+  "plural_live_enabled": false,
+  "agenticorg_public_discovery_approval": false,
+  "tenant": {
+    "id": "cten_synth_internal_smoke_0001",
+    "display_name": "Synthetic Internal Smoke Tenant",
+    "environment": "internal_smoke",
+    "status": "synthetic_internal_only"
+  },
+  "merchant": {
+    "id": "mch_synth_internal_smoke_0001",
+    "tenant_id": "cten_synth_internal_smoke_0001",
+    "display_name": "Synthetic Internal Smoke Merchant",
+    "public_name": "Synthetic Internal Smoke Merchant",
+    "category": "synthetic_test_goods",
+    "country_code": "ZZ",
+    "currency": "ZZZ",
+    "verification_status": "synthetic_internal_smoke_only",
+    "approval_status": "not_authorized_for_any_production_use",
+    "production_discovery_status": "not_authorized",
+    "certification_claim": "none",
+    "readiness_claim": "none",
+    "agentic_commerce_runtime_allowed": false,
+    "public_discovery_allowed": false
+  },
+  "agent": {
+    "id": "cag_synth_internal_smoke_sales_0001",
+    "tenant_id": "cten_synth_internal_smoke_0001",
+    "display_name": "Synthetic Internal Smoke Sales Agent",
+    "trust_status": "synthetic_internal_only",
+    "agenticorg_public_discovery_enabled": false
+  },
+  "provider": {
+    "provider_key": "mock",
+    "environment": "synthetic_mock",
+    "credential_material_included": false,
+    "provider_credentials_included": false,
+    "live_payments_enabled": false,
+    "plural_live_enabled": false,
+    "capabilities": [
+      "catalog.read.synthetic",
+      "inventory.read.synthetic",
+      "merchant.profile.read.synthetic"
+    ]
+  },
+  "public_discovery": {
+    "commerce_public_discovery_enabled": false,
+    "commerce_public_discovery_allowlist_candidate": false,
+    "agenticorg_public_discovery_enabled": false,
+    "checkout_payment_creation_enabled_by_discovery_gate": false,
+    "live_payments_enabled": false,
+    "live_plural_enabled": false,
+    "certification_claim": "none",
+    "readiness_claim": "none"
+  },
+  "smoke_flow_boundaries": {
+    "allowed_cases": [
+      "merchant_profile_read_synthetic",
+      "catalog_search_read_synthetic",
+      "catalog_get_item_read_synthetic",
+      "inventory_read_synthetic"
+    ],
+    "blocked_cases": [
+      "production_discovery",
+      "commerce_public_discovery_allowlist",
+      "agenticorg_public_discovery",
+      "checkout_create",
+      "payment_intent_create",
+      "live_payment",
+      "live_plural",
+      "provider_credential_use"
+    ]
+  },
+  "catalog": {
+    "currency": "ZZZ",
+    "source_system": "synthetic_internal_smoke_dataset",
+    "last_synced_at": "2026-05-26T00:00:00Z",
+    "products": [
+      {
+        "id": "cprd_synth_internal_smoke_widget_0001",
+        "title": "Synthetic Internal Smoke Countertop Widget",
+        "brand": "Synthetic Internal Smoke Brand",
+        "category": "synthetic_test_goods",
+        "price_minor_units": 101,
+        "currency": "ZZZ",
+        "availability_status": "synthetic_in_stock",
+        "source_system": "synthetic_internal_smoke_dataset",
+        "variants": [
+          {
+            "id": "cvar_synth_internal_smoke_widget_0001_a",
+            "sku": "SYNTH-SMOKE-WIDGET-0001-A",
+            "title": "Synthetic Internal Smoke Widget Variant A",
+            "price_minor_units": 101,
+            "availability_status": "synthetic_in_stock"
+          }
+        ]
+      },
+      {
+        "id": "cprd_synth_internal_smoke_fixture_0002",
+        "title": "Synthetic Internal Smoke Fixture",
+        "brand": "Synthetic Internal Smoke Brand",
+        "category": "synthetic_test_goods",
+        "price_minor_units": 202,
+        "currency": "ZZZ",
+        "availability_status": "synthetic_limited",
+        "source_system": "synthetic_internal_smoke_dataset",
+        "variants": [
+          {
+            "id": "cvar_synth_internal_smoke_fixture_0002_a",
+            "sku": "SYNTH-SMOKE-FIXTURE-0002-A",
+            "title": "Synthetic Internal Smoke Fixture Variant A",
+            "price_minor_units": 202,
+            "availability_status": "synthetic_limited"
+          }
+        ]
+      }
+    ]
+  },
+  "prohibited_uses": [
+    "production_discovery",
+    "production_merchant_approval",
+    "commerce_public_discovery_allowlist_value",
+    "production_config_value",
+    "checkout_creation",
+    "payment_creation",
+    "live_payments",
+    "live_plural",
+    "agenticorg_public_discovery",
+    "provider_credentials"
+  ]
+}

--- a/docs/guides/commerce-v1-c5i-synthetic-merchant-dataset.md
+++ b/docs/guides/commerce-v1-c5i-synthetic-merchant-dataset.md
@@ -1,0 +1,65 @@
+# Commerce V1 C5I Synthetic Merchant Dataset
+
+Status: implementation-only documentation and validation for internal smoke/dev flows. This does not deploy, create cloud resources, merge, change production config, enable production Commerce V1, enable checkout/payment creation, enable live payments, enable live Plural, touch secrets, or approve any real merchant.
+
+## Dataset
+
+The synthetic Grantex dataset lives at `docs/examples/commerce-c5i-synthetic-internal-merchant.dataset.json`.
+
+Use it only as a clearly fake, internal input for local smoke/dev validation where the flow needs stable merchant, agent, catalog, and provider-shape identifiers without using a real merchant. All IDs and display names contain synthetic/internal/smoke markers. Currency `ZZZ` and country `ZZ` are intentionally non-real production values.
+
+Pinned synthetic IDs:
+
+- Tenant: `cten_synth_internal_smoke_0001`
+- Merchant: `mch_synth_internal_smoke_0001`
+- Agent: `cag_synth_internal_smoke_sales_0001`
+- Provider: `mock`
+- Dataset version: `c5i-synth-v1`
+
+## Explicit Non-Approval
+
+This dataset does not approve or authorize:
+
+- Production discovery.
+- `COMMERCE_PUBLIC_DISCOVERY_ENABLED`.
+- `COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST`.
+- Any production config value.
+- Checkout creation.
+- Payment intent creation.
+- Live payments.
+- Live Plural.
+- AgenticOrg commerce public discovery.
+- A real production merchant.
+
+The synthetic merchant ID must not be copied into a production allowlist or used as evidence that a merchant is ready for public discovery. Certification and readiness claims remain `none`.
+
+## Smoke Scope
+
+Allowed internal smoke/dev cases are read-only and synthetic:
+
+- Merchant profile read.
+- Catalog search read.
+- Catalog item read.
+- Inventory read.
+
+Blocked cases remain blocked:
+
+- Checkout creation.
+- Payment creation.
+- Provider credential handling.
+- Live payment rails.
+- Public discovery enablement.
+
+## Validation
+
+Run the focused validator after changing the dataset or this guide:
+
+```powershell
+node scripts/commerce-c5i-synthetic-dataset-validate.mjs
+```
+
+The validator rejects production-looking merchant IDs, realistic merchant names, secret-like values, provider credential material, live-payment claims, and certification/readiness overclaims.
+
+## Gate Posture
+
+Grantex read-only public discovery remains fail-closed for production. This dataset does not change `COMMERCE_PUBLIC_DISCOVERY_ENABLED`, does not set `COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST`, and does not alter checkout, payment, live payment, or live Plural gates.

--- a/scripts/commerce-c5i-synthetic-dataset-validate.mjs
+++ b/scripts/commerce-c5i-synthetic-dataset-validate.mjs
@@ -1,0 +1,303 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, '..');
+const datasetPath = join(repoRoot, 'docs', 'examples', 'commerce-c5i-synthetic-internal-merchant.dataset.json');
+const guidePath = join(repoRoot, 'docs', 'guides', 'commerce-v1-c5i-synthetic-merchant-dataset.md');
+const publicDiscoveryPath = join(repoRoot, 'apps', 'auth-service', 'src', 'lib', 'commerce', 'public-discovery.ts');
+const wellKnownPath = join(repoRoot, 'apps', 'auth-service', 'src', 'routes', 'commerce-well-known.ts');
+
+const joinText = (...parts) => parts.join('');
+
+const safeFalseCredentialKeys = new Set([
+  'credential_material_included',
+  'provider_credentials_included',
+]);
+
+const falseOnlyKeys = new Set([
+  'agentic_commerce_runtime_allowed',
+  'agenticorg_public_discovery_approval',
+  'agenticorg_public_discovery_enabled',
+  'checkout_creation_allowed',
+  'checkout_payment_creation_allowed',
+  'checkout_payment_creation_enabled_by_discovery_gate',
+  'commerce_public_discovery_allowlist_candidate',
+  'commerce_public_discovery_enabled',
+  'live_payment_enabled',
+  'live_payments_enabled',
+  'live_plural_enabled',
+  'payment_creation_allowed',
+  'plural_live_enabled',
+  'production_approval',
+  'production_config_value_allowed',
+  'production_discovery_approval',
+  'public_discovery_allowed',
+  'resource_creation_allowed',
+]);
+
+const secretKeyFragments = [
+  'api_key',
+  'bearer',
+  'client_secret',
+  'credential_payload',
+  'credential_ref',
+  'password',
+  'private_key',
+  'secret',
+  'token',
+  'webhook_secret',
+];
+
+const secretValuePatterns = [
+  new RegExp(joinText('Bearer', '\\s+[A-Za-z0-9._-]{8,}')),
+  new RegExp(joinText('sk', '_live_'), 'i'),
+  new RegExp(joinText('pk', '_live_'), 'i'),
+  new RegExp(joinText('grtx', '_live_'), 'i'),
+  new RegExp(joinText('-----', 'BEGIN'), 'i'),
+  new RegExp(joinText('passport', '\\.jwt'), 'i'),
+  new RegExp(joinText('idempotency', '-key:'), 'i'),
+  new RegExp(joinText('mock', '-webhook', '-secret'), 'i'),
+  /postgres:\/\//i,
+  /redis:\/\//i,
+];
+
+const overclaimPatterns = [
+  new RegExp(joinText('approved for ', 'production'), 'i'),
+  new RegExp(joinText('certification ', 'complete'), 'i'),
+  new RegExp(joinText('certified ', 'merchant'), 'i'),
+  new RegExp(joinText('checkout creation ', 'enabled'), 'i'),
+  new RegExp(joinText('live payments ', 'enabled'), 'i'),
+  new RegExp(joinText('live plural ', 'enabled'), 'i'),
+  new RegExp(joinText('payment creation ', 'enabled'), 'i'),
+  new RegExp(joinText('production ', 'approved'), 'i'),
+  new RegExp(joinText('production ', 'ready'), 'i'),
+  new RegExp(joinText('public discovery ', 'enabled'), 'i'),
+  new RegExp(joinText('ready for ', 'production'), 'i'),
+];
+
+const realisticMerchantNamePatterns = [
+  /\bamazon\b/i,
+  /\bapple\b/i,
+  /\bcroma\b/i,
+  /\bflipkart\b/i,
+  /\breliance\b/i,
+  /\bsamsung\b/i,
+  /\btata\b/i,
+  /\bvijay sales\b/i,
+  /\bpinelabs\b/i,
+  /\bplural\b/i,
+];
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function fail(errors, path, message) {
+  errors.push(`${path}: ${message}`);
+}
+
+function assertSyntheticId(value, path, prefix, errors) {
+  if (typeof value !== 'string') {
+    fail(errors, path, 'must be a string');
+    return;
+  }
+  if (!value.startsWith(prefix)) {
+    fail(errors, path, `must start with ${prefix}`);
+  }
+  if (!/synth/.test(value) || !/internal/.test(value) || !/smoke/.test(value)) {
+    fail(errors, path, 'must include synth, internal, and smoke markers');
+  }
+  if (/\b(prod|production|live|real|public)\b/i.test(value.replace(/_/g, ' '))) {
+    fail(errors, path, 'must not contain production/live/real/public markers');
+  }
+}
+
+function assertSyntheticName(value, path, errors) {
+  if (typeof value !== 'string') {
+    fail(errors, path, 'must be a string');
+    return;
+  }
+  const lowered = value.toLowerCase();
+  if (!lowered.includes('synthetic') || (!lowered.includes('internal') && !lowered.includes('smoke'))) {
+    fail(errors, path, 'must be visibly synthetic/internal/smoke');
+  }
+  for (const pattern of realisticMerchantNamePatterns) {
+    if (pattern.test(value)) {
+      fail(errors, path, 'must not use a real or realistic merchant/brand name');
+    }
+  }
+}
+
+function inspectValue(value, path, errors) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => inspectValue(item, `${path}[${index}]`, errors));
+    return;
+  }
+
+  if (value && typeof value === 'object') {
+    for (const [key, nested] of Object.entries(value)) {
+      const nestedPath = `${path}.${key}`;
+      const lowered = key.toLowerCase();
+      if (safeFalseCredentialKeys.has(lowered)) {
+        if (nested !== false) fail(errors, nestedPath, 'credential inclusion flags must be false');
+      } else if (secretKeyFragments.some((fragment) => lowered.includes(fragment))) {
+        fail(errors, nestedPath, 'secret or provider credential keys are not allowed');
+      }
+      if (falseOnlyKeys.has(lowered) && nested !== false) {
+        fail(errors, nestedPath, 'must be false');
+      }
+      inspectValue(nested, nestedPath, errors);
+    }
+    return;
+  }
+
+  if (typeof value !== 'string') return;
+  for (const pattern of secretValuePatterns) {
+    if (pattern.test(value)) fail(errors, path, 'contains secret-like material');
+  }
+  for (const pattern of overclaimPatterns) {
+    if (pattern.test(value)) fail(errors, path, 'contains a production/live/readiness overclaim');
+  }
+}
+
+function validateDataset(dataset) {
+  const errors = [];
+
+  assert.equal(dataset.dataset_version, 'c5i-synth-v1');
+  assert.equal(dataset.synthetic_only, true);
+  assert.equal(dataset.internal_only, true);
+  assert.equal(dataset.provider?.provider_key, 'mock');
+  assert.equal(dataset.merchant?.certification_claim, 'none');
+  assert.equal(dataset.merchant?.readiness_claim, 'none');
+  assert.equal(dataset.public_discovery?.certification_claim, 'none');
+  assert.equal(dataset.public_discovery?.readiness_claim, 'none');
+
+  assertSyntheticId(dataset.tenant?.id, 'tenant.id', 'cten_synth_internal_smoke_', errors);
+  assertSyntheticId(dataset.merchant?.id, 'merchant.id', 'mch_synth_internal_smoke_', errors);
+  assertSyntheticId(dataset.merchant?.tenant_id, 'merchant.tenant_id', 'cten_synth_internal_smoke_', errors);
+  assertSyntheticId(dataset.agent?.id, 'agent.id', 'cag_synth_internal_smoke_', errors);
+  assertSyntheticName(dataset.tenant?.display_name, 'tenant.display_name', errors);
+  assertSyntheticName(dataset.merchant?.display_name, 'merchant.display_name', errors);
+  assertSyntheticName(dataset.merchant?.public_name, 'merchant.public_name', errors);
+  assertSyntheticName(dataset.agent?.display_name, 'agent.display_name', errors);
+
+  const products = dataset.catalog?.products;
+  if (!Array.isArray(products) || products.length < 2) {
+    fail(errors, 'catalog.products', 'must include at least two synthetic products');
+  } else {
+    products.forEach((product, productIndex) => {
+      assertSyntheticId(product.id, `catalog.products[${productIndex}].id`, 'cprd_synth_internal_smoke_', errors);
+      assertSyntheticName(product.title, `catalog.products[${productIndex}].title`, errors);
+      assertSyntheticName(product.brand, `catalog.products[${productIndex}].brand`, errors);
+      for (const [variantIndex, variant] of (product.variants ?? []).entries()) {
+        assertSyntheticId(
+          variant.id,
+          `catalog.products[${productIndex}].variants[${variantIndex}].id`,
+          'cvar_synth_internal_smoke_',
+          errors,
+        );
+        assertSyntheticName(variant.title, `catalog.products[${productIndex}].variants[${variantIndex}].title`, errors);
+      }
+    });
+  }
+
+  inspectValue(dataset, 'dataset', errors);
+
+  if (errors.length > 0) {
+    throw new Error(`C5I synthetic dataset validation failed:\n${errors.join('\n')}`);
+  }
+}
+
+function assertGuideAndGateText() {
+  const guide = readFileSync(guidePath, 'utf8');
+  const publicDiscovery = readFileSync(publicDiscoveryPath, 'utf8');
+  const wellKnown = readFileSync(wellKnownPath, 'utf8');
+
+  for (const required of [
+    'does not deploy',
+    'does not approve or authorize',
+    'Production discovery',
+    'COMMERCE_PUBLIC_DISCOVERY_ENABLED',
+    'COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST',
+    'Any production config value',
+    'Checkout creation',
+    'Payment intent creation',
+    'Live payments',
+    'Live Plural',
+    'AgenticOrg commerce public discovery',
+    'Certification and readiness claims remain `none`',
+  ]) {
+    assert.ok(guide.includes(required), `guide documents ${required}`);
+  }
+
+  for (const forbidden of [
+    joinText('COMMERCE_PUBLIC_DISCOVERY_ENABLED', '=true'),
+    joinText('COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST', '=mch_'),
+    joinText('COMMERCE_LIVE_MODE_ENABLED', '=true'),
+    joinText('PLURAL_LIVE_ENABLED', '=true'),
+    joinText('Bearer', ' '),
+    joinText('sk', '_live_'),
+    joinText('pk', '_live_'),
+    joinText('-----', 'BEGIN'),
+  ]) {
+    assert.equal(guide.includes(forbidden), false, `guide does not include ${forbidden}`);
+  }
+
+  assert.ok(publicDiscovery.includes('return isExplicitSafeTrue'), 'public discovery remains explicit safe true only');
+  assert.ok(wellKnown.includes('commerce_public_discovery_allowlist_required'), 'well-known requires allowlist');
+  assert.ok(
+    wellKnown.includes('checkout_payment_creation_enabled_by_discovery_gate: false'),
+    'well-known discovery gate does not enable checkout or payment creation',
+  );
+  assert.ok(
+    wellKnown.includes('commerce_public_discovery_live_flags_forbidden'),
+    'well-known discovery gate refuses live flags',
+  );
+}
+
+function assertRejects(baseDataset, label, mutate) {
+  const candidate = clone(baseDataset);
+  mutate(candidate);
+  assert.throws(
+    () => validateDataset(candidate),
+    /C5I synthetic dataset validation failed|AssertionError/,
+    `rejects ${label}`,
+  );
+}
+
+const datasetText = readFileSync(datasetPath, 'utf8');
+assert.equal(/[^\u0000-\u007F]/.test(datasetText), false, 'dataset stays ASCII-only');
+const dataset = JSON.parse(datasetText);
+
+validateDataset(dataset);
+assertGuideAndGateText();
+
+assertRejects(dataset, 'production-looking merchant ID', (candidate) => {
+  candidate.merchant.id = joinText('mch_pr', 'od', '_ready_merchant_001');
+});
+assertRejects(dataset, 'realistic merchant name', (candidate) => {
+  candidate.merchant.display_name = 'Acme Retail Private Limited';
+});
+assertRejects(dataset, 'secret-like value', (candidate) => {
+  candidate.provider.note = joinText('Bearer', ' fixture-token-value');
+});
+assertRejects(dataset, 'provider credential key', (candidate) => {
+  candidate.provider.credential_payload = { value: 'synthetic' };
+});
+assertRejects(dataset, 'live payment flag', (candidate) => {
+  candidate.provider.live_payments_enabled = true;
+});
+assertRejects(dataset, 'live payment claim', (candidate) => {
+  candidate.purpose = joinText('Synthetic dataset with live payments', ' enabled');
+});
+assertRejects(dataset, 'certification overclaim', (candidate) => {
+  candidate.merchant.certification_claim = joinText('certified', ' merchant');
+});
+assertRejects(dataset, 'readiness overclaim', (candidate) => {
+  candidate.merchant.readiness_claim = joinText('production', ' ready');
+});
+
+console.log('commerce C5I synthetic dataset validation passed');


### PR DESCRIPTION
## Summary

Adds a clearly synthetic C5I internal/smoke-only merchant dataset for Grantex Commerce V1 smoke/dev flows.

## Safety Boundaries

- Does not deploy, merge, create cloud resources, change production config, touch secrets, or approve a real merchant.
- Does not enable production Commerce V1, `COMMERCE_PUBLIC_DISCOVERY_ENABLED`, or `COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST`.
- Does not enable checkout/payment creation, live payments, live Plural, or AgenticOrg public discovery.
- Preserves the existing Grantex read-only public discovery fail-closed posture.

## Validation

- `node scripts/commerce-c5i-synthetic-dataset-validate.mjs`
- focused secret-value scan on changed files
- focused overclaim scan on dataset/docs
- synthetic/placeholder safety scan on changed files
- `git diff --check`