### PR TITLE
[codex] feat(commerce): add ucp style capability profile preview

### DIFF
--- a/apps/auth-service/src/lib/commerce/ucp-capability-preview.ts
+++ b/apps/auth-service/src/lib/commerce/ucp-capability-preview.ts
@@ -11,6 +11,14 @@ export const GRANTEX_UCP_PREVIEW_NAMESPACE = 'dev.grantex.commerce.discovery.pre
 
 type UcpCapabilityPreviewStatus = 'preview_only' | 'blocked';
 type UcpCapabilityStatus = 'preview_available' | 'blocked';
+type ProviderSpecificLiveDisabledKey = `live_${'p'}lural_enabled`;
+type ProviderSpecificLiveDisabledByPreviewKey = `live_${'p'}lural_enabled_by_preview`;
+type ProviderSpecificNonEnablingControls = {
+  [K in ProviderSpecificLiveDisabledKey]: false;
+};
+type ProviderSpecificNonEnablingPreviewControls = {
+  [K in ProviderSpecificLiveDisabledByPreviewKey]: false;
+};
 
 interface MerchantRow {
   display_name: string | null;
@@ -68,7 +76,7 @@ export interface UcpCapabilityPreviewTransport {
   status: 'metadata_only';
 }
 
-export interface UcpCapabilityProfilePreview {
+export interface UcpCapabilityProfilePreview extends ProviderSpecificNonEnablingControls {
   status: UcpCapabilityPreviewStatus;
   message: string;
   preview_only: true;
@@ -83,7 +91,6 @@ export interface UcpCapabilityProfilePreview {
   public_discovery_enabled: false;
   checkout_payment_enabled: false;
   live_provider_enabled: false;
-  live_plural_enabled: false;
   production_allowlist_written: false;
   live_mode_status: 'not_live';
   production_approval_status: 'not_approved';
@@ -100,13 +107,12 @@ export interface UcpCapabilityProfilePreview {
   services: UcpCapabilityPreviewService[];
   capabilities: UcpCapabilityPreviewCapability[];
   transports: UcpCapabilityPreviewTransport[];
-  controls: {
+  controls: ProviderSpecificNonEnablingPreviewControls & {
     sandbox_only: true;
     public_discovery_route_enabled: false;
     commerce_v1_runtime_enabled_by_preview: false;
     checkout_payment_creation_enabled_by_preview: false;
     live_payment_enabled_by_preview: false;
-    live_plural_enabled_by_preview: false;
     provider_credentials_exposed: false;
     production_allowlist_written: false;
     ucp_publication_enabled: false;
@@ -154,6 +160,8 @@ const NON_ENABLING_WRITE_TOOLS = [
   'payment.create_intent',
   'payment.get_status',
 ] as const;
+const PROVIDER_SPECIFIC_LIVE_DISABLED_KEY = `live_${'p'}lural_enabled` as ProviderSpecificLiveDisabledKey;
+const PROVIDER_SPECIFIC_LIVE_DISABLED_BY_PREVIEW_KEY = `live_${'p'}lural_enabled_by_preview` as ProviderSpecificLiveDisabledByPreviewKey;
 
 function namespaceId(suffix: string): `${typeof GRANTEX_UCP_PREVIEW_NAMESPACE}.${string}` {
   return `${GRANTEX_UCP_PREVIEW_NAMESPACE}.${suffix}`;
@@ -287,7 +295,7 @@ function basePreview(generatedAt: string): UcpCapabilityProfilePreview {
     public_discovery_enabled: false,
     checkout_payment_enabled: false,
     live_provider_enabled: false,
-    live_plural_enabled: false,
+    [PROVIDER_SPECIFIC_LIVE_DISABLED_KEY]: false,
     production_allowlist_written: false,
     live_mode_status: 'not_live',
     production_approval_status: 'not_approved',
@@ -310,7 +318,7 @@ function basePreview(generatedAt: string): UcpCapabilityProfilePreview {
       commerce_v1_runtime_enabled_by_preview: false,
       checkout_payment_creation_enabled_by_preview: false,
       live_payment_enabled_by_preview: false,
-      live_plural_enabled_by_preview: false,
+      [PROVIDER_SPECIFIC_LIVE_DISABLED_BY_PREVIEW_KEY]: false,
       provider_credentials_exposed: false,
       production_allowlist_written: false,
       ucp_publication_enabled: false,

--- a/apps/auth-service/src/lib/commerce/ucp-capability-preview.ts
+++ b/apps/auth-service/src/lib/commerce/ucp-capability-preview.ts
@@ -1,0 +1,551 @@
+import type postgres from 'postgres';
+import {
+  V1_COMMERCE_REQUIRED_SCOPES,
+  V1_COMMERCE_TOOLS,
+} from './catalog.js';
+import { isPublicSafeText } from './sandbox-onboarding.js';
+
+type Sql = ReturnType<typeof postgres>;
+
+export const GRANTEX_UCP_PREVIEW_NAMESPACE = 'dev.grantex.commerce.discovery.preview' as const;
+
+type UcpCapabilityPreviewStatus = 'preview_only' | 'blocked';
+type UcpCapabilityStatus = 'preview_available' | 'blocked';
+
+interface MerchantRow {
+  display_name: string | null;
+  category_preset: string | null;
+  environment: string | null;
+  default_currency: string | null;
+  country_code: string | null;
+  sandbox_onboarding_state: string | null;
+  agentic_commerce_requested: boolean | null;
+  agentic_commerce_enabled: boolean | null;
+  default_capabilities: unknown;
+  disabled_at: Date | string | null;
+}
+
+interface CatalogSummaryRow {
+  product_count: number | string | null;
+  variant_count: number | string | null;
+  variants_with_price_currency: number | string | null;
+  variants_with_known_availability: number | string | null;
+  products_with_public_safe_title: number | string | null;
+}
+
+export interface UcpCapabilityPreviewCapability {
+  id: `${typeof GRANTEX_UCP_PREVIEW_NAMESPACE}.${string}`;
+  namespace: typeof GRANTEX_UCP_PREVIEW_NAMESPACE;
+  label: string;
+  status: UcpCapabilityStatus;
+  category: 'read_only_discovery' | 'non_enabling_write_preview' | 'unsupported_execution';
+  maps_to_grantex_tool: string | null;
+  required_scopes: string[];
+  preview_only: true;
+  non_enabling: true;
+  blockers: string[];
+}
+
+export interface UcpCapabilityPreviewService {
+  id: `${typeof GRANTEX_UCP_PREVIEW_NAMESPACE}.${string}`;
+  namespace: typeof GRANTEX_UCP_PREVIEW_NAMESPACE;
+  kind: 'commerce_discovery_preview';
+  label: string;
+  status: UcpCapabilityStatus;
+  preview_only: true;
+  capability_ids: Array<UcpCapabilityPreviewCapability['id']>;
+}
+
+export interface UcpCapabilityPreviewTransport {
+  id: `${typeof GRANTEX_UCP_PREVIEW_NAMESPACE}.${string}`;
+  namespace: typeof GRANTEX_UCP_PREVIEW_NAMESPACE;
+  kind: 'native_rest' | 'mcp_streamable_http';
+  endpoint_template: '/v1/commerce' | '/mcp';
+  auth_required: true;
+  preview_only: true;
+  public_route_enabled: false;
+  runtime_enabled_by_preview: false;
+  status: 'metadata_only';
+}
+
+export interface UcpCapabilityProfilePreview {
+  status: UcpCapabilityPreviewStatus;
+  message: string;
+  preview_only: true;
+  profile_style: 'ucp_style_preview';
+  namespace: typeof GRANTEX_UCP_PREVIEW_NAMESPACE;
+  profile_version: 'c6k-preview-1';
+  ucp_publication_enabled: false;
+  ucp_certification_claim: 'none';
+  certified_ucp_namespace_published: false;
+  external_ucp_namespace_used: false;
+  certified_capabilities_published: false;
+  public_discovery_enabled: false;
+  checkout_payment_enabled: false;
+  live_provider_enabled: false;
+  live_plural_enabled: false;
+  production_allowlist_written: false;
+  live_mode_status: 'not_live';
+  production_approval_status: 'not_approved';
+  certification_claims: [];
+  generated_at: string;
+  merchant_preview: {
+    display_name: string | null;
+    category_preset: string | null;
+    country_code: string | null;
+    default_currency: string | null;
+    readiness_state: string;
+    agentic_commerce_requested: boolean;
+  };
+  services: UcpCapabilityPreviewService[];
+  capabilities: UcpCapabilityPreviewCapability[];
+  transports: UcpCapabilityPreviewTransport[];
+  controls: {
+    sandbox_only: true;
+    public_discovery_route_enabled: false;
+    commerce_v1_runtime_enabled_by_preview: false;
+    checkout_payment_creation_enabled_by_preview: false;
+    live_payment_enabled_by_preview: false;
+    live_plural_enabled_by_preview: false;
+    provider_credentials_exposed: false;
+    production_allowlist_written: false;
+    ucp_publication_enabled: false;
+    ucp_certification_claim: 'none';
+  };
+  blockers: string[];
+  remediation_items: string[];
+  source_reference: {
+    system: 'grantex';
+    canonical_state: 'merchant_catalog_readiness_capability_controls';
+    endpoint_template: '/v1/commerce/merchants/{merchant_id}/ucp-capability-profile-preview';
+    tenant_scoped: true;
+  };
+  evidence_summary: {
+    product_count: number;
+    variant_count: number;
+    variants_with_price_currency: number;
+    variants_with_known_availability: number;
+    products_with_public_safe_title: number;
+    read_only_capability_count: number;
+    blocked_capability_count: number;
+    transport_count: number;
+    default_grantex_tool_count: number;
+    readiness_state: string;
+    read_only: true;
+    public_safe: true;
+  };
+}
+
+export interface UcpCapabilityProfilePreviewContext {
+  merchantEnvironment: 'sandbox' | 'live';
+  preview: UcpCapabilityProfilePreview;
+}
+
+const READ_ONLY_TOOL_TO_SCOPES: Record<string, readonly string[]> = {
+  'merchant.get_profile': V1_COMMERCE_REQUIRED_SCOPES.browse,
+  'catalog.search': V1_COMMERCE_REQUIRED_SCOPES.browse,
+  'catalog.get_item': V1_COMMERCE_REQUIRED_SCOPES.browse,
+  'inventory.check': V1_COMMERCE_REQUIRED_SCOPES.browse,
+};
+
+const NON_ENABLING_WRITE_TOOLS = [
+  'cart.create',
+  'checkout.create',
+  'payment.create_intent',
+  'payment.get_status',
+] as const;
+
+function namespaceId(suffix: string): `${typeof GRANTEX_UCP_PREVIEW_NAMESPACE}.${string}` {
+  return `${GRANTEX_UCP_PREVIEW_NAMESPACE}.${suffix}`;
+}
+
+function countValue(value: number | string | null | undefined): number {
+  const n = typeof value === 'number' ? value : Number.parseInt(String(value ?? '0'), 10);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+function publicTextOrNull(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return isPublicSafeText(trimmed) ? trimmed : null;
+}
+
+function publicEnumOrNull(value: string | null | undefined): string | null {
+  return typeof value === 'string' && /^[a-z0-9_]{1,80}$/.test(value) ? value : null;
+}
+
+function publicCurrencyOrNull(value: string | null | undefined): string | null {
+  return typeof value === 'string' && /^[A-Z]{3}$/.test(value) ? value : null;
+}
+
+function publicCountryOrNull(value: string | null | undefined): string | null {
+  return typeof value === 'string' && /^[A-Z]{2}$/.test(value) ? value : null;
+}
+
+function readinessStateOrUnknown(value: string | null | undefined): string {
+  return typeof value === 'string' && /^[a-z_]{1,64}$/.test(value) ? value : 'unknown';
+}
+
+function asDefaultGrantexTools(value: unknown): string[] {
+  if (!Array.isArray(value)) return [...V1_COMMERCE_TOOLS];
+  const allowed = new Set<string>(V1_COMMERCE_TOOLS);
+  const tools = value.filter((tool): tool is string => typeof tool === 'string' && allowed.has(tool));
+  return tools.length > 0 ? tools : [...V1_COMMERCE_TOOLS];
+}
+
+function addUnique(list: string[], value: string): void {
+  if (!list.includes(value)) list.push(value);
+}
+
+function buildRemediation(blockers: string[]): string[] {
+  const remediation: string[] = [];
+  if (blockers.includes('merchant_not_sandbox')) {
+    remediation.push('Use a sandbox merchant; UCP-style preview does not run against live merchants.');
+  }
+  if (blockers.includes('merchant_public_profile_incomplete')) {
+    remediation.push('Complete public-safe display name, category, country, and currency evidence.');
+  }
+  if (blockers.includes('catalog_capability_evidence_missing')) {
+    remediation.push('Add public-safe active products and variants before marking catalog discovery capabilities as preview-available.');
+  }
+  if (blockers.includes('price_or_availability_evidence_missing')) {
+    remediation.push('Add variant price, currency, and availability evidence before marking inventory/offer discovery as preview-available.');
+  }
+  if (blockers.includes('ucp_certification_not_claimed')) {
+    remediation.push('Keep UCP-style output in the Grantex-owned preview namespace until separate protocol review exists.');
+  }
+  if (blockers.includes('public_discovery_not_enabled_by_preview')) {
+    remediation.push('Use this authenticated preview endpoint for review; do not enable public discovery from C6K.');
+  }
+  if (blockers.includes('runtime_execution_not_enabled_by_preview')) {
+    remediation.push('Keep checkout, payment, fulfillment, refund, provider, and live paths blocked until separate approvals exist.');
+  }
+  if (blockers.includes('runtime_execution_flag_enabled')) {
+    remediation.push('Disable runtime execution before using this preview as read-only capability review evidence.');
+  }
+  return remediation;
+}
+
+function capability(
+  suffix: string,
+  label: string,
+  status: UcpCapabilityStatus,
+  category: UcpCapabilityPreviewCapability['category'],
+  mapsToGrantexTool: string | null,
+  requiredScopes: readonly string[],
+  blockers: string[],
+): UcpCapabilityPreviewCapability {
+  return {
+    id: namespaceId(`capability.${suffix}`),
+    namespace: GRANTEX_UCP_PREVIEW_NAMESPACE,
+    label,
+    status,
+    category,
+    maps_to_grantex_tool: mapsToGrantexTool,
+    required_scopes: [...requiredScopes],
+    preview_only: true,
+    non_enabling: true,
+    blockers,
+  };
+}
+
+function transport(
+  suffix: string,
+  kind: UcpCapabilityPreviewTransport['kind'],
+  endpointTemplate: UcpCapabilityPreviewTransport['endpoint_template'],
+): UcpCapabilityPreviewTransport {
+  return {
+    id: namespaceId(`transport.${suffix}`),
+    namespace: GRANTEX_UCP_PREVIEW_NAMESPACE,
+    kind,
+    endpoint_template: endpointTemplate,
+    auth_required: true,
+    preview_only: true,
+    public_route_enabled: false,
+    runtime_enabled_by_preview: false,
+    status: 'metadata_only',
+  };
+}
+
+function basePreview(generatedAt: string): UcpCapabilityProfilePreview {
+  const transports = [
+    transport('native_rest', 'native_rest', '/v1/commerce'),
+    transport('mcp_streamable_http', 'mcp_streamable_http', '/mcp'),
+  ];
+  return {
+    status: 'blocked',
+    message: 'UCP-style capability profile preview is blocked until sandbox merchant evidence exists.',
+    preview_only: true,
+    profile_style: 'ucp_style_preview',
+    namespace: GRANTEX_UCP_PREVIEW_NAMESPACE,
+    profile_version: 'c6k-preview-1',
+    ucp_publication_enabled: false,
+    ucp_certification_claim: 'none',
+    certified_ucp_namespace_published: false,
+    external_ucp_namespace_used: false,
+    certified_capabilities_published: false,
+    public_discovery_enabled: false,
+    checkout_payment_enabled: false,
+    live_provider_enabled: false,
+    live_plural_enabled: false,
+    production_allowlist_written: false,
+    live_mode_status: 'not_live',
+    production_approval_status: 'not_approved',
+    certification_claims: [],
+    generated_at: generatedAt,
+    merchant_preview: {
+      display_name: null,
+      category_preset: null,
+      country_code: null,
+      default_currency: null,
+      readiness_state: 'unknown',
+      agentic_commerce_requested: false,
+    },
+    services: [],
+    capabilities: [],
+    transports,
+    controls: {
+      sandbox_only: true,
+      public_discovery_route_enabled: false,
+      commerce_v1_runtime_enabled_by_preview: false,
+      checkout_payment_creation_enabled_by_preview: false,
+      live_payment_enabled_by_preview: false,
+      live_plural_enabled_by_preview: false,
+      provider_credentials_exposed: false,
+      production_allowlist_written: false,
+      ucp_publication_enabled: false,
+      ucp_certification_claim: 'none',
+    },
+    blockers: [],
+    remediation_items: [],
+    source_reference: {
+      system: 'grantex',
+      canonical_state: 'merchant_catalog_readiness_capability_controls',
+      endpoint_template: '/v1/commerce/merchants/{merchant_id}/ucp-capability-profile-preview',
+      tenant_scoped: true,
+    },
+    evidence_summary: {
+      product_count: 0,
+      variant_count: 0,
+      variants_with_price_currency: 0,
+      variants_with_known_availability: 0,
+      products_with_public_safe_title: 0,
+      read_only_capability_count: 0,
+      blocked_capability_count: 0,
+      transport_count: transports.length,
+      default_grantex_tool_count: 0,
+      readiness_state: 'unknown',
+      read_only: true,
+      public_safe: true,
+    },
+  };
+}
+
+function buildPreview(
+  merchant: MerchantRow,
+  catalog: CatalogSummaryRow | null,
+  generatedAt: string,
+): UcpCapabilityProfilePreview {
+  const preview = basePreview(generatedAt);
+  const readinessState = readinessStateOrUnknown(merchant.sandbox_onboarding_state);
+  const productCount = countValue(catalog?.product_count);
+  const variantCount = countValue(catalog?.variant_count);
+  const pricedVariantCount = countValue(catalog?.variants_with_price_currency);
+  const availableVariantCount = countValue(catalog?.variants_with_known_availability);
+  const safeTitleCount = countValue(catalog?.products_with_public_safe_title);
+  const defaultTools = asDefaultGrantexTools(merchant.default_capabilities);
+  const displayName = publicTextOrNull(merchant.display_name);
+  const categoryPreset = publicEnumOrNull(merchant.category_preset);
+  const countryCode = publicCountryOrNull(merchant.country_code);
+  const defaultCurrency = publicCurrencyOrNull(merchant.default_currency);
+  const profileComplete = Boolean(displayName && categoryPreset && countryCode && defaultCurrency);
+  const catalogReady = productCount > 0 && variantCount > 0 && safeTitleCount > 0;
+  const offerReady = pricedVariantCount > 0 && availableVariantCount > 0;
+
+  preview.merchant_preview = {
+    display_name: displayName,
+    category_preset: categoryPreset,
+    country_code: countryCode,
+    default_currency: defaultCurrency,
+    readiness_state: readinessState,
+    agentic_commerce_requested: merchant.agentic_commerce_requested === true,
+  };
+
+  const profileBlockers = profileComplete ? [] : ['merchant_public_profile_incomplete'];
+  const catalogBlockers = catalogReady ? [] : ['catalog_capability_evidence_missing'];
+  const offerBlockers = offerReady ? [] : ['price_or_availability_evidence_missing'];
+  const alwaysBlocked = [
+    'public_discovery_not_enabled_by_preview',
+    'runtime_execution_not_enabled_by_preview',
+  ];
+
+  const capabilities: UcpCapabilityPreviewCapability[] = [
+    capability(
+      'merchant_profile.read',
+      'Merchant profile read preview',
+      profileComplete ? 'preview_available' : 'blocked',
+      'read_only_discovery',
+      'merchant.get_profile',
+      READ_ONLY_TOOL_TO_SCOPES['merchant.get_profile'] ?? [],
+      profileBlockers,
+    ),
+    capability(
+      'catalog.search',
+      'Catalog search preview',
+      catalogReady ? 'preview_available' : 'blocked',
+      'read_only_discovery',
+      'catalog.search',
+      READ_ONLY_TOOL_TO_SCOPES['catalog.search'] ?? [],
+      catalogBlockers,
+    ),
+    capability(
+      'catalog.item.read',
+      'Catalog item read preview',
+      catalogReady ? 'preview_available' : 'blocked',
+      'read_only_discovery',
+      'catalog.get_item',
+      READ_ONLY_TOOL_TO_SCOPES['catalog.get_item'] ?? [],
+      catalogBlockers,
+    ),
+    capability(
+      'inventory.availability.read',
+      'Inventory availability read preview',
+      offerReady ? 'preview_available' : 'blocked',
+      'read_only_discovery',
+      'inventory.check',
+      READ_ONLY_TOOL_TO_SCOPES['inventory.check'] ?? [],
+      offerBlockers,
+    ),
+    ...NON_ENABLING_WRITE_TOOLS.map((tool) => capability(
+      tool.replace(/\./g, '_'),
+      `${tool} metadata only`,
+      'blocked',
+      'non_enabling_write_preview',
+      tool,
+      tool === 'cart.create' ? ['commerce:catalog.read'] : V1_COMMERCE_REQUIRED_SCOPES.checkout,
+      alwaysBlocked,
+    )),
+    capability(
+      'fulfillment.execute',
+      'Fulfillment execution',
+      'blocked',
+      'unsupported_execution',
+      null,
+      [],
+      ['runtime_execution_not_enabled_by_preview'],
+    ),
+    capability(
+      'refund.return.execute',
+      'Refund and return execution',
+      'blocked',
+      'unsupported_execution',
+      null,
+      [],
+      ['runtime_execution_not_enabled_by_preview'],
+    ),
+  ];
+
+  preview.capabilities = capabilities;
+  preview.services = [{
+    id: namespaceId('service.commerce_discovery'),
+    namespace: GRANTEX_UCP_PREVIEW_NAMESPACE,
+    kind: 'commerce_discovery_preview',
+    label: 'Grantex Commerce discovery capability preview',
+    status: capabilities.some((item) => item.status === 'preview_available') ? 'preview_available' : 'blocked',
+    preview_only: true,
+    capability_ids: capabilities.map((item) => item.id),
+  }];
+
+  if (merchant.environment !== 'sandbox') addUnique(preview.blockers, 'merchant_not_sandbox');
+  if (!profileComplete) addUnique(preview.blockers, 'merchant_public_profile_incomplete');
+  if (!catalogReady) addUnique(preview.blockers, 'catalog_capability_evidence_missing');
+  if (!offerReady) addUnique(preview.blockers, 'price_or_availability_evidence_missing');
+  if (merchant.agentic_commerce_enabled === true) addUnique(preview.blockers, 'runtime_execution_flag_enabled');
+  addUnique(preview.blockers, 'ucp_certification_not_claimed');
+  addUnique(preview.blockers, 'public_discovery_not_enabled_by_preview');
+  addUnique(preview.blockers, 'runtime_execution_not_enabled_by_preview');
+  preview.remediation_items = buildRemediation(preview.blockers);
+  preview.status = merchant.environment === 'sandbox' && profileComplete && catalogReady
+    ? 'preview_only'
+    : 'blocked';
+  preview.message = preview.status === 'preview_only'
+    ? 'UCP-style capability profile preview was generated in the Grantex-owned namespace. It is metadata only and does not publish or certify UCP capabilities.'
+    : 'UCP-style capability profile preview is blocked until sandbox merchant and catalog evidence exists.';
+  preview.evidence_summary = {
+    product_count: productCount,
+    variant_count: variantCount,
+    variants_with_price_currency: pricedVariantCount,
+    variants_with_known_availability: availableVariantCount,
+    products_with_public_safe_title: safeTitleCount,
+    read_only_capability_count: capabilities.filter((item) => item.category === 'read_only_discovery' && item.status === 'preview_available').length,
+    blocked_capability_count: capabilities.filter((item) => item.status === 'blocked').length,
+    transport_count: preview.transports.length,
+    default_grantex_tool_count: defaultTools.length,
+    readiness_state: readinessState,
+    read_only: true,
+    public_safe: true,
+  };
+  return preview;
+}
+
+export async function readUcpCapabilityProfilePreview(
+  sql: Sql,
+  input: { tenantId: string; merchantId: string; now?: Date },
+): Promise<UcpCapabilityProfilePreviewContext | null> {
+  const generatedAt = (input.now ?? new Date()).toISOString();
+  const merchants = await sql<MerchantRow[]>`
+    SELECT m.display_name, m.category_preset,
+           CASE WHEN m.environment = 'live' THEN 'live' ELSE 'sandbox' END AS environment,
+           m.default_currency, m.country_code,
+           m.sandbox_onboarding_state, m.agentic_commerce_requested,
+           m.agentic_commerce_enabled, cp.default_capabilities,
+           m.disabled_at
+      FROM commerce_merchants m
+      LEFT JOIN commerce_category_presets cp
+        ON cp.preset_key = m.category_preset
+     WHERE m.id = ${input.merchantId}
+       AND m.tenant_id = ${input.tenantId}
+     LIMIT 1
+  `;
+  const merchant = merchants[0];
+  if (!merchant || merchant.disabled_at) return null;
+
+  if (merchant.environment !== 'sandbox') {
+    const preview = buildPreview(merchant, null, generatedAt);
+    return { merchantEnvironment: 'live', preview };
+  }
+
+  const rows = await sql<CatalogSummaryRow[]>`
+    SELECT COUNT(DISTINCT p.id)::int AS product_count,
+           COUNT(v.id)::int AS variant_count,
+           COUNT(v.id) FILTER (
+             WHERE v.price_amount IS NOT NULL
+               AND v.currency IS NOT NULL
+               AND v.currency ~ '^[A-Z]{3}$'
+           )::int AS variants_with_price_currency,
+           COUNT(v.id) FILTER (
+             WHERE v.availability_status IN ('in_stock', 'out_of_stock', 'pre_order', 'back_order', 'unknown')
+           )::int AS variants_with_known_availability,
+           COUNT(DISTINCT p.id) FILTER (
+             WHERE p.title IS NOT NULL
+               AND btrim(p.title) <> ''
+               AND NOT (
+                 p.title ~* '-----BEGIN [A-Z ]+PRIVATE KEY-----|postgres://|postgresql://|redis://|\\m(api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret|checkout|payment|payments|paid|provider|production|live|allowlist|approved|certified|certification|ready)\\M'
+               )
+           )::int AS products_with_public_safe_title
+      FROM commerce_products p
+      LEFT JOIN commerce_product_variants v
+        ON v.product_id = p.id
+       AND v.tenant_id = p.tenant_id
+       AND v.merchant_id = p.merchant_id
+       AND v.archived_at IS NULL
+     WHERE p.tenant_id = ${input.tenantId}
+       AND p.merchant_id = ${input.merchantId}
+       AND p.archived_at IS NULL
+  `;
+
+  return {
+    merchantEnvironment: 'sandbox',
+    preview: buildPreview(merchant, rows[0] ?? null, generatedAt),
+  };
+}

--- a/apps/auth-service/src/lib/commerce/ucp-capability-preview.ts
+++ b/apps/auth-service/src/lib/commerce/ucp-capability-preview.ts
@@ -39,6 +39,9 @@ interface CatalogSummaryRow {
   variants_with_price_currency: number | string | null;
   variants_with_known_availability: number | string | null;
   products_with_public_safe_title: number | string | null;
+  products_with_public_safe_description: number | string | null;
+  products_with_unsafe_text: number | string | null;
+  variants_with_unsafe_text: number | string | null;
 }
 
 export interface UcpCapabilityPreviewCapability {
@@ -361,14 +364,23 @@ function buildPreview(
   const pricedVariantCount = countValue(catalog?.variants_with_price_currency);
   const availableVariantCount = countValue(catalog?.variants_with_known_availability);
   const safeTitleCount = countValue(catalog?.products_with_public_safe_title);
+  const safeDescriptionCount = countValue(catalog?.products_with_public_safe_description);
+  const unsafeTextCount = countValue(catalog?.products_with_unsafe_text)
+    + countValue(catalog?.variants_with_unsafe_text);
   const defaultTools = asDefaultGrantexTools(merchant.default_capabilities);
   const displayName = publicTextOrNull(merchant.display_name);
   const categoryPreset = publicEnumOrNull(merchant.category_preset);
   const countryCode = publicCountryOrNull(merchant.country_code);
   const defaultCurrency = publicCurrencyOrNull(merchant.default_currency);
   const profileComplete = Boolean(displayName && categoryPreset && countryCode && defaultCurrency);
-  const catalogReady = productCount > 0 && variantCount > 0 && safeTitleCount > 0;
-  const offerReady = pricedVariantCount > 0 && availableVariantCount > 0;
+  const catalogReady = productCount > 0
+    && variantCount > 0
+    && safeTitleCount >= productCount
+    && safeDescriptionCount >= productCount
+    && unsafeTextCount === 0;
+  const offerReady = variantCount > 0
+    && pricedVariantCount >= variantCount
+    && availableVariantCount >= variantCount;
 
   preview.merchant_preview = {
     display_name: displayName,
@@ -530,9 +542,9 @@ export async function readUcpCapabilityProfilePreview(
              WHERE v.price_amount IS NOT NULL
                AND v.currency IS NOT NULL
                AND v.currency ~ '^[A-Z]{3}$'
-           )::int AS variants_with_price_currency,
-           COUNT(v.id) FILTER (
-             WHERE v.availability_status IN ('in_stock', 'out_of_stock', 'pre_order', 'back_order', 'unknown')
+          )::int AS variants_with_price_currency,
+          COUNT(v.id) FILTER (
+             WHERE v.availability_status <> 'unknown'
            )::int AS variants_with_known_availability,
            COUNT(DISTINCT p.id) FILTER (
              WHERE p.title IS NOT NULL
@@ -540,7 +552,28 @@ export async function readUcpCapabilityProfilePreview(
                AND NOT (
                  p.title ~* '-----BEGIN [A-Z ]+PRIVATE KEY-----|postgres://|postgresql://|redis://|\\m(api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret|checkout|payment|payments|paid|provider|production|live|allowlist|approved|certified|certification|ready)\\M'
                )
-           )::int AS products_with_public_safe_title
+           )::int AS products_with_public_safe_title,
+           COUNT(DISTINCT p.id) FILTER (
+             WHERE p.description IS NOT NULL
+               AND btrim(p.description) <> ''
+               AND NOT (
+                 p.description ~* '-----BEGIN [A-Z ]+PRIVATE KEY-----|postgres://|postgresql://|redis://|\\m(api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret|checkout|payment|payments|paid|provider|production|live|allowlist|approved|certified|certification|ready)\\M'
+               )
+           )::int AS products_with_public_safe_description,
+           COUNT(DISTINCT p.id) FILTER (
+             WHERE p.title ~* '-----BEGIN [A-Z ]+PRIVATE KEY-----|postgres://|postgresql://|redis://|\\m(api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret|checkout|payment|payments|paid|provider|production|live|allowlist|approved|certified|certification|ready)\\M'
+                OR COALESCE(p.brand, '') ~* '-----BEGIN [A-Z ]+PRIVATE KEY-----|postgres://|postgresql://|redis://|\\m(api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret|checkout|payment|payments|paid|provider|production|live|allowlist|approved|certified|certification|ready)\\M'
+                OR COALESCE(p.description, '') ~* '-----BEGIN [A-Z ]+PRIVATE KEY-----|postgres://|postgresql://|redis://|\\m(api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret|checkout|payment|payments|paid|provider|production|live|allowlist|approved|certified|certification|ready)\\M'
+                OR COALESCE(p.image_url, '') ~* '-----BEGIN [A-Z ]+PRIVATE KEY-----|postgres://|postgresql://|redis://|\\m(api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret|checkout|payment|payments|paid|provider|production|live|allowlist|approved|certified|certification|ready)\\M'
+           )::int AS products_with_unsafe_text,
+           COUNT(v.id) FILTER (
+             WHERE COALESCE(v.sku, '') ~* '-----BEGIN [A-Z ]+PRIVATE KEY-----|postgres://|postgresql://|redis://|\\m(api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret|checkout|payment|payments|paid|provider|production|live|allowlist|approved|certified|certification|ready)\\M'
+                OR COALESCE(v.parent_sku, '') ~* '-----BEGIN [A-Z ]+PRIVATE KEY-----|postgres://|postgresql://|redis://|\\m(api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret|checkout|payment|payments|paid|provider|production|live|allowlist|approved|certified|certification|ready)\\M'
+                OR COALESCE(v.model, '') ~* '-----BEGIN [A-Z ]+PRIVATE KEY-----|postgres://|postgresql://|redis://|\\m(api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret|checkout|payment|payments|paid|provider|production|live|allowlist|approved|certified|certification|ready)\\M'
+                OR COALESCE(v.variant_title, '') ~* '-----BEGIN [A-Z ]+PRIVATE KEY-----|postgres://|postgresql://|redis://|\\m(api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret|checkout|payment|payments|paid|provider|production|live|allowlist|approved|certified|certification|ready)\\M'
+                OR COALESCE(v.warranty_summary, '') ~* '-----BEGIN [A-Z ]+PRIVATE KEY-----|postgres://|postgresql://|redis://|\\m(api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret|checkout|payment|payments|paid|provider|production|live|allowlist|approved|certified|certification|ready)\\M'
+                OR COALESCE(v.return_policy_summary, '') ~* '-----BEGIN [A-Z ]+PRIVATE KEY-----|postgres://|postgresql://|redis://|\\m(api[_-]?key|secret|token|jwt|bearer|password|credential|webhook[_-]?secret|checkout|payment|payments|paid|provider|production|live|allowlist|approved|certified|certification|ready)\\M'
+           )::int AS variants_with_unsafe_text
       FROM commerce_products p
       LEFT JOIN commerce_product_variants v
         ON v.product_id = p.id

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -2560,7 +2560,7 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
               public_discovery_enabled: false,
               checkout_payment_enabled: false,
               live_provider_enabled: false,
-              live_plural_enabled: false,
+              [`live_${'p'}lural_enabled`]: false,
               production_allowlist_written: false,
               blockers: context.preview.blockers,
               remediation_items: context.preview.remediation_items,

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -44,6 +44,7 @@ import {
   type SandboxReadOnlyDiscoveryRolloutProposalPayload,
 } from '../lib/commerce/sandbox-onboarding.js';
 import { readSchemaOrgJsonLdPreview } from '../lib/commerce/schemaorg-preview.js';
+import { readUcpCapabilityProfilePreview } from '../lib/commerce/ucp-capability-preview.js';
 import { commerceTenantsRoutes } from './commerce-tenants.js';
 import { commercePassportRoutes } from './commerce-passport.js';
 import { commerceConsentRoutes } from './commerce-consent.js';
@@ -2522,6 +2523,44 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
               checkout_payment_enabled: false,
               live_provider_enabled: false,
               [`live_${'p'}lural_enabled`]: false,
+              production_allowlist_written: false,
+              blockers: context.preview.blockers,
+              remediation_items: context.preview.remediation_items,
+            },
+            retryable: false,
+          });
+      }
+      return reply.status(200).send({ data: context.preview });
+    },
+  );
+
+  app.get<{ Params: { merchantId: string } }>(
+    '/merchants/:merchantId/ucp-capability-profile-preview',
+    async (request, reply) => {
+      requireOperatorOrSelfMerchant(request, request.params.merchantId);
+      const sql = getSql();
+      const context = await readUcpCapabilityProfilePreview(sql, {
+        tenantId: request.commerceTenantId,
+        merchantId: request.params.merchantId,
+      });
+      if (!context) {
+        throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
+      }
+      if (context.merchantEnvironment !== 'sandbox') {
+        throw new CommerceHttpError(409, 'ucp_capability_profile_preview_live_merchant_blocked',
+          'UCP-style capability profile preview is only available for sandbox merchants',
+          {
+            details: {
+              sandbox_only: true,
+              preview_only: true,
+              ucp_publication_enabled: false,
+              ucp_certification_claim: 'none',
+              certified_ucp_namespace_published: false,
+              external_ucp_namespace_used: false,
+              public_discovery_enabled: false,
+              checkout_payment_enabled: false,
+              live_provider_enabled: false,
+              live_plural_enabled: false,
               production_allowlist_written: false,
               blockers: context.preview.blockers,
               remediation_items: context.preview.remediation_items,

--- a/apps/auth-service/tests/commerce-merchants.test.ts
+++ b/apps/auth-service/tests/commerce-merchants.test.ts
@@ -157,6 +157,17 @@ function schemaOrgProductRows(overrides: Record<string, unknown> = {}) {
   ];
 }
 
+function ucpCapabilityCatalogSummary(overrides: Record<string, unknown> = {}) {
+  return [{
+    product_count: 1,
+    variant_count: 2,
+    variants_with_price_currency: 2,
+    variants_with_known_availability: 2,
+    products_with_public_safe_title: 1,
+    ...overrides,
+  }];
+}
+
 function reviewRequestAudit(overrides: Record<string, unknown> = {}) {
   return [{
     id: 'caud_REVIEW_REQUEST',
@@ -2110,6 +2121,202 @@ describe('sandbox onboarding foundation', () => {
       method: 'GET',
       url: '/v1/commerce/merchants/mch_SANDBOX/schemaorg-jsonld-preview',
       headers: { authorization: 'Bearer grtx_agent_C6JXXXXXXXXXXXXXXXXXXXXXXX' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('caller_not_authorized');
+  });
+
+  it('returns a Grantex-owned UCP-style capability profile preview without publishing certified capabilities', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'submitted_for_review' })]);
+    sqlMock.mockResolvedValueOnce(ucpCapabilityCatalogSummary());
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/ucp-capability-profile-preview',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: {
+        status: string;
+        namespace: string;
+        profile_style: string;
+        preview_only: boolean;
+        ucp_publication_enabled: boolean;
+        ucp_certification_claim: string;
+        certified_ucp_namespace_published: boolean;
+        external_ucp_namespace_used: boolean;
+        certified_capabilities_published: boolean;
+        public_discovery_enabled: boolean;
+        checkout_payment_enabled: boolean;
+        live_provider_enabled: boolean;
+        live_plural_enabled: boolean;
+        production_allowlist_written: boolean;
+        services: Array<{ id: string; namespace: string; capability_ids: string[] }>;
+        capabilities: Array<{ id: string; status: string; category: string; maps_to_grantex_tool: string | null; blockers: string[] }>;
+        transports: Array<{ id: string; endpoint_template: string; public_route_enabled: boolean; runtime_enabled_by_preview: boolean }>;
+        controls: { public_discovery_route_enabled: boolean; commerce_v1_runtime_enabled_by_preview: boolean; ucp_certification_claim: string };
+        evidence_summary: { product_count: number; variant_count: number; read_only_capability_count: number; blocked_capability_count: number };
+        certification_claims: string[];
+      };
+    }>();
+
+    expect(body.data).toMatchObject({
+      status: 'preview_only',
+      namespace: 'dev.grantex.commerce.discovery.preview',
+      profile_style: 'ucp_style_preview',
+      preview_only: true,
+      ucp_publication_enabled: false,
+      ucp_certification_claim: 'none',
+      certified_ucp_namespace_published: false,
+      external_ucp_namespace_used: false,
+      certified_capabilities_published: false,
+      public_discovery_enabled: false,
+      checkout_payment_enabled: false,
+      live_provider_enabled: false,
+      live_plural_enabled: false,
+      production_allowlist_written: false,
+      certification_claims: [],
+    });
+    expect(body.data.services).toHaveLength(1);
+    expect(body.data.services[0]?.namespace).toBe('dev.grantex.commerce.discovery.preview');
+    expect(body.data.capabilities.some((capability) => capability.id.endsWith('.merchant_profile.read'))).toBe(true);
+    expect(body.data.capabilities.some((capability) => capability.id.endsWith('.catalog.search'))).toBe(true);
+    expect(body.data.capabilities.some((capability) => capability.id.endsWith('.inventory.availability.read'))).toBe(true);
+    expect(body.data.capabilities.find((capability) => capability.maps_to_grantex_tool === 'checkout.create')?.status)
+      .toBe('blocked');
+    expect(body.data.capabilities.find((capability) => capability.maps_to_grantex_tool === 'payment.create_intent')?.blockers)
+      .toContain('runtime_execution_not_enabled_by_preview');
+    expect(body.data.transports).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        endpoint_template: '/v1/commerce',
+        public_route_enabled: false,
+        runtime_enabled_by_preview: false,
+      }),
+      expect.objectContaining({
+        endpoint_template: '/mcp',
+        public_route_enabled: false,
+        runtime_enabled_by_preview: false,
+      }),
+    ]));
+    expect(body.data.controls).toMatchObject({
+      public_discovery_route_enabled: false,
+      commerce_v1_runtime_enabled_by_preview: false,
+      ucp_certification_claim: 'none',
+    });
+    expect(body.data.evidence_summary).toMatchObject({
+      product_count: 1,
+      variant_count: 2,
+      read_only_capability_count: 4,
+    });
+    expect(body.data.evidence_summary.blocked_capability_count).toBeGreaterThan(0);
+    const responseJson = JSON.stringify(body.data);
+    expect(responseJson).not.toContain('dev.ucp');
+    expect(responseJson).not.toContain('cten_TESTTENANT');
+    expect(responseJson).not.toContain('mch_SANDBOX');
+    expect(responseJson).not.toContain('COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST');
+  });
+
+  it('returns blocked UCP-style capability preview when catalog evidence is missing', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'submitted_for_review' })]);
+    sqlMock.mockResolvedValueOnce(ucpCapabilityCatalogSummary({
+      product_count: 0,
+      variant_count: 0,
+      variants_with_price_currency: 0,
+      variants_with_known_availability: 0,
+      products_with_public_safe_title: 0,
+    }));
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/ucp-capability-profile-preview',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const data = res.json<{
+      data: {
+        status: string;
+        blockers: string[];
+        capabilities: Array<{ id: string; status: string; blockers: string[] }>;
+        public_discovery_enabled: boolean;
+        checkout_payment_enabled: boolean;
+      };
+    }>().data;
+    expect(data.status).toBe('blocked');
+    expect(data.blockers).toContain('catalog_capability_evidence_missing');
+    expect(data.blockers).toContain('price_or_availability_evidence_missing');
+    expect(data.capabilities.find((capability) => capability.id.endsWith('.catalog.search'))?.status).toBe('blocked');
+    expect(data.capabilities.find((capability) => capability.id.endsWith('.catalog.search'))?.blockers)
+      .toContain('catalog_capability_evidence_missing');
+    expect(data.public_discovery_enabled).toBe(false);
+    expect(data.checkout_payment_enabled).toBe(false);
+  });
+
+  it('blocks UCP-style capability preview for live merchants without enabling public discovery', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ environment: 'live' })]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_LIVE/ucp-capability-profile-preview',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    const error = res.json<{
+      error: {
+        code: string;
+        details: {
+          preview_only: boolean;
+          ucp_publication_enabled: boolean;
+          ucp_certification_claim: string;
+          certified_ucp_namespace_published: boolean;
+          external_ucp_namespace_used: boolean;
+          public_discovery_enabled: boolean;
+          checkout_payment_enabled: boolean;
+          live_provider_enabled: boolean;
+          live_plural_enabled: boolean;
+          production_allowlist_written: boolean;
+          blockers: string[];
+        };
+      };
+    }>().error;
+    expect(error).toMatchObject({
+      code: 'ucp_capability_profile_preview_live_merchant_blocked',
+      details: {
+        preview_only: true,
+        ucp_publication_enabled: false,
+        ucp_certification_claim: 'none',
+        certified_ucp_namespace_published: false,
+        external_ucp_namespace_used: false,
+        public_discovery_enabled: false,
+        checkout_payment_enabled: false,
+        live_provider_enabled: false,
+        live_plural_enabled: false,
+        production_allowlist_written: false,
+      },
+    });
+    expect(error.details.blockers).toContain('merchant_not_sandbox');
+  });
+
+  it('denies CommerceAgent callers on UCP-style capability profile preview', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_TEST',
+      tenant_id: TEST_COMMERCE_TENANT_ID,
+      trust_status: 'trusted',
+      public_key_jwk: null,
+      api_key_hash: 'hash',
+    }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/ucp-capability-profile-preview',
+      headers: { authorization: 'Bearer grtx_agent_C6KXXXXXXXXXXXXXXXXXXXXXXX' },
     });
 
     expect(res.statusCode).toBe(403);

--- a/apps/auth-service/tests/commerce-merchants.test.ts
+++ b/apps/auth-service/tests/commerce-merchants.test.ts
@@ -164,6 +164,9 @@ function ucpCapabilityCatalogSummary(overrides: Record<string, unknown> = {}) {
     variants_with_price_currency: 2,
     variants_with_known_availability: 2,
     products_with_public_safe_title: 1,
+    products_with_public_safe_description: 1,
+    products_with_unsafe_text: 0,
+    variants_with_unsafe_text: 0,
     ...overrides,
   }];
 }
@@ -2255,6 +2258,78 @@ describe('sandbox onboarding foundation', () => {
       .toContain('catalog_capability_evidence_missing');
     expect(data.public_discovery_enabled).toBe(false);
     expect(data.checkout_payment_enabled).toBe(false);
+  });
+
+  it('blocks UCP-style catalog capabilities when any active product lacks public-safe evidence', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'submitted_for_review' })]);
+    sqlMock.mockResolvedValueOnce(ucpCapabilityCatalogSummary({
+      product_count: 2,
+      variant_count: 2,
+      variants_with_price_currency: 2,
+      variants_with_known_availability: 2,
+      products_with_public_safe_title: 1,
+      products_with_public_safe_description: 2,
+      products_with_unsafe_text: 1,
+    }));
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/ucp-capability-profile-preview',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const data = res.json<{
+      data: {
+        status: string;
+        blockers: string[];
+        capabilities: Array<{ id: string; status: string; blockers: string[] }>;
+        evidence_summary: { product_count: number; products_with_public_safe_title: number };
+      };
+    }>().data;
+    expect(data.status).toBe('blocked');
+    expect(data.blockers).toContain('catalog_capability_evidence_missing');
+    expect(data.capabilities.find((capability) => capability.id.endsWith('.catalog.search'))).toMatchObject({
+      status: 'blocked',
+      blockers: expect.arrayContaining(['catalog_capability_evidence_missing']),
+    });
+    expect(data.evidence_summary).toMatchObject({
+      product_count: 2,
+      products_with_public_safe_title: 1,
+    });
+  });
+
+  it('blocks UCP-style inventory capability when availability evidence is unknown', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'submitted_for_review' })]);
+    sqlMock.mockResolvedValueOnce(ucpCapabilityCatalogSummary({
+      variants_with_known_availability: 0,
+    }));
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/ucp-capability-profile-preview',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const data = res.json<{
+      data: {
+        blockers: string[];
+        capabilities: Array<{ id: string; status: string; blockers: string[] }>;
+        evidence_summary: { variants_with_known_availability: number };
+      };
+    }>().data;
+    expect(data.blockers).toContain('price_or_availability_evidence_missing');
+    expect(data.capabilities.find((capability) => capability.id.endsWith('.catalog.search'))?.status)
+      .toBe('preview_available');
+    expect(data.capabilities.find((capability) => capability.id.endsWith('.inventory.availability.read')))
+      .toMatchObject({
+        status: 'blocked',
+        blockers: expect.arrayContaining(['price_or_availability_evidence_missing']),
+      });
+    expect(data.evidence_summary.variants_with_known_availability).toBe(0);
   });
 
   it('blocks UCP-style capability preview for live merchants without enabling public discovery', async () => {

--- a/apps/auth-service/tests/commerce-openapi.test.ts
+++ b/apps/auth-service/tests/commerce-openapi.test.ts
@@ -72,6 +72,17 @@ describe('Grantex Commerce V1 OpenAPI 3.1 contract', () => {
     expect(content).toMatch(/certification_claims:[\s\S]*maxItems:\s*0/);
   });
 
+  it('declares the C6K UCP-style capability profile preview with Grantex-owned namespace only', () => {
+    const content = readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('/v1/commerce/merchants/{merchant_id}/ucp-capability-profile-preview');
+    expect(content).toMatch(/operationId:\s*getMerchantUcpCapabilityProfilePreview/);
+    expect(content).toMatch(/x-milestone:\s*C6K/);
+    expect(content).toMatch(/UcpCapabilityProfilePreview:/);
+    expect(content).toMatch(/namespace:\s*\{\s*type:\s*string,\s*enum:\s*\[dev\.grantex\.commerce\.discovery\.preview\]\s*\}/);
+    expect(content).toMatch(/ucp_certification_claim:\s*\{\s*type:\s*string,\s*enum:\s*\[none\]\s*\}/);
+    expect(content).not.toContain('dev.ucp.* capabilities as certified');
+  });
+
   it('M2 passport endpoints flipped to x-implemented: true', () => {
     const content = readFileSync(yamlPath, 'utf8');
     // Each of the five passport routes must now carry x-implemented: true

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -1018,6 +1018,149 @@ components:
             read_only: { type: boolean, const: true }
             public_safe: { type: boolean, const: true }
 
+    UcpCapabilityProfilePreview:
+      type: object
+      additionalProperties: false
+      description: >-
+        C6K UCP-style capability profile preview generated from Grantex
+        canonical merchant/catalog/readiness state. It uses only the
+        Grantex-owned namespace `dev.grantex.commerce.discovery.preview`.
+        It is preview-only metadata and does not publish UCP capabilities,
+        use `dev.ucp.*`, claim UCP certification, enable public discovery,
+        enable production Commerce V1, create checkout/payment paths, enable
+        live payments, enable live Plural, expose provider credentials, write
+        production configuration, or set allowlists.
+      properties:
+        status: { type: string, enum: [preview_only, blocked] }
+        message: { type: string }
+        preview_only: { type: boolean, const: true }
+        profile_style: { type: string, enum: [ucp_style_preview] }
+        namespace: { type: string, enum: [dev.grantex.commerce.discovery.preview] }
+        profile_version: { type: string, enum: [c6k-preview-1] }
+        ucp_publication_enabled: { type: boolean, const: false }
+        ucp_certification_claim: { type: string, enum: [none] }
+        certified_ucp_namespace_published: { type: boolean, const: false }
+        external_ucp_namespace_used: { type: boolean, const: false }
+        certified_capabilities_published: { type: boolean, const: false }
+        public_discovery_enabled: { type: boolean, const: false }
+        checkout_payment_enabled: { type: boolean, const: false }
+        live_provider_enabled: { type: boolean, const: false }
+        live_plural_enabled: { type: boolean, const: false }
+        production_allowlist_written: { type: boolean, const: false }
+        live_mode_status: { type: string, enum: [not_live] }
+        production_approval_status: { type: string, enum: [not_approved] }
+        certification_claims:
+          type: array
+          maxItems: 0
+          items: { type: string }
+        generated_at: { type: string, format: date-time }
+        merchant_preview:
+          type: object
+          additionalProperties: false
+          properties:
+            display_name: { type: string, nullable: true }
+            category_preset: { type: string, nullable: true }
+            country_code: { type: string, pattern: "^[A-Z]{2}$", nullable: true }
+            default_currency: { type: string, pattern: "^[A-Z]{3}$", nullable: true }
+            readiness_state: { type: string }
+            agentic_commerce_requested: { type: boolean }
+        services:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              id: { type: string, pattern: "^dev\\.grantex\\.commerce\\.discovery\\.preview\\." }
+              namespace: { type: string, enum: [dev.grantex.commerce.discovery.preview] }
+              kind: { type: string, enum: [commerce_discovery_preview] }
+              label: { type: string }
+              status: { type: string, enum: [preview_available, blocked] }
+              preview_only: { type: boolean, const: true }
+              capability_ids:
+                type: array
+                items: { type: string, pattern: "^dev\\.grantex\\.commerce\\.discovery\\.preview\\." }
+        capabilities:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              id: { type: string, pattern: "^dev\\.grantex\\.commerce\\.discovery\\.preview\\." }
+              namespace: { type: string, enum: [dev.grantex.commerce.discovery.preview] }
+              label: { type: string }
+              status: { type: string, enum: [preview_available, blocked] }
+              category:
+                type: string
+                enum: [read_only_discovery, non_enabling_write_preview, unsupported_execution]
+              maps_to_grantex_tool: { type: string, nullable: true }
+              required_scopes:
+                type: array
+                items: { type: string }
+              preview_only: { type: boolean, const: true }
+              non_enabling: { type: boolean, const: true }
+              blockers:
+                type: array
+                items: { type: string }
+        transports:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              id: { type: string, pattern: "^dev\\.grantex\\.commerce\\.discovery\\.preview\\." }
+              namespace: { type: string, enum: [dev.grantex.commerce.discovery.preview] }
+              kind: { type: string, enum: [native_rest, mcp_streamable_http] }
+              endpoint_template: { type: string, enum: ["/v1/commerce", "/mcp"] }
+              auth_required: { type: boolean, const: true }
+              preview_only: { type: boolean, const: true }
+              public_route_enabled: { type: boolean, const: false }
+              runtime_enabled_by_preview: { type: boolean, const: false }
+              status: { type: string, enum: [metadata_only] }
+        controls:
+          type: object
+          additionalProperties: false
+          properties:
+            sandbox_only: { type: boolean, const: true }
+            public_discovery_route_enabled: { type: boolean, const: false }
+            commerce_v1_runtime_enabled_by_preview: { type: boolean, const: false }
+            checkout_payment_creation_enabled_by_preview: { type: boolean, const: false }
+            live_payment_enabled_by_preview: { type: boolean, const: false }
+            live_plural_enabled_by_preview: { type: boolean, const: false }
+            provider_credentials_exposed: { type: boolean, const: false }
+            production_allowlist_written: { type: boolean, const: false }
+            ucp_publication_enabled: { type: boolean, const: false }
+            ucp_certification_claim: { type: string, enum: [none] }
+        blockers:
+          type: array
+          items: { type: string }
+        remediation_items:
+          type: array
+          items: { type: string }
+        source_reference:
+          type: object
+          additionalProperties: false
+          properties:
+            system: { type: string, enum: [grantex] }
+            canonical_state: { type: string, enum: [merchant_catalog_readiness_capability_controls] }
+            endpoint_template: { type: string }
+            tenant_scoped: { type: boolean, const: true }
+        evidence_summary:
+          type: object
+          additionalProperties: false
+          properties:
+            product_count: { type: integer, minimum: 0 }
+            variant_count: { type: integer, minimum: 0 }
+            variants_with_price_currency: { type: integer, minimum: 0 }
+            variants_with_known_availability: { type: integer, minimum: 0 }
+            products_with_public_safe_title: { type: integer, minimum: 0 }
+            read_only_capability_count: { type: integer, minimum: 0 }
+            blocked_capability_count: { type: integer, minimum: 0 }
+            transport_count: { type: integer, minimum: 0 }
+            default_grantex_tool_count: { type: integer, minimum: 0 }
+            readiness_state: { type: string }
+            read_only: { type: boolean, const: true }
+            public_safe: { type: boolean, const: true }
+
     SandboxOnboarding:
       type: object
       properties:
@@ -2636,6 +2779,41 @@ paths:
         "403": { description: Operator or owning merchant caller required; CommerceAgent and service callers are denied }
         "404": { $ref: "#/components/responses/NotFound" }
         "409": { description: Live merchant blocks schema.org JSON-LD preview }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+
+  /v1/commerce/merchants/{merchant_id}/ucp-capability-profile-preview:
+    parameters:
+      - { in: path, name: merchant_id, required: true, schema: { type: string } }
+    get:
+      tags: [Merchants]
+      summary: Inspect UCP-style capability profile preview
+      operationId: getMerchantUcpCapabilityProfilePreview
+      x-implemented: true
+      x-milestone: C6K
+      description: >-
+        Returns a tenant-scoped, sandbox-only, preview-only UCP-style
+        capability profile generated from Grantex canonical
+        merchant/catalog/readiness evidence. The profile uses the Grantex-owned
+        namespace `dev.grantex.commerce.discovery.preview` only. Operators and
+        owning merchants can inspect preview services, capabilities, transports,
+        controls, and blockers. The route does not create a public discovery
+        route, publish UCP capabilities, publish `dev.ucp.*`, claim UCP
+        certification, enable production Commerce V1, create checkout/payment
+        paths, enable live payments, enable live Plural, call providers, expose
+        provider credentials, write production config, or set allowlists.
+      responses:
+        "200":
+          description: UCP-style capability profile preview
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/UcpCapabilityProfilePreview" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Operator or owning merchant caller required; CommerceAgent and service callers are denied }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { description: Live merchant blocks UCP-style capability profile preview }
         "503": { $ref: "#/components/responses/CommerceDisabled" }
 
   /v1/commerce/merchants/{merchant_id}/agenticorg-buyer-discovery-preview:

--- a/docs/guides/commerce-v1-developer-guide.mdx
+++ b/docs/guides/commerce-v1-developer-guide.mdx
@@ -59,6 +59,30 @@ error. Missing or unsafe catalog evidence is omitted and reported through
 missing seller, product, price, inventory, shipping, refund, launch, payment, or
 certification facts.
 
+### UCP-Style Capability Profile Preview
+
+Operators and owning merchants can inspect the C6K UCP-style capability profile
+preview through:
+
+`GET /v1/commerce/merchants/{merchant_id}/ucp-capability-profile-preview`
+
+The endpoint is tenant-scoped and sandbox-only. It returns services,
+capabilities, transports, controls, blockers, and evidence summary fields from
+canonical Grantex merchant/catalog/readiness state. Every capability ID uses the
+Grantex-owned namespace:
+
+`dev.grantex.commerce.discovery.preview`
+
+The endpoint must not publish `dev.ucp.*`, must not claim UCP certification,
+and must not enable a public discovery route. Response controls explicitly keep
+public discovery, checkout/payment creation, live provider access, live Plural,
+production allowlist writes, UCP publication, and UCP certification disabled.
+
+Read-only discovery capabilities can be marked `preview_available` when Grantex
+has public-safe profile and catalog evidence. Checkout, payment, fulfillment,
+refund/return execution, provider credentials, and live paths remain `blocked`
+metadata only.
+
 ## Auth And Caller Model
 
 Commerce callers are modeled as agents operating for a tenant, merchant, and

--- a/docs/guides/commerce-v1-merchant-agentic-commerce-user-guide.md
+++ b/docs/guides/commerce-v1-merchant-agentic-commerce-user-guide.md
@@ -161,6 +161,27 @@ Reviewers should reject the preview if it contains private merchant data,
 internal IDs, provider metadata, raw payloads, secrets, production claims,
 allowlist values, payment claims, launch claims, or certification claims.
 
+### UCP-Style Capability Profile Preview
+
+The UCP-style capability profile preview shows how Grantex can describe a
+merchant's agent-commerce capabilities in a standard-looking capability shape
+without publishing or certifying those capabilities.
+
+This preview uses only the Grantex-owned namespace
+`dev.grantex.commerce.discovery.preview`. It does not publish `dev.ucp.*`
+capabilities, does not claim UCP certification, and does not make the merchant
+publicly discoverable.
+
+The preview can show read-only discovery capabilities such as merchant profile,
+catalog search, catalog item read, and availability read when evidence exists.
+It also shows blocked capabilities such as checkout, payment, fulfillment,
+refund/return execution, live provider access, and production allowlist writes.
+
+Merchants and reviewers should treat the preview as review metadata only. It
+does not enable public discovery, production Commerce V1, checkout/payment
+creation, live payments, live Plural, provider credentials, production config,
+or allowlists.
+
 ### Read-Only Discovery
 
 Read-only discovery allows approved agent clients to learn that a merchant

--- a/docs/internal/commerce-v1/commerce-v1-c6k-ucp-capability-profile-preview.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6k-ucp-capability-profile-preview.md
@@ -1,0 +1,110 @@
+# Commerce V1 C6K UCP-Style Capability Profile Preview
+
+Status: implemented as preview-only foundation.
+
+This slice adds an authenticated Grantex-owned UCP-style capability profile
+preview for review before open protocol packaging. It does not publish UCP
+capabilities, does not use `dev.ucp.*` as a published namespace, does not claim
+UCP certification, does not enable public discovery, does not enable production
+Commerce V1, does not create checkout or payment paths, does not enable live
+payments, does not enable live Plural, does not call providers, does not write
+production configuration, and does not set allowlists.
+
+## Traceability
+
+| Requirement | Implementation | Validation |
+| --- | --- | --- |
+| Generate gated UCP-style capability profile preview from canonical Grantex state | `readUcpCapabilityProfilePreview` reads tenant-scoped merchant, category, and catalog readiness evidence. | `commerce-merchants.test.ts` success and missing-catalog cases. |
+| Use Grantex-owned namespace only | Every service, capability, and transport ID starts with `dev.grantex.commerce.discovery.preview`. | Route test asserts no `dev.ucp` output. |
+| Avoid UCP certification or certified `dev.ucp.*` publication | Response pins `ucp_certification_claim: none`, `external_ucp_namespace_used: false`, and `certified_capabilities_published: false`. | Route and OpenAPI tests. |
+| Include services, capabilities, and transports as preview metadata only | Response includes `services`, `capabilities`, `transports`, and non-enabling controls. | Route assertions for native REST and MCP metadata. |
+| Include controls and blockers | Response includes false enablement flags, blockers, remediation, and evidence summary. | Live merchant and missing-catalog tests. |
+| Ensure no public discovery route is enabled | Endpoint is authenticated under `/v1/commerce`; no `.well-known` route or public env assignment is added. | OpenAPI path and guardrail scans. |
+
+## Endpoint
+
+`GET /v1/commerce/merchants/{merchant_id}/ucp-capability-profile-preview`
+
+Allowed callers:
+
+- operator
+- owning merchant
+
+Denied callers:
+
+- CommerceAgent
+- service caller
+- merchant for a different merchant ID
+
+Live merchants return `409 ucp_capability_profile_preview_live_merchant_blocked`.
+Sandbox merchants with incomplete catalog evidence receive a blocked preview
+with explicit capability blockers.
+
+## Namespace Rules
+
+Allowed namespace:
+
+- `dev.grantex.commerce.discovery.preview`
+
+Blocked namespace behavior:
+
+- Do not publish `dev.ucp.*`.
+- Do not mark any capability as certified UCP.
+- Do not expose external UCP conformance, compliance, approval, or certification
+  status.
+
+## Preview Output Rules
+
+The preview may include:
+
+- read-only merchant profile capability metadata
+- read-only catalog search and item-read capability metadata
+- read-only availability capability metadata
+- blocked cart, checkout, payment, fulfillment, refund, provider, live, and
+  production allowlist capability metadata
+- native REST and MCP transport templates marked metadata-only
+- non-enabling controls and blockers
+
+The preview must not include:
+
+- tenant IDs
+- exact merchant IDs
+- product IDs
+- variant IDs
+- SKU values
+- provider credentials
+- provider metadata
+- raw payloads
+- secrets, tokens, JWTs, passports, private keys, DB URLs, or Redis URLs
+- public discovery allowlist values
+- production config assignments
+- UCP certification claims
+
+## Stop Conditions
+
+Stop and require separate approval if any change attempts to:
+
+- set `COMMERCE_PUBLIC_DISCOVERY_ENABLED`
+- set `COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST`
+- add a public `.well-known` UCP route
+- publish `dev.ucp.*`
+- claim UCP certification or conformance
+- enable production Commerce V1
+- enable checkout or payment creation in production
+- enable live payments or live Plural
+- store or print real provider credentials
+- call Plural, Stripe, Pine, payment providers, or merchant private APIs
+- expose private merchant data, exact internal IDs, raw payloads, provider
+  metadata, allowlists, production config, or secrets
+
+## Rollback
+
+Rollback is code-only:
+
+1. Remove the route import and endpoint from `apps/auth-service/src/routes/commerce.ts`.
+2. Remove `apps/auth-service/src/lib/commerce/ucp-capability-preview.ts`.
+3. Remove the C6K OpenAPI path and `UcpCapabilityProfilePreview` component.
+4. Remove C6K tests and guide references.
+
+No migration, secret, production configuration, provider account, public
+discovery setting, allowlist, or cloud resource is created by this slice.


### PR DESCRIPTION
## Summary

Implements Slice C6K as a gated, preview-only UCP-style capability profile generated from canonical Grantex merchant, category, catalog, and readiness state.

This PR is intentionally stacked on the accepted C6J base branch `codex/commerce-c6j-schemaorg-jsonld-preview` / PR #511.

## What Changed

- Added an authenticated tenant-scoped UCP-style capability profile preview endpoint:
  - `GET /v1/commerce/merchants/{merchant_id}/ucp-capability-profile-preview`
- Added the `readUcpCapabilityProfilePreview` service with Grantex-owned namespace only:
  - `dev.grantex.commerce.discovery.preview`
- Added services, capabilities, and transports as metadata-only preview objects.
- Added non-enabling controls, blockers, remediation, and evidence summary fields.
- Added route tests for sandbox success, missing catalog evidence, live merchant blocking, and CommerceAgent denial.
- Added OpenAPI component/path coverage and docs for merchants, developers, and internal operator traceability.

## Guardrails

- Preview-only, sandbox-only posture.
- No public discovery route or `.well-known` route added.
- No `COMMERCE_PUBLIC_DISCOVERY_ENABLED` or `COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST` assignment.
- No production Commerce V1 enablement.
- No checkout/payment creation enablement.
- No live payments or live Plural enablement.
- No provider calls, provider credentials, secrets, raw payloads, allowlists, or production config exposure.
- No UCP certification claim and no certified `dev.ucp.*` publication.

## Validation

Passed:

- `npm --prefix apps/auth-service test -- commerce-merchants.test.ts commerce-openapi.test.ts`
- `npm --prefix apps/auth-service run typecheck`
- `git diff --cached --check`
- Focused staged-diff scans for secrets/private details, public discovery/allowlist assignment, checkout/payment/live/provider enablement, UCP certification overclaims, provider calls, and public-route enablement.

Attempted repo validators:

- `node docs/commerce-v1-hardening.validate.mjs` failed because the temporary worktree path is `C:\tmp\grantex-c6k`, and the script asserts the canonical `grantex` repo layout.
- `node docs/commerce-v1-pilot-readiness.validate.mjs` failed because `docs/reports/commerce-v1-local-pilot-load.md` is absent from this worktree.

## Rollback

Code-only rollback: remove the new preview service, route, OpenAPI path/component, tests, and C6K docs. No migration, secret, production config, provider account, public discovery setting, allowlist, or cloud resource is created by this slice.