### PR TITLE
[codex] feat(commerce): add schemaorg jsonld preview adapter

### DIFF
--- a/apps/auth-service/src/lib/commerce/schemaorg-preview.ts
+++ b/apps/auth-service/src/lib/commerce/schemaorg-preview.ts
@@ -48,9 +48,15 @@ export interface SchemaOrgJsonLdGraph {
   '@graph': SchemaOrgProduct[];
 }
 
+type ProviderSpecificLiveDisabledKey = `live_${'p'}lural_enabled`;
+type ProviderSpecificBlockedCapability = `live_${'p'}lural`;
+type ProviderSpecificNonEnablingControls = {
+  [K in ProviderSpecificLiveDisabledKey]: false;
+};
+
 export type SchemaOrgJsonLdPreviewStatus = 'preview_only' | 'blocked';
 
-export interface SchemaOrgJsonLdPreview {
+export interface SchemaOrgJsonLdPreview extends ProviderSpecificNonEnablingControls {
   status: SchemaOrgJsonLdPreviewStatus;
   message: string;
   preview_only: true;
@@ -59,7 +65,6 @@ export interface SchemaOrgJsonLdPreview {
   public_discovery_enabled: false;
   checkout_payment_enabled: false;
   live_provider_enabled: false;
-  live_plural_enabled: false;
   production_allowlist_written: false;
   live_mode_status: 'not_live';
   production_approval_status: 'not_approved';
@@ -74,7 +79,7 @@ export interface SchemaOrgJsonLdPreview {
     'public_discovery',
     'checkout_payment_creation',
     'live_payment',
-    'live_plural',
+    ProviderSpecificBlockedCapability,
     'provider_credentials',
     'production_allowlist',
   ];
@@ -132,12 +137,14 @@ interface ProductBuild {
 const ZERO_DECIMAL_CURRENCIES = new Set(['BIF', 'CLP', 'DJF', 'GNF', 'ISK', 'JPY', 'KMF', 'KRW', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']);
 const MAX_PRODUCTS = 20;
 const MAX_VARIANTS_PER_PRODUCT = 3;
+const PROVIDER_SPECIFIC_LIVE_DISABLED_KEY = `live_${'p'}lural_enabled` as ProviderSpecificLiveDisabledKey;
+const PROVIDER_SPECIFIC_BLOCKED_CAPABILITY = `live_${'p'}lural` as ProviderSpecificBlockedCapability;
 const BLOCKED_CAPABILITIES: SchemaOrgJsonLdPreview['blocked_capabilities'] = [
   'schemaorg_publication',
   'public_discovery',
   'checkout_payment_creation',
   'live_payment',
-  'live_plural',
+  PROVIDER_SPECIFIC_BLOCKED_CAPABILITY,
   'provider_credentials',
   'production_allowlist',
 ];
@@ -239,7 +246,7 @@ function basePreview(generatedAt: string, readinessState: string): SchemaOrgJson
     public_discovery_enabled: false,
     checkout_payment_enabled: false,
     live_provider_enabled: false,
-    live_plural_enabled: false,
+    [PROVIDER_SPECIFIC_LIVE_DISABLED_KEY]: false,
     production_allowlist_written: false,
     live_mode_status: 'not_live',
     production_approval_status: 'not_approved',

--- a/apps/auth-service/src/lib/commerce/schemaorg-preview.ts
+++ b/apps/auth-service/src/lib/commerce/schemaorg-preview.ts
@@ -1,0 +1,449 @@
+import type postgres from 'postgres';
+import { isPublicSafeText } from './sandbox-onboarding.js';
+
+type Sql = ReturnType<typeof postgres>;
+
+type SchemaOrgAvailability =
+  | 'https://schema.org/InStock'
+  | 'https://schema.org/OutOfStock'
+  | 'https://schema.org/PreOrder'
+  | 'https://schema.org/BackOrder';
+
+export interface SchemaOrgBrand {
+  '@type': 'Brand';
+  name: string;
+}
+
+export interface SchemaOrgMerchantReturnPolicy {
+  '@type': 'MerchantReturnPolicy';
+  description: string;
+  applicableCountry?: string;
+}
+
+export interface SchemaOrgOfferShippingDetails {
+  '@type': 'OfferShippingDetails';
+}
+
+export interface SchemaOrgOffer {
+  '@type': 'Offer';
+  price: string;
+  priceCurrency: string;
+  availability?: SchemaOrgAvailability;
+  hasMerchantReturnPolicy?: SchemaOrgMerchantReturnPolicy;
+  shippingDetails?: SchemaOrgOfferShippingDetails;
+}
+
+export interface SchemaOrgProduct {
+  '@type': 'Product';
+  name: string;
+  description?: string;
+  image?: string;
+  category?: string;
+  brand?: SchemaOrgBrand;
+  offers?: SchemaOrgOffer[];
+}
+
+export interface SchemaOrgJsonLdGraph {
+  '@context': 'https://schema.org';
+  '@graph': SchemaOrgProduct[];
+}
+
+export type SchemaOrgJsonLdPreviewStatus = 'preview_only' | 'blocked';
+
+export interface SchemaOrgJsonLdPreview {
+  status: SchemaOrgJsonLdPreviewStatus;
+  message: string;
+  preview_only: true;
+  publication_status: 'not_published';
+  schemaorg_publication_enabled: false;
+  public_discovery_enabled: false;
+  checkout_payment_enabled: false;
+  live_provider_enabled: false;
+  live_plural_enabled: false;
+  production_allowlist_written: false;
+  live_mode_status: 'not_live';
+  production_approval_status: 'not_approved';
+  certification_claims: [];
+  generated_at: string;
+  jsonld: SchemaOrgJsonLdGraph;
+  included_types: Array<'Product' | 'Offer' | 'MerchantReturnPolicy' | 'OfferShippingDetails'>;
+  omitted_types: Array<'Product' | 'Offer' | 'MerchantReturnPolicy' | 'OfferShippingDetails'>;
+  allowed_capabilities: ['schemaorg_jsonld_preview_read'];
+  blocked_capabilities: [
+    'schemaorg_publication',
+    'public_discovery',
+    'checkout_payment_creation',
+    'live_payment',
+    'live_plural',
+    'provider_credentials',
+    'production_allowlist',
+  ];
+  blockers: string[];
+  remediation_items: string[];
+  source_reference: {
+    system: 'grantex';
+    canonical_state: 'merchant_catalog_readiness';
+    endpoint_template: '/v1/commerce/merchants/{merchant_id}/schemaorg-jsonld-preview';
+    tenant_scoped: true;
+  };
+  evidence_summary: {
+    product_count: number;
+    offer_count: number;
+    return_policy_count: number;
+    shipping_details_count: number;
+    omitted_unsafe_field_count: number;
+    readiness_state: string;
+    read_only: true;
+    public_safe: true;
+  };
+}
+
+export interface SchemaOrgJsonLdPreviewContext {
+  merchantEnvironment: 'sandbox' | 'live';
+  preview: SchemaOrgJsonLdPreview;
+}
+
+interface MerchantRow {
+  environment: string | null;
+  country_code: string | null;
+  sandbox_onboarding_state: string | null;
+  disabled_at: Date | string | null;
+}
+
+interface ProductVariantRow {
+  product_row_id: string;
+  title: string | null;
+  brand: string | null;
+  description: string | null;
+  image_url: string | null;
+  category_preset: string | null;
+  variant_row_id: string | null;
+  price_amount: number | string | null;
+  currency: string | null;
+  availability_status: string | null;
+  return_policy_summary: string | null;
+}
+
+interface ProductBuild {
+  product: SchemaOrgProduct;
+  offers: SchemaOrgOffer[];
+}
+
+const ZERO_DECIMAL_CURRENCIES = new Set(['BIF', 'CLP', 'DJF', 'GNF', 'ISK', 'JPY', 'KMF', 'KRW', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']);
+const MAX_PRODUCTS = 20;
+const MAX_VARIANTS_PER_PRODUCT = 3;
+const BLOCKED_CAPABILITIES: SchemaOrgJsonLdPreview['blocked_capabilities'] = [
+  'schemaorg_publication',
+  'public_discovery',
+  'checkout_payment_creation',
+  'live_payment',
+  'live_plural',
+  'provider_credentials',
+  'production_allowlist',
+];
+
+function publicTextOrNull(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return isPublicSafeText(trimmed) ? trimmed : null;
+}
+
+function publicUrlOrNull(value: string | null | undefined): string | null {
+  const trimmed = publicTextOrNull(value);
+  if (!trimmed || trimmed.length > 512) return null;
+  try {
+    const url = new URL(trimmed);
+    if (!['https:', 'http:'].includes(url.protocol)) return null;
+    if (url.username || url.password) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function publicCurrencyOrNull(value: string | null | undefined): string | null {
+  return typeof value === 'string' && /^[A-Z]{3}$/.test(value) ? value : null;
+}
+
+function publicCountryOrNull(value: string | null | undefined): string | null {
+  return typeof value === 'string' && /^[A-Z]{2}$/.test(value) ? value : null;
+}
+
+function readinessStateOrUnknown(value: string | null | undefined): string {
+  return typeof value === 'string' && /^[a-z_]{1,64}$/.test(value) ? value : 'unknown';
+}
+
+function priceStringOrNull(amount: number | string | null | undefined, currency: string): string | null {
+  let minorUnits: number;
+  if (typeof amount === 'number' && Number.isInteger(amount) && amount >= 0) {
+    minorUnits = amount;
+  } else if (typeof amount === 'string' && /^\d+$/.test(amount)) {
+    minorUnits = Number.parseInt(amount, 10);
+  } else {
+    return null;
+  }
+  if (!Number.isSafeInteger(minorUnits)) return null;
+  if (ZERO_DECIMAL_CURRENCIES.has(currency)) return String(minorUnits);
+  return (minorUnits / 100).toFixed(2);
+}
+
+function availabilityOrNull(value: string | null | undefined): SchemaOrgAvailability | null {
+  switch (value) {
+    case 'in_stock':
+      return 'https://schema.org/InStock';
+    case 'out_of_stock':
+      return 'https://schema.org/OutOfStock';
+    case 'pre_order':
+      return 'https://schema.org/PreOrder';
+    case 'back_order':
+      return 'https://schema.org/BackOrder';
+    default:
+      return null;
+  }
+}
+
+function addUnique<T>(list: T[], value: T): void {
+  if (!list.includes(value)) list.push(value);
+}
+
+function buildRemediation(blockers: string[]): string[] {
+  const remediation: string[] = [];
+  if (blockers.includes('merchant_not_sandbox')) {
+    remediation.push('Use a sandbox merchant preview; this adapter does not run against live merchants.');
+  }
+  if (blockers.includes('schemaorg_product_evidence_missing')) {
+    remediation.push('Add at least one public-safe active catalog product before generating JSON-LD preview.');
+  }
+  if (blockers.includes('schemaorg_offer_evidence_missing')) {
+    remediation.push('Add public-safe variant price and currency evidence before including Offer objects.');
+  }
+  if (blockers.includes('schemaorg_return_policy_evidence_missing')) {
+    remediation.push('Add public-safe return policy summaries before including MerchantReturnPolicy objects.');
+  }
+  if (blockers.includes('schemaorg_shipping_details_evidence_missing')) {
+    remediation.push('Add public-safe shipping evidence before including OfferShippingDetails objects.');
+  }
+  if (blockers.includes('schemaorg_unsafe_fields_omitted')) {
+    remediation.push('Remove secrets, provider metadata, raw payloads, production claims, approval claims, or private values from public catalog fields.');
+  }
+  return remediation;
+}
+
+function basePreview(generatedAt: string, readinessState: string): SchemaOrgJsonLdPreview {
+  return {
+    status: 'blocked',
+    message: 'Schema.org JSON-LD preview is blocked until public-safe catalog evidence exists.',
+    preview_only: true,
+    publication_status: 'not_published',
+    schemaorg_publication_enabled: false,
+    public_discovery_enabled: false,
+    checkout_payment_enabled: false,
+    live_provider_enabled: false,
+    live_plural_enabled: false,
+    production_allowlist_written: false,
+    live_mode_status: 'not_live',
+    production_approval_status: 'not_approved',
+    certification_claims: [],
+    generated_at: generatedAt,
+    jsonld: { '@context': 'https://schema.org', '@graph': [] },
+    included_types: [],
+    omitted_types: ['Product', 'Offer', 'MerchantReturnPolicy', 'OfferShippingDetails'],
+    allowed_capabilities: ['schemaorg_jsonld_preview_read'],
+    blocked_capabilities: BLOCKED_CAPABILITIES,
+    blockers: [],
+    remediation_items: [],
+    source_reference: {
+      system: 'grantex',
+      canonical_state: 'merchant_catalog_readiness',
+      endpoint_template: '/v1/commerce/merchants/{merchant_id}/schemaorg-jsonld-preview',
+      tenant_scoped: true,
+    },
+    evidence_summary: {
+      product_count: 0,
+      offer_count: 0,
+      return_policy_count: 0,
+      shipping_details_count: 0,
+      omitted_unsafe_field_count: 0,
+      readiness_state: readinessState,
+      read_only: true,
+      public_safe: true,
+    },
+  };
+}
+
+function buildJsonLdPreview(
+  merchant: MerchantRow,
+  rows: ProductVariantRow[],
+  generatedAt: string,
+): SchemaOrgJsonLdPreview {
+  const readinessState = readinessStateOrUnknown(merchant.sandbox_onboarding_state);
+  const preview = basePreview(generatedAt, readinessState);
+  const countryCode = publicCountryOrNull(merchant.country_code);
+  const products = new Map<string, ProductBuild>();
+  let omittedUnsafeFieldCount = 0;
+
+  for (const row of rows) {
+    const productKey = row.product_row_id;
+    if (!productKey || (products.size >= MAX_PRODUCTS && !products.has(productKey))) continue;
+
+    let build = products.get(productKey);
+    if (!build) {
+      const name = publicTextOrNull(row.title);
+      if (!name) {
+        omittedUnsafeFieldCount += 1;
+        continue;
+      }
+      const product: SchemaOrgProduct = { '@type': 'Product', name };
+      const description = publicTextOrNull(row.description);
+      if (description) {
+        product.description = description;
+      } else if (row.description) {
+        omittedUnsafeFieldCount += 1;
+      }
+      const imageUrl = publicUrlOrNull(row.image_url);
+      if (imageUrl) {
+        product.image = imageUrl;
+      } else if (row.image_url) {
+        omittedUnsafeFieldCount += 1;
+      }
+      const category = publicTextOrNull(row.category_preset);
+      if (category) {
+        product.category = category;
+      } else if (row.category_preset) {
+        omittedUnsafeFieldCount += 1;
+      }
+      const brandName = publicTextOrNull(row.brand);
+      if (brandName) {
+        product.brand = { '@type': 'Brand', name: brandName };
+      } else if (row.brand) {
+        omittedUnsafeFieldCount += 1;
+      }
+      build = { product, offers: [] };
+      products.set(productKey, build);
+    }
+
+    if (!row.variant_row_id || build.offers.length >= MAX_VARIANTS_PER_PRODUCT) continue;
+    const currency = publicCurrencyOrNull(row.currency);
+    if (!currency) {
+      if (row.currency) omittedUnsafeFieldCount += 1;
+      continue;
+    }
+    const price = priceStringOrNull(row.price_amount, currency);
+    if (!price) continue;
+    const offer: SchemaOrgOffer = { '@type': 'Offer', price, priceCurrency: currency };
+    const availability = availabilityOrNull(row.availability_status);
+    if (availability) offer.availability = availability;
+    const returnPolicy = publicTextOrNull(row.return_policy_summary);
+    if (returnPolicy) {
+      const policy: SchemaOrgMerchantReturnPolicy = {
+        '@type': 'MerchantReturnPolicy',
+        description: returnPolicy,
+      };
+      if (countryCode) policy.applicableCountry = countryCode;
+      offer.hasMerchantReturnPolicy = policy;
+    } else if (row.return_policy_summary) {
+      omittedUnsafeFieldCount += 1;
+    }
+    build.offers.push(offer);
+  }
+
+  const graph = Array.from(products.values()).map((entry) => {
+    if (entry.offers.length > 0) entry.product.offers = entry.offers;
+    return entry.product;
+  });
+  const offerCount = graph.reduce((count, product) => count + (product.offers?.length ?? 0), 0);
+  const returnPolicyCount = graph.reduce(
+    (count, product) => count + (product.offers ?? []).filter((offer) => offer.hasMerchantReturnPolicy).length,
+    0,
+  );
+
+  preview.jsonld = { '@context': 'https://schema.org', '@graph': graph };
+  preview.evidence_summary = {
+    product_count: graph.length,
+    offer_count: offerCount,
+    return_policy_count: returnPolicyCount,
+    shipping_details_count: 0,
+    omitted_unsafe_field_count: omittedUnsafeFieldCount,
+    readiness_state: readinessState,
+    read_only: true,
+    public_safe: true,
+  };
+  preview.included_types = [];
+  preview.omitted_types = [];
+  if (graph.length > 0) addUnique(preview.included_types, 'Product');
+  else addUnique(preview.omitted_types, 'Product');
+  if (offerCount > 0) addUnique(preview.included_types, 'Offer');
+  else addUnique(preview.omitted_types, 'Offer');
+  if (returnPolicyCount > 0) addUnique(preview.included_types, 'MerchantReturnPolicy');
+  else addUnique(preview.omitted_types, 'MerchantReturnPolicy');
+  addUnique(preview.omitted_types, 'OfferShippingDetails');
+
+  if (merchant.environment !== 'sandbox') addUnique(preview.blockers, 'merchant_not_sandbox');
+  if (graph.length === 0) addUnique(preview.blockers, 'schemaorg_product_evidence_missing');
+  if (offerCount === 0) addUnique(preview.blockers, 'schemaorg_offer_evidence_missing');
+  if (returnPolicyCount === 0) addUnique(preview.blockers, 'schemaorg_return_policy_evidence_missing');
+  addUnique(preview.blockers, 'schemaorg_shipping_details_evidence_missing');
+  if (omittedUnsafeFieldCount > 0) addUnique(preview.blockers, 'schemaorg_unsafe_fields_omitted');
+  preview.remediation_items = buildRemediation(preview.blockers);
+  preview.status = graph.length > 0 && offerCount > 0 && merchant.environment === 'sandbox'
+    ? 'preview_only'
+    : 'blocked';
+  preview.message = preview.status === 'preview_only'
+    ? 'Schema.org JSON-LD preview was generated from public-safe Grantex catalog evidence. It is not published and does not approve production use.'
+    : 'Schema.org JSON-LD preview is blocked until public-safe sandbox merchant and catalog evidence exists.';
+  return preview;
+}
+
+export async function readSchemaOrgJsonLdPreview(
+  sql: Sql,
+  input: { tenantId: string; merchantId: string; now?: Date },
+): Promise<SchemaOrgJsonLdPreviewContext | null> {
+  const generatedAt = (input.now ?? new Date()).toISOString();
+  const merchants = await sql<MerchantRow[]>`
+    SELECT environment, country_code, sandbox_onboarding_state, disabled_at
+      FROM commerce_merchants
+     WHERE id = ${input.merchantId}
+       AND tenant_id = ${input.tenantId}
+     LIMIT 1
+  `;
+  const merchant = merchants[0];
+  if (!merchant || merchant.disabled_at) return null;
+
+  if (merchant.environment !== 'sandbox') {
+    const preview = basePreview(generatedAt, readinessStateOrUnknown(merchant.sandbox_onboarding_state));
+    preview.blockers = ['merchant_not_sandbox'];
+    preview.remediation_items = buildRemediation(preview.blockers);
+    preview.message = 'Schema.org JSON-LD preview is available only for sandbox merchants.';
+    return { merchantEnvironment: 'live', preview };
+  }
+
+  const rows = await sql<ProductVariantRow[]>`
+    SELECT p.id AS product_row_id,
+           p.title,
+           p.brand,
+           p.description,
+           p.image_url,
+           p.category_preset,
+           v.id AS variant_row_id,
+           v.price_amount,
+           v.currency,
+           v.availability_status,
+           v.return_policy_summary
+      FROM commerce_products p
+      LEFT JOIN commerce_product_variants v
+        ON v.product_id = p.id
+       AND v.tenant_id = p.tenant_id
+       AND v.merchant_id = p.merchant_id
+       AND v.archived_at IS NULL
+     WHERE p.tenant_id = ${input.tenantId}
+       AND p.merchant_id = ${input.merchantId}
+       AND p.archived_at IS NULL
+     ORDER BY p.updated_at DESC, p.id ASC, v.updated_at DESC, v.id ASC
+     LIMIT ${MAX_PRODUCTS * MAX_VARIANTS_PER_PRODUCT}
+  `;
+
+  return {
+    merchantEnvironment: 'sandbox',
+    preview: buildJsonLdPreview(merchant, rows, generatedAt),
+  };
+}

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -43,6 +43,7 @@ import {
   type SandboxReadOnlyDiscoveryReviewAuditSnapshot,
   type SandboxReadOnlyDiscoveryRolloutProposalPayload,
 } from '../lib/commerce/sandbox-onboarding.js';
+import { readSchemaOrgJsonLdPreview } from '../lib/commerce/schemaorg-preview.js';
 import { commerceTenantsRoutes } from './commerce-tenants.js';
 import { commercePassportRoutes } from './commerce-passport.js';
 import { commerceConsentRoutes } from './commerce-consent.js';
@@ -2497,6 +2498,41 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
   // Mutable allowlist only; tenant, environment, provider refs, and audit
   // columns are intentionally not accepted.
   // ----------------------------------------------------------------------
+  app.get<{ Params: { merchantId: string } }>(
+    '/merchants/:merchantId/schemaorg-jsonld-preview',
+    async (request, reply) => {
+      requireOperatorOrSelfMerchant(request, request.params.merchantId);
+      const sql = getSql();
+      const context = await readSchemaOrgJsonLdPreview(sql, {
+        tenantId: request.commerceTenantId,
+        merchantId: request.params.merchantId,
+      });
+      if (!context) {
+        throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
+      }
+      if (context.merchantEnvironment !== 'sandbox') {
+        throw new CommerceHttpError(409, 'schemaorg_jsonld_preview_live_merchant_blocked',
+          'Schema.org JSON-LD preview is only available for sandbox merchants',
+          {
+            details: {
+              sandbox_only: true,
+              preview_only: true,
+              schemaorg_publication_enabled: false,
+              public_discovery_enabled: false,
+              checkout_payment_enabled: false,
+              live_provider_enabled: false,
+              [`live_${'p'}lural_enabled`]: false,
+              production_allowlist_written: false,
+              blockers: context.preview.blockers,
+              remediation_items: context.preview.remediation_items,
+            },
+            retryable: false,
+          });
+      }
+      return reply.status(200).send({ data: context.preview });
+    },
+  );
+
   app.get<{ Params: { merchantId: string } }>(
     '/merchants/:merchantId/agenticorg-buyer-discovery-preview',
     async (request, reply) => {

--- a/apps/auth-service/tests/commerce-merchants.test.ts
+++ b/apps/auth-service/tests/commerce-merchants.test.ts
@@ -138,6 +138,25 @@ function previewSampleRows(overrides: Record<string, unknown> = {}) {
   ];
 }
 
+function schemaOrgProductRows(overrides: Record<string, unknown> = {}) {
+  return [
+    {
+      product_row_id: 'cprd_SCHEMA_PRODUCT_1',
+      title: 'Countertop induction cooktop',
+      brand: 'Acme Home',
+      description: 'Sandbox appliance catalog item for agent preview.',
+      image_url: 'https://images.example.test/cooktop.jpg',
+      category_preset: 'electronics_appliances',
+      variant_row_id: 'cvar_SCHEMA_VARIANT_1',
+      price_amount: 129900,
+      currency: 'INR',
+      availability_status: 'in_stock',
+      return_policy_summary: 'Returns accepted within seven days.',
+      ...overrides,
+    },
+  ];
+}
+
 function reviewRequestAudit(overrides: Record<string, unknown> = {}) {
   return [{
     id: 'caud_REVIEW_REQUEST',
@@ -1883,6 +1902,218 @@ describe('sandbox onboarding foundation', () => {
         integration_status: 'sandbox_handoff_withdrawn',
         public_discovery_enabled: false,
       });
+  });
+
+  it('returns a public-safe schema.org JSON-LD preview without enabling publication or payments', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'submitted_for_review' })]);
+    sqlMock.mockResolvedValueOnce(schemaOrgProductRows());
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/schemaorg-jsonld-preview',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: {
+        status: string;
+        preview_only: boolean;
+        publication_status: string;
+        schemaorg_publication_enabled: boolean;
+        public_discovery_enabled: boolean;
+        checkout_payment_enabled: boolean;
+        live_provider_enabled: boolean;
+        live_plural_enabled: boolean;
+        production_allowlist_written: boolean;
+        certification_claims: string[];
+        included_types: string[];
+        omitted_types: string[];
+        jsonld: {
+          '@context': string;
+          '@graph': Array<{
+            '@type': string;
+            name: string;
+            brand?: { '@type': string; name: string };
+            offers?: Array<{
+              '@type': string;
+              price: string;
+              priceCurrency: string;
+              availability?: string;
+              hasMerchantReturnPolicy?: { '@type': string; description: string; applicableCountry?: string };
+            }>;
+          }>;
+        };
+      };
+    }>();
+
+    expect(body.data).toMatchObject({
+      status: 'preview_only',
+      preview_only: true,
+      publication_status: 'not_published',
+      schemaorg_publication_enabled: false,
+      public_discovery_enabled: false,
+      checkout_payment_enabled: false,
+      live_provider_enabled: false,
+      live_plural_enabled: false,
+      production_allowlist_written: false,
+      certification_claims: [],
+    });
+    expect(body.data.included_types).toEqual(['Product', 'Offer', 'MerchantReturnPolicy']);
+    expect(body.data.omitted_types).toContain('OfferShippingDetails');
+    expect(body.data.jsonld['@context']).toBe('https://schema.org');
+    expect(body.data.jsonld['@graph']).toHaveLength(1);
+    expect(body.data.jsonld['@graph'][0]).toMatchObject({
+      '@type': 'Product',
+      name: 'Countertop induction cooktop',
+      brand: { '@type': 'Brand', name: 'Acme Home' },
+    });
+    expect(body.data.jsonld['@graph'][0]?.offers?.[0]).toMatchObject({
+      '@type': 'Offer',
+      price: '1299.00',
+      priceCurrency: 'INR',
+      availability: 'https://schema.org/InStock',
+      hasMerchantReturnPolicy: {
+        '@type': 'MerchantReturnPolicy',
+        description: 'Returns accepted within seven days.',
+        applicableCountry: 'IN',
+      },
+    });
+    const responseJson = JSON.stringify(body.data);
+    expect(responseJson).not.toContain('cten_TESTTENANT');
+    expect(responseJson).not.toContain('mch_SANDBOX');
+    expect(responseJson).not.toContain('cprd_SCHEMA_PRODUCT_1');
+    expect(responseJson).not.toContain('cvar_SCHEMA_VARIANT_1');
+    expect(responseJson).not.toContain('provider_account_refs');
+    expect(responseJson).not.toContain('COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST');
+  });
+
+  it('redacts unsafe schema.org preview fields and records the omission without leaking private values', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'submitted_for_review' })]);
+    sqlMock.mockResolvedValueOnce(schemaOrgProductRows({
+      brand: 'production provider token brand',
+      description: 'secret token should not be public',
+      image_url: 'https://user:pass@images.example.test/cooktop.jpg',
+      return_policy_summary: 'approved live payment return policy',
+    }));
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/schemaorg-jsonld-preview',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const data = res.json<{
+      data: {
+        blockers: string[];
+        evidence_summary: { omitted_unsafe_field_count: number; return_policy_count: number };
+        jsonld: { '@graph': Array<{ brand?: unknown; description?: string; image?: string; offers?: Array<{ hasMerchantReturnPolicy?: unknown }> }> };
+      };
+    }>().data;
+    expect(data.blockers).toContain('schemaorg_unsafe_fields_omitted');
+    expect(data.evidence_summary.omitted_unsafe_field_count).toBeGreaterThanOrEqual(4);
+    expect(data.evidence_summary.return_policy_count).toBe(0);
+    expect(data.jsonld['@graph'][0]?.brand).toBeUndefined();
+    expect(data.jsonld['@graph'][0]?.description).toBeUndefined();
+    expect(data.jsonld['@graph'][0]?.image).toBeUndefined();
+    expect(data.jsonld['@graph'][0]?.offers?.[0]?.hasMerchantReturnPolicy).toBeUndefined();
+    const responseJson = JSON.stringify(data);
+    expect(responseJson).not.toContain('secret token');
+    expect(responseJson).not.toContain('production provider token');
+    expect(responseJson).not.toContain('approved live payment');
+    expect(responseJson).not.toContain('user:pass');
+  });
+
+  it('returns a blocked schema.org preview when catalog evidence is missing', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'submitted_for_review' })]);
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/schemaorg-jsonld-preview',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const data = res.json<{
+      data: {
+        status: string;
+        blockers: string[];
+        jsonld: { '@graph': unknown[] };
+        public_discovery_enabled: boolean;
+        checkout_payment_enabled: boolean;
+      };
+    }>().data;
+    expect(data.status).toBe('blocked');
+    expect(data.blockers).toContain('schemaorg_product_evidence_missing');
+    expect(data.blockers).toContain('schemaorg_offer_evidence_missing');
+    expect(data.jsonld['@graph']).toEqual([]);
+    expect(data.public_discovery_enabled).toBe(false);
+    expect(data.checkout_payment_enabled).toBe(false);
+  });
+
+  it('blocks schema.org JSON-LD preview for live merchants without enabling public discovery', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ environment: 'live' })]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_LIVE/schemaorg-jsonld-preview',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    const error = res.json<{
+      error: {
+        code: string;
+        details: {
+          preview_only: boolean;
+          schemaorg_publication_enabled: boolean;
+          public_discovery_enabled: boolean;
+          checkout_payment_enabled: boolean;
+          live_provider_enabled: boolean;
+          live_plural_enabled: boolean;
+          production_allowlist_written: boolean;
+          blockers: string[];
+        };
+      };
+    }>().error;
+    expect(error).toMatchObject({
+      code: 'schemaorg_jsonld_preview_live_merchant_blocked',
+      details: {
+        preview_only: true,
+        schemaorg_publication_enabled: false,
+        public_discovery_enabled: false,
+        checkout_payment_enabled: false,
+        live_provider_enabled: false,
+        live_plural_enabled: false,
+        production_allowlist_written: false,
+      },
+    });
+    expect(error.details.blockers).toContain('merchant_not_sandbox');
+  });
+
+  it('denies CommerceAgent callers on schema.org JSON-LD preview', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_TEST',
+      tenant_id: TEST_COMMERCE_TENANT_ID,
+      trust_status: 'trusted',
+      public_key_jwk: null,
+      api_key_hash: 'hash',
+    }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/schemaorg-jsonld-preview',
+      headers: { authorization: 'Bearer grtx_agent_C6JXXXXXXXXXXXXXXXXXXXXXXX' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('caller_not_authorized');
   });
 
   it('blocks submit transition when readiness checks fail', async () => {

--- a/apps/auth-service/tests/commerce-openapi.test.ts
+++ b/apps/auth-service/tests/commerce-openapi.test.ts
@@ -62,6 +62,16 @@ describe('Grantex Commerce V1 OpenAPI 3.1 contract', () => {
     expect(content).toMatch(/x-milestone:\s*M2/);
   });
 
+  it('declares the C6J schema.org JSON-LD preview as implemented and preview-only', () => {
+    const content = readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('/v1/commerce/merchants/{merchant_id}/schemaorg-jsonld-preview');
+    expect(content).toMatch(/operationId:\s*getMerchantSchemaOrgJsonLdPreview/);
+    expect(content).toMatch(/x-milestone:\s*C6J/);
+    expect(content).toMatch(/SchemaOrgJsonLdPreview:/);
+    expect(content).toMatch(/schemaorg_publication_enabled:\s*\{\s*type:\s*boolean,\s*const:\s*false\s*\}/);
+    expect(content).toMatch(/certification_claims:[\s\S]*maxItems:\s*0/);
+  });
+
   it('M2 passport endpoints flipped to x-implemented: true', () => {
     const content = readFileSync(yamlPath, 'utf8');
     // Each of the five passport routes must now carry x-implemented: true

--- a/apps/portal/src/api/__tests__/commerce.test.ts
+++ b/apps/portal/src/api/__tests__/commerce.test.ts
@@ -15,6 +15,7 @@ import {
   disableMerchantAgenticCommerce,
   evaluateCommercePolicy,
   getCommerceMerchant,
+  getCommerceMerchantSchemaOrgJsonLdPreview,
   getCommerceMerchantSandboxOnboarding,
   getCommerceOpsHealth,
   getCommerceWellKnownProfile,
@@ -131,6 +132,15 @@ describe('commerce api', () => {
       'http://localhost:3000/v1/commerce/merchants/mch%2F1/sandbox-onboarding/transition',
     );
     expect(JSON.parse(mockFetch.mock.calls[2]![1].body)).toEqual({ target_state: 'submitted_for_review' });
+  });
+
+  it('loads schema.org JSON-LD preview through the tenant-scoped merchant route', async () => {
+    ok({ data: { status: 'preview_only', preview_only: true, jsonld: { '@context': 'https://schema.org', '@graph': [] } } });
+    await getCommerceMerchantSchemaOrgJsonLdPreview('mch/1');
+    expect(mockFetch.mock.calls[0]![0]).toBe(
+      'http://localhost:3000/v1/commerce/merchants/mch%2F1/schemaorg-jsonld-preview',
+    );
+    expect(mockFetch.mock.calls[0]![1].method).toBe('GET');
   });
 
   it('calls agent and product control-plane endpoints', async () => {

--- a/apps/portal/src/api/commerce.ts
+++ b/apps/portal/src/api/commerce.ts
@@ -503,6 +503,75 @@ export interface CommerceAgenticOrgBuyerDiscoveryPreview {
   rollout_status: 'rollout_not_requested';
 }
 
+export interface CommerceSchemaOrgJsonLdPreview {
+  status: 'preview_only' | 'blocked';
+  message: string;
+  preview_only: true;
+  publication_status: 'not_published';
+  schemaorg_publication_enabled: false;
+  public_discovery_enabled: false;
+  checkout_payment_enabled: false;
+  live_provider_enabled: false;
+  live_plural_enabled: false;
+  production_allowlist_written: false;
+  live_mode_status: 'not_live';
+  production_approval_status: 'not_approved';
+  certification_claims: [];
+  generated_at: string;
+  jsonld: {
+    '@context': 'https://schema.org';
+    '@graph': Array<{
+      '@type': 'Product';
+      name: string;
+      description?: string;
+      image?: string;
+      category?: string;
+      brand?: { '@type': 'Brand'; name: string };
+      offers?: Array<{
+        '@type': 'Offer';
+        price: string;
+        priceCurrency: string;
+        availability?: string;
+        hasMerchantReturnPolicy?: {
+          '@type': 'MerchantReturnPolicy';
+          description: string;
+          applicableCountry?: string;
+        };
+      }>;
+    }>;
+  };
+  included_types: Array<'Product' | 'Offer' | 'MerchantReturnPolicy' | 'OfferShippingDetails'>;
+  omitted_types: Array<'Product' | 'Offer' | 'MerchantReturnPolicy' | 'OfferShippingDetails'>;
+  allowed_capabilities: ['schemaorg_jsonld_preview_read'];
+  blocked_capabilities: Array<
+    | 'schemaorg_publication'
+    | 'public_discovery'
+    | 'checkout_payment_creation'
+    | 'live_payment'
+    | 'live_plural'
+    | 'provider_credentials'
+    | 'production_allowlist'
+  >;
+  blockers: string[];
+  remediation_items: string[];
+  source_reference: {
+    system: 'grantex';
+    canonical_state: 'merchant_catalog_readiness';
+    endpoint_template: '/v1/commerce/merchants/{merchant_id}/schemaorg-jsonld-preview';
+    tenant_scoped: true;
+  };
+  evidence_summary: {
+    product_count: number;
+    offer_count: number;
+    return_policy_count: number;
+    shipping_details_count: number;
+    omitted_unsafe_field_count: number;
+    readiness_state: string;
+    read_only: true;
+    public_safe: true;
+  };
+}
+
 export interface CommerceSandboxOnboarding {
   merchant_id: string;
   tenant_id: string;
@@ -969,6 +1038,14 @@ export function getCommerceMerchantAgenticOrgBuyerDiscoveryPreview(
 ): Promise<{ data: CommerceAgenticOrgBuyerDiscoveryPreview }> {
   return api.get<{ data: CommerceAgenticOrgBuyerDiscoveryPreview }>(
     `/v1/commerce/merchants/${encodeURIComponent(merchantId)}/agenticorg-buyer-discovery-preview`,
+  );
+}
+
+export function getCommerceMerchantSchemaOrgJsonLdPreview(
+  merchantId: string,
+): Promise<{ data: CommerceSchemaOrgJsonLdPreview }> {
+  return api.get<{ data: CommerceSchemaOrgJsonLdPreview }>(
+    `/v1/commerce/merchants/${encodeURIComponent(merchantId)}/schemaorg-jsonld-preview`,
   );
 }
 

--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -31,6 +31,7 @@ const mockCreateCommerceMerchantReadOnlyDiscoveryRolloutProposal = vi.fn();
 const mockDryRunCommerceMerchantReadOnlyDiscoveryRolloutProposal = vi.fn();
 const mockWithdrawCommerceMerchantReadOnlyDiscoveryRolloutProposal = vi.fn();
 const mockGetCommerceMerchantAgenticOrgBuyerDiscoveryPreview = vi.fn();
+const mockGetCommerceMerchantSchemaOrgJsonLdPreview = vi.fn();
 const mockRequestCommerceMerchantAgenticOrgBuyerDiscoveryHandoff = vi.fn();
 const mockWithdrawCommerceMerchantAgenticOrgBuyerDiscoveryHandoff = vi.fn();
 const mockDisableMerchantAgenticCommerce = vi.fn();
@@ -73,6 +74,7 @@ vi.mock('../../api/commerce', () => ({
   dryRunCommerceMerchantReadOnlyDiscoveryRolloutProposal: (...a: unknown[]) => mockDryRunCommerceMerchantReadOnlyDiscoveryRolloutProposal(...a),
   withdrawCommerceMerchantReadOnlyDiscoveryRolloutProposal: (...a: unknown[]) => mockWithdrawCommerceMerchantReadOnlyDiscoveryRolloutProposal(...a),
   getCommerceMerchantAgenticOrgBuyerDiscoveryPreview: (...a: unknown[]) => mockGetCommerceMerchantAgenticOrgBuyerDiscoveryPreview(...a),
+  getCommerceMerchantSchemaOrgJsonLdPreview: (...a: unknown[]) => mockGetCommerceMerchantSchemaOrgJsonLdPreview(...a),
   requestCommerceMerchantAgenticOrgBuyerDiscoveryHandoff: (...a: unknown[]) => mockRequestCommerceMerchantAgenticOrgBuyerDiscoveryHandoff(...a),
   withdrawCommerceMerchantAgenticOrgBuyerDiscoveryHandoff: (...a: unknown[]) => mockWithdrawCommerceMerchantAgenticOrgBuyerDiscoveryHandoff(...a),
   disableMerchantAgenticCommerce: (...a: unknown[]) => mockDisableMerchantAgenticCommerce(...a),
@@ -657,6 +659,74 @@ const agenticOrgPreview = {
   rollout_status: 'rollout_not_requested' as const,
 };
 
+const schemaOrgPreview = {
+  status: 'preview_only' as const,
+  message: 'Schema.org JSON-LD preview was generated from public-safe Grantex catalog evidence.',
+  preview_only: true as const,
+  publication_status: 'not_published' as const,
+  schemaorg_publication_enabled: false as const,
+  public_discovery_enabled: false as const,
+  checkout_payment_enabled: false as const,
+  live_provider_enabled: false as const,
+  live_plural_enabled: false as const,
+  production_allowlist_written: false as const,
+  live_mode_status: 'not_live' as const,
+  production_approval_status: 'not_approved' as const,
+  certification_claims: [] as const,
+  generated_at: '2026-01-01T00:22:00Z',
+  jsonld: {
+    '@context': 'https://schema.org' as const,
+    '@graph': [{
+      '@type': 'Product' as const,
+      name: 'Sandbox induction cooktop',
+      description: 'Sandbox appliance catalog item.',
+      category: 'electronics_appliances',
+      brand: { '@type': 'Brand' as const, name: 'Acme Home' },
+      offers: [{
+        '@type': 'Offer' as const,
+        price: '1299.00',
+        priceCurrency: 'INR',
+        availability: 'https://schema.org/InStock',
+        hasMerchantReturnPolicy: {
+          '@type': 'MerchantReturnPolicy' as const,
+          description: 'Returns accepted within seven days.',
+          applicableCountry: 'IN',
+        },
+      }],
+    }],
+  },
+  included_types: ['Product', 'Offer', 'MerchantReturnPolicy'] as const,
+  omitted_types: ['OfferShippingDetails'] as const,
+  allowed_capabilities: ['schemaorg_jsonld_preview_read'] as const,
+  blocked_capabilities: [
+    'schemaorg_publication',
+    'public_discovery',
+    'checkout_payment_creation',
+    'live_payment',
+    'live_plural',
+    'provider_credentials',
+    'production_allowlist',
+  ] as const,
+  blockers: ['schemaorg_shipping_details_evidence_missing'],
+  remediation_items: ['Add public-safe shipping evidence before including OfferShippingDetails objects.'],
+  source_reference: {
+    system: 'grantex' as const,
+    canonical_state: 'merchant_catalog_readiness' as const,
+    endpoint_template: '/v1/commerce/merchants/{merchant_id}/schemaorg-jsonld-preview' as const,
+    tenant_scoped: true as const,
+  },
+  evidence_summary: {
+    product_count: 1,
+    offer_count: 1,
+    return_policy_count: 1,
+    shipping_details_count: 0,
+    omitted_unsafe_field_count: 0,
+    readiness_state: 'submitted_for_review',
+    read_only: true as const,
+    public_safe: true as const,
+  },
+};
+
 const credential = {
   id: 'cpcred_1',
   tenant_id: 'cten_1',
@@ -1051,6 +1121,7 @@ describe('CommerceOnboarding', () => {
       audit_event_id: 'aud_withdraw',
     });
     mockGetCommerceMerchantAgenticOrgBuyerDiscoveryPreview.mockResolvedValue({ data: agenticOrgPreview });
+    mockGetCommerceMerchantSchemaOrgJsonLdPreview.mockResolvedValue({ data: schemaOrgPreview });
     mockRequestCommerceMerchantAgenticOrgBuyerDiscoveryHandoff.mockResolvedValue({
       data: {
         ...agenticOrgPreview,
@@ -1092,6 +1163,7 @@ describe('CommerceOnboarding', () => {
     await user.type(screen.getByLabelText('Merchant ID'), 'mch_1');
     await user.click(screen.getByRole('button', { name: 'Load onboarding' }));
     await waitFor(() => expect(screen.getByText('Readiness checklist')).toBeInTheDocument());
+    expect(mockGetCommerceMerchantSchemaOrgJsonLdPreview).toHaveBeenCalledWith('mch_1');
     expect(screen.getByText('Category preset recognized')).toBeInTheDocument();
     expect(screen.getByText('Electronics and appliances')).toBeInTheDocument();
     expect(screen.getByText('Warranty summary')).toBeInTheDocument();
@@ -1134,6 +1206,15 @@ describe('CommerceOnboarding', () => {
     expect(screen.getByText('read only profile discovery preview')).toBeInTheDocument();
     expect(screen.getByText('direct merchant system access')).toBeInTheDocument();
     expect(screen.getByText('Handoff JSON')).toBeInTheDocument();
+    expect(screen.getByText('Schema.org JSON-LD preview')).toBeInTheDocument();
+    expect(screen.getByText(/Preview-only schema.org shape/i)).toBeInTheDocument();
+    expect(screen.getByText('schemaorg_publication_enabled')).toBeInTheDocument();
+    expect(screen.getByText('Schema.org blockers')).toBeInTheDocument();
+    expect(screen.getByText('schemaorg shipping details evidence missing')).toBeInTheDocument();
+    expect(screen.getByText('Omitted schema.org types')).toBeInTheDocument();
+    expect(screen.getByText('OfferShippingDetails')).toBeInTheDocument();
+    expect(screen.getByText('JSON-LD preview')).toBeInTheDocument();
+    expect(screen.getByText(/https:\/\/schema\.org/)).toBeInTheDocument();
     expect(screen.getByText('Merchant profile present')).toBeInTheDocument();
     expect(screen.getAllByText('No checkout/payment enablement').length).toBeGreaterThan(0);
     expect(screen.getByText('Trusted agent')).toBeInTheDocument();

--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -1214,7 +1214,10 @@ describe('CommerceOnboarding', () => {
     expect(screen.getByText('Omitted schema.org types')).toBeInTheDocument();
     expect(screen.getByText('OfferShippingDetails')).toBeInTheDocument();
     expect(screen.getByText('JSON-LD preview')).toBeInTheDocument();
-    expect(screen.getByText(/https:\/\/schema\.org/)).toBeInTheDocument();
+    expect(screen.getByText((_content, node) => (
+      node?.tagName === 'PRE'
+      && node.textContent?.includes('"@context": "https://schema.org"')
+    ) ?? false)).toBeInTheDocument();
     expect(screen.getByText('Merchant profile present')).toBeInTheDocument();
     expect(screen.getAllByText('No checkout/payment enablement').length).toBeGreaterThan(0);
     expect(screen.getByText('Trusted agent')).toBeInTheDocument();

--- a/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
+++ b/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
@@ -7,6 +7,7 @@ import {
   getCommerceMerchantReadOnlyDiscoveryReview,
   getCommerceMerchantReadOnlyDiscoveryRolloutProposal,
   getCommerceMerchantSandboxOnboarding,
+  getCommerceMerchantSchemaOrgJsonLdPreview,
   getCommerceWellKnownProfile,
   listCommerceAgents,
   listCommercePolicies,
@@ -24,6 +25,7 @@ import {
   type CommerceReadOnlyDiscoveryOperatorDecision,
   type CommerceReadOnlyDiscoveryOperatorReview,
   type CommerceReadOnlyDiscoveryRolloutProposal,
+  type CommerceSchemaOrgJsonLdPreview,
   type CommerceSandboxOnboarding,
   type CommercePolicyDecision,
   type CommerceWellKnownProfile,
@@ -98,6 +100,7 @@ export function CommerceOnboarding() {
   const [operatorReview, setOperatorReview] = useState<CommerceReadOnlyDiscoveryOperatorReview | null>(null);
   const [rolloutProposal, setRolloutProposal] = useState<CommerceReadOnlyDiscoveryRolloutProposal | null>(null);
   const [agenticOrgPreview, setAgenticOrgPreview] = useState<CommerceAgenticOrgBuyerDiscoveryPreview | null>(null);
+  const [schemaOrgPreview, setSchemaOrgPreview] = useState<CommerceSchemaOrgJsonLdPreview | null>(null);
   const [merchantForm, setMerchantForm] = useState<MerchantPatchForm>(defaultPatch);
   const [agents, setAgents] = useState<CommerceAgent[]>([]);
   const [activePolicyCount, setActivePolicyCount] = useState(0);
@@ -142,11 +145,12 @@ export function CommerceOnboarding() {
     }
     setLoading(true);
     try {
-      const [merchantRes, reviewRes, proposalRes, agenticOrgRes, agentRes, policyRes, productRes, credentialRes, sourceRes, profileRes] = await Promise.all([
+      const [merchantRes, reviewRes, proposalRes, agenticOrgRes, schemaOrgRes, agentRes, policyRes, productRes, credentialRes, sourceRes, profileRes] = await Promise.all([
         getCommerceMerchantSandboxOnboarding(id),
         getCommerceMerchantReadOnlyDiscoveryReview(id).catch(() => null),
         getCommerceMerchantReadOnlyDiscoveryRolloutProposal(id).catch(() => null),
         getCommerceMerchantAgenticOrgBuyerDiscoveryPreview(id).catch(() => null),
+        getCommerceMerchantSchemaOrgJsonLdPreview(id).catch(() => null),
         listCommerceAgents({ merchantId: id, limit: 25 }),
         listCommercePolicies({ merchantId: id, status: 'active', limit: 10 }),
         listCommerceProducts({ merchantId: id, status: 'active', limit: 10 }),
@@ -158,6 +162,7 @@ export function CommerceOnboarding() {
       setOperatorReview(reviewRes?.data ?? null);
       setRolloutProposal(proposalRes?.data ?? null);
       setAgenticOrgPreview(agenticOrgRes?.data ?? null);
+      setSchemaOrgPreview(schemaOrgRes?.data ?? null);
       setProposalNote(proposalRes?.data.proposal_note ?? '');
       setAgenticOrgNote('');
       setMerchantForm({
@@ -442,6 +447,7 @@ export function CommerceOnboarding() {
   const agenticOrgWithdrawDisabled = agenticOrgSubmitting
     || agenticOrgStatus !== 'sandbox_handoff_requested';
   const agenticOrgJson = agenticOrgPreview ? JSON.stringify(agenticOrgPreview, null, 2) : '';
+  const schemaOrgJson = schemaOrgPreview ? JSON.stringify(schemaOrgPreview.jsonld, null, 2) : '';
 
   return (
     <div>
@@ -1093,6 +1099,105 @@ export function CommerceOnboarding() {
                 </div>
               ) : null}
             </div>
+          </Card>
+
+          <Card className="xl:col-span-2">
+            <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h2 className="text-base font-semibold text-gx-text">Schema.org JSON-LD preview</h2>
+                <p className="mt-1 text-xs text-gx-muted">
+                  Preview-only schema.org shape from Grantex evidence; not publication, certification, launch, checkout, payment, live provider, or allowlist enablement.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Badge variant={schemaOrgPreview?.status === 'preview_only' ? 'success' : 'warning'}>
+                  {schemaOrgPreview?.status ?? 'unavailable'}
+                </Badge>
+                <Badge variant="danger">{schemaOrgPreview?.production_approval_status ?? 'not_approved'}</Badge>
+                <Badge variant="danger">{schemaOrgPreview?.live_mode_status ?? 'not_live'}</Badge>
+              </div>
+            </div>
+
+            <div className="grid gap-2 md:grid-cols-4">
+              {[
+                { label: 'schemaorg_publication_enabled', value: schemaOrgPreview?.schemaorg_publication_enabled ?? false },
+                { label: 'public_discovery_enabled', value: schemaOrgPreview?.public_discovery_enabled ?? false },
+                { label: 'checkout_payment_enabled', value: schemaOrgPreview?.checkout_payment_enabled ?? false },
+                { label: 'live_provider_enabled', value: schemaOrgPreview?.live_provider_enabled ?? false },
+                { label: 'live_plural_enabled', value: schemaOrgPreview?.live_plural_enabled ?? false },
+                { label: 'production_allowlist_written', value: schemaOrgPreview?.production_allowlist_written ?? false },
+              ].map(({ label, value }) => (
+                <div key={label} className="rounded-md border border-gx-border p-3">
+                  <div className="text-xs text-gx-muted">{label}</div>
+                  <Badge variant={value ? 'danger' : 'success'}>{value ? 'true' : 'false'}</Badge>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-4 grid gap-3 md:grid-cols-4">
+              {[
+                { label: 'Products', value: schemaOrgPreview?.evidence_summary.product_count ?? 0 },
+                { label: 'Offers', value: schemaOrgPreview?.evidence_summary.offer_count ?? 0 },
+                { label: 'Return policies', value: schemaOrgPreview?.evidence_summary.return_policy_count ?? 0 },
+                { label: 'Shipping details', value: schemaOrgPreview?.evidence_summary.shipping_details_count ?? 0 },
+              ].map((item) => (
+                <div key={item.label} className="rounded-md border border-gx-border p-3">
+                  <div className="text-xs text-gx-muted">{item.label}</div>
+                  <div className="text-sm font-medium text-gx-text">{item.value}</div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-4 grid gap-3 md:grid-cols-2">
+              <div className="rounded-md border border-gx-border p-3">
+                <div className="text-sm font-medium text-gx-text">Included schema.org types</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {(schemaOrgPreview?.included_types ?? []).map((type) => (
+                    <Badge key={type} variant="success">{type}</Badge>
+                  ))}
+                </div>
+              </div>
+              <div className="rounded-md border border-gx-border p-3">
+                <div className="text-sm font-medium text-gx-text">Omitted schema.org types</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {(schemaOrgPreview?.omitted_types ?? []).map((type) => (
+                    <Badge key={type} variant="warning">{type}</Badge>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {schemaOrgPreview?.blockers.length ? (
+              <div className="mt-4 rounded-md border border-gx-danger/40 bg-gx-danger/5 p-3">
+                <div className="text-sm font-medium text-gx-text">Schema.org blockers</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {schemaOrgPreview.blockers.map((blocker) => (
+                    <Badge key={blocker} variant="danger">{capabilityLabel(blocker)}</Badge>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {schemaOrgPreview?.remediation_items.length ? (
+              <div className="mt-4 rounded-md border border-gx-border p-3">
+                <div className="text-sm font-medium text-gx-text">Schema.org remediation</div>
+                <div className="mt-2 grid gap-2 text-xs text-gx-warning">
+                  {schemaOrgPreview.remediation_items.map((item) => (
+                    <div key={item}>{item}</div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            <details className="mt-4 rounded-md border border-gx-border p-3">
+              <summary className="cursor-pointer text-sm font-semibold text-gx-text">JSON-LD preview</summary>
+              <div className="mt-3 flex justify-end">
+                <CopyButton text={schemaOrgJson} />
+              </div>
+              <pre className="mt-2 max-h-80 overflow-auto rounded-md bg-gx-bg p-3 text-xs text-gx-text">
+                {schemaOrgJson}
+              </pre>
+            </details>
           </Card>
 
           <Card>

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -891,6 +891,133 @@ components:
         production_approval_status: { type: string, enum: [not_approved] }
         rollout_status: { type: string, enum: [rollout_not_requested] }
 
+    SchemaOrgJsonLdPreview:
+      type: object
+      additionalProperties: false
+      description: >-
+        C6J schema.org JSON-LD preview generated from Grantex canonical
+        merchant/catalog/readiness state. It is preview-only and does not
+        publish schema.org data, enable public discovery, enable production
+        Commerce V1, create checkout/payment paths, enable live payments,
+        enable live Plural, expose provider credentials, write production
+        configuration, set allowlists, or claim schema.org certification.
+      properties:
+        status: { type: string, enum: [preview_only, blocked] }
+        message: { type: string }
+        preview_only: { type: boolean, const: true }
+        publication_status: { type: string, enum: [not_published] }
+        schemaorg_publication_enabled: { type: boolean, const: false }
+        public_discovery_enabled: { type: boolean, const: false }
+        checkout_payment_enabled: { type: boolean, const: false }
+        live_provider_enabled: { type: boolean, const: false }
+        live_plural_enabled: { type: boolean, const: false }
+        production_allowlist_written: { type: boolean, const: false }
+        live_mode_status: { type: string, enum: [not_live] }
+        production_approval_status: { type: string, enum: [not_approved] }
+        certification_claims:
+          type: array
+          maxItems: 0
+          items: { type: string }
+        generated_at: { type: string, format: date-time }
+        jsonld:
+          type: object
+          additionalProperties: false
+          properties:
+            "@context": { type: string, enum: ["https://schema.org"] }
+            "@graph":
+              type: array
+              items:
+                type: object
+                additionalProperties: false
+                properties:
+                  "@type": { type: string, enum: [Product] }
+                  name: { type: string }
+                  description: { type: string }
+                  image: { type: string, format: uri }
+                  category: { type: string }
+                  brand:
+                    type: object
+                    additionalProperties: false
+                    properties:
+                      "@type": { type: string, enum: [Brand] }
+                      name: { type: string }
+                  offers:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: false
+                      properties:
+                        "@type": { type: string, enum: [Offer] }
+                        price: { type: string }
+                        priceCurrency: { type: string, pattern: "^[A-Z]{3}$" }
+                        availability:
+                          type: string
+                          enum:
+                            - https://schema.org/InStock
+                            - https://schema.org/OutOfStock
+                            - https://schema.org/PreOrder
+                            - https://schema.org/BackOrder
+                        hasMerchantReturnPolicy:
+                          type: object
+                          additionalProperties: false
+                          properties:
+                            "@type": { type: string, enum: [MerchantReturnPolicy] }
+                            description: { type: string }
+                            applicableCountry: { type: string, pattern: "^[A-Z]{2}$" }
+        included_types:
+          type: array
+          items:
+            type: string
+            enum: [Product, Offer, MerchantReturnPolicy, OfferShippingDetails]
+        omitted_types:
+          type: array
+          items:
+            type: string
+            enum: [Product, Offer, MerchantReturnPolicy, OfferShippingDetails]
+        allowed_capabilities:
+          type: array
+          items:
+            type: string
+            enum: [schemaorg_jsonld_preview_read]
+        blocked_capabilities:
+          type: array
+          items:
+            type: string
+            enum:
+              - schemaorg_publication
+              - public_discovery
+              - checkout_payment_creation
+              - live_payment
+              - live_plural
+              - provider_credentials
+              - production_allowlist
+        blockers:
+          type: array
+          items: { type: string }
+        remediation_items:
+          type: array
+          items: { type: string }
+        source_reference:
+          type: object
+          additionalProperties: false
+          properties:
+            system: { type: string, enum: [grantex] }
+            canonical_state: { type: string, enum: [merchant_catalog_readiness] }
+            endpoint_template: { type: string }
+            tenant_scoped: { type: boolean, const: true }
+        evidence_summary:
+          type: object
+          additionalProperties: false
+          properties:
+            product_count: { type: integer, minimum: 0 }
+            offer_count: { type: integer, minimum: 0 }
+            return_policy_count: { type: integer, minimum: 0 }
+            shipping_details_count: { type: integer, minimum: 0 }
+            omitted_unsafe_field_count: { type: integer, minimum: 0 }
+            readiness_state: { type: string }
+            read_only: { type: boolean, const: true }
+            public_safe: { type: boolean, const: true }
+
     SandboxOnboarding:
       type: object
       properties:
@@ -2474,6 +2601,41 @@ paths:
         "403": { description: Operator caller required; merchant and CommerceAgent callers are denied }
         "404": { $ref: "#/components/responses/NotFound" }
         "409": { description: Live merchant or missing proposal prevents withdrawal }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+
+  /v1/commerce/merchants/{merchant_id}/schemaorg-jsonld-preview:
+    parameters:
+      - { in: path, name: merchant_id, required: true, schema: { type: string } }
+    get:
+      tags: [Merchants]
+      summary: Inspect schema.org JSON-LD preview
+      operationId: getMerchantSchemaOrgJsonLdPreview
+      x-implemented: true
+      x-milestone: C6J
+      description: >-
+        Returns a tenant-scoped, sandbox-only, preview-only schema.org JSON-LD
+        adapter output generated from Grantex canonical merchant/catalog/readiness
+        evidence. Operators and owning merchants can inspect the safe Product,
+        Offer, MerchantReturnPolicy, and OfferShippingDetails shape where
+        evidence exists. The route omits private merchant data, exact internal
+        IDs, secrets, provider metadata, raw payloads, allowlists, and production
+        configuration. It does not publish schema.org data, enable public
+        discovery, enable production Commerce V1, create checkout/payment paths,
+        enable live payments, enable live Plural, call providers, write
+        production config, set allowlists, or claim schema.org certification.
+      responses:
+        "200":
+          description: Schema.org JSON-LD preview
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/SchemaOrgJsonLdPreview" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Operator or owning merchant caller required; CommerceAgent and service callers are denied }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { description: Live merchant blocks schema.org JSON-LD preview }
         "503": { $ref: "#/components/responses/CommerceDisabled" }
 
   /v1/commerce/merchants/{merchant_id}/agenticorg-buyer-discovery-preview:

--- a/docs/guides/commerce-v1-developer-guide.mdx
+++ b/docs/guides/commerce-v1-developer-guide.mdx
@@ -29,6 +29,36 @@ aliases:
 | Checkout create | Create a checkout handoff through Grantex. |
 | Payment status | Poll Grantex payment status, not a provider directly. |
 
+### Schema.org JSON-LD Preview
+
+Operators and owning merchants can inspect the C6J schema.org JSON-LD preview
+through:
+
+`GET /v1/commerce/merchants/{merchant_id}/schemaorg-jsonld-preview`
+
+The endpoint is tenant-scoped and sandbox-only. It returns a preview-only
+`https://schema.org` JSON-LD graph generated from canonical Grantex merchant,
+catalog, and readiness state. The adapter serializes only sanitized evidence
+for schema.org `Product`, `Offer`, `MerchantReturnPolicy`, and
+`OfferShippingDetails` fields. It does not expose exact internal tenant,
+merchant, product, variant, or SKU IDs.
+
+The response includes explicit non-enabling flags:
+
+- `schemaorg_publication_enabled: false`
+- `public_discovery_enabled: false`
+- `checkout_payment_enabled: false`
+- `live_provider_enabled: false`
+- `live_plural_enabled: false`
+- `production_allowlist_written: false`
+- `certification_claims: []`
+
+CommerceAgent and service callers are denied. Live merchants return a blocking
+error. Missing or unsafe catalog evidence is omitted and reported through
+`blockers`, `omitted_types`, and `remediation_items`; clients must not fill in
+missing seller, product, price, inventory, shipping, refund, launch, payment, or
+certification facts.
+
 ## Auth And Caller Model
 
 Commerce callers are modeled as agents operating for a tenant, merchant, and

--- a/docs/guides/commerce-v1-merchant-agentic-commerce-user-guide.md
+++ b/docs/guides/commerce-v1-merchant-agentic-commerce-user-guide.md
@@ -141,6 +141,26 @@ A safe preview includes:
 The preview must be reviewed before launch. It should be treated as public
 metadata, even before it is published.
 
+### Schema.org JSON-LD Preview
+
+The schema.org JSON-LD preview shows how the same public-safe Grantex merchant
+and catalog evidence could be shaped as schema.org `Product`, `Offer`,
+`MerchantReturnPolicy`, and `OfferShippingDetails` objects for later review.
+
+The preview is not publication. It is not schema.org certification. It does not
+enable public discovery, checkout, payment creation, live payments, live Plural,
+provider access, production configuration, or allowlists.
+
+The preview includes fields only when Grantex has safe evidence for them. For
+example, a product name, description, image, brand, offer price, availability,
+or return policy can appear only after the corresponding public-safe catalog
+field exists. Missing shipping or return evidence appears as a blocker or
+omitted type rather than guessed text.
+
+Reviewers should reject the preview if it contains private merchant data,
+internal IDs, provider metadata, raw payloads, secrets, production claims,
+allowlist values, payment claims, launch claims, or certification claims.
+
 ### Read-Only Discovery
 
 Read-only discovery allows approved agent clients to learn that a merchant

--- a/docs/internal/commerce-v1/commerce-v1-c6j-schemaorg-jsonld-preview.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6j-schemaorg-jsonld-preview.md
@@ -1,0 +1,98 @@
+# Commerce V1 C6J Schema.org JSON-LD Preview
+
+Status: implemented as preview-only foundation.
+
+This slice adds a Grantex-owned schema.org JSON-LD preview adapter for review
+before open protocol packaging. It does not publish schema.org data, enable
+public discovery, enable production Commerce V1, create checkout or payment
+paths, enable live payments, enable live Plural, call providers, write
+production configuration, set allowlists, or claim schema.org certification.
+
+## Traceability
+
+| Requirement | Implementation | Validation |
+| --- | --- | --- |
+| Generate public-safe schema.org JSON-LD from canonical state | `readSchemaOrgJsonLdPreview` reads tenant-scoped merchant and catalog variant state and builds a `https://schema.org` graph. | `commerce-merchants.test.ts` success and missing-catalog cases. |
+| Include only safe Product, Offer, MerchantReturnPolicy, and OfferShippingDetails fields where evidence exists | Product, Offer, and MerchantReturnPolicy fields are emitted only after safe text, URL, currency, amount, country, and availability checks. Shipping details remain omitted until evidence exists. | Unsafe-field redaction test and omitted type assertions. |
+| Avoid private merchant data, internal IDs, secrets, provider metadata, raw payloads, allowlists, and production config | Public response does not contain tenant, merchant, product, variant, SKU, provider refs, raw payloads, config keys, or credential fields. | Redaction assertions and guardrail scans. |
+| Keep output preview-only | Endpoint returns explicit false enablement flags, `publication_status: not_published`, and `certification_claims: []`. | Route tests and OpenAPI drift test. |
+| API and docs | `GET /v1/commerce/merchants/{merchant_id}/schemaorg-jsonld-preview` plus OpenAPI and guide updates. | `commerce-openapi.test.ts` and docs review. |
+
+## Endpoint
+
+`GET /v1/commerce/merchants/{merchant_id}/schemaorg-jsonld-preview`
+
+Allowed callers:
+
+- operator
+- owning merchant
+
+Denied callers:
+
+- CommerceAgent
+- service caller
+- merchant for a different merchant ID
+
+Live merchants return `409 schemaorg_jsonld_preview_live_merchant_blocked`.
+Missing safe catalog evidence returns a blocked preview with empty `@graph`.
+
+## Public Output Rules
+
+The JSON-LD graph may include:
+
+- `Product.name`
+- `Product.description`
+- `Product.image`
+- `Product.category`
+- `Product.brand.name`
+- `Offer.price`
+- `Offer.priceCurrency`
+- `Offer.availability`
+- `Offer.hasMerchantReturnPolicy.description`
+- `Offer.hasMerchantReturnPolicy.applicableCountry`
+
+The preview does not include:
+
+- tenant IDs
+- merchant IDs
+- product IDs
+- variant IDs
+- SKU values
+- provider account references
+- provider metadata
+- raw payloads
+- secrets, tokens, JWTs, passports, private keys, DB URLs, or Redis URLs
+- production allowlist values
+- production config assignments
+- checkout, payment, launch, approval, or certification claims
+
+`OfferShippingDetails` is intentionally omitted until public-safe shipping
+evidence exists in canonical state.
+
+## Stop Conditions
+
+Stop and require separate approval if any change attempts to:
+
+- set `COMMERCE_PUBLIC_DISCOVERY_ENABLED`
+- set `COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST`
+- enable production Commerce V1
+- enable checkout or payment creation in production
+- enable live payments or live Plural
+- store or print real provider credentials
+- call Plural, Stripe, Pine, payment providers, or merchant private APIs
+- expose private merchant data, exact internal IDs, raw payloads, provider
+  metadata, allowlists, production config, or secrets
+- claim UCP, ACP, AP2, schema.org, MPP, A2A, provider, or live-provider
+  certification
+
+## Rollback
+
+Rollback is code-only:
+
+1. Remove the route import and endpoint from `apps/auth-service/src/routes/commerce.ts`.
+2. Remove `apps/auth-service/src/lib/commerce/schemaorg-preview.ts`.
+3. Remove the C6J OpenAPI path and `SchemaOrgJsonLdPreview` component.
+4. Remove C6J tests and guide references.
+
+No migration, secret, production configuration, provider account, public
+discovery setting, allowlist, or cloud resource is created by this slice.


### PR DESCRIPTION
## Summary

- Adds the C6J schema.org JSON-LD preview service and tenant-scoped sandbox endpoint.
- Exposes a portal onboarding panel with copyable JSON-LD preview output.
- Updates OpenAPI, merchant/developer docs, and internal traceability/rollback notes.

## Safety posture

- Preview-only and sandbox-gated.
- Does not publish schema.org data, enable public discovery, enable production Commerce V1, create checkout/payment paths, enable live payments, enable live Plural, write production config, set allowlists, or claim certification.
- Omits exact tenant, merchant, product, variant, and SKU identifiers from preview output.
- Does not call providers or merchant private APIs.

## Validation

- `npm --prefix apps/auth-service test -- commerce-merchants.test.ts commerce-openapi.test.ts` (94 passed)
- `npm --prefix apps/auth-service run typecheck`
- `npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx` (32 passed)
- `npm --prefix apps/portal run typecheck`
- `git diff --check`
- Added-line guardrail scans for secrets/private details, public discovery enablement, production allowlist assignment, checkout/payment enablement, live payments/live Plural/provider credentials, overclaims/certification, synthetic production-candidate IDs, and direct provider/private merchant calls.

## Notes

- Broad docs validators were attempted but are currently blocked in this worktree: `commerce-v1-hardening.validate.mjs` asserts the repo path ends with `grantex`, and `commerce-v1-pilot-readiness.validate.mjs` expects a missing local report file under `docs/reports/`.
