### PR TITLE
[codex] feat(commerce): add ap2 style evidence preview

### DIFF
--- a/apps/auth-service/src/lib/commerce/ap2-evidence-preview.ts
+++ b/apps/auth-service/src/lib/commerce/ap2-evidence-preview.ts
@@ -1,0 +1,962 @@
+import type postgres from 'postgres';
+import { sha256hex } from '../hash.js';
+import { stableJson } from './idempotency.js';
+import { isPublicSafeText } from './sandbox-onboarding.js';
+
+type Sql = ReturnType<typeof postgres>;
+
+type Ap2PreviewStatus = 'preview_only' | 'blocked';
+
+interface MerchantRow {
+  display_name: string | null;
+  environment: string | null;
+  default_currency: string | null;
+  country_code: string | null;
+  sandbox_onboarding_state: string | null;
+  agentic_commerce_requested: boolean | null;
+  agentic_commerce_enabled: boolean | null;
+  disabled_at: Date | string | null;
+}
+
+interface Ap2EvidenceRow {
+  payment_status: string | null;
+  payment_amount: number | string | null;
+  payment_currency: string | null;
+  provider_environment: string | null;
+  payment_policy_version: string | null;
+  payment_decision_id: string | null;
+  payment_idempotency_key_hash: string | null;
+  payment_created_at: Date | string | null;
+  cart_status: string | null;
+  cart_currency: string | null;
+  cart_total_amount: number | string | null;
+  cart_snapshot_hash: string | null;
+  cart_idempotency_key_hash: string | null;
+  cart_line_items_snapshot: unknown;
+  passport_type: string | null;
+  passport_environment: string | null;
+  passport_scopes: unknown;
+  passport_max_amount: number | string | null;
+  passport_currency: string | null;
+  passport_policy_version: string | null;
+  passport_not_before: Date | string | null;
+  passport_expires_at: Date | string | null;
+  passport_not_expired: boolean | null;
+  passport_agent_auth_method: string | null;
+  passport_revoked: boolean | null;
+  consent_status: string | null;
+  consent_passport_type: string | null;
+  consent_requested_scopes: unknown;
+  consent_approved_scopes: unknown;
+  consent_max_amount: number | string | null;
+  consent_currency: string | null;
+  consent_text_version: string | null;
+  presented_payload_hash: string | null;
+  consent_approved_at: Date | string | null;
+  consent_agent_auth_method: string | null;
+  policy_status: string | null;
+  policy_rules: unknown;
+  agent_trust_status: string | null;
+  agent_disabled_at: Date | string | null;
+  agent_id: string | null;
+}
+
+interface AuditRow {
+  id: string | null;
+  event_type: string | null;
+  occurred_at: Date | string | null;
+  passport_jti: string | null;
+  policy_version: string | null;
+  decision_id: string | null;
+  idempotency_key_hash: string | null;
+}
+
+interface AmountCap {
+  amount_minor_units: number | null;
+  currency: string | null;
+  source: 'passport' | 'consent' | 'policy' | 'missing';
+}
+
+export interface Ap2EvidencePreview {
+  status: Ap2PreviewStatus;
+  message: string;
+  preview_only: true;
+  profile_style: 'ap2_style_evidence_preview';
+  profile_version: 'c6m-preview-1';
+  ap2_certification_claim: 'none';
+  ap2_publication_enabled: false;
+  ap2_signed_mandate_created: false;
+  signed_production_mandate_created: false;
+  signature_status: 'unsigned_preview';
+  signing_key_used: false;
+  payment_network_submission_enabled: false;
+  public_discovery_enabled: false;
+  checkout_payment_enabled: false;
+  live_provider_enabled: false;
+  live_plural_enabled: false;
+  provider_credentials_exposed: false;
+  production_allowlist_written: false;
+  live_mode_status: 'not_live';
+  production_approval_status: 'not_approved';
+  certification_claims: [];
+  generated_at: string;
+  evidence_package: {
+    format: 'ap2_style_unsigned_evidence_preview';
+    deterministic: true;
+    signed: false;
+    hash_algorithm: 'sha256';
+    evidence_hash: string | null;
+    signing_key_reference: null;
+    production_mandate_reference: null;
+    includes: [
+      'commerce_passport',
+      'consent_record',
+      'policy_decision',
+      'cart_hash',
+      'amount_cap',
+      'merchant_state',
+      'agent_identity',
+      'audit_reference',
+      'idempotency_replay',
+    ];
+  };
+  merchant_state: {
+    display_name: string | null;
+    environment: 'sandbox' | 'live';
+    country_code: string | null;
+    default_currency: string | null;
+    readiness_state: string;
+    agentic_commerce_requested: boolean;
+    agentic_commerce_enabled: boolean;
+  };
+  commerce_passport_evidence: {
+    present: boolean;
+    passport_type: string | null;
+    environment: string | null;
+    scope_count: number;
+    required_checkout_scopes_present: boolean;
+    max_amount_minor_units: number | null;
+    currency: string | null;
+    policy_version_present: boolean;
+    not_before_present: boolean;
+    expires_at_present: boolean;
+    not_expired: boolean | null;
+    revoked: boolean | null;
+    agent_auth_method: string | null;
+    passport_jti_exposed: false;
+    raw_passport_jwt_exposed: false;
+  };
+  consent_evidence: {
+    present: boolean;
+    status: string | null;
+    passport_type: string | null;
+    requested_scope_count: number;
+    approved_scope_count: number;
+    approved_required_checkout_scopes_present: boolean;
+    max_amount_minor_units: number | null;
+    currency: string | null;
+    consent_text_version: string | null;
+    presented_payload_hash_present: boolean;
+    approved_at_present: boolean;
+    agent_auth_method: string | null;
+    consent_record_id_exposed: false;
+    consent_request_id_exposed: false;
+    user_principal_exposed: false;
+  };
+  policy_evidence: {
+    present: boolean;
+    active_policy_present: boolean;
+    policy_version_present: boolean;
+    decision_reference_present: boolean;
+    decision_reference_hash: string | null;
+    amount_cap_minor_units: number | null;
+    amount_cap_currency: string | null;
+    emergency_disabled: boolean | null;
+    raw_policy_rules_exposed: false;
+  };
+  cart_evidence: {
+    present: boolean;
+    status: string | null;
+    line_item_count: number;
+    snapshot_hash: string | null;
+    total_amount_minor_units: number | null;
+    currency: string | null;
+    idempotency_key_hash_present: boolean;
+    raw_line_items_exposed: false;
+    cart_id_exposed: false;
+  };
+  amount_evidence: {
+    payment_amount_minor_units: number | null;
+    payment_currency: string | null;
+    amount_cap_minor_units: number | null;
+    amount_cap_currency: string | null;
+    amount_cap_source: AmountCap['source'];
+    within_amount_cap: boolean | null;
+  };
+  agent_identity_evidence: {
+    present: boolean;
+    agent_reference_hash: string | null;
+    trust_status: string | null;
+    disabled: boolean | null;
+    auth_method: string | null;
+    agent_id_exposed: false;
+    agent_api_key_exposed: false;
+  };
+  audit_evidence: {
+    present: boolean;
+    audit_reference_hash: string | null;
+    event_type: string | null;
+    occurred_at: string | null;
+    policy_version_present: boolean;
+    decision_reference_present: boolean;
+    idempotency_key_hash_present: boolean;
+    audit_event_id_exposed: false;
+  };
+  replay_idempotency_evidence: {
+    idempotency_supported: true;
+    replay_record_source: 'commerce_idempotency_records';
+    cart_idempotency_key_hash_present: boolean;
+    payment_intent_idempotency_key_hash_present: boolean;
+    audit_idempotency_key_hash_present: boolean;
+    raw_idempotency_key_exposed: false;
+  };
+  payment_intent_evidence: {
+    present: boolean;
+    status: string | null;
+    provider_environment: string | null;
+    created_at_present: boolean;
+    provider_reference_exposed: false;
+    checkout_url_exposed: false;
+    provider_metadata_exposed: false;
+    provider_raw_status_exposed: false;
+  };
+  controls: {
+    sandbox_only: true;
+    deterministic_unsigned_preview: true;
+    signing_enabled_by_preview: false;
+    ap2_certification_claim: 'none';
+    ap2_publication_enabled: false;
+    payment_network_submission_enabled: false;
+    checkout_payment_creation_enabled_by_preview: false;
+    live_payment_enabled_by_preview: false;
+    live_plural_enabled_by_preview: false;
+    provider_call_enabled_by_preview: false;
+    provider_credentials_exposed: false;
+    production_allowlist_written: false;
+  };
+  blockers: string[];
+  remediation_items: string[];
+  source_reference: {
+    system: 'grantex';
+    canonical_state: 'commerce_passport_consent_policy_cart_payment_audit_idempotency';
+    endpoint_template: '/v1/commerce/merchants/{merchant_id}/ap2-evidence-preview';
+    tenant_scoped: true;
+  };
+  evidence_summary: {
+    complete_required_evidence: boolean;
+    passport_present: boolean;
+    consent_granted: boolean;
+    active_policy_present: boolean;
+    policy_decision_present: boolean;
+    cart_hash_present: boolean;
+    amount_cap_present: boolean;
+    merchant_state_present: boolean;
+    agent_identity_present: boolean;
+    audit_reference_present: boolean;
+    idempotency_evidence_present: boolean;
+    sandbox_only: true;
+    unsigned_preview: true;
+    payment_enabled: false;
+    provider_called: false;
+  };
+}
+
+export interface Ap2EvidencePreviewContext {
+  merchantEnvironment: 'sandbox' | 'live';
+  preview: Ap2EvidencePreview;
+}
+
+const REQUIRED_CHECKOUT_SCOPES = [
+  'commerce:catalog.read',
+  'commerce:inventory.read',
+  'commerce:checkout.create',
+  'commerce:payment.initiate',
+  'commerce:payment.status.read',
+] as const;
+
+function countValue(value: number | string | null | undefined): number {
+  const n = typeof value === 'number' ? value : Number.parseInt(String(value ?? '0'), 10);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+function amountValue(value: number | string | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  const n = typeof value === 'number' ? value : Number.parseInt(String(value), 10);
+  return Number.isSafeInteger(n) && n >= 0 ? n : null;
+}
+
+function publicTextOrNull(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return isPublicSafeText(trimmed) ? trimmed : null;
+}
+
+function publicCurrencyOrNull(value: string | null | undefined): string | null {
+  return typeof value === 'string' && /^[A-Z]{3}$/.test(value) ? value : null;
+}
+
+function publicCountryOrNull(value: string | null | undefined): string | null {
+  return typeof value === 'string' && /^[A-Z]{2}$/.test(value) ? value : null;
+}
+
+function publicStatusOrNull(value: string | null | undefined): string | null {
+  return typeof value === 'string' && /^[a-z0-9_.:-]{1,100}$/.test(value) ? value : null;
+}
+
+function publicAuthMethodOrNull(value: string | null | undefined): string | null {
+  return value === 'jwt' || value === 'api_key' ? value : null;
+}
+
+function readinessStateOrUnknown(value: string | null | undefined): string {
+  return typeof value === 'string' && /^[a-z_]{1,64}$/.test(value) ? value : 'unknown';
+}
+
+function dateStringOrNull(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === 'string' && /^[a-z0-9:._-]{1,80}$/.test(item))
+    .slice(0, 20);
+}
+
+function lineItemCount(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function hasRequiredCheckoutScopes(scopes: string[]): boolean {
+  return REQUIRED_CHECKOUT_SCOPES.every((scope) => scopes.includes(scope));
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function addUnique(list: string[], value: string): void {
+  if (!list.includes(value)) list.push(value);
+}
+
+function hashedReference(value: string | null | undefined, prefix: string): string | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  return `${prefix}_${sha256hex(value).slice(0, 24)}`;
+}
+
+function policyAmountCap(policyRules: unknown): {
+  amount: number | null;
+  currency: string | null;
+  emergencyDisabled: boolean | null;
+} {
+  if (!isPlainObject(policyRules)) {
+    return { amount: null, currency: null, emergencyDisabled: null };
+  }
+  const amountCap = policyRules['amount_cap'];
+  const emergency = typeof policyRules['emergency_disable'] === 'boolean'
+    ? policyRules['emergency_disable']
+    : null;
+  if (!isPlainObject(amountCap)) {
+    return { amount: null, currency: null, emergencyDisabled: emergency };
+  }
+  return {
+    amount: amountValue(amountCap['max_amount_minor_units'] as number | string | null | undefined),
+    currency: publicCurrencyOrNull(amountCap['currency'] as string | null | undefined),
+    emergencyDisabled: emergency,
+  };
+}
+
+function chooseAmountCap(row: Ap2EvidenceRow | null, policyCap: ReturnType<typeof policyAmountCap>): AmountCap {
+  const passportAmount = amountValue(row?.passport_max_amount);
+  const passportCurrency = publicCurrencyOrNull(row?.passport_currency ?? null);
+  if (passportAmount !== null && passportCurrency) {
+    return { amount_minor_units: passportAmount, currency: passportCurrency, source: 'passport' };
+  }
+  const consentAmount = amountValue(row?.consent_max_amount);
+  const consentCurrency = publicCurrencyOrNull(row?.consent_currency ?? null);
+  if (consentAmount !== null && consentCurrency) {
+    return { amount_minor_units: consentAmount, currency: consentCurrency, source: 'consent' };
+  }
+  if (policyCap.amount !== null && policyCap.currency) {
+    return { amount_minor_units: policyCap.amount, currency: policyCap.currency, source: 'policy' };
+  }
+  return { amount_minor_units: null, currency: null, source: 'missing' };
+}
+
+function buildRemediation(blockers: string[]): string[] {
+  const remediation: string[] = [];
+  if (blockers.includes('merchant_not_sandbox')) {
+    remediation.push('Use a sandbox merchant; AP2-style evidence preview does not run against live merchants.');
+  }
+  if (blockers.includes('commerce_passport_evidence_missing')) {
+    remediation.push('Issue an unrevoked sandbox checkout Commerce Passport before previewing AP2-style evidence.');
+  }
+  if (blockers.includes('consent_evidence_missing')) {
+    remediation.push('Complete a granted checkout consent record before previewing AP2-style evidence.');
+  }
+  if (blockers.includes('policy_decision_evidence_missing')) {
+    remediation.push('Create a guarded sandbox payment intent so policy version and decision evidence exist.');
+  }
+  if (blockers.includes('cart_hash_evidence_missing')) {
+    remediation.push('Create a sandbox cart with an immutable line-item snapshot hash.');
+  }
+  if (blockers.includes('amount_cap_evidence_missing')) {
+    remediation.push('Bind an amount cap and currency through the passport, consent record, or active policy.');
+  }
+  if (blockers.includes('agent_identity_evidence_missing')) {
+    remediation.push('Use a registered, trusted CommerceAgent for the checkout evidence chain.');
+  }
+  if (blockers.includes('audit_reference_evidence_missing')) {
+    remediation.push('Ensure protected checkout evidence has an append-only audit reference.');
+  }
+  if (blockers.includes('idempotency_evidence_missing')) {
+    remediation.push('Use existing idempotent cart/payment flows so replay evidence is available.');
+  }
+  if (blockers.includes('unsigned_preview_only')) {
+    remediation.push('Keep the AP2-style evidence preview unsigned until separate signing and protocol review exists.');
+  }
+  if (blockers.includes('ap2_certification_not_claimed')) {
+    remediation.push('Do not claim AP2 certification; this is Grantex evidence preview metadata only.');
+  }
+  return remediation;
+}
+
+function basePreview(generatedAt: string): Ap2EvidencePreview {
+  return {
+    status: 'blocked',
+    message: 'AP2-style evidence preview is blocked until sandbox passport, consent, policy, cart hash, amount cap, agent, audit, and idempotency evidence exists.',
+    preview_only: true,
+    profile_style: 'ap2_style_evidence_preview',
+    profile_version: 'c6m-preview-1',
+    ap2_certification_claim: 'none',
+    ap2_publication_enabled: false,
+    ap2_signed_mandate_created: false,
+    signed_production_mandate_created: false,
+    signature_status: 'unsigned_preview',
+    signing_key_used: false,
+    payment_network_submission_enabled: false,
+    public_discovery_enabled: false,
+    checkout_payment_enabled: false,
+    live_provider_enabled: false,
+    live_plural_enabled: false,
+    provider_credentials_exposed: false,
+    production_allowlist_written: false,
+    live_mode_status: 'not_live',
+    production_approval_status: 'not_approved',
+    certification_claims: [],
+    generated_at: generatedAt,
+    evidence_package: {
+      format: 'ap2_style_unsigned_evidence_preview',
+      deterministic: true,
+      signed: false,
+      hash_algorithm: 'sha256',
+      evidence_hash: null,
+      signing_key_reference: null,
+      production_mandate_reference: null,
+      includes: [
+        'commerce_passport',
+        'consent_record',
+        'policy_decision',
+        'cart_hash',
+        'amount_cap',
+        'merchant_state',
+        'agent_identity',
+        'audit_reference',
+        'idempotency_replay',
+      ],
+    },
+    merchant_state: {
+      display_name: null,
+      environment: 'sandbox',
+      country_code: null,
+      default_currency: null,
+      readiness_state: 'unknown',
+      agentic_commerce_requested: false,
+      agentic_commerce_enabled: false,
+    },
+    commerce_passport_evidence: {
+      present: false,
+      passport_type: null,
+      environment: null,
+      scope_count: 0,
+      required_checkout_scopes_present: false,
+      max_amount_minor_units: null,
+      currency: null,
+      policy_version_present: false,
+      not_before_present: false,
+      expires_at_present: false,
+      not_expired: null,
+      revoked: null,
+      agent_auth_method: null,
+      passport_jti_exposed: false,
+      raw_passport_jwt_exposed: false,
+    },
+    consent_evidence: {
+      present: false,
+      status: null,
+      passport_type: null,
+      requested_scope_count: 0,
+      approved_scope_count: 0,
+      approved_required_checkout_scopes_present: false,
+      max_amount_minor_units: null,
+      currency: null,
+      consent_text_version: null,
+      presented_payload_hash_present: false,
+      approved_at_present: false,
+      agent_auth_method: null,
+      consent_record_id_exposed: false,
+      consent_request_id_exposed: false,
+      user_principal_exposed: false,
+    },
+    policy_evidence: {
+      present: false,
+      active_policy_present: false,
+      policy_version_present: false,
+      decision_reference_present: false,
+      decision_reference_hash: null,
+      amount_cap_minor_units: null,
+      amount_cap_currency: null,
+      emergency_disabled: null,
+      raw_policy_rules_exposed: false,
+    },
+    cart_evidence: {
+      present: false,
+      status: null,
+      line_item_count: 0,
+      snapshot_hash: null,
+      total_amount_minor_units: null,
+      currency: null,
+      idempotency_key_hash_present: false,
+      raw_line_items_exposed: false,
+      cart_id_exposed: false,
+    },
+    amount_evidence: {
+      payment_amount_minor_units: null,
+      payment_currency: null,
+      amount_cap_minor_units: null,
+      amount_cap_currency: null,
+      amount_cap_source: 'missing',
+      within_amount_cap: null,
+    },
+    agent_identity_evidence: {
+      present: false,
+      agent_reference_hash: null,
+      trust_status: null,
+      disabled: null,
+      auth_method: null,
+      agent_id_exposed: false,
+      agent_api_key_exposed: false,
+    },
+    audit_evidence: {
+      present: false,
+      audit_reference_hash: null,
+      event_type: null,
+      occurred_at: null,
+      policy_version_present: false,
+      decision_reference_present: false,
+      idempotency_key_hash_present: false,
+      audit_event_id_exposed: false,
+    },
+    replay_idempotency_evidence: {
+      idempotency_supported: true,
+      replay_record_source: 'commerce_idempotency_records',
+      cart_idempotency_key_hash_present: false,
+      payment_intent_idempotency_key_hash_present: false,
+      audit_idempotency_key_hash_present: false,
+      raw_idempotency_key_exposed: false,
+    },
+    payment_intent_evidence: {
+      present: false,
+      status: null,
+      provider_environment: null,
+      created_at_present: false,
+      provider_reference_exposed: false,
+      checkout_url_exposed: false,
+      provider_metadata_exposed: false,
+      provider_raw_status_exposed: false,
+    },
+    controls: {
+      sandbox_only: true,
+      deterministic_unsigned_preview: true,
+      signing_enabled_by_preview: false,
+      ap2_certification_claim: 'none',
+      ap2_publication_enabled: false,
+      payment_network_submission_enabled: false,
+      checkout_payment_creation_enabled_by_preview: false,
+      live_payment_enabled_by_preview: false,
+      live_plural_enabled_by_preview: false,
+      provider_call_enabled_by_preview: false,
+      provider_credentials_exposed: false,
+      production_allowlist_written: false,
+    },
+    blockers: [],
+    remediation_items: [],
+    source_reference: {
+      system: 'grantex',
+      canonical_state: 'commerce_passport_consent_policy_cart_payment_audit_idempotency',
+      endpoint_template: '/v1/commerce/merchants/{merchant_id}/ap2-evidence-preview',
+      tenant_scoped: true,
+    },
+    evidence_summary: {
+      complete_required_evidence: false,
+      passport_present: false,
+      consent_granted: false,
+      active_policy_present: false,
+      policy_decision_present: false,
+      cart_hash_present: false,
+      amount_cap_present: false,
+      merchant_state_present: false,
+      agent_identity_present: false,
+      audit_reference_present: false,
+      idempotency_evidence_present: false,
+      sandbox_only: true,
+      unsigned_preview: true,
+      payment_enabled: false,
+      provider_called: false,
+    },
+  };
+}
+
+function buildPreview(
+  merchant: MerchantRow,
+  row: Ap2EvidenceRow | null,
+  audit: AuditRow | null,
+  generatedAt: string,
+): Ap2EvidencePreview {
+  const preview = basePreview(generatedAt);
+  const environment = merchant.environment === 'live' ? 'live' : 'sandbox';
+  const passportScopes = stringArray(row?.passport_scopes);
+  const approvedScopes = stringArray(row?.consent_approved_scopes);
+  const policyCap = policyAmountCap(row?.policy_rules);
+  const amountCap = chooseAmountCap(row, policyCap);
+  const paymentAmount = amountValue(row?.payment_amount);
+  const paymentCurrency = publicCurrencyOrNull(row?.payment_currency ?? null);
+  const withinAmountCap = paymentAmount !== null
+    && paymentCurrency !== null
+    && amountCap.amount_minor_units !== null
+    && amountCap.currency !== null
+    ? paymentCurrency === amountCap.currency && paymentAmount <= amountCap.amount_minor_units
+    : null;
+  const passportPresent = row?.passport_type === 'checkout' && row.passport_environment === 'sandbox';
+  const consentGranted = row?.consent_status === 'granted' && row.consent_passport_type === 'checkout';
+  const activePolicyPresent = row?.policy_status === 'active';
+  const policyDecisionPresent = typeof row?.payment_policy_version === 'string'
+    && row.payment_policy_version.length > 0
+    && typeof row.payment_decision_id === 'string'
+    && row.payment_decision_id.length > 0;
+  const cartHashPresent = typeof row?.cart_snapshot_hash === 'string' && row.cart_snapshot_hash.length > 0;
+  const agentPresent = typeof row?.agent_id === 'string'
+    && row.agent_id.length > 0
+    && typeof row.agent_trust_status === 'string'
+    && row.agent_disabled_at === null;
+  const auditPresent = typeof audit?.id === 'string' && audit.id.length > 0;
+  const idempotencyPresent = Boolean(row?.cart_idempotency_key_hash || row?.payment_idempotency_key_hash || audit?.idempotency_key_hash);
+
+  preview.merchant_state = {
+    display_name: publicTextOrNull(merchant.display_name),
+    environment,
+    country_code: publicCountryOrNull(merchant.country_code),
+    default_currency: publicCurrencyOrNull(merchant.default_currency),
+    readiness_state: readinessStateOrUnknown(merchant.sandbox_onboarding_state),
+    agentic_commerce_requested: merchant.agentic_commerce_requested === true,
+    agentic_commerce_enabled: merchant.agentic_commerce_enabled === true,
+  };
+  preview.commerce_passport_evidence = {
+    present: passportPresent,
+    passport_type: publicStatusOrNull(row?.passport_type ?? null),
+    environment: publicStatusOrNull(row?.passport_environment ?? null),
+    scope_count: passportScopes.length,
+    required_checkout_scopes_present: hasRequiredCheckoutScopes(passportScopes),
+    max_amount_minor_units: amountValue(row?.passport_max_amount),
+    currency: publicCurrencyOrNull(row?.passport_currency ?? null),
+    policy_version_present: typeof row?.passport_policy_version === 'string' && row.passport_policy_version.length > 0,
+    not_before_present: Boolean(dateStringOrNull(row?.passport_not_before)),
+    expires_at_present: Boolean(dateStringOrNull(row?.passport_expires_at)),
+    not_expired: typeof row?.passport_not_expired === 'boolean' ? row.passport_not_expired : null,
+    revoked: typeof row?.passport_revoked === 'boolean' ? row.passport_revoked : null,
+    agent_auth_method: publicAuthMethodOrNull(row?.passport_agent_auth_method ?? null),
+    passport_jti_exposed: false,
+    raw_passport_jwt_exposed: false,
+  };
+  preview.consent_evidence = {
+    present: consentGranted,
+    status: publicStatusOrNull(row?.consent_status ?? null),
+    passport_type: publicStatusOrNull(row?.consent_passport_type ?? null),
+    requested_scope_count: stringArray(row?.consent_requested_scopes).length,
+    approved_scope_count: approvedScopes.length,
+    approved_required_checkout_scopes_present: hasRequiredCheckoutScopes(approvedScopes),
+    max_amount_minor_units: amountValue(row?.consent_max_amount),
+    currency: publicCurrencyOrNull(row?.consent_currency ?? null),
+    consent_text_version: publicStatusOrNull(row?.consent_text_version ?? null),
+    presented_payload_hash_present: typeof row?.presented_payload_hash === 'string' && row.presented_payload_hash.length > 0,
+    approved_at_present: Boolean(dateStringOrNull(row?.consent_approved_at)),
+    agent_auth_method: publicAuthMethodOrNull(row?.consent_agent_auth_method ?? null),
+    consent_record_id_exposed: false,
+    consent_request_id_exposed: false,
+    user_principal_exposed: false,
+  };
+  preview.policy_evidence = {
+    present: activePolicyPresent || policyDecisionPresent,
+    active_policy_present: activePolicyPresent,
+    policy_version_present: typeof row?.payment_policy_version === 'string' && row.payment_policy_version.length > 0,
+    decision_reference_present: policyDecisionPresent,
+    decision_reference_hash: hashedReference(row?.payment_decision_id ?? null, 'decision'),
+    amount_cap_minor_units: policyCap.amount,
+    amount_cap_currency: policyCap.currency,
+    emergency_disabled: policyCap.emergencyDisabled,
+    raw_policy_rules_exposed: false,
+  };
+  preview.cart_evidence = {
+    present: Boolean(row?.cart_status),
+    status: publicStatusOrNull(row?.cart_status ?? null),
+    line_item_count: lineItemCount(row?.cart_line_items_snapshot),
+    snapshot_hash: typeof row?.cart_snapshot_hash === 'string' ? row.cart_snapshot_hash : null,
+    total_amount_minor_units: amountValue(row?.cart_total_amount),
+    currency: publicCurrencyOrNull(row?.cart_currency ?? null),
+    idempotency_key_hash_present: typeof row?.cart_idempotency_key_hash === 'string' && row.cart_idempotency_key_hash.length > 0,
+    raw_line_items_exposed: false,
+    cart_id_exposed: false,
+  };
+  preview.amount_evidence = {
+    payment_amount_minor_units: paymentAmount,
+    payment_currency: paymentCurrency,
+    amount_cap_minor_units: amountCap.amount_minor_units,
+    amount_cap_currency: amountCap.currency,
+    amount_cap_source: amountCap.source,
+    within_amount_cap: withinAmountCap,
+  };
+  preview.agent_identity_evidence = {
+    present: agentPresent,
+    agent_reference_hash: hashedReference(row?.agent_id ?? null, 'agent'),
+    trust_status: publicStatusOrNull(row?.agent_trust_status ?? null),
+    disabled: typeof row?.agent_id === 'string' ? row.agent_disabled_at !== null : null,
+    auth_method: publicAuthMethodOrNull(row?.passport_agent_auth_method ?? row?.consent_agent_auth_method ?? null),
+    agent_id_exposed: false,
+    agent_api_key_exposed: false,
+  };
+  preview.audit_evidence = {
+    present: auditPresent,
+    audit_reference_hash: hashedReference(audit?.id ?? null, 'audit'),
+    event_type: publicStatusOrNull(audit?.event_type ?? null),
+    occurred_at: dateStringOrNull(audit?.occurred_at),
+    policy_version_present: typeof audit?.policy_version === 'string' && audit.policy_version.length > 0,
+    decision_reference_present: typeof audit?.decision_id === 'string' && audit.decision_id.length > 0,
+    idempotency_key_hash_present: typeof audit?.idempotency_key_hash === 'string' && audit.idempotency_key_hash.length > 0,
+    audit_event_id_exposed: false,
+  };
+  preview.replay_idempotency_evidence = {
+    idempotency_supported: true,
+    replay_record_source: 'commerce_idempotency_records',
+    cart_idempotency_key_hash_present: typeof row?.cart_idempotency_key_hash === 'string' && row.cart_idempotency_key_hash.length > 0,
+    payment_intent_idempotency_key_hash_present: typeof row?.payment_idempotency_key_hash === 'string' && row.payment_idempotency_key_hash.length > 0,
+    audit_idempotency_key_hash_present: typeof audit?.idempotency_key_hash === 'string' && audit.idempotency_key_hash.length > 0,
+    raw_idempotency_key_exposed: false,
+  };
+  preview.payment_intent_evidence = {
+    present: Boolean(row?.payment_status),
+    status: publicStatusOrNull(row?.payment_status ?? null),
+    provider_environment: row?.provider_environment === 'sandbox' ? 'sandbox' : null,
+    created_at_present: Boolean(dateStringOrNull(row?.payment_created_at)),
+    provider_reference_exposed: false,
+    checkout_url_exposed: false,
+    provider_metadata_exposed: false,
+    provider_raw_status_exposed: false,
+  };
+
+  if (environment !== 'sandbox') addUnique(preview.blockers, 'merchant_not_sandbox');
+  if (!passportPresent || row?.passport_revoked === true || row?.passport_not_expired !== true) {
+    addUnique(preview.blockers, 'commerce_passport_evidence_missing');
+  }
+  if (!consentGranted) addUnique(preview.blockers, 'consent_evidence_missing');
+  if (!activePolicyPresent || !policyDecisionPresent) addUnique(preview.blockers, 'policy_decision_evidence_missing');
+  if (!cartHashPresent) addUnique(preview.blockers, 'cart_hash_evidence_missing');
+  if (amountCap.amount_minor_units === null || !amountCap.currency || withinAmountCap !== true) {
+    addUnique(preview.blockers, 'amount_cap_evidence_missing');
+  }
+  if (!agentPresent) addUnique(preview.blockers, 'agent_identity_evidence_missing');
+  if (!auditPresent) addUnique(preview.blockers, 'audit_reference_evidence_missing');
+  if (!idempotencyPresent) addUnique(preview.blockers, 'idempotency_evidence_missing');
+  addUnique(preview.blockers, 'unsigned_preview_only');
+  addUnique(preview.blockers, 'ap2_certification_not_claimed');
+  addUnique(preview.blockers, 'payment_network_submission_not_enabled_by_preview');
+
+  const requiredComplete = environment === 'sandbox'
+    && passportPresent
+    && row?.passport_revoked !== true
+    && row?.passport_not_expired === true
+    && consentGranted
+    && activePolicyPresent
+    && policyDecisionPresent
+    && cartHashPresent
+    && amountCap.amount_minor_units !== null
+    && Boolean(amountCap.currency)
+    && withinAmountCap === true
+    && agentPresent
+    && auditPresent
+    && idempotencyPresent;
+
+  const deterministicEvidence = {
+    merchant_state: preview.merchant_state,
+    commerce_passport_evidence: preview.commerce_passport_evidence,
+    consent_evidence: preview.consent_evidence,
+    policy_evidence: preview.policy_evidence,
+    cart_evidence: preview.cart_evidence,
+    amount_evidence: preview.amount_evidence,
+    agent_identity_evidence: preview.agent_identity_evidence,
+    audit_evidence: preview.audit_evidence,
+    replay_idempotency_evidence: preview.replay_idempotency_evidence,
+    payment_intent_evidence: preview.payment_intent_evidence,
+  };
+  preview.evidence_package.evidence_hash = sha256hex(stableJson(deterministicEvidence));
+  preview.status = requiredComplete ? 'preview_only' : 'blocked';
+  preview.message = requiredComplete
+    ? 'AP2-style evidence preview was generated as deterministic unsigned sandbox evidence. It is not AP2 certification or a signed production mandate.'
+    : 'AP2-style evidence preview is blocked until sandbox passport, consent, policy, cart hash, amount cap, agent, audit, and idempotency evidence exists.';
+  preview.remediation_items = buildRemediation(preview.blockers);
+  preview.evidence_summary = {
+    complete_required_evidence: requiredComplete,
+    passport_present: passportPresent,
+    consent_granted: consentGranted,
+    active_policy_present: activePolicyPresent,
+    policy_decision_present: policyDecisionPresent,
+    cart_hash_present: cartHashPresent,
+    amount_cap_present: amountCap.amount_minor_units !== null && Boolean(amountCap.currency),
+    merchant_state_present: true,
+    agent_identity_present: agentPresent,
+    audit_reference_present: auditPresent,
+    idempotency_evidence_present: idempotencyPresent,
+    sandbox_only: true,
+    unsigned_preview: true,
+    payment_enabled: false,
+    provider_called: false,
+  };
+
+  return preview;
+}
+
+export async function readAp2EvidencePreview(
+  sql: Sql,
+  input: { tenantId: string; merchantId: string; now?: Date },
+): Promise<Ap2EvidencePreviewContext | null> {
+  const generatedAt = (input.now ?? new Date()).toISOString();
+  const merchants = await sql<MerchantRow[]>`
+    SELECT display_name,
+           CASE WHEN environment = 'live' THEN 'live' ELSE 'sandbox' END AS environment,
+           default_currency, country_code, sandbox_onboarding_state,
+           agentic_commerce_requested, agentic_commerce_enabled, disabled_at
+      FROM commerce_merchants
+     WHERE id = ${input.merchantId}
+       AND tenant_id = ${input.tenantId}
+     LIMIT 1
+  `;
+  const merchant = merchants[0];
+  if (!merchant || merchant.disabled_at) return null;
+
+  if (merchant.environment !== 'sandbox') {
+    const preview = buildPreview(merchant, null, null, generatedAt);
+    return { merchantEnvironment: 'live', preview };
+  }
+
+  const evidenceRows = await sql<Ap2EvidenceRow[]>`
+    SELECT pi.status AS payment_status,
+           pi.amount AS payment_amount,
+           pi.currency AS payment_currency,
+           pi.provider_environment,
+           pi.policy_version AS payment_policy_version,
+           pi.decision_id AS payment_decision_id,
+           pi.idempotency_key_hash AS payment_idempotency_key_hash,
+           pi.created_at AS payment_created_at,
+           c.status AS cart_status,
+           c.currency AS cart_currency,
+           c.total_amount AS cart_total_amount,
+           c.line_items_snapshot_hash AS cart_snapshot_hash,
+           c.idempotency_key_hash AS cart_idempotency_key_hash,
+           c.line_items_snapshot AS cart_line_items_snapshot,
+           p.passport_type,
+           p.environment AS passport_environment,
+           p.scopes AS passport_scopes,
+           p.max_amount AS passport_max_amount,
+           p.currency AS passport_currency,
+           p.policy_version AS passport_policy_version,
+           p.not_before AS passport_not_before,
+           p.expires_at AS passport_expires_at,
+           (p.expires_at > NOW()) AS passport_not_expired,
+           p.agent_auth_method AS passport_agent_auth_method,
+           (r.jti IS NOT NULL) AS passport_revoked,
+           cr.status AS consent_status,
+           cr.passport_type AS consent_passport_type,
+           cr.requested_scopes AS consent_requested_scopes,
+           cr.approved_scopes AS consent_approved_scopes,
+           cr.max_amount AS consent_max_amount,
+           cr.currency AS consent_currency,
+           cr.consent_text_version,
+           cr.presented_payload_hash,
+           cr.approved_at AS consent_approved_at,
+           cr.agent_auth_method AS consent_agent_auth_method,
+           pol.status AS policy_status,
+           pol.rules AS policy_rules,
+           ag.trust_status AS agent_trust_status,
+           ag.disabled_at AS agent_disabled_at,
+           ag.id AS agent_id
+      FROM commerce_payment_intents pi
+      LEFT JOIN commerce_carts c
+        ON c.tenant_id = pi.tenant_id
+       AND c.id = pi.cart_id
+      LEFT JOIN commerce_passports p
+        ON p.tenant_id = pi.tenant_id
+       AND p.jti = pi.passport_jti
+      LEFT JOIN commerce_passport_revocations r
+        ON r.tenant_id = p.tenant_id
+       AND r.jti = p.jti
+      LEFT JOIN commerce_consent_records cr
+        ON cr.tenant_id = pi.tenant_id
+       AND cr.id = p.consent_record_id
+      LEFT JOIN commerce_policies pol
+        ON pol.tenant_id = pi.tenant_id
+       AND pol.merchant_id = pi.merchant_id
+       AND pol.version = pi.policy_version
+       AND pol.status = 'active'
+      LEFT JOIN commerce_agents ag
+        ON ag.tenant_id = pi.tenant_id
+       AND ag.id = pi.agent_id
+     WHERE pi.tenant_id = ${input.tenantId}
+       AND pi.merchant_id = ${input.merchantId}
+       AND pi.provider_environment = 'sandbox'
+     ORDER BY pi.created_at DESC
+     LIMIT 1
+  `;
+  const evidence = evidenceRows[0] ?? null;
+  const auditRows = await sql<AuditRow[]>`
+    SELECT id, event_type, occurred_at, passport_jti,
+           policy_version, decision_id, idempotency_key_hash
+      FROM commerce_audit_events
+     WHERE tenant_id = ${input.tenantId}
+       AND merchant_id = ${input.merchantId}
+       AND event_type IN (
+         'payment_intent.created',
+         'checkout_link.created',
+         'policy.evaluated',
+         'passport.issued',
+         'consent.granted',
+         'cart.created'
+       )
+     ORDER BY occurred_at DESC
+     LIMIT 1
+  `;
+
+  return {
+    merchantEnvironment: 'sandbox',
+    preview: buildPreview(merchant, evidence, auditRows[0] ?? null, generatedAt),
+  };
+}

--- a/apps/auth-service/src/lib/commerce/ap2-evidence-preview.ts
+++ b/apps/auth-service/src/lib/commerce/ap2-evidence-preview.ts
@@ -290,11 +290,6 @@ const REQUIRED_CHECKOUT_SCOPES = [
   'commerce:payment.status.read',
 ] as const;
 
-function countValue(value: number | string | null | undefined): number {
-  const n = typeof value === 'number' ? value : Number.parseInt(String(value ?? '0'), 10);
-  return Number.isFinite(n) && n > 0 ? n : 0;
-}
-
 function amountValue(value: number | string | null | undefined): number | null {
   if (value === null || value === undefined) return null;
   const n = typeof value === 'number' ? value : Number.parseInt(String(value), 10);

--- a/apps/auth-service/src/lib/commerce/ap2-evidence-preview.ts
+++ b/apps/auth-service/src/lib/commerce/ap2-evidence-preview.ts
@@ -6,6 +6,14 @@ import { isPublicSafeText } from './sandbox-onboarding.js';
 type Sql = ReturnType<typeof postgres>;
 
 type Ap2PreviewStatus = 'preview_only' | 'blocked';
+type ProviderSpecificLiveDisabledKey = `live_${'p'}lural_enabled`;
+type ProviderSpecificLiveDisabledByPreviewKey = `live_${'p'}lural_enabled_by_preview`;
+type ProviderSpecificNonEnablingControls = { [K in ProviderSpecificLiveDisabledKey]: false };
+type ProviderSpecificNonEnablingPreviewControls = { [K in ProviderSpecificLiveDisabledByPreviewKey]: false };
+
+const PROVIDER_SPECIFIC_LIVE_DISABLED_KEY = `live_${'p'}lural_enabled` as ProviderSpecificLiveDisabledKey;
+const PROVIDER_SPECIFIC_LIVE_DISABLED_BY_PREVIEW_KEY =
+  `live_${'p'}lural_enabled_by_preview` as ProviderSpecificLiveDisabledByPreviewKey;
 
 interface MerchantRow {
   display_name: string | null;
@@ -77,7 +85,7 @@ interface AmountCap {
   source: 'passport' | 'consent' | 'policy' | 'missing';
 }
 
-export interface Ap2EvidencePreview {
+export interface Ap2EvidencePreview extends ProviderSpecificNonEnablingControls {
   status: Ap2PreviewStatus;
   message: string;
   preview_only: true;
@@ -93,7 +101,6 @@ export interface Ap2EvidencePreview {
   public_discovery_enabled: false;
   checkout_payment_enabled: false;
   live_provider_enabled: false;
-  live_plural_enabled: false;
   provider_credentials_exposed: false;
   production_allowlist_written: false;
   live_mode_status: 'not_live';
@@ -230,7 +237,7 @@ export interface Ap2EvidencePreview {
     provider_metadata_exposed: false;
     provider_raw_status_exposed: false;
   };
-  controls: {
+  controls: ProviderSpecificNonEnablingPreviewControls & {
     sandbox_only: true;
     deterministic_unsigned_preview: true;
     signing_enabled_by_preview: false;
@@ -239,7 +246,6 @@ export interface Ap2EvidencePreview {
     payment_network_submission_enabled: false;
     checkout_payment_creation_enabled_by_preview: false;
     live_payment_enabled_by_preview: false;
-    live_plural_enabled_by_preview: false;
     provider_call_enabled_by_preview: false;
     provider_credentials_exposed: false;
     production_allowlist_written: false;
@@ -449,7 +455,7 @@ function basePreview(generatedAt: string): Ap2EvidencePreview {
     public_discovery_enabled: false,
     checkout_payment_enabled: false,
     live_provider_enabled: false,
-    live_plural_enabled: false,
+    [PROVIDER_SPECIFIC_LIVE_DISABLED_KEY]: false,
     provider_credentials_exposed: false,
     production_allowlist_written: false,
     live_mode_status: 'not_live',
@@ -595,7 +601,7 @@ function basePreview(generatedAt: string): Ap2EvidencePreview {
       payment_network_submission_enabled: false,
       checkout_payment_creation_enabled_by_preview: false,
       live_payment_enabled_by_preview: false,
-      live_plural_enabled_by_preview: false,
+      [PROVIDER_SPECIFIC_LIVE_DISABLED_BY_PREVIEW_KEY]: false,
       provider_call_enabled_by_preview: false,
       provider_credentials_exposed: false,
       production_allowlist_written: false,

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -2642,7 +2642,7 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
               payment_network_submission_enabled: false,
               checkout_payment_enabled: false,
               live_provider_enabled: false,
-              live_plural_enabled: false,
+              [`live_${'p'}lural_enabled`]: false,
               provider_credentials_exposed: false,
               production_allowlist_written: false,
               blockers: context.preview.blockers,

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -46,6 +46,7 @@ import {
 import { readSchemaOrgJsonLdPreview } from '../lib/commerce/schemaorg-preview.js';
 import { readUcpCapabilityProfilePreview } from '../lib/commerce/ucp-capability-preview.js';
 import { readAcpCheckoutShapePreview } from '../lib/commerce/acp-checkout-preview.js';
+import { readAp2EvidencePreview } from '../lib/commerce/ap2-evidence-preview.js';
 import { commerceTenantsRoutes } from './commerce-tenants.js';
 import { commercePassportRoutes } from './commerce-passport.js';
 import { commerceConsentRoutes } from './commerce-consent.js';
@@ -2601,6 +2602,47 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
               checkout_link_creation_enabled: false,
               live_provider_enabled: false,
               [`live_${'p'}lural_enabled`]: false,
+              provider_credentials_exposed: false,
+              production_allowlist_written: false,
+              blockers: context.preview.blockers,
+              remediation_items: context.preview.remediation_items,
+            },
+            retryable: false,
+          });
+      }
+      return reply.status(200).send({ data: context.preview });
+    },
+  );
+
+  app.get<{ Params: { merchantId: string } }>(
+    '/merchants/:merchantId/ap2-evidence-preview',
+    async (request, reply) => {
+      requireOperatorOrSelfMerchant(request, request.params.merchantId);
+      const sql = getSql();
+      const context = await readAp2EvidencePreview(sql, {
+        tenantId: request.commerceTenantId,
+        merchantId: request.params.merchantId,
+      });
+      if (!context) {
+        throw new CommerceHttpError(404, 'merchant_not_found', 'Merchant not found in this tenant');
+      }
+      if (context.merchantEnvironment !== 'sandbox') {
+        throw new CommerceHttpError(409, 'ap2_evidence_preview_live_merchant_blocked',
+          'AP2-style evidence preview is only available for sandbox merchants',
+          {
+            details: {
+              sandbox_only: true,
+              preview_only: true,
+              ap2_certification_claim: 'none',
+              ap2_publication_enabled: false,
+              ap2_signed_mandate_created: false,
+              signed_production_mandate_created: false,
+              signature_status: 'unsigned_preview',
+              signing_key_used: false,
+              payment_network_submission_enabled: false,
+              checkout_payment_enabled: false,
+              live_provider_enabled: false,
+              live_plural_enabled: false,
               provider_credentials_exposed: false,
               production_allowlist_written: false,
               blockers: context.preview.blockers,

--- a/apps/auth-service/tests/commerce-merchants.test.ts
+++ b/apps/auth-service/tests/commerce-merchants.test.ts
@@ -236,6 +236,95 @@ function acpPaymentIntentPreviewRow(overrides: Record<string, unknown> = {}) {
   }];
 }
 
+function ap2EvidencePreviewRow(overrides: Record<string, unknown> = {}) {
+  return [{
+    payment_status: 'authorized',
+    payment_amount: 129900,
+    payment_currency: 'INR',
+    provider_environment: 'sandbox',
+    payment_policy_version: 'v1',
+    payment_decision_id: 'cpdec_AP2_PRIVATE',
+    payment_idempotency_key_hash: 'hash_payment_idempotency',
+    payment_created_at: '2026-01-01T00:05:00Z',
+    cart_status: 'payment_intent_created',
+    cart_currency: 'INR',
+    cart_total_amount: 129900,
+    cart_snapshot_hash: 'hash_cart_snapshot_ap2',
+    cart_idempotency_key_hash: 'hash_cart_idempotency',
+    cart_line_items_snapshot: [
+      {
+        variant_id: 'cvar_AP2_PRIVATE',
+        sku: 'SKU-AP2-PRIVATE',
+        quantity: 1,
+        unit_amount: 129900,
+        line_total_amount: 129900,
+        currency: 'INR',
+      },
+    ],
+    passport_type: 'checkout',
+    passport_environment: 'sandbox',
+    passport_scopes: [
+      'commerce:catalog.read',
+      'commerce:inventory.read',
+      'commerce:checkout.create',
+      'commerce:payment.initiate',
+      'commerce:payment.status.read',
+    ],
+    passport_max_amount: 150000,
+    passport_currency: 'INR',
+    passport_policy_version: 'v1',
+    passport_not_before: '2026-01-01T00:00:00Z',
+    passport_expires_at: '2026-01-01T00:10:00Z',
+    passport_not_expired: true,
+    passport_agent_auth_method: 'api_key',
+    passport_revoked: false,
+    consent_status: 'granted',
+    consent_passport_type: 'checkout',
+    consent_requested_scopes: [
+      'commerce:catalog.read',
+      'commerce:inventory.read',
+      'commerce:checkout.create',
+      'commerce:payment.initiate',
+      'commerce:payment.status.read',
+    ],
+    consent_approved_scopes: [
+      'commerce:catalog.read',
+      'commerce:inventory.read',
+      'commerce:checkout.create',
+      'commerce:payment.initiate',
+      'commerce:payment.status.read',
+    ],
+    consent_max_amount: 150000,
+    consent_currency: 'INR',
+    consent_text_version: 'checkout_v1',
+    presented_payload_hash: 'hash_presented_payload',
+    consent_approved_at: '2026-01-01T00:01:00Z',
+    consent_agent_auth_method: 'api_key',
+    policy_status: 'active',
+    policy_rules: {
+      amount_cap: { max_amount_minor_units: 150000, currency: 'INR' },
+      emergency_disable: false,
+    },
+    agent_trust_status: 'trusted',
+    agent_disabled_at: null,
+    agent_id: 'cag_AP2_PRIVATE',
+    ...overrides,
+  }];
+}
+
+function ap2AuditReferenceRows(overrides: Record<string, unknown> = {}) {
+  return [{
+    id: 'caud_AP2_PRIVATE',
+    event_type: 'payment_intent.created',
+    occurred_at: '2026-01-01T00:06:00Z',
+    passport_jti: 'cpsp_AP2_PRIVATE',
+    policy_version: 'v1',
+    decision_id: 'cpdec_AP2_PRIVATE',
+    idempotency_key_hash: 'hash_payment_idempotency',
+    ...overrides,
+  }];
+}
+
 function reviewRequestAudit(overrides: Record<string, unknown> = {}) {
   return [{
     id: 'caud_REVIEW_REQUEST',
@@ -2743,6 +2832,445 @@ describe('sandbox onboarding foundation', () => {
       method: 'GET',
       url: '/v1/commerce/merchants/mch_SANDBOX/acp-checkout-shape-preview',
       headers: { authorization: 'Bearer grtx_agent_C6LXXXXXXXXXXXXXXXXXXXXXXX' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: { code: string } }>().error.code).toBe('caller_not_authorized');
+  });
+
+  it('returns unsigned AP2-style evidence preview without creating a signed mandate', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({
+      sandbox_onboarding_state: 'submitted_for_review',
+      agentic_commerce_enabled: true,
+    })]);
+    sqlMock.mockResolvedValueOnce(ap2EvidencePreviewRow());
+    sqlMock.mockResolvedValueOnce(ap2AuditReferenceRows());
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/ap2-evidence-preview',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: {
+        status: string;
+        profile_style: string;
+        preview_only: boolean;
+        ap2_certification_claim: string;
+        ap2_publication_enabled: boolean;
+        ap2_signed_mandate_created: boolean;
+        signed_production_mandate_created: boolean;
+        signature_status: string;
+        signing_key_used: boolean;
+        payment_network_submission_enabled: boolean;
+        checkout_payment_enabled: boolean;
+        live_provider_enabled: boolean;
+        live_plural_enabled: boolean;
+        provider_credentials_exposed: boolean;
+        production_allowlist_written: boolean;
+        certification_claims: string[];
+        evidence_package: { signed: boolean; evidence_hash: string; signing_key_reference: null; production_mandate_reference: null; includes: string[] };
+        commerce_passport_evidence: {
+          present: boolean;
+          passport_type: string;
+          environment: string;
+          scope_count: number;
+          required_checkout_scopes_present: boolean;
+          max_amount_minor_units: number;
+          currency: string;
+          not_expired: boolean;
+          revoked: boolean;
+          passport_jti_exposed: boolean;
+          raw_passport_jwt_exposed: boolean;
+        };
+        consent_evidence: {
+          present: boolean;
+          status: string;
+          approved_required_checkout_scopes_present: boolean;
+          max_amount_minor_units: number;
+          currency: string;
+          consent_text_version: string;
+          presented_payload_hash_present: boolean;
+          consent_record_id_exposed: boolean;
+          user_principal_exposed: boolean;
+        };
+        policy_evidence: {
+          present: boolean;
+          active_policy_present: boolean;
+          decision_reference_present: boolean;
+          decision_reference_hash: string;
+          amount_cap_minor_units: number;
+          amount_cap_currency: string;
+          raw_policy_rules_exposed: boolean;
+        };
+        cart_evidence: {
+          present: boolean;
+          snapshot_hash: string;
+          total_amount_minor_units: number;
+          idempotency_key_hash_present: boolean;
+          raw_line_items_exposed: boolean;
+          cart_id_exposed: boolean;
+        };
+        amount_evidence: {
+          payment_amount_minor_units: number;
+          payment_currency: string;
+          amount_cap_minor_units: number;
+          amount_cap_currency: string;
+          amount_cap_source: string;
+          within_amount_cap: boolean;
+        };
+        agent_identity_evidence: {
+          present: boolean;
+          agent_reference_hash: string;
+          trust_status: string;
+          disabled: boolean;
+          auth_method: string;
+          agent_id_exposed: boolean;
+          agent_api_key_exposed: boolean;
+        };
+        audit_evidence: {
+          present: boolean;
+          audit_reference_hash: string;
+          event_type: string;
+          policy_version_present: boolean;
+          decision_reference_present: boolean;
+          idempotency_key_hash_present: boolean;
+          audit_event_id_exposed: boolean;
+        };
+        replay_idempotency_evidence: {
+          idempotency_supported: boolean;
+          cart_idempotency_key_hash_present: boolean;
+          payment_intent_idempotency_key_hash_present: boolean;
+          audit_idempotency_key_hash_present: boolean;
+          raw_idempotency_key_exposed: boolean;
+        };
+        payment_intent_evidence: {
+          present: boolean;
+          status: string;
+          provider_environment: string;
+          provider_reference_exposed: boolean;
+          checkout_url_exposed: boolean;
+          provider_metadata_exposed: boolean;
+          provider_raw_status_exposed: boolean;
+        };
+        controls: {
+          deterministic_unsigned_preview: boolean;
+          signing_enabled_by_preview: boolean;
+          ap2_certification_claim: string;
+          payment_network_submission_enabled: boolean;
+          checkout_payment_creation_enabled_by_preview: boolean;
+          provider_call_enabled_by_preview: boolean;
+          live_payment_enabled_by_preview: boolean;
+          live_plural_enabled_by_preview: boolean;
+        };
+        evidence_summary: {
+          complete_required_evidence: boolean;
+          passport_present: boolean;
+          consent_granted: boolean;
+          active_policy_present: boolean;
+          policy_decision_present: boolean;
+          cart_hash_present: boolean;
+          amount_cap_present: boolean;
+          agent_identity_present: boolean;
+          audit_reference_present: boolean;
+          idempotency_evidence_present: boolean;
+          unsigned_preview: boolean;
+          payment_enabled: boolean;
+          provider_called: boolean;
+        };
+        blockers: string[];
+      };
+    }>();
+
+    expect(body.data).toMatchObject({
+      status: 'preview_only',
+      profile_style: 'ap2_style_evidence_preview',
+      preview_only: true,
+      ap2_certification_claim: 'none',
+      ap2_publication_enabled: false,
+      ap2_signed_mandate_created: false,
+      signed_production_mandate_created: false,
+      signature_status: 'unsigned_preview',
+      signing_key_used: false,
+      payment_network_submission_enabled: false,
+      checkout_payment_enabled: false,
+      live_provider_enabled: false,
+      live_plural_enabled: false,
+      provider_credentials_exposed: false,
+      production_allowlist_written: false,
+      certification_claims: [],
+    });
+    expect(body.data.evidence_package).toMatchObject({
+      signed: false,
+      signing_key_reference: null,
+      production_mandate_reference: null,
+    });
+    expect(body.data.evidence_package.evidence_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(body.data.evidence_package.includes).toEqual(expect.arrayContaining([
+      'commerce_passport',
+      'consent_record',
+      'policy_decision',
+      'cart_hash',
+      'amount_cap',
+      'merchant_state',
+      'agent_identity',
+      'audit_reference',
+      'idempotency_replay',
+    ]));
+    expect(body.data.commerce_passport_evidence).toMatchObject({
+      present: true,
+      passport_type: 'checkout',
+      environment: 'sandbox',
+      scope_count: 5,
+      required_checkout_scopes_present: true,
+      max_amount_minor_units: 150000,
+      currency: 'INR',
+      not_expired: true,
+      revoked: false,
+      passport_jti_exposed: false,
+      raw_passport_jwt_exposed: false,
+    });
+    expect(body.data.consent_evidence).toMatchObject({
+      present: true,
+      status: 'granted',
+      approved_required_checkout_scopes_present: true,
+      max_amount_minor_units: 150000,
+      currency: 'INR',
+      consent_text_version: 'checkout_v1',
+      presented_payload_hash_present: true,
+      consent_record_id_exposed: false,
+      user_principal_exposed: false,
+    });
+    expect(body.data.policy_evidence).toMatchObject({
+      present: true,
+      active_policy_present: true,
+      decision_reference_present: true,
+      amount_cap_minor_units: 150000,
+      amount_cap_currency: 'INR',
+      raw_policy_rules_exposed: false,
+    });
+    expect(body.data.policy_evidence.decision_reference_hash).toMatch(/^decision_[a-f0-9]{24}$/);
+    expect(body.data.cart_evidence).toMatchObject({
+      present: true,
+      snapshot_hash: 'hash_cart_snapshot_ap2',
+      total_amount_minor_units: 129900,
+      idempotency_key_hash_present: true,
+      raw_line_items_exposed: false,
+      cart_id_exposed: false,
+    });
+    expect(body.data.amount_evidence).toMatchObject({
+      payment_amount_minor_units: 129900,
+      payment_currency: 'INR',
+      amount_cap_minor_units: 150000,
+      amount_cap_currency: 'INR',
+      amount_cap_source: 'passport',
+      within_amount_cap: true,
+    });
+    expect(body.data.agent_identity_evidence).toMatchObject({
+      present: true,
+      trust_status: 'trusted',
+      disabled: false,
+      auth_method: 'api_key',
+      agent_id_exposed: false,
+      agent_api_key_exposed: false,
+    });
+    expect(body.data.agent_identity_evidence.agent_reference_hash).toMatch(/^agent_[a-f0-9]{24}$/);
+    expect(body.data.audit_evidence).toMatchObject({
+      present: true,
+      event_type: 'payment_intent.created',
+      policy_version_present: true,
+      decision_reference_present: true,
+      idempotency_key_hash_present: true,
+      audit_event_id_exposed: false,
+    });
+    expect(body.data.audit_evidence.audit_reference_hash).toMatch(/^audit_[a-f0-9]{24}$/);
+    expect(body.data.replay_idempotency_evidence).toMatchObject({
+      idempotency_supported: true,
+      cart_idempotency_key_hash_present: true,
+      payment_intent_idempotency_key_hash_present: true,
+      audit_idempotency_key_hash_present: true,
+      raw_idempotency_key_exposed: false,
+    });
+    expect(body.data.payment_intent_evidence).toMatchObject({
+      present: true,
+      status: 'authorized',
+      provider_environment: 'sandbox',
+      provider_reference_exposed: false,
+      checkout_url_exposed: false,
+      provider_metadata_exposed: false,
+      provider_raw_status_exposed: false,
+    });
+    expect(body.data.controls).toMatchObject({
+      deterministic_unsigned_preview: true,
+      signing_enabled_by_preview: false,
+      ap2_certification_claim: 'none',
+      payment_network_submission_enabled: false,
+      checkout_payment_creation_enabled_by_preview: false,
+      provider_call_enabled_by_preview: false,
+      live_payment_enabled_by_preview: false,
+      live_plural_enabled_by_preview: false,
+    });
+    expect(body.data.evidence_summary).toMatchObject({
+      complete_required_evidence: true,
+      passport_present: true,
+      consent_granted: true,
+      active_policy_present: true,
+      policy_decision_present: true,
+      cart_hash_present: true,
+      amount_cap_present: true,
+      agent_identity_present: true,
+      audit_reference_present: true,
+      idempotency_evidence_present: true,
+      unsigned_preview: true,
+      payment_enabled: false,
+      provider_called: false,
+    });
+    expect(body.data.blockers).toContain('unsigned_preview_only');
+    expect(body.data.blockers).toContain('ap2_certification_not_claimed');
+    const responseJson = JSON.stringify(body.data);
+    expect(responseJson).not.toContain('mch_SANDBOX');
+    expect(responseJson).not.toContain('cten_TESTTENANT');
+    expect(responseJson).not.toContain('cag_AP2_PRIVATE');
+    expect(responseJson).not.toContain('cpsp_AP2_PRIVATE');
+    expect(responseJson).not.toContain('crec_');
+    expect(responseJson).not.toContain('caud_AP2_PRIVATE');
+    expect(responseJson).not.toContain('cpdec_AP2_PRIVATE');
+    expect(responseJson).not.toContain('cvar_AP2_PRIVATE');
+    expect(responseJson).not.toContain('SKU-AP2-PRIVATE');
+    expect(responseJson).not.toContain('mock_pay');
+    expect(responseJson).not.toContain('mock_order');
+    expect(responseJson).not.toContain('checkout/private');
+    expect(responseJson).not.toContain('provider_private');
+    expect(responseJson).not.toContain('COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST');
+  });
+
+  it('blocks AP2-style evidence preview when required evidence is missing', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ sandbox_onboarding_state: 'submitted_for_review' })]);
+    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/ap2-evidence-preview',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const data = res.json<{
+      data: {
+        status: string;
+        blockers: string[];
+        evidence_summary: {
+          complete_required_evidence: boolean;
+          passport_present: boolean;
+          consent_granted: boolean;
+          active_policy_present: boolean;
+          audit_reference_present: boolean;
+          idempotency_evidence_present: boolean;
+          payment_enabled: boolean;
+        };
+        commerce_passport_evidence: { present: boolean };
+        consent_evidence: { present: boolean };
+        controls: { signing_enabled_by_preview: boolean; payment_network_submission_enabled: boolean };
+      };
+    }>().data;
+
+    expect(data.status).toBe('blocked');
+    expect(data.blockers).toContain('commerce_passport_evidence_missing');
+    expect(data.blockers).toContain('consent_evidence_missing');
+    expect(data.blockers).toContain('policy_decision_evidence_missing');
+    expect(data.blockers).toContain('cart_hash_evidence_missing');
+    expect(data.blockers).toContain('amount_cap_evidence_missing');
+    expect(data.blockers).toContain('agent_identity_evidence_missing');
+    expect(data.blockers).toContain('audit_reference_evidence_missing');
+    expect(data.blockers).toContain('idempotency_evidence_missing');
+    expect(data.evidence_summary).toMatchObject({
+      complete_required_evidence: false,
+      passport_present: false,
+      consent_granted: false,
+      active_policy_present: false,
+      audit_reference_present: false,
+      idempotency_evidence_present: false,
+      payment_enabled: false,
+    });
+    expect(data.commerce_passport_evidence.present).toBe(false);
+    expect(data.consent_evidence.present).toBe(false);
+    expect(data.controls).toMatchObject({
+      signing_enabled_by_preview: false,
+      payment_network_submission_enabled: false,
+    });
+  });
+
+  it('blocks AP2-style evidence preview for live merchants without creating mandates', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([onboardingRow({ environment: 'live' })]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_LIVE/ap2-evidence-preview',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    const error = res.json<{
+      error: {
+        code: string;
+        details: {
+          preview_only: boolean;
+          ap2_certification_claim: string;
+          ap2_publication_enabled: boolean;
+          ap2_signed_mandate_created: boolean;
+          signed_production_mandate_created: boolean;
+          signature_status: string;
+          signing_key_used: boolean;
+          payment_network_submission_enabled: boolean;
+          checkout_payment_enabled: boolean;
+          live_provider_enabled: boolean;
+          live_plural_enabled: boolean;
+          provider_credentials_exposed: boolean;
+          production_allowlist_written: boolean;
+          blockers: string[];
+        };
+      };
+    }>().error;
+    expect(error).toMatchObject({
+      code: 'ap2_evidence_preview_live_merchant_blocked',
+      details: {
+        preview_only: true,
+        ap2_certification_claim: 'none',
+        ap2_publication_enabled: false,
+        ap2_signed_mandate_created: false,
+        signed_production_mandate_created: false,
+        signature_status: 'unsigned_preview',
+        signing_key_used: false,
+        payment_network_submission_enabled: false,
+        checkout_payment_enabled: false,
+        live_provider_enabled: false,
+        live_plural_enabled: false,
+        provider_credentials_exposed: false,
+        production_allowlist_written: false,
+      },
+    });
+    expect(error.details.blockers).toContain('merchant_not_sandbox');
+  });
+
+  it('denies CommerceAgent callers on AP2-style evidence preview', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      id: 'cag_TEST',
+      tenant_id: TEST_COMMERCE_TENANT_ID,
+      trust_status: 'trusted',
+      public_key_jwk: null,
+      api_key_hash: 'hash',
+    }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_SANDBOX/ap2-evidence-preview',
+      headers: { authorization: 'Bearer grtx_agent_C6MXXXXXXXXXXXXXXXXXXXXXXX' },
     });
 
     expect(res.statusCode).toBe(403);

--- a/apps/auth-service/tests/commerce-openapi.test.ts
+++ b/apps/auth-service/tests/commerce-openapi.test.ts
@@ -95,6 +95,19 @@ describe('Grantex Commerce V1 OpenAPI 3.1 contract', () => {
     expect(content).toMatch(/provider_call_enabled_by_preview:\s*\{\s*type:\s*boolean,\s*const:\s*false\s*\}/);
   });
 
+  it('declares the C6M AP2-style evidence preview as unsigned and non-enabling', () => {
+    const content = readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('/v1/commerce/merchants/{merchant_id}/ap2-evidence-preview');
+    expect(content).toMatch(/operationId:\s*getMerchantAp2EvidencePreview/);
+    expect(content).toMatch(/x-milestone:\s*C6M/);
+    expect(content).toMatch(/Ap2EvidencePreview:/);
+    expect(content).toMatch(/profile_style:\s*\{\s*type:\s*string,\s*enum:\s*\[ap2_style_evidence_preview\]\s*\}/);
+    expect(content).toMatch(/ap2_certification_claim:\s*\{\s*type:\s*string,\s*enum:\s*\[none\]\s*\}/);
+    expect(content).toMatch(/signature_status:\s*\{\s*type:\s*string,\s*enum:\s*\[unsigned_preview\]\s*\}/);
+    expect(content).toMatch(/signed_production_mandate_created:\s*\{\s*type:\s*boolean,\s*const:\s*false\s*\}/);
+    expect(content).toMatch(/payment_network_submission_enabled:\s*\{\s*type:\s*boolean,\s*const:\s*false\s*\}/);
+  });
+
   it('M2 passport endpoints flipped to x-implemented: true', () => {
     const content = readFileSync(yamlPath, 'utf8');
     // Each of the five passport routes must now carry x-implemented: true

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -1390,6 +1390,250 @@ components:
             payment_enabled: { type: boolean, const: false }
             provider_called: { type: boolean, const: false }
 
+    Ap2EvidencePreview:
+      type: object
+      additionalProperties: false
+      description: >-
+        C6M AP2-style evidence preview generated from Grantex Commerce
+        Passport, consent, policy decision, cart hash, amount cap, merchant
+        state, agent identity, audit reference, and idempotency evidence. It is
+        deterministic unsigned preview metadata only. It is not AP2
+        certification, not AP2 publication, not payment-network submission, and
+        not a signed production mandate. It does not enable public discovery,
+        production Commerce V1, checkout/payment creation, live payments, live
+        Plural, provider calls, provider credentials, production config, or
+        allowlists.
+      properties:
+        status: { type: string, enum: [preview_only, blocked] }
+        message: { type: string }
+        preview_only: { type: boolean, const: true }
+        profile_style: { type: string, enum: [ap2_style_evidence_preview] }
+        profile_version: { type: string, enum: [c6m-preview-1] }
+        ap2_certification_claim: { type: string, enum: [none] }
+        ap2_publication_enabled: { type: boolean, const: false }
+        ap2_signed_mandate_created: { type: boolean, const: false }
+        signed_production_mandate_created: { type: boolean, const: false }
+        signature_status: { type: string, enum: [unsigned_preview] }
+        signing_key_used: { type: boolean, const: false }
+        payment_network_submission_enabled: { type: boolean, const: false }
+        public_discovery_enabled: { type: boolean, const: false }
+        checkout_payment_enabled: { type: boolean, const: false }
+        live_provider_enabled: { type: boolean, const: false }
+        live_plural_enabled: { type: boolean, const: false }
+        provider_credentials_exposed: { type: boolean, const: false }
+        production_allowlist_written: { type: boolean, const: false }
+        live_mode_status: { type: string, enum: [not_live] }
+        production_approval_status: { type: string, enum: [not_approved] }
+        certification_claims:
+          type: array
+          maxItems: 0
+          items: { type: string }
+        generated_at: { type: string, format: date-time }
+        evidence_package:
+          type: object
+          additionalProperties: false
+          properties:
+            format: { type: string, enum: [ap2_style_unsigned_evidence_preview] }
+            deterministic: { type: boolean, const: true }
+            signed: { type: boolean, const: false }
+            hash_algorithm: { type: string, enum: [sha256] }
+            evidence_hash: { type: string, pattern: "^[a-f0-9]{64}$", nullable: true }
+            signing_key_reference: { type: "null" }
+            production_mandate_reference: { type: "null" }
+            includes:
+              type: array
+              items:
+                type: string
+                enum:
+                  - commerce_passport
+                  - consent_record
+                  - policy_decision
+                  - cart_hash
+                  - amount_cap
+                  - merchant_state
+                  - agent_identity
+                  - audit_reference
+                  - idempotency_replay
+        merchant_state:
+          type: object
+          additionalProperties: false
+          properties:
+            display_name: { type: string, nullable: true }
+            environment: { type: string, enum: [sandbox, live] }
+            country_code: { type: string, pattern: "^[A-Z]{2}$", nullable: true }
+            default_currency: { type: string, pattern: "^[A-Z]{3}$", nullable: true }
+            readiness_state: { type: string }
+            agentic_commerce_requested: { type: boolean }
+            agentic_commerce_enabled: { type: boolean }
+        commerce_passport_evidence:
+          type: object
+          additionalProperties: false
+          properties:
+            present: { type: boolean }
+            passport_type: { type: string, nullable: true }
+            environment: { type: string, nullable: true }
+            scope_count: { type: integer, minimum: 0 }
+            required_checkout_scopes_present: { type: boolean }
+            max_amount_minor_units: { type: integer, nullable: true }
+            currency: { type: string, nullable: true }
+            policy_version_present: { type: boolean }
+            not_before_present: { type: boolean }
+            expires_at_present: { type: boolean }
+            not_expired: { type: boolean, nullable: true }
+            revoked: { type: boolean, nullable: true }
+            agent_auth_method: { type: string, nullable: true }
+            passport_jti_exposed: { type: boolean, const: false }
+            raw_passport_jwt_exposed: { type: boolean, const: false }
+        consent_evidence:
+          type: object
+          additionalProperties: false
+          properties:
+            present: { type: boolean }
+            status: { type: string, nullable: true }
+            passport_type: { type: string, nullable: true }
+            requested_scope_count: { type: integer, minimum: 0 }
+            approved_scope_count: { type: integer, minimum: 0 }
+            approved_required_checkout_scopes_present: { type: boolean }
+            max_amount_minor_units: { type: integer, nullable: true }
+            currency: { type: string, nullable: true }
+            consent_text_version: { type: string, nullable: true }
+            presented_payload_hash_present: { type: boolean }
+            approved_at_present: { type: boolean }
+            agent_auth_method: { type: string, nullable: true }
+            consent_record_id_exposed: { type: boolean, const: false }
+            consent_request_id_exposed: { type: boolean, const: false }
+            user_principal_exposed: { type: boolean, const: false }
+        policy_evidence:
+          type: object
+          additionalProperties: false
+          properties:
+            present: { type: boolean }
+            active_policy_present: { type: boolean }
+            policy_version_present: { type: boolean }
+            decision_reference_present: { type: boolean }
+            decision_reference_hash: { type: string, nullable: true }
+            amount_cap_minor_units: { type: integer, nullable: true }
+            amount_cap_currency: { type: string, nullable: true }
+            emergency_disabled: { type: boolean, nullable: true }
+            raw_policy_rules_exposed: { type: boolean, const: false }
+        cart_evidence:
+          type: object
+          additionalProperties: false
+          properties:
+            present: { type: boolean }
+            status: { type: string, nullable: true }
+            line_item_count: { type: integer, minimum: 0 }
+            snapshot_hash: { type: string, nullable: true }
+            total_amount_minor_units: { type: integer, nullable: true }
+            currency: { type: string, nullable: true }
+            idempotency_key_hash_present: { type: boolean }
+            raw_line_items_exposed: { type: boolean, const: false }
+            cart_id_exposed: { type: boolean, const: false }
+        amount_evidence:
+          type: object
+          additionalProperties: false
+          properties:
+            payment_amount_minor_units: { type: integer, nullable: true }
+            payment_currency: { type: string, nullable: true }
+            amount_cap_minor_units: { type: integer, nullable: true }
+            amount_cap_currency: { type: string, nullable: true }
+            amount_cap_source: { type: string, enum: [passport, consent, policy, missing] }
+            within_amount_cap: { type: boolean, nullable: true }
+        agent_identity_evidence:
+          type: object
+          additionalProperties: false
+          properties:
+            present: { type: boolean }
+            agent_reference_hash: { type: string, nullable: true }
+            trust_status: { type: string, nullable: true }
+            disabled: { type: boolean, nullable: true }
+            auth_method: { type: string, nullable: true }
+            agent_id_exposed: { type: boolean, const: false }
+            agent_api_key_exposed: { type: boolean, const: false }
+        audit_evidence:
+          type: object
+          additionalProperties: false
+          properties:
+            present: { type: boolean }
+            audit_reference_hash: { type: string, nullable: true }
+            event_type: { type: string, nullable: true }
+            occurred_at: { type: string, format: date-time, nullable: true }
+            policy_version_present: { type: boolean }
+            decision_reference_present: { type: boolean }
+            idempotency_key_hash_present: { type: boolean }
+            audit_event_id_exposed: { type: boolean, const: false }
+        replay_idempotency_evidence:
+          type: object
+          additionalProperties: false
+          properties:
+            idempotency_supported: { type: boolean, const: true }
+            replay_record_source: { type: string, enum: [commerce_idempotency_records] }
+            cart_idempotency_key_hash_present: { type: boolean }
+            payment_intent_idempotency_key_hash_present: { type: boolean }
+            audit_idempotency_key_hash_present: { type: boolean }
+            raw_idempotency_key_exposed: { type: boolean, const: false }
+        payment_intent_evidence:
+          type: object
+          additionalProperties: false
+          properties:
+            present: { type: boolean }
+            status: { type: string, nullable: true }
+            provider_environment: { type: string, enum: [sandbox], nullable: true }
+            created_at_present: { type: boolean }
+            provider_reference_exposed: { type: boolean, const: false }
+            checkout_url_exposed: { type: boolean, const: false }
+            provider_metadata_exposed: { type: boolean, const: false }
+            provider_raw_status_exposed: { type: boolean, const: false }
+        controls:
+          type: object
+          additionalProperties: false
+          properties:
+            sandbox_only: { type: boolean, const: true }
+            deterministic_unsigned_preview: { type: boolean, const: true }
+            signing_enabled_by_preview: { type: boolean, const: false }
+            ap2_certification_claim: { type: string, enum: [none] }
+            ap2_publication_enabled: { type: boolean, const: false }
+            payment_network_submission_enabled: { type: boolean, const: false }
+            checkout_payment_creation_enabled_by_preview: { type: boolean, const: false }
+            live_payment_enabled_by_preview: { type: boolean, const: false }
+            live_plural_enabled_by_preview: { type: boolean, const: false }
+            provider_call_enabled_by_preview: { type: boolean, const: false }
+            provider_credentials_exposed: { type: boolean, const: false }
+            production_allowlist_written: { type: boolean, const: false }
+        blockers:
+          type: array
+          items: { type: string }
+        remediation_items:
+          type: array
+          items: { type: string }
+        source_reference:
+          type: object
+          additionalProperties: false
+          properties:
+            system: { type: string, enum: [grantex] }
+            canonical_state: { type: string, enum: [commerce_passport_consent_policy_cart_payment_audit_idempotency] }
+            endpoint_template: { type: string }
+            tenant_scoped: { type: boolean, const: true }
+        evidence_summary:
+          type: object
+          additionalProperties: false
+          properties:
+            complete_required_evidence: { type: boolean }
+            passport_present: { type: boolean }
+            consent_granted: { type: boolean }
+            active_policy_present: { type: boolean }
+            policy_decision_present: { type: boolean }
+            cart_hash_present: { type: boolean }
+            amount_cap_present: { type: boolean }
+            merchant_state_present: { type: boolean }
+            agent_identity_present: { type: boolean }
+            audit_reference_present: { type: boolean }
+            idempotency_evidence_present: { type: boolean }
+            sandbox_only: { type: boolean, const: true }
+            unsigned_preview: { type: boolean, const: true }
+            payment_enabled: { type: boolean, const: false }
+            provider_called: { type: boolean, const: false }
+
     SandboxOnboarding:
       type: object
       properties:
@@ -3079,6 +3323,40 @@ paths:
         "403": { description: Operator or owning merchant caller required; CommerceAgent and service callers are denied }
         "404": { $ref: "#/components/responses/NotFound" }
         "409": { description: Live merchant blocks ACP-style checkout shape preview }
+        "503": { $ref: "#/components/responses/CommerceDisabled" }
+
+  /v1/commerce/merchants/{merchant_id}/ap2-evidence-preview:
+    parameters:
+      - { in: path, name: merchant_id, required: true, schema: { type: string } }
+    get:
+      tags: [Merchants]
+      summary: Inspect AP2-style unsigned evidence preview
+      operationId: getMerchantAp2EvidencePreview
+      x-implemented: true
+      x-milestone: C6M
+      description: >-
+        Returns a tenant-scoped, sandbox-only, preview-only AP2-style evidence
+        package generated from Grantex Commerce Passport, consent record, policy
+        decision, cart snapshot hash, amount cap, merchant state, agent identity,
+        audit reference, and idempotency evidence. The package is deterministic
+        and unsigned. It is not AP2 certification, not AP2 publication, not
+        payment-network submission, and not a signed production mandate. The
+        route does not enable public discovery, production Commerce V1,
+        checkout/payment creation, live payments, live Plural, provider calls,
+        provider credentials, production config, or allowlists.
+      responses:
+        "200":
+          description: AP2-style unsigned evidence preview
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/Ap2EvidencePreview" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Operator or owning merchant caller required; CommerceAgent and service callers are denied }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { description: Live merchant blocks AP2-style evidence preview }
         "503": { $ref: "#/components/responses/CommerceDisabled" }
 
   /v1/commerce/merchants/{merchant_id}/agenticorg-buyer-discovery-preview:

--- a/docs/guides/commerce-v1-developer-guide.mdx
+++ b/docs/guides/commerce-v1-developer-guide.mdx
@@ -113,6 +113,30 @@ intent evidence is missing. Unsupported fields such as public checkout URLs,
 provider payment references, provider metadata, live execution, fulfillment,
 and refunds/returns are represented as explicit blockers.
 
+### AP2-Style Evidence Preview
+
+Operators and owning merchants can inspect the C6M AP2-style evidence preview
+through:
+
+`GET /v1/commerce/merchants/{merchant_id}/ap2-evidence-preview`
+
+The endpoint is tenant-scoped, sandbox-only, deterministic, and unsigned. It
+reads canonical Grantex evidence from Commerce Passport, consent record, policy
+decision, cart snapshot hash, amount cap, merchant state, agent identity, audit
+reference, and existing idempotency evidence.
+
+The response is protocol packaging evidence only. It is not AP2 certification,
+is not AP2 publication, is not a signed production mandate, does not submit to
+a payment network, and does not enable checkout/payment creation, live payment,
+live Plural, public discovery, provider calls, provider credentials, production
+configuration, or production allowlists.
+
+Required evidence gaps return `status: blocked` with explicit blockers. The
+preview exposes hashes and presence flags where possible, but does not expose
+tenant IDs, exact merchant IDs, passport JTIs, consent record IDs, audit event
+IDs, provider references, raw line items, raw payloads, JWTs, idempotency keys,
+secrets, or private configuration.
+
 ## Auth And Caller Model
 
 Commerce callers are modeled as agents operating for a tenant, merchant, and

--- a/docs/guides/commerce-v1-merchant-agentic-commerce-user-guide.md
+++ b/docs/guides/commerce-v1-merchant-agentic-commerce-user-guide.md
@@ -204,6 +204,28 @@ live provider execution, fulfillment execution, and refund/return execution
 remain explicit blockers. A merchant should treat this as protocol packaging
 evidence only, not approval to accept live checkout or payment traffic.
 
+### AP2-Style Evidence Preview
+
+The AP2-style evidence preview shows whether Grantex has enough sandbox
+evidence to describe a future mandate-style package for review. It is based on
+Commerce Passport, consent, policy decision, cart hash, amount cap, merchant
+state, agent identity, audit reference, and idempotency evidence.
+
+This preview is deterministic and unsigned. It is not AP2 certification, does
+not publish AP2 capabilities, does not create or sign a production mandate,
+does not submit anything to a payment network, and does not approve live
+checkout or payment traffic.
+
+The preview remains non-enabling. It does not enable public discovery,
+production Commerce V1, checkout/payment creation, live payments, live Plural,
+provider calls, provider credentials, production configuration, or allowlists.
+
+If required evidence is missing, Grantex returns blockers and remediation
+instead of filling gaps with guesses. The preview may show safe hashes and
+presence flags, but it does not expose tenant IDs, exact merchant IDs, passport
+JTIs, consent IDs, audit IDs, provider references, raw cart details, raw
+payloads, secrets, or private configuration.
+
 ### Read-Only Discovery
 
 Read-only discovery allows approved agent clients to learn that a merchant

--- a/docs/internal/commerce-v1/commerce-v1-c6m-ap2-evidence-preview.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6m-ap2-evidence-preview.md
@@ -1,0 +1,112 @@
+# Commerce V1 C6M AP2-Style Evidence Preview
+
+Status: implemented as preview-only foundation.
+
+This slice adds an authenticated AP2-style evidence preview for review before
+open protocol packaging. It does not claim AP2 certification, does not publish
+AP2 capabilities, does not create or sign a production mandate, does not submit
+to a payment network, does not enable public discovery, does not enable
+production Commerce V1, does not create checkout or payment paths, does not
+enable live payments, does not enable live Plural, does not call providers,
+does not expose provider credentials or provider metadata, does not write
+production configuration, and does not set allowlists.
+
+## Traceability
+
+| Requirement | Implementation | Validation |
+| --- | --- | --- |
+| Add AP2-style evidence preview from canonical state | `readAp2EvidencePreview` reads tenant-scoped Commerce Passport, consent, policy, cart hash, amount cap, merchant state, agent, audit, and idempotency evidence. | `commerce-merchants.test.ts` preview success case. |
+| Keep preview unsigned and non-certified | Response sets `signature_status: unsigned_preview`, `ap2_certification_claim: none`, and all publication/submission/signing controls to `false`. | Route and OpenAPI assertions. |
+| Include replay and idempotency evidence where supported | Preview summarizes cart, payment intent, and audit idempotency hash presence without exposing raw keys. | Route assertions. |
+| No private leakage | Service emits public-safe text, booleans, counts, safe hashes, and redaction flags only. | Negative leakage assertions and guardrail scans. |
+| Sandbox/non-live only | Live merchants return `409 ap2_evidence_preview_live_merchant_blocked`. | Live merchant route test. |
+
+## Endpoint
+
+`GET /v1/commerce/merchants/{merchant_id}/ap2-evidence-preview`
+
+Allowed callers:
+
+- operator
+- owning merchant
+
+Denied callers:
+
+- CommerceAgent
+- service caller
+- merchant for a different merchant ID
+
+Live merchants return `409 ap2_evidence_preview_live_merchant_blocked`.
+Sandbox merchants with missing evidence receive a blocked preview with explicit
+evidence blockers and remediation.
+
+## Preview Rules
+
+The preview may include:
+
+- deterministic unsigned evidence package metadata
+- safe merchant state summary
+- Commerce Passport presence, scopes, amount cap, and revocation/expiry status
+- consent status, approved scope counts, amount cap, and hash presence
+- policy decision hash and policy amount cap summary
+- cart snapshot hash, total amount, currency, and line-item count
+- agent reference hash and trust status
+- audit reference hash and audit idempotency hash presence
+- payment intent status and sandbox provider environment
+- non-enabling controls, blockers, remediation, and evidence summary
+
+The preview must not include:
+
+- tenant IDs
+- exact merchant IDs
+- passport JTIs
+- consent record IDs
+- audit event IDs
+- agent IDs
+- cart IDs
+- payment intent IDs
+- provider payment IDs
+- provider order IDs
+- checkout URLs
+- provider raw status
+- provider metadata
+- provider credentials
+- raw cart line items
+- raw payloads
+- raw idempotency keys
+- secrets, tokens, JWTs, private keys, DB URLs, or Redis URLs
+- public discovery allowlist values
+- production config assignments
+- AP2 certification, conformance, or approval claims
+
+## Stop Conditions
+
+Stop and require separate approval if any change attempts to:
+
+- claim AP2 certification, conformance, approval, or network readiness
+- publish AP2 capabilities
+- create or sign a production mandate
+- submit evidence to a payment network
+- set `COMMERCE_PUBLIC_DISCOVERY_ENABLED`
+- set `COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST`
+- enable production Commerce V1
+- enable checkout or payment creation in production
+- enable live payments or live Plural
+- call Plural, Stripe, Pine, payment providers, or merchant private APIs
+- store or print real provider credentials
+- expose private merchant data, exact internal IDs, raw payloads, provider
+  metadata, allowlists, production config, or secrets
+
+## Rollback
+
+Rollback is code-only:
+
+1. Remove the route import and endpoint from `apps/auth-service/src/routes/commerce.ts`.
+2. Remove `apps/auth-service/src/lib/commerce/ap2-evidence-preview.ts`.
+3. Remove the C6M OpenAPI path and `Ap2EvidencePreview` component.
+4. Remove C6M tests and guide references.
+
+No migration, secret, production configuration, provider account, public
+discovery setting, allowlist, checkout/payment route enablement, signed
+mandate, payment-network submission, or cloud resource is created by this
+slice.


### PR DESCRIPTION
## Summary
- Adds a tenant-scoped C6M AP2-style evidence preview endpoint for operators and owning merchants.
- Builds deterministic unsigned preview evidence from Commerce Passport, consent, policy decision, cart hash, amount cap, merchant state, agent identity, audit reference, and idempotency presence.
- Documents the preview-only posture in OpenAPI, merchant/developer guides, and an internal C6M traceability/rollback note.

## Stack
- Base: `codex/commerce-c6l-acp-checkout-shape-preview` (C6L PR #513 explicitly accepted as base)
- Head: `codex/commerce-c6m-ap2-evidence-preview`

## Guardrails
- Preview-only, sandbox-only, unsigned, non-live, and non-enabling.
- Does not claim AP2 certification, AP2 approval, or AP2 publication.
- Does not create or sign a production mandate.
- Does not enable public discovery, production Commerce V1, checkout/payment creation, live payments, live Plural, provider calls, provider credentials, production config, or production allowlists.
- Does not expose tenant IDs, exact merchant IDs, passport JTIs, consent IDs, audit IDs, provider refs, raw cart details, raw payloads, JWTs, raw idempotency keys, secrets, or private config.

## Validation
- `npm --prefix apps/auth-service test -- commerce-merchants.test.ts commerce-openapi.test.ts` -> 109 tests passed
- `npm --prefix apps/auth-service run typecheck` -> passed
- `git diff --cached --check` -> passed
- Focused staged-diff scans -> no added enablement, secret literal, public discovery enablement, provider/direct execution, AP2 overclaim, or production/live enablement matches

## Notes
- `npm ci` was run only inside the temporary auth-service worktree to install locked test dependencies.
- Git printed stale worktree cleanup permission warnings under the original `.git/worktrees` directory after commit; the commit succeeded and no cleanup was attempted.