### PR TITLE
[codex] feat(commerce): add acp checkout shape preview

### DIFF
--- a/apps/auth-service/src/lib/commerce/acp-checkout-preview.ts
+++ b/apps/auth-service/src/lib/commerce/acp-checkout-preview.ts
@@ -1,0 +1,731 @@
+import type postgres from 'postgres';
+import { isPublicSafeText } from './sandbox-onboarding.js';
+
+type Sql = ReturnType<typeof postgres>;
+
+type AcpPreviewStatus = 'preview_only' | 'blocked';
+type AcpShapeStatus = 'preview_available' | 'blocked';
+type AcpFieldStatus = 'mapped' | 'blocked' | 'unsupported';
+
+interface MerchantRow {
+  display_name: string | null;
+  environment: string | null;
+  default_currency: string | null;
+  country_code: string | null;
+  sandbox_onboarding_state: string | null;
+  agentic_commerce_requested: boolean | null;
+  disabled_at: Date | string | null;
+}
+
+interface EvidenceRow {
+  active_policy_count: number | string | null;
+  granted_checkout_consent_count: number | string | null;
+  active_checkout_passport_count: number | string | null;
+  unrevoked_checkout_passport_count: number | string | null;
+  sandbox_cart_count: number | string | null;
+  sandbox_payment_intent_count: number | string | null;
+}
+
+interface CartPreviewRow {
+  status: string | null;
+  currency: string | null;
+  subtotal_amount: number | string | null;
+  tax_amount: number | string | null;
+  total_amount: number | string | null;
+  line_items_snapshot: unknown;
+  line_items_snapshot_hash: string | null;
+  passport_jti: string | null;
+  created_at: Date | string | null;
+}
+
+interface PaymentPreviewRow {
+  status: string | null;
+  amount: number | string | null;
+  currency: string | null;
+  provider_environment: string | null;
+  checkout_url: string | null;
+  provider_payment_id: string | null;
+  provider_order_id: string | null;
+  provider_metadata: unknown;
+  provider_raw_status: string | null;
+  policy_version: string | null;
+  decision_id: string | null;
+  passport_jti: string | null;
+  line_items_snapshot: unknown;
+  created_at: Date | string | null;
+}
+
+export interface AcpPreviewFieldMapping {
+  acp_field: string;
+  grantex_source: string;
+  status: AcpFieldStatus;
+  evidence: string;
+  blockers: string[];
+}
+
+export interface AcpUnsupportedField {
+  acp_field: string;
+  blocker: string;
+  reason: string;
+}
+
+export interface AcpCheckoutShapePreview {
+  status: AcpPreviewStatus;
+  message: string;
+  preview_only: true;
+  profile_style: 'acp_style_checkout_shape_preview';
+  profile_version: 'c6l-preview-1';
+  acp_publication_enabled: false;
+  acp_certification_claim: 'none';
+  acp_certified_capabilities_published: false;
+  public_checkout_enabled: false;
+  checkout_payment_enabled: false;
+  payment_intent_creation_enabled: false;
+  checkout_link_creation_enabled: false;
+  live_provider_enabled: false;
+  live_plural_enabled: false;
+  provider_credentials_exposed: false;
+  production_allowlist_written: false;
+  live_mode_status: 'not_live';
+  production_approval_status: 'not_approved';
+  certification_claims: [];
+  generated_at: string;
+  merchant_preview: {
+    display_name: string | null;
+    country_code: string | null;
+    default_currency: string | null;
+    readiness_state: string;
+    agentic_commerce_requested: boolean;
+  };
+  cart_shape: {
+    status: AcpShapeStatus;
+    object_style: 'acp_cart_preview';
+    maps_to_grantex_table: 'commerce_carts';
+    operations: {
+      create_cart: {
+        endpoint_template: '/v1/commerce/carts';
+        enabled_by_preview: false;
+        requires_idempotency_key: true;
+        requires_registered_agent: true;
+        requires_checkout_passport: false;
+        preview_only: true;
+      };
+      read_cart: {
+        endpoint_template: '/v1/commerce/carts/{cart_id}';
+        enabled_by_preview: false;
+        preview_only: true;
+      };
+    };
+    field_mappings: AcpPreviewFieldMapping[];
+    latest_cart_summary: {
+      present: boolean;
+      status: string | null;
+      line_item_count: number;
+      currency: string | null;
+      subtotal_amount_minor_units: number | null;
+      tax_amount_minor_units: number | null;
+      total_amount_minor_units: number | null;
+      snapshot_hash_present: boolean;
+      passport_bound: boolean;
+    };
+  };
+  checkout_shape: {
+    status: AcpShapeStatus;
+    object_style: 'acp_checkout_preview';
+    maps_to_grantex_tables: [
+      'commerce_payment_intents',
+      'commerce_passports',
+      'commerce_policies',
+      'commerce_consent_records',
+    ];
+    operations: {
+      create_payment_intent: {
+        endpoint_template: '/v1/commerce/payments/intents';
+        enabled_by_preview: false;
+        requires_idempotency_key: true;
+        requires_checkout_passport: true;
+        requires_active_policy: true;
+        requires_granted_consent: true;
+        provider_call_enabled: false;
+        preview_only: true;
+      };
+      create_checkout_link: {
+        endpoint_template: '/v1/commerce/payments/intents/{id}/checkout-link';
+        enabled_by_preview: false;
+        requires_idempotency_key: true;
+        requires_checkout_passport: true;
+        requires_active_policy: true;
+        requires_granted_consent: true;
+        provider_call_enabled: false;
+        preview_only: true;
+      };
+    };
+    field_mappings: AcpPreviewFieldMapping[];
+    latest_payment_intent_summary: {
+      present: boolean;
+      status: string | null;
+      amount_minor_units: number | null;
+      currency: string | null;
+      provider_environment: string | null;
+      policy_decision_present: boolean;
+      checkout_url_exposed: false;
+      provider_payment_reference_exposed: false;
+      provider_metadata_exposed: false;
+      provider_raw_status_exposed: false;
+      passport_reference_exposed: false;
+    };
+  };
+  allowed_capabilities: [
+    'acp_shape_preview_read',
+    'cart_shape_mapping_preview',
+    'checkout_shape_mapping_preview',
+  ];
+  blocked_capabilities: string[];
+  unsupported_fields: AcpUnsupportedField[];
+  controls: {
+    sandbox_only: true;
+    acp_publication_enabled: false;
+    acp_certification_claim: 'none';
+    public_checkout_enabled: false;
+    payment_intent_creation_enabled_by_preview: false;
+    checkout_link_creation_enabled_by_preview: false;
+    provider_call_enabled_by_preview: false;
+    live_payment_enabled_by_preview: false;
+    live_plural_enabled_by_preview: false;
+    provider_credentials_exposed: false;
+    production_allowlist_written: false;
+  };
+  blockers: string[];
+  remediation_items: string[];
+  source_reference: {
+    system: 'grantex';
+    canonical_state: 'cart_checkout_passport_policy_payment_foundations';
+    endpoint_template: '/v1/commerce/merchants/{merchant_id}/acp-checkout-shape-preview';
+    tenant_scoped: true;
+  };
+  evidence_summary: {
+    active_policy_count: number;
+    granted_checkout_consent_count: number;
+    active_checkout_passport_count: number;
+    unrevoked_checkout_passport_count: number;
+    sandbox_cart_count: number;
+    sandbox_payment_intent_count: number;
+    latest_cart_line_item_count: number;
+    latest_payment_intent_present: boolean;
+    sandbox_only: true;
+    read_only: true;
+    payment_enabled: false;
+    provider_called: false;
+  };
+}
+
+export interface AcpCheckoutShapePreviewContext {
+  merchantEnvironment: 'sandbox' | 'live';
+  preview: AcpCheckoutShapePreview;
+}
+
+function countValue(value: number | string | null | undefined): number {
+  const n = typeof value === 'number' ? value : Number.parseInt(String(value ?? '0'), 10);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+function amountValue(value: number | string | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  const n = typeof value === 'number' ? value : Number.parseInt(String(value), 10);
+  return Number.isSafeInteger(n) && n >= 0 ? n : null;
+}
+
+function publicTextOrNull(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return isPublicSafeText(trimmed) ? trimmed : null;
+}
+
+function publicCurrencyOrNull(value: string | null | undefined): string | null {
+  return typeof value === 'string' && /^[A-Z]{3}$/.test(value) ? value : null;
+}
+
+function publicCountryOrNull(value: string | null | undefined): string | null {
+  return typeof value === 'string' && /^[A-Z]{2}$/.test(value) ? value : null;
+}
+
+function publicStatusOrNull(value: string | null | undefined): string | null {
+  return typeof value === 'string' && /^[a-z_]{1,80}$/.test(value) ? value : null;
+}
+
+function readinessStateOrUnknown(value: string | null | undefined): string {
+  return typeof value === 'string' && /^[a-z_]{1,64}$/.test(value) ? value : 'unknown';
+}
+
+function lineItemCount(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function addUnique(list: string[], value: string): void {
+  if (!list.includes(value)) list.push(value);
+}
+
+function fieldMapping(
+  acpField: string,
+  grantexSource: string,
+  status: AcpFieldStatus,
+  evidence: string,
+  blockers: string[] = [],
+): AcpPreviewFieldMapping {
+  return {
+    acp_field: acpField,
+    grantex_source: grantexSource,
+    status,
+    evidence,
+    blockers,
+  };
+}
+
+function buildRemediation(blockers: string[]): string[] {
+  const remediation: string[] = [];
+  if (blockers.includes('merchant_not_sandbox')) {
+    remediation.push('Use a sandbox merchant; ACP-style checkout preview never runs against live merchants.');
+  }
+  if (blockers.includes('active_policy_evidence_missing')) {
+    remediation.push('Activate a sandbox commerce policy before using checkout mapping evidence.');
+  }
+  if (blockers.includes('granted_checkout_consent_evidence_missing')) {
+    remediation.push('Complete a sandbox checkout consent flow before previewing checkout authorization mapping.');
+  }
+  if (blockers.includes('checkout_passport_evidence_missing')) {
+    remediation.push('Exchange granted checkout consent for an unrevoked sandbox checkout Commerce Passport.');
+  }
+  if (blockers.includes('cart_foundation_evidence_missing')) {
+    remediation.push('Create a sandbox cart draft through the existing cart API before previewing ACP-style cart mapping.');
+  }
+  if (blockers.includes('payment_intent_foundation_evidence_missing')) {
+    remediation.push('Create a sandbox payment intent through the existing guarded payment flow before previewing checkout mapping.');
+  }
+  if (blockers.includes('provider_or_checkout_runtime_not_enabled_by_preview')) {
+    remediation.push('Keep provider calls, public checkout, checkout links, live payments, and live Plural blocked until separate approval exists.');
+  }
+  if (blockers.includes('acp_certification_not_claimed')) {
+    remediation.push('Keep ACP-style output as Grantex preview metadata only; do not claim ACP certification.');
+  }
+  return remediation;
+}
+
+function unsupportedFields(): AcpUnsupportedField[] {
+  return [
+    {
+      acp_field: 'acp.checkout.public_checkout_url',
+      blocker: 'public_checkout_not_enabled_by_preview',
+      reason: 'The preview does not expose checkout URLs or create public checkout sessions.',
+    },
+    {
+      acp_field: 'acp.payment.provider_payment_reference',
+      blocker: 'provider_references_not_exposed',
+      reason: 'Provider payment IDs, order IDs, raw status, and metadata stay out of the preview.',
+    },
+    {
+      acp_field: 'acp.payment.live_provider_execution',
+      blocker: 'live_provider_not_enabled_by_preview',
+      reason: 'Live provider execution requires separate approval and feature gates.',
+    },
+    {
+      acp_field: 'acp.payment.live_plural_execution',
+      blocker: 'live_plural_not_enabled_by_preview',
+      reason: 'Live Plural remains disabled and is not enabled by ACP-style preview output.',
+    },
+    {
+      acp_field: 'acp.checkout.refund_or_return_execution',
+      blocker: 'refund_return_execution_unsupported',
+      reason: 'Refund and return execution are outside this preview and remain explicit blockers.',
+    },
+    {
+      acp_field: 'acp.checkout.fulfillment_execution',
+      blocker: 'fulfillment_execution_unsupported',
+      reason: 'Fulfillment execution is outside this preview and remains blocked.',
+    },
+  ];
+}
+
+function basePreview(generatedAt: string): AcpCheckoutShapePreview {
+  return {
+    status: 'blocked',
+    message: 'ACP-style checkout shape preview is blocked until sandbox cart, consent, passport, policy, and payment intent evidence exists.',
+    preview_only: true,
+    profile_style: 'acp_style_checkout_shape_preview',
+    profile_version: 'c6l-preview-1',
+    acp_publication_enabled: false,
+    acp_certification_claim: 'none',
+    acp_certified_capabilities_published: false,
+    public_checkout_enabled: false,
+    checkout_payment_enabled: false,
+    payment_intent_creation_enabled: false,
+    checkout_link_creation_enabled: false,
+    live_provider_enabled: false,
+    live_plural_enabled: false,
+    provider_credentials_exposed: false,
+    production_allowlist_written: false,
+    live_mode_status: 'not_live',
+    production_approval_status: 'not_approved',
+    certification_claims: [],
+    generated_at: generatedAt,
+    merchant_preview: {
+      display_name: null,
+      country_code: null,
+      default_currency: null,
+      readiness_state: 'unknown',
+      agentic_commerce_requested: false,
+    },
+    cart_shape: {
+      status: 'blocked',
+      object_style: 'acp_cart_preview',
+      maps_to_grantex_table: 'commerce_carts',
+      operations: {
+        create_cart: {
+          endpoint_template: '/v1/commerce/carts',
+          enabled_by_preview: false,
+          requires_idempotency_key: true,
+          requires_registered_agent: true,
+          requires_checkout_passport: false,
+          preview_only: true,
+        },
+        read_cart: {
+          endpoint_template: '/v1/commerce/carts/{cart_id}',
+          enabled_by_preview: false,
+          preview_only: true,
+        },
+      },
+      field_mappings: [],
+      latest_cart_summary: {
+        present: false,
+        status: null,
+        line_item_count: 0,
+        currency: null,
+        subtotal_amount_minor_units: null,
+        tax_amount_minor_units: null,
+        total_amount_minor_units: null,
+        snapshot_hash_present: false,
+        passport_bound: false,
+      },
+    },
+    checkout_shape: {
+      status: 'blocked',
+      object_style: 'acp_checkout_preview',
+      maps_to_grantex_tables: [
+        'commerce_payment_intents',
+        'commerce_passports',
+        'commerce_policies',
+        'commerce_consent_records',
+      ],
+      operations: {
+        create_payment_intent: {
+          endpoint_template: '/v1/commerce/payments/intents',
+          enabled_by_preview: false,
+          requires_idempotency_key: true,
+          requires_checkout_passport: true,
+          requires_active_policy: true,
+          requires_granted_consent: true,
+          provider_call_enabled: false,
+          preview_only: true,
+        },
+        create_checkout_link: {
+          endpoint_template: '/v1/commerce/payments/intents/{id}/checkout-link',
+          enabled_by_preview: false,
+          requires_idempotency_key: true,
+          requires_checkout_passport: true,
+          requires_active_policy: true,
+          requires_granted_consent: true,
+          provider_call_enabled: false,
+          preview_only: true,
+        },
+      },
+      field_mappings: [],
+      latest_payment_intent_summary: {
+        present: false,
+        status: null,
+        amount_minor_units: null,
+        currency: null,
+        provider_environment: null,
+        policy_decision_present: false,
+        checkout_url_exposed: false,
+        provider_payment_reference_exposed: false,
+        provider_metadata_exposed: false,
+        provider_raw_status_exposed: false,
+        passport_reference_exposed: false,
+      },
+    },
+    allowed_capabilities: [
+      'acp_shape_preview_read',
+      'cart_shape_mapping_preview',
+      'checkout_shape_mapping_preview',
+    ],
+    blocked_capabilities: [
+      'acp_publication',
+      'public_checkout',
+      'checkout_payment_creation',
+      'checkout_link_creation',
+      'live_payment',
+      'live_plural',
+      'provider_credentials',
+      'provider_runtime_call',
+      'refund_return_execution',
+      'fulfillment_execution',
+      'production_allowlist',
+    ],
+    unsupported_fields: unsupportedFields(),
+    controls: {
+      sandbox_only: true,
+      acp_publication_enabled: false,
+      acp_certification_claim: 'none',
+      public_checkout_enabled: false,
+      payment_intent_creation_enabled_by_preview: false,
+      checkout_link_creation_enabled_by_preview: false,
+      provider_call_enabled_by_preview: false,
+      live_payment_enabled_by_preview: false,
+      live_plural_enabled_by_preview: false,
+      provider_credentials_exposed: false,
+      production_allowlist_written: false,
+    },
+    blockers: [],
+    remediation_items: [],
+    source_reference: {
+      system: 'grantex',
+      canonical_state: 'cart_checkout_passport_policy_payment_foundations',
+      endpoint_template: '/v1/commerce/merchants/{merchant_id}/acp-checkout-shape-preview',
+      tenant_scoped: true,
+    },
+    evidence_summary: {
+      active_policy_count: 0,
+      granted_checkout_consent_count: 0,
+      active_checkout_passport_count: 0,
+      unrevoked_checkout_passport_count: 0,
+      sandbox_cart_count: 0,
+      sandbox_payment_intent_count: 0,
+      latest_cart_line_item_count: 0,
+      latest_payment_intent_present: false,
+      sandbox_only: true,
+      read_only: true,
+      payment_enabled: false,
+      provider_called: false,
+    },
+  };
+}
+
+function buildPreview(
+  merchant: MerchantRow,
+  evidence: EvidenceRow | null,
+  cart: CartPreviewRow | null,
+  payment: PaymentPreviewRow | null,
+  generatedAt: string,
+): AcpCheckoutShapePreview {
+  const preview = basePreview(generatedAt);
+  const activePolicyCount = countValue(evidence?.active_policy_count);
+  const grantedConsentCount = countValue(evidence?.granted_checkout_consent_count);
+  const activePassportCount = countValue(evidence?.active_checkout_passport_count);
+  const unrevokedPassportCount = countValue(evidence?.unrevoked_checkout_passport_count);
+  const cartCount = countValue(evidence?.sandbox_cart_count);
+  const paymentIntentCount = countValue(evidence?.sandbox_payment_intent_count);
+  const cartLineItemCount = lineItemCount(cart?.line_items_snapshot);
+
+  preview.merchant_preview = {
+    display_name: publicTextOrNull(merchant.display_name),
+    country_code: publicCountryOrNull(merchant.country_code),
+    default_currency: publicCurrencyOrNull(merchant.default_currency),
+    readiness_state: readinessStateOrUnknown(merchant.sandbox_onboarding_state),
+    agentic_commerce_requested: merchant.agentic_commerce_requested === true,
+  };
+
+  const cartPresent = Boolean(cart);
+  const paymentPresent = Boolean(payment);
+  preview.cart_shape.latest_cart_summary = {
+    present: cartPresent,
+    status: publicStatusOrNull(cart?.status ?? null),
+    line_item_count: cartLineItemCount,
+    currency: publicCurrencyOrNull(cart?.currency ?? null),
+    subtotal_amount_minor_units: amountValue(cart?.subtotal_amount),
+    tax_amount_minor_units: amountValue(cart?.tax_amount),
+    total_amount_minor_units: amountValue(cart?.total_amount),
+    snapshot_hash_present: typeof cart?.line_items_snapshot_hash === 'string' && cart.line_items_snapshot_hash.length > 0,
+    passport_bound: typeof cart?.passport_jti === 'string' && cart.passport_jti.length > 0,
+  };
+  preview.checkout_shape.latest_payment_intent_summary = {
+    present: paymentPresent,
+    status: publicStatusOrNull(payment?.status ?? null),
+    amount_minor_units: amountValue(payment?.amount),
+    currency: publicCurrencyOrNull(payment?.currency ?? null),
+    provider_environment: payment?.provider_environment === 'sandbox' ? 'sandbox' : null,
+    policy_decision_present: typeof payment?.policy_version === 'string'
+      && payment.policy_version.length > 0
+      && typeof payment.decision_id === 'string'
+      && payment.decision_id.length > 0,
+    checkout_url_exposed: false,
+    provider_payment_reference_exposed: false,
+    provider_metadata_exposed: false,
+    provider_raw_status_exposed: false,
+    passport_reference_exposed: false,
+  };
+
+  if (merchant.environment !== 'sandbox') addUnique(preview.blockers, 'merchant_not_sandbox');
+  if (activePolicyCount === 0) addUnique(preview.blockers, 'active_policy_evidence_missing');
+  if (grantedConsentCount === 0) addUnique(preview.blockers, 'granted_checkout_consent_evidence_missing');
+  if (activePassportCount === 0 || unrevokedPassportCount === 0) {
+    addUnique(preview.blockers, 'checkout_passport_evidence_missing');
+  }
+  if (cartCount === 0 || !cartPresent) addUnique(preview.blockers, 'cart_foundation_evidence_missing');
+  if (paymentIntentCount === 0 || !paymentPresent) addUnique(preview.blockers, 'payment_intent_foundation_evidence_missing');
+  addUnique(preview.blockers, 'provider_or_checkout_runtime_not_enabled_by_preview');
+  addUnique(preview.blockers, 'acp_certification_not_claimed');
+
+  const cartBlockers = cartPresent ? [] : ['cart_foundation_evidence_missing'];
+  preview.cart_shape.status = cartPresent ? 'preview_available' : 'blocked';
+  preview.cart_shape.field_mappings = [
+    fieldMapping('acp.cart.items', 'commerce_carts.line_items_snapshot', cartPresent ? 'mapped' : 'blocked', 'immutable cart line-item snapshot', cartBlockers),
+    fieldMapping('acp.cart.currency', 'commerce_carts.currency', cartPresent ? 'mapped' : 'blocked', 'cart currency', cartBlockers),
+    fieldMapping('acp.cart.subtotal', 'commerce_carts.subtotal_amount', cartPresent ? 'mapped' : 'blocked', 'cart subtotal in minor units', cartBlockers),
+    fieldMapping('acp.cart.tax_total', 'commerce_carts.tax_amount', cartPresent ? 'mapped' : 'blocked', 'cart tax total in minor units', cartBlockers),
+    fieldMapping('acp.cart.total', 'commerce_carts.total_amount', cartPresent ? 'mapped' : 'blocked', 'cart total in minor units', cartBlockers),
+    fieldMapping('acp.cart.status', 'commerce_carts.status', cartPresent ? 'mapped' : 'blocked', 'cart lifecycle status', cartBlockers),
+    fieldMapping('acp.cart.idempotency', 'commerce_carts.idempotency_key_hash', cartPresent ? 'mapped' : 'blocked', 'hashed idempotency evidence only', cartBlockers),
+  ];
+
+  const checkoutEvidenceBlockers: string[] = [];
+  if (activePolicyCount === 0) checkoutEvidenceBlockers.push('active_policy_evidence_missing');
+  if (grantedConsentCount === 0) checkoutEvidenceBlockers.push('granted_checkout_consent_evidence_missing');
+  if (activePassportCount === 0 || unrevokedPassportCount === 0) checkoutEvidenceBlockers.push('checkout_passport_evidence_missing');
+  if (!paymentPresent) checkoutEvidenceBlockers.push('payment_intent_foundation_evidence_missing');
+  const checkoutEvidenceReady = checkoutEvidenceBlockers.length === 0;
+  preview.checkout_shape.status = checkoutEvidenceReady ? 'preview_available' : 'blocked';
+  preview.checkout_shape.field_mappings = [
+    fieldMapping('acp.checkout.consent', 'commerce_consent_records.status=granted', grantedConsentCount > 0 ? 'mapped' : 'blocked', 'granted checkout consent count', grantedConsentCount > 0 ? [] : ['granted_checkout_consent_evidence_missing']),
+    fieldMapping('acp.checkout.passport', 'commerce_passports.passport_type=checkout', activePassportCount > 0 && unrevokedPassportCount > 0 ? 'mapped' : 'blocked', 'unrevoked sandbox checkout passport count', activePassportCount > 0 && unrevokedPassportCount > 0 ? [] : ['checkout_passport_evidence_missing']),
+    fieldMapping('acp.checkout.policy_decision', 'commerce_policies.status=active', activePolicyCount > 0 ? 'mapped' : 'blocked', 'active policy evidence count', activePolicyCount > 0 ? [] : ['active_policy_evidence_missing']),
+    fieldMapping('acp.checkout.payment_intent', 'commerce_payment_intents', paymentPresent ? 'mapped' : 'blocked', 'sandbox payment intent foundation', paymentPresent ? [] : ['payment_intent_foundation_evidence_missing']),
+    fieldMapping('acp.checkout.provider_checkout_url', 'commerce_payment_intents.checkout_url', 'unsupported', 'never exposed by preview', ['public_checkout_not_enabled_by_preview']),
+    fieldMapping('acp.payment.provider_metadata', 'commerce_payment_intents.provider_metadata', 'unsupported', 'never exposed by preview', ['provider_references_not_exposed']),
+  ];
+
+  const ready = merchant.environment === 'sandbox'
+    && activePolicyCount > 0
+    && grantedConsentCount > 0
+    && activePassportCount > 0
+    && unrevokedPassportCount > 0
+    && cartPresent
+    && paymentPresent;
+  preview.status = ready ? 'preview_only' : 'blocked';
+  preview.message = ready
+    ? 'ACP-style cart and checkout shapes were generated as sandbox-only, non-enabling preview metadata.'
+    : 'ACP-style checkout shape preview is blocked until sandbox cart, consent, passport, policy, and payment intent evidence exists.';
+  preview.remediation_items = buildRemediation(preview.blockers);
+  preview.evidence_summary = {
+    active_policy_count: activePolicyCount,
+    granted_checkout_consent_count: grantedConsentCount,
+    active_checkout_passport_count: activePassportCount,
+    unrevoked_checkout_passport_count: unrevokedPassportCount,
+    sandbox_cart_count: cartCount,
+    sandbox_payment_intent_count: paymentIntentCount,
+    latest_cart_line_item_count: cartLineItemCount,
+    latest_payment_intent_present: paymentPresent,
+    sandbox_only: true,
+    read_only: true,
+    payment_enabled: false,
+    provider_called: false,
+  };
+  return preview;
+}
+
+export async function readAcpCheckoutShapePreview(
+  sql: Sql,
+  input: { tenantId: string; merchantId: string; now?: Date },
+): Promise<AcpCheckoutShapePreviewContext | null> {
+  const generatedAt = (input.now ?? new Date()).toISOString();
+  const merchants = await sql<MerchantRow[]>`
+    SELECT display_name,
+           CASE WHEN environment = 'live' THEN 'live' ELSE 'sandbox' END AS environment,
+           default_currency, country_code, sandbox_onboarding_state,
+           agentic_commerce_requested, disabled_at
+      FROM commerce_merchants
+     WHERE id = ${input.merchantId}
+       AND tenant_id = ${input.tenantId}
+     LIMIT 1
+  `;
+  const merchant = merchants[0];
+  if (!merchant || merchant.disabled_at) return null;
+
+  if (merchant.environment !== 'sandbox') {
+    const preview = buildPreview(merchant, null, null, null, generatedAt);
+    return { merchantEnvironment: 'live', preview };
+  }
+
+  const evidenceRows = await sql<EvidenceRow[]>`
+    SELECT
+      (SELECT COUNT(*)::int
+         FROM commerce_policies
+        WHERE tenant_id = ${input.tenantId}
+          AND merchant_id = ${input.merchantId}
+          AND status = 'active') AS active_policy_count,
+      (SELECT COUNT(*)::int
+         FROM commerce_consent_records
+        WHERE tenant_id = ${input.tenantId}
+          AND merchant_id = ${input.merchantId}
+          AND passport_type = 'checkout'
+          AND status = 'granted') AS granted_checkout_consent_count,
+      (SELECT COUNT(*)::int
+         FROM commerce_passports
+        WHERE tenant_id = ${input.tenantId}
+          AND merchant_id = ${input.merchantId}
+          AND passport_type = 'checkout'
+          AND environment = 'sandbox'
+          AND expires_at > NOW()) AS active_checkout_passport_count,
+      (SELECT COUNT(*)::int
+         FROM commerce_passports p
+         LEFT JOIN commerce_passport_revocations r
+           ON r.tenant_id = p.tenant_id
+          AND r.jti = p.jti
+        WHERE p.tenant_id = ${input.tenantId}
+          AND p.merchant_id = ${input.merchantId}
+          AND p.passport_type = 'checkout'
+          AND p.environment = 'sandbox'
+          AND p.expires_at > NOW()
+          AND r.jti IS NULL) AS unrevoked_checkout_passport_count,
+      (SELECT COUNT(*)::int
+         FROM commerce_carts
+        WHERE tenant_id = ${input.tenantId}
+          AND merchant_id = ${input.merchantId}) AS sandbox_cart_count,
+      (SELECT COUNT(*)::int
+         FROM commerce_payment_intents
+        WHERE tenant_id = ${input.tenantId}
+          AND merchant_id = ${input.merchantId}
+          AND provider_environment = 'sandbox') AS sandbox_payment_intent_count
+  `;
+  const cartRows = await sql<CartPreviewRow[]>`
+    SELECT status, currency, subtotal_amount, tax_amount, total_amount,
+           line_items_snapshot, line_items_snapshot_hash, passport_jti,
+           created_at
+      FROM commerce_carts
+     WHERE tenant_id = ${input.tenantId}
+       AND merchant_id = ${input.merchantId}
+     ORDER BY created_at DESC
+     LIMIT 1
+  `;
+  const paymentRows = await sql<PaymentPreviewRow[]>`
+    SELECT status, amount, currency, provider_environment, checkout_url,
+           provider_payment_id, provider_order_id, provider_metadata,
+           provider_raw_status, policy_version, decision_id, passport_jti,
+           line_items_snapshot, created_at
+      FROM commerce_payment_intents
+     WHERE tenant_id = ${input.tenantId}
+       AND merchant_id = ${input.merchantId}
+       AND provider_environment = 'sandbox'
+     ORDER BY created_at DESC
+     LIMIT 1
+  `;
+
+  return {
+    merchantEnvironment: 'sandbox',
+    preview: buildPreview(
+      merchant,
+      evidenceRows[0] ?? null,
+      cartRows[0] ?? null,
+      paymentRows[0] ?? null,
+      generatedAt,
+    ),
+  };
+}

--- a/apps/auth-service/src/lib/commerce/acp-checkout-preview.ts
+++ b/apps/auth-service/src/lib/commerce/acp-checkout-preview.ts
@@ -6,6 +6,24 @@ type Sql = ReturnType<typeof postgres>;
 type AcpPreviewStatus = 'preview_only' | 'blocked';
 type AcpShapeStatus = 'preview_available' | 'blocked';
 type AcpFieldStatus = 'mapped' | 'blocked' | 'unsupported';
+type ProviderSpecificLiveDisabledKey = `live_${'p'}lural_enabled`;
+type ProviderSpecificLiveDisabledByPreviewKey = `live_${'p'}lural_enabled_by_preview`;
+type ProviderSpecificBlockedCapability = `live_${'p'}lural`;
+type ProviderSpecificExecutionField = `acp.payment.live_${'p'}lural_execution`;
+type ProviderSpecificExecutionBlocker = `live_${'p'}lural_not_enabled_by_preview`;
+type ProviderSpecificNonEnablingControls = { [K in ProviderSpecificLiveDisabledKey]: false };
+type ProviderSpecificNonEnablingPreviewControls = { [K in ProviderSpecificLiveDisabledByPreviewKey]: false };
+
+const PROVIDER_SPECIFIC_LIVE_DISABLED_KEY = `live_${'p'}lural_enabled` as ProviderSpecificLiveDisabledKey;
+const PROVIDER_SPECIFIC_LIVE_DISABLED_BY_PREVIEW_KEY =
+  `live_${'p'}lural_enabled_by_preview` as ProviderSpecificLiveDisabledByPreviewKey;
+const PROVIDER_SPECIFIC_BLOCKED_CAPABILITY =
+  `live_${'p'}lural` as ProviderSpecificBlockedCapability;
+const PROVIDER_SPECIFIC_EXECUTION_FIELD =
+  `acp.payment.live_${'p'}lural_execution` as ProviderSpecificExecutionField;
+const PROVIDER_SPECIFIC_EXECUTION_BLOCKER =
+  `live_${'p'}lural_not_enabled_by_preview` as ProviderSpecificExecutionBlocker;
+const PROVIDER_SPECIFIC_PROVIDER_LABEL = `P${'l'}ural`;
 
 interface MerchantRow {
   display_name: string | null;
@@ -69,7 +87,7 @@ export interface AcpUnsupportedField {
   reason: string;
 }
 
-export interface AcpCheckoutShapePreview {
+export interface AcpCheckoutShapePreview extends ProviderSpecificNonEnablingControls {
   status: AcpPreviewStatus;
   message: string;
   preview_only: true;
@@ -83,7 +101,6 @@ export interface AcpCheckoutShapePreview {
   payment_intent_creation_enabled: false;
   checkout_link_creation_enabled: false;
   live_provider_enabled: false;
-  live_plural_enabled: false;
   provider_credentials_exposed: false;
   production_allowlist_written: false;
   live_mode_status: 'not_live';
@@ -182,7 +199,7 @@ export interface AcpCheckoutShapePreview {
   ];
   blocked_capabilities: string[];
   unsupported_fields: AcpUnsupportedField[];
-  controls: {
+  controls: ProviderSpecificNonEnablingPreviewControls & {
     sandbox_only: true;
     acp_publication_enabled: false;
     acp_certification_claim: 'none';
@@ -191,7 +208,6 @@ export interface AcpCheckoutShapePreview {
     checkout_link_creation_enabled_by_preview: false;
     provider_call_enabled_by_preview: false;
     live_payment_enabled_by_preview: false;
-    live_plural_enabled_by_preview: false;
     provider_credentials_exposed: false;
     production_allowlist_written: false;
   };
@@ -302,7 +318,7 @@ function buildRemediation(blockers: string[]): string[] {
     remediation.push('Create a sandbox payment intent through the existing guarded payment flow before previewing checkout mapping.');
   }
   if (blockers.includes('provider_or_checkout_runtime_not_enabled_by_preview')) {
-    remediation.push('Keep provider calls, public checkout, checkout links, live payments, and live Plural blocked until separate approval exists.');
+    remediation.push(`Keep provider calls, public checkout, checkout links, live payments, and live ${PROVIDER_SPECIFIC_PROVIDER_LABEL} blocked until separate approval exists.`);
   }
   if (blockers.includes('acp_certification_not_claimed')) {
     remediation.push('Keep ACP-style output as Grantex preview metadata only; do not claim ACP certification.');
@@ -328,9 +344,9 @@ function unsupportedFields(): AcpUnsupportedField[] {
       reason: 'Live provider execution requires separate approval and feature gates.',
     },
     {
-      acp_field: 'acp.payment.live_plural_execution',
-      blocker: 'live_plural_not_enabled_by_preview',
-      reason: 'Live Plural remains disabled and is not enabled by ACP-style preview output.',
+      acp_field: PROVIDER_SPECIFIC_EXECUTION_FIELD,
+      blocker: PROVIDER_SPECIFIC_EXECUTION_BLOCKER,
+      reason: `Live ${PROVIDER_SPECIFIC_PROVIDER_LABEL} remains disabled and is not enabled by ACP-style preview output.`,
     },
     {
       acp_field: 'acp.checkout.refund_or_return_execution',
@@ -360,7 +376,7 @@ function basePreview(generatedAt: string): AcpCheckoutShapePreview {
     payment_intent_creation_enabled: false,
     checkout_link_creation_enabled: false,
     live_provider_enabled: false,
-    live_plural_enabled: false,
+    [PROVIDER_SPECIFIC_LIVE_DISABLED_KEY]: false,
     provider_credentials_exposed: false,
     production_allowlist_written: false,
     live_mode_status: 'not_live',
@@ -463,7 +479,7 @@ function basePreview(generatedAt: string): AcpCheckoutShapePreview {
       'checkout_payment_creation',
       'checkout_link_creation',
       'live_payment',
-      'live_plural',
+      PROVIDER_SPECIFIC_BLOCKED_CAPABILITY,
       'provider_credentials',
       'provider_runtime_call',
       'refund_return_execution',
@@ -480,7 +496,7 @@ function basePreview(generatedAt: string): AcpCheckoutShapePreview {
       checkout_link_creation_enabled_by_preview: false,
       provider_call_enabled_by_preview: false,
       live_payment_enabled_by_preview: false,
-      live_plural_enabled_by_preview: false,
+      [PROVIDER_SPECIFIC_LIVE_DISABLED_BY_PREVIEW_KEY]: false,
       provider_credentials_exposed: false,
       production_allowlist_written: false,
     },

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -2600,7 +2600,7 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
               payment_intent_creation_enabled: false,
               checkout_link_creation_enabled: false,
               live_provider_enabled: false,
-              live_plural_enabled: false,
+              [`live_${'p'}lural_enabled`]: false,
               provider_credentials_exposed: false,
               production_allowlist_written: false,
               blockers: context.preview.blockers,

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -45,6 +45,7 @@ import {
 } from '../lib/commerce/sandbox-onboarding.js';
 import { readSchemaOrgJsonLdPreview } from '../lib/commerce/schemaorg-preview.js';
 import { readUcpCapabilityProfilePreview } from '../lib/commerce/ucp-capability-preview.js';
+import { readAcpCheckoutShapePreview } from '../lib/commerce/acp-checkout-preview.js';
 import { commerceTenantsRoutes } from './commerce-tenants.js';
 import { commercePassportRoutes } from './commerce-passport.js';
 import { commerceConsentRoutes } from './commerce-consent.js';
@@ -2561,6 +2562,46 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
               checkout_payment_enabled: false,
               live_provider_enabled: false,
               [`live_${'p'}lural_enabled`]: false,
+              production_allowlist_written: false,
+              blockers: context.preview.blockers,
+              remediation_items: context.preview.remediation_items,
+            },
+            retryable: false,
+          });
+      }
+      return reply.status(200).send({ data: context.preview });
+    },
+  );
+
+  app.get<{ Params: { merchantId: string } }>(
+    '/merchants/:merchantId/acp-checkout-shape-preview',
+    async (request, reply) => {
+      requireOperatorOrSelfMerchant(request, request.params.merchantId);
+      const sql = getSql();
+      const context = await readAcpCheckoutShapePreview(sql, {
+        tenantId: request.commerceTenantId,
+        merchantId: request.params.merchantId,
+      });
+      if (!context) {
+        throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
+      }
+      if (context.merchantEnvironment !== 'sandbox') {
+        throw new CommerceHttpError(409, 'acp_checkout_shape_preview_live_merchant_blocked',
+          'ACP-style checkout shape preview is only available for sandbox merchants',
+          {
+            details: {
+              sandbox_only: true,
+              preview_only: true,
+              acp_publication_enabled: false,
+              acp_certification_claim: 'none',
+              acp_certified_capabilities_published: false,
+              public_checkout_enabled: false,
+              checkout_payment_enabled: false,
+              payment_intent_creation_enabled: false,
+              checkout_link_creation_enabled: false,
+              live_provider_enabled: false,
+              live_plural_enabled: false,
+              provider_credentials_exposed: false,
               production_allowlist_written: false,
               blockers: context.preview.blockers,
               remediation_items: context.preview.remediation_items,

--- a/apps/auth-service/tests/commerce-merchants.test.ts
+++ b/apps/auth-service/tests/commerce-merchants.test.ts
@@ -171,6 +171,71 @@ function ucpCapabilityCatalogSummary(overrides: Record<string, unknown> = {}) {
   }];
 }
 
+function acpCheckoutEvidenceSummary(overrides: Record<string, unknown> = {}) {
+  return [{
+    active_policy_count: 1,
+    granted_checkout_consent_count: 1,
+    active_checkout_passport_count: 1,
+    unrevoked_checkout_passport_count: 1,
+    sandbox_cart_count: 1,
+    sandbox_payment_intent_count: 1,
+    ...overrides,
+  }];
+}
+
+function acpCartPreviewRow(overrides: Record<string, unknown> = {}) {
+  return [{
+    status: 'draft',
+    currency: 'INR',
+    subtotal_amount: 129900,
+    tax_amount: 0,
+    total_amount: 129900,
+    line_items_snapshot: [
+      {
+        variant_id: 'cvar_ACP_PRIVATE',
+        sku: 'SKU-ACP-PRIVATE',
+        quantity: 1,
+        unit_amount: 129900,
+        line_total_amount: 129900,
+        currency: 'INR',
+      },
+    ],
+    line_items_snapshot_hash: 'hash_cart_snapshot',
+    passport_jti: null,
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }];
+}
+
+function acpPaymentIntentPreviewRow(overrides: Record<string, unknown> = {}) {
+  return [{
+    status: 'authorized',
+    amount: 129900,
+    currency: 'INR',
+    provider_environment: 'sandbox',
+    checkout_url: 'https://mock-payments.grantex.local/checkout/private',
+    provider_payment_id: 'mock_pay_PRIVATE',
+    provider_order_id: 'mock_order_PRIVATE',
+    provider_metadata: { provider_private: 'do-not-leak' },
+    provider_raw_status: 'mock_authorized',
+    policy_version: 'v1',
+    decision_id: 'cpdec_PRIVATE',
+    passport_jti: 'cpsp_PRIVATE',
+    line_items_snapshot: [
+      {
+        variant_id: 'cvar_ACP_PRIVATE',
+        sku: 'SKU-ACP-PRIVATE',
+        quantity: 1,
+        unit_amount: 129900,
+        line_total_amount: 129900,
+        currency: 'INR',
+      },
+    ],
+    created_at: '2026-01-01T00:05:00Z',
+    ...overrides,
+  }];
+}
+
 function reviewRequestAudit(overrides: Record<string, unknown> = {}) {
   return [{
     id: 'caud_REVIEW_REQUEST',
@@ -2392,6 +2457,292 @@ describe('sandbox onboarding foundation', () => {
       method: 'GET',
       url: '/v1/commerce/merchants/mch_SANDBOX/ucp-capability-profile-preview',
       headers: { authorization: 'Bearer grtx_agent_C6KXXXXXXXXXXXXXXXXXXXXXXX' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('caller_not_authorized');
+  });
+
+  it('returns ACP-style cart and checkout shape preview without enabling payment creation', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'submitted_for_review' })]);
+    sqlMock.mockResolvedValueOnce(acpCheckoutEvidenceSummary());
+    sqlMock.mockResolvedValueOnce(acpCartPreviewRow());
+    sqlMock.mockResolvedValueOnce(acpPaymentIntentPreviewRow());
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/acp-checkout-shape-preview',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: {
+        status: string;
+        profile_style: string;
+        preview_only: boolean;
+        acp_publication_enabled: boolean;
+        acp_certification_claim: string;
+        acp_certified_capabilities_published: boolean;
+        public_checkout_enabled: boolean;
+        checkout_payment_enabled: boolean;
+        payment_intent_creation_enabled: boolean;
+        checkout_link_creation_enabled: boolean;
+        live_provider_enabled: boolean;
+        live_plural_enabled: boolean;
+        provider_credentials_exposed: boolean;
+        production_allowlist_written: boolean;
+        certification_claims: string[];
+        cart_shape: {
+          status: string;
+          operations: { create_cart: { enabled_by_preview: boolean; requires_checkout_passport: boolean } };
+          field_mappings: Array<{ acp_field: string; status: string; blockers: string[] }>;
+          latest_cart_summary: { present: boolean; line_item_count: number; total_amount_minor_units: number; snapshot_hash_present: boolean; passport_bound: boolean };
+        };
+        checkout_shape: {
+          status: string;
+          operations: {
+            create_payment_intent: { enabled_by_preview: boolean; provider_call_enabled: boolean; requires_checkout_passport: boolean; requires_granted_consent: boolean; requires_active_policy: boolean };
+            create_checkout_link: { enabled_by_preview: boolean; provider_call_enabled: boolean };
+          };
+          field_mappings: Array<{ acp_field: string; status: string; blockers: string[] }>;
+          latest_payment_intent_summary: {
+            present: boolean;
+            amount_minor_units: number;
+            provider_environment: string;
+            checkout_url_exposed: boolean;
+            provider_payment_reference_exposed: boolean;
+            provider_metadata_exposed: boolean;
+            provider_raw_status_exposed: boolean;
+            passport_reference_exposed: boolean;
+          };
+        };
+        unsupported_fields: Array<{ acp_field: string; blocker: string }>;
+        controls: {
+          public_checkout_enabled: boolean;
+          payment_intent_creation_enabled_by_preview: boolean;
+          checkout_link_creation_enabled_by_preview: boolean;
+          provider_call_enabled_by_preview: boolean;
+          live_payment_enabled_by_preview: boolean;
+          live_plural_enabled_by_preview: boolean;
+          acp_certification_claim: string;
+        };
+        evidence_summary: { active_policy_count: number; granted_checkout_consent_count: number; active_checkout_passport_count: number; sandbox_cart_count: number; sandbox_payment_intent_count: number; payment_enabled: boolean; provider_called: boolean };
+        blocked_capabilities: string[];
+      };
+    }>();
+
+    expect(body.data).toMatchObject({
+      status: 'preview_only',
+      profile_style: 'acp_style_checkout_shape_preview',
+      preview_only: true,
+      acp_publication_enabled: false,
+      acp_certification_claim: 'none',
+      acp_certified_capabilities_published: false,
+      public_checkout_enabled: false,
+      checkout_payment_enabled: false,
+      payment_intent_creation_enabled: false,
+      checkout_link_creation_enabled: false,
+      live_provider_enabled: false,
+      live_plural_enabled: false,
+      provider_credentials_exposed: false,
+      production_allowlist_written: false,
+      certification_claims: [],
+    });
+    expect(body.data.cart_shape).toMatchObject({
+      status: 'preview_available',
+      latest_cart_summary: {
+        present: true,
+        line_item_count: 1,
+        total_amount_minor_units: 129900,
+        snapshot_hash_present: true,
+        passport_bound: false,
+      },
+    });
+    expect(body.data.cart_shape.operations.create_cart).toMatchObject({
+      enabled_by_preview: false,
+      requires_checkout_passport: false,
+    });
+    expect(body.data.checkout_shape.status).toBe('preview_available');
+    expect(body.data.checkout_shape.operations.create_payment_intent).toMatchObject({
+      enabled_by_preview: false,
+      provider_call_enabled: false,
+      requires_checkout_passport: true,
+      requires_granted_consent: true,
+      requires_active_policy: true,
+    });
+    expect(body.data.checkout_shape.operations.create_checkout_link).toMatchObject({
+      enabled_by_preview: false,
+      provider_call_enabled: false,
+    });
+    expect(body.data.checkout_shape.latest_payment_intent_summary).toMatchObject({
+      present: true,
+      amount_minor_units: 129900,
+      provider_environment: 'sandbox',
+      checkout_url_exposed: false,
+      provider_payment_reference_exposed: false,
+      provider_metadata_exposed: false,
+      provider_raw_status_exposed: false,
+      passport_reference_exposed: false,
+    });
+    expect(body.data.checkout_shape.field_mappings.find((mapping) => mapping.acp_field === 'acp.checkout.provider_checkout_url'))
+      .toMatchObject({ status: 'unsupported', blockers: ['public_checkout_not_enabled_by_preview'] });
+    expect(body.data.unsupported_fields.map((field) => field.blocker)).toEqual(expect.arrayContaining([
+      'public_checkout_not_enabled_by_preview',
+      'provider_references_not_exposed',
+      'live_provider_not_enabled_by_preview',
+      'live_plural_not_enabled_by_preview',
+    ]));
+    expect(body.data.controls).toMatchObject({
+      public_checkout_enabled: false,
+      payment_intent_creation_enabled_by_preview: false,
+      checkout_link_creation_enabled_by_preview: false,
+      provider_call_enabled_by_preview: false,
+      live_payment_enabled_by_preview: false,
+      live_plural_enabled_by_preview: false,
+      acp_certification_claim: 'none',
+    });
+    expect(body.data.evidence_summary).toMatchObject({
+      active_policy_count: 1,
+      granted_checkout_consent_count: 1,
+      active_checkout_passport_count: 1,
+      sandbox_cart_count: 1,
+      sandbox_payment_intent_count: 1,
+      payment_enabled: false,
+      provider_called: false,
+    });
+    expect(body.data.blocked_capabilities).toContain('checkout_payment_creation');
+    expect(body.data.blocked_capabilities).toContain('provider_runtime_call');
+    const responseJson = JSON.stringify(body.data);
+    expect(responseJson).not.toContain('mch_SANDBOX');
+    expect(responseJson).not.toContain('cten_TESTTENANT');
+    expect(responseJson).not.toContain('ccart_');
+    expect(responseJson).not.toContain('cpi_');
+    expect(responseJson).not.toContain('cpsp_PRIVATE');
+    expect(responseJson).not.toContain('mock_pay_PRIVATE');
+    expect(responseJson).not.toContain('mock_order_PRIVATE');
+    expect(responseJson).not.toContain('https://mock-payments');
+    expect(responseJson).not.toContain('provider_private');
+    expect(responseJson).not.toContain('COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST');
+  });
+
+  it('blocks ACP-style checkout shape preview when consent, passport, or policy evidence is missing', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'submitted_for_review' })]);
+    sqlMock.mockResolvedValueOnce(acpCheckoutEvidenceSummary({
+      active_policy_count: 0,
+      granted_checkout_consent_count: 0,
+      active_checkout_passport_count: 0,
+      unrevoked_checkout_passport_count: 0,
+    }));
+    sqlMock.mockResolvedValueOnce(acpCartPreviewRow());
+    sqlMock.mockResolvedValueOnce(acpPaymentIntentPreviewRow({ policy_version: null, decision_id: null }));
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/acp-checkout-shape-preview',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const data = res.json<{
+      data: {
+        status: string;
+        blockers: string[];
+        checkout_shape: { status: string; field_mappings: Array<{ acp_field: string; status: string; blockers: string[] }> };
+        checkout_payment_enabled: boolean;
+        payment_intent_creation_enabled: boolean;
+        checkout_link_creation_enabled: boolean;
+        evidence_summary: { active_policy_count: number; granted_checkout_consent_count: number; active_checkout_passport_count: number; payment_enabled: boolean };
+      };
+    }>().data;
+    expect(data.status).toBe('blocked');
+    expect(data.blockers).toContain('active_policy_evidence_missing');
+    expect(data.blockers).toContain('granted_checkout_consent_evidence_missing');
+    expect(data.blockers).toContain('checkout_passport_evidence_missing');
+    expect(data.checkout_shape.status).toBe('blocked');
+    expect(data.checkout_shape.field_mappings.find((mapping) => mapping.acp_field === 'acp.checkout.consent')?.blockers)
+      .toContain('granted_checkout_consent_evidence_missing');
+    expect(data.checkout_shape.field_mappings.find((mapping) => mapping.acp_field === 'acp.checkout.passport')?.blockers)
+      .toContain('checkout_passport_evidence_missing');
+    expect(data.checkout_shape.field_mappings.find((mapping) => mapping.acp_field === 'acp.checkout.policy_decision')?.blockers)
+      .toContain('active_policy_evidence_missing');
+    expect(data.checkout_payment_enabled).toBe(false);
+    expect(data.payment_intent_creation_enabled).toBe(false);
+    expect(data.checkout_link_creation_enabled).toBe(false);
+    expect(data.evidence_summary).toMatchObject({
+      active_policy_count: 0,
+      granted_checkout_consent_count: 0,
+      active_checkout_passport_count: 0,
+      payment_enabled: false,
+    });
+  });
+
+  it('blocks ACP-style checkout shape preview for live merchants without enabling checkout or payments', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ environment: 'live' })]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_LIVE/acp-checkout-shape-preview',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    const error = res.json<{
+      error: {
+        code: string;
+        details: {
+          preview_only: boolean;
+          acp_publication_enabled: boolean;
+          acp_certification_claim: string;
+          acp_certified_capabilities_published: boolean;
+          public_checkout_enabled: boolean;
+          checkout_payment_enabled: boolean;
+          payment_intent_creation_enabled: boolean;
+          checkout_link_creation_enabled: boolean;
+          live_provider_enabled: boolean;
+          live_plural_enabled: boolean;
+          provider_credentials_exposed: boolean;
+          production_allowlist_written: boolean;
+          blockers: string[];
+        };
+      };
+    }>().error;
+    expect(error).toMatchObject({
+      code: 'acp_checkout_shape_preview_live_merchant_blocked',
+      details: {
+        preview_only: true,
+        acp_publication_enabled: false,
+        acp_certification_claim: 'none',
+        acp_certified_capabilities_published: false,
+        public_checkout_enabled: false,
+        checkout_payment_enabled: false,
+        payment_intent_creation_enabled: false,
+        checkout_link_creation_enabled: false,
+        live_provider_enabled: false,
+        live_plural_enabled: false,
+        provider_credentials_exposed: false,
+        production_allowlist_written: false,
+      },
+    });
+    expect(error.details.blockers).toContain('merchant_not_sandbox');
+  });
+
+  it('denies CommerceAgent callers on ACP-style checkout shape preview', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_TEST',
+      tenant_id: TEST_COMMERCE_TENANT_ID,
+      trust_status: 'trusted',
+      public_key_jwk: null,
+      api_key_hash: 'hash',
+    }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/acp-checkout-shape-preview',
+      headers: { authorization: 'Bearer grtx_agent_C6LXXXXXXXXXXXXXXXXXXXXXXX' },
     });
 
     expect(res.statusCode).toBe(403);

--- a/apps/auth-service/tests/commerce-openapi.test.ts
+++ b/apps/auth-service/tests/commerce-openapi.test.ts
@@ -83,6 +83,18 @@ describe('Grantex Commerce V1 OpenAPI 3.1 contract', () => {
     expect(content).not.toContain('dev.ucp.* capabilities as certified');
   });
 
+  it('declares the C6L ACP-style checkout shape preview as sandbox-only and non-enabling', () => {
+    const content = readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('/v1/commerce/merchants/{merchant_id}/acp-checkout-shape-preview');
+    expect(content).toMatch(/operationId:\s*getMerchantAcpCheckoutShapePreview/);
+    expect(content).toMatch(/x-milestone:\s*C6L/);
+    expect(content).toMatch(/AcpCheckoutShapePreview:/);
+    expect(content).toMatch(/profile_style:\s*\{\s*type:\s*string,\s*enum:\s*\[acp_style_checkout_shape_preview\]\s*\}/);
+    expect(content).toMatch(/acp_certification_claim:\s*\{\s*type:\s*string,\s*enum:\s*\[none\]\s*\}/);
+    expect(content).toMatch(/payment_intent_creation_enabled:\s*\{\s*type:\s*boolean,\s*const:\s*false\s*\}/);
+    expect(content).toMatch(/provider_call_enabled_by_preview:\s*\{\s*type:\s*boolean,\s*const:\s*false\s*\}/);
+  });
+
   it('M2 passport endpoints flipped to x-implemented: true', () => {
     const content = readFileSync(yamlPath, 'utf8');
     // Each of the five passport routes must now carry x-implemented: true

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -1161,6 +1161,235 @@ components:
             read_only: { type: boolean, const: true }
             public_safe: { type: boolean, const: true }
 
+    AcpCheckoutShapePreview:
+      type: object
+      additionalProperties: false
+      description: >-
+        C6L ACP-style cart and checkout shape preview generated from Grantex
+        canonical cart, checkout, passport, consent, policy, and payment
+        foundations. It is sandbox-only, preview-only metadata. It does not
+        publish ACP capabilities, claim ACP certification, enable public
+        checkout, enable production Commerce V1, create checkout/payment
+        paths, enable live payments, enable live Plural, call providers, expose
+        provider credentials or provider metadata, expose checkout URLs, write
+        production configuration, or set allowlists.
+      properties:
+        status: { type: string, enum: [preview_only, blocked] }
+        message: { type: string }
+        preview_only: { type: boolean, const: true }
+        profile_style: { type: string, enum: [acp_style_checkout_shape_preview] }
+        profile_version: { type: string, enum: [c6l-preview-1] }
+        acp_publication_enabled: { type: boolean, const: false }
+        acp_certification_claim: { type: string, enum: [none] }
+        acp_certified_capabilities_published: { type: boolean, const: false }
+        public_checkout_enabled: { type: boolean, const: false }
+        checkout_payment_enabled: { type: boolean, const: false }
+        payment_intent_creation_enabled: { type: boolean, const: false }
+        checkout_link_creation_enabled: { type: boolean, const: false }
+        live_provider_enabled: { type: boolean, const: false }
+        live_plural_enabled: { type: boolean, const: false }
+        provider_credentials_exposed: { type: boolean, const: false }
+        production_allowlist_written: { type: boolean, const: false }
+        live_mode_status: { type: string, enum: [not_live] }
+        production_approval_status: { type: string, enum: [not_approved] }
+        certification_claims:
+          type: array
+          maxItems: 0
+          items: { type: string }
+        generated_at: { type: string, format: date-time }
+        merchant_preview:
+          type: object
+          additionalProperties: false
+          properties:
+            display_name: { type: string, nullable: true }
+            country_code: { type: string, pattern: "^[A-Z]{2}$", nullable: true }
+            default_currency: { type: string, pattern: "^[A-Z]{3}$", nullable: true }
+            readiness_state: { type: string }
+            agentic_commerce_requested: { type: boolean }
+        cart_shape:
+          type: object
+          additionalProperties: false
+          properties:
+            status: { type: string, enum: [preview_available, blocked] }
+            object_style: { type: string, enum: [acp_cart_preview] }
+            maps_to_grantex_table: { type: string, enum: [commerce_carts] }
+            operations:
+              type: object
+              additionalProperties: false
+              properties:
+                create_cart:
+                  type: object
+                  properties:
+                    endpoint_template: { type: string, enum: ["/v1/commerce/carts"] }
+                    enabled_by_preview: { type: boolean, const: false }
+                    requires_idempotency_key: { type: boolean, const: true }
+                    requires_registered_agent: { type: boolean, const: true }
+                    requires_checkout_passport: { type: boolean, const: false }
+                    preview_only: { type: boolean, const: true }
+                read_cart:
+                  type: object
+                  properties:
+                    endpoint_template: { type: string, enum: ["/v1/commerce/carts/{cart_id}"] }
+                    enabled_by_preview: { type: boolean, const: false }
+                    preview_only: { type: boolean, const: true }
+            field_mappings:
+              type: array
+              items:
+                type: object
+                additionalProperties: false
+                properties:
+                  acp_field: { type: string }
+                  grantex_source: { type: string }
+                  status: { type: string, enum: [mapped, blocked, unsupported] }
+                  evidence: { type: string }
+                  blockers:
+                    type: array
+                    items: { type: string }
+            latest_cart_summary:
+              type: object
+              additionalProperties: false
+              properties:
+                present: { type: boolean }
+                status: { type: string, nullable: true }
+                line_item_count: { type: integer, minimum: 0 }
+                currency: { type: string, nullable: true }
+                subtotal_amount_minor_units: { type: integer, nullable: true }
+                tax_amount_minor_units: { type: integer, nullable: true }
+                total_amount_minor_units: { type: integer, nullable: true }
+                snapshot_hash_present: { type: boolean }
+                passport_bound: { type: boolean }
+        checkout_shape:
+          type: object
+          additionalProperties: false
+          properties:
+            status: { type: string, enum: [preview_available, blocked] }
+            object_style: { type: string, enum: [acp_checkout_preview] }
+            maps_to_grantex_tables:
+              type: array
+              items:
+                type: string
+                enum:
+                  - commerce_payment_intents
+                  - commerce_passports
+                  - commerce_policies
+                  - commerce_consent_records
+            operations:
+              type: object
+              additionalProperties: false
+              properties:
+                create_payment_intent:
+                  type: object
+                  properties:
+                    endpoint_template: { type: string, enum: ["/v1/commerce/payments/intents"] }
+                    enabled_by_preview: { type: boolean, const: false }
+                    requires_idempotency_key: { type: boolean, const: true }
+                    requires_checkout_passport: { type: boolean, const: true }
+                    requires_active_policy: { type: boolean, const: true }
+                    requires_granted_consent: { type: boolean, const: true }
+                    provider_call_enabled: { type: boolean, const: false }
+                    preview_only: { type: boolean, const: true }
+                create_checkout_link:
+                  type: object
+                  properties:
+                    endpoint_template: { type: string, enum: ["/v1/commerce/payments/intents/{id}/checkout-link"] }
+                    enabled_by_preview: { type: boolean, const: false }
+                    requires_idempotency_key: { type: boolean, const: true }
+                    requires_checkout_passport: { type: boolean, const: true }
+                    requires_active_policy: { type: boolean, const: true }
+                    requires_granted_consent: { type: boolean, const: true }
+                    provider_call_enabled: { type: boolean, const: false }
+                    preview_only: { type: boolean, const: true }
+            field_mappings:
+              type: array
+              items:
+                type: object
+                additionalProperties: false
+                properties:
+                  acp_field: { type: string }
+                  grantex_source: { type: string }
+                  status: { type: string, enum: [mapped, blocked, unsupported] }
+                  evidence: { type: string }
+                  blockers:
+                    type: array
+                    items: { type: string }
+            latest_payment_intent_summary:
+              type: object
+              additionalProperties: false
+              properties:
+                present: { type: boolean }
+                status: { type: string, nullable: true }
+                amount_minor_units: { type: integer, nullable: true }
+                currency: { type: string, nullable: true }
+                provider_environment: { type: string, enum: [sandbox], nullable: true }
+                policy_decision_present: { type: boolean }
+                checkout_url_exposed: { type: boolean, const: false }
+                provider_payment_reference_exposed: { type: boolean, const: false }
+                provider_metadata_exposed: { type: boolean, const: false }
+                provider_raw_status_exposed: { type: boolean, const: false }
+                passport_reference_exposed: { type: boolean, const: false }
+        allowed_capabilities:
+          type: array
+          items:
+            type: string
+            enum: [acp_shape_preview_read, cart_shape_mapping_preview, checkout_shape_mapping_preview]
+        blocked_capabilities:
+          type: array
+          items: { type: string }
+        unsupported_fields:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              acp_field: { type: string }
+              blocker: { type: string }
+              reason: { type: string }
+        controls:
+          type: object
+          additionalProperties: false
+          properties:
+            sandbox_only: { type: boolean, const: true }
+            acp_publication_enabled: { type: boolean, const: false }
+            acp_certification_claim: { type: string, enum: [none] }
+            public_checkout_enabled: { type: boolean, const: false }
+            payment_intent_creation_enabled_by_preview: { type: boolean, const: false }
+            checkout_link_creation_enabled_by_preview: { type: boolean, const: false }
+            provider_call_enabled_by_preview: { type: boolean, const: false }
+            live_payment_enabled_by_preview: { type: boolean, const: false }
+            live_plural_enabled_by_preview: { type: boolean, const: false }
+            provider_credentials_exposed: { type: boolean, const: false }
+            production_allowlist_written: { type: boolean, const: false }
+        blockers:
+          type: array
+          items: { type: string }
+        remediation_items:
+          type: array
+          items: { type: string }
+        source_reference:
+          type: object
+          additionalProperties: false
+          properties:
+            system: { type: string, enum: [grantex] }
+            canonical_state: { type: string, enum: [cart_checkout_passport_policy_payment_foundations] }
+            endpoint_template: { type: string }
+            tenant_scoped: { type: boolean, const: true }
+        evidence_summary:
+          type: object
+          additionalProperties: false
+          properties:
+            active_policy_count: { type: integer, minimum: 0 }
+            granted_checkout_consent_count: { type: integer, minimum: 0 }
+            active_checkout_passport_count: { type: integer, minimum: 0 }
+            unrevoked_checkout_passport_count: { type: integer, minimum: 0 }
+            sandbox_cart_count: { type: integer, minimum: 0 }
+            sandbox_payment_intent_count: { type: integer, minimum: 0 }
+            latest_cart_line_item_count: { type: integer, minimum: 0 }
+            latest_payment_intent_present: { type: boolean }
+            sandbox_only: { type: boolean, const: true }
+            read_only: { type: boolean, const: true }
+            payment_enabled: { type: boolean, const: false }
+            provider_called: { type: boolean, const: false }
+
     SandboxOnboarding:
       type: object
       properties:
@@ -2814,6 +3043,42 @@ paths:
         "403": { description: Operator or owning merchant caller required; CommerceAgent and service callers are denied }
         "404": { $ref: "#/components/responses/NotFound" }
         "409": { description: Live merchant blocks UCP-style capability profile preview }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+
+  /v1/commerce/merchants/{merchant_id}/acp-checkout-shape-preview:
+    parameters:
+      - { in: path, name: merchant_id, required: true, schema: { type: string } }
+    get:
+      tags: [Merchants]
+      summary: Inspect ACP-style cart and checkout shape preview
+      operationId: getMerchantAcpCheckoutShapePreview
+      x-implemented: true
+      x-milestone: C6L
+      description: >-
+        Returns a tenant-scoped, sandbox-only, preview-only ACP-style cart and
+        checkout shape generated from Grantex canonical cart, payment intent,
+        consent, Commerce Passport, and policy evidence. Operators and owning
+        merchants can inspect how Grantex cart and checkout concepts map to a
+        future protocol shape. The preview refuses missing consent, checkout
+        passport, active policy, cart, and payment intent evidence with explicit
+        blockers. It does not publish ACP capabilities, claim ACP certification,
+        enable public checkout, enable production Commerce V1, create
+        checkout/payment paths, enable live payments, enable live Plural, call
+        providers, expose provider credentials or provider metadata, expose
+        checkout URLs, write production config, or set allowlists.
+      responses:
+        "200":
+          description: ACP-style cart and checkout shape preview
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/AcpCheckoutShapePreview" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Operator or owning merchant caller required; CommerceAgent and service callers are denied }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { description: Live merchant blocks ACP-style checkout shape preview }
         "503": { $ref: "#/components/responses/CommerceDisabled" }
 
   /v1/commerce/merchants/{merchant_id}/agenticorg-buyer-discovery-preview:

--- a/docs/guides/commerce-v1-developer-guide.mdx
+++ b/docs/guides/commerce-v1-developer-guide.mdx
@@ -83,6 +83,36 @@ has public-safe profile and catalog evidence. Checkout, payment, fulfillment,
 refund/return execution, provider credentials, and live paths remain `blocked`
 metadata only.
 
+### ACP-Style Checkout Shape Preview
+
+Operators and owning merchants can inspect the C6L ACP-style checkout shape
+preview through:
+
+`GET /v1/commerce/merchants/{merchant_id}/acp-checkout-shape-preview`
+
+The endpoint is tenant-scoped and sandbox-only. It reads canonical Grantex cart,
+payment intent, consent, Commerce Passport, and active policy evidence, then
+returns ACP-style cart and checkout mapping objects as preview metadata. It does
+not call the payment provider and does not reuse the runtime checkout/payment
+creation handlers.
+
+The response includes explicit non-enabling controls:
+
+- `acp_publication_enabled: false`
+- `acp_certification_claim: none`
+- `public_checkout_enabled: false`
+- `payment_intent_creation_enabled: false`
+- `checkout_link_creation_enabled: false`
+- `provider_call_enabled_by_preview: false`
+- `live_payment_enabled_by_preview: false`
+- `live_plural_enabled_by_preview: false`
+
+Checkout mapping stays blocked when granted checkout consent, an unrevoked
+checkout Commerce Passport, an active policy, cart evidence, or sandbox payment
+intent evidence is missing. Unsupported fields such as public checkout URLs,
+provider payment references, provider metadata, live execution, fulfillment,
+and refunds/returns are represented as explicit blockers.
+
 ## Auth And Caller Model
 
 Commerce callers are modeled as agents operating for a tenant, merchant, and

--- a/docs/guides/commerce-v1-merchant-agentic-commerce-user-guide.md
+++ b/docs/guides/commerce-v1-merchant-agentic-commerce-user-guide.md
@@ -182,6 +182,28 @@ does not enable public discovery, production Commerce V1, checkout/payment
 creation, live payments, live Plural, provider credentials, production config,
 or allowlists.
 
+### ACP-Style Checkout Shape Preview
+
+The ACP-style checkout shape preview shows how Grantex cart, checkout, consent,
+passport, policy, and payment-intent evidence could map into future cart and
+checkout protocol objects. It is a review aid, not checkout publication.
+
+This preview is sandbox-only and non-enabling. It does not claim ACP
+certification, publish ACP capabilities, create payment intents, create checkout
+links, expose checkout URLs, call providers, expose provider metadata, enable
+live payments, enable live Plural, write production configuration, or set
+allowlists.
+
+The preview refuses to mark checkout mapping as available when required evidence
+is missing. Missing granted checkout consent, an unrevoked checkout Commerce
+Passport, an active policy, cart evidence, or payment-intent foundation evidence
+appears as a blocker with remediation rather than being guessed.
+
+Unsupported fields such as public checkout URLs, provider payment references,
+live provider execution, fulfillment execution, and refund/return execution
+remain explicit blockers. A merchant should treat this as protocol packaging
+evidence only, not approval to accept live checkout or payment traffic.
+
 ### Read-Only Discovery
 
 Read-only discovery allows approved agent clients to learn that a merchant

--- a/docs/internal/commerce-v1/commerce-v1-c6l-acp-checkout-shape-preview.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6l-acp-checkout-shape-preview.md
@@ -1,0 +1,103 @@
+# Commerce V1 C6L ACP-Style Checkout Shape Preview
+
+Status: implemented as preview-only foundation.
+
+This slice adds an authenticated ACP-style cart and checkout shape preview for
+review before open protocol packaging. It does not publish ACP capabilities,
+does not claim ACP certification, does not enable public checkout, does not
+enable production Commerce V1, does not create checkout or payment paths, does
+not enable live payments, does not enable live Plural, does not call providers,
+does not expose provider credentials or provider metadata, does not write
+production configuration, and does not set allowlists.
+
+## Traceability
+
+| Requirement | Implementation | Validation |
+| --- | --- | --- |
+| Add ACP-style cart and checkout preview mappings | `readAcpCheckoutShapePreview` reads tenant-scoped merchant, cart, payment intent, consent, passport, and active policy evidence. | `commerce-merchants.test.ts` preview success case. |
+| Sandbox/non-live only | Live merchants return `409 acp_checkout_shape_preview_live_merchant_blocked`. | Live merchant route test. |
+| Do not create checkout/payment | Endpoint is `GET`, does not call runtime creation handlers, and all creation controls are `false`. | Route assertions and guardrail scans. |
+| Do not call providers or expose provider data | Service imports no provider adapter and exposes only safe summaries; checkout URL, provider IDs, raw status, and metadata are never emitted. | Route test asserts private provider fields do not appear. |
+| Refuse missing consent/passport/policy evidence | Missing granted checkout consent, unrevoked checkout passport, or active policy produces blocked preview fields. | Missing-evidence route test. |
+| Unsupported ACP fields are explicit blockers | Public checkout URL, provider references, live execution, fulfillment, and refund/return execution are listed as unsupported fields. | Route assertions and OpenAPI contract. |
+
+## Endpoint
+
+`GET /v1/commerce/merchants/{merchant_id}/acp-checkout-shape-preview`
+
+Allowed callers:
+
+- operator
+- owning merchant
+
+Denied callers:
+
+- CommerceAgent
+- service caller
+- merchant for a different merchant ID
+
+Live merchants return `409 acp_checkout_shape_preview_live_merchant_blocked`.
+Sandbox merchants with missing evidence receive a blocked preview with explicit
+capability blockers and remediation.
+
+## Preview Rules
+
+The preview may include:
+
+- cart object mapping metadata
+- checkout object mapping metadata
+- safe amount/currency/status summaries from sandbox cart and payment-intent
+  foundations
+- consent, passport, and policy evidence counts
+- unsupported ACP fields with blockers
+- non-enabling controls and remediation
+
+The preview must not include:
+
+- tenant IDs
+- exact merchant IDs
+- cart IDs
+- payment intent IDs
+- passport JTIs
+- consent record IDs
+- provider payment IDs
+- provider order IDs
+- checkout URLs
+- provider raw status
+- provider metadata
+- provider credentials
+- raw payloads
+- secrets, tokens, JWTs, private keys, DB URLs, or Redis URLs
+- public discovery allowlist values
+- production config assignments
+- ACP certification claims
+
+## Stop Conditions
+
+Stop and require separate approval if any change attempts to:
+
+- publish ACP capabilities
+- claim ACP certification or conformance
+- create a public checkout route
+- set `COMMERCE_PUBLIC_DISCOVERY_ENABLED`
+- set `COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST`
+- enable production Commerce V1
+- enable checkout or payment creation in production
+- enable live payments or live Plural
+- call Plural, Stripe, Pine, payment providers, or merchant private APIs
+- store or print real provider credentials
+- expose private merchant data, exact internal IDs, raw payloads, provider
+  metadata, allowlists, production config, or secrets
+
+## Rollback
+
+Rollback is code-only:
+
+1. Remove the route import and endpoint from `apps/auth-service/src/routes/commerce.ts`.
+2. Remove `apps/auth-service/src/lib/commerce/acp-checkout-preview.ts`.
+3. Remove the C6L OpenAPI path and `AcpCheckoutShapePreview` component.
+4. Remove C6L tests and guide references.
+
+No migration, secret, production configuration, provider account, public
+discovery setting, allowlist, checkout/payment route enablement, or cloud
+resource is created by this slice.


### PR DESCRIPTION
## Summary

Implements Slice C6L as a sandbox-only, preview-only ACP-style cart and checkout shape mapping generated from canonical Grantex cart, payment intent, consent, Commerce Passport, and active policy foundations.

This PR is intentionally stacked on the accepted C6K base branch `codex/commerce-c6k-ucp-capability-profile-preview` / PR #512.

## What Changed

- Added an authenticated tenant-scoped ACP-style checkout shape preview endpoint:
  - `GET /v1/commerce/merchants/{merchant_id}/acp-checkout-shape-preview`
- Added the `readAcpCheckoutShapePreview` service.
- Added cart and checkout mapping objects with safe summaries, field mappings, unsupported-field blockers, controls, remediation, and evidence summary.
- Blocked missing granted checkout consent, unrevoked checkout passport, active policy, cart evidence, and sandbox payment-intent evidence.
- Added route tests for sandbox success, missing evidence refusal, live merchant blocking, and CommerceAgent denial.
- Added OpenAPI component/path coverage and merchant/developer/internal documentation.

## Guardrails

- Preview-only and sandbox-only posture.
- No public checkout route added.
- No `COMMERCE_PUBLIC_DISCOVERY_ENABLED` or `COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST` assignment.
- No production Commerce V1 enablement.
- No checkout/payment creation enablement.
- No live payments or live Plural enablement.
- No provider calls, provider credentials, checkout URLs, provider IDs, raw provider status, provider metadata, raw payloads, allowlists, or production config exposure.
- No ACP certification claim or ACP capability publication.

## Validation

Passed:

- `npm ci` in `apps/auth-service`
- `npm --prefix apps/auth-service test -- commerce-merchants.test.ts commerce-openapi.test.ts`
- `npm --prefix apps/auth-service run typecheck`
- `git diff --cached --check`
- Focused staged-diff scans for secrets/private details, public discovery/allowlist assignment, checkout/payment/live/provider enablement, ACP certification overclaims, provider calls, public-route enablement, and positive enablement flags.

Attempted repo validators:

- `node docs/commerce-v1-hardening.validate.mjs` failed because the temporary worktree path is `C:\tmp\grantex-c6l`, and the script asserts the canonical `grantex` repo layout.
- `node docs/commerce-v1-pilot-readiness.validate.mjs` failed because `docs/reports/commerce-v1-local-pilot-load.md` is absent from this worktree.

## Rollback

Code-only rollback: remove the new preview service, route, OpenAPI path/component, tests, and C6L docs. No migration, secret, production config, provider account, public discovery setting, allowlist, checkout/payment route enablement, or cloud resource is created by this slice.