### PR TITLE
[codex] feat(commerce): add catalog readiness preview

### DIFF
--- a/apps/auth-service/src/lib/commerce/sandbox-onboarding.ts
+++ b/apps/auth-service/src/lib/commerce/sandbox-onboarding.ts
@@ -17,11 +17,19 @@ export type CategoryReadinessItemStatus = 'pass' | 'fail' | 'blocked' | 'not_app
 export interface SandboxOnboardingCatalogSummary {
   product_count?: number | string | null;
   variant_count?: number | string | null;
+  products_with_image?: number | string | null;
+  products_with_public_safe_title?: number | string | null;
+  products_with_public_safe_description?: number | string | null;
+  products_with_category_mapping?: number | string | null;
+  products_with_unsafe_text?: number | string | null;
+  variants_with_sku?: number | string | null;
+  variants_with_price_currency?: number | string | null;
   variants_with_warranty_summary?: number | string | null;
   variants_with_return_policy_summary?: number | string | null;
   variants_with_tax_metadata?: number | string | null;
   variants_with_fresh_inventory?: number | string | null;
   variants_with_known_availability?: number | string | null;
+  variants_with_unsafe_text?: number | string | null;
 }
 
 export interface SandboxOnboardingMerchant {
@@ -75,6 +83,63 @@ export interface CategoryReadinessScore {
   blocked: number;
 }
 
+export interface CatalogReadinessItem {
+  key:
+    | 'catalog_products_present'
+    | 'catalog_variants_present'
+    | 'products_public_safe_title'
+    | 'products_public_safe_description'
+    | 'products_category_mapping'
+    | 'variants_sku_present'
+    | 'variants_price_currency_present'
+    | 'products_image_media'
+    | 'variants_availability_freshness'
+    | 'variants_warranty_summary'
+    | 'variants_return_policy_summary'
+    | 'variants_tax_gst_metadata'
+    | 'no_unsafe_catalog_text';
+  label: string;
+  description: string;
+  severity: CategoryReadinessSeverity;
+  status: CategoryReadinessItemStatus;
+  count?: number;
+  total?: number;
+  remediation: string;
+}
+
+export interface CatalogReadinessScore {
+  passed: number;
+  total: number;
+  percentage: number;
+  required_passed: boolean;
+  required_passed_count: number;
+  required_total: number;
+  recommended_passed: number;
+  recommended_total: number;
+  recommended_completion_percentage: number;
+  blocker_count: number;
+}
+
+export interface SandboxCatalogReadiness {
+  status: SandboxReadinessStatus;
+  required_passed: boolean;
+  score_percent: number;
+  recommended_completion_percent: number;
+  blocker_count: number;
+  product_count: number;
+  variant_count: number;
+  score: CatalogReadinessScore;
+  items: CatalogReadinessItem[];
+  summary: string;
+  intake: {
+    manual_entry_supported: true;
+    csv_dry_run_supported: true;
+    bulk_api_dry_run_supported: true;
+    async_import_job_supported: false;
+    external_connector_supported: false;
+  };
+}
+
 export interface SandboxCategoryReadiness {
   preset_key: string | null;
   label: string;
@@ -106,6 +171,7 @@ export interface SandboxOnboardingReadiness {
   score_percent: number;
   checks: SandboxOnboardingCheck[];
   category_readiness: SandboxCategoryReadiness;
+  catalog_readiness: SandboxCatalogReadiness;
   live_mode_status: 'not_live';
   production_approval_status: 'not_approved';
   rollout_status: 'rollout_not_requested';
@@ -222,6 +288,22 @@ function categoryItem(
   return { key, label, description, severity, status, remediation };
 }
 
+function catalogItem(
+  key: CatalogReadinessItem['key'],
+  label: string,
+  description: string,
+  severity: CategoryReadinessSeverity,
+  status: CategoryReadinessItemStatus,
+  remediation: string,
+  count?: number,
+  total?: number,
+): CatalogReadinessItem {
+  const item: CatalogReadinessItem = { key, label, description, severity, status, remediation };
+  if (count !== undefined) item.count = count;
+  if (total !== undefined) item.total = total;
+  return item;
+}
+
 function passFail(pass: boolean): 'pass' | 'fail' {
   return pass ? 'pass' : 'fail';
 }
@@ -241,10 +323,225 @@ function categoryScore(items: CategoryReadinessItem[]): CategoryReadinessScore {
   };
 }
 
+function catalogScore(items: CatalogReadinessItem[]): CatalogReadinessScore {
+  const applicable = items.filter((item) => item.status !== 'not_applicable');
+  const required = items.filter((item) => item.severity === 'required');
+  const recommended = items.filter((item) => item.severity === 'recommended' && item.status !== 'not_applicable');
+  const passed = applicable.filter((item) => item.status === 'pass').length;
+  const requiredPassedCount = required.filter((item) => item.status === 'pass').length;
+  const recommendedPassed = recommended.filter((item) => item.status === 'pass').length;
+  return {
+    passed,
+    total: applicable.length,
+    percentage: applicable.length === 0 ? 0 : Math.round((passed / applicable.length) * 100),
+    required_passed: requiredPassedCount === required.length,
+    required_passed_count: requiredPassedCount,
+    required_total: required.length,
+    recommended_passed: recommendedPassed,
+    recommended_total: recommended.length,
+    recommended_completion_percentage: recommended.length === 0
+      ? 100
+      : Math.round((recommendedPassed / recommended.length) * 100),
+    blocker_count: items.filter((item) => item.status === 'blocked').length,
+  };
+}
+
+export function computeSandboxCatalogReadiness(
+  merchant: SandboxOnboardingMerchant,
+  catalogSummary: SandboxOnboardingCatalogSummary | null = null,
+): SandboxCatalogReadiness {
+  const productCount = countValue(catalogSummary?.product_count);
+  const variantCount = countValue(catalogSummary?.variant_count);
+  const productsWithImage = countValue(catalogSummary?.products_with_image);
+  const productsWithSafeTitle = countValue(catalogSummary?.products_with_public_safe_title);
+  const productsWithSafeDescription = countValue(catalogSummary?.products_with_public_safe_description);
+  const productsWithCategoryMapping = countValue(catalogSummary?.products_with_category_mapping);
+  const productsWithUnsafeText = countValue(catalogSummary?.products_with_unsafe_text);
+  const variantsWithSku = countValue(catalogSummary?.variants_with_sku);
+  const variantsWithPriceCurrency = countValue(catalogSummary?.variants_with_price_currency);
+  const variantsWithWarranty = countValue(catalogSummary?.variants_with_warranty_summary);
+  const variantsWithReturnPolicy = countValue(catalogSummary?.variants_with_return_policy_summary);
+  const variantsWithTaxMetadata = countValue(catalogSummary?.variants_with_tax_metadata);
+  const variantsWithFreshInventory = countValue(catalogSummary?.variants_with_fresh_inventory);
+  const variantsWithKnownAvailability = countValue(catalogSummary?.variants_with_known_availability);
+  const variantsWithUnsafeText = countValue(catalogSummary?.variants_with_unsafe_text);
+  const taxApplicable = merchant.country_code === 'IN';
+  const unsafeTextCount = productsWithUnsafeText + variantsWithUnsafeText;
+
+  const items: CatalogReadinessItem[] = [
+    catalogItem(
+      'catalog_products_present',
+      'Catalog products present',
+      'Read-only discovery review needs at least one active sandbox product.',
+      'required',
+      passFail(productCount > 0),
+      'Add at least one active sandbox product through manual entry, CSV dry-run plus bulk upsert, or the existing catalog API.',
+      productCount,
+      1,
+    ),
+    catalogItem(
+      'catalog_variants_present',
+      'Catalog variants present',
+      'Every discoverable product needs at least one active purchasable variant.',
+      'required',
+      passFail(variantCount > 0),
+      'Add at least one active variant with SKU, price, and currency.',
+      variantCount,
+      1,
+    ),
+    catalogItem(
+      'products_public_safe_title',
+      'Public-safe product titles',
+      'Product titles must be present and free of private, production, provider, approval, or payment claims.',
+      'required',
+      passFail(productCount > 0 && productsWithSafeTitle >= productCount),
+      'Update every active product with a public-safe title.',
+      productsWithSafeTitle,
+      productCount,
+    ),
+    catalogItem(
+      'products_public_safe_description',
+      'Public-safe product descriptions',
+      'Agent-facing product previews need public-safe descriptions for grounding.',
+      'required',
+      passFail(productCount > 0 && productsWithSafeDescription >= productCount),
+      'Add a public-safe description to every active product.',
+      productsWithSafeDescription,
+      productCount,
+    ),
+    catalogItem(
+      'products_category_mapping',
+      'Product category mapping',
+      'Active products must map to the selected electronics/appliances category preset for this C6B slice.',
+      'required',
+      passFail(productCount > 0
+        && merchant.category_preset === ELECTRONICS_APPLIANCES_PRESET
+        && productsWithCategoryMapping >= productCount),
+      'Map every active product to electronics_appliances before requesting review.',
+      productsWithCategoryMapping,
+      productCount,
+    ),
+    catalogItem(
+      'variants_sku_present',
+      'Variant SKU present',
+      'Agent-safe previews need stable SKU identifiers for every active variant.',
+      'required',
+      passFail(variantCount > 0 && variantsWithSku >= variantCount),
+      'Add SKU values to every active variant.',
+      variantsWithSku,
+      variantCount,
+    ),
+    catalogItem(
+      'variants_price_currency_present',
+      'Variant price and currency present',
+      'Read-only discovery preview needs price and ISO currency for every active variant.',
+      'required',
+      passFail(variantCount > 0 && variantsWithPriceCurrency >= variantCount),
+      'Add non-negative price_amount and uppercase ISO currency to every active variant.',
+      variantsWithPriceCurrency,
+      variantCount,
+    ),
+    catalogItem(
+      'products_image_media',
+      'Product image/media present',
+      'Images help operators check what agents will show, but missing images do not require connector implementation in C6B.',
+      'recommended',
+      passFail(productCount > 0 && productsWithImage >= productCount),
+      'Add a public-safe image_url for every active product when available.',
+      productsWithImage,
+      productCount,
+    ),
+    catalogItem(
+      'variants_availability_freshness',
+      'Availability freshness',
+      'Availability should use known buckets and a 24-hour freshness window without exposing exact quantities.',
+      'recommended',
+      passFail(variantCount > 0
+        && variantsWithFreshInventory >= variantCount
+        && variantsWithKnownAvailability >= variantCount),
+      'Keep variant last_synced_at within 24 hours and avoid unknown availability buckets.',
+      Math.min(variantsWithFreshInventory, variantsWithKnownAvailability),
+      variantCount,
+    ),
+    catalogItem(
+      'variants_warranty_summary',
+      'Warranty summary coverage',
+      'Electronics/appliances variants should carry warranty summary text for operator review.',
+      'recommended',
+      passFail(variantCount > 0 && variantsWithWarranty >= variantCount),
+      'Add warranty_summary to every active variant.',
+      variantsWithWarranty,
+      variantCount,
+    ),
+    catalogItem(
+      'variants_return_policy_summary',
+      'Return-policy summary coverage',
+      'Electronics/appliances variants should carry return-policy summary text for operator review.',
+      'recommended',
+      passFail(variantCount > 0 && variantsWithReturnPolicy >= variantCount),
+      'Add return_policy_summary to every active variant.',
+      variantsWithReturnPolicy,
+      variantCount,
+    ),
+    catalogItem(
+      'variants_tax_gst_metadata',
+      'Tax/GST metadata coverage',
+      'India electronics/appliances variants should carry GST, tax-rate, or HSN metadata.',
+      'recommended',
+      taxApplicable ? passFail(variantCount > 0 && variantsWithTaxMetadata >= variantCount) : 'not_applicable',
+      taxApplicable
+        ? 'Add GST slab, tax rate, or HSN code metadata to every active variant.'
+        : 'Tax/GST metadata is not applicable for the selected country in this sandbox checklist.',
+      variantsWithTaxMetadata,
+      variantCount,
+    ),
+    catalogItem(
+      'no_unsafe_catalog_text',
+      'No unsafe catalog text',
+      'Catalog public/runtime fields must not include private artifacts, production claims, provider/payment claims, secrets, or approval claims.',
+      'blocked',
+      unsafeTextCount === 0 ? 'pass' : 'blocked',
+      'Remove private, secret, provider, payment, live, production, approval, readiness, or certification claims from product and variant text.',
+      unsafeTextCount,
+      productCount + variantCount,
+    ),
+  ];
+
+  const score = catalogScore(items);
+  const status: SandboxReadinessStatus = score.blocker_count > 0
+    ? 'blocked'
+    : score.required_passed ? 'pass' : 'fail';
+
+  return {
+    status,
+    required_passed: score.required_passed,
+    score_percent: score.percentage,
+    recommended_completion_percent: score.recommended_completion_percentage,
+    blocker_count: score.blocker_count,
+    product_count: productCount,
+    variant_count: variantCount,
+    score,
+    items,
+    summary: status === 'pass'
+      ? 'Required catalog fields pass for sandbox read-only discovery review. Recommended catalog details may still improve the preview score.'
+      : status === 'blocked'
+        ? 'Catalog readiness is blocked by unsafe public/runtime catalog text.'
+        : 'Required catalog fields are incomplete for sandbox read-only discovery review.',
+    intake: {
+      manual_entry_supported: true,
+      csv_dry_run_supported: true,
+      bulk_api_dry_run_supported: true,
+      async_import_job_supported: false,
+      external_connector_supported: false,
+    },
+  };
+}
+
 export function computeSandboxCategoryReadiness(
   merchant: SandboxOnboardingMerchant,
   catalogSummary: SandboxOnboardingCatalogSummary | null = null,
   env: NodeJS.ProcessEnv = process.env,
+  catalogReadiness: SandboxCatalogReadiness | null = null,
 ): SandboxCategoryReadiness {
   const publicFields = [
     merchant.display_name,
@@ -272,6 +569,7 @@ export function computeSandboxCategoryReadiness(
   const presetRecognized = preset === ELECTRONICS_APPLIANCES_PRESET;
   const productCount = countValue(catalogSummary?.product_count);
   const variantCount = countValue(catalogSummary?.variant_count);
+  const resolvedCatalogReadiness = catalogReadiness ?? computeSandboxCatalogReadiness(merchant, catalogSummary);
   const warrantyCount = countValue(catalogSummary?.variants_with_warranty_summary);
   const returnPolicyCount = countValue(catalogSummary?.variants_with_return_policy_summary);
   const taxMetadataCount = countValue(catalogSummary?.variants_with_tax_metadata);
@@ -326,10 +624,12 @@ export function computeSandboxCategoryReadiness(
     categoryItem(
       'product_data_readiness',
       'Product data readiness',
-      'Electronics/appliances preview scoring looks for at least one active product with one purchasable variant.',
-      'recommended',
-      passFail(productCount > 0 && variantCount > 0),
-      'Add at least one sandbox product and variant through the existing catalog APIs. Catalog connector work is deferred.',
+      'Electronics/appliances review needs at least one public-safe active product and purchasable variant with critical fields.',
+      'required',
+      resolvedCatalogReadiness.status === 'blocked'
+        ? 'blocked'
+        : passFail(resolvedCatalogReadiness.required_passed),
+      'Complete required catalog readiness items through manual entry, CSV dry-run plus bulk upsert, or the existing catalog APIs. Catalog connector work is deferred.',
     ),
     categoryItem(
       'warranty_summary',
@@ -506,19 +806,25 @@ export function computeSandboxOnboardingReadiness(
     ),
   ];
 
-  const categoryReadiness = computeSandboxCategoryReadiness(merchant, catalogSummary, env);
+  const catalogReadiness = computeSandboxCatalogReadiness(merchant, catalogSummary);
+  const resolvedCategoryReadiness = computeSandboxCategoryReadiness(merchant, catalogSummary, env, catalogReadiness);
   const baselineReady = checks.every((item) => item.status === 'pass');
-  const ready = baselineReady && categoryReadiness.status === 'pass';
-  const status: SandboxReadinessStatus = !baselineReady || categoryReadiness.status === 'blocked'
+  const ready = baselineReady
+    && resolvedCategoryReadiness.status === 'pass'
+    && catalogReadiness.status === 'pass';
+  const status: SandboxReadinessStatus = !baselineReady
+    || resolvedCategoryReadiness.status === 'blocked'
+    || catalogReadiness.status === 'blocked'
     ? 'blocked'
     : ready ? 'pass' : 'fail';
 
   return {
     ready,
     status,
-    score_percent: categoryReadiness.score_percent,
+    score_percent: Math.round((resolvedCategoryReadiness.score_percent + catalogReadiness.score_percent) / 2),
     checks,
-    category_readiness: categoryReadiness,
+    category_readiness: resolvedCategoryReadiness,
+    catalog_readiness: catalogReadiness,
     live_mode_status: 'not_live',
     production_approval_status: 'not_approved',
     rollout_status: 'rollout_not_requested',

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -332,15 +332,47 @@ function parseBoolean(v: unknown): boolean | null {
   return null;
 }
 
+const CATALOG_PUBLIC_UNSAFE_PATTERN =
+  '-----BEGIN [A-Z ]+PRIVATE KEY-----|postgres://|postgresql://|redis://|\\m(api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret|checkout|payment|payments|paid|provider|production|live|allowlist|approved|certified|certification|ready)\\M';
+
 async function readSandboxOnboardingCatalogSummary(
   sql: Sql,
   tenantId: string,
   merchantId: string,
 ): Promise<SandboxOnboardingCatalogSummary> {
   const rows = await sql<SandboxOnboardingCatalogSummary[]>`
-    SELECT
+      SELECT
       COUNT(DISTINCT p.id)::int AS product_count,
       COUNT(v.id)::int AS variant_count,
+      COUNT(DISTINCT p.id) FILTER (
+        WHERE NULLIF(TRIM(p.image_url), '') IS NOT NULL
+      )::int AS products_with_image,
+      COUNT(DISTINCT p.id) FILTER (
+        WHERE NULLIF(TRIM(p.title), '') IS NOT NULL
+          AND LENGTH(TRIM(p.title)) <= 1000
+          AND p.title !~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+      )::int AS products_with_public_safe_title,
+      COUNT(DISTINCT p.id) FILTER (
+        WHERE NULLIF(TRIM(p.description), '') IS NOT NULL
+          AND LENGTH(TRIM(p.description)) <= 1000
+          AND p.description !~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+      )::int AS products_with_public_safe_description,
+      COUNT(DISTINCT p.id) FILTER (
+        WHERE p.category_preset = 'electronics_appliances'
+      )::int AS products_with_category_mapping,
+      COUNT(DISTINCT p.id) FILTER (
+        WHERE p.title ~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+           OR COALESCE(p.brand, '') ~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+           OR COALESCE(p.description, '') ~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+           OR COALESCE(p.image_url, '') ~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+      )::int AS products_with_unsafe_text,
+      COUNT(v.id) FILTER (
+        WHERE NULLIF(TRIM(v.sku), '') IS NOT NULL
+      )::int AS variants_with_sku,
+      COUNT(v.id) FILTER (
+        WHERE v.price_amount >= 0
+          AND v.currency ~ '^[A-Z]{3}$'
+      )::int AS variants_with_price_currency,
       COUNT(v.id) FILTER (
         WHERE NULLIF(TRIM(v.warranty_summary), '') IS NOT NULL
       )::int AS variants_with_warranty_summary,
@@ -357,7 +389,15 @@ async function readSandboxOnboardingCatalogSummary(
       )::int AS variants_with_fresh_inventory,
       COUNT(v.id) FILTER (
         WHERE v.availability_status <> 'unknown'
-      )::int AS variants_with_known_availability
+      )::int AS variants_with_known_availability,
+      COUNT(v.id) FILTER (
+        WHERE COALESCE(v.sku, '') ~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+           OR COALESCE(v.parent_sku, '') ~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+           OR COALESCE(v.model, '') ~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+           OR COALESCE(v.variant_title, '') ~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+           OR COALESCE(v.warranty_summary, '') ~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+           OR COALESCE(v.return_policy_summary, '') ~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+      )::int AS variants_with_unsafe_text
     FROM commerce_products p
     LEFT JOIN commerce_product_variants v
       ON v.tenant_id = p.tenant_id

--- a/apps/auth-service/tests/commerce-merchants.test.ts
+++ b/apps/auth-service/tests/commerce-merchants.test.ts
@@ -44,11 +44,19 @@ function catalogReadySummary(overrides: Record<string, unknown> = {}) {
   return {
     product_count: 1,
     variant_count: 2,
+    products_with_image: 1,
+    products_with_public_safe_title: 1,
+    products_with_public_safe_description: 1,
+    products_with_category_mapping: 1,
+    products_with_unsafe_text: 0,
+    variants_with_sku: 2,
+    variants_with_price_currency: 2,
     variants_with_warranty_summary: 2,
     variants_with_return_policy_summary: 2,
     variants_with_tax_metadata: 2,
     variants_with_fresh_inventory: 2,
     variants_with_known_availability: 2,
+    variants_with_unsafe_text: 0,
     ...overrides,
   };
 }
@@ -57,11 +65,40 @@ function catalogMissingSummary(overrides: Record<string, unknown> = {}) {
   return {
     product_count: 1,
     variant_count: 2,
+    products_with_image: 0,
+    products_with_public_safe_title: 1,
+    products_with_public_safe_description: 1,
+    products_with_category_mapping: 1,
+    products_with_unsafe_text: 0,
+    variants_with_sku: 2,
+    variants_with_price_currency: 2,
     variants_with_warranty_summary: 0,
     variants_with_return_policy_summary: 0,
     variants_with_tax_metadata: 0,
     variants_with_fresh_inventory: 0,
     variants_with_known_availability: 1,
+    variants_with_unsafe_text: 0,
+    ...overrides,
+  };
+}
+
+function catalogEmptySummary(overrides: Record<string, unknown> = {}) {
+  return {
+    product_count: 0,
+    variant_count: 0,
+    products_with_image: 0,
+    products_with_public_safe_title: 0,
+    products_with_public_safe_description: 0,
+    products_with_category_mapping: 0,
+    products_with_unsafe_text: 0,
+    variants_with_sku: 0,
+    variants_with_price_currency: 0,
+    variants_with_warranty_summary: 0,
+    variants_with_return_policy_summary: 0,
+    variants_with_tax_metadata: 0,
+    variants_with_fresh_inventory: 0,
+    variants_with_known_availability: 0,
+    variants_with_unsafe_text: 0,
     ...overrides,
   };
 }
@@ -248,6 +285,7 @@ describe('sandbox onboarding foundation', () => {
           rollout_status: string;
           score_percent: number;
           category_readiness: { status: string; score_percent: number; required_passed: boolean };
+          catalog_readiness: { status: string; score_percent: number; required_passed: boolean; product_count: number; variant_count: number };
         };
       };
     }>();
@@ -258,6 +296,13 @@ describe('sandbox onboarding foundation', () => {
       status: 'pass',
       score_percent: 100,
       required_passed: true,
+    });
+    expect(body.data.readiness.catalog_readiness).toMatchObject({
+      status: 'pass',
+      score_percent: 100,
+      required_passed: true,
+      product_count: 1,
+      variant_count: 2,
     });
     expect(body.data.readiness.production_approval_status).toBe('not_approved');
     expect(body.data.readiness.rollout_status).toBe('rollout_not_requested');
@@ -313,13 +358,18 @@ describe('sandbox onboarding foundation', () => {
     const body = res.json<{
       data: {
         sandbox_onboarding_state: string;
-        readiness: { ready: boolean; category_readiness: { status: string; score_percent: number } };
+        readiness: {
+          ready: boolean;
+          category_readiness: { status: string; score_percent: number };
+          catalog_readiness: { status: string; required_passed: boolean };
+        };
       };
       audit_event_id: string;
     }>();
     expect(body.data.sandbox_onboarding_state).toBe('sandbox_ready');
     expect(body.data.readiness.ready).toBe(true);
     expect(body.data.readiness.category_readiness).toMatchObject({ status: 'pass', score_percent: 100 });
+    expect(body.data.readiness.catalog_readiness).toMatchObject({ status: 'pass', required_passed: true });
     expect(body.audit_event_id).toBe('caud_ONBOARDING');
   });
 
@@ -383,6 +433,110 @@ describe('sandbox onboarding foundation', () => {
       expect(item).toMatchObject({ severity: 'recommended', status: 'fail' });
       expect(item?.remediation.length).toBeGreaterThan(10);
     }
+  });
+
+  it('fails required catalog readiness when no products are present', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow()]);
+    sqlMock.mockResolvedValueOnce([catalogEmptySummary()]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const readiness = res.json<{
+      data: {
+        readiness: {
+          ready: boolean;
+          catalog_readiness: {
+            status: string;
+            required_passed: boolean;
+            product_count: number;
+            variant_count: number;
+            items: Array<{ key: string; severity: string; status: string; remediation: string }>;
+          };
+        };
+      };
+    }>().data.readiness;
+    expect(readiness.ready).toBe(false);
+    expect(readiness.catalog_readiness).toMatchObject({
+      status: 'fail',
+      required_passed: false,
+      product_count: 0,
+      variant_count: 0,
+    });
+    expect(readiness.catalog_readiness.items.find((item) => item.key === 'catalog_products_present'))
+      .toMatchObject({ severity: 'required', status: 'fail' });
+  });
+
+  it('reports remediation for missing catalog fields without enabling production paths', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow()]);
+    sqlMock.mockResolvedValueOnce([catalogReadySummary({
+      products_with_image: 0,
+      products_with_public_safe_title: 0,
+      products_with_public_safe_description: 0,
+      products_with_category_mapping: 0,
+      variants_with_sku: 1,
+      variants_with_price_currency: 1,
+    })]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const catalog = res.json<{
+      data: {
+        readiness: {
+          ready: boolean;
+          catalog_readiness: {
+            status: string;
+            items: Array<{ key: string; severity: string; status: string; count?: number; total?: number; remediation: string }>;
+          };
+        };
+      };
+    }>().data.readiness.catalog_readiness;
+    expect(catalog.status).toBe('fail');
+    const expected = [
+      'products_public_safe_title',
+      'products_public_safe_description',
+      'products_category_mapping',
+      'variants_sku_present',
+      'variants_price_currency_present',
+      'products_image_media',
+    ];
+    for (const key of expected) {
+      const item = catalog.items.find((candidate) => candidate.key === key);
+      expect(item).toBeDefined();
+      expect(item?.status).toBe('fail');
+      expect(item?.remediation.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('blocks catalog readiness when unsafe product or variant text is detected', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow()]);
+    sqlMock.mockResolvedValueOnce([catalogReadySummary({ products_with_unsafe_text: 1 })]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const catalog = res.json<{
+      data: { readiness: { ready: boolean; catalog_readiness: { status: string; blocker_count: number; items: Array<{ key: string; status: string }> } } };
+    }>().data.readiness.catalog_readiness;
+    expect(catalog).toMatchObject({ status: 'blocked', blocker_count: 1 });
+    expect(catalog.items.find((item) => item.key === 'no_unsafe_catalog_text'))
+      .toMatchObject({ status: 'blocked' });
   });
 
   it('fails required category readiness when category preset is missing', async () => {
@@ -501,6 +655,23 @@ describe('sandbox onboarding foundation', () => {
       sandbox_onboarding_state: 'sandbox_ready',
     })]);
     sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding/transition',
+      headers: authHeader(),
+      payload: { target_state: 'submitted_for_review' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json<{ error: { code: string; message: string } }>().error.code)
+      .toBe('invalid_sandbox_onboarding_transition');
+  });
+
+  it('blocks submit transition when required catalog readiness fails', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'sandbox_ready' })]);
+    sqlMock.mockResolvedValueOnce([catalogEmptySummary()]);
 
     const res = await app.inject({
       method: 'POST',

--- a/apps/portal/src/api/commerce.ts
+++ b/apps/portal/src/api/commerce.ts
@@ -165,6 +165,61 @@ export interface CommerceCategoryReadiness {
   summary: string;
 }
 
+export interface CommerceCatalogReadinessItem {
+  key:
+    | 'catalog_products_present'
+    | 'catalog_variants_present'
+    | 'products_public_safe_title'
+    | 'products_public_safe_description'
+    | 'products_category_mapping'
+    | 'variants_sku_present'
+    | 'variants_price_currency_present'
+    | 'products_image_media'
+    | 'variants_availability_freshness'
+    | 'variants_warranty_summary'
+    | 'variants_return_policy_summary'
+    | 'variants_tax_gst_metadata'
+    | 'no_unsafe_catalog_text';
+  label: string;
+  description: string;
+  severity: 'required' | 'recommended' | 'blocked';
+  status: 'pass' | 'fail' | 'blocked' | 'not_applicable';
+  count?: number;
+  total?: number;
+  remediation: string;
+}
+
+export interface CommerceCatalogReadiness {
+  status: 'pass' | 'fail' | 'blocked';
+  required_passed: boolean;
+  score_percent: number;
+  recommended_completion_percent: number;
+  blocker_count: number;
+  product_count: number;
+  variant_count: number;
+  score: {
+    passed: number;
+    total: number;
+    percentage: number;
+    required_passed: boolean;
+    required_passed_count: number;
+    required_total: number;
+    recommended_passed: number;
+    recommended_total: number;
+    recommended_completion_percentage: number;
+    blocker_count: number;
+  };
+  items: CommerceCatalogReadinessItem[];
+  summary: string;
+  intake: {
+    manual_entry_supported: true;
+    csv_dry_run_supported: true;
+    bulk_api_dry_run_supported: true;
+    async_import_job_supported: false;
+    external_connector_supported: false;
+  };
+}
+
 export interface CommerceSandboxOnboarding {
   merchant_id: string;
   tenant_id: string;
@@ -187,6 +242,7 @@ export interface CommerceSandboxOnboarding {
     score_percent: number;
     checks: CommerceSandboxOnboardingCheck[];
     category_readiness: CommerceCategoryReadiness;
+    catalog_readiness: CommerceCatalogReadiness;
     live_mode_status: 'not_live';
     production_approval_status: 'not_approved';
     rollout_status: 'rollout_not_requested';

--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -238,6 +238,77 @@ const sandboxOnboarding = {
         },
       ],
     },
+    catalog_readiness: {
+      status: 'pass' as const,
+      required_passed: true,
+      score_percent: 100,
+      recommended_completion_percent: 100,
+      blocker_count: 0,
+      product_count: 1,
+      variant_count: 2,
+      score: {
+        passed: 13,
+        total: 13,
+        percentage: 100,
+        required_passed: true,
+        required_passed_count: 7,
+        required_total: 7,
+        recommended_passed: 5,
+        recommended_total: 5,
+        recommended_completion_percentage: 100,
+        blocker_count: 0,
+      },
+      summary: 'Required catalog fields pass for sandbox read-only discovery review.',
+      intake: {
+        manual_entry_supported: true as const,
+        csv_dry_run_supported: true as const,
+        bulk_api_dry_run_supported: true as const,
+        async_import_job_supported: false as const,
+        external_connector_supported: false as const,
+      },
+      items: [
+        {
+          key: 'catalog_products_present' as const,
+          label: 'Catalog products present',
+          description: 'Read-only discovery review needs at least one active sandbox product.',
+          severity: 'required' as const,
+          status: 'pass' as const,
+          count: 1,
+          total: 1,
+          remediation: 'Add at least one active sandbox product through manual entry, CSV dry-run plus bulk upsert, or the existing catalog API.',
+        },
+        {
+          key: 'variants_price_currency_present' as const,
+          label: 'Variant price and currency present',
+          description: 'Read-only discovery preview needs price and ISO currency for every active variant.',
+          severity: 'required' as const,
+          status: 'pass' as const,
+          count: 2,
+          total: 2,
+          remediation: 'Add non-negative price_amount and uppercase ISO currency to every active variant.',
+        },
+        {
+          key: 'products_image_media' as const,
+          label: 'Product image/media present',
+          description: 'Images help operators check what agents will show.',
+          severity: 'recommended' as const,
+          status: 'pass' as const,
+          count: 1,
+          total: 1,
+          remediation: 'Add a public-safe image_url for every active product when available.',
+        },
+        {
+          key: 'no_unsafe_catalog_text' as const,
+          label: 'No unsafe catalog text',
+          description: 'Catalog public/runtime fields must not include private artifacts, production claims, provider/payment claims, secrets, or approval claims.',
+          severity: 'blocked' as const,
+          status: 'pass' as const,
+          count: 0,
+          total: 3,
+          remediation: 'Remove private, secret, provider, payment, live, production, approval, readiness, or certification claims from product and variant text.',
+        },
+      ],
+    },
     checks: [
       {
         key: 'merchant_profile_present' as const,
@@ -640,6 +711,14 @@ describe('CommerceOnboarding', () => {
     expect(screen.getByText('Category preset recognized')).toBeInTheDocument();
     expect(screen.getByText('Electronics and appliances')).toBeInTheDocument();
     expect(screen.getByText('Warranty summary')).toBeInTheDocument();
+    expect(screen.getByText('Catalog readiness')).toBeInTheDocument();
+    expect(screen.getByText('1 products / 2 variants')).toBeInTheDocument();
+    expect(screen.getByText('Catalog products present')).toBeInTheDocument();
+    expect(screen.getByText('Variant price and currency present')).toBeInTheDocument();
+    expect(screen.getByText('CSV dry-run: available')).toBeInTheDocument();
+    expect(screen.getByText('Bulk API dry-run: available')).toBeInTheDocument();
+    expect(screen.getByText('Async import job: deferred')).toBeInTheDocument();
+    expect(screen.getByText('Connector import: deferred')).toBeInTheDocument();
     expect(screen.getByText('Merchant profile present')).toBeInTheDocument();
     expect(screen.getAllByText('No checkout/payment enablement').length).toBeGreaterThan(0);
     expect(screen.getByText('Trusted agent')).toBeInTheDocument();

--- a/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
+++ b/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
@@ -67,6 +67,13 @@ function severityVariant(severity: string): 'default' | 'success' | 'warning' | 
   return 'default';
 }
 
+function countLabel(count?: number, total?: number): string | null {
+  if (count === undefined && total === undefined) return null;
+  if (count !== undefined && total !== undefined) return `${count}/${total}`;
+  if (count !== undefined) return String(count);
+  return `0/${total}`;
+}
+
 export function CommerceOnboarding() {
   const [merchantId, setMerchantId] = useState('');
   const [merchant, setMerchant] = useState<CommerceSandboxOnboarding | null>(null);
@@ -206,7 +213,7 @@ export function CommerceOnboarding() {
     <div>
       <PageHeader
         title="Commerce Onboarding"
-        description="Merchant control-plane entry point for profile, readiness checklist, trusted agents, policy simulation, and public discovery status."
+        description="Merchant control-plane entry point for sandbox profile, readiness checklist, trusted agents, policy simulation, and blocked discovery status."
         action={<Button variant="secondary" size="sm" onClick={load} disabled={loading}>{loading ? 'Loading' : 'Refresh'}</Button>}
       />
       <BlockerBanner />
@@ -360,6 +367,59 @@ export function CommerceOnboarding() {
                     ) : null}
                   </div>
                 ))}
+              </div>
+            </div>
+            <div className="mb-4 rounded-md border border-gx-border p-3">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="text-xs text-gx-muted">Catalog readiness</div>
+                  <div className="mt-1 text-sm font-medium text-gx-text">
+                    {merchant.readiness.catalog_readiness.product_count} products / {merchant.readiness.catalog_readiness.variant_count} variants
+                  </div>
+                  <div className="mt-1 text-xs text-gx-muted">{merchant.readiness.catalog_readiness.summary}</div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant={readinessVariant(merchant.readiness.catalog_readiness.status)}>
+                    {merchant.readiness.catalog_readiness.status}
+                  </Badge>
+                  <Badge variant="default">{merchant.readiness.catalog_readiness.score_percent}%</Badge>
+                  <Badge variant="default">
+                    recommended {merchant.readiness.catalog_readiness.recommended_completion_percent}%
+                  </Badge>
+                </div>
+              </div>
+              <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-gx-border">
+                <div
+                  className="h-full rounded-full bg-gx-accent"
+                  style={{ width: `${Math.max(0, Math.min(100, merchant.readiness.catalog_readiness.score_percent))}%` }}
+                />
+              </div>
+              <div className="mt-3 grid gap-2">
+                {merchant.readiness.catalog_readiness.items.map((item) => (
+                  <div key={item.key} className="rounded-md border border-gx-border p-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <span className="text-sm font-medium text-gx-text">{item.label}</span>
+                      <div className="flex flex-wrap gap-2">
+                        {countLabel(item.count, item.total) ? (
+                          <Badge variant="default">{countLabel(item.count, item.total)}</Badge>
+                        ) : null}
+                        <Badge variant={severityVariant(item.severity)}>{item.severity}</Badge>
+                        <Badge variant={readinessVariant(item.status)}>{item.status}</Badge>
+                      </div>
+                    </div>
+                    <div className="mt-1 text-xs text-gx-muted">{item.description}</div>
+                    {item.status !== 'pass' && item.status !== 'not_applicable' ? (
+                      <div className="mt-2 text-xs text-gx-warning">{item.remediation}</div>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+              <div className="mt-3 grid gap-2 text-xs text-gx-muted md:grid-cols-3">
+                <div>Manual entry: {merchant.readiness.catalog_readiness.intake.manual_entry_supported ? 'available' : 'unavailable'}</div>
+                <div>CSV dry-run: {merchant.readiness.catalog_readiness.intake.csv_dry_run_supported ? 'available' : 'unavailable'}</div>
+                <div>Bulk API dry-run: {merchant.readiness.catalog_readiness.intake.bulk_api_dry_run_supported ? 'available' : 'unavailable'}</div>
+                <div>Async import job: {merchant.readiness.catalog_readiness.intake.async_import_job_supported ? 'available' : 'deferred'}</div>
+                <div>Connector import: {merchant.readiness.catalog_readiness.intake.external_connector_supported ? 'available' : 'deferred'}</div>
               </div>
             </div>
             <h3 className="mb-3 text-sm font-semibold text-gx-text">Production gates</h3>

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -25,7 +25,10 @@ info:
     seller onboarding foundation that records public-safe profile drafts,
     readiness checks, and review state without production approval,
     checkout/payment creation, provider credential capture, public discovery
-    enablement, live payments, or live Plural.
+    enablement, live payments, or live Plural. C6A adds category readiness
+    scoring, and C6B adds catalog readiness preview from existing sandbox
+    catalog data without connectors, checkout, payments, or public discovery
+    enablement.
 servers:
   - url: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
     description: Production (Cloud Run)
@@ -269,6 +272,76 @@ components:
           items: { $ref: "#/components/schemas/CategoryReadinessItem" }
         summary: { type: string }
 
+    CatalogReadinessItem:
+      type: object
+      properties:
+        key:
+          type: string
+          enum:
+            - catalog_products_present
+            - catalog_variants_present
+            - products_public_safe_title
+            - products_public_safe_description
+            - products_category_mapping
+            - variants_sku_present
+            - variants_price_currency_present
+            - products_image_media
+            - variants_availability_freshness
+            - variants_warranty_summary
+            - variants_return_policy_summary
+            - variants_tax_gst_metadata
+            - no_unsafe_catalog_text
+        label: { type: string }
+        description: { type: string }
+        severity: { type: string, enum: [required, recommended, blocked] }
+        status: { type: string, enum: [pass, fail, blocked, not_applicable] }
+        count: { type: integer, minimum: 0, nullable: true }
+        total: { type: integer, minimum: 0, nullable: true }
+        remediation: { type: string }
+
+    CatalogReadiness:
+      type: object
+      description: >-
+        C6B computed sandbox catalog readiness preview. It is derived from
+        tenant-owned sandbox catalog product and variant rows. Passing this
+        checklist only means required catalog fields are ready for sandbox
+        read-only discovery review; it is not merchant approval, production
+        readiness, public discovery enablement, checkout/payment readiness,
+        live payment readiness, or live Plural readiness.
+      properties:
+        status: { $ref: "#/components/schemas/SandboxReadinessStatus" }
+        required_passed: { type: boolean }
+        score_percent: { type: integer, minimum: 0, maximum: 100 }
+        recommended_completion_percent: { type: integer, minimum: 0, maximum: 100 }
+        blocker_count: { type: integer, minimum: 0 }
+        product_count: { type: integer, minimum: 0 }
+        variant_count: { type: integer, minimum: 0 }
+        score:
+          type: object
+          properties:
+            passed: { type: integer, minimum: 0 }
+            total: { type: integer, minimum: 0 }
+            percentage: { type: integer, minimum: 0, maximum: 100 }
+            required_passed: { type: boolean }
+            required_passed_count: { type: integer, minimum: 0 }
+            required_total: { type: integer, minimum: 0 }
+            recommended_passed: { type: integer, minimum: 0 }
+            recommended_total: { type: integer, minimum: 0 }
+            recommended_completion_percentage: { type: integer, minimum: 0, maximum: 100 }
+            blocker_count: { type: integer, minimum: 0 }
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/CatalogReadinessItem" }
+        summary: { type: string }
+        intake:
+          type: object
+          properties:
+            manual_entry_supported: { type: boolean, const: true }
+            csv_dry_run_supported: { type: boolean, const: true }
+            bulk_api_dry_run_supported: { type: boolean, const: true }
+            async_import_job_supported: { type: boolean, const: false }
+            external_connector_supported: { type: boolean, const: false }
+
     SandboxOnboarding:
       type: object
       properties:
@@ -299,6 +372,7 @@ components:
             production_approval_status: { type: string, enum: [not_approved] }
             rollout_status: { type: string, enum: [rollout_not_requested] }
             category_readiness: { $ref: "#/components/schemas/CategoryReadiness" }
+            catalog_readiness: { $ref: "#/components/schemas/CatalogReadiness" }
             checks:
               type: array
               items:
@@ -1475,8 +1549,9 @@ paths:
       x-milestone: C5Z
       description: >-
         Returns public-safe sandbox onboarding fields, baseline readiness checks,
-        C6A category readiness scoring, and fail-closed production statuses.
-        The response never includes provider
+        C6A category readiness scoring, C6B catalog readiness preview from
+        existing sandbox product/variant rows, and fail-closed production
+        statuses. The response never includes provider
         account references, credentials, secrets, production allowlist values,
         checkout/payment material, or live-provider paths.
       responses:
@@ -1538,9 +1613,9 @@ paths:
       description: >-
         Moves a sandbox onboarding workspace through the review-oriented state
         machine. Transitions to sandbox_ready or submitted_for_review require
-        baseline and category required readiness checks to pass. No transition
-        approves production, enables public discovery, enables checkout/payment
-        creation, or enables live payments/live Plural.
+        baseline, category, and required catalog readiness checks to pass. No
+        transition approves production, enables public discovery, enables
+        checkout/payment creation, or enables live payments/live Plural.
       requestBody:
         required: true
         content:

--- a/docs/guides/commerce-v1-merchant-operator-guide.mdx
+++ b/docs/guides/commerce-v1-merchant-operator-guide.mdx
@@ -76,9 +76,26 @@ exact inventory quantities in this slice. Blocked checks continue to fail closed
 for private artifacts, production discovery or allowlist config, live provider
 paths, and checkout/payment enablement.
 
-Passing category readiness means only "sandbox profile can be reviewed"; it is
-not merchant approval, production readiness, public discovery approval,
-checkout/payment readiness, live payment readiness, or live Plural readiness.
+C6B adds a computed catalog readiness preview for the same sandbox onboarding
+surface. It reads the merchant-owned sandbox catalog rows already stored in
+Grantex and reports product count, variant count, public-safe title and
+description coverage, category mapping, SKU coverage, price/currency coverage,
+image/media coverage, availability freshness, warranty summaries,
+return-policy summaries, tax/GST metadata where applicable, and unsafe public
+catalog text blockers.
+
+Required catalog gaps block `sandbox_ready` and `submitted_for_review` because
+the profile is not ready for read-only discovery review. Recommended catalog
+gaps lower the readiness score and show remediation, but they do not require a
+catalog connector implementation. Operators can prepare the catalog through the
+existing manual product entry and CSV dry-run/bulk catalog API. Async import
+jobs, Shopify/WooCommerce/Magento connectors, provider credentials, checkout,
+payments, public discovery, live payments, and live Plural remain out of scope.
+
+Passing category or catalog readiness means only "sandbox profile can be
+reviewed"; it is not merchant approval, production readiness, public discovery
+approval, checkout/payment readiness, live payment readiness, or live Plural
+readiness.
 
 ## Catalog And Inventory
 

--- a/docs/internal/commerce-v1/commerce-v1-c6b-catalog-readiness-preview.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6b-catalog-readiness-preview.md
@@ -1,0 +1,85 @@
+# Commerce V1 C6B Catalog Readiness Preview
+
+Date: 2026-05-31
+
+## Scope
+
+C6B extends seller self-serve sandbox onboarding with a computed catalog
+readiness preview for `electronics_appliances`. The preview is sandbox-only and
+tenant-scoped. It does not approve a merchant, enable production Commerce V1,
+enable public discovery, create checkout/payment paths, collect provider
+credentials, enable live payments, or enable live Plural.
+
+## Data Source
+
+No migration is required. Readiness is computed from existing
+`commerce_products` and `commerce_product_variants` rows owned by the same
+tenant and merchant. Existing catalog APIs already support manual product entry
+and the CSV/bulk dry-run path; C6B only surfaces readiness from that data.
+
+The slice intentionally does not add external connector credentials, async
+import jobs, Shopify/WooCommerce/Magento connectors, orders, fulfillment,
+refunds, settlement, checkout enablement, payment enablement, public discovery,
+or AgenticOrg channel launch.
+
+## Catalog Checklist
+
+Required items:
+
+- catalog products present;
+- catalog variants present;
+- public-safe product title coverage;
+- public-safe product description coverage;
+- product category mapping to `electronics_appliances`;
+- variant SKU coverage;
+- variant price and currency coverage.
+
+Recommended items:
+
+- product image/media coverage;
+- availability freshness without exposing exact inventory quantity;
+- warranty summary coverage;
+- return-policy summary coverage;
+- tax/GST metadata coverage when applicable.
+
+Blocked item:
+
+- unsafe catalog text in public/runtime catalog fields, including private
+  artifacts, secrets, provider/payment claims, production/live claims, approval
+  claims, readiness claims, or certification claims.
+
+## Scoring And State Integration
+
+The sandbox onboarding response now includes `readiness.catalog_readiness` with:
+
+- `status`;
+- `score_percent`;
+- `required_passed`;
+- `recommended_completion_percent`;
+- `blocker_count`;
+- `product_count`;
+- `variant_count`;
+- checklist `items` with key, label, description, severity, status,
+  count/total where applicable, and remediation;
+- intake capability flags for manual entry, CSV dry-run, bulk API dry-run,
+  async import job support, and external connector support.
+
+`sandbox_ready` and `submitted_for_review` require baseline readiness,
+category readiness, and required catalog readiness to pass. Recommended catalog
+gaps lower the score and show remediation but do not block a save. Passing
+catalog readiness means only that the sandbox catalog has the minimum public
+fields needed for read-only discovery review. It does not mean merchant
+approval, production readiness, public discovery approval, checkout/payment
+readiness, live payment readiness, or live Plural readiness.
+
+## Security Controls
+
+- Tenant and merchant boundaries use the existing commerce route helpers and
+  merchant-scoped SQL filters.
+- CommerceAgent callers are not granted merchant admin access.
+- The preview does not store or return private contracts, private contacts,
+  customer data, secrets, provider credentials, tokens, JWTs, raw payloads,
+  DB/Redis URLs, private keys, production config values, or allowlist values.
+- Live merchants remain blocked from sandbox onboarding.
+- State-changing onboarding actions continue to write audit evidence through
+  the C5Z audit path.


### PR DESCRIPTION
## Summary
- adds computed sandbox catalog readiness for electronics_appliances from existing tenant-scoped product and variant rows
- exposes catalog readiness score/items/intake flags in the sandbox onboarding API and portal UI
- documents the sandbox-only posture and manual/CSV dry-run intake foundation

## Guardrails
- no deployment, merge, cloud command, cloud resource, production config, or secret changes
- no public discovery, production Commerce V1, checkout/payment creation, live payment, or live Plural enablement
- no real merchant approval and no production allowlist values

## Validation
- apps/auth-service: npm test -- commerce-merchants.test.ts commerce-products.test.ts commerce-tenant-boundary.test.ts commerce-audit.test.ts commerce-schema.test.ts commerce-live-mode-guard.test.ts commerce-no-plural-leak.test.ts commerce-openapi.test.ts
- apps/auth-service: npm test -- commerce-cart-payment.test.ts commerce-payment-foundations.test.ts commerce-live-mode-guard.test.ts commerce-no-plural-leak.test.ts
- apps/auth-service: npm run typecheck
- apps/portal: npm test -- src/pages/__tests__/CommerceDashboard.test.tsx src/api/__tests__/commerce.test.ts
- apps/portal: npm run typecheck
- git diff --cached --check
- focused secret/private-detail, production config/allowlist, public discovery, checkout/payment, live payment/Plural/provider credential, overclaim, realistic merchant/private detail, and synthetic/demo production-candidate scans