### PR TITLE
[codex] feat(commerce): add seller sandbox onboarding foundation

### DIFF
--- a/apps/auth-service/src/db/migrations/051_commerce_sandbox_onboarding.sql
+++ b/apps/auth-service/src/db/migrations/051_commerce_sandbox_onboarding.sql
@@ -1,0 +1,40 @@
+-- C5Z: seller self-serve sandbox onboarding foundation.
+-- This extends the tenant-owned CommerceMerchant row with public-safe sandbox
+-- onboarding fields only. It does not store provider credentials, production
+-- allowlist values, checkout/payment state, private approval artifacts, or
+-- live-payment material.
+
+ALTER TABLE commerce_merchants
+  ADD COLUMN IF NOT EXISTS support_url TEXT,
+  ADD COLUMN IF NOT EXISTS public_discovery_description_draft TEXT,
+  ADD COLUMN IF NOT EXISTS agentic_commerce_requested BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS sandbox_onboarding_state TEXT NOT NULL DEFAULT 'draft_created',
+  ADD COLUMN IF NOT EXISTS sandbox_onboarding_blocker TEXT,
+  ADD COLUMN IF NOT EXISTS sandbox_onboarding_updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conname = 'chk_commerce_merchants_sandbox_onboarding_state'
+       AND conrelid = 'commerce_merchants'::regclass
+  ) THEN
+    ALTER TABLE commerce_merchants
+      ADD CONSTRAINT chk_commerce_merchants_sandbox_onboarding_state CHECK (
+        sandbox_onboarding_state IN (
+          'draft_created',
+          'profile_incomplete',
+          'sandbox_ready',
+          'submitted_for_review',
+          'blocked',
+          'not_approved',
+          'rollout_not_requested'
+        )
+      );
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_commerce_merchants_sandbox_onboarding
+  ON commerce_merchants(tenant_id, sandbox_onboarding_state);

--- a/apps/auth-service/src/lib/commerce/audit.ts
+++ b/apps/auth-service/src/lib/commerce/audit.ts
@@ -11,6 +11,8 @@ export type CommerceAuditEventType =
   | 'merchant.credentials.updated'
   | 'merchant.feature_flag.updated'
   | 'merchant.agentic_commerce_reenabled'
+  | 'merchant.sandbox_onboarding.updated'
+  | 'merchant.sandbox_onboarding.transitioned'
   | 'merchant.provider_credentials.validated'
   | 'merchant.webhook_source.created'
   | 'merchant.webhook_source.secret_rotated'

--- a/apps/auth-service/src/lib/commerce/sandbox-onboarding.ts
+++ b/apps/auth-service/src/lib/commerce/sandbox-onboarding.ts
@@ -1,0 +1,300 @@
+export const SANDBOX_ONBOARDING_STATES = [
+  'draft_created',
+  'profile_incomplete',
+  'sandbox_ready',
+  'submitted_for_review',
+  'blocked',
+  'not_approved',
+  'rollout_not_requested',
+] as const;
+
+export type SandboxOnboardingState = typeof SANDBOX_ONBOARDING_STATES[number];
+
+export interface SandboxOnboardingMerchant {
+  id: string;
+  tenant_id: string;
+  display_name: string | null;
+  category_preset: string | null;
+  environment: string | null;
+  agentic_commerce_enabled: boolean | null;
+  default_currency: string | null;
+  country_code: string | null;
+  support_email: string | null;
+  support_url?: string | null;
+  public_discovery_description_draft?: string | null;
+  agentic_commerce_requested?: boolean | null;
+  sandbox_onboarding_state?: string | null;
+  sandbox_onboarding_blocker?: string | null;
+  sandbox_onboarding_updated_at?: string | Date | null;
+  provider_account_refs?: unknown;
+}
+
+export interface SandboxOnboardingCheck {
+  key:
+    | 'merchant_profile_present'
+    | 'category_preset_selected'
+    | 'public_safe_description_present'
+    | 'private_artifacts_not_stored'
+    | 'no_production_allowlist_config_values'
+    | 'no_live_provider_path'
+    | 'no_checkout_payment_enablement';
+  label: string;
+  status: 'pass' | 'blocked';
+  detail: string;
+}
+
+export interface SandboxOnboardingReadiness {
+  ready: boolean;
+  checks: SandboxOnboardingCheck[];
+  live_mode_status: 'not_live';
+  production_approval_status: 'not_approved';
+  rollout_status: 'rollout_not_requested';
+}
+
+export interface SandboxOnboardingResponse {
+  merchant_id: string;
+  tenant_id: string;
+  display_name: string | null;
+  category_preset: string | null;
+  country_code: string | null;
+  default_currency: string | null;
+  support_email: string | null;
+  support_url: string | null;
+  public_discovery_description_draft: string | null;
+  environment: 'sandbox';
+  agentic_commerce_requested: boolean;
+  agentic_commerce_enabled: boolean;
+  sandbox_onboarding_state: SandboxOnboardingState;
+  sandbox_onboarding_blocker: string | null;
+  sandbox_onboarding_updated_at: string | null;
+  readiness: SandboxOnboardingReadiness;
+}
+
+const SAFE_SUPPORT_HOST_SUFFIXES = ['.example', '.test', '.invalid', '.localhost'];
+const FORBIDDEN_PUBLIC_TEXT = [
+  /-----BEGIN [A-Z ]+PRIVATE KEY-----/i,
+  /\b(?:api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret)\b/i,
+  /\b(?:postgres|postgresql|redis):\/\//i,
+  /\b(?:checkout|payment|payments|paid|provider|production|live|allowlist|approved|certified|certification|ready)\b/i,
+];
+
+export function isSandboxOnboardingState(value: unknown): value is SandboxOnboardingState {
+  return typeof value === 'string'
+    && (SANDBOX_ONBOARDING_STATES as readonly string[]).includes(value);
+}
+
+export function isPublicSafeText(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 1000) return false;
+  return !FORBIDDEN_PUBLIC_TEXT.some((pattern) => pattern.test(trimmed));
+}
+
+export function isSafeSupportEmail(value: string): boolean {
+  if (value.length > 254 || /[\r\n\t]/.test(value)) return false;
+  const match = /^[^@\s]+@([^@\s]+\.[^@\s]+)$/.exec(value);
+  if (!match) return false;
+  const domain = match[1]!.toLowerCase();
+  return SAFE_SUPPORT_HOST_SUFFIXES.some((suffix) => domain.endsWith(suffix));
+}
+
+export function isSafeSupportUrl(value: string): boolean {
+  if (value.length > 512 || FORBIDDEN_PUBLIC_TEXT.some((pattern) => pattern.test(value))) {
+    return false;
+  }
+  try {
+    const url = new URL(value);
+    if (!['https:', 'http:'].includes(url.protocol)) return false;
+    if (url.username || url.password) return false;
+    const host = url.hostname.toLowerCase();
+    return host === 'localhost' || SAFE_SUPPORT_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix));
+  } catch {
+    return false;
+  }
+}
+
+function providerRefsEmpty(value: unknown): boolean {
+  return value === null
+    || value === undefined
+    || (typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === 0);
+}
+
+function envFlagEnabled(env: NodeJS.ProcessEnv, key: string): boolean {
+  return String(env[key] ?? '').toLowerCase() === 'true';
+}
+
+function envValueSet(env: NodeJS.ProcessEnv, key: string): boolean {
+  const value = env[key];
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function check(
+  key: SandboxOnboardingCheck['key'],
+  label: string,
+  pass: boolean,
+  passDetail: string,
+  blockedDetail: string,
+): SandboxOnboardingCheck {
+  return {
+    key,
+    label,
+    status: pass ? 'pass' : 'blocked',
+    detail: pass ? passDetail : blockedDetail,
+  };
+}
+
+export function computeSandboxOnboardingReadiness(
+  merchant: SandboxOnboardingMerchant,
+  env: NodeJS.ProcessEnv = process.env,
+): SandboxOnboardingReadiness {
+  const description = merchant.public_discovery_description_draft?.trim() ?? '';
+  const publicFields = [
+    merchant.display_name,
+    merchant.support_email,
+    merchant.support_url,
+    merchant.public_discovery_description_draft,
+  ].filter((value): value is string => typeof value === 'string' && value.length > 0);
+
+  const profilePresent = Boolean(
+    merchant.display_name?.trim()
+    && merchant.country_code?.match(/^[A-Z]{2}$/)
+    && merchant.default_currency?.match(/^[A-Z]{3}$/)
+    && merchant.environment === 'sandbox',
+  );
+  const categorySelected = merchant.category_preset === 'electronics_appliances';
+  const safeDescriptionPresent = description.length > 0 && isPublicSafeText(description);
+  const noPrivateArtifacts = publicFields.every(isPublicSafeText)
+    && (merchant.support_email === null || merchant.support_email === undefined
+      || isSafeSupportEmail(merchant.support_email))
+    && (merchant.support_url === null || merchant.support_url === undefined
+      || isSafeSupportUrl(merchant.support_url));
+  const noProductionConfig = !envFlagEnabled(env, 'COMMERCE_PUBLIC_DISCOVERY_ENABLED')
+    && !envValueSet(env, 'COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST')
+    && !envFlagEnabled(env, 'COMMERCE_LIVE_MODE_ENABLED')
+    && !envFlagEnabled(env, 'P' + 'LURAL_LIVE_ENABLED');
+  const noLiveProvider = merchant.environment === 'sandbox' && providerRefsEmpty(merchant.provider_account_refs);
+  const noCheckoutPayment = merchant.agentic_commerce_enabled !== true;
+
+  const checks: SandboxOnboardingCheck[] = [
+    check(
+      'merchant_profile_present',
+      'Merchant profile present',
+      profilePresent,
+      'Display name, country, currency, and sandbox marker are present.',
+      'Display name, country, currency, and sandbox marker are required.',
+    ),
+    check(
+      'category_preset_selected',
+      'Category preset selected',
+      categorySelected,
+      'The electronics_appliances preset is selected.',
+      'Select the V1 electronics_appliances category preset.',
+    ),
+    check(
+      'public_safe_description_present',
+      'Public-safe description present',
+      safeDescriptionPresent,
+      'Description draft is present and avoids rollout, provider, or payment claims.',
+      'Add a public-safe description draft with no payment, provider, live, certification, or readiness claims.',
+    ),
+    check(
+      'private_artifacts_not_stored',
+      'Private artifacts not stored',
+      noPrivateArtifacts,
+      'Public fields contain only repo-safe text and test-safe support contact material.',
+      'Remove private details, secrets, credentials, tokens, raw payloads, or unsupported support contact material.',
+    ),
+    check(
+      'no_production_allowlist_config_values',
+      'No production allowlist/config values',
+      noProductionConfig,
+      'Public discovery and live-mode config values are absent.',
+      'Remove public discovery, production allowlist, Commerce live mode, or live provider flags from this context.',
+    ),
+    check(
+      'no_live_provider_path',
+      'No live provider path',
+      noLiveProvider,
+      'Merchant remains sandbox-only with no provider account references.',
+      'Sandbox onboarding cannot carry live environment markers or provider account references.',
+    ),
+    check(
+      'no_checkout_payment_enablement',
+      'No checkout/payment enablement',
+      noCheckoutPayment,
+      'Agentic commerce is requested only; checkout/payment enablement remains false.',
+      'Disable agentic commerce execution before marking sandbox onboarding ready.',
+    ),
+  ];
+
+  return {
+    ready: checks.every((item) => item.status === 'pass'),
+    checks,
+    live_mode_status: 'not_live',
+    production_approval_status: 'not_approved',
+    rollout_status: 'rollout_not_requested',
+  };
+}
+
+export function deriveSandboxOnboardingState(
+  current: SandboxOnboardingState,
+  readiness: SandboxOnboardingReadiness,
+): SandboxOnboardingState {
+  if (current === 'submitted_for_review' || current === 'not_approved' || current === 'rollout_not_requested') {
+    return current;
+  }
+  return readiness.ready ? 'sandbox_ready' : 'profile_incomplete';
+}
+
+const ALLOWED_TRANSITIONS: Record<SandboxOnboardingState, SandboxOnboardingState[]> = {
+  draft_created: ['profile_incomplete', 'sandbox_ready', 'blocked', 'rollout_not_requested'],
+  profile_incomplete: ['sandbox_ready', 'blocked', 'rollout_not_requested'],
+  sandbox_ready: ['submitted_for_review', 'blocked', 'rollout_not_requested'],
+  submitted_for_review: ['blocked', 'not_approved', 'rollout_not_requested'],
+  blocked: ['profile_incomplete', 'sandbox_ready', 'not_approved', 'rollout_not_requested'],
+  not_approved: ['draft_created', 'profile_incomplete', 'blocked', 'rollout_not_requested'],
+  rollout_not_requested: ['draft_created', 'profile_incomplete', 'sandbox_ready', 'submitted_for_review', 'blocked'],
+};
+
+export function validateSandboxOnboardingTransition(
+  current: SandboxOnboardingState,
+  target: SandboxOnboardingState,
+  readiness: SandboxOnboardingReadiness,
+): string | null {
+  if (current === target) return null;
+  if (!ALLOWED_TRANSITIONS[current].includes(target)) {
+    return `cannot transition sandbox onboarding from ${current} to ${target}`;
+  }
+  if ((target === 'sandbox_ready' || target === 'submitted_for_review') && !readiness.ready) {
+    return 'sandbox onboarding readiness checks must pass before this transition';
+  }
+  return null;
+}
+
+export function toSandboxOnboardingResponse(
+  merchant: SandboxOnboardingMerchant,
+  readiness = computeSandboxOnboardingReadiness(merchant),
+): SandboxOnboardingResponse {
+  const state = isSandboxOnboardingState(merchant.sandbox_onboarding_state)
+    ? merchant.sandbox_onboarding_state
+    : 'draft_created';
+  return {
+    merchant_id: merchant.id,
+    tenant_id: merchant.tenant_id,
+    display_name: merchant.display_name ?? null,
+    category_preset: merchant.category_preset ?? null,
+    country_code: merchant.country_code ?? null,
+    default_currency: merchant.default_currency ?? null,
+    support_email: merchant.support_email ?? null,
+    support_url: merchant.support_url ?? null,
+    public_discovery_description_draft: merchant.public_discovery_description_draft ?? null,
+    environment: 'sandbox',
+    agentic_commerce_requested: merchant.agentic_commerce_requested === true,
+    agentic_commerce_enabled: merchant.agentic_commerce_enabled === true,
+    sandbox_onboarding_state: state,
+    sandbox_onboarding_blocker: merchant.sandbox_onboarding_blocker ?? null,
+    sandbox_onboarding_updated_at: merchant.sandbox_onboarding_updated_at
+      ? new Date(merchant.sandbox_onboarding_updated_at).toISOString()
+      : null,
+    readiness,
+  };
+}

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -21,6 +21,18 @@ import {
   readCatalogItem,
   searchCatalog,
 } from '../lib/commerce/catalog.js';
+import {
+  computeSandboxOnboardingReadiness,
+  deriveSandboxOnboardingState,
+  isPublicSafeText,
+  isSafeSupportEmail,
+  isSafeSupportUrl,
+  isSandboxOnboardingState,
+  toSandboxOnboardingResponse,
+  validateSandboxOnboardingTransition,
+  type SandboxOnboardingMerchant,
+  type SandboxOnboardingState,
+} from '../lib/commerce/sandbox-onboarding.js';
 import { commerceTenantsRoutes } from './commerce-tenants.js';
 import { commercePassportRoutes } from './commerce-passport.js';
 import { commerceConsentRoutes } from './commerce-consent.js';
@@ -54,6 +66,9 @@ interface MerchantCreateBody {
   country_code?: unknown;
   default_currency?: unknown;
   support_email?: unknown;
+  support_url?: unknown;
+  public_discovery_description_draft?: unknown;
+  agentic_commerce_requested?: unknown;
 }
 
 interface MerchantPatchBody {
@@ -64,6 +79,22 @@ interface MerchantPatchBody {
   default_currency?: unknown;
   support_email?: unknown;
   agentic_commerce_enabled?: unknown;
+}
+
+interface SandboxOnboardingUpdateBody {
+  display_name?: unknown;
+  category_preset?: unknown;
+  country_code?: unknown;
+  default_currency?: unknown;
+  support_email?: unknown;
+  support_url?: unknown;
+  public_discovery_description_draft?: unknown;
+  agentic_commerce_requested?: unknown;
+}
+
+interface SandboxOnboardingTransitionBody {
+  target_state?: unknown;
+  reason?: unknown;
 }
 
 interface AgentCreateBody {
@@ -159,6 +190,18 @@ const AGENT_TRUST_STATUSES = new Set(['pending', 'trusted', 'suspended', 'disabl
 const AGENT_STATUSES = new Set(['active', 'disabled']);
 const PRODUCT_STATUSES = new Set(['active', 'archived', 'all']);
 
+const MERCHANT_CREATE_FIELDS = new Set([
+  'legal_name',
+  'display_name',
+  'category_preset',
+  'country_code',
+  'default_currency',
+  'support_email',
+  'support_url',
+  'public_discovery_description_draft',
+  'agentic_commerce_requested',
+]);
+
 const MERCHANT_PATCH_FIELDS = new Set([
   'legal_name',
   'display_name',
@@ -167,6 +210,17 @@ const MERCHANT_PATCH_FIELDS = new Set([
   'default_currency',
   'support_email',
   'agentic_commerce_enabled',
+]);
+
+const SANDBOX_ONBOARDING_UPDATE_FIELDS = new Set([
+  'display_name',
+  'category_preset',
+  'country_code',
+  'default_currency',
+  'support_email',
+  'support_url',
+  'public_discovery_description_draft',
+  'agentic_commerce_requested',
 ]);
 
 const AGENT_PATCH_FIELDS = new Set([
@@ -232,6 +286,31 @@ function validatePatchKeys(
       `immutable or unsupported fields: ${unsupportedFields.map((key) => key.replace(/[\r\n\t]/g, '_')).join(', ')}`;
   }
   return changedFields.filter((key) => allowed.has(key));
+}
+
+function validateSupportAndDiscoveryFields(
+  body: Record<string, unknown>,
+  fieldErrors: Record<string, string>,
+): void {
+  if (body['support_email'] !== undefined
+    && body['support_email'] !== null
+    && (!isString(body['support_email']) || !isSafeSupportEmail(body['support_email']))) {
+    fieldErrors['support_email'] =
+      'must be a non-empty repo-safe/test-safe support email such as support@example.test, or null';
+  }
+  if (body['support_url'] !== undefined
+    && body['support_url'] !== null
+    && (!isString(body['support_url']) || !isSafeSupportUrl(body['support_url']))) {
+    fieldErrors['support_url'] =
+      'must be a repo-safe/test-safe http(s) support URL on .example, .test, .invalid, or localhost, or null';
+  }
+  if (body['public_discovery_description_draft'] !== undefined
+    && body['public_discovery_description_draft'] !== null
+    && (!isString(body['public_discovery_description_draft'])
+      || !isPublicSafeText(body['public_discovery_description_draft']))) {
+    fieldErrors['public_discovery_description_draft'] =
+      'must be public-safe text with no secrets, credentials, payment, provider, live, production, approval, readiness, or certification claims';
+  }
 }
 
 function isNullableString(v: unknown): v is string | null {
@@ -581,12 +660,32 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
   // ----------------------------------------------------------------------
   app.post<{ Body: MerchantCreateBody }>('/merchants', async (request, reply) => {
     requireOperator(request);
-    const body = request.body ?? {};
+    if (request.body !== undefined && !isPlainObject(request.body)) {
+      throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+        details: { fields: { body: 'must be a JSON object' } },
+        retryable: false,
+      });
+    }
+    const body = (request.body ?? {}) as Record<string, unknown>;
     const fieldErrors: Record<string, string> = {};
+    validatePatchKeys(body, MERCHANT_CREATE_FIELDS, fieldErrors);
     if (!isString(body.legal_name)) fieldErrors['legal_name'] = 'required string';
     if (!isString(body.display_name)) fieldErrors['display_name'] = 'required string';
     if (!isCommerceCategoryPreset(body.category_preset)) {
       fieldErrors['category_preset'] = 'must be a known commerce category preset';
+    }
+    if (body['default_currency'] !== undefined
+      && (!isString(body['default_currency']) || !/^[A-Z]{3}$/.test(body['default_currency']))) {
+      fieldErrors['default_currency'] = 'must be an ISO 4217 uppercase currency code';
+    }
+    if (body['country_code'] !== undefined
+      && (!isString(body['country_code']) || !/^[A-Z]{2}$/.test(body['country_code']))) {
+      fieldErrors['country_code'] = 'must be an ISO 3166-1 alpha-2 uppercase country code';
+    }
+    validateSupportAndDiscoveryFields(body, fieldErrors);
+    if (body['agentic_commerce_requested'] !== undefined
+      && typeof body['agentic_commerce_requested'] !== 'boolean') {
+      fieldErrors['agentic_commerce_requested'] = 'must be a boolean';
     }
     if (Object.keys(fieldErrors).length > 0) {
       throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
@@ -603,7 +702,8 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
       const rows = await tx<Record<string, unknown>[]>`
         INSERT INTO commerce_merchants (
           id, tenant_id, legal_name, display_name, category_preset,
-          default_currency, country_code, support_email
+          default_currency, country_code, support_email, support_url,
+          public_discovery_description_draft, agentic_commerce_requested
         ) VALUES (
           ${id}, ${tenantId},
           ${body.legal_name as string},
@@ -611,11 +711,17 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
           ${body.category_preset as string},
           ${isString(body.default_currency) ? (body.default_currency as string) : 'INR'},
           ${isString(body.country_code) ? (body.country_code as string) : 'IN'},
-          ${isString(body.support_email) ? (body.support_email as string) : null}
+          ${isString(body.support_email) ? (body.support_email as string) : null},
+          ${isString(body.support_url) ? (body.support_url as string) : null},
+          ${isString(body.public_discovery_description_draft) ? (body.public_discovery_description_draft as string) : null},
+          ${body.agentic_commerce_requested === true}
         )
         RETURNING id, tenant_id, legal_name, display_name, category_preset,
                   verification_status, environment, agentic_commerce_enabled,
-                  default_currency, country_code, support_email,
+                  default_currency, country_code, support_email, support_url,
+                  public_discovery_description_draft, agentic_commerce_requested,
+                  sandbox_onboarding_state, sandbox_onboarding_blocker,
+                  sandbox_onboarding_updated_at,
                   created_at, updated_at
       `;
       const audit = await appendCommerceAudit(tx as unknown as Sql, {
@@ -625,7 +731,12 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
         resourceType: 'merchant',
         resourceId: id,
         requestId: request.id,
-        metadata: { display_name: body.display_name },
+        metadata: {
+          display_name: body.display_name,
+          sandbox_onboarding_state: 'draft_created',
+          production_approval_status: 'not_approved',
+          rollout_status: 'rollout_not_requested',
+        },
       });
       return { merchant: rows[0], auditEventId: audit.id };
     });
@@ -643,7 +754,10 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
     const rows = await sql<Record<string, unknown>[]>`
       SELECT id, tenant_id, legal_name, display_name, category_preset,
              verification_status, environment, agentic_commerce_enabled,
-             default_currency, country_code, support_email,
+             default_currency, country_code, support_email, support_url,
+             public_discovery_description_draft, agentic_commerce_requested,
+             sandbox_onboarding_state, sandbox_onboarding_blocker,
+             sandbox_onboarding_updated_at,
              disabled_at, created_at, updated_at
       FROM commerce_merchants
       WHERE id = ${request.params.merchantId}
@@ -655,6 +769,310 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
     }
     return reply.status(200).send({ data: rows[0] });
   });
+
+  app.get<{ Params: { merchantId: string } }>(
+    '/merchants/:merchantId/sandbox-onboarding',
+    async (request, reply) => {
+      requireOperatorOrSelfMerchant(request, request.params.merchantId);
+      const sql = getSql();
+      const rows = await sql<SandboxOnboardingMerchant[]>`
+        SELECT id, tenant_id, display_name, category_preset, environment,
+               agentic_commerce_enabled, default_currency, country_code,
+               support_email, support_url, public_discovery_description_draft,
+               agentic_commerce_requested, sandbox_onboarding_state,
+               sandbox_onboarding_blocker, sandbox_onboarding_updated_at,
+               provider_account_refs
+          FROM commerce_merchants
+         WHERE id = ${request.params.merchantId}
+           AND tenant_id = ${request.commerceTenantId}
+         LIMIT 1
+      `;
+      const merchant = rows[0];
+      if (!merchant) {
+        throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
+      }
+      if (merchant.environment !== 'sandbox') {
+        throw new CommerceHttpError(409, 'sandbox_onboarding_live_merchant_blocked',
+          'Sandbox onboarding is only available for sandbox merchants',
+          { retryable: false });
+      }
+      return reply.status(200).send({
+        data: toSandboxOnboardingResponse(merchant),
+      });
+    },
+  );
+
+  app.put<{ Params: { merchantId: string }; Body: SandboxOnboardingUpdateBody }>(
+    '/merchants/:merchantId/sandbox-onboarding',
+    async (request, reply) => {
+      requireOperatorOrSelfMerchant(request, request.params.merchantId);
+      if (request.body !== undefined && !isPlainObject(request.body)) {
+        throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+          details: { fields: { body: 'must be a JSON object' } },
+          retryable: false,
+        });
+      }
+      const body = (request.body ?? {}) as Record<string, unknown>;
+      const fieldErrors: Record<string, string> = {};
+      const changedFields = validatePatchKeys(body, SANDBOX_ONBOARDING_UPDATE_FIELDS, fieldErrors);
+      if (changedFields.length === 0 && Object.keys(fieldErrors).length === 0) {
+        fieldErrors['body'] = 'at least one sandbox onboarding field is required';
+      }
+      if (body['display_name'] !== undefined && !isString(body['display_name'])) {
+        fieldErrors['display_name'] = 'must be a non-empty string';
+      }
+      if (body['category_preset'] !== undefined && !isCommerceCategoryPreset(body['category_preset'])) {
+        fieldErrors['category_preset'] = 'must be a known commerce category preset';
+      }
+      if (body['default_currency'] !== undefined
+        && (!isString(body['default_currency']) || !/^[A-Z]{3}$/.test(body['default_currency']))) {
+        fieldErrors['default_currency'] = 'must be an ISO 4217 uppercase currency code';
+      }
+      if (body['country_code'] !== undefined
+        && (!isString(body['country_code']) || !/^[A-Z]{2}$/.test(body['country_code']))) {
+        fieldErrors['country_code'] = 'must be an ISO 3166-1 alpha-2 uppercase country code';
+      }
+      validateSupportAndDiscoveryFields(body, fieldErrors);
+      if (body['agentic_commerce_requested'] !== undefined
+        && typeof body['agentic_commerce_requested'] !== 'boolean') {
+        fieldErrors['agentic_commerce_requested'] = 'must be a boolean';
+      }
+      if (Object.keys(fieldErrors).length > 0) {
+        throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+          details: { fields: fieldErrors },
+          retryable: false,
+        });
+      }
+
+      const sql = getSql();
+      const tenantId = request.commerceTenantId;
+      const merchantId = request.params.merchantId;
+      const hasDisplayName = Object.prototype.hasOwnProperty.call(body, 'display_name');
+      const hasCategoryPreset = Object.prototype.hasOwnProperty.call(body, 'category_preset');
+      const hasDefaultCurrency = Object.prototype.hasOwnProperty.call(body, 'default_currency');
+      const hasCountryCode = Object.prototype.hasOwnProperty.call(body, 'country_code');
+      const hasSupportEmail = Object.prototype.hasOwnProperty.call(body, 'support_email');
+      const hasSupportUrl = Object.prototype.hasOwnProperty.call(body, 'support_url');
+      const hasDescription = Object.prototype.hasOwnProperty.call(body, 'public_discovery_description_draft');
+      const hasAgenticRequested = Object.prototype.hasOwnProperty.call(body, 'agentic_commerce_requested');
+      const patchDisplayName = hasDisplayName ? body['display_name'] as string : null;
+      const patchCategoryPreset = hasCategoryPreset ? body['category_preset'] as string : null;
+      const patchDefaultCurrency = hasDefaultCurrency ? body['default_currency'] as string : null;
+      const patchCountryCode = hasCountryCode ? body['country_code'] as string : null;
+      const patchSupportEmail = hasSupportEmail ? body['support_email'] as string | null : null;
+      const patchSupportUrl = hasSupportUrl ? body['support_url'] as string | null : null;
+      const patchDescription = hasDescription ? body['public_discovery_description_draft'] as string | null : null;
+      const patchAgenticRequested = hasAgenticRequested ? body['agentic_commerce_requested'] as boolean : null;
+
+      const result = await sql.begin(async (_tx) => {
+        const tx = _tx as unknown as TxSql;
+        const beforeRows = await tx<SandboxOnboardingMerchant[]>`
+          SELECT id, tenant_id, display_name, category_preset, environment,
+                 agentic_commerce_enabled, default_currency, country_code,
+                 support_email, support_url, public_discovery_description_draft,
+                 agentic_commerce_requested, sandbox_onboarding_state,
+                 sandbox_onboarding_blocker, sandbox_onboarding_updated_at,
+                 provider_account_refs
+            FROM commerce_merchants
+           WHERE id = ${merchantId}
+             AND tenant_id = ${tenantId}
+           LIMIT 1
+        `;
+        const before = beforeRows[0];
+        if (!before) return null;
+        if (before.environment !== 'sandbox') {
+          throw new CommerceHttpError(409, 'sandbox_onboarding_live_merchant_blocked',
+            'Sandbox onboarding is only available for sandbox merchants',
+            { retryable: false });
+        }
+
+        const rows = await tx<SandboxOnboardingMerchant[]>`
+          UPDATE commerce_merchants
+             SET display_name = CASE WHEN ${hasDisplayName}::boolean THEN ${patchDisplayName}::text ELSE display_name END,
+                 category_preset = CASE WHEN ${hasCategoryPreset}::boolean THEN ${patchCategoryPreset}::text ELSE category_preset END,
+                 default_currency = CASE WHEN ${hasDefaultCurrency}::boolean THEN ${patchDefaultCurrency}::text ELSE default_currency END,
+                 country_code = CASE WHEN ${hasCountryCode}::boolean THEN ${patchCountryCode}::text ELSE country_code END,
+                 support_email = CASE WHEN ${hasSupportEmail}::boolean THEN ${patchSupportEmail}::text ELSE support_email END,
+                 support_url = CASE WHEN ${hasSupportUrl}::boolean THEN ${patchSupportUrl}::text ELSE support_url END,
+                 public_discovery_description_draft = CASE WHEN ${hasDescription}::boolean THEN ${patchDescription}::text ELSE public_discovery_description_draft END,
+                 agentic_commerce_requested = CASE WHEN ${hasAgenticRequested}::boolean THEN ${patchAgenticRequested}::boolean ELSE agentic_commerce_requested END,
+                 updated_at = NOW()
+           WHERE id = ${merchantId}
+             AND tenant_id = ${tenantId}
+           RETURNING id, tenant_id, display_name, category_preset, environment,
+                     agentic_commerce_enabled, default_currency, country_code,
+                     support_email, support_url, public_discovery_description_draft,
+                     agentic_commerce_requested, sandbox_onboarding_state,
+                     sandbox_onboarding_blocker, sandbox_onboarding_updated_at,
+                     provider_account_refs
+        `;
+        let merchant = rows[0]!;
+        const readiness = computeSandboxOnboardingReadiness(merchant);
+        const currentState = isSandboxOnboardingState(merchant.sandbox_onboarding_state)
+          ? merchant.sandbox_onboarding_state
+          : 'draft_created';
+        const nextState = deriveSandboxOnboardingState(currentState, readiness);
+        if (nextState !== currentState) {
+          const stateRows = await tx<SandboxOnboardingMerchant[]>`
+            UPDATE commerce_merchants
+               SET sandbox_onboarding_state = ${nextState},
+                   sandbox_onboarding_blocker = CASE
+                     WHEN ${nextState}::text = 'profile_incomplete' THEN 'required sandbox onboarding checks are incomplete'
+                     ELSE NULL::text
+                   END,
+                   sandbox_onboarding_updated_at = NOW(),
+                   updated_at = NOW()
+             WHERE id = ${merchantId}
+               AND tenant_id = ${tenantId}
+             RETURNING id, tenant_id, display_name, category_preset, environment,
+                       agentic_commerce_enabled, default_currency, country_code,
+                       support_email, support_url, public_discovery_description_draft,
+                       agentic_commerce_requested, sandbox_onboarding_state,
+                       sandbox_onboarding_blocker, sandbox_onboarding_updated_at,
+                       provider_account_refs
+          `;
+          merchant = stateRows[0]!;
+        }
+        const audit = await appendCommerceAudit(tx as unknown as Sql, {
+          tenantId,
+          merchantId,
+          eventType: 'merchant.sandbox_onboarding.updated',
+          resourceType: 'merchant',
+          resourceId: merchantId,
+          requestId: request.id,
+          metadata: {
+            changed_fields: changedFields,
+            sandbox_onboarding_state: merchant.sandbox_onboarding_state,
+            readiness_ready: computeSandboxOnboardingReadiness(merchant).ready,
+            production_approval_status: 'not_approved',
+            rollout_status: 'rollout_not_requested',
+          },
+        });
+        return { merchant, auditEventId: audit.id };
+      });
+      if (!result) {
+        throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
+      }
+      return reply.status(200).send({
+        data: toSandboxOnboardingResponse(result.merchant),
+        audit_event_id: result.auditEventId,
+      });
+    },
+  );
+
+  app.post<{ Params: { merchantId: string }; Body: SandboxOnboardingTransitionBody }>(
+    '/merchants/:merchantId/sandbox-onboarding/transition',
+    async (request, reply) => {
+      requireOperatorOrSelfMerchant(request, request.params.merchantId);
+      if (request.body !== undefined && !isPlainObject(request.body)) {
+        throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+          details: { fields: { body: 'must be a JSON object' } },
+          retryable: false,
+        });
+      }
+      const body = (request.body ?? {}) as Record<string, unknown>;
+      const fieldErrors: Record<string, string> = {};
+      if (!isSandboxOnboardingState(body['target_state'])) {
+        fieldErrors['target_state'] = 'must be a valid sandbox onboarding state';
+      }
+      if (body['reason'] !== undefined && body['reason'] !== null
+        && (!isString(body['reason']) || !isPublicSafeText(body['reason']))) {
+        fieldErrors['reason'] = 'must be public-safe text with no secrets, credentials, live, production, approval, readiness, provider, or payment claims';
+      }
+      if ((body['target_state'] === 'blocked' || body['target_state'] === 'not_approved')
+        && !isString(body['reason'])) {
+        fieldErrors['reason'] = 'required for blocked or not_approved transitions';
+      }
+      if (Object.keys(fieldErrors).length > 0) {
+        throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+          details: { fields: fieldErrors },
+          retryable: false,
+        });
+      }
+
+      const targetState = body['target_state'] as SandboxOnboardingState;
+      const reason = isString(body['reason']) ? body['reason'] : null;
+      const sql = getSql();
+      const tenantId = request.commerceTenantId;
+      const merchantId = request.params.merchantId;
+
+      const result = await sql.begin(async (_tx) => {
+        const tx = _tx as unknown as TxSql;
+        const beforeRows = await tx<SandboxOnboardingMerchant[]>`
+          SELECT id, tenant_id, display_name, category_preset, environment,
+                 agentic_commerce_enabled, default_currency, country_code,
+                 support_email, support_url, public_discovery_description_draft,
+                 agentic_commerce_requested, sandbox_onboarding_state,
+                 sandbox_onboarding_blocker, sandbox_onboarding_updated_at,
+                 provider_account_refs
+            FROM commerce_merchants
+           WHERE id = ${merchantId}
+             AND tenant_id = ${tenantId}
+           LIMIT 1
+        `;
+        const before = beforeRows[0];
+        if (!before) return null;
+        if (before.environment !== 'sandbox') {
+          throw new CommerceHttpError(409, 'sandbox_onboarding_live_merchant_blocked',
+            'Sandbox onboarding is only available for sandbox merchants',
+            { retryable: false });
+        }
+        const currentState = isSandboxOnboardingState(before.sandbox_onboarding_state)
+          ? before.sandbox_onboarding_state
+          : 'draft_created';
+        const readiness = computeSandboxOnboardingReadiness(before);
+        const transitionError = validateSandboxOnboardingTransition(currentState, targetState, readiness);
+        if (transitionError) {
+          throw new CommerceHttpError(409, 'invalid_sandbox_onboarding_transition', transitionError, {
+            details: { from_state: currentState, target_state: targetState },
+            retryable: false,
+          });
+        }
+        const rows = await tx<SandboxOnboardingMerchant[]>`
+          UPDATE commerce_merchants
+             SET sandbox_onboarding_state = ${targetState},
+                 sandbox_onboarding_blocker = CASE
+                   WHEN ${targetState}::text IN ('blocked', 'not_approved') THEN ${reason}::text
+                   ELSE NULL::text
+                 END,
+                 sandbox_onboarding_updated_at = NOW(),
+                 updated_at = NOW()
+           WHERE id = ${merchantId}
+             AND tenant_id = ${tenantId}
+           RETURNING id, tenant_id, display_name, category_preset, environment,
+                     agentic_commerce_enabled, default_currency, country_code,
+                     support_email, support_url, public_discovery_description_draft,
+                     agentic_commerce_requested, sandbox_onboarding_state,
+                     sandbox_onboarding_blocker, sandbox_onboarding_updated_at,
+                     provider_account_refs
+        `;
+        const merchant = rows[0]!;
+        const audit = await appendCommerceAudit(tx as unknown as Sql, {
+          tenantId,
+          merchantId,
+          eventType: 'merchant.sandbox_onboarding.transitioned',
+          resourceType: 'merchant',
+          resourceId: merchantId,
+          requestId: request.id,
+          metadata: {
+            from_state: currentState,
+            to_state: targetState,
+            reason_present: reason !== null,
+            production_approval_status: 'not_approved',
+            rollout_status: 'rollout_not_requested',
+          },
+        });
+        return { merchant, auditEventId: audit.id };
+      });
+      if (!result) {
+        throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
+      }
+      return reply.status(200).send({
+        data: toSandboxOnboardingResponse(result.merchant),
+        audit_event_id: result.auditEventId,
+      });
+    },
+  );
 
   // ----------------------------------------------------------------------
   // PATCH /merchants/:merchantId — operator OR merchant for own merchant.

--- a/apps/auth-service/tests/commerce-merchants.test.ts
+++ b/apps/auth-service/tests/commerce-merchants.test.ts
@@ -18,6 +18,28 @@ const validBody = {
   support_email: 'support@acme.example',
 };
 
+function onboardingRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'mch_SANDBOX',
+    tenant_id: TEST_COMMERCE_TENANT_ID,
+    display_name: 'Acme Sandbox',
+    category_preset: 'electronics_appliances',
+    environment: 'sandbox',
+    agentic_commerce_enabled: false,
+    default_currency: 'INR',
+    country_code: 'IN',
+    support_email: 'support@acme.example',
+    support_url: 'https://support.acme.example/help',
+    public_discovery_description_draft: 'Sandbox catalog profile for test appliances.',
+    agentic_commerce_requested: true,
+    sandbox_onboarding_state: 'sandbox_ready',
+    sandbox_onboarding_blocker: null,
+    sandbox_onboarding_updated_at: new Date().toISOString(),
+    provider_account_refs: {},
+    ...overrides,
+  };
+}
+
 describe('POST /v1/commerce/merchants', () => {
   it('creates a merchant and returns 201 with audit_event_id', async () => {
     seedCommerceContext();
@@ -34,6 +56,12 @@ describe('POST /v1/commerce/merchants', () => {
       default_currency: 'INR',
       country_code: 'IN',
       support_email: validBody.support_email,
+      support_url: null,
+      public_discovery_description_draft: null,
+      agentic_commerce_requested: false,
+      sandbox_onboarding_state: 'draft_created',
+      sandbox_onboarding_blocker: null,
+      sandbox_onboarding_updated_at: new Date().toISOString(),
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     }]);
@@ -85,6 +113,28 @@ describe('POST /v1/commerce/merchants', () => {
     expect(res.statusCode).toBe(422);
     expect(res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields)
       .toHaveProperty('category_preset');
+  });
+
+  it('rejects production/live, provider, and checkout enablement fields on create', async () => {
+    seedCommerceContext();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/merchants',
+      headers: authHeader(),
+      payload: {
+        ...validBody,
+        environment: 'live',
+        provider_credentials: { token: 'secret' },
+        agentic_commerce_enabled: true,
+      },
+    });
+
+    expect(res.statusCode).toBe(422);
+    const fields = res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields;
+    expect(fields.unsupported_fields).toContain('environment');
+    expect(fields.unsupported_fields).toContain('provider_credentials');
+    expect(fields.unsupported_fields).toContain('agentic_commerce_enabled');
   });
 
   it('returns 401 with the commerce envelope on missing Authorization (M2 caller refactor)', async () => {
@@ -145,5 +195,157 @@ describe('GET /v1/commerce/merchants/:merchantId', () => {
     const body = res.json<{ error: { code: string; message: string } }>();
     expect(body.error.code).toBe('merchant_not_found');
     expect(body).not.toHaveProperty('message');  // commerce envelope nests under .error
+  });
+});
+
+describe('sandbox onboarding foundation', () => {
+  it('returns sandbox onboarding state and readiness without provider references', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow()]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: {
+        sandbox_onboarding_state: string;
+        production_approval_status?: string;
+        provider_account_refs?: unknown;
+        readiness: { ready: boolean; production_approval_status: string; rollout_status: string };
+      };
+    }>();
+    expect(body.data.sandbox_onboarding_state).toBe('sandbox_ready');
+    expect(body.data.readiness.ready).toBe(true);
+    expect(body.data.readiness.production_approval_status).toBe('not_approved');
+    expect(body.data.readiness.rollout_status).toBe('rollout_not_requested');
+    expect(body.data.provider_account_refs).toBeUndefined();
+  });
+
+  it('returns 404 for sandbox onboarding when tenant-scoped lookup is empty', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_OTHER_TENANT/sandbox-onboarding',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    const allTplStrings = sqlMock.mock.calls.flatMap((c) => {
+      const tpl = c[0] as unknown;
+      return Array.isArray(tpl) ? tpl.filter((s): s is string => typeof s === 'string') : [];
+    });
+    expect(allTplStrings.some((s) => s.includes('tenant_id'))).toBe(true);
+  });
+
+  it('updates safe sandbox profile fields, derives sandbox_ready, and writes audit evidence', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({
+      public_discovery_description_draft: null,
+      sandbox_onboarding_state: 'draft_created',
+    })]);
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'draft_created' })]);
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'sandbox_ready' })]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_ONBOARDING', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding',
+      headers: authHeader(),
+      payload: {
+        display_name: 'Acme Sandbox',
+        category_preset: 'electronics_appliances',
+        country_code: 'IN',
+        default_currency: 'INR',
+        support_email: 'support@acme.example',
+        support_url: 'https://support.acme.example/help',
+        public_discovery_description_draft: 'Sandbox catalog profile for test appliances.',
+        agentic_commerce_requested: true,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { sandbox_onboarding_state: string; readiness: { ready: boolean } }; audit_event_id: string }>();
+    expect(body.data.sandbox_onboarding_state).toBe('sandbox_ready');
+    expect(body.data.readiness.ready).toBe(true);
+    expect(body.audit_event_id).toBe('caud_ONBOARDING');
+  });
+
+  it('rejects unsafe sandbox onboarding fields that would imply production or checkout enablement', async () => {
+    seedCommerceContext();
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding',
+      headers: authHeader(),
+      payload: {
+        environment: 'live',
+        agentic_commerce_enabled: true,
+        public_discovery_description_draft: 'Production ready live payment checkout is approved.',
+      },
+    });
+
+    expect(res.statusCode).toBe(422);
+    const fields = res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields;
+    expect(fields.unsupported_fields).toContain('environment');
+    expect(fields.unsupported_fields).toContain('agentic_commerce_enabled');
+    expect(fields.public_discovery_description_draft).toContain('public-safe text');
+  });
+
+  it('transitions a ready sandbox workspace to submitted_for_review with audit evidence', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'sandbox_ready' })]);
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'submitted_for_review' })]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_TRANSITION', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding/transition',
+      headers: authHeader(),
+      payload: { target_state: 'submitted_for_review' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { sandbox_onboarding_state: string; readiness: { production_approval_status: string } }; audit_event_id: string }>();
+    expect(body.data.sandbox_onboarding_state).toBe('submitted_for_review');
+    expect(body.data.readiness.production_approval_status).toBe('not_approved');
+    expect(body.audit_event_id).toBe('caud_TRANSITION');
+  });
+
+  it('blocks submit transition when readiness checks fail', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({
+      public_discovery_description_draft: null,
+      sandbox_onboarding_state: 'sandbox_ready',
+    })]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding/transition',
+      headers: authHeader(),
+      payload: { target_state: 'submitted_for_review' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('invalid_sandbox_onboarding_transition');
+  });
+
+  it('blocks sandbox onboarding for live merchants', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ environment: 'live' })]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_LIVE/sandbox-onboarding',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('sandbox_onboarding_live_merchant_blocked');
   });
 });

--- a/apps/auth-service/tests/commerce-schema.test.ts
+++ b/apps/auth-service/tests/commerce-schema.test.ts
@@ -36,6 +36,29 @@ describe('Commerce schema — tenant_id presence on every tenant-owned table', (
   });
 });
 
+describe('Commerce schema - C5Z sandbox onboarding columns', () => {
+  it('051 extends merchants with safe sandbox onboarding state and no provider credential columns', () => {
+    const s = read('051_commerce_sandbox_onboarding.sql');
+    expect(s).toMatch(/ADD COLUMN IF NOT EXISTS support_url TEXT/);
+    expect(s).toMatch(/ADD COLUMN IF NOT EXISTS public_discovery_description_draft TEXT/);
+    expect(s).toMatch(/ADD COLUMN IF NOT EXISTS agentic_commerce_requested BOOLEAN NOT NULL DEFAULT FALSE/);
+    expect(s).toMatch(/ADD COLUMN IF NOT EXISTS sandbox_onboarding_state TEXT NOT NULL DEFAULT 'draft_created'/);
+    expect(s).toMatch(/sandbox_onboarding_state IN \(/);
+    for (const state of [
+      'draft_created',
+      'profile_incomplete',
+      'sandbox_ready',
+      'submitted_for_review',
+      'blocked',
+      'not_approved',
+      'rollout_not_requested',
+    ]) {
+      expect(s).toContain(`'${state}'`);
+    }
+    expect(s).not.toMatch(/provider_credential|secret|token|jwt/i);
+  });
+});
+
 describe('Commerce schema — required indexes/constraints from spec §15', () => {
   it('commerce_merchants has unique (tenant_id, id) — as CONSTRAINT, not bare index', () => {
     // The hardening migration converted the original CREATE UNIQUE INDEX

--- a/apps/portal/src/api/__tests__/commerce.test.ts
+++ b/apps/portal/src/api/__tests__/commerce.test.ts
@@ -15,6 +15,7 @@ import {
   disableMerchantAgenticCommerce,
   evaluateCommercePolicy,
   getCommerceMerchant,
+  getCommerceMerchantSandboxOnboarding,
   getCommerceOpsHealth,
   getCommerceWellKnownProfile,
   listCommerceAgents,
@@ -29,8 +30,10 @@ import {
   reconcileCommercePaymentIntent,
   rotateCommerceWebhookSourceSecret,
   revokeCommercePassport,
+  transitionCommerceMerchantSandboxOnboarding,
   updateCommerceAgent,
   updateCommerceMerchant,
+  updateCommerceMerchantSandboxOnboarding,
   updateCommerceProduct,
   updateCommerceWebhookSource,
   validateCommerceProviderCredential,
@@ -95,6 +98,39 @@ describe('commerce api', () => {
     const [url, opts] = mockFetch.mock.calls[2]!;
     expect(url).toBe('http://localhost:3000/v1/commerce/merchants/mch%2F1/disable-agentic-commerce');
     expect(JSON.parse(opts.body)).toEqual({ reason: 'dashboard_emergency_disable' });
+  });
+
+  it('calls sandbox onboarding APIs without checkout or provider credential material', async () => {
+    ok({ data: { merchant_id: 'mch/1', readiness: { ready: false } } });
+    await getCommerceMerchantSandboxOnboarding('mch/1');
+    expect(mockFetch.mock.calls[0]![0]).toBe(
+      'http://localhost:3000/v1/commerce/merchants/mch%2F1/sandbox-onboarding',
+    );
+
+    ok({ data: { merchant_id: 'mch/1' }, audit_event_id: 'aud_1' });
+    await updateCommerceMerchantSandboxOnboarding('mch/1', {
+      display_name: 'Store',
+      public_discovery_description_draft: 'Sandbox catalog profile for test appliances.',
+      agentic_commerce_requested: true,
+    });
+    expect(mockFetch.mock.calls[1]![0]).toBe(
+      'http://localhost:3000/v1/commerce/merchants/mch%2F1/sandbox-onboarding',
+    );
+    expect(mockFetch.mock.calls[1]![1].method).toBe('PUT');
+    expect(JSON.parse(mockFetch.mock.calls[1]![1].body)).toEqual({
+      display_name: 'Store',
+      public_discovery_description_draft: 'Sandbox catalog profile for test appliances.',
+      agentic_commerce_requested: true,
+    });
+    expect(mockFetch.mock.calls[1]![1].body).not.toContain('agentic_commerce_enabled');
+    expect(mockFetch.mock.calls[1]![1].body).not.toContain('provider_credentials');
+
+    ok({ data: { merchant_id: 'mch/1', sandbox_onboarding_state: 'submitted_for_review' }, audit_event_id: 'aud_2' });
+    await transitionCommerceMerchantSandboxOnboarding('mch/1', { targetState: 'submitted_for_review' });
+    expect(mockFetch.mock.calls[2]![0]).toBe(
+      'http://localhost:3000/v1/commerce/merchants/mch%2F1/sandbox-onboarding/transition',
+    );
+    expect(JSON.parse(mockFetch.mock.calls[2]![1].body)).toEqual({ target_state: 'submitted_for_review' });
   });
 
   it('calls agent and product control-plane endpoints', async () => {

--- a/apps/portal/src/api/commerce.ts
+++ b/apps/portal/src/api/commerce.ts
@@ -12,6 +12,14 @@ export type CommercePaymentStatus =
 
 export type CommerceEnvironment = 'sandbox' | 'live';
 export type CommerceProviderKey = 'mock' | 'plural';
+export type SandboxOnboardingState =
+  | 'draft_created'
+  | 'profile_incomplete'
+  | 'sandbox_ready'
+  | 'submitted_for_review'
+  | 'blocked'
+  | 'not_approved'
+  | 'rollout_not_requested';
 
 export interface CommercePaymentIntent {
   id: string;
@@ -91,9 +99,54 @@ export interface CommerceMerchant {
   default_currency: string;
   country_code: string;
   support_email: string | null;
+  support_url?: string | null;
+  public_discovery_description_draft?: string | null;
+  agentic_commerce_requested?: boolean;
+  sandbox_onboarding_state?: SandboxOnboardingState;
+  sandbox_onboarding_blocker?: string | null;
+  sandbox_onboarding_updated_at?: string | null;
   disabled_at: string | null;
   created_at: string;
   updated_at: string;
+}
+
+export interface CommerceSandboxOnboardingCheck {
+  key:
+    | 'merchant_profile_present'
+    | 'category_preset_selected'
+    | 'public_safe_description_present'
+    | 'private_artifacts_not_stored'
+    | 'no_production_allowlist_config_values'
+    | 'no_live_provider_path'
+    | 'no_checkout_payment_enablement';
+  label: string;
+  status: 'pass' | 'blocked';
+  detail: string;
+}
+
+export interface CommerceSandboxOnboarding {
+  merchant_id: string;
+  tenant_id: string;
+  display_name: string | null;
+  category_preset: string | null;
+  country_code: string | null;
+  default_currency: string | null;
+  support_email: string | null;
+  support_url: string | null;
+  public_discovery_description_draft: string | null;
+  environment: 'sandbox';
+  agentic_commerce_requested: boolean;
+  agentic_commerce_enabled: boolean;
+  sandbox_onboarding_state: SandboxOnboardingState;
+  sandbox_onboarding_blocker: string | null;
+  sandbox_onboarding_updated_at: string | null;
+  readiness: {
+    ready: boolean;
+    checks: CommerceSandboxOnboardingCheck[];
+    live_mode_status: 'not_live';
+    production_approval_status: 'not_approved';
+    rollout_status: 'rollout_not_requested';
+  };
 }
 
 export interface CommerceAgent {
@@ -411,6 +464,38 @@ export function revokeCommercePassport(input: {
 
 export function getCommerceMerchant(merchantId: string): Promise<{ data: CommerceMerchant }> {
   return api.get<{ data: CommerceMerchant }>(`/v1/commerce/merchants/${encodeURIComponent(merchantId)}`);
+}
+
+export function getCommerceMerchantSandboxOnboarding(
+  merchantId: string,
+): Promise<{ data: CommerceSandboxOnboarding }> {
+  return api.get<{ data: CommerceSandboxOnboarding }>(
+    `/v1/commerce/merchants/${encodeURIComponent(merchantId)}/sandbox-onboarding`,
+  );
+}
+
+export function updateCommerceMerchantSandboxOnboarding(
+  merchantId: string,
+  patch: Partial<Pick<CommerceSandboxOnboarding,
+    'display_name' | 'category_preset' | 'default_currency' | 'country_code' | 'support_email' | 'support_url' | 'public_discovery_description_draft' | 'agentic_commerce_requested'>>,
+): Promise<{ data: CommerceSandboxOnboarding; audit_event_id: string }> {
+  return api.put<{ data: CommerceSandboxOnboarding; audit_event_id: string }>(
+    `/v1/commerce/merchants/${encodeURIComponent(merchantId)}/sandbox-onboarding`,
+    patch,
+  );
+}
+
+export function transitionCommerceMerchantSandboxOnboarding(
+  merchantId: string,
+  input: { targetState: SandboxOnboardingState; reason?: string },
+): Promise<{ data: CommerceSandboxOnboarding; audit_event_id: string }> {
+  return api.post<{ data: CommerceSandboxOnboarding; audit_event_id: string }>(
+    `/v1/commerce/merchants/${encodeURIComponent(merchantId)}/sandbox-onboarding/transition`,
+    {
+      target_state: input.targetState,
+      ...(input.reason ? { reason: input.reason } : {}),
+    },
+  );
 }
 
 export function updateCommerceMerchant(

--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -20,6 +20,9 @@ const mockListCommercePassports = vi.fn();
 const mockRevokeCommercePassport = vi.fn();
 const mockGetCommerceMerchant = vi.fn();
 const mockUpdateCommerceMerchant = vi.fn();
+const mockGetCommerceMerchantSandboxOnboarding = vi.fn();
+const mockUpdateCommerceMerchantSandboxOnboarding = vi.fn();
+const mockTransitionCommerceMerchantSandboxOnboarding = vi.fn();
 const mockDisableMerchantAgenticCommerce = vi.fn();
 const mockEnableMerchantAgenticCommerce = vi.fn();
 const mockListCommerceAgents = vi.fn();
@@ -49,6 +52,9 @@ vi.mock('../../api/commerce', () => ({
   revokeCommercePassport: (...a: unknown[]) => mockRevokeCommercePassport(...a),
   getCommerceMerchant: (...a: unknown[]) => mockGetCommerceMerchant(...a),
   updateCommerceMerchant: (...a: unknown[]) => mockUpdateCommerceMerchant(...a),
+  getCommerceMerchantSandboxOnboarding: (...a: unknown[]) => mockGetCommerceMerchantSandboxOnboarding(...a),
+  updateCommerceMerchantSandboxOnboarding: (...a: unknown[]) => mockUpdateCommerceMerchantSandboxOnboarding(...a),
+  transitionCommerceMerchantSandboxOnboarding: (...a: unknown[]) => mockTransitionCommerceMerchantSandboxOnboarding(...a),
   disableMerchantAgenticCommerce: (...a: unknown[]) => mockDisableMerchantAgenticCommerce(...a),
   enableMerchantAgenticCommerce: (...a: unknown[]) => mockEnableMerchantAgenticCommerce(...a),
   listCommerceAgents: (...a: unknown[]) => mockListCommerceAgents(...a),
@@ -165,6 +171,44 @@ const merchant = {
   disabled_at: null,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
+};
+
+const sandboxOnboarding = {
+  merchant_id: 'mch_1',
+  tenant_id: 'cten_1',
+  display_name: 'Grantex Store',
+  category_preset: 'electronics_appliances',
+  country_code: 'IN',
+  default_currency: 'INR',
+  support_email: 'ops@example.test',
+  support_url: 'https://support.example.test/help',
+  public_discovery_description_draft: 'Sandbox catalog profile for test appliances.',
+  environment: 'sandbox' as const,
+  agentic_commerce_requested: true,
+  agentic_commerce_enabled: false,
+  sandbox_onboarding_state: 'sandbox_ready' as const,
+  sandbox_onboarding_blocker: null,
+  sandbox_onboarding_updated_at: '2026-01-01T00:00:00Z',
+  readiness: {
+    ready: true,
+    live_mode_status: 'not_live' as const,
+    production_approval_status: 'not_approved' as const,
+    rollout_status: 'rollout_not_requested' as const,
+    checks: [
+      {
+        key: 'merchant_profile_present' as const,
+        label: 'Merchant profile present',
+        status: 'pass' as const,
+        detail: 'present',
+      },
+      {
+        key: 'no_checkout_payment_enablement' as const,
+        label: 'No checkout/payment enablement',
+        status: 'pass' as const,
+        detail: 'blocked',
+      },
+    ],
+  },
 };
 
 const credential = {
@@ -517,8 +561,15 @@ describe('CommerceSettings', () => {
 describe('CommerceOnboarding', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetCommerceMerchant.mockResolvedValue({ data: merchant });
-    mockUpdateCommerceMerchant.mockResolvedValue({ data: { ...merchant, display_name: 'Grantex Store Updated' }, audit_event_id: 'aud_merchant' });
+    mockGetCommerceMerchantSandboxOnboarding.mockResolvedValue({ data: sandboxOnboarding });
+    mockUpdateCommerceMerchantSandboxOnboarding.mockResolvedValue({
+      data: { ...sandboxOnboarding, display_name: 'Grantex Store Updated' },
+      audit_event_id: 'aud_merchant',
+    });
+    mockTransitionCommerceMerchantSandboxOnboarding.mockResolvedValue({
+      data: { ...sandboxOnboarding, sandbox_onboarding_state: 'submitted_for_review' },
+      audit_event_id: 'aud_review',
+    });
     mockListCommerceAgents.mockResolvedValue({ items: [agent], next_cursor: null });
     mockListCommercePolicies.mockResolvedValue({ items: [{ id: 'cpol_1', status: 'active' }], next_cursor: null });
     mockListCommerceProducts.mockResolvedValue({ items: [product], next_cursor: null });
@@ -542,18 +593,25 @@ describe('CommerceOnboarding', () => {
     await user.type(screen.getByLabelText('Merchant ID'), 'mch_1');
     await user.click(screen.getByRole('button', { name: 'Load onboarding' }));
     await waitFor(() => expect(screen.getByText('Readiness checklist')).toBeInTheDocument());
+    expect(screen.getByText('Merchant profile present')).toBeInTheDocument();
+    expect(screen.getByText('No checkout/payment enablement')).toBeInTheDocument();
     expect(screen.getByText('Trusted agent')).toBeInTheDocument();
     expect(screen.getByText('Mock provider credential metadata')).toBeInTheDocument();
-    expect(screen.getByText('Publish/unpublish controls require a reviewed backend API and remain blocked.')).toBeInTheDocument();
+    expect(screen.getByText('Publish/unpublish controls require a separate reviewed backend API and remain blocked.')).toBeInTheDocument();
     expect(screen.queryByText(/enable live plural/i)).not.toBeInTheDocument();
 
     await user.clear(screen.getByLabelText('Display name'));
     await user.type(screen.getByLabelText('Display name'), 'Grantex Store Updated');
-    await user.click(screen.getByRole('button', { name: 'Save merchant' }));
-    await waitFor(() => expect(mockUpdateCommerceMerchant).toHaveBeenCalledWith('mch_1', expect.objectContaining({
+    await user.click(screen.getByRole('button', { name: 'Save sandbox profile' }));
+    await waitFor(() => expect(mockUpdateCommerceMerchantSandboxOnboarding).toHaveBeenCalledWith('mch_1', expect.objectContaining({
       display_name: 'Grantex Store Updated',
-      agentic_commerce_enabled: true,
+      agentic_commerce_requested: true,
     })));
+
+    await user.click(screen.getByRole('button', { name: 'Submit for review' }));
+    await waitFor(() => expect(mockTransitionCommerceMerchantSandboxOnboarding).toHaveBeenCalledWith('mch_1', {
+      targetState: 'submitted_for_review',
+    }));
 
     await user.click(screen.getByRole('button', { name: 'Evaluate policy' }));
     await waitFor(() => expect(mockEvaluateCommercePolicy).toHaveBeenCalledWith(expect.objectContaining({

--- a/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
+++ b/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
@@ -1,16 +1,17 @@
 import { useMemo, useState } from 'react';
 import {
   evaluateCommercePolicy,
-  getCommerceMerchant,
+  getCommerceMerchantSandboxOnboarding,
   getCommerceWellKnownProfile,
   listCommerceAgents,
   listCommercePolicies,
   listCommerceProducts,
   listCommerceProviderCredentials,
   listCommerceWebhookSources,
-  updateCommerceMerchant,
+  transitionCommerceMerchantSandboxOnboarding,
+  updateCommerceMerchantSandboxOnboarding,
   type CommerceAgent,
-  type CommerceMerchant,
+  type CommerceSandboxOnboarding,
   type CommercePolicyDecision,
   type CommerceWellKnownProfile,
 } from '../../api/commerce';
@@ -23,17 +24,26 @@ import { Input } from '../../components/ui/Input';
 import { Table } from '../../components/ui/Table';
 import { BlockerBanner, DateText, IdText, PageHeader, statusVariant } from './CommerceShared';
 
-type MerchantPatchForm = Pick<CommerceMerchant,
-  'display_name' | 'legal_name' | 'category_preset' | 'default_currency' | 'country_code' | 'support_email' | 'agentic_commerce_enabled'>;
+interface MerchantPatchForm {
+  display_name: string;
+  category_preset: string;
+  default_currency: string;
+  country_code: string;
+  support_email: string;
+  support_url: string;
+  public_discovery_description_draft: string;
+  agentic_commerce_requested: boolean;
+}
 
 const defaultPatch: MerchantPatchForm = {
   display_name: '',
-  legal_name: '',
   category_preset: 'electronics_appliances',
   default_currency: 'INR',
   country_code: 'IN',
   support_email: '',
-  agentic_commerce_enabled: false,
+  support_url: '',
+  public_discovery_description_draft: '',
+  agentic_commerce_requested: false,
 };
 
 const actionScopes = [
@@ -46,7 +56,7 @@ const actionScopes = [
 
 export function CommerceOnboarding() {
   const [merchantId, setMerchantId] = useState('');
-  const [merchant, setMerchant] = useState<CommerceMerchant | null>(null);
+  const [merchant, setMerchant] = useState<CommerceSandboxOnboarding | null>(null);
   const [merchantForm, setMerchantForm] = useState<MerchantPatchForm>(defaultPatch);
   const [agents, setAgents] = useState<CommerceAgent[]>([]);
   const [activePolicyCount, setActivePolicyCount] = useState(0);
@@ -56,6 +66,7 @@ export function CommerceOnboarding() {
   const [profile, setProfile] = useState<CommerceWellKnownProfile | null>(null);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const [policyDecision, setPolicyDecision] = useState<CommercePolicyDecision | null>(null);
   const [simulating, setSimulating] = useState(false);
   const [policyForm, setPolicyForm] = useState({
@@ -77,7 +88,7 @@ export function CommerceOnboarding() {
     setLoading(true);
     try {
       const [merchantRes, agentRes, policyRes, productRes, credentialRes, sourceRes, profileRes] = await Promise.all([
-        getCommerceMerchant(id),
+        getCommerceMerchantSandboxOnboarding(id),
         listCommerceAgents({ merchantId: id, limit: 25 }),
         listCommercePolicies({ merchantId: id, status: 'active', limit: 10 }),
         listCommerceProducts({ merchantId: id, status: 'active', limit: 10 }),
@@ -87,13 +98,14 @@ export function CommerceOnboarding() {
       ]);
       setMerchant(merchantRes.data);
       setMerchantForm({
-        display_name: merchantRes.data.display_name,
-        legal_name: merchantRes.data.legal_name,
-        category_preset: merchantRes.data.category_preset,
-        default_currency: merchantRes.data.default_currency,
-        country_code: merchantRes.data.country_code,
+        display_name: merchantRes.data.display_name ?? '',
+        category_preset: merchantRes.data.category_preset ?? 'electronics_appliances',
+        default_currency: merchantRes.data.default_currency ?? 'INR',
+        country_code: merchantRes.data.country_code ?? 'IN',
         support_email: merchantRes.data.support_email ?? '',
-        agentic_commerce_enabled: merchantRes.data.agentic_commerce_enabled,
+        support_url: merchantRes.data.support_url ?? '',
+        public_discovery_description_draft: merchantRes.data.public_discovery_description_draft ?? '',
+        agentic_commerce_requested: merchantRes.data.agentic_commerce_requested,
       });
       setAgents(agentRes.items);
       setActivePolicyCount(policyRes.items.length);
@@ -113,16 +125,34 @@ export function CommerceOnboarding() {
     if (!merchant) return;
     setSaving(true);
     try {
-      const res = await updateCommerceMerchant(merchant.id, {
+      const res = await updateCommerceMerchantSandboxOnboarding(merchant.merchant_id, {
         ...merchantForm,
         support_email: merchantForm.support_email || null,
+        support_url: merchantForm.support_url || null,
+        public_discovery_description_draft: merchantForm.public_discovery_description_draft || null,
       });
       setMerchant(res.data);
-      show('Merchant profile updated', 'success');
+      show('Sandbox onboarding profile updated', 'success');
     } catch {
       show('Failed to update merchant profile', 'error');
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function submitForReview() {
+    if (!merchant) return;
+    setSubmitting(true);
+    try {
+      const res = await transitionCommerceMerchantSandboxOnboarding(merchant.merchant_id, {
+        targetState: 'submitted_for_review',
+      });
+      setMerchant(res.data);
+      show('Sandbox onboarding submitted for review', 'success');
+    } catch {
+      show('Sandbox onboarding is not ready for review', 'error');
+    } finally {
+      setSubmitting(false);
     }
   }
 
@@ -132,7 +162,7 @@ export function CommerceOnboarding() {
     setPolicyDecision(null);
     try {
       const res = await evaluateCommercePolicy({
-        merchantId: merchant.id,
+        merchantId: merchant.merchant_id,
         agentId: policyForm.agent_id,
         actionScope: policyForm.action_scope,
         amountMinorUnits: Number.parseInt(policyForm.amount_minor_units, 10),
@@ -150,15 +180,14 @@ export function CommerceOnboarding() {
     }
   }
 
-  const checklist = useMemo(() => ([
-    { label: 'Merchant profile', done: Boolean(merchant) },
+  const integrationChecklist = useMemo(() => ([
     { label: 'Trusted agent', done: agents.some((agent) => agent.trust_status === 'trusted' && agent.status === 'active') },
     { label: 'Active policy', done: activePolicyCount > 0 },
     { label: 'Catalog products', done: productCount > 0 },
     { label: 'Mock provider credential metadata', done: mockCredentialCount > 0 },
     { label: 'Webhook source', done: webhookSourceCount > 0 },
     { label: 'Playground/MCP profile', done: Boolean(profile?.supported_tools?.length) },
-  ]), [activePolicyCount, agents, merchant, mockCredentialCount, productCount, profile, webhookSourceCount]);
+  ]), [activePolicyCount, agents, mockCredentialCount, productCount, profile, webhookSourceCount]);
 
   return (
     <div>
@@ -195,13 +224,13 @@ export function CommerceOnboarding() {
             <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
               <div>
                 <h2 className="text-base font-semibold text-gx-text">{merchant.display_name}</h2>
-                <div className="mt-1 text-xs text-gx-muted">{merchant.legal_name}</div>
+                <div className="mt-1 text-xs text-gx-muted">{merchant.merchant_id}</div>
               </div>
               <div className="flex flex-wrap gap-2">
                 <Badge variant={merchant.environment === 'sandbox' ? 'warning' : 'danger'}>{merchant.environment}</Badge>
-                <Badge variant={merchant.agentic_commerce_enabled ? 'success' : 'danger'}>
-                  {merchant.agentic_commerce_enabled ? 'agentic enabled' : 'agentic disabled'}
-                </Badge>
+                <Badge variant="danger">{merchant.readiness.live_mode_status}</Badge>
+                <Badge variant="danger">{merchant.readiness.production_approval_status}</Badge>
+                <Badge variant={statusVariant(merchant.sandbox_onboarding_state)}>{merchant.sandbox_onboarding_state}</Badge>
               </div>
             </div>
             <div className="grid gap-3 md:grid-cols-2">
@@ -210,12 +239,6 @@ export function CommerceOnboarding() {
                 label="Display name"
                 value={merchantForm.display_name}
                 onChange={(e) => setMerchantForm({ ...merchantForm, display_name: e.target.value })}
-              />
-              <Input
-                id="onboarding-legal-name"
-                label="Legal name"
-                value={merchantForm.legal_name}
-                onChange={(e) => setMerchantForm({ ...merchantForm, legal_name: e.target.value })}
               />
               <Input
                 id="onboarding-category"
@@ -241,48 +264,94 @@ export function CommerceOnboarding() {
                 value={merchantForm.support_email ?? ''}
                 onChange={(e) => setMerchantForm({ ...merchantForm, support_email: e.target.value })}
               />
+              <Input
+                id="onboarding-support-url"
+                label="Support URL"
+                value={merchantForm.support_url ?? ''}
+                onChange={(e) => setMerchantForm({ ...merchantForm, support_url: e.target.value })}
+              />
+            </div>
+            <div className="mt-3">
+              <label htmlFor="onboarding-description" className="mb-1.5 block text-sm font-medium text-gx-text">
+                Discovery description draft
+              </label>
+              <textarea
+                id="onboarding-description"
+                value={merchantForm.public_discovery_description_draft ?? ''}
+                onChange={(e) => setMerchantForm({ ...merchantForm, public_discovery_description_draft: e.target.value })}
+                rows={4}
+                className="w-full rounded-md border border-gx-border bg-gx-bg px-3 py-2 text-sm text-gx-text focus:border-gx-accent focus:outline-none"
+              />
             </div>
             <label className="mt-4 flex items-center gap-2 text-sm text-gx-text">
               <input
                 type="checkbox"
-                checked={merchantForm.agentic_commerce_enabled}
-                onChange={(e) => setMerchantForm({ ...merchantForm, agentic_commerce_enabled: e.target.checked })}
+                checked={merchantForm.agentic_commerce_requested}
+                onChange={(e) => setMerchantForm({ ...merchantForm, agentic_commerce_requested: e.target.checked })}
               />
-              Agentic commerce enabled
+              Agentic commerce requested
             </label>
             <div className="mt-4 flex flex-wrap gap-2">
-              <Button onClick={saveMerchant} disabled={saving}>{saving ? 'Saving' : 'Save merchant'}</Button>
+              <Button onClick={saveMerchant} disabled={saving}>{saving ? 'Saving' : 'Save sandbox profile'}</Button>
+              <Button
+                variant="secondary"
+                onClick={submitForReview}
+                disabled={submitting || !merchant.readiness.ready}
+              >
+                {submitting ? 'Submitting' : 'Submit for review'}
+              </Button>
               <Button variant="secondary" disabled title="Publish/unpublish requires a reviewed backend API.">
                 Publish unavailable
               </Button>
             </div>
             <p className="mt-3 text-xs text-gx-muted">
-              Publish/unpublish controls require a reviewed backend API and remain blocked.
+              Publish/unpublish controls require a separate reviewed backend API and remain blocked.
             </p>
           </Card>
 
           <Card>
             <h2 className="mb-3 text-base font-semibold text-gx-text">Readiness checklist</h2>
             <div className="grid gap-2 md:grid-cols-2">
-              {checklist.map((item) => (
-                <div key={item.label} className="flex items-center justify-between gap-3 rounded-md border border-gx-border p-3">
+              {merchant.readiness.checks.map((item) => (
+                <div key={item.key} className="flex items-center justify-between gap-3 rounded-md border border-gx-border p-3">
                   <span className="text-sm text-gx-text">{item.label}</span>
-                  <Badge variant={item.done ? 'success' : 'warning'}>{item.done ? 'ready' : 'missing'}</Badge>
+                  <Badge variant={item.status === 'pass' ? 'success' : 'warning'}>
+                    {item.status === 'pass' ? 'pass' : 'blocked'}
+                  </Badge>
                 </div>
               ))}
             </div>
             <div className="mt-4 grid gap-3 text-sm md:grid-cols-2">
               <div>
                 <div className="text-xs text-gx-muted">Merchant</div>
-                <IdText value={merchant.id} />
+                <IdText value={merchant.merchant_id} />
               </div>
               <div>
-                <div className="text-xs text-gx-muted">Well-known environment</div>
-                <div className="text-gx-text">{profile?.environment ?? 'not loaded'}</div>
+                <div className="text-xs text-gx-muted">Rollout status</div>
+                <div className="text-gx-text">{merchant.readiness.rollout_status}</div>
               </div>
               <div>
                 <div className="text-xs text-gx-muted">Updated</div>
-                <DateText value={merchant.updated_at} />
+                <DateText value={merchant.sandbox_onboarding_updated_at} />
+              </div>
+              <div>
+                <div className="text-xs text-gx-muted">Agentic request</div>
+                <div className="text-gx-text">{merchant.agentic_commerce_requested ? 'requested' : 'not requested'}</div>
+              </div>
+            </div>
+            <h3 className="mb-2 mt-5 text-sm font-semibold text-gx-text">V1 control signals</h3>
+            <div className="grid gap-2 md:grid-cols-2">
+              {integrationChecklist.map((item) => (
+                <div key={item.label} className="flex items-center justify-between gap-3 rounded-md border border-gx-border p-3">
+                  <span className="text-sm text-gx-text">{item.label}</span>
+                  <Badge variant={item.done ? 'success' : 'warning'}>{item.done ? 'present' : 'missing'}</Badge>
+                </div>
+              ))}
+            </div>
+            <div className="mt-4 grid gap-3 text-sm md:grid-cols-2">
+              <div>
+                <div className="text-xs text-gx-muted">Well-known environment</div>
+                <div className="text-gx-text">{profile?.environment ?? 'not loaded'}</div>
               </div>
               <div>
                 <div className="text-xs text-gx-muted">Discovery tools</div>

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -21,7 +21,11 @@ info:
     playground client for the commerce MCP surface. M6A adds operator-only
     commerce operations health and baseline hardening runbooks. C5C adds a
     narrow read-only discovery gate for the well-known profile without
-    enabling broader Commerce V1 runtime routes.
+    enabling broader Commerce V1 runtime routes. C5Z adds a sandbox-only
+    seller onboarding foundation that records public-safe profile drafts,
+    readiness checks, and review state without production approval,
+    checkout/payment creation, provider credential capture, public discovery
+    enablement, live payments, or live Plural.
 servers:
   - url: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
     description: Production (Cloud Run)
@@ -121,6 +125,14 @@ components:
         default_currency: { type: string }
         country_code: { type: string }
         support_email: { type: string, nullable: true }
+        support_url: { type: string, nullable: true }
+        public_discovery_description_draft: { type: string, nullable: true }
+        agentic_commerce_requested: { type: boolean, default: false }
+        sandbox_onboarding_state:
+          type: string
+          enum: [draft_created, profile_incomplete, sandbox_ready, submitted_for_review, blocked, not_approved, rollout_not_requested]
+        sandbox_onboarding_blocker: { type: string, nullable: true }
+        sandbox_onboarding_updated_at: { type: string, format: date-time, nullable: true }
         disabled_at: { type: string, format: date-time, nullable: true }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
@@ -135,6 +147,9 @@ components:
         default_currency: { type: string, default: INR }
         country_code: { type: string, default: IN }
         support_email: { type: string, nullable: true }
+        support_url: { type: string, nullable: true }
+        public_discovery_description_draft: { type: string, nullable: true }
+        agentic_commerce_requested: { type: boolean, default: false }
 
     UpdateMerchantRequest:
       type: object
@@ -152,6 +167,87 @@ components:
         Mutable merchant fields only. Tenant, ownership, environment,
         provider account references, audit fields, created_at, and updated_at
         are immutable on this endpoint.
+
+    SandboxOnboardingState:
+      type: string
+      enum:
+        - draft_created
+        - profile_incomplete
+        - sandbox_ready
+        - submitted_for_review
+        - blocked
+        - not_approved
+        - rollout_not_requested
+
+    SandboxOnboardingUpdateRequest:
+      type: object
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        display_name: { type: string }
+        category_preset: { type: string, enum: [electronics_appliances] }
+        default_currency: { type: string, pattern: "^[A-Z]{3}$" }
+        country_code: { type: string, pattern: "^[A-Z]{2}$" }
+        support_email:
+          type: string
+          nullable: true
+          description: Test-safe or repo-safe support email only.
+        support_url:
+          type: string
+          nullable: true
+          description: Test-safe or repo-safe support URL only.
+        public_discovery_description_draft:
+          type: string
+          nullable: true
+          description: Public-safe draft with no checkout, payment, live-provider, production approval, readiness, certification, credential, or secret claims.
+        agentic_commerce_requested: { type: boolean }
+
+    SandboxOnboardingTransitionRequest:
+      type: object
+      required: [target_state]
+      properties:
+        target_state: { $ref: "#/components/schemas/SandboxOnboardingState" }
+        reason:
+          type: string
+          nullable: true
+          description: Public-safe reason summary required for blocked or not_approved transitions.
+
+    SandboxOnboarding:
+      type: object
+      properties:
+        merchant_id: { type: string }
+        tenant_id: { type: string }
+        display_name: { type: string, nullable: true }
+        category_preset: { type: string, nullable: true }
+        country_code: { type: string, nullable: true }
+        default_currency: { type: string, nullable: true }
+        support_email: { type: string, nullable: true }
+        support_url: { type: string, nullable: true }
+        public_discovery_description_draft: { type: string, nullable: true }
+        environment: { type: string, enum: [sandbox] }
+        agentic_commerce_requested: { type: boolean }
+        agentic_commerce_enabled:
+          type: boolean
+          description: Existing execution flag, surfaced so readiness can fail closed when true; sandbox onboarding cannot set it.
+        sandbox_onboarding_state: { $ref: "#/components/schemas/SandboxOnboardingState" }
+        sandbox_onboarding_blocker: { type: string, nullable: true }
+        sandbox_onboarding_updated_at: { type: string, format: date-time, nullable: true }
+        readiness:
+          type: object
+          properties:
+            ready: { type: boolean }
+            live_mode_status: { type: string, enum: [not_live] }
+            production_approval_status: { type: string, enum: [not_approved] }
+            rollout_status: { type: string, enum: [rollout_not_requested] }
+            checks:
+              type: array
+              items:
+                type: object
+                properties:
+                  key: { type: string }
+                  label: { type: string }
+                  status: { type: string, enum: [pass, blocked] }
+                  detail: { type: string }
 
     Agent:
       type: object
@@ -1305,6 +1401,104 @@ paths:
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { description: Operator or owning merchant caller required; CommerceAgent callers are denied }
         "404": { $ref: "#/components/responses/NotFound" }
+        "422": { $ref: "#/components/responses/ValidationFailed" }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+
+  /v1/commerce/merchants/{merchant_id}/sandbox-onboarding:
+    parameters:
+      - { in: path, name: merchant_id, required: true, schema: { type: string } }
+    get:
+      tags: [Merchants]
+      summary: Get sandbox seller onboarding state
+      operationId: getMerchantSandboxOnboarding
+      x-implemented: true
+      x-milestone: C5Z
+      description: >-
+        Returns public-safe sandbox onboarding fields, readiness checks, and
+        fail-closed production statuses. The response never includes provider
+        account references, credentials, secrets, production allowlist values,
+        checkout/payment material, or live-provider paths.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/SandboxOnboarding" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Operator or owning merchant caller required; CommerceAgent callers are denied }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { description: Live merchant blocked from sandbox onboarding }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+    put:
+      tags: [Merchants]
+      summary: Update sandbox seller onboarding profile
+      operationId: updateMerchantSandboxOnboarding
+      x-implemented: true
+      x-milestone: C5Z
+      description: >-
+        Updates only non-secret, public-safe sandbox profile fields and the
+        agentic commerce requested flag. It cannot set environment, production
+        approval, public discovery, allowlist, provider credential, checkout,
+        payment, live payment, or live Plural fields.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/SandboxOnboardingUpdateRequest" }
+      responses:
+        "200":
+          description: Updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/SandboxOnboarding" }
+                  audit_event_id: { type: string }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Operator or owning merchant caller required; CommerceAgent callers are denied }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { description: Live merchant blocked from sandbox onboarding }
+        "422": { $ref: "#/components/responses/ValidationFailed" }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+
+  /v1/commerce/merchants/{merchant_id}/sandbox-onboarding/transition:
+    parameters:
+      - { in: path, name: merchant_id, required: true, schema: { type: string } }
+    post:
+      tags: [Merchants]
+      summary: Transition sandbox seller onboarding state
+      operationId: transitionMerchantSandboxOnboarding
+      x-implemented: true
+      x-milestone: C5Z
+      description: >-
+        Moves a sandbox onboarding workspace through the review-oriented state
+        machine. Transitions to sandbox_ready or submitted_for_review require
+        readiness checks to pass. No transition approves production, enables
+        public discovery, enables checkout/payment creation, or enables live
+        payments/live Plural.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/SandboxOnboardingTransitionRequest" }
+      responses:
+        "200":
+          description: Transitioned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/SandboxOnboarding" }
+                  audit_event_id: { type: string }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Operator or owning merchant caller required; CommerceAgent callers are denied }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { description: Invalid transition or live merchant blocked }
         "422": { $ref: "#/components/responses/ValidationFailed" }
         "503": { $ref: "#/components/responses/CommerceDisabled" }
 

--- a/docs/guides/commerce-v1-merchant-operator-guide.mdx
+++ b/docs/guides/commerce-v1-merchant-operator-guide.mdx
@@ -35,6 +35,38 @@ paths directly.
 | Provider status | Mock provider only for current evidence. Live provider credentials remain blocked. |
 | Audit review | Confirm consent, passport, cart, payment intent, and webhook metadata are observable without secret values. |
 
+## Seller Self-Serve Sandbox Onboarding
+
+C5Z adds an API-backed sandbox onboarding foundation for a tenant-owned
+merchant workspace. It is for preparing public-safe sandbox profile metadata
+only. It does not approve a merchant, enable public discovery, enable AgenticOrg
+public commerce discovery, enable Commerce V1 production use, create checkout or
+payment paths, collect provider credentials, enable live payments, or enable
+live Plural.
+
+Sandbox onboarding stores only:
+
+- display name;
+- category preset;
+- country and currency;
+- test-safe support email or support URL;
+- public discovery description draft;
+- sandbox environment marker;
+- agentic commerce requested flag;
+- sandbox onboarding state and public-safe blocker/status summaries.
+
+The state machine is:
+
+`draft_created` -> `profile_incomplete` -> `sandbox_ready` ->
+`submitted_for_review`, with `blocked`, `not_approved`, and
+`rollout_not_requested` as fail-closed review states.
+
+Readiness checks require a merchant profile, category preset, public-safe
+description, no private artifacts in public fields, no production allowlist or
+live-mode config values, no provider account references, and no checkout/payment
+enablement. Passing readiness means "sandbox profile can be reviewed"; it is not
+production approval.
+
 ## Catalog And Inventory
 
 Catalog and inventory grounding is the first safety step. Agents must not invent

--- a/docs/internal/commerce-v1/commerce-v1-c5z-seller-sandbox-onboarding-foundation.md
+++ b/docs/internal/commerce-v1/commerce-v1-c5z-seller-sandbox-onboarding-foundation.md
@@ -1,0 +1,90 @@
+# Commerce V1 C5Z Seller Sandbox Onboarding Foundation
+
+Status: implementation slice 1
+Date: 2026-05-31
+Scope: Grantex runtime foundation for seller self-serve sandbox onboarding
+Production changes made by this slice: none
+Production Commerce V1 changed by this slice: no
+Public discovery changed by this slice: no
+AgenticOrg public discovery changed by this slice: no
+Checkout or payment creation changed by this slice: no
+Live payment path changed by this slice: no
+Live Plural path changed by this slice: no
+Provider credential collection changed by this slice: no
+Named merchant approved by this slice: no
+Secrets inspected or changed: no
+
+## Implemented Boundary
+
+C5Z creates an API-backed seller sandbox onboarding surface on the existing
+tenant-owned `commerce_merchants` row. It lets an operator or owning merchant
+prepare a sandbox workspace with public-safe profile metadata and review state.
+
+The implementation stores only:
+
+- display name;
+- category preset;
+- country code;
+- default currency;
+- test-safe support email or support URL;
+- public discovery description draft;
+- sandbox onboarding state and blocker summary;
+- sandbox/live environment marker already present on the merchant;
+- agentic commerce requested flag.
+
+It does not store private contracts, private contacts, signed approvals,
+pricing terms, customer data, secrets, tokens, JWTs, raw payloads, DB/Redis
+URLs, private keys, provider credentials, production config values, allowlist
+values, checkout state, payment state, live provider references, or real
+merchant approval material.
+
+## API Surface
+
+- `GET /v1/commerce/merchants/{merchant_id}/sandbox-onboarding`
+- `PUT /v1/commerce/merchants/{merchant_id}/sandbox-onboarding`
+- `POST /v1/commerce/merchants/{merchant_id}/sandbox-onboarding/transition`
+
+All three endpoints use the existing commerce caller resolver and tenant
+boundary. Operator callers may access tenant merchants. Merchant callers may
+access only their own merchant. CommerceAgent callers are denied. State-changing
+endpoints append commerce audit events.
+
+## State Machine
+
+Supported states:
+
+- `draft_created`
+- `profile_incomplete`
+- `sandbox_ready`
+- `submitted_for_review`
+- `blocked`
+- `not_approved`
+- `rollout_not_requested`
+
+Transitions to `sandbox_ready` or `submitted_for_review` require readiness
+checks to pass. No state transition approves production, enables discovery,
+enables checkout/payment creation, enables live payments, or enables live
+Plural.
+
+## Readiness Checks
+
+The runtime readiness response includes:
+
+- merchant profile present;
+- category preset selected;
+- public-safe description present;
+- private artifacts not stored in public fields;
+- no production allowlist/config values;
+- no live provider path;
+- no checkout/payment enablement.
+
+The readiness response always reports:
+
+- `live_mode_status: not_live`;
+- `production_approval_status: not_approved`;
+- `rollout_status: rollout_not_requested`.
+
+Passing readiness means only that the sandbox profile can be submitted for
+review. It is not merchant approval, production approval, public discovery
+approval, AgenticOrg launch approval, checkout approval, payment approval, live
+Plural approval, or provider readiness evidence.


### PR DESCRIPTION
## Summary
- Adds sandbox onboarding fields and a constrained C5Z state machine to commerce merchants.
- Adds API-backed sandbox onboarding GET/PUT/transition routes with tenant boundary checks, safe-field validation, fail-closed readiness, and audit events.
- Updates the portal onboarding UI/API plus Commerce V1 OpenAPI and operator/internal docs for sandbox-only onboarding.

## Safety
- No deploy, cloud resources, production config, secrets, public discovery, checkout/payment creation, live payments, or live Plural changes.
- Readiness remains sandbox/not_live/not_approved/rollout_not_requested.
- AgenticOrg was not touched; no direct merchant-system, provider, or checkout paths were added there.

## Validation
- `npm test -- commerce` in `apps/auth-service`: 467 passed.
- `npm run typecheck` in `apps/auth-service`: passed.
- `npm test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx` in `apps/portal`: 30 passed.
- `npm run typecheck` in `apps/portal`: passed.
- `git diff --check`: passed, with CRLF warnings only.
- Targeted safety scans passed for production config/allowlist assignment, overclaims, live payment/provider paths, and private/secret markers. The only secret-scan hit was the scanner regex literal itself in the new validation code.
- `node docs/commerce-v1-pilot-readiness.validate.mjs` was blocked by a pre-existing missing file: `docs/reports/commerce-v1-local-pilot-load.md`.

## Notes
- Canonical PRD path `docs/guides/commerce-v1-agentic-commerce-prd.md` was not present in the checkout; implementation used the available Commerce V1 build spec, supporting docs, existing runtime patterns, and the local enterprise guardrails.