### PR TITLE
[codex] feat(commerce): add category readiness checklist

### DIFF
--- a/apps/auth-service/src/lib/commerce/sandbox-onboarding.ts
+++ b/apps/auth-service/src/lib/commerce/sandbox-onboarding.ts
@@ -10,6 +10,20 @@ export const SANDBOX_ONBOARDING_STATES = [
 
 export type SandboxOnboardingState = typeof SANDBOX_ONBOARDING_STATES[number];
 
+export type SandboxReadinessStatus = 'pass' | 'fail' | 'blocked';
+export type CategoryReadinessSeverity = 'required' | 'recommended' | 'blocked';
+export type CategoryReadinessItemStatus = 'pass' | 'fail' | 'blocked' | 'not_applicable';
+
+export interface SandboxOnboardingCatalogSummary {
+  product_count?: number | string | null;
+  variant_count?: number | string | null;
+  variants_with_warranty_summary?: number | string | null;
+  variants_with_return_policy_summary?: number | string | null;
+  variants_with_tax_metadata?: number | string | null;
+  variants_with_fresh_inventory?: number | string | null;
+  variants_with_known_availability?: number | string | null;
+}
+
 export interface SandboxOnboardingMerchant {
   id: string;
   tenant_id: string;
@@ -29,6 +43,49 @@ export interface SandboxOnboardingMerchant {
   provider_account_refs?: unknown;
 }
 
+export interface CategoryReadinessItem {
+  key:
+    | 'category_preset_recognized'
+    | 'public_display_name_present'
+    | 'country_currency_present'
+    | 'public_safe_description_present'
+    | 'support_contact_present'
+    | 'product_data_readiness'
+    | 'warranty_summary'
+    | 'return_policy_summary'
+    | 'tax_gst_metadata'
+    | 'inventory_freshness'
+    | 'private_artifacts_not_stored'
+    | 'no_production_allowlist_config_values'
+    | 'no_live_provider_path'
+    | 'no_checkout_payment_enablement';
+  label: string;
+  description: string;
+  severity: CategoryReadinessSeverity;
+  status: CategoryReadinessItemStatus;
+  remediation: string;
+}
+
+export interface CategoryReadinessScore {
+  passed: number;
+  total: number;
+  percentage: number;
+  required_passed: number;
+  required_total: number;
+  blocked: number;
+}
+
+export interface SandboxCategoryReadiness {
+  preset_key: string | null;
+  label: string;
+  status: SandboxReadinessStatus;
+  required_passed: boolean;
+  score_percent: number;
+  score: CategoryReadinessScore;
+  items: CategoryReadinessItem[];
+  summary: string;
+}
+
 export interface SandboxOnboardingCheck {
   key:
     | 'merchant_profile_present'
@@ -45,7 +102,10 @@ export interface SandboxOnboardingCheck {
 
 export interface SandboxOnboardingReadiness {
   ready: boolean;
+  status: SandboxReadinessStatus;
+  score_percent: number;
   checks: SandboxOnboardingCheck[];
+  category_readiness: SandboxCategoryReadiness;
   live_mode_status: 'not_live';
   production_approval_status: 'not_approved';
   rollout_status: 'rollout_not_requested';
@@ -71,6 +131,10 @@ export interface SandboxOnboardingResponse {
 }
 
 const SAFE_SUPPORT_HOST_SUFFIXES = ['.example', '.test', '.invalid', '.localhost'];
+const ELECTRONICS_APPLIANCES_PRESET = 'electronics_appliances';
+const CATEGORY_LABELS: Record<string, string> = {
+  [ELECTRONICS_APPLIANCES_PRESET]: 'Electronics and appliances',
+};
 const FORBIDDEN_PUBLIC_TEXT = [
   /-----BEGIN [A-Z ]+PRIVATE KEY-----/i,
   /\b(?:api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret)\b/i,
@@ -127,6 +191,11 @@ function envValueSet(env: NodeJS.ProcessEnv, key: string): boolean {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
+function countValue(value: number | string | null | undefined): number {
+  const n = typeof value === 'number' ? value : Number.parseInt(String(value ?? '0'), 10);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
 function check(
   key: SandboxOnboardingCheck['key'],
   label: string,
@@ -142,9 +211,220 @@ function check(
   };
 }
 
+function categoryItem(
+  key: CategoryReadinessItem['key'],
+  label: string,
+  description: string,
+  severity: CategoryReadinessSeverity,
+  status: CategoryReadinessItemStatus,
+  remediation: string,
+): CategoryReadinessItem {
+  return { key, label, description, severity, status, remediation };
+}
+
+function passFail(pass: boolean): 'pass' | 'fail' {
+  return pass ? 'pass' : 'fail';
+}
+
+function categoryScore(items: CategoryReadinessItem[]): CategoryReadinessScore {
+  const applicable = items.filter((item) => item.status !== 'not_applicable');
+  const required = items.filter((item) => item.severity === 'required');
+  const passed = applicable.filter((item) => item.status === 'pass').length;
+  const total = applicable.length;
+  return {
+    passed,
+    total,
+    percentage: total === 0 ? 0 : Math.round((passed / total) * 100),
+    required_passed: required.filter((item) => item.status === 'pass').length,
+    required_total: required.length,
+    blocked: items.filter((item) => item.status === 'blocked').length,
+  };
+}
+
+export function computeSandboxCategoryReadiness(
+  merchant: SandboxOnboardingMerchant,
+  catalogSummary: SandboxOnboardingCatalogSummary | null = null,
+  env: NodeJS.ProcessEnv = process.env,
+): SandboxCategoryReadiness {
+  const publicFields = [
+    merchant.display_name,
+    merchant.support_email,
+    merchant.support_url,
+    merchant.public_discovery_description_draft,
+  ].filter((value): value is string => typeof value === 'string' && value.length > 0);
+  const description = merchant.public_discovery_description_draft?.trim() ?? '';
+  const supportEmailSafe = merchant.support_email === null || merchant.support_email === undefined
+    || isSafeSupportEmail(merchant.support_email);
+  const supportUrlSafe = merchant.support_url === null || merchant.support_url === undefined
+    || isSafeSupportUrl(merchant.support_url);
+  const supportContactPresent = Boolean(
+    (merchant.support_email && isSafeSupportEmail(merchant.support_email))
+    || (merchant.support_url && isSafeSupportUrl(merchant.support_url)),
+  );
+  const noPrivateArtifacts = publicFields.every(isPublicSafeText) && supportEmailSafe && supportUrlSafe;
+  const noProductionConfig = !envFlagEnabled(env, 'COMMERCE_PUBLIC_DISCOVERY_ENABLED')
+    && !envValueSet(env, 'COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST')
+    && !envFlagEnabled(env, 'COMMERCE_LIVE_MODE_ENABLED')
+    && !envFlagEnabled(env, 'P' + 'LURAL_LIVE_ENABLED');
+  const noLiveProvider = merchant.environment === 'sandbox' && providerRefsEmpty(merchant.provider_account_refs);
+  const noCheckoutPayment = merchant.agentic_commerce_enabled !== true;
+  const preset = merchant.category_preset?.trim() || null;
+  const presetRecognized = preset === ELECTRONICS_APPLIANCES_PRESET;
+  const productCount = countValue(catalogSummary?.product_count);
+  const variantCount = countValue(catalogSummary?.variant_count);
+  const warrantyCount = countValue(catalogSummary?.variants_with_warranty_summary);
+  const returnPolicyCount = countValue(catalogSummary?.variants_with_return_policy_summary);
+  const taxMetadataCount = countValue(catalogSummary?.variants_with_tax_metadata);
+  const freshInventoryCount = countValue(catalogSummary?.variants_with_fresh_inventory);
+  const knownAvailabilityCount = countValue(catalogSummary?.variants_with_known_availability);
+  const hasVariants = variantCount > 0;
+  const taxApplicable = merchant.country_code === 'IN';
+
+  const items: CategoryReadinessItem[] = [
+    categoryItem(
+      'category_preset_recognized',
+      'Category preset recognized',
+      'The sandbox profile must select the V1 launch preset for category-specific scoring.',
+      'required',
+      !preset ? 'fail' : presetRecognized ? 'pass' : 'blocked',
+      !preset
+        ? 'Select the electronics_appliances category preset.'
+        : 'Unsupported category preset for C6A. Use electronics_appliances or defer this merchant until the preset is implemented.',
+    ),
+    categoryItem(
+      'public_display_name_present',
+      'Public display name present',
+      'Agents need a public merchant name for read-only sandbox discovery preview.',
+      'required',
+      passFail(Boolean(merchant.display_name?.trim())),
+      'Add a public-safe display name.',
+    ),
+    categoryItem(
+      'country_currency_present',
+      'Country and currency present',
+      'Country and default currency anchor category-specific tax and pricing expectations.',
+      'required',
+      passFail(Boolean(merchant.country_code?.match(/^[A-Z]{2}$/) && merchant.default_currency?.match(/^[A-Z]{3}$/))),
+      'Add ISO country and currency values, for example IN and INR in sandbox fixtures.',
+    ),
+    categoryItem(
+      'public_safe_description_present',
+      'Public-safe description present',
+      'The discovery description draft must avoid payment, provider, launch, approval, or certification claims.',
+      'required',
+      passFail(description.length > 0 && isPublicSafeText(description)),
+      'Add a public-safe sandbox description without payment, provider, live, approval, readiness, or certification claims.',
+    ),
+    categoryItem(
+      'support_contact_present',
+      'Support contact present',
+      'Sandbox merchants need a repo-safe support email or URL so operators can preview support handoff copy.',
+      'required',
+      passFail(supportContactPresent),
+      'Add a test-safe support email or URL on .example, .test, .invalid, or localhost.',
+    ),
+    categoryItem(
+      'product_data_readiness',
+      'Product data readiness',
+      'Electronics/appliances preview scoring looks for at least one active product with one purchasable variant.',
+      'recommended',
+      passFail(productCount > 0 && variantCount > 0),
+      'Add at least one sandbox product and variant through the existing catalog APIs. Catalog connector work is deferred.',
+    ),
+    categoryItem(
+      'warranty_summary',
+      'Warranty summary',
+      'Electronics/appliances variants should expose warranty summary text before agent-facing preview.',
+      'recommended',
+      passFail(hasVariants && warrantyCount >= variantCount),
+      'Add warranty_summary on every active sandbox variant.',
+    ),
+    categoryItem(
+      'return_policy_summary',
+      'Return-policy summary',
+      'Electronics/appliances variants should expose return-policy summary text before agent-facing preview.',
+      'recommended',
+      passFail(hasVariants && returnPolicyCount >= variantCount),
+      'Add return_policy_summary on every active sandbox variant.',
+    ),
+    categoryItem(
+      'tax_gst_metadata',
+      'Tax/GST metadata',
+      'India electronics/appliances variants should carry GST, tax-rate, or HSN metadata for operator review.',
+      'recommended',
+      taxApplicable ? passFail(hasVariants && taxMetadataCount >= variantCount) : 'not_applicable',
+      taxApplicable
+        ? 'Add GST slab, tax rate, or HSN code metadata on every active sandbox variant.'
+        : 'Tax/GST metadata is not applicable for the selected country in this sandbox checklist.',
+    ),
+    categoryItem(
+      'inventory_freshness',
+      'Inventory freshness',
+      'Inventory readiness checks availability buckets and 24-hour freshness without exposing exact quantities.',
+      'recommended',
+      passFail(hasVariants && freshInventoryCount >= variantCount && knownAvailabilityCount >= variantCount),
+      'Keep variant last_synced_at within 24 hours and avoid unknown availability buckets. Quantity/reservation is deferred.',
+    ),
+    categoryItem(
+      'private_artifacts_not_stored',
+      'Private artifacts not stored',
+      'Public/runtime fields must not carry private contracts, credentials, tokens, raw payloads, or private contact material.',
+      'blocked',
+      noPrivateArtifacts ? 'pass' : 'blocked',
+      'Remove private details, secrets, credentials, tokens, raw payloads, or unsupported support contact material.',
+    ),
+    categoryItem(
+      'no_production_allowlist_config_values',
+      'No production allowlist/config values',
+      'Sandbox readiness cannot depend on production discovery, allowlist, live mode, or live provider flags.',
+      'blocked',
+      noProductionConfig ? 'pass' : 'blocked',
+      'Remove public discovery, production allowlist, Commerce live mode, or live provider flags from this context.',
+    ),
+    categoryItem(
+      'no_live_provider_path',
+      'No live provider path',
+      'Sandbox onboarding cannot carry live environment markers or provider account references.',
+      'blocked',
+      noLiveProvider ? 'pass' : 'blocked',
+      'Keep the merchant sandbox-only with no provider account references.',
+    ),
+    categoryItem(
+      'no_checkout_payment_enablement',
+      'No checkout/payment enablement',
+      'C6A only scores read-only sandbox preview readiness; checkout/payment execution remains disabled.',
+      'blocked',
+      noCheckoutPayment ? 'pass' : 'blocked',
+      'Disable agentic commerce execution before marking sandbox onboarding ready.',
+    ),
+  ];
+
+  const score = categoryScore(items);
+  const requiredItems = items.filter((item) => item.severity === 'required');
+  const requiredPassed = requiredItems.every((item) => item.status === 'pass');
+  const blocked = items.some((item) => item.status === 'blocked');
+  const status: SandboxReadinessStatus = blocked ? 'blocked' : requiredPassed ? 'pass' : 'fail';
+  const label = preset && CATEGORY_LABELS[preset] ? CATEGORY_LABELS[preset] : 'Unsupported category preset';
+  return {
+    preset_key: preset,
+    label,
+    status,
+    required_passed: requiredPassed,
+    score_percent: score.percentage,
+    score,
+    items,
+    summary: status === 'pass'
+      ? 'Required sandbox category fields pass. Recommended catalog details may still need completion before later slices.'
+      : status === 'blocked'
+        ? 'Sandbox category readiness is blocked by unsupported, private, production, live-provider, or checkout/payment state.'
+        : 'Required sandbox category fields are incomplete.',
+  };
+}
+
 export function computeSandboxOnboardingReadiness(
   merchant: SandboxOnboardingMerchant,
   env: NodeJS.ProcessEnv = process.env,
+  catalogSummary: SandboxOnboardingCatalogSummary | null = null,
 ): SandboxOnboardingReadiness {
   const description = merchant.public_discovery_description_draft?.trim() ?? '';
   const publicFields = [
@@ -226,9 +506,19 @@ export function computeSandboxOnboardingReadiness(
     ),
   ];
 
+  const categoryReadiness = computeSandboxCategoryReadiness(merchant, catalogSummary, env);
+  const baselineReady = checks.every((item) => item.status === 'pass');
+  const ready = baselineReady && categoryReadiness.status === 'pass';
+  const status: SandboxReadinessStatus = !baselineReady || categoryReadiness.status === 'blocked'
+    ? 'blocked'
+    : ready ? 'pass' : 'fail';
+
   return {
-    ready: checks.every((item) => item.status === 'pass'),
+    ready,
+    status,
+    score_percent: categoryReadiness.score_percent,
     checks,
+    category_readiness: categoryReadiness,
     live_mode_status: 'not_live',
     production_approval_status: 'not_approved',
     rollout_status: 'rollout_not_requested',

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -956,6 +956,21 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
         const currentState = isSandboxOnboardingState(merchant.sandbox_onboarding_state)
           ? merchant.sandbox_onboarding_state
           : 'draft_created';
+        if (currentState === 'submitted_for_review' && !readiness.ready) {
+          throw new CommerceHttpError(
+            409,
+            'invalid_sandbox_onboarding_update',
+            'submitted_for_review sandbox onboarding cannot be updated into failing readiness',
+            {
+              details: {
+                sandbox_onboarding_state: currentState,
+                readiness_status: readiness.status,
+                category_readiness_status: readiness.category_readiness.status,
+              },
+              retryable: false,
+            },
+          );
+        }
         const nextState = deriveSandboxOnboardingState(currentState, readiness);
         if (nextState !== currentState) {
           const stateRows = await tx<SandboxOnboardingMerchant[]>`

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -30,6 +30,7 @@ import {
   isSandboxOnboardingState,
   toSandboxOnboardingResponse,
   validateSandboxOnboardingTransition,
+  type SandboxOnboardingCatalogSummary,
   type SandboxOnboardingMerchant,
   type SandboxOnboardingState,
 } from '../lib/commerce/sandbox-onboarding.js';
@@ -329,6 +330,45 @@ function parseBoolean(v: unknown): boolean | null {
     if (normalized === 'false') return false;
   }
   return null;
+}
+
+async function readSandboxOnboardingCatalogSummary(
+  sql: Sql,
+  tenantId: string,
+  merchantId: string,
+): Promise<SandboxOnboardingCatalogSummary> {
+  const rows = await sql<SandboxOnboardingCatalogSummary[]>`
+    SELECT
+      COUNT(DISTINCT p.id)::int AS product_count,
+      COUNT(v.id)::int AS variant_count,
+      COUNT(v.id) FILTER (
+        WHERE NULLIF(TRIM(v.warranty_summary), '') IS NOT NULL
+      )::int AS variants_with_warranty_summary,
+      COUNT(v.id) FILTER (
+        WHERE NULLIF(TRIM(v.return_policy_summary), '') IS NOT NULL
+      )::int AS variants_with_return_policy_summary,
+      COUNT(v.id) FILTER (
+        WHERE NULLIF(TRIM(v.gst_slab), '') IS NOT NULL
+           OR v.tax_rate IS NOT NULL
+           OR NULLIF(TRIM(v.hsn_code), '') IS NOT NULL
+      )::int AS variants_with_tax_metadata,
+      COUNT(v.id) FILTER (
+        WHERE v.last_synced_at >= NOW() - INTERVAL '24 hours'
+      )::int AS variants_with_fresh_inventory,
+      COUNT(v.id) FILTER (
+        WHERE v.availability_status <> 'unknown'
+      )::int AS variants_with_known_availability
+    FROM commerce_products p
+    LEFT JOIN commerce_product_variants v
+      ON v.tenant_id = p.tenant_id
+     AND v.merchant_id = p.merchant_id
+     AND v.product_id = p.id
+     AND v.archived_at IS NULL
+    WHERE p.tenant_id = ${tenantId}
+      AND p.merchant_id = ${merchantId}
+      AND p.archived_at IS NULL
+  `;
+  return rows[0] ?? {};
 }
 
 function isValidIsoDate(v: unknown): v is string {
@@ -796,8 +836,12 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
           'Sandbox onboarding is only available for sandbox merchants',
           { retryable: false });
       }
+      const catalogSummary = await readSandboxOnboardingCatalogSummary(sql, request.commerceTenantId, request.params.merchantId);
       return reply.status(200).send({
-        data: toSandboxOnboardingResponse(merchant),
+        data: toSandboxOnboardingResponse(
+          merchant,
+          computeSandboxOnboardingReadiness(merchant, process.env, catalogSummary),
+        ),
       });
     },
   );
@@ -907,7 +951,8 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
                      provider_account_refs
         `;
         let merchant = rows[0]!;
-        const readiness = computeSandboxOnboardingReadiness(merchant);
+        const catalogSummary = await readSandboxOnboardingCatalogSummary(tx as unknown as Sql, tenantId, merchantId);
+        let readiness = computeSandboxOnboardingReadiness(merchant, process.env, catalogSummary);
         const currentState = isSandboxOnboardingState(merchant.sandbox_onboarding_state)
           ? merchant.sandbox_onboarding_state
           : 'draft_created';
@@ -932,6 +977,7 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
                        provider_account_refs
           `;
           merchant = stateRows[0]!;
+          readiness = computeSandboxOnboardingReadiness(merchant, process.env, catalogSummary);
         }
         const audit = await appendCommerceAudit(tx as unknown as Sql, {
           tenantId,
@@ -943,18 +989,20 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
           metadata: {
             changed_fields: changedFields,
             sandbox_onboarding_state: merchant.sandbox_onboarding_state,
-            readiness_ready: computeSandboxOnboardingReadiness(merchant).ready,
+            readiness_ready: readiness.ready,
+            category_readiness_status: readiness.category_readiness.status,
+            category_readiness_score_percent: readiness.category_readiness.score_percent,
             production_approval_status: 'not_approved',
             rollout_status: 'rollout_not_requested',
           },
         });
-        return { merchant, auditEventId: audit.id };
+        return { merchant, readiness, auditEventId: audit.id };
       });
       if (!result) {
         throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
       }
       return reply.status(200).send({
-        data: toSandboxOnboardingResponse(result.merchant),
+        data: toSandboxOnboardingResponse(result.merchant, result.readiness),
         audit_event_id: result.auditEventId,
       });
     },
@@ -1020,7 +1068,8 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
         const currentState = isSandboxOnboardingState(before.sandbox_onboarding_state)
           ? before.sandbox_onboarding_state
           : 'draft_created';
-        const readiness = computeSandboxOnboardingReadiness(before);
+        const catalogSummary = await readSandboxOnboardingCatalogSummary(tx as unknown as Sql, tenantId, merchantId);
+        const readiness = computeSandboxOnboardingReadiness(before, process.env, catalogSummary);
         const transitionError = validateSandboxOnboardingTransition(currentState, targetState, readiness);
         if (transitionError) {
           throw new CommerceHttpError(409, 'invalid_sandbox_onboarding_transition', transitionError, {
@@ -1058,17 +1107,23 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
             from_state: currentState,
             to_state: targetState,
             reason_present: reason !== null,
+            category_readiness_status: readiness.category_readiness.status,
+            category_readiness_score_percent: readiness.category_readiness.score_percent,
             production_approval_status: 'not_approved',
             rollout_status: 'rollout_not_requested',
           },
         });
-        return { merchant, auditEventId: audit.id };
+        return {
+          merchant,
+          readiness: computeSandboxOnboardingReadiness(merchant, process.env, catalogSummary),
+          auditEventId: audit.id,
+        };
       });
       if (!result) {
         throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
       }
       return reply.status(200).send({
-        data: toSandboxOnboardingResponse(result.merchant),
+        data: toSandboxOnboardingResponse(result.merchant, result.readiness),
         audit_event_id: result.auditEventId,
       });
     },

--- a/apps/auth-service/tests/commerce-merchants.test.ts
+++ b/apps/auth-service/tests/commerce-merchants.test.ts
@@ -323,6 +323,34 @@ describe('sandbox onboarding foundation', () => {
     expect(body.audit_event_id).toBe('caud_ONBOARDING');
   });
 
+  it('rejects submitted_for_review profile updates that would fail required readiness', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'submitted_for_review' })]);
+    sqlMock.mockResolvedValueOnce([onboardingRow({
+      sandbox_onboarding_state: 'submitted_for_review',
+      support_email: null,
+      support_url: null,
+    })]);
+    sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding',
+      headers: authHeader(),
+      payload: {
+        support_email: null,
+        support_url: null,
+      },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json<{ error: { code: string; details: { category_readiness_status: string } } }>().error)
+      .toMatchObject({
+        code: 'invalid_sandbox_onboarding_update',
+        details: { category_readiness_status: 'fail' },
+      });
+  });
+
   it('reports recommended electronics catalog remediation without blocking required sandbox review fields', async () => {
     seedCommerceContext();
     sqlMock.mockResolvedValueOnce([onboardingRow()]);

--- a/apps/auth-service/tests/commerce-merchants.test.ts
+++ b/apps/auth-service/tests/commerce-merchants.test.ts
@@ -40,6 +40,32 @@ function onboardingRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function catalogReadySummary(overrides: Record<string, unknown> = {}) {
+  return {
+    product_count: 1,
+    variant_count: 2,
+    variants_with_warranty_summary: 2,
+    variants_with_return_policy_summary: 2,
+    variants_with_tax_metadata: 2,
+    variants_with_fresh_inventory: 2,
+    variants_with_known_availability: 2,
+    ...overrides,
+  };
+}
+
+function catalogMissingSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    product_count: 1,
+    variant_count: 2,
+    variants_with_warranty_summary: 0,
+    variants_with_return_policy_summary: 0,
+    variants_with_tax_metadata: 0,
+    variants_with_fresh_inventory: 0,
+    variants_with_known_availability: 1,
+    ...overrides,
+  };
+}
+
 describe('POST /v1/commerce/merchants', () => {
   it('creates a merchant and returns 201 with audit_event_id', async () => {
     seedCommerceContext();
@@ -202,6 +228,7 @@ describe('sandbox onboarding foundation', () => {
   it('returns sandbox onboarding state and readiness without provider references', async () => {
     seedCommerceContext();
     sqlMock.mockResolvedValueOnce([onboardingRow()]);
+    sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
 
     const res = await app.inject({
       method: 'GET',
@@ -215,11 +242,23 @@ describe('sandbox onboarding foundation', () => {
         sandbox_onboarding_state: string;
         production_approval_status?: string;
         provider_account_refs?: unknown;
-        readiness: { ready: boolean; production_approval_status: string; rollout_status: string };
+        readiness: {
+          ready: boolean;
+          production_approval_status: string;
+          rollout_status: string;
+          score_percent: number;
+          category_readiness: { status: string; score_percent: number; required_passed: boolean };
+        };
       };
     }>();
     expect(body.data.sandbox_onboarding_state).toBe('sandbox_ready');
     expect(body.data.readiness.ready).toBe(true);
+    expect(body.data.readiness.score_percent).toBe(100);
+    expect(body.data.readiness.category_readiness).toMatchObject({
+      status: 'pass',
+      score_percent: 100,
+      required_passed: true,
+    });
     expect(body.data.readiness.production_approval_status).toBe('not_approved');
     expect(body.data.readiness.rollout_status).toBe('rollout_not_requested');
     expect(body.data.provider_account_refs).toBeUndefined();
@@ -250,6 +289,7 @@ describe('sandbox onboarding foundation', () => {
       sandbox_onboarding_state: 'draft_created',
     })]);
     sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'draft_created' })]);
+    sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
     sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'sandbox_ready' })]);
     sqlMock.mockResolvedValueOnce([{ id: 'caud_ONBOARDING', occurred_at: new Date().toISOString() }]);
 
@@ -270,10 +310,98 @@ describe('sandbox onboarding foundation', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    const body = res.json<{ data: { sandbox_onboarding_state: string; readiness: { ready: boolean } }; audit_event_id: string }>();
+    const body = res.json<{
+      data: {
+        sandbox_onboarding_state: string;
+        readiness: { ready: boolean; category_readiness: { status: string; score_percent: number } };
+      };
+      audit_event_id: string;
+    }>();
     expect(body.data.sandbox_onboarding_state).toBe('sandbox_ready');
     expect(body.data.readiness.ready).toBe(true);
+    expect(body.data.readiness.category_readiness).toMatchObject({ status: 'pass', score_percent: 100 });
     expect(body.audit_event_id).toBe('caud_ONBOARDING');
+  });
+
+  it('reports recommended electronics catalog remediation without blocking required sandbox review fields', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow()]);
+    sqlMock.mockResolvedValueOnce([catalogMissingSummary()]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const items = res.json<{
+      data: {
+        readiness: {
+          ready: boolean;
+          category_readiness: {
+            status: string;
+            score_percent: number;
+            items: Array<{ key: string; severity: string; status: string; remediation: string }>;
+          };
+        };
+      };
+    }>().data.readiness.category_readiness.items;
+    expect(res.json<{ data: { readiness: { ready: boolean; category_readiness: { status: string } } } }>()
+      .data.readiness).toMatchObject({ ready: true, category_readiness: { status: 'pass' } });
+    for (const key of ['warranty_summary', 'return_policy_summary', 'tax_gst_metadata', 'inventory_freshness']) {
+      const item = items.find((candidate) => candidate.key === key);
+      expect(item).toBeDefined();
+      expect(item).toMatchObject({ severity: 'recommended', status: 'fail' });
+      expect(item?.remediation.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('fails required category readiness when category preset is missing', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ category_preset: null })]);
+    sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const readiness = res.json<{
+      data: {
+        readiness: {
+          ready: boolean;
+          category_readiness: { status: string; required_passed: boolean; items: Array<{ key: string; status: string }> };
+        };
+      };
+    }>().data.readiness;
+    expect(readiness.ready).toBe(false);
+    expect(readiness.category_readiness).toMatchObject({ status: 'fail', required_passed: false });
+    expect(readiness.category_readiness.items.find((item) => item.key === 'category_preset_recognized'))
+      .toMatchObject({ status: 'fail' });
+  });
+
+  it('fails closed when an existing merchant row has an unsupported category preset', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ category_preset: 'fashion_lifestyle' })]);
+    sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const category = res.json<{
+      data: { readiness: { ready: boolean; category_readiness: { status: string; summary: string; items: Array<{ key: string; status: string; remediation: string }> } } };
+    }>().data.readiness.category_readiness;
+    expect(category.status).toBe('blocked');
+    expect(category.items.find((item) => item.key === 'category_preset_recognized'))
+      .toMatchObject({ status: 'blocked' });
+    expect(category.summary).toContain('blocked');
   });
 
   it('rejects unsafe sandbox onboarding fields that would imply production or checkout enablement', async () => {
@@ -300,6 +428,7 @@ describe('sandbox onboarding foundation', () => {
   it('transitions a ready sandbox workspace to submitted_for_review with audit evidence', async () => {
     seedCommerceContext();
     sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'sandbox_ready' })]);
+    sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
     sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'submitted_for_review' })]);
     sqlMock.mockResolvedValueOnce([{ id: 'caud_TRANSITION', occurred_at: new Date().toISOString() }]);
 
@@ -323,6 +452,7 @@ describe('sandbox onboarding foundation', () => {
       public_discovery_description_draft: null,
       sandbox_onboarding_state: 'sandbox_ready',
     })]);
+    sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
 
     const res = await app.inject({
       method: 'POST',
@@ -333,6 +463,27 @@ describe('sandbox onboarding foundation', () => {
 
     expect(res.statusCode).toBe(409);
     expect(res.json<{ error: { code: string } }>().error.code).toBe('invalid_sandbox_onboarding_transition');
+  });
+
+  it('blocks submit transition when required category readiness fails', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({
+      support_email: null,
+      support_url: null,
+      sandbox_onboarding_state: 'sandbox_ready',
+    })]);
+    sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding/transition',
+      headers: authHeader(),
+      payload: { target_state: 'submitted_for_review' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json<{ error: { code: string; message: string } }>().error.code)
+      .toBe('invalid_sandbox_onboarding_transition');
   });
 
   it('blocks sandbox onboarding for live merchants', async () => {

--- a/apps/portal/src/api/commerce.ts
+++ b/apps/portal/src/api/commerce.ts
@@ -124,6 +124,47 @@ export interface CommerceSandboxOnboardingCheck {
   detail: string;
 }
 
+export interface CommerceCategoryReadinessItem {
+  key:
+    | 'category_preset_recognized'
+    | 'public_display_name_present'
+    | 'country_currency_present'
+    | 'public_safe_description_present'
+    | 'support_contact_present'
+    | 'product_data_readiness'
+    | 'warranty_summary'
+    | 'return_policy_summary'
+    | 'tax_gst_metadata'
+    | 'inventory_freshness'
+    | 'private_artifacts_not_stored'
+    | 'no_production_allowlist_config_values'
+    | 'no_live_provider_path'
+    | 'no_checkout_payment_enablement';
+  label: string;
+  description: string;
+  severity: 'required' | 'recommended' | 'blocked';
+  status: 'pass' | 'fail' | 'blocked' | 'not_applicable';
+  remediation: string;
+}
+
+export interface CommerceCategoryReadiness {
+  preset_key: string | null;
+  label: string;
+  status: 'pass' | 'fail' | 'blocked';
+  required_passed: boolean;
+  score_percent: number;
+  score: {
+    passed: number;
+    total: number;
+    percentage: number;
+    required_passed: number;
+    required_total: number;
+    blocked: number;
+  };
+  items: CommerceCategoryReadinessItem[];
+  summary: string;
+}
+
 export interface CommerceSandboxOnboarding {
   merchant_id: string;
   tenant_id: string;
@@ -142,7 +183,10 @@ export interface CommerceSandboxOnboarding {
   sandbox_onboarding_updated_at: string | null;
   readiness: {
     ready: boolean;
+    status: 'pass' | 'fail' | 'blocked';
+    score_percent: number;
     checks: CommerceSandboxOnboardingCheck[];
+    category_readiness: CommerceCategoryReadiness;
     live_mode_status: 'not_live';
     production_approval_status: 'not_approved';
     rollout_status: 'rollout_not_requested';

--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -191,9 +191,53 @@ const sandboxOnboarding = {
   sandbox_onboarding_updated_at: '2026-01-01T00:00:00Z',
   readiness: {
     ready: true,
+    status: 'pass' as const,
+    score_percent: 100,
     live_mode_status: 'not_live' as const,
     production_approval_status: 'not_approved' as const,
     rollout_status: 'rollout_not_requested' as const,
+    category_readiness: {
+      preset_key: 'electronics_appliances',
+      label: 'Electronics and appliances',
+      status: 'pass' as const,
+      required_passed: true,
+      score_percent: 100,
+      score: {
+        passed: 14,
+        total: 14,
+        percentage: 100,
+        required_passed: 5,
+        required_total: 5,
+        blocked: 0,
+      },
+      summary: 'Required sandbox category fields pass.',
+      items: [
+        {
+          key: 'category_preset_recognized' as const,
+          label: 'Category preset recognized',
+          description: 'The sandbox profile must select the V1 launch preset for category-specific scoring.',
+          severity: 'required' as const,
+          status: 'pass' as const,
+          remediation: 'Select the electronics_appliances category preset.',
+        },
+        {
+          key: 'warranty_summary' as const,
+          label: 'Warranty summary',
+          description: 'Electronics/appliances variants should expose warranty summary text before agent-facing preview.',
+          severity: 'recommended' as const,
+          status: 'pass' as const,
+          remediation: 'Add warranty_summary on every active sandbox variant.',
+        },
+        {
+          key: 'no_checkout_payment_enablement' as const,
+          label: 'No checkout/payment enablement',
+          description: 'C6A only scores read-only sandbox preview readiness; checkout/payment execution remains disabled.',
+          severity: 'blocked' as const,
+          status: 'pass' as const,
+          remediation: 'Disable agentic commerce execution before marking sandbox onboarding ready.',
+        },
+      ],
+    },
     checks: [
       {
         key: 'merchant_profile_present' as const,
@@ -593,8 +637,11 @@ describe('CommerceOnboarding', () => {
     await user.type(screen.getByLabelText('Merchant ID'), 'mch_1');
     await user.click(screen.getByRole('button', { name: 'Load onboarding' }));
     await waitFor(() => expect(screen.getByText('Readiness checklist')).toBeInTheDocument());
+    expect(screen.getByText('Category preset recognized')).toBeInTheDocument();
+    expect(screen.getByText('Electronics and appliances')).toBeInTheDocument();
+    expect(screen.getByText('Warranty summary')).toBeInTheDocument();
     expect(screen.getByText('Merchant profile present')).toBeInTheDocument();
-    expect(screen.getByText('No checkout/payment enablement')).toBeInTheDocument();
+    expect(screen.getAllByText('No checkout/payment enablement').length).toBeGreaterThan(0);
     expect(screen.getByText('Trusted agent')).toBeInTheDocument();
     expect(screen.getByText('Mock provider credential metadata')).toBeInTheDocument();
     expect(screen.getByText('Publish/unpublish controls require a separate reviewed backend API and remain blocked.')).toBeInTheDocument();

--- a/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
+++ b/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
@@ -54,6 +54,19 @@ const actionScopes = [
   'commerce:payment.status.read',
 ];
 
+function readinessVariant(status: string): 'default' | 'success' | 'warning' | 'danger' {
+  if (status === 'pass') return 'success';
+  if (status === 'fail' || status === 'not_applicable' || status === 'recommended') return 'warning';
+  if (status === 'blocked') return 'danger';
+  return 'default';
+}
+
+function severityVariant(severity: string): 'default' | 'success' | 'warning' | 'danger' {
+  if (severity === 'blocked') return 'danger';
+  if (severity === 'required') return 'warning';
+  return 'default';
+}
+
 export function CommerceOnboarding() {
   const [merchantId, setMerchantId] = useState('');
   const [merchant, setMerchant] = useState<CommerceSandboxOnboarding | null>(null);
@@ -311,6 +324,45 @@ export function CommerceOnboarding() {
 
           <Card>
             <h2 className="mb-3 text-base font-semibold text-gx-text">Readiness checklist</h2>
+            <div className="mb-4 rounded-md border border-gx-border p-3">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="text-xs text-gx-muted">Category preset</div>
+                  <div className="mt-1 text-sm font-medium text-gx-text">{merchant.readiness.category_readiness.label}</div>
+                  <div className="mt-1 text-xs text-gx-muted">{merchant.readiness.category_readiness.summary}</div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant={readinessVariant(merchant.readiness.category_readiness.status)}>
+                    {merchant.readiness.category_readiness.status}
+                  </Badge>
+                  <Badge variant="default">{merchant.readiness.category_readiness.score_percent}%</Badge>
+                </div>
+              </div>
+              <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-gx-border">
+                <div
+                  className="h-full rounded-full bg-gx-accent"
+                  style={{ width: `${Math.max(0, Math.min(100, merchant.readiness.category_readiness.score_percent))}%` }}
+                />
+              </div>
+              <div className="mt-3 grid gap-2">
+                {merchant.readiness.category_readiness.items.map((item) => (
+                  <div key={item.key} className="rounded-md border border-gx-border p-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <span className="text-sm font-medium text-gx-text">{item.label}</span>
+                      <div className="flex flex-wrap gap-2">
+                        <Badge variant={severityVariant(item.severity)}>{item.severity}</Badge>
+                        <Badge variant={readinessVariant(item.status)}>{item.status}</Badge>
+                      </div>
+                    </div>
+                    <div className="mt-1 text-xs text-gx-muted">{item.description}</div>
+                    {item.status !== 'pass' && item.status !== 'not_applicable' ? (
+                      <div className="mt-2 text-xs text-gx-warning">{item.remediation}</div>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+            <h3 className="mb-3 text-sm font-semibold text-gx-text">Production gates</h3>
             <div className="grid gap-2 md:grid-cols-2">
               {merchant.readiness.checks.map((item) => (
                 <div key={item.key} className="flex items-center justify-between gap-3 rounded-md border border-gx-border p-3">

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -212,6 +212,63 @@ components:
           nullable: true
           description: Public-safe reason summary required for blocked or not_approved transitions.
 
+    SandboxReadinessStatus:
+      type: string
+      enum: [pass, fail, blocked]
+
+    CategoryReadinessItem:
+      type: object
+      properties:
+        key:
+          type: string
+          enum:
+            - category_preset_recognized
+            - public_display_name_present
+            - country_currency_present
+            - public_safe_description_present
+            - support_contact_present
+            - product_data_readiness
+            - warranty_summary
+            - return_policy_summary
+            - tax_gst_metadata
+            - inventory_freshness
+            - private_artifacts_not_stored
+            - no_production_allowlist_config_values
+            - no_live_provider_path
+            - no_checkout_payment_enablement
+        label: { type: string }
+        description: { type: string }
+        severity: { type: string, enum: [required, recommended, blocked] }
+        status: { type: string, enum: [pass, fail, blocked, not_applicable] }
+        remediation: { type: string }
+
+    CategoryReadiness:
+      type: object
+      description: >-
+        C6A category-specific sandbox checklist. Passing this checklist means
+        only that the sandbox profile can be reviewed; it is not merchant
+        approval, production readiness, public discovery, checkout/payment
+        readiness, live payment readiness, or live Plural readiness.
+      properties:
+        preset_key: { type: string, nullable: true }
+        label: { type: string }
+        status: { $ref: "#/components/schemas/SandboxReadinessStatus" }
+        required_passed: { type: boolean }
+        score_percent: { type: integer, minimum: 0, maximum: 100 }
+        score:
+          type: object
+          properties:
+            passed: { type: integer, minimum: 0 }
+            total: { type: integer, minimum: 0 }
+            percentage: { type: integer, minimum: 0, maximum: 100 }
+            required_passed: { type: integer, minimum: 0 }
+            required_total: { type: integer, minimum: 0 }
+            blocked: { type: integer, minimum: 0 }
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/CategoryReadinessItem" }
+        summary: { type: string }
+
     SandboxOnboarding:
       type: object
       properties:
@@ -236,9 +293,12 @@ components:
           type: object
           properties:
             ready: { type: boolean }
+            status: { $ref: "#/components/schemas/SandboxReadinessStatus" }
+            score_percent: { type: integer, minimum: 0, maximum: 100 }
             live_mode_status: { type: string, enum: [not_live] }
             production_approval_status: { type: string, enum: [not_approved] }
             rollout_status: { type: string, enum: [rollout_not_requested] }
+            category_readiness: { $ref: "#/components/schemas/CategoryReadiness" }
             checks:
               type: array
               items:
@@ -1414,8 +1474,9 @@ paths:
       x-implemented: true
       x-milestone: C5Z
       description: >-
-        Returns public-safe sandbox onboarding fields, readiness checks, and
-        fail-closed production statuses. The response never includes provider
+        Returns public-safe sandbox onboarding fields, baseline readiness checks,
+        C6A category readiness scoring, and fail-closed production statuses.
+        The response never includes provider
         account references, credentials, secrets, production allowlist values,
         checkout/payment material, or live-provider paths.
       responses:
@@ -1477,9 +1538,9 @@ paths:
       description: >-
         Moves a sandbox onboarding workspace through the review-oriented state
         machine. Transitions to sandbox_ready or submitted_for_review require
-        readiness checks to pass. No transition approves production, enables
-        public discovery, enables checkout/payment creation, or enables live
-        payments/live Plural.
+        baseline and category required readiness checks to pass. No transition
+        approves production, enables public discovery, enables checkout/payment
+        creation, or enables live payments/live Plural.
       requestBody:
         required: true
         content:

--- a/docs/guides/commerce-v1-merchant-operator-guide.mdx
+++ b/docs/guides/commerce-v1-merchant-operator-guide.mdx
@@ -64,8 +64,21 @@ The state machine is:
 Readiness checks require a merchant profile, category preset, public-safe
 description, no private artifacts in public fields, no production allowlist or
 live-mode config values, no provider account references, and no checkout/payment
-enablement. Passing readiness means "sandbox profile can be reviewed"; it is not
-production approval.
+enablement.
+
+C6A extends this with a category readiness checklist and score. For
+`electronics_appliances`, required checks cover a recognized category preset,
+public display name, country/currency, public-safe description, and test-safe
+support contact. Recommended checks score sandbox product/variant presence,
+warranty summary, return-policy summary, India tax/GST metadata where
+applicable, and inventory freshness without requiring a catalog connector or
+exact inventory quantities in this slice. Blocked checks continue to fail closed
+for private artifacts, production discovery or allowlist config, live provider
+paths, and checkout/payment enablement.
+
+Passing category readiness means only "sandbox profile can be reviewed"; it is
+not merchant approval, production readiness, public discovery approval,
+checkout/payment readiness, live payment readiness, or live Plural readiness.
 
 ## Catalog And Inventory
 

--- a/docs/internal/commerce-v1/commerce-v1-c6a-category-preset-readiness-checklist.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6a-category-preset-readiness-checklist.md
@@ -1,0 +1,64 @@
+# Commerce V1 C6A Category Preset Readiness Checklist
+
+Status: implementation slice
+Date: 2026-05-31
+Scope: Grantex seller sandbox onboarding category readiness scoring
+Production changes made by this slice: none
+Public discovery changed by this slice: no
+Checkout or payment creation changed by this slice: no
+Live payment path changed by this slice: no
+Live Plural path changed by this slice: no
+Provider credential collection changed by this slice: no
+Named merchant approved by this slice: no
+Secrets inspected or changed: no
+
+## Boundary
+
+C6A extends the C5Z sandbox onboarding response with computed category
+readiness. It does not add persistence, production flags, allowlists, provider
+credentials, checkout/payment state, live-provider paths, real merchant
+approval, or AgenticOrg public discovery.
+
+No migration is required. The score is derived from existing tenant-owned
+merchant and catalog tables:
+
+- `commerce_merchants`
+- `commerce_products`
+- `commerce_product_variants`
+
+## Electronics/Appliances Checklist
+
+Required items:
+
+- recognized `electronics_appliances` preset;
+- public display name;
+- country and currency;
+- public-safe discovery description draft;
+- repo-safe/test-safe support email or support URL.
+
+Recommended scoring items:
+
+- at least one active sandbox product and purchasable variant;
+- warranty summary on active variants;
+- return-policy summary on active variants;
+- GST, tax-rate, or HSN metadata for India sandbox variants;
+- known availability bucket and 24-hour inventory freshness.
+
+Blocked items:
+
+- private artifacts in public/runtime fields;
+- production public discovery or allowlist config values;
+- live provider path or provider account references;
+- checkout/payment enablement.
+
+## Readiness Semantics
+
+`sandbox_ready` and `submitted_for_review` require baseline readiness and all
+required category items to pass. Recommended product/catalog items affect the
+score and remediation copy but do not force catalog connector implementation in
+this slice.
+
+Passing C6A readiness means only that the sandbox profile can be reviewed. It is
+not merchant approval, production readiness, public discovery enablement,
+checkout/payment readiness, live payment readiness, live Plural readiness, or
+provider readiness evidence.


### PR DESCRIPTION
## Summary
- Adds C6A category-specific sandbox onboarding readiness scoring for the V1 `electronics_appliances` preset.
- Extends the existing sandbox onboarding readiness response with score, pass/fail/blocked status, category checklist items, severity, remediation, and fail-closed required-item gating.
- Updates portal onboarding UI, API typings, tests, OpenAPI, and operator/internal docs.

## Safety
- Draft PR only. No merge, deploy command, cloud command, production config, secrets, public discovery enablement, production Commerce V1 enablement, checkout/payment enablement, live payments, or live Plural changes.
- No migration was needed; readiness is computed from existing tenant-owned merchant and catalog tables.
- Recommended catalog details score warranty, return policy, tax/GST metadata, product presence, and inventory freshness without implementing catalog connectors or inventory quantity/reservation.
- Passing readiness still means only that a sandbox profile can be reviewed; it is not merchant approval or production readiness.

## Validation
- `npm test -- commerce` in `apps/auth-service`: 471 passed.
- `npm run typecheck` in `apps/auth-service`: passed.
- `npm test -- commerce-tenant-boundary.test.ts commerce-audit.test.ts commerce-live-mode-guard.test.ts commerce-no-plural-leak.test.ts commerce-schema.test.ts`: 52 passed.
- `npm test -- src/pages/__tests__/CommerceDashboard.test.tsx src/api/__tests__/commerce.test.ts` in `apps/portal`: 30 passed.
- `npm run typecheck` in `apps/portal`: passed.
- `git diff --check`: passed, with CRLF warnings only.
- Focused safety scans passed; whole-file scans had only existing test/OpenAPI references or explicit negative guardrail language.

## Caveats
- `docs/guides/commerce-v1-agentic-commerce-prd.md` remains absent on latest `origin/main`; this slice used the V1 build spec, master PRD, C5Z docs, and guardrails.
- `node docs/commerce-v1-pilot-readiness.validate.mjs` remains blocked by pre-existing missing `docs/reports/commerce-v1-local-pilot-load.md`.
- Local Vite route returned HTTP 200, but Browser plugin verification was blocked by the Windows sandbox browser runtime issue.