### PR TITLE
[codex] Fix mentions dashboard workflow

### DIFF
--- a/.github/workflows/monitor-mentions.yml
+++ b/.github/workflows/monitor-mentions.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 9 * * *' # Daily at 9am UTC
   workflow_dispatch:
 
+concurrency:
+  group: monitor-mentions
+  cancel-in-progress: true
+
 permissions:
   issues: write
   contents: read
@@ -17,47 +21,70 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Monitor GitHub mentions
+      - name: Build mentions and metrics dashboard
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "## GitHub Mentions Report — $(date -u +%Y-%m-%d)" > report.md
+          set -euo pipefail
+
+          tmp_dir="$(mktemp -d)"
+          trap 'rm -rf "$tmp_dir"' EXIT
+
+          append_section() {
+            local title="$1"
+            local empty_message="$2"
+            local source_file="$3"
+
+            echo "### ${title}" >> report.md
+            if [ -s "$source_file" ]; then
+              cat "$source_file" >> report.md
+            else
+              echo "- ${empty_message}" >> report.md
+            fi
+            echo "" >> report.md
+          }
+
+          echo "## GitHub Mentions Report - $(date -u +%Y-%m-%d)" > report.md
+          echo "" >> report.md
+          echo "_Updated by the Monitor Mentions workflow. The issue body is replaced on each run so the dashboard stays readable._" >> report.md
           echo "" >> report.md
 
-          # Search GitHub issues/PRs/discussions mentioning grantex (exclude our own repo)
-          echo "### GitHub Code & Issues" >> report.md
+          # Search GitHub issues/PRs/discussions mentioning grantex (exclude our own repo).
           gh api -X GET "search/issues?q=grantex+NOT+repo:mishrasanjeev/grantex&sort=created&order=desc&per_page=10" \
-            --jq '.items[] | "- [\(.title)](\(.html_url)) — \(.repository_url | split("/") | .[-2:] | join("/")) — \(.created_at | split("T")[0])"' >> report.md 2>/dev/null || echo "- No new mentions found" >> report.md
-          echo "" >> report.md
+            --jq '.items[] | "- [\(.title)](\(.html_url)) - \(.repository_url | split("/") | .[-2:] | join("/")) - \(.created_at | split("T")[0])"' \
+            > "$tmp_dir/issues.md" 2>/dev/null || true
+          append_section "GitHub Code & Issues" "No new mentions found" "$tmp_dir/issues.md"
 
-          # Search GitHub repos mentioning grantex
-          echo "### GitHub Repositories" >> report.md
+          # Search GitHub repos mentioning grantex.
           gh api -X GET "search/repositories?q=grantex+NOT+user:mishrasanjeev&sort=updated&order=desc&per_page=10" \
-            --jq '.items[] | "- [\(.full_name)](\(.html_url)) — \(.description // "No description") — \(.stargazers_count) stars"' >> report.md 2>/dev/null || echo "- No new repos found" >> report.md
-          echo "" >> report.md
+            --jq '.items[] | "- [\(.full_name)](\(.html_url)) - \(.description // "No description") - \(.stargazers_count) stars"' \
+            > "$tmp_dir/repositories.md" 2>/dev/null || true
+          append_section "GitHub Repositories" "No new repos found" "$tmp_dir/repositories.md"
 
-          # Search GitHub code references
-          echo "### GitHub Code References" >> report.md
+          # Search GitHub code references.
           gh api -X GET "search/code?q=grantex+NOT+repo:mishrasanjeev/grantex&sort=indexed&order=desc&per_page=10" \
-            --jq '.items[] | "- [\(.repository.full_name)/\(.name)](\(.html_url))"' >> report.md 2>/dev/null || echo "- No code references found" >> report.md
-          echo "" >> report.md
-
-          cat report.md
+            --jq '.items[] | "- [\(.repository.full_name)/\(.name)](\(.html_url))"' \
+            > "$tmp_dir/code.md" 2>/dev/null || true
+          append_section "GitHub Code References" "No code references found" "$tmp_dir/code.md"
 
       - name: Check npm download trends
         run: |
+          set -euo pipefail
+
           echo "### npm Downloads (last 7 days)" >> report.md
           for pkg in "@grantex/sdk" "@grantex/cli" "@grantex/langchain" "@grantex/express" "@grantex/mcp" "@grantex/vercel-ai" "@grantex/gateway" "@grantex/conformance" "@grantex/a2a"; do
-            DOWNLOADS=$(curl -s "https://api.npmjs.org/downloads/point/last-week/${pkg}" | jq -r '.downloads // 0')
+            DOWNLOADS=$(curl -fsS "https://api.npmjs.org/downloads/point/last-week/${pkg}" 2>/dev/null | jq -r '.downloads // 0' 2>/dev/null || echo "unavailable")
             echo "- \`${pkg}\`: ${DOWNLOADS} downloads" >> report.md
           done
           echo "" >> report.md
 
       - name: Check PyPI download trends
         run: |
+          set -euo pipefail
+
           echo "### PyPI Downloads (recent)" >> report.md
           for pkg in "grantex" "grantex-crewai" "grantex-openai-agents" "grantex-adk" "grantex-fastapi" "grantex-a2a"; do
-            VERSION=$(curl -s "https://pypi.org/pypi/${pkg}/json" 2>/dev/null | jq -r '.info.version // "not found"')
+            VERSION=$(curl -fsS "https://pypi.org/pypi/${pkg}/json" 2>/dev/null | jq -r '.info.version // "not found"' 2>/dev/null || echo "unavailable")
             echo "- \`${pkg}\`: latest v${VERSION}" >> report.md
           done
           echo "" >> report.md
@@ -66,10 +93,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+
           echo "### Repository Stats" >> report.md
-          STARS=$(gh api repos/mishrasanjeev/grantex --jq '.stargazers_count')
-          FORKS=$(gh api repos/mishrasanjeev/grantex --jq '.forks_count')
-          WATCHERS=$(gh api repos/mishrasanjeev/grantex --jq '.subscribers_count')
+          STATS=$(gh api repos/mishrasanjeev/grantex --jq '[.stargazers_count, .forks_count, .subscribers_count] | @tsv' 2>/dev/null || echo "unavailable unavailable unavailable")
+          STATS=${STATS:-"unavailable unavailable unavailable"}
+          read -r STARS FORKS WATCHERS <<< "$STATS"
           echo "- Stars: ${STARS}" >> report.md
           echo "- Forks: ${FORKS}" >> report.md
           echo "- Watchers: ${WATCHERS}" >> report.md
@@ -77,33 +106,42 @@ jobs:
 
       - name: Search web mentions
         run: |
+          set -euo pipefail
+
           echo "### Web Mentions (search hits)" >> report.md
-          # Check common sites for mentions
+          # Best-effort checks for common sites where Grantex may be discussed.
           for site in "reddit.com" "news.ycombinator.com" "dev.to" "medium.com" "stackoverflow.com"; do
-            COUNT=$(curl -s "https://www.google.com/search?q=site:${site}+grantex+agent+authorization" -A "Mozilla/5.0" 2>/dev/null | grep -c "grantex" || echo "0")
+            COUNT=$(curl -fsSL "https://www.google.com/search?q=site:${site}+grantex+agent+authorization" -A "Mozilla/5.0" 2>/dev/null | grep -oi "grantex" | wc -l | tr -d '[:space:]' || true)
+            COUNT=${COUNT:-0}
             echo "- ${site}: ~${COUNT} mention signals" >> report.md
           done
           echo "" >> report.md
+
+      - name: Publish dashboard to job summary
+        run: cat report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create or update monitoring issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          REPORT=$(cat report.md)
-          DATE=$(date -u +%Y-%m-%d)
+          set -euo pipefail
 
-          # Check if a monitoring issue already exists
-          ISSUE_NUMBER=$(gh issue list --label "monitoring" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          # Find the dashboard issue precisely so another monitoring issue is not updated accidentally.
+          ISSUE_NUMBER=$(gh issue list \
+            --label "monitoring" \
+            --state open \
+            --search "Mentions & Metrics Dashboard in:title" \
+            --json number,title \
+            --jq '.[] | select(.title == "Mentions & Metrics Dashboard") | .number' \
+            2>/dev/null | head -n 1 || true)
 
           if [ -n "$ISSUE_NUMBER" ]; then
-            # Add as a comment to existing issue
-            gh issue comment "$ISSUE_NUMBER" --body "$REPORT"
+            gh issue edit "$ISSUE_NUMBER" --body-file report.md
             echo "Updated issue #${ISSUE_NUMBER}"
           else
-            # Create new issue
             gh issue create \
               --title "Mentions & Metrics Dashboard" \
               --label "monitoring" \
-              --body "$REPORT"
+              --body-file report.md
             echo "Created new monitoring issue"
           fi


### PR DESCRIPTION
Refs #452

## Summary
- Change the mentions dashboard workflow to update the monitoring issue body instead of appending a new comment on every run.
- Match the dashboard issue by title and label so another monitoring issue is not updated accidentally.
- Add concurrency, stable empty-section output, ASCII-safe report separators, and best-effort fallbacks for npm, PyPI, GitHub stats, and web mention lookups.
- Publish the generated dashboard to the GitHub Actions job summary for easier run inspection.

## Validation
- `git diff --check`
- `rg -n "[^\\x00-\\x7F]" .github\\workflows\\monitor-mentions.yml` returned no matches

#452 is a persistent monitoring dashboard issue, so this PR references it without auto-closing it.