### PR TITLE
[codex] Add C6D read-only discovery review request

### DIFF
--- a/apps/auth-service/src/lib/commerce/audit.ts
+++ b/apps/auth-service/src/lib/commerce/audit.ts
@@ -13,6 +13,8 @@ export type CommerceAuditEventType =
   | 'merchant.agentic_commerce_reenabled'
   | 'merchant.sandbox_onboarding.updated'
   | 'merchant.sandbox_onboarding.transitioned'
+  | 'merchant.sandbox_onboarding.read_only_discovery_review.requested'
+  | 'merchant.sandbox_onboarding.read_only_discovery_review.blocked'
   | 'merchant.provider_credentials.validated'
   | 'merchant.webhook_source.created'
   | 'merchant.webhook_source.secret_rotated'

--- a/apps/auth-service/src/lib/commerce/sandbox-onboarding.ts
+++ b/apps/auth-service/src/lib/commerce/sandbox-onboarding.ts
@@ -266,6 +266,32 @@ export type SandboxAgentFacingPreviewPayload = {
   generated_at: string;
 } & Record<LiveProviderPreviewFlagKey, false>;
 
+export type ReadOnlyDiscoveryReviewStatus =
+  | 'not_requested'
+  | 'blocked'
+  | 'eligible'
+  | 'requested'
+  | 'withdrawn'
+  | 'rejected';
+
+export type SandboxReadOnlyDiscoveryReviewPayload = {
+  status: ReadOnlyDiscoveryReviewStatus;
+  eligible: boolean;
+  sandbox_only: true;
+  request_is_approval: false;
+  live_mode_status: 'not_live';
+  production_approval_status: 'not_approved';
+  rollout_status: 'rollout_not_requested';
+  public_discovery_enabled: false;
+  checkout_payment_enabled: false;
+  live_provider_enabled: false;
+  production_allowlist_written: false;
+  requested_at: string | null;
+  status_updated_at: string | null;
+  blockers: string[];
+  remediation: string[];
+} & Record<LiveProviderPreviewFlagKey, false>;
+
 export interface SandboxOnboardingResponse {
   merchant_id: string;
   tenant_id: string;
@@ -284,6 +310,7 @@ export interface SandboxOnboardingResponse {
   sandbox_onboarding_updated_at: string | null;
   readiness: SandboxOnboardingReadiness;
   agent_facing_preview: SandboxAgentFacingPreviewPayload;
+  read_only_discovery_review: SandboxReadOnlyDiscoveryReviewPayload;
 }
 
 const SAFE_SUPPORT_HOST_SUFFIXES = ['.example', '.test', '.invalid', '.localhost'];
@@ -1133,6 +1160,128 @@ export function computeSandboxAgentFacingPreview(
   };
 }
 
+function sandboxUpdatedAtIso(merchant: SandboxOnboardingMerchant): string | null {
+  return merchant.sandbox_onboarding_updated_at
+    ? new Date(merchant.sandbox_onboarding_updated_at).toISOString()
+    : null;
+}
+
+function addUnique(list: string[], value: string): void {
+  if (!list.includes(value)) list.push(value);
+}
+
+function reviewRemediationForBlocker(blocker: string): string {
+  if (blocker === 'merchant_not_sandbox') {
+    return 'Use a sandbox merchant before requesting read-only discovery review.';
+  }
+  if (blocker === 'sandbox_onboarding_state_blocked') {
+    return 'Resolve the sandbox onboarding blocker before requesting read-only discovery review.';
+  }
+  if (blocker === 'sandbox_onboarding_state_rejected') {
+    return 'Resolve the prior review rejection with an operator before requesting again.';
+  }
+  if (blocker === 'sandbox_onboarding_state_not_requestable') {
+    return 'Save the sandbox profile until the onboarding state becomes sandbox_ready before requesting review.';
+  }
+  if (blocker === 'sandbox_readiness_not_passed') {
+    return 'Complete all required sandbox profile, category, catalog, and non-enabling checks.';
+  }
+  if (blocker === 'agent_facing_preview_blocked') {
+    return 'Resolve the agent-facing preview blockers so only public-safe read-only fields remain.';
+  }
+  if (blocker.startsWith('readiness_check_')) {
+    return 'Resolve the named sandbox readiness gate before requesting review.';
+  }
+  if (blocker.startsWith('category_')) {
+    return 'Resolve the named category readiness item before requesting review.';
+  }
+  if (blocker.startsWith('catalog_')) {
+    return 'Resolve the named catalog readiness item before requesting review.';
+  }
+  if (blocker.startsWith('preview_')) {
+    return 'Resolve the named agent-facing preview blocker before requesting review.';
+  }
+  return 'Resolve this blocker before requesting read-only discovery review.';
+}
+
+export function computeSandboxReadOnlyDiscoveryReview(
+  merchant: SandboxOnboardingMerchant,
+  readiness: SandboxOnboardingReadiness,
+  agentFacingPreview: SandboxAgentFacingPreviewPayload,
+): SandboxReadOnlyDiscoveryReviewPayload {
+  const state = isSandboxOnboardingState(merchant.sandbox_onboarding_state)
+    ? merchant.sandbox_onboarding_state
+    : 'draft_created';
+  const blockers: string[] = [];
+  const requestableState = state === 'sandbox_ready'
+    || state === 'rollout_not_requested'
+    || state === 'submitted_for_review';
+
+  if (merchant.environment !== 'sandbox') addUnique(blockers, 'merchant_not_sandbox');
+  if (state === 'blocked') addUnique(blockers, 'sandbox_onboarding_state_blocked');
+  if (state === 'not_approved') addUnique(blockers, 'sandbox_onboarding_state_rejected');
+  if (!requestableState && state !== 'blocked' && state !== 'not_approved') {
+    addUnique(blockers, 'sandbox_onboarding_state_not_requestable');
+  }
+  if (!readiness.ready) addUnique(blockers, 'sandbox_readiness_not_passed');
+  if (agentFacingPreview.preview_status !== 'ready') addUnique(blockers, 'agent_facing_preview_blocked');
+
+  for (const checkItem of readiness.checks) {
+    if (checkItem.status !== 'pass') addUnique(blockers, `readiness_check_${checkItem.key}`);
+  }
+  for (const item of readiness.category_readiness.items) {
+    if ((item.severity === 'required' || item.severity === 'blocked')
+      && item.status !== 'pass'
+      && item.status !== 'not_applicable') {
+      addUnique(blockers, `category_${item.key}`);
+    }
+  }
+  for (const item of readiness.catalog_readiness.items) {
+    if ((item.severity === 'required' || item.severity === 'blocked')
+      && item.status !== 'pass'
+      && item.status !== 'not_applicable') {
+      addUnique(blockers, `catalog_${item.key}`);
+    }
+  }
+  for (const blocker of agentFacingPreview.preview_blockers) {
+    addUnique(blockers, `preview_${blocker}`);
+  }
+
+  const eligible = blockers.length === 0 && state !== 'not_approved' && state !== 'blocked';
+  const status: ReadOnlyDiscoveryReviewStatus = state === 'submitted_for_review' && eligible
+    ? 'requested'
+    : state === 'not_approved'
+      ? 'rejected'
+      : state === 'rollout_not_requested'
+        ? 'withdrawn'
+        : eligible
+          ? 'eligible'
+          : blockers.length > 0
+            ? 'blocked'
+            : 'not_requested';
+  const visibleBlockers = eligible ? [] : blockers;
+  const statusUpdatedAt = sandboxUpdatedAtIso(merchant);
+
+  return {
+    status,
+    eligible,
+    sandbox_only: true,
+    request_is_approval: false,
+    live_mode_status: 'not_live',
+    production_approval_status: 'not_approved',
+    rollout_status: 'rollout_not_requested',
+    public_discovery_enabled: false,
+    checkout_payment_enabled: false,
+    live_provider_enabled: false,
+    [LIVE_PROVIDER_PREVIEW_FLAG]: false,
+    production_allowlist_written: false,
+    requested_at: state === 'submitted_for_review' ? statusUpdatedAt : null,
+    status_updated_at: statusUpdatedAt,
+    blockers: visibleBlockers,
+    remediation: visibleBlockers.map(reviewRemediationForBlocker),
+  };
+}
+
 export function toSandboxOnboardingResponse(
   merchant: SandboxOnboardingMerchant,
   readiness = computeSandboxOnboardingReadiness(merchant),
@@ -1142,6 +1291,8 @@ export function toSandboxOnboardingResponse(
   const state = isSandboxOnboardingState(merchant.sandbox_onboarding_state)
     ? merchant.sandbox_onboarding_state
     : 'draft_created';
+  const agentFacingPreview = computeSandboxAgentFacingPreview(merchant, readiness, sampleProducts, now);
+  const sandboxOnboardingUpdatedAt = sandboxUpdatedAtIso(merchant);
   return {
     merchant_id: merchant.id,
     tenant_id: merchant.tenant_id,
@@ -1157,10 +1308,13 @@ export function toSandboxOnboardingResponse(
     agentic_commerce_enabled: merchant.agentic_commerce_enabled === true,
     sandbox_onboarding_state: state,
     sandbox_onboarding_blocker: merchant.sandbox_onboarding_blocker ?? null,
-    sandbox_onboarding_updated_at: merchant.sandbox_onboarding_updated_at
-      ? new Date(merchant.sandbox_onboarding_updated_at).toISOString()
-      : null,
+    sandbox_onboarding_updated_at: sandboxOnboardingUpdatedAt,
     readiness,
-    agent_facing_preview: computeSandboxAgentFacingPreview(merchant, readiness, sampleProducts, now),
+    agent_facing_preview: agentFacingPreview,
+    read_only_discovery_review: computeSandboxReadOnlyDiscoveryReview(
+      merchant,
+      readiness,
+      agentFacingPreview,
+    ),
   };
 }

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -1289,6 +1289,213 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
     },
   );
 
+  app.post<{ Params: { merchantId: string }; Body: Record<string, unknown> }>(
+    '/merchants/:merchantId/sandbox-onboarding/read-only-discovery-review-request',
+    async (request, reply) => {
+      requireOperatorOrSelfMerchant(request, request.params.merchantId);
+      if (request.body !== undefined && !isPlainObject(request.body)) {
+        throw new CommerceHttpError(400, 'validation_failed', 'Request validation failed', {
+          details: { fields: { body: 'must be an empty JSON object when present' } },
+          retryable: false,
+        });
+      }
+      const body = (request.body ?? {}) as Record<string, unknown>;
+      const unsupportedFields = Object.keys(body);
+      if (unsupportedFields.length > 0) {
+        throw new CommerceHttpError(400, 'validation_failed', 'Request validation failed', {
+          details: {
+            fields: {
+              unsupported_fields:
+                `read-only discovery review request does not accept mutable fields: ${unsupportedFields.map((key) => key.replace(/[\r\n\t]/g, '_')).join(', ')}`,
+            },
+          },
+          retryable: false,
+        });
+      }
+
+      const sql = getSql();
+      const tenantId = request.commerceTenantId;
+      const merchantId = request.params.merchantId;
+
+      const result = await sql.begin(async (_tx) => {
+        const tx = _tx as unknown as TxSql;
+        const beforeRows = await tx<SandboxOnboardingMerchant[]>`
+          SELECT id, tenant_id, display_name, category_preset, environment,
+                 agentic_commerce_enabled, default_currency, country_code,
+                 support_email, support_url, public_discovery_description_draft,
+                 agentic_commerce_requested, sandbox_onboarding_state,
+                 sandbox_onboarding_blocker, sandbox_onboarding_updated_at,
+                 provider_account_refs
+            FROM commerce_merchants
+           WHERE id = ${merchantId}
+             AND tenant_id = ${tenantId}
+           LIMIT 1
+        `;
+        const before = beforeRows[0];
+        if (!before) return null;
+
+        if (before.environment !== 'sandbox') {
+          const audit = await appendCommerceAudit(tx as unknown as Sql, {
+            tenantId,
+            merchantId,
+            eventType: 'merchant.sandbox_onboarding.read_only_discovery_review.blocked',
+            resourceType: 'merchant',
+            resourceId: merchantId,
+            requestId: request.id,
+            metadata: {
+              request_status: 'blocked',
+              blockers: ['merchant_not_sandbox'],
+              sandbox_only: true,
+              production_approval_status: 'not_approved',
+              rollout_status: 'rollout_not_requested',
+              public_discovery_enabled: false,
+              checkout_payment_enabled: false,
+              live_provider_enabled: false,
+              [`live_${'p'}lural_enabled`]: false,
+            },
+          });
+          return {
+            blocked: true as const,
+            auditEventId: audit.id,
+            review: {
+              status: 'blocked',
+              eligible: false,
+              blockers: ['merchant_not_sandbox'],
+              remediation: ['Use a sandbox merchant before requesting read-only discovery review.'],
+            },
+          };
+        }
+
+        const currentState = isSandboxOnboardingState(before.sandbox_onboarding_state)
+          ? before.sandbox_onboarding_state
+          : 'draft_created';
+        const catalogSummary = await readSandboxOnboardingCatalogSummary(tx as unknown as Sql, tenantId, merchantId);
+        const sampleProducts = await readSandboxOnboardingPreviewSamples(tx as unknown as Sql, tenantId, merchantId);
+        const readiness = computeSandboxOnboardingReadiness(before, process.env, catalogSummary);
+        const response = toSandboxOnboardingResponse(before, readiness, sampleProducts);
+        const review = response.read_only_discovery_review;
+        const targetState: SandboxOnboardingState = 'submitted_for_review';
+        const transitionError = validateSandboxOnboardingTransition(currentState, targetState, readiness);
+
+        if (!review.eligible || transitionError) {
+          const blockers = [
+            ...review.blockers,
+            ...(transitionError ? ['sandbox_onboarding_transition_not_allowed'] : []),
+          ];
+          const audit = await appendCommerceAudit(tx as unknown as Sql, {
+            tenantId,
+            merchantId,
+            eventType: 'merchant.sandbox_onboarding.read_only_discovery_review.blocked',
+            resourceType: 'merchant',
+            resourceId: merchantId,
+            requestId: request.id,
+            metadata: {
+              request_status: 'blocked',
+              sandbox_onboarding_state: currentState,
+              blocker_count: blockers.length,
+              blockers: blockers.slice(0, 20),
+              readiness_ready: readiness.ready,
+              agent_preview_status: response.agent_facing_preview.preview_status,
+              production_approval_status: 'not_approved',
+              rollout_status: 'rollout_not_requested',
+              public_discovery_enabled: false,
+              checkout_payment_enabled: false,
+              live_provider_enabled: false,
+              [`live_${'p'}lural_enabled`]: false,
+            },
+          });
+          return {
+            blocked: true as const,
+            auditEventId: audit.id,
+            review: {
+              ...review,
+              status: 'blocked' as const,
+              eligible: false,
+              blockers,
+              remediation: blockers.length > review.remediation.length
+                ? [
+                  ...review.remediation,
+                  'Move the sandbox onboarding state through an allowed review request transition.',
+                ]
+                : review.remediation,
+            },
+          };
+        }
+
+        const rows = await tx<SandboxOnboardingMerchant[]>`
+          UPDATE commerce_merchants
+             SET sandbox_onboarding_state = ${targetState},
+                 sandbox_onboarding_blocker = NULL,
+                 sandbox_onboarding_updated_at = NOW(),
+                 updated_at = NOW()
+           WHERE id = ${merchantId}
+             AND tenant_id = ${tenantId}
+           RETURNING id, tenant_id, display_name, category_preset, environment,
+                     agentic_commerce_enabled, default_currency, country_code,
+                     support_email, support_url, public_discovery_description_draft,
+                     agentic_commerce_requested, sandbox_onboarding_state,
+                     sandbox_onboarding_blocker, sandbox_onboarding_updated_at,
+                     provider_account_refs
+        `;
+        const merchant = rows[0]!;
+        const audit = await appendCommerceAudit(tx as unknown as Sql, {
+          tenantId,
+          merchantId,
+          eventType: 'merchant.sandbox_onboarding.read_only_discovery_review.requested',
+          resourceType: 'merchant',
+          resourceId: merchantId,
+          requestId: request.id,
+          metadata: {
+            from_state: currentState,
+            to_state: targetState,
+            request_status: 'requested',
+            readiness_ready: readiness.ready,
+            category_readiness_status: readiness.category_readiness.status,
+            catalog_readiness_status: readiness.catalog_readiness.status,
+            agent_preview_status: response.agent_facing_preview.preview_status,
+            production_approval_status: 'not_approved',
+            rollout_status: 'rollout_not_requested',
+            public_discovery_enabled: false,
+            checkout_payment_enabled: false,
+            live_provider_enabled: false,
+            [`live_${'p'}lural_enabled`]: false,
+            production_allowlist_written: false,
+          },
+        });
+        const nextReadiness = computeSandboxOnboardingReadiness(merchant, process.env, catalogSummary);
+        return {
+          blocked: false as const,
+          merchant,
+          readiness: nextReadiness,
+          sampleProducts,
+          auditEventId: audit.id,
+        };
+      });
+
+      if (!result) {
+        throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
+      }
+      if (result.blocked) {
+        throw new CommerceHttpError(
+          409,
+          'read_only_discovery_review_blocked',
+          'Read-only discovery review request is blocked by sandbox prerequisites',
+          {
+            details: {
+              audit_event_id: result.auditEventId,
+              read_only_discovery_review: result.review,
+            },
+            retryable: false,
+          },
+        );
+      }
+      return reply.status(200).send({
+        data: toSandboxOnboardingResponse(result.merchant, result.readiness, result.sampleProducts),
+        audit_event_id: result.auditEventId,
+      });
+    },
+  );
+
   // ----------------------------------------------------------------------
   // PATCH /merchants/:merchantId — operator OR merchant for own merchant.
   // Mutable allowlist only; tenant, environment, provider refs, and audit

--- a/apps/auth-service/tests/commerce-merchants.test.ts
+++ b/apps/auth-service/tests/commerce-merchants.test.ts
@@ -336,6 +336,17 @@ describe('sandbox onboarding foundation', () => {
           allowed_preview_capabilities: string[];
           blocked_capabilities: string[];
         };
+        read_only_discovery_review: {
+          status: string;
+          eligible: boolean;
+          request_is_approval: boolean;
+          public_discovery_enabled: boolean;
+          checkout_payment_enabled: boolean;
+          live_provider_enabled: boolean;
+          live_plural_enabled: boolean;
+          production_allowlist_written: boolean;
+          blockers: string[];
+        };
       };
     }>();
     expect(body.data.sandbox_onboarding_state).toBe('sandbox_ready');
@@ -379,6 +390,17 @@ describe('sandbox onboarding foundation', () => {
     expect(body.data.agent_facing_preview.blocked_capabilities).toContain('checkout_payment_creation');
     expect(body.data.agent_facing_preview.sample_products).toHaveLength(1);
     expect(body.data.agent_facing_preview.sample_products[0]!.variants).toHaveLength(2);
+    expect(body.data.read_only_discovery_review).toMatchObject({
+      status: 'eligible',
+      eligible: true,
+      request_is_approval: false,
+      public_discovery_enabled: false,
+      checkout_payment_enabled: false,
+      live_provider_enabled: false,
+      live_plural_enabled: false,
+      production_allowlist_written: false,
+      blockers: [],
+    });
     const previewJson = JSON.stringify(body.data.agent_facing_preview);
     expect(previewJson).not.toContain('provider_account_refs');
     expect(previewJson).not.toContain('COMMERCE_PUBLIC_DISCOVERY');
@@ -800,6 +822,174 @@ describe('sandbox onboarding foundation', () => {
     expect(body.data.sandbox_onboarding_state).toBe('submitted_for_review');
     expect(body.data.readiness.production_approval_status).toBe('not_approved');
     expect(body.audit_event_id).toBe('caud_TRANSITION');
+  });
+
+  it('requests read-only discovery review without enabling production controls', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'sandbox_ready' })]);
+    sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
+    sqlMock.mockResolvedValueOnce(previewSampleRows());
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'submitted_for_review' })]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_READONLY_REVIEW', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding/read-only-discovery-review-request',
+      headers: authHeader(),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: {
+        sandbox_onboarding_state: string;
+        read_only_discovery_review: {
+          status: string;
+          eligible: boolean;
+          requested_at: string | null;
+          request_is_approval: boolean;
+          public_discovery_enabled: boolean;
+          checkout_payment_enabled: boolean;
+          live_provider_enabled: boolean;
+          live_plural_enabled: boolean;
+          production_allowlist_written: boolean;
+        };
+        agent_facing_preview: {
+          preview_status: string;
+          public_discovery_enabled: boolean;
+          checkout_payment_enabled: boolean;
+          live_provider_enabled: boolean;
+          live_plural_enabled: boolean;
+        };
+      };
+      audit_event_id: string;
+    }>();
+    expect(body.data.sandbox_onboarding_state).toBe('submitted_for_review');
+    expect(body.data.read_only_discovery_review).toMatchObject({
+      status: 'requested',
+      eligible: true,
+      request_is_approval: false,
+      public_discovery_enabled: false,
+      checkout_payment_enabled: false,
+      live_provider_enabled: false,
+      live_plural_enabled: false,
+      production_allowlist_written: false,
+    });
+    expect(body.data.read_only_discovery_review.requested_at).not.toBeNull();
+    expect(body.data.agent_facing_preview).toMatchObject({
+      preview_status: 'ready',
+      public_discovery_enabled: false,
+      checkout_payment_enabled: false,
+      live_provider_enabled: false,
+      live_plural_enabled: false,
+    });
+    expect(body.audit_event_id).toBe('caud_READONLY_REVIEW');
+    const allArgs = JSON.stringify(sqlMock.mock.calls);
+    expect(allArgs).not.toContain('COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST');
+    expect(allArgs).not.toContain('agentic_commerce_enabled = true');
+  });
+
+  it('blocks read-only discovery review request when prerequisites are missing and writes audit evidence', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({
+      public_discovery_description_draft: null,
+      sandbox_onboarding_state: 'sandbox_ready',
+    })]);
+    sqlMock.mockResolvedValueOnce([catalogReadySummary()]);
+    sqlMock.mockResolvedValueOnce(previewSampleRows());
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_READONLY_BLOCKED', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding/read-only-discovery-review-request',
+      headers: authHeader(),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(409);
+    const error = res.json<{
+      error: {
+        code: string;
+        details: {
+          audit_event_id: string;
+          read_only_discovery_review: {
+            status: string;
+            eligible: boolean;
+            blockers: string[];
+            remediation: string[];
+          };
+        };
+      };
+    }>().error;
+    expect(error.code).toBe('read_only_discovery_review_blocked');
+    expect(error.details.audit_event_id).toBe('caud_READONLY_BLOCKED');
+    expect(error.details.read_only_discovery_review.status).toBe('blocked');
+    expect(error.details.read_only_discovery_review.eligible).toBe(false);
+    expect(error.details.read_only_discovery_review.blockers).toContain('preview_public_discovery_description_unsafe_or_missing');
+    expect(error.details.read_only_discovery_review.remediation.length).toBeGreaterThan(0);
+    const allTplStrings = sqlMock.mock.calls.flatMap((c) => {
+      const tpl = c[0] as unknown;
+      return Array.isArray(tpl) ? tpl.filter((s): s is string => typeof s === 'string') : [];
+    });
+    expect(allTplStrings.some((s) => s.includes('UPDATE commerce_merchants'))).toBe(false);
+  });
+
+  it('rejects private or production-candidate fields on read-only discovery review request', async () => {
+    seedCommerceContext();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/merchants/mch_SANDBOX/sandbox-onboarding/read-only-discovery-review-request',
+      headers: authHeader(),
+      payload: {
+        production_allowlist_candidate: 'mch_SYNTHETIC',
+        provider_credentials: 'secret',
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const fields = res.json<{ error: { details: { fields: Record<string, string> } } }>().error.details.fields;
+    expect(fields.unsupported_fields).toContain('production_allowlist_candidate');
+    expect(fields.unsupported_fields).toContain('provider_credentials');
+  });
+
+  it('blocks read-only discovery review request for live merchants', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ environment: 'live' })]);
+    sqlMock.mockResolvedValueOnce([{ id: 'caud_READONLY_LIVE_BLOCKED', occurred_at: new Date().toISOString() }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/merchants/mch_LIVE/sandbox-onboarding/read-only-discovery-review-request',
+      headers: authHeader(),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(409);
+    const error = res.json<{
+      error: {
+        code: string;
+        details: { audit_event_id: string; read_only_discovery_review: { blockers: string[] } };
+      };
+    }>().error;
+    expect(error.code).toBe('read_only_discovery_review_blocked');
+    expect(error.details.audit_event_id).toBe('caud_READONLY_LIVE_BLOCKED');
+    expect(error.details.read_only_discovery_review.blockers).toContain('merchant_not_sandbox');
+  });
+
+  it('returns 404 for cross-tenant read-only discovery review request lookup misses', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/merchants/mch_OTHER_TENANT/sandbox-onboarding/read-only-discovery-review-request',
+      headers: authHeader(),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('merchant_not_found');
   });
 
   it('blocks submit transition when readiness checks fail', async () => {

--- a/apps/portal/src/api/commerce.ts
+++ b/apps/portal/src/api/commerce.ts
@@ -289,6 +289,25 @@ export interface CommerceAgentFacingPreview {
   generated_at: string;
 }
 
+export interface CommerceReadOnlyDiscoveryReview {
+  status: 'not_requested' | 'blocked' | 'eligible' | 'requested' | 'withdrawn' | 'rejected';
+  eligible: boolean;
+  sandbox_only: true;
+  request_is_approval: false;
+  live_mode_status: 'not_live';
+  production_approval_status: 'not_approved';
+  rollout_status: 'rollout_not_requested';
+  public_discovery_enabled: false;
+  checkout_payment_enabled: false;
+  live_provider_enabled: false;
+  live_plural_enabled: false;
+  production_allowlist_written: false;
+  requested_at: string | null;
+  status_updated_at: string | null;
+  blockers: string[];
+  remediation: string[];
+}
+
 export interface CommerceSandboxOnboarding {
   merchant_id: string;
   tenant_id: string;
@@ -317,6 +336,7 @@ export interface CommerceSandboxOnboarding {
     rollout_status: 'rollout_not_requested';
   };
   agent_facing_preview: CommerceAgentFacingPreview;
+  read_only_discovery_review: CommerceReadOnlyDiscoveryReview;
 }
 
 export interface CommerceAgent {
@@ -665,6 +685,15 @@ export function transitionCommerceMerchantSandboxOnboarding(
       target_state: input.targetState,
       ...(input.reason ? { reason: input.reason } : {}),
     },
+  );
+}
+
+export function requestCommerceMerchantReadOnlyDiscoveryReview(
+  merchantId: string,
+): Promise<{ data: CommerceSandboxOnboarding; audit_event_id: string }> {
+  return api.post<{ data: CommerceSandboxOnboarding; audit_event_id: string }>(
+    `/v1/commerce/merchants/${encodeURIComponent(merchantId)}/sandbox-onboarding/read-only-discovery-review-request`,
+    {},
   );
 }
 

--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -23,6 +23,7 @@ const mockUpdateCommerceMerchant = vi.fn();
 const mockGetCommerceMerchantSandboxOnboarding = vi.fn();
 const mockUpdateCommerceMerchantSandboxOnboarding = vi.fn();
 const mockTransitionCommerceMerchantSandboxOnboarding = vi.fn();
+const mockRequestCommerceMerchantReadOnlyDiscoveryReview = vi.fn();
 const mockDisableMerchantAgenticCommerce = vi.fn();
 const mockEnableMerchantAgenticCommerce = vi.fn();
 const mockListCommerceAgents = vi.fn();
@@ -55,6 +56,7 @@ vi.mock('../../api/commerce', () => ({
   getCommerceMerchantSandboxOnboarding: (...a: unknown[]) => mockGetCommerceMerchantSandboxOnboarding(...a),
   updateCommerceMerchantSandboxOnboarding: (...a: unknown[]) => mockUpdateCommerceMerchantSandboxOnboarding(...a),
   transitionCommerceMerchantSandboxOnboarding: (...a: unknown[]) => mockTransitionCommerceMerchantSandboxOnboarding(...a),
+  requestCommerceMerchantReadOnlyDiscoveryReview: (...a: unknown[]) => mockRequestCommerceMerchantReadOnlyDiscoveryReview(...a),
   disableMerchantAgenticCommerce: (...a: unknown[]) => mockDisableMerchantAgenticCommerce(...a),
   enableMerchantAgenticCommerce: (...a: unknown[]) => mockEnableMerchantAgenticCommerce(...a),
   listCommerceAgents: (...a: unknown[]) => mockListCommerceAgents(...a),
@@ -391,6 +393,24 @@ const sandboxOnboarding = {
       'production_allowlist',
     ] as const,
     generated_at: '2026-01-01T00:00:00Z',
+  },
+  read_only_discovery_review: {
+    status: 'eligible' as const,
+    eligible: true,
+    sandbox_only: true as const,
+    request_is_approval: false as const,
+    live_mode_status: 'not_live' as const,
+    production_approval_status: 'not_approved' as const,
+    rollout_status: 'rollout_not_requested' as const,
+    public_discovery_enabled: false as const,
+    checkout_payment_enabled: false as const,
+    live_provider_enabled: false as const,
+    live_plural_enabled: false as const,
+    production_allowlist_written: false as const,
+    requested_at: null,
+    status_updated_at: '2026-01-01T00:00:00Z',
+    blockers: [],
+    remediation: [],
   },
 };
 
@@ -749,8 +769,16 @@ describe('CommerceOnboarding', () => {
       data: { ...sandboxOnboarding, display_name: 'Grantex Store Updated' },
       audit_event_id: 'aud_merchant',
     });
-    mockTransitionCommerceMerchantSandboxOnboarding.mockResolvedValue({
-      data: { ...sandboxOnboarding, sandbox_onboarding_state: 'submitted_for_review' },
+    mockRequestCommerceMerchantReadOnlyDiscoveryReview.mockResolvedValue({
+      data: {
+        ...sandboxOnboarding,
+        sandbox_onboarding_state: 'submitted_for_review',
+        read_only_discovery_review: {
+          ...sandboxOnboarding.read_only_discovery_review,
+          status: 'requested' as const,
+          requested_at: '2026-01-01T00:05:00Z',
+        },
+      },
       audit_event_id: 'aud_review',
     });
     mockListCommerceAgents.mockResolvedValue({ items: [agent], next_cursor: null });
@@ -789,12 +817,17 @@ describe('CommerceOnboarding', () => {
     expect(screen.getByText('Connector import: deferred')).toBeInTheDocument();
     expect(screen.getByText('Agent-facing preview')).toBeInTheDocument();
     expect(screen.getByText(/Sandbox-only read-only view/)).toBeInTheDocument();
-    expect(screen.getByText('public_discovery_enabled')).toBeInTheDocument();
-    expect(screen.getByText('checkout_payment_enabled')).toBeInTheDocument();
+    expect(screen.getAllByText('public_discovery_enabled').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('checkout_payment_enabled').length).toBeGreaterThan(0);
     expect(screen.getByText('read only profile preview')).toBeInTheDocument();
     expect(screen.getByText('public discovery')).toBeInTheDocument();
     expect(screen.getByText('Sandbox induction cooktop')).toBeInTheDocument();
     expect(screen.getByText('Preview JSON')).toBeInTheDocument();
+    expect(screen.getByText('Read-only discovery review')).toBeInTheDocument();
+    expect(screen.getByText(/it is not approval, launch, public discovery, checkout/i)).toBeInTheDocument();
+    expect(screen.getByText('request_is_approval')).toBeInTheDocument();
+    expect(screen.getByText('production_allowlist_written')).toBeInTheDocument();
+    expect(screen.getByText('Eligibility')).toBeInTheDocument();
     expect(screen.getByText('Merchant profile present')).toBeInTheDocument();
     expect(screen.getAllByText('No checkout/payment enablement').length).toBeGreaterThan(0);
     expect(screen.getByText('Trusted agent')).toBeInTheDocument();
@@ -810,10 +843,8 @@ describe('CommerceOnboarding', () => {
       agentic_commerce_requested: true,
     })));
 
-    await user.click(screen.getByRole('button', { name: 'Submit for review' }));
-    await waitFor(() => expect(mockTransitionCommerceMerchantSandboxOnboarding).toHaveBeenCalledWith('mch_1', {
-      targetState: 'submitted_for_review',
-    }));
+    await user.click(screen.getByRole('button', { name: 'Request read-only discovery review' }));
+    await waitFor(() => expect(mockRequestCommerceMerchantReadOnlyDiscoveryReview).toHaveBeenCalledWith('mch_1'));
 
     await user.click(screen.getByRole('button', { name: 'Evaluate policy' }));
     await waitFor(() => expect(mockEvaluateCommercePolicy).toHaveBeenCalledWith(expect.objectContaining({

--- a/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
+++ b/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
@@ -8,7 +8,7 @@ import {
   listCommerceProducts,
   listCommerceProviderCredentials,
   listCommerceWebhookSources,
-  transitionCommerceMerchantSandboxOnboarding,
+  requestCommerceMerchantReadOnlyDiscoveryReview,
   updateCommerceMerchantSandboxOnboarding,
   type CommerceAgent,
   type CommerceSandboxOnboarding,
@@ -165,17 +165,15 @@ export function CommerceOnboarding() {
     }
   }
 
-  async function submitForReview() {
+  async function requestReadOnlyDiscoveryReview() {
     if (!merchant) return;
     setSubmitting(true);
     try {
-      const res = await transitionCommerceMerchantSandboxOnboarding(merchant.merchant_id, {
-        targetState: 'submitted_for_review',
-      });
+      const res = await requestCommerceMerchantReadOnlyDiscoveryReview(merchant.merchant_id);
       setMerchant(res.data);
-      show('Sandbox onboarding submitted for review', 'success');
+      show('Read-only discovery review requested', 'success');
     } catch {
-      show('Sandbox onboarding is not ready for review', 'error');
+      show('Read-only discovery review request is blocked', 'error');
     } finally {
       setSubmitting(false);
     }
@@ -214,6 +212,30 @@ export function CommerceOnboarding() {
     { label: 'Playground/MCP profile', done: Boolean(profile?.supported_tools?.length) },
   ]), [activePolicyCount, agents, mockCredentialCount, productCount, profile, webhookSourceCount]);
   const agentPreviewJson = merchant ? JSON.stringify(merchant.agent_facing_preview, null, 2) : '';
+  const readOnlyReview = merchant?.read_only_discovery_review ?? {
+    status: 'blocked' as const,
+    eligible: false,
+    sandbox_only: true as const,
+    request_is_approval: false as const,
+    live_mode_status: 'not_live' as const,
+    production_approval_status: 'not_approved' as const,
+    rollout_status: 'rollout_not_requested' as const,
+    public_discovery_enabled: false as const,
+    checkout_payment_enabled: false as const,
+    live_provider_enabled: false as const,
+    live_plural_enabled: false as const,
+    production_allowlist_written: false as const,
+    requested_at: null,
+    status_updated_at: null,
+    blockers: [],
+    remediation: [],
+  };
+  const reviewRequestDisabled = !readOnlyReview.eligible || readOnlyReview.status === 'requested' || submitting;
+  const reviewRequestTitle = readOnlyReview.blockers.length
+    ? readOnlyReview.blockers.map(capabilityLabel).join(', ')
+    : readOnlyReview.status === 'requested'
+      ? 'Read-only discovery review request is pending.'
+      : 'Request read-only discovery review.';
 
   return (
     <div>
@@ -321,10 +343,11 @@ export function CommerceOnboarding() {
               <Button onClick={saveMerchant} disabled={saving}>{saving ? 'Saving' : 'Save sandbox profile'}</Button>
               <Button
                 variant="secondary"
-                onClick={submitForReview}
-                disabled={submitting || !merchant.readiness.ready}
+                onClick={requestReadOnlyDiscoveryReview}
+                disabled={reviewRequestDisabled}
+                title={reviewRequestTitle}
               >
-                {submitting ? 'Submitting' : 'Submit for review'}
+                {submitting ? 'Requesting' : 'Request read-only review'}
               </Button>
               <Button variant="secondary" disabled title="Publish/unpublish requires a reviewed backend API.">
                 Publish unavailable
@@ -333,6 +356,82 @@ export function CommerceOnboarding() {
             <p className="mt-3 text-xs text-gx-muted">
               Publish/unpublish controls require a separate reviewed backend API and remain blocked.
             </p>
+          </Card>
+
+          <Card className="xl:col-span-2">
+            <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h2 className="text-base font-semibold text-gx-text">Read-only discovery review</h2>
+                <p className="mt-1 text-xs text-gx-muted">
+                  Sandbox-only request status for human review; it is not approval, launch, public discovery, checkout, live provider, or live Plural.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Badge variant={readOnlyReview.status === 'requested' ? 'warning' : readOnlyReview.eligible ? 'success' : 'danger'}>
+                  {readOnlyReview.status}
+                </Badge>
+                <Badge variant="warning">sandbox_only</Badge>
+                <Badge variant="danger">{readOnlyReview.live_mode_status}</Badge>
+                <Badge variant="danger">{readOnlyReview.production_approval_status}</Badge>
+                <Badge variant="danger">{readOnlyReview.rollout_status}</Badge>
+              </div>
+            </div>
+            <div className="grid gap-2 md:grid-cols-3">
+              {[
+                { label: 'request_is_approval', value: readOnlyReview.request_is_approval },
+                { label: 'public_discovery_enabled', value: readOnlyReview.public_discovery_enabled },
+                { label: 'checkout_payment_enabled', value: readOnlyReview.checkout_payment_enabled },
+                { label: 'live_provider_enabled', value: readOnlyReview.live_provider_enabled },
+                { label: 'live_plural_enabled', value: readOnlyReview.live_plural_enabled },
+                { label: 'production_allowlist_written', value: readOnlyReview.production_allowlist_written },
+              ].map(({ label, value }) => (
+                <div key={label} className="rounded-md border border-gx-border p-3">
+                  <div className="text-xs text-gx-muted">{label}</div>
+                  <Badge variant={value ? 'danger' : 'success'}>{value ? 'true' : 'false'}</Badge>
+                </div>
+              ))}
+            </div>
+            <div className="mt-4 grid gap-3 text-sm md:grid-cols-3">
+              <div>
+                <div className="text-xs text-gx-muted">Eligibility</div>
+                <Badge variant={readOnlyReview.eligible ? 'success' : 'danger'}>
+                  {readOnlyReview.eligible ? 'eligible' : 'blocked'}
+                </Badge>
+              </div>
+              <div>
+                <div className="text-xs text-gx-muted">Requested</div>
+                <DateText value={readOnlyReview.requested_at} />
+              </div>
+              <div>
+                <div className="text-xs text-gx-muted">Status updated</div>
+                <DateText value={readOnlyReview.status_updated_at} />
+              </div>
+            </div>
+            {readOnlyReview.blockers.length > 0 ? (
+              <div className="mt-4 rounded-md border border-gx-danger/40 bg-gx-danger/5 p-3">
+                <div className="text-sm font-medium text-gx-text">Review blockers</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {readOnlyReview.blockers.map((blocker) => (
+                    <Badge key={blocker} variant="danger">{capabilityLabel(blocker)}</Badge>
+                  ))}
+                </div>
+                <div className="mt-3 grid gap-2 text-xs text-gx-warning">
+                  {readOnlyReview.remediation.map((item) => (
+                    <div key={item}>{item}</div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+            <div className="mt-4">
+              <Button
+                variant="secondary"
+                onClick={requestReadOnlyDiscoveryReview}
+                disabled={reviewRequestDisabled}
+                title={reviewRequestTitle}
+              >
+                {submitting ? 'Requesting' : readOnlyReview.status === 'requested' ? 'Review requested' : 'Request read-only discovery review'}
+              </Button>
+            </div>
           </Card>
 
           <Card>

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -446,6 +446,46 @@ components:
               - production_allowlist
         generated_at: { type: string, format: date-time }
 
+    SandboxReadOnlyDiscoveryReview:
+      type: object
+      additionalProperties: false
+      description: >-
+        C6D computed sandbox-only request status for read-only discovery review.
+        Requesting review is not approval, launch, public discovery,
+        checkout/payment creation, live payment, live Plural, provider
+        credential access, or production allowlisting.
+      properties:
+        status:
+          type: string
+          enum: [not_requested, blocked, eligible, requested, withdrawn, rejected]
+        eligible: { type: boolean }
+        sandbox_only: { type: boolean, const: true }
+        request_is_approval: { type: boolean, const: false }
+        live_mode_status: { type: string, enum: [not_live] }
+        production_approval_status: { type: string, enum: [not_approved] }
+        rollout_status: { type: string, enum: [rollout_not_requested] }
+        public_discovery_enabled: { type: boolean, const: false }
+        checkout_payment_enabled: { type: boolean, const: false }
+        live_provider_enabled: { type: boolean, const: false }
+        live_plural_enabled: { type: boolean, const: false }
+        production_allowlist_written: { type: boolean, const: false }
+        requested_at: { type: string, format: date-time, nullable: true }
+        status_updated_at: { type: string, format: date-time, nullable: true }
+        blockers:
+          type: array
+          items: { type: string }
+        remediation:
+          type: array
+          items: { type: string }
+
+    SandboxReadOnlyDiscoveryReviewRequest:
+      type: object
+      additionalProperties: false
+      maxProperties: 0
+      description: >-
+        Empty request body. The endpoint accepts no merchant, production,
+        allowlist, provider, payment, checkout, credential, or live-mode fields.
+
     SandboxOnboarding:
       type: object
       properties:
@@ -487,6 +527,7 @@ components:
                   status: { type: string, enum: [pass, blocked] }
                   detail: { type: string }
         agent_facing_preview: { $ref: "#/components/schemas/SandboxAgentFacingPreview" }
+        read_only_discovery_review: { $ref: "#/components/schemas/SandboxReadOnlyDiscoveryReview" }
 
     Agent:
       type: object
@@ -1656,7 +1697,8 @@ paths:
         Returns public-safe sandbox onboarding fields, baseline readiness checks,
         C6A category readiness scoring, C6B catalog readiness preview from
         existing sandbox product/variant rows, a C6C tenant-scoped
-        agent-facing preview payload, and fail-closed production statuses. The
+        agent-facing preview payload, a C6D read-only discovery review request
+        status, and fail-closed production statuses. The
         response never includes provider
         account references, credentials, secrets, production allowlist values,
         checkout/payment material, or live-provider paths.
@@ -1685,7 +1727,8 @@ paths:
         agentic commerce requested flag. It cannot set environment, production
         approval, public discovery, allowlist, provider credential, checkout,
         payment, live payment, or live Plural fields. The response includes the
-        recomputed sandbox-only agent-facing preview payload.
+        recomputed sandbox-only agent-facing preview payload and read-only
+        discovery review eligibility.
       requestBody:
         required: true
         content:
@@ -1745,6 +1788,44 @@ paths:
         "404": { $ref: "#/components/responses/NotFound" }
         "409": { description: Invalid transition or live merchant blocked }
         "422": { $ref: "#/components/responses/ValidationFailed" }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+
+  /v1/commerce/merchants/{merchant_id}/sandbox-onboarding/read-only-discovery-review-request:
+    parameters:
+      - { in: path, name: merchant_id, required: true, schema: { type: string } }
+    post:
+      tags: [Merchants]
+      summary: Request sandbox read-only discovery review
+      operationId: requestMerchantReadOnlyDiscoveryReview
+      x-implemented: true
+      x-milestone: C6D
+      description: >-
+        Requests human review of the tenant-scoped sandbox read-only discovery
+        preview only after C5Z, C6A, C6B, and C6C prerequisites pass. This
+        request is not approval and does not enable public discovery, production
+        Commerce V1, checkout/payment creation, live payments, live Plural,
+        provider credentials, or production allowlists. Blocked attempts write
+        public-safe audit evidence with blocker summaries only.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/SandboxReadOnlyDiscoveryReviewRequest" }
+      responses:
+        "200":
+          description: Read-only discovery review requested
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/SandboxOnboarding" }
+                  audit_event_id: { type: string }
+        "400": { $ref: "#/components/responses/ValidationFailed" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Operator or owning merchant caller required; CommerceAgent callers are denied }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { description: Live merchant or sandbox prerequisite blockers prevent request }
         "503": { $ref: "#/components/responses/CommerceDisabled" }
 
   /v1/commerce/merchants/{merchant_id}/disable-agentic-commerce:

--- a/docs/guides/commerce-v1-merchant-operator-guide.mdx
+++ b/docs/guides/commerce-v1-merchant-operator-guide.mdx
@@ -104,6 +104,18 @@ labels. It excludes private legal details, contracts, private contacts,
 approval evidence, pricing terms, customer data, raw payloads, credentials,
 tokens, provider secrets, production config values, and production allowlists.
 
+C6D adds a read-only discovery review request workflow for sandbox merchants.
+The onboarding response now includes `read_only_discovery_review`, which shows
+whether the tenant-scoped sandbox merchant is eligible, requested, blocked,
+withdrawn, or rejected for review. A merchant or operator may request review
+only after the sandbox profile, category checklist, catalog checklist, and
+agent-facing preview all pass. The request writes audit evidence with public
+blocker summaries, but it is not approval and it does not publish public
+discovery, change production configuration, set allowlists, create checkout or
+payment paths, enable provider credentials, enable live payments, or enable
+live Plural. Blocked requests return remediation so the merchant can fix the
+sandbox profile or catalog before trying again.
+
 Passing category or catalog readiness means only "sandbox profile can be
 reviewed"; it is not merchant approval, production readiness, public discovery
 approval, checkout/payment readiness, live payment readiness, or live Plural

--- a/docs/internal/commerce-v1/commerce-v1-c6d-read-only-discovery-review-request.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6d-read-only-discovery-review-request.md
@@ -1,0 +1,102 @@
+# Commerce V1 C6D Read-Only Discovery Review Request
+
+## Scope
+
+C6D adds a sandbox-only request workflow for read-only discovery review. It
+lets a tenant-scoped merchant or operator ask for human review after the C5Z
+sandbox profile, C6A category checklist, C6B catalog readiness, and C6C
+agent-facing preview all pass.
+
+The request is not approval. It does not enable public discovery, production
+Commerce V1, checkout/payment creation, live payments, live Plural, provider
+credentials, order fulfillment, refunds, or production allowlisting.
+
+## Runtime Behavior
+
+- `GET /v1/commerce/merchants/{merchant_id}/sandbox-onboarding` returns a
+  computed `read_only_discovery_review` payload.
+- `POST /v1/commerce/merchants/{merchant_id}/sandbox-onboarding/read-only-discovery-review-request`
+  accepts an empty body only.
+- The request endpoint is tenant-scoped and uses the existing operator or
+  owning-merchant caller boundary. CommerceAgent callers do not gain merchant
+  admin access through this route.
+- Accepted requests transition the existing sandbox onboarding state to
+  `submitted_for_review`.
+- Blocked attempts return blocker/remediation details and write public-safe
+  audit evidence.
+- Live merchants are blocked.
+
+## Eligibility
+
+A request is accepted only when:
+
+- the merchant exists in the caller tenant;
+- the merchant environment is sandbox;
+- sandbox profile readiness passes;
+- category required checks pass;
+- catalog required checks pass;
+- the agent-facing preview is ready;
+- public-safe fields pass validation;
+- no private artifacts appear in public/runtime fields;
+- no production config or allowlist values are present;
+- checkout/payment execution remains disabled;
+- live provider and live Plural paths remain disabled;
+- provider credentials are not included;
+- no synthetic/demo ID is submitted as a production candidate.
+
+## Fixed Non-Enabling Controls
+
+The computed review payload always reports:
+
+- `sandbox_only: true`
+- `request_is_approval: false`
+- `live_mode_status: not_live`
+- `production_approval_status: not_approved`
+- `rollout_status: rollout_not_requested`
+- `public_discovery_enabled: false`
+- `checkout_payment_enabled: false`
+- `live_provider_enabled: false`
+- `live_plural_enabled: false`
+- `production_allowlist_written: false`
+
+## Audit Evidence
+
+Accepted requests write
+`merchant.sandbox_onboarding.read_only_discovery_review.requested`.
+
+Blocked requests write
+`merchant.sandbox_onboarding.read_only_discovery_review.blocked`.
+
+Audit metadata is limited to tenant/merchant context, request status, state,
+readiness status, preview status, blocker summaries, and fixed false controls.
+It must not include secrets, private merchant details, raw payloads, provider
+credentials, tokens, passports, DB/Redis URLs, private keys, concrete
+production allowlist values, or production config values.
+
+## No Migration Decision
+
+C6D intentionally reuses the existing sandbox onboarding state machine. The
+request state maps to `submitted_for_review`; blocked/rejected/withdrawn-like
+states map to the existing `blocked`, `not_approved`, and
+`rollout_not_requested` values. A later slice can add dedicated immutable
+request timestamps if product needs a separate history beyond
+`sandbox_onboarding_updated_at`.
+
+## Validation Evidence
+
+Implementation readiness should include:
+
+- auth-service commerce tests;
+- auth-service typecheck;
+- portal onboarding tests;
+- portal typecheck;
+- OpenAPI/schema validation;
+- `git diff --check`;
+- secret/private-detail scan;
+- production config and allowlist assignment scan;
+- public discovery enablement scan;
+- checkout/payment enablement scan;
+- live payment/live Plural/provider credential path scan;
+- overclaim scan;
+- realistic merchant/private detail scan;
+- synthetic/demo production-candidate scan.


### PR DESCRIPTION
## Summary
- Adds a no-migration C6D read-only discovery review request workflow on sandbox onboarding.
- Computes read_only_discovery_review from tenant-scoped sandbox readiness, catalog readiness, and agent-facing preview data.
- Adds a sandbox-only request endpoint, public-safe audit events, portal UI, OpenAPI, and operator/internal docs.

## Guardrails
- Does not deploy or trigger workflows manually.
- Does not create cloud resources or run cloud commands.
- Does not change production config, secrets, public discovery flags, production allowlists, checkout/payment enablement, live payments, or live Plural.
- Keeps request as non-approval and non-enabling with false/not-live/not-approved controls.

## Validation
- apps/auth-service: npm run typecheck
- apps/auth-service: npm test -- commerce-merchants.test.ts
- apps/auth-service: npm test -- commerce-openapi.test.ts
- apps/auth-service: npm test
- apps/portal: npm run typecheck
- apps/portal: npm test -- CommerceDashboard.test.tsx
- apps/portal: npm test
- git diff --check
- Guardrail scans for production discovery assignments, allowlist assignments, checkout/payment enablement, live/provider enablement, and synthetic production-candidate values