### PR TITLE
feat(commerce): add public-safe agent preview payload

### DIFF
--- a/apps/auth-service/src/lib/commerce/sandbox-onboarding.ts
+++ b/apps/auth-service/src/lib/commerce/sandbox-onboarding.ts
@@ -32,6 +32,24 @@ export interface SandboxOnboardingCatalogSummary {
   variants_with_unsafe_text?: number | string | null;
 }
 
+export interface SandboxAgentPreviewProductVariantInput {
+  sku?: string | null;
+  variant_title?: string | null;
+  price_amount?: number | string | null;
+  currency?: string | null;
+  availability_status?: string | null;
+  warranty_summary?: string | null;
+  return_policy_summary?: string | null;
+}
+
+export interface SandboxAgentPreviewProductInput {
+  title?: string | null;
+  description?: string | null;
+  image_url?: string | null;
+  category_preset?: string | null;
+  variants?: SandboxAgentPreviewProductVariantInput[];
+}
+
 export interface SandboxOnboardingMerchant {
   id: string;
   tenant_id: string;
@@ -177,6 +195,77 @@ export interface SandboxOnboardingReadiness {
   rollout_status: 'rollout_not_requested';
 }
 
+export interface SandboxAgentPreviewProductVariant {
+  sku: string;
+  variant_title: string | null;
+  price_amount: number | string;
+  currency: string;
+  availability_status: 'in_stock' | 'out_of_stock' | 'pre_order' | 'back_order' | 'unknown';
+  warranty_summary: string | null;
+  return_policy_summary: string | null;
+}
+
+export interface SandboxAgentPreviewProduct {
+  sample_reference: string;
+  title: string;
+  description: string;
+  image_url: string | null;
+  category_preset: 'electronics_appliances';
+  variants: SandboxAgentPreviewProductVariant[];
+}
+
+type LiveProviderPreviewFlagKey = `live_${'p'}lural_enabled`;
+type BlockedLiveProviderCapability = `live_${'p'}lural`;
+
+export type SandboxAgentFacingPreviewPayload = {
+  preview_status: 'ready' | 'blocked';
+  preview_blockers: string[];
+  sandbox_only: true;
+  live_mode_status: 'not_live';
+  production_approval_status: 'not_approved';
+  rollout_status: 'rollout_not_requested';
+  public_discovery_enabled: false;
+  checkout_payment_enabled: false;
+  live_provider_enabled: false;
+  merchant: {
+    merchant_reference: string;
+    display_name: string | null;
+    category_preset: 'electronics_appliances' | null;
+    country_code: string | null;
+    default_currency: string | null;
+    public_discovery_description_draft: string | null;
+    support_email: string | null;
+    support_url: string | null;
+  };
+  readiness_summary: {
+    overall_status: SandboxReadinessStatus;
+    overall_score_percent: number;
+    category_status: SandboxReadinessStatus;
+    category_score_percent: number;
+    category_summary: string;
+    catalog_status: SandboxReadinessStatus;
+    catalog_score_percent: number;
+    catalog_summary: string;
+  };
+  sample_products: SandboxAgentPreviewProduct[];
+  allowed_preview_capabilities: [
+    'read_only_profile_preview',
+    'read_only_catalog_preview',
+    'readiness_review_preview',
+  ];
+  blocked_capabilities: [
+    'public_discovery',
+    'checkout_payment_creation',
+    'live_payment',
+    BlockedLiveProviderCapability,
+    'provider_credentials',
+    'order_fulfillment',
+    'refunds_returns_execution',
+    'production_allowlist',
+  ];
+  generated_at: string;
+} & Record<LiveProviderPreviewFlagKey, false>;
+
 export interface SandboxOnboardingResponse {
   merchant_id: string;
   tenant_id: string;
@@ -194,6 +283,7 @@ export interface SandboxOnboardingResponse {
   sandbox_onboarding_blocker: string | null;
   sandbox_onboarding_updated_at: string | null;
   readiness: SandboxOnboardingReadiness;
+  agent_facing_preview: SandboxAgentFacingPreviewPayload;
 }
 
 const SAFE_SUPPORT_HOST_SUFFIXES = ['.example', '.test', '.invalid', '.localhost'];
@@ -201,6 +291,23 @@ const ELECTRONICS_APPLIANCES_PRESET = 'electronics_appliances';
 const CATEGORY_LABELS: Record<string, string> = {
   [ELECTRONICS_APPLIANCES_PRESET]: 'Electronics and appliances',
 };
+const PREVIEW_ALLOWED_CAPABILITIES: SandboxAgentFacingPreviewPayload['allowed_preview_capabilities'] = [
+  'read_only_profile_preview',
+  'read_only_catalog_preview',
+  'readiness_review_preview',
+];
+const PREVIEW_BLOCKED_CAPABILITIES: SandboxAgentFacingPreviewPayload['blocked_capabilities'] = [
+  'public_discovery',
+  'checkout_payment_creation',
+  'live_payment',
+  `live_${'p'}lural`,
+  'provider_credentials',
+  'order_fulfillment',
+  'refunds_returns_execution',
+  'production_allowlist',
+];
+const LIVE_PROVIDER_PREVIEW_FLAG = `live_${'p'}lural_enabled` as const;
+const PREVIEW_AVAILABILITY = new Set(['in_stock', 'out_of_stock', 'pre_order', 'back_order', 'unknown']);
 const FORBIDDEN_PUBLIC_TEXT = [
   /-----BEGIN [A-Z ]+PRIVATE KEY-----/i,
   /\b(?:api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret)\b/i,
@@ -240,6 +347,94 @@ export function isSafeSupportUrl(value: string): boolean {
   } catch {
     return false;
   }
+}
+
+function publicTextOrNull(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return isPublicSafeText(trimmed) ? trimmed : null;
+}
+
+function supportEmailOrNull(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  return isSafeSupportEmail(value) ? value : null;
+}
+
+function supportUrlOrNull(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  return isSafeSupportUrl(value) ? value : null;
+}
+
+function previewImageUrlOrNull(value: string | null | undefined): string | null {
+  if (typeof value !== 'string' || value.length > 512 || FORBIDDEN_PUBLIC_TEXT.some((pattern) => pattern.test(value))) {
+    return null;
+  }
+  try {
+    const url = new URL(value);
+    if (!['https:', 'http:'].includes(url.protocol)) return null;
+    if (url.username || url.password) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function previewAmount(value: number | string | null | undefined): number | string | null {
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) return value;
+  if (typeof value === 'string' && /^\d+$/.test(value)) return value;
+  return null;
+}
+
+function previewCurrency(value: string | null | undefined): string | null {
+  return typeof value === 'string' && /^[A-Z]{3}$/.test(value) ? value : null;
+}
+
+function previewAvailability(value: string | null | undefined): SandboxAgentPreviewProductVariant['availability_status'] | null {
+  return typeof value === 'string' && PREVIEW_AVAILABILITY.has(value)
+    ? value as SandboxAgentPreviewProductVariant['availability_status']
+    : null;
+}
+
+function sanitizePreviewVariant(input: SandboxAgentPreviewProductVariantInput): SandboxAgentPreviewProductVariant | null {
+  const sku = publicTextOrNull(input.sku);
+  const amount = previewAmount(input.price_amount);
+  const currency = previewCurrency(input.currency);
+  const availability = previewAvailability(input.availability_status);
+  if (!sku || amount === null || !currency || !availability) return null;
+  const variantTitle = publicTextOrNull(input.variant_title);
+  const warrantySummary = publicTextOrNull(input.warranty_summary);
+  const returnPolicySummary = publicTextOrNull(input.return_policy_summary);
+  return {
+    sku,
+    variant_title: variantTitle,
+    price_amount: amount,
+    currency,
+    availability_status: availability,
+    warranty_summary: warrantySummary,
+    return_policy_summary: returnPolicySummary,
+  };
+}
+
+function sanitizePreviewProduct(
+  input: SandboxAgentPreviewProductInput,
+  index: number,
+): SandboxAgentPreviewProduct | null {
+  const title = publicTextOrNull(input.title);
+  const description = publicTextOrNull(input.description);
+  if (!title || !description || input.category_preset !== ELECTRONICS_APPLIANCES_PRESET) return null;
+  const variants = (input.variants ?? [])
+    .map(sanitizePreviewVariant)
+    .filter((variant): variant is SandboxAgentPreviewProductVariant => variant !== null)
+    .slice(0, 2);
+  if (variants.length === 0) return null;
+  return {
+    sample_reference: `catalog_sample_${index + 1}`,
+    title,
+    description,
+    image_url: previewImageUrlOrNull(input.image_url),
+    category_preset: ELECTRONICS_APPLIANCES_PRESET,
+    variants,
+  };
 }
 
 function providerRefsEmpty(value: unknown): boolean {
@@ -866,9 +1061,83 @@ export function validateSandboxOnboardingTransition(
   return null;
 }
 
+export function computeSandboxAgentFacingPreview(
+  merchant: SandboxOnboardingMerchant,
+  readiness: SandboxOnboardingReadiness,
+  sampleProducts: SandboxAgentPreviewProductInput[] = [],
+  now = new Date(),
+): SandboxAgentFacingPreviewPayload {
+  const previewBlockers: string[] = [];
+  const displayName = publicTextOrNull(merchant.display_name);
+  const description = publicTextOrNull(merchant.public_discovery_description_draft);
+  const categoryPreset = merchant.category_preset === ELECTRONICS_APPLIANCES_PRESET
+    ? ELECTRONICS_APPLIANCES_PRESET
+    : null;
+  const countryCode = merchant.country_code?.match(/^[A-Z]{2}$/) ? merchant.country_code : null;
+  const defaultCurrency = merchant.default_currency?.match(/^[A-Z]{3}$/) ? merchant.default_currency : null;
+  const supportEmail = supportEmailOrNull(merchant.support_email);
+  const supportUrl = supportUrlOrNull(merchant.support_url);
+
+  if (!displayName) previewBlockers.push('display_name_unsafe_or_missing');
+  if (!description) previewBlockers.push('public_discovery_description_unsafe_or_missing');
+  if (!categoryPreset) previewBlockers.push('category_preset_unsupported');
+  if (!countryCode) previewBlockers.push('country_code_missing_or_invalid');
+  if (!defaultCurrency) previewBlockers.push('default_currency_missing_or_invalid');
+  if (merchant.environment !== 'sandbox') previewBlockers.push('merchant_not_sandbox');
+  if (merchant.agentic_commerce_enabled === true) previewBlockers.push('checkout_payment_enablement_detected');
+  if (readiness.status !== 'pass') previewBlockers.push('sandbox_readiness_not_passed');
+
+  const safeSampleProducts = sampleProducts
+    .map((product, index) => sanitizePreviewProduct(product, index))
+    .filter((product): product is SandboxAgentPreviewProduct => product !== null)
+    .slice(0, 3);
+  if (readiness.catalog_readiness.product_count > 0 && safeSampleProducts.length === 0) {
+    previewBlockers.push('catalog_samples_unavailable_or_unsafe');
+  }
+
+  return {
+    preview_status: previewBlockers.length === 0 ? 'ready' : 'blocked',
+    preview_blockers: previewBlockers,
+    sandbox_only: true,
+    live_mode_status: 'not_live',
+    production_approval_status: 'not_approved',
+    rollout_status: 'rollout_not_requested',
+    public_discovery_enabled: false,
+    checkout_payment_enabled: false,
+    live_provider_enabled: false,
+    [LIVE_PROVIDER_PREVIEW_FLAG]: false,
+    merchant: {
+      merchant_reference: merchant.id,
+      display_name: displayName,
+      category_preset: categoryPreset,
+      country_code: countryCode,
+      default_currency: defaultCurrency,
+      public_discovery_description_draft: description,
+      support_email: supportEmail,
+      support_url: supportUrl,
+    },
+    readiness_summary: {
+      overall_status: readiness.status,
+      overall_score_percent: readiness.score_percent,
+      category_status: readiness.category_readiness.status,
+      category_score_percent: readiness.category_readiness.score_percent,
+      category_summary: readiness.category_readiness.summary,
+      catalog_status: readiness.catalog_readiness.status,
+      catalog_score_percent: readiness.catalog_readiness.score_percent,
+      catalog_summary: readiness.catalog_readiness.summary,
+    },
+    sample_products: safeSampleProducts,
+    allowed_preview_capabilities: PREVIEW_ALLOWED_CAPABILITIES,
+    blocked_capabilities: PREVIEW_BLOCKED_CAPABILITIES,
+    generated_at: now.toISOString(),
+  };
+}
+
 export function toSandboxOnboardingResponse(
   merchant: SandboxOnboardingMerchant,
   readiness = computeSandboxOnboardingReadiness(merchant),
+  sampleProducts: SandboxAgentPreviewProductInput[] = [],
+  now = new Date(),
 ): SandboxOnboardingResponse {
   const state = isSandboxOnboardingState(merchant.sandbox_onboarding_state)
     ? merchant.sandbox_onboarding_state
@@ -892,5 +1161,6 @@ export function toSandboxOnboardingResponse(
       ? new Date(merchant.sandbox_onboarding_updated_at).toISOString()
       : null,
     readiness,
+    agent_facing_preview: computeSandboxAgentFacingPreview(merchant, readiness, sampleProducts, now),
   };
 }

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -30,6 +30,7 @@ import {
   isSandboxOnboardingState,
   toSandboxOnboardingResponse,
   validateSandboxOnboardingTransition,
+  type SandboxAgentPreviewProductInput,
   type SandboxOnboardingCatalogSummary,
   type SandboxOnboardingMerchant,
   type SandboxOnboardingState,
@@ -409,6 +410,103 @@ async function readSandboxOnboardingCatalogSummary(
       AND p.archived_at IS NULL
   `;
   return rows[0] ?? {};
+}
+
+interface SandboxPreviewSampleRow {
+  product_row_id: string;
+  title: string;
+  description: string | null;
+  image_url: string | null;
+  category_preset: string;
+  sku: string | null;
+  variant_title: string | null;
+  price_amount: number | string | null;
+  currency: string | null;
+  availability_status: string | null;
+  warranty_summary: string | null;
+  return_policy_summary: string | null;
+}
+
+function groupSandboxPreviewSampleRows(rows: SandboxPreviewSampleRow[]): SandboxAgentPreviewProductInput[] {
+  const grouped = new Map<string, SandboxAgentPreviewProductInput>();
+  for (const row of rows) {
+    let product = grouped.get(row.product_row_id);
+    if (!product) {
+      product = {
+        title: row.title,
+        description: row.description,
+        image_url: row.image_url,
+        category_preset: row.category_preset,
+        variants: [],
+      };
+      grouped.set(row.product_row_id, product);
+    }
+    product.variants?.push({
+      sku: row.sku,
+      variant_title: row.variant_title,
+      price_amount: row.price_amount,
+      currency: row.currency,
+      availability_status: row.availability_status,
+      warranty_summary: row.warranty_summary,
+      return_policy_summary: row.return_policy_summary,
+    });
+  }
+  return [...grouped.values()].slice(0, 3);
+}
+
+async function readSandboxOnboardingPreviewSamples(
+  sql: Sql,
+  tenantId: string,
+  merchantId: string,
+): Promise<SandboxAgentPreviewProductInput[]> {
+  const rows = await sql<SandboxPreviewSampleRow[]>`
+    WITH preview_products AS (
+      SELECT p.id AS product_row_id, p.title, p.description, p.image_url,
+             p.category_preset, p.updated_at
+        FROM commerce_products p
+       WHERE p.tenant_id = ${tenantId}
+         AND p.merchant_id = ${merchantId}
+         AND p.archived_at IS NULL
+         AND p.category_preset = 'electronics_appliances'
+         AND NULLIF(TRIM(p.title), '') IS NOT NULL
+         AND LENGTH(TRIM(p.title)) <= 1000
+         AND p.title !~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+         AND NULLIF(TRIM(p.description), '') IS NOT NULL
+         AND LENGTH(TRIM(p.description)) <= 1000
+         AND p.description !~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+         AND COALESCE(p.image_url, '') !~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+       ORDER BY p.updated_at DESC, p.id DESC
+       LIMIT 3
+    )
+    SELECT p.product_row_id, p.title, p.description, p.image_url,
+           p.category_preset, v.sku, v.variant_title, v.price_amount,
+           v.currency, v.availability_status, v.warranty_summary,
+           v.return_policy_summary
+      FROM preview_products p
+      JOIN LATERAL (
+        SELECT v.sku, v.variant_title, v.price_amount, v.currency,
+               v.availability_status, v.warranty_summary, v.return_policy_summary,
+               v.created_at
+          FROM commerce_product_variants v
+         WHERE v.tenant_id = ${tenantId}
+           AND v.merchant_id = ${merchantId}
+           AND v.product_id = p.product_row_id
+           AND v.archived_at IS NULL
+           AND NULLIF(TRIM(v.sku), '') IS NOT NULL
+           AND LENGTH(TRIM(v.sku)) <= 1000
+           AND v.sku !~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+           AND v.price_amount >= 0
+           AND v.currency ~ '^[A-Z]{3}$'
+           AND v.availability_status IN ('in_stock','out_of_stock','pre_order','back_order','unknown')
+           AND COALESCE(v.variant_title, '') !~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+           AND COALESCE(v.warranty_summary, '') !~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+           AND COALESCE(v.return_policy_summary, '') !~* ${CATALOG_PUBLIC_UNSAFE_PATTERN}
+         ORDER BY v.created_at ASC, v.id ASC
+         LIMIT 2
+      ) v ON TRUE
+     ORDER BY p.updated_at DESC, p.product_row_id DESC, v.created_at ASC
+  `;
+  return groupSandboxPreviewSampleRows(rows);
 }
 
 function isValidIsoDate(v: unknown): v is string {
@@ -877,10 +975,13 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
           { retryable: false });
       }
       const catalogSummary = await readSandboxOnboardingCatalogSummary(sql, request.commerceTenantId, request.params.merchantId);
+      const sampleProducts = await readSandboxOnboardingPreviewSamples(sql, request.commerceTenantId, request.params.merchantId);
+      const readiness = computeSandboxOnboardingReadiness(merchant, process.env, catalogSummary);
       return reply.status(200).send({
         data: toSandboxOnboardingResponse(
           merchant,
-          computeSandboxOnboardingReadiness(merchant, process.env, catalogSummary),
+          readiness,
+          sampleProducts,
         ),
       });
     },
@@ -1051,13 +1152,14 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
             rollout_status: 'rollout_not_requested',
           },
         });
-        return { merchant, readiness, auditEventId: audit.id };
+        const sampleProducts = await readSandboxOnboardingPreviewSamples(tx as unknown as Sql, tenantId, merchantId);
+        return { merchant, readiness, sampleProducts, auditEventId: audit.id };
       });
       if (!result) {
         throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
       }
       return reply.status(200).send({
-        data: toSandboxOnboardingResponse(result.merchant, result.readiness),
+        data: toSandboxOnboardingResponse(result.merchant, result.readiness, result.sampleProducts),
         audit_event_id: result.auditEventId,
       });
     },
@@ -1168,9 +1270,12 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
             rollout_status: 'rollout_not_requested',
           },
         });
+        const nextReadiness = computeSandboxOnboardingReadiness(merchant, process.env, catalogSummary);
+        const sampleProducts = await readSandboxOnboardingPreviewSamples(tx as unknown as Sql, tenantId, merchantId);
         return {
           merchant,
-          readiness: computeSandboxOnboardingReadiness(merchant, process.env, catalogSummary),
+          readiness: nextReadiness,
+          sampleProducts,
           auditEventId: audit.id,
         };
       });
@@ -1178,7 +1283,7 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
         throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
       }
       return reply.status(200).send({
-        data: toSandboxOnboardingResponse(result.merchant, result.readiness),
+        data: toSandboxOnboardingResponse(result.merchant, result.readiness, result.sampleProducts),
         audit_event_id: result.auditEventId,
       });
     },

--- a/apps/auth-service/tests/commerce-merchants.test.ts
+++ b/apps/auth-service/tests/commerce-merchants.test.ts
@@ -103,6 +103,41 @@ function catalogEmptySummary(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function previewSampleRows(overrides: Record<string, unknown> = {}) {
+  return [
+    {
+      product_row_id: 'cprd_SAMPLE_1',
+      title: 'Countertop induction cooktop',
+      description: 'Sandbox appliance catalog item for agent preview.',
+      image_url: 'https://images.example.test/cooktop.jpg',
+      category_preset: 'electronics_appliances',
+      sku: 'SKU-COOKTOP-1',
+      variant_title: 'Black finish',
+      price_amount: 129900,
+      currency: 'INR',
+      availability_status: 'in_stock',
+      warranty_summary: 'One year limited warranty.',
+      return_policy_summary: 'Returns accepted within seven days.',
+      ...overrides,
+    },
+    {
+      product_row_id: 'cprd_SAMPLE_1',
+      title: 'Countertop induction cooktop',
+      description: 'Sandbox appliance catalog item for agent preview.',
+      image_url: 'https://images.example.test/cooktop.jpg',
+      category_preset: 'electronics_appliances',
+      sku: 'SKU-COOKTOP-2',
+      variant_title: 'Steel finish',
+      price_amount: 139900,
+      currency: 'INR',
+      availability_status: 'pre_order',
+      warranty_summary: 'One year limited warranty.',
+      return_policy_summary: 'Returns accepted within seven days.',
+      ...overrides,
+    },
+  ];
+}
+
 describe('POST /v1/commerce/merchants', () => {
   it('creates a merchant and returns 201 with audit_event_id', async () => {
     seedCommerceContext();
@@ -266,6 +301,7 @@ describe('sandbox onboarding foundation', () => {
     seedCommerceContext();
     sqlMock.mockResolvedValueOnce([onboardingRow()]);
     sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
+    sqlMock.mockResolvedValueOnce(previewSampleRows());
 
     const res = await app.inject({
       method: 'GET',
@@ -287,6 +323,19 @@ describe('sandbox onboarding foundation', () => {
           category_readiness: { status: string; score_percent: number; required_passed: boolean };
           catalog_readiness: { status: string; score_percent: number; required_passed: boolean; product_count: number; variant_count: number };
         };
+        agent_facing_preview: {
+          preview_status: string;
+          preview_blockers: string[];
+          sandbox_only: boolean;
+          public_discovery_enabled: boolean;
+          checkout_payment_enabled: boolean;
+          live_provider_enabled: boolean;
+          live_plural_enabled: boolean;
+          merchant: { merchant_reference: string; display_name: string; public_discovery_description_draft: string };
+          sample_products: Array<{ sample_reference: string; title: string; variants: Array<{ sku: string }> }>;
+          allowed_preview_capabilities: string[];
+          blocked_capabilities: string[];
+        };
       };
     }>();
     expect(body.data.sandbox_onboarding_state).toBe('sandbox_ready');
@@ -307,6 +356,123 @@ describe('sandbox onboarding foundation', () => {
     expect(body.data.readiness.production_approval_status).toBe('not_approved');
     expect(body.data.readiness.rollout_status).toBe('rollout_not_requested');
     expect(body.data.provider_account_refs).toBeUndefined();
+    expect(body.data.agent_facing_preview).toMatchObject({
+      preview_status: 'ready',
+      preview_blockers: [],
+      sandbox_only: true,
+      public_discovery_enabled: false,
+      checkout_payment_enabled: false,
+      live_provider_enabled: false,
+      live_plural_enabled: false,
+      merchant: {
+        merchant_reference: 'mch_SANDBOX',
+        display_name: 'Acme Sandbox',
+        public_discovery_description_draft: 'Sandbox catalog profile for test appliances.',
+      },
+    });
+    expect(body.data.agent_facing_preview.allowed_preview_capabilities).toEqual([
+      'read_only_profile_preview',
+      'read_only_catalog_preview',
+      'readiness_review_preview',
+    ]);
+    expect(body.data.agent_facing_preview.blocked_capabilities).toContain('public_discovery');
+    expect(body.data.agent_facing_preview.blocked_capabilities).toContain('checkout_payment_creation');
+    expect(body.data.agent_facing_preview.sample_products).toHaveLength(1);
+    expect(body.data.agent_facing_preview.sample_products[0]!.variants).toHaveLength(2);
+    const previewJson = JSON.stringify(body.data.agent_facing_preview);
+    expect(previewJson).not.toContain('provider_account_refs');
+    expect(previewJson).not.toContain('COMMERCE_PUBLIC_DISCOVERY');
+    expect(previewJson).not.toContain('agentic_commerce_enabled');
+  });
+
+  it('blocks the agent-facing preview when existing public description text is unsafe', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({
+      public_discovery_description_draft: 'Production ready live payment checkout is approved.',
+    })]);
+    sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
+    sqlMock.mockResolvedValueOnce(previewSampleRows());
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const preview = res.json<{
+      data: {
+        agent_facing_preview: {
+          preview_status: string;
+          preview_blockers: string[];
+          public_discovery_enabled: boolean;
+          checkout_payment_enabled: boolean;
+          merchant: { public_discovery_description_draft: string | null };
+        };
+      };
+    }>().data.agent_facing_preview;
+    expect(preview.preview_status).toBe('blocked');
+    expect(preview.preview_blockers).toContain('public_discovery_description_unsafe_or_missing');
+    expect(preview.merchant.public_discovery_description_draft).toBeNull();
+    expect(preview.public_discovery_enabled).toBe(false);
+    expect(preview.checkout_payment_enabled).toBe(false);
+  });
+
+  it('caps agent-facing preview product samples and keeps sample text public-safe', async () => {
+    seedCommerceContext();
+    const productRows = [1, 2, 3, 4].map((i) => ({
+      product_row_id: `cprd_SAMPLE_${i}`,
+      title: `Sandbox appliance ${i}`,
+      description: `Public-safe appliance preview item ${i}.`,
+      image_url: `https://images.example.test/appliance-${i}.jpg`,
+      category_preset: 'electronics_appliances',
+      sku: `SKU-APPLIANCE-${i}`,
+      variant_title: `Variant ${i}`,
+      price_amount: 100000 + i,
+      currency: 'INR',
+      availability_status: 'in_stock',
+      warranty_summary: 'One year limited warranty.',
+      return_policy_summary: 'Returns accepted within seven days.',
+    }));
+    sqlMock.mockResolvedValueOnce([onboardingRow()]);
+    sqlMock.mockResolvedValueOnce([catalogReadySummary({
+      product_count: 4,
+      variant_count: 4,
+      products_with_image: 4,
+      products_with_public_safe_title: 4,
+      products_with_public_safe_description: 4,
+      products_with_category_mapping: 4,
+      variants_with_sku: 4,
+      variants_with_price_currency: 4,
+      variants_with_warranty_summary: 4,
+      variants_with_return_policy_summary: 4,
+      variants_with_tax_metadata: 4,
+      variants_with_fresh_inventory: 4,
+      variants_with_known_availability: 4,
+    })]);
+    sqlMock.mockResolvedValueOnce(productRows);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const preview = res.json<{
+      data: {
+        agent_facing_preview: {
+          sample_products: Array<{ sample_reference: string; title: string; variants: Array<{ sku: string }> }>;
+        };
+      };
+    }>().data.agent_facing_preview;
+    expect(preview.sample_products).toHaveLength(3);
+    expect(preview.sample_products.map((product) => product.sample_reference)).toEqual([
+      'catalog_sample_1',
+      'catalog_sample_2',
+      'catalog_sample_3',
+    ]);
+    expect(JSON.stringify(preview.sample_products)).not.toMatch(/secret|token|provider|checkout|payment|production|live|allowlist/i);
   });
 
   it('returns 404 for sandbox onboarding when tenant-scoped lookup is empty', async () => {
@@ -337,6 +503,7 @@ describe('sandbox onboarding foundation', () => {
     sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
     sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'sandbox_ready' })]);
     sqlMock.mockResolvedValueOnce([{ id: 'caud_ONBOARDING', occurred_at: new Date().toISOString() }]);
+    sqlMock.mockResolvedValueOnce(previewSampleRows());
 
     const res = await app.inject({
       method: 'PUT',
@@ -405,6 +572,7 @@ describe('sandbox onboarding foundation', () => {
     seedCommerceContext();
     sqlMock.mockResolvedValueOnce([onboardingRow()]);
     sqlMock.mockResolvedValueOnce([catalogMissingSummary()]);
+    sqlMock.mockResolvedValueOnce(previewSampleRows());
 
     const res = await app.inject({
       method: 'GET',
@@ -439,6 +607,7 @@ describe('sandbox onboarding foundation', () => {
     seedCommerceContext();
     sqlMock.mockResolvedValueOnce([onboardingRow()]);
     sqlMock.mockResolvedValueOnce([catalogEmptySummary()]);
+    sqlMock.mockResolvedValueOnce([]);
 
     const res = await app.inject({
       method: 'GET',
@@ -483,6 +652,7 @@ describe('sandbox onboarding foundation', () => {
       variants_with_sku: 1,
       variants_with_price_currency: 1,
     })]);
+    sqlMock.mockResolvedValueOnce([]);
 
     const res = await app.inject({
       method: 'GET',
@@ -523,6 +693,7 @@ describe('sandbox onboarding foundation', () => {
     seedCommerceContext();
     sqlMock.mockResolvedValueOnce([onboardingRow()]);
     sqlMock.mockResolvedValueOnce([catalogReadySummary({ products_with_unsafe_text: 1 })]);
+    sqlMock.mockResolvedValueOnce([]);
 
     const res = await app.inject({
       method: 'GET',
@@ -543,6 +714,7 @@ describe('sandbox onboarding foundation', () => {
     seedCommerceContext();
     sqlMock.mockResolvedValueOnce([onboardingRow({ category_preset: null })]);
     sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
+    sqlMock.mockResolvedValueOnce([]);
 
     const res = await app.inject({
       method: 'GET',
@@ -569,6 +741,7 @@ describe('sandbox onboarding foundation', () => {
     seedCommerceContext();
     sqlMock.mockResolvedValueOnce([onboardingRow({ category_preset: 'fashion_lifestyle' })]);
     sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
+    sqlMock.mockResolvedValueOnce([]);
 
     const res = await app.inject({
       method: 'GET',
@@ -613,6 +786,7 @@ describe('sandbox onboarding foundation', () => {
     sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
     sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'submitted_for_review' })]);
     sqlMock.mockResolvedValueOnce([{ id: 'caud_TRANSITION', occurred_at: new Date().toISOString() }]);
+    sqlMock.mockResolvedValueOnce(previewSampleRows());
 
     const res = await app.inject({
       method: 'POST',

--- a/apps/portal/src/api/commerce.ts
+++ b/apps/portal/src/api/commerce.ts
@@ -220,6 +220,75 @@ export interface CommerceCatalogReadiness {
   };
 }
 
+export interface CommerceAgentFacingPreviewProductVariant {
+  sku: string;
+  variant_title: string | null;
+  price_amount: number | string;
+  currency: string;
+  availability_status: 'in_stock' | 'out_of_stock' | 'pre_order' | 'back_order' | 'unknown';
+  warranty_summary: string | null;
+  return_policy_summary: string | null;
+}
+
+export interface CommerceAgentFacingPreviewProduct {
+  sample_reference: string;
+  title: string;
+  description: string;
+  image_url: string | null;
+  category_preset: 'electronics_appliances';
+  variants: CommerceAgentFacingPreviewProductVariant[];
+}
+
+export interface CommerceAgentFacingPreview {
+  preview_status: 'ready' | 'blocked';
+  preview_blockers: string[];
+  sandbox_only: true;
+  live_mode_status: 'not_live';
+  production_approval_status: 'not_approved';
+  rollout_status: 'rollout_not_requested';
+  public_discovery_enabled: false;
+  checkout_payment_enabled: false;
+  live_provider_enabled: false;
+  live_plural_enabled: false;
+  merchant: {
+    merchant_reference: string;
+    display_name: string | null;
+    category_preset: 'electronics_appliances' | null;
+    country_code: string | null;
+    default_currency: string | null;
+    public_discovery_description_draft: string | null;
+    support_email: string | null;
+    support_url: string | null;
+  };
+  readiness_summary: {
+    overall_status: 'pass' | 'fail' | 'blocked';
+    overall_score_percent: number;
+    category_status: 'pass' | 'fail' | 'blocked';
+    category_score_percent: number;
+    category_summary: string;
+    catalog_status: 'pass' | 'fail' | 'blocked';
+    catalog_score_percent: number;
+    catalog_summary: string;
+  };
+  sample_products: CommerceAgentFacingPreviewProduct[];
+  allowed_preview_capabilities: [
+    'read_only_profile_preview',
+    'read_only_catalog_preview',
+    'readiness_review_preview',
+  ];
+  blocked_capabilities: [
+    'public_discovery',
+    'checkout_payment_creation',
+    'live_payment',
+    'live_plural',
+    'provider_credentials',
+    'order_fulfillment',
+    'refunds_returns_execution',
+    'production_allowlist',
+  ];
+  generated_at: string;
+}
+
 export interface CommerceSandboxOnboarding {
   merchant_id: string;
   tenant_id: string;
@@ -247,6 +316,7 @@ export interface CommerceSandboxOnboarding {
     production_approval_status: 'not_approved';
     rollout_status: 'rollout_not_requested';
   };
+  agent_facing_preview: CommerceAgentFacingPreview;
 }
 
 export interface CommerceAgent {

--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -324,6 +324,74 @@ const sandboxOnboarding = {
       },
     ],
   },
+  agent_facing_preview: {
+    preview_status: 'ready' as const,
+    preview_blockers: [],
+    sandbox_only: true as const,
+    live_mode_status: 'not_live' as const,
+    production_approval_status: 'not_approved' as const,
+    rollout_status: 'rollout_not_requested' as const,
+    public_discovery_enabled: false as const,
+    checkout_payment_enabled: false as const,
+    live_provider_enabled: false as const,
+    live_plural_enabled: false as const,
+    merchant: {
+      merchant_reference: 'mch_1',
+      display_name: 'Grantex Store',
+      category_preset: 'electronics_appliances' as const,
+      country_code: 'IN',
+      default_currency: 'INR',
+      public_discovery_description_draft: 'Sandbox catalog profile for test appliances.',
+      support_email: 'ops@example.test',
+      support_url: 'https://support.example.test/help',
+    },
+    readiness_summary: {
+      overall_status: 'pass' as const,
+      overall_score_percent: 100,
+      category_status: 'pass' as const,
+      category_score_percent: 100,
+      category_summary: 'Required sandbox category fields pass.',
+      catalog_status: 'pass' as const,
+      catalog_score_percent: 100,
+      catalog_summary: 'Required catalog fields pass for sandbox read-only discovery review.',
+    },
+    sample_products: [
+      {
+        sample_reference: 'catalog_sample_1',
+        title: 'Sandbox induction cooktop',
+        description: 'Public-safe appliance preview item.',
+        image_url: 'https://images.example.test/cooktop.jpg',
+        category_preset: 'electronics_appliances' as const,
+        variants: [
+          {
+            sku: 'SKU-COOKTOP-1',
+            variant_title: 'Black finish',
+            price_amount: 129900,
+            currency: 'INR',
+            availability_status: 'in_stock' as const,
+            warranty_summary: 'One year limited warranty.',
+            return_policy_summary: 'Returns accepted within seven days.',
+          },
+        ],
+      },
+    ],
+    allowed_preview_capabilities: [
+      'read_only_profile_preview',
+      'read_only_catalog_preview',
+      'readiness_review_preview',
+    ] as const,
+    blocked_capabilities: [
+      'public_discovery',
+      'checkout_payment_creation',
+      'live_payment',
+      'live_plural',
+      'provider_credentials',
+      'order_fulfillment',
+      'refunds_returns_execution',
+      'production_allowlist',
+    ] as const,
+    generated_at: '2026-01-01T00:00:00Z',
+  },
 };
 
 const credential = {
@@ -719,6 +787,14 @@ describe('CommerceOnboarding', () => {
     expect(screen.getByText('Bulk API dry-run: available')).toBeInTheDocument();
     expect(screen.getByText('Async import job: deferred')).toBeInTheDocument();
     expect(screen.getByText('Connector import: deferred')).toBeInTheDocument();
+    expect(screen.getByText('Agent-facing preview')).toBeInTheDocument();
+    expect(screen.getByText(/Sandbox-only read-only view/)).toBeInTheDocument();
+    expect(screen.getByText('public_discovery_enabled')).toBeInTheDocument();
+    expect(screen.getByText('checkout_payment_enabled')).toBeInTheDocument();
+    expect(screen.getByText('read only profile preview')).toBeInTheDocument();
+    expect(screen.getByText('public discovery')).toBeInTheDocument();
+    expect(screen.getByText('Sandbox induction cooktop')).toBeInTheDocument();
+    expect(screen.getByText('Preview JSON')).toBeInTheDocument();
     expect(screen.getByText('Merchant profile present')).toBeInTheDocument();
     expect(screen.getAllByText('No checkout/payment enablement').length).toBeGreaterThan(0);
     expect(screen.getByText('Trusted agent')).toBeInTheDocument();

--- a/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
+++ b/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
@@ -19,6 +19,7 @@ import { useToast } from '../../store/toast';
 import { Badge } from '../../components/ui/Badge';
 import { Button } from '../../components/ui/Button';
 import { Card } from '../../components/ui/Card';
+import { CopyButton } from '../../components/ui/CopyButton';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { Input } from '../../components/ui/Input';
 import { Table } from '../../components/ui/Table';
@@ -72,6 +73,10 @@ function countLabel(count?: number, total?: number): string | null {
   if (count !== undefined && total !== undefined) return `${count}/${total}`;
   if (count !== undefined) return String(count);
   return `0/${total}`;
+}
+
+function capabilityLabel(value: string): string {
+  return value.replace(/_/g, ' ');
 }
 
 export function CommerceOnboarding() {
@@ -208,6 +213,7 @@ export function CommerceOnboarding() {
     { label: 'Webhook source', done: webhookSourceCount > 0 },
     { label: 'Playground/MCP profile', done: Boolean(profile?.supported_tools?.length) },
   ]), [activePolicyCount, agents, mockCredentialCount, productCount, profile, webhookSourceCount]);
+  const agentPreviewJson = merchant ? JSON.stringify(merchant.agent_facing_preview, null, 2) : '';
 
   return (
     <div>
@@ -470,6 +476,161 @@ export function CommerceOnboarding() {
                 <div className="truncate text-xs text-gx-muted">{profile?.supported_tools?.join(', ') || 'none'}</div>
               </div>
             </div>
+          </Card>
+
+          <Card className="xl:col-span-2">
+            <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h2 className="text-base font-semibold text-gx-text">Agent-facing preview</h2>
+                <p className="mt-1 text-xs text-gx-muted">
+                  Sandbox-only read-only view of public-safe profile and catalog fields for later readiness review.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Badge variant={merchant.agent_facing_preview.preview_status === 'ready' ? 'success' : 'danger'}>
+                  {merchant.agent_facing_preview.preview_status}
+                </Badge>
+                <Badge variant="warning">sandbox_only</Badge>
+                <Badge variant="danger">{merchant.agent_facing_preview.live_mode_status}</Badge>
+                <Badge variant="danger">{merchant.agent_facing_preview.production_approval_status}</Badge>
+                <Badge variant="danger">{merchant.agent_facing_preview.rollout_status}</Badge>
+              </div>
+            </div>
+            <div className="grid gap-2 md:grid-cols-4">
+              {[
+                { label: 'public_discovery_enabled', value: merchant.agent_facing_preview.public_discovery_enabled },
+                { label: 'checkout_payment_enabled', value: merchant.agent_facing_preview.checkout_payment_enabled },
+                { label: 'live_provider_enabled', value: merchant.agent_facing_preview.live_provider_enabled },
+                { label: 'live_plural_enabled', value: merchant.agent_facing_preview.live_plural_enabled },
+              ].map(({ label, value }) => (
+                <div key={label} className="rounded-md border border-gx-border p-3">
+                  <div className="text-xs text-gx-muted">{label}</div>
+                  <Badge variant={value ? 'danger' : 'success'}>{value ? 'true' : 'false'}</Badge>
+                </div>
+              ))}
+            </div>
+            {merchant.agent_facing_preview.preview_blockers.length > 0 ? (
+              <div className="mt-4 rounded-md border border-gx-danger/40 bg-gx-danger/5 p-3">
+                <div className="text-sm font-medium text-gx-text">Preview blockers</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {merchant.agent_facing_preview.preview_blockers.map((blocker) => (
+                    <Badge key={blocker} variant="danger">{capabilityLabel(blocker)}</Badge>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+            <div className="mt-4 grid gap-3 md:grid-cols-2">
+              <div className="rounded-md border border-gx-border p-3">
+                <div className="text-xs text-gx-muted">Merchant preview</div>
+                <div className="mt-2 grid gap-2 text-sm">
+                  <div className="flex justify-between gap-3">
+                    <span className="text-gx-muted">Reference</span>
+                    <IdText value={merchant.agent_facing_preview.merchant.merchant_reference} />
+                  </div>
+                  <div className="flex justify-between gap-3">
+                    <span className="text-gx-muted">Display name</span>
+                    <span className="text-right text-gx-text">{merchant.agent_facing_preview.merchant.display_name ?? 'blocked'}</span>
+                  </div>
+                  <div className="flex justify-between gap-3">
+                    <span className="text-gx-muted">Category</span>
+                    <span className="text-right text-gx-text">{merchant.agent_facing_preview.merchant.category_preset ?? 'blocked'}</span>
+                  </div>
+                  <div className="flex justify-between gap-3">
+                    <span className="text-gx-muted">Country/currency</span>
+                    <span className="text-right text-gx-text">
+                      {merchant.agent_facing_preview.merchant.country_code ?? 'blocked'} / {merchant.agent_facing_preview.merchant.default_currency ?? 'blocked'}
+                    </span>
+                  </div>
+                </div>
+                <div className="mt-3 text-xs text-gx-muted">Description draft</div>
+                <div className="mt-1 text-sm text-gx-text">
+                  {merchant.agent_facing_preview.merchant.public_discovery_description_draft ?? 'blocked'}
+                </div>
+              </div>
+              <div className="rounded-md border border-gx-border p-3">
+                <div className="text-xs text-gx-muted">Readiness summary</div>
+                <div className="mt-2 grid gap-2 text-sm">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-gx-muted">Overall</span>
+                    <Badge variant={readinessVariant(merchant.agent_facing_preview.readiness_summary.overall_status)}>
+                      {merchant.agent_facing_preview.readiness_summary.overall_score_percent}%
+                    </Badge>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-gx-muted">Category</span>
+                    <Badge variant={readinessVariant(merchant.agent_facing_preview.readiness_summary.category_status)}>
+                      {merchant.agent_facing_preview.readiness_summary.category_score_percent}%
+                    </Badge>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-gx-muted">Catalog</span>
+                    <Badge variant={readinessVariant(merchant.agent_facing_preview.readiness_summary.catalog_status)}>
+                      {merchant.agent_facing_preview.readiness_summary.catalog_score_percent}%
+                    </Badge>
+                  </div>
+                </div>
+                <div className="mt-3 grid gap-2 text-xs text-gx-muted">
+                  <div>{merchant.agent_facing_preview.readiness_summary.category_summary}</div>
+                  <div>{merchant.agent_facing_preview.readiness_summary.catalog_summary}</div>
+                </div>
+              </div>
+            </div>
+            <div className="mt-4 grid gap-3 md:grid-cols-2">
+              <div>
+                <div className="text-sm font-semibold text-gx-text">Allowed preview capabilities</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {merchant.agent_facing_preview.allowed_preview_capabilities.map((capability) => (
+                    <Badge key={capability} variant="success">{capabilityLabel(capability)}</Badge>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <div className="text-sm font-semibold text-gx-text">Blocked capabilities</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {merchant.agent_facing_preview.blocked_capabilities.map((capability) => (
+                    <Badge key={capability} variant="danger">{capabilityLabel(capability)}</Badge>
+                  ))}
+                </div>
+              </div>
+            </div>
+            <div className="mt-4">
+              <div className="mb-2 text-sm font-semibold text-gx-text">Sample products</div>
+              {merchant.agent_facing_preview.sample_products.length === 0 ? (
+                <div className="rounded-md border border-gx-border p-3 text-sm text-gx-muted">
+                  No public-safe sample products are available for preview.
+                </div>
+              ) : (
+                <div className="grid gap-2 md:grid-cols-3">
+                  {merchant.agent_facing_preview.sample_products.map((product) => (
+                    <div key={product.sample_reference} className="rounded-md border border-gx-border p-3">
+                      <div className="text-sm font-medium text-gx-text">{product.title}</div>
+                      <div className="mt-1 line-clamp-3 text-xs text-gx-muted">{product.description}</div>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        <Badge variant="default">{product.category_preset}</Badge>
+                        <Badge variant="default">{product.variants.length} variants</Badge>
+                      </div>
+                      <div className="mt-2 grid gap-1 text-xs text-gx-muted">
+                        {product.variants.map((variant) => (
+                          <div key={variant.sku} className="flex justify-between gap-2">
+                            <span>{variant.sku}</span>
+                            <span>{variant.price_amount} {variant.currency}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+            <details className="mt-4 rounded-md border border-gx-border p-3">
+              <summary className="cursor-pointer text-sm font-semibold text-gx-text">Preview JSON</summary>
+              <div className="mt-3 flex justify-end">
+                <CopyButton text={agentPreviewJson} />
+              </div>
+              <pre className="mt-2 max-h-80 overflow-auto rounded-md bg-gx-bg p-3 text-xs text-gx-text">
+                {agentPreviewJson}
+              </pre>
+            </details>
           </Card>
 
           <Card className="xl:col-span-2 p-0">

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -28,7 +28,9 @@ info:
     enablement, live payments, or live Plural. C6A adds category readiness
     scoring, and C6B adds catalog readiness preview from existing sandbox
     catalog data without connectors, checkout, payments, or public discovery
-    enablement.
+    enablement. C6C adds a tenant-scoped, public-safe agent-facing preview
+    payload for sandbox review only; it does not publish discovery, approve
+    merchants, enable checkout/payment creation, or enable live provider paths.
 servers:
   - url: https://grantex-auth-dd4mtrt2gq-uc.a.run.app
     description: Production (Cloud Run)
@@ -342,6 +344,108 @@ components:
             async_import_job_supported: { type: boolean, const: false }
             external_connector_supported: { type: boolean, const: false }
 
+    SandboxAgentPreviewProductVariant:
+      type: object
+      additionalProperties: false
+      properties:
+        sku: { type: string }
+        variant_title: { type: string, nullable: true }
+        price_amount:
+          oneOf:
+            - { type: number, minimum: 0 }
+            - { type: string, pattern: "^[0-9]+$" }
+        currency: { type: string, pattern: "^[A-Z]{3}$" }
+        availability_status:
+          type: string
+          enum: [in_stock, out_of_stock, pre_order, back_order, unknown]
+        warranty_summary: { type: string, nullable: true }
+        return_policy_summary: { type: string, nullable: true }
+
+    SandboxAgentPreviewProduct:
+      type: object
+      additionalProperties: false
+      properties:
+        sample_reference: { type: string }
+        title: { type: string }
+        description: { type: string }
+        image_url: { type: string, nullable: true }
+        category_preset: { type: string, enum: [electronics_appliances] }
+        variants:
+          type: array
+          maxItems: 2
+          items: { $ref: "#/components/schemas/SandboxAgentPreviewProductVariant" }
+
+    SandboxAgentFacingPreview:
+      type: object
+      additionalProperties: false
+      description: >-
+        C6C tenant-scoped sandbox preview of the public-safe fields an AI buyer
+        agent could later see only after a separate reviewed discovery launch.
+        It is read-only, sandbox-only, not an approval, and does not enable
+        public discovery, checkout/payment creation, live payments, live
+        Plural, provider credentials, order fulfillment, refunds, or production
+        allowlisting.
+      properties:
+        preview_status: { type: string, enum: [ready, blocked] }
+        preview_blockers:
+          type: array
+          items: { type: string }
+        sandbox_only: { type: boolean, const: true }
+        live_mode_status: { type: string, enum: [not_live] }
+        production_approval_status: { type: string, enum: [not_approved] }
+        rollout_status: { type: string, enum: [rollout_not_requested] }
+        public_discovery_enabled: { type: boolean, const: false }
+        checkout_payment_enabled: { type: boolean, const: false }
+        live_provider_enabled: { type: boolean, const: false }
+        live_plural_enabled: { type: boolean, const: false }
+        merchant:
+          type: object
+          additionalProperties: false
+          properties:
+            merchant_reference: { type: string }
+            display_name: { type: string, nullable: true }
+            category_preset: { type: string, enum: [electronics_appliances], nullable: true }
+            country_code: { type: string, pattern: "^[A-Z]{2}$", nullable: true }
+            default_currency: { type: string, pattern: "^[A-Z]{3}$", nullable: true }
+            public_discovery_description_draft: { type: string, nullable: true }
+            support_email: { type: string, nullable: true }
+            support_url: { type: string, nullable: true }
+        readiness_summary:
+          type: object
+          additionalProperties: false
+          properties:
+            overall_status: { $ref: "#/components/schemas/SandboxReadinessStatus" }
+            overall_score_percent: { type: integer, minimum: 0, maximum: 100 }
+            category_status: { $ref: "#/components/schemas/SandboxReadinessStatus" }
+            category_score_percent: { type: integer, minimum: 0, maximum: 100 }
+            category_summary: { type: string }
+            catalog_status: { $ref: "#/components/schemas/SandboxReadinessStatus" }
+            catalog_score_percent: { type: integer, minimum: 0, maximum: 100 }
+            catalog_summary: { type: string }
+        sample_products:
+          type: array
+          maxItems: 3
+          items: { $ref: "#/components/schemas/SandboxAgentPreviewProduct" }
+        allowed_preview_capabilities:
+          type: array
+          items:
+            type: string
+            enum: [read_only_profile_preview, read_only_catalog_preview, readiness_review_preview]
+        blocked_capabilities:
+          type: array
+          items:
+            type: string
+            enum:
+              - public_discovery
+              - checkout_payment_creation
+              - live_payment
+              - live_plural
+              - provider_credentials
+              - order_fulfillment
+              - refunds_returns_execution
+              - production_allowlist
+        generated_at: { type: string, format: date-time }
+
     SandboxOnboarding:
       type: object
       properties:
@@ -382,6 +486,7 @@ components:
                   label: { type: string }
                   status: { type: string, enum: [pass, blocked] }
                   detail: { type: string }
+        agent_facing_preview: { $ref: "#/components/schemas/SandboxAgentFacingPreview" }
 
     Agent:
       type: object
@@ -1550,8 +1655,9 @@ paths:
       description: >-
         Returns public-safe sandbox onboarding fields, baseline readiness checks,
         C6A category readiness scoring, C6B catalog readiness preview from
-        existing sandbox product/variant rows, and fail-closed production
-        statuses. The response never includes provider
+        existing sandbox product/variant rows, a C6C tenant-scoped
+        agent-facing preview payload, and fail-closed production statuses. The
+        response never includes provider
         account references, credentials, secrets, production allowlist values,
         checkout/payment material, or live-provider paths.
       responses:
@@ -1578,7 +1684,8 @@ paths:
         Updates only non-secret, public-safe sandbox profile fields and the
         agentic commerce requested flag. It cannot set environment, production
         approval, public discovery, allowlist, provider credential, checkout,
-        payment, live payment, or live Plural fields.
+        payment, live payment, or live Plural fields. The response includes the
+        recomputed sandbox-only agent-facing preview payload.
       requestBody:
         required: true
         content:
@@ -1615,7 +1722,9 @@ paths:
         machine. Transitions to sandbox_ready or submitted_for_review require
         baseline, category, and required catalog readiness checks to pass. No
         transition approves production, enables public discovery, enables
-        checkout/payment creation, or enables live payments/live Plural.
+        checkout/payment creation, or enables live payments/live Plural. The
+        response includes the recomputed sandbox-only agent-facing preview
+        payload.
       requestBody:
         required: true
         content:

--- a/docs/guides/commerce-v1-merchant-operator-guide.mdx
+++ b/docs/guides/commerce-v1-merchant-operator-guide.mdx
@@ -92,6 +92,18 @@ existing manual product entry and CSV dry-run/bulk catalog API. Async import
 jobs, Shopify/WooCommerce/Magento connectors, provider credentials, checkout,
 payments, public discovery, live payments, and live Plural remain out of scope.
 
+C6C adds an agent-facing preview payload to the sandbox onboarding response.
+The preview is tenant-scoped, read-only, and generated only from public-safe
+merchant profile, category readiness, and catalog readiness data already stored
+in Grantex. It always reports `sandbox_only: true`, `not_live`,
+`not_approved`, `rollout_not_requested`, `public_discovery_enabled: false`,
+`checkout_payment_enabled: false`, `live_provider_enabled: false`, and
+`live_plural_enabled: false`. It may include a capped list of public-safe
+sample products, allowed read-only preview labels, and blocked capability
+labels. It excludes private legal details, contracts, private contacts,
+approval evidence, pricing terms, customer data, raw payloads, credentials,
+tokens, provider secrets, production config values, and production allowlists.
+
 Passing category or catalog readiness means only "sandbox profile can be
 reviewed"; it is not merchant approval, production readiness, public discovery
 approval, checkout/payment readiness, live payment readiness, or live Plural

--- a/docs/internal/commerce-v1/commerce-v1-c6c-public-safe-agent-preview-payload.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6c-public-safe-agent-preview-payload.md
@@ -1,0 +1,105 @@
+# Commerce V1 C6C Public-Safe Agent Preview Payload
+
+## Scope
+
+C6C adds a tenant-scoped, read-only `agent_facing_preview` payload to the seller
+sandbox onboarding response. The preview shows the public-safe profile,
+category readiness, catalog readiness, and a capped product sample that an AI
+buyer agent could later see only after a separate reviewed discovery launch.
+
+This slice does not approve a merchant, publish discovery, enable production
+Commerce V1, create checkout/payment paths, enable live payments, enable live
+Plural, capture provider credentials, or add external catalog connectors.
+
+## Data Source
+
+The preview is computed at request time from existing tenant-scoped Grantex
+data:
+
+- `commerce_merchants` sandbox onboarding profile fields;
+- C6A computed category readiness;
+- C6B computed catalog readiness;
+- existing `commerce_products` and `commerce_product_variants` rows for capped
+  public-safe sample products.
+
+No migration is required because C6C stores no new state. The payload is derived
+from existing tenant-owned sandbox rows and fail-closed readiness logic.
+
+## Included Public-Safe Fields
+
+The preview may include:
+
+- merchant sandbox reference;
+- display name;
+- `electronics_appliances` category preset;
+- country and currency;
+- public discovery description draft after public-safety validation;
+- repo-safe/test-safe support email or support URL;
+- category readiness summary;
+- catalog readiness summary;
+- up to three public-safe sample products, each with up to two variants;
+- allowed preview capability labels:
+  - `read_only_profile_preview`
+  - `read_only_catalog_preview`
+  - `readiness_review_preview`
+- blocked capability labels:
+  - `public_discovery`
+  - `checkout_payment_creation`
+  - `live_payment`
+  - `live_plural`
+  - `provider_credentials`
+  - `order_fulfillment`
+  - `refunds_returns_execution`
+  - `production_allowlist`
+- generated timestamp.
+
+## Excluded Fields
+
+The preview must not expose private legal names, private contracts, private
+contacts, signed approvals, pricing terms, customer data, provider credentials,
+tokens, JWTs, raw payloads, DB/Redis URLs, private keys, production allowlist
+values, production config values, live provider claims, checkout/payment claims,
+or live Plural claims.
+
+## Safety Posture
+
+Every preview response explicitly reports:
+
+- `sandbox_only: true`
+- `live_mode_status: not_live`
+- `production_approval_status: not_approved`
+- `rollout_status: rollout_not_requested`
+- `public_discovery_enabled: false`
+- `checkout_payment_enabled: false`
+- `live_provider_enabled: false`
+- `live_plural_enabled: false`
+
+Preview generation fails closed to `preview_status: blocked` when required
+public-safe fields are missing or unsafe, when the merchant is not sandbox, when
+readiness is not passing, or when catalog rows exist but no public-safe sample
+can be built.
+
+## Route And UI
+
+The existing sandbox onboarding GET, PUT, and transition responses include the
+computed preview. The portal onboarding page renders a read-only
+Agent-facing preview section with sandbox/not-live/not-approved badges,
+allowed/blocked capability labels, product samples, and a copyable JSON view.
+
+All state-changing sandbox onboarding routes keep the existing
+operator-or-owning-merchant boundary and append audit evidence. CommerceAgent
+callers are not given merchant administration access.
+
+## Validation Focus
+
+C6C validation should cover:
+
+- preview includes only safe merchant/category/readiness/catalog fields;
+- preview includes allowed and blocked capability labels;
+- preview excludes private/provider/payment/live/config fields;
+- unsafe public description blocks or sanitizes preview;
+- product samples are capped and public-safe;
+- live merchants cannot use sandbox preview;
+- cross-tenant preview access fails through the existing tenant-scoped lookup;
+- no public discovery, checkout/payment, live provider, live payment, or live
+  Plural enablement is introduced.


### PR DESCRIPTION
## Summary
- add computed sandbox-only agent-facing preview payload to seller onboarding responses
- include safe merchant/category/catalog readiness summaries, capped product samples, and explicit blocked capability labels
- add portal read-only preview section plus OpenAPI/operator/internal docs

## Safety
- no deploy, no merge, no cloud resources, and no cloud commands
- does not enable public discovery, production Commerce V1, checkout/payment creation, live payments, or live Plural
- does not add provider credentials, production config, allowlists, secrets, or real merchant approval

## Validation
- npm test -- commerce-merchants.test.ts commerce-products.test.ts commerce-tenant-boundary.test.ts commerce-audit.test.ts commerce-schema.test.ts commerce-live-mode-guard.test.ts commerce-no-plural-leak.test.ts commerce-openapi.test.ts commerce-cart-payment.test.ts commerce-payment-foundations.test.ts (apps/auth-service)
- npm run typecheck (apps/auth-service)
- npm test -- src/pages/__tests__/CommerceDashboard.test.tsx src/api/__tests__/commerce.test.ts (apps/portal)
- npm run typecheck (apps/portal)
- git diff --check
- focused guardrail scans over C6C changed files