### PR TITLE
[codex] docs(commerce): add open protocol packaging draft

### DIFF
--- a/docs/guides/commerce-v1-agentic-commerce-prd.md
+++ b/docs/guides/commerce-v1-agentic-commerce-prd.md
@@ -97,13 +97,12 @@ Status as of 2026-06-07:
   read-only discovery handoff path: C5Z, C6A, C6B, C6C, C6D, C6E, C6F, and
   C6G are merged on Grantex main.
 - AgenticOrg read-only buyer discovery consumer foundation is merged through
-  C6H. C6I buyer-session orchestration is accepted as a draft PR and remains
-  pending merge.
+  C6H. C6I buyer-session orchestration is merged on AgenticOrg main.
 - Grantex protocol-adapter and connector foundations C6J, C6K, C6L, C6M, and
-  C6N are accepted as stacked draft PRs and remain pending merge.
-- The open-protocol packaging draft is an internal docs-only stacked PR on top
-  of C6N. It is not public protocol publication, not certification, and not
-  production approval.
+  C6N are merged on Grantex main.
+- The open-protocol packaging draft is an internal docs-only PR refreshed on
+  the merged C6I-C6N base. It is not public protocol publication, not
+  certification, and not production approval.
 - Public discovery, production Commerce V1, checkout/payment enablement, live
   payments, live Plural, production allowlists, certification claims, provider
   calls, and AgenticOrg direct merchant-system calls remain blocked.
@@ -116,12 +115,12 @@ Status as of 2026-06-07:
 | Category presets | `electronics_appliances` readiness checklist and scoring exist for the sandbox path. | Multi-category presets and policy/eval defaults remain future work. |
 | Catalog and variants | Product/variant APIs, search/detail, bulk dry-run/upsert, patch/archive, CSV/JSON-oriented portal support, catalog readiness preview, and public-safe sample preview exist. | Large async imports, connector sync, conflict handling, rollback, richer price/offer models, and quantity inventory remain pending. |
 | Inventory | Variant availability and freshness exist. | Quantity, location, confidence, reservations, stock holds, and delivery feasibility are missing. |
-| Consent and Commerce Passport | Consent request/exchange/verify/revoke/challenge foundation exists. C6M AP2-style deterministic unsigned evidence preview is accepted as a draft PR. | Production challenge delivery, signed mandate evidence, independent AP2 conformance, and live payment approval are pending. |
-| Cart/payment intent | Cart draft and provider-neutral payment intent foundation exists. C6L ACP-style cart/checkout shape preview is accepted as a draft PR. | Cart update/cancel/expire, fulfillment selection, ACP conformance, and broad live checkout readiness are pending. |
+| Consent and Commerce Passport | Consent request/exchange/verify/revoke/challenge foundation exists. C6M AP2-style deterministic unsigned evidence preview is merged. | Production challenge delivery, signed mandate evidence, independent AP2 conformance, and live payment approval are pending. |
+| Cart/payment intent | Cart draft and provider-neutral payment intent foundation exists. C6L ACP-style cart/checkout shape preview is merged. | Cart update/cancel/expire, fulfillment selection, ACP conformance, and broad live checkout readiness are pending. |
 | Provider/webhooks | Provider credential and webhook intake/replay/reconciliation foundations exist. | Live Plural/provider approval, signature evidence, outage handling, and rollback proof remain gated. |
 | Merchant webhooks | Signed merchant webhook source and catalog update intake exist. | Inventory-only, price-only, order, fulfillment, support, return, and refund webhooks are pending. |
-| Existing-system connectors | C6N metadata-only connector registry, source precedence, sync health, stale/conflict blockers, and no-credential/no-execution guardrails are accepted as a draft PR. | Real Shopify/WooCommerce/Magento/ERP/OMS/WMS/logistics/support/payment sync adapters remain pending. |
-| Standards adapters | C6J schema.org JSON-LD preview, C6K UCP-style capability profile preview, C6L ACP-style checkout shape preview, and C6M AP2-style evidence preview are accepted as draft PRs. | Public publication, certification, conformance suites, live capability negotiation, and public discovery remain blocked. |
+| Existing-system connectors | C6N metadata-only connector registry, source precedence, sync health, stale/conflict blockers, and no-credential/no-execution guardrails are merged. | Real Shopify/WooCommerce/Magento/ERP/OMS/WMS/logistics/support/payment sync adapters remain pending. |
+| Standards adapters | C6J schema.org JSON-LD preview, C6K UCP-style capability profile preview, C6L ACP-style checkout shape preview, and C6M AP2-style evidence preview are merged. | Public publication, certification, conformance suites, live capability negotiation, and public discovery remain blocked. |
 | MCP/native surface | Read and checkout-oriented tools exist behind Grantex; C6G adds sandbox AgenticOrg buyer discovery handoff. | Public discovery remains fail-closed; public standards conformance is not complete. |
 | Docs and CI | Commerce docs, docs-only workflow guard, and internal open-protocol packaging draft exist. | Keep consolidated PRD, overview, guides, manifests, and nav current as stacked PRs merge. |
 
@@ -130,12 +129,12 @@ Status as of 2026-06-07:
 | Capability | Current state | Gap |
 | --- | --- | --- |
 | Grantex-only connector aliases | Merchant profile, catalog search/detail, inventory, cart, consent, payment intent, checkout, payment status, and read-only buyer discovery preview aliases exist. | Order, fulfillment, support, return, refund, settlement, and payout aliases wait on Grantex APIs. |
-| Buyer discovery workflow | C6H read-only consumer foundation is merged. C6I channel-neutral buyer-session orchestration is accepted as a draft PR. | Live channel adapters and write-capable buyer flows remain blocked. |
-| Sales agent guardrails | Missing consent/passport, amount-cap breach, disabled merchant/agent, policy denial, no-direct-provider, and read-only buyer discovery refusal protections exist or are accepted in C6I. | Guardrails must expand as Grantex adds order, fulfillment, support, return, refund, settlement, and payout capabilities. |
+| Buyer discovery workflow | C6H read-only consumer foundation is merged. C6I channel-neutral buyer-session orchestration is merged. | Live channel adapters and write-capable buyer flows remain blocked. |
+| Sales agent guardrails | Missing consent/passport, amount-cap breach, disabled merchant/agent, policy denial, no-direct-provider, and read-only buyer discovery refusal protections exist or are merged in C6I. | Guardrails must expand as Grantex adds order, fulfillment, support, return, refund, settlement, and payout capabilities. |
 | Demo/evals | Demo, golden evals, hosted smoke, no-direct-provider regressions, and focused buyer discovery tests exist. | Channel-specific smoke and live buyer UX evals are pending. |
 | Public discovery | Fail-closed behind AgenticOrg public discovery flag. | Real merchant public discovery requires Grantex approval and AgenticOrg gating. |
 | Docs-only CI guard | Docs-only changes skip build/push/deploy-adjacent jobs. | Keep guard current, especially for workflow changes. |
-| Buyer channel launch | Channel-neutral response model is accepted in C6I. | ChatGPT, Claude, Gemini, WhatsApp, Telegram, web/mobile, and future live adapters are not launch-ready yet. |
+| Buyer channel launch | Channel-neutral response model is merged in C6I. | ChatGPT, Claude, Gemini, WhatsApp, Telegram, web/mobile, and future live adapters are not launch-ready yet. |
 
 ## 5. End-To-End Architecture
 
@@ -381,7 +380,7 @@ in V1 form; others are future gaps.
 | CommerceTenant | Grantex | Tenant boundary. | Foundation exists. |
 | CommerceMerchant | Grantex | Seller identity and policy anchor. | Foundation exists. |
 | CommerceCategoryPreset | Grantex | Category-required fields and defaults. | `electronics_appliances` readiness foundation exists. |
-| CommerceConnectorSource | Grantex | Existing-system connection and health. | C6N metadata-only registry accepted as draft; no credentials or outbound sync. |
+| CommerceConnectorSource | Grantex | Existing-system connection and health. | C6N metadata-only registry merged; no credentials or outbound sync. |
 | CommerceImportJob | Grantex | Async import, dry-run, errors, rollback. | Gap. |
 | CommerceProduct | Grantex | Product truth. | Foundation exists. |
 | CommerceProductVariant | Grantex | SKU/variant/price/inventory anchor. | Foundation exists. |
@@ -398,7 +397,7 @@ in V1 form; others are future gaps.
 | CommerceRefundRequest | Grantex | Refund request and approval. | Gap. |
 | CommerceSettlement/Payout | Grantex | Seller payment reporting. | Gap. |
 | CommerceAuditEvent | Grantex | Append-only evidence. | Foundation exists. |
-| CommerceAgentSession | AgenticOrg/Grantex boundary | Buyer-agent session attribution and channel state. | C6I channel-neutral session orchestration accepted as draft; live channels pending. |
+| CommerceAgentSession | AgenticOrg/Grantex boundary | Buyer-agent session attribution and channel state. | C6I channel-neutral session orchestration merged; live channels pending. |
 | ChannelAdapterConfig | AgenticOrg | Platform launch and capability limits. | Gap. |
 
 ## 14. Product Requirements By Surface
@@ -425,7 +424,7 @@ in V1 form; others are future gaps.
 | --- | --- | --- | --- | --- |
 | Self-serve merchant signup | Merchants need to join without engineering tickets. | Grantex | Sandbox workspace, roles, category, checklist. | Operator-only onboarding does not scale. |
 | Merchant verification | Real merchant identity must be trusted. | Grantex + reviewers | Private evidence refs and review workflow. | No live approval. |
-| Existing-system connectors | Merchants will not duplicate data manually. | Grantex | C6N metadata-only connector registry accepted; real sync adapters next. | Stale or manual-only launch. |
+| Existing-system connectors | Merchants will not duplicate data manually. | Grantex | C6N metadata-only connector registry merged; real sync adapters next. | Stale or manual-only launch. |
 | Large catalog imports | Real sellers have many SKUs. | Grantex | Async import, dry-run, row errors, rollback. | Timeouts and silent data loss. |
 | Source-of-truth precedence | Systems can disagree. | Grantex | Conflict rules and sync timestamps. | Wrong price/stock/order facts. |
 | Inventory depth | Agents must not promise stock incorrectly. | Grantex | Quantity/location/freshness/reservation model. | Unsafe checkout promises. |
@@ -439,9 +438,9 @@ in V1 form; others are future gaps.
 | Live provider readiness | Payments need approval. | Grantex | Sandbox validation, live credential approval, webhook signatures. | Live provider risk. |
 | Commerce Passport production delivery | Real consent needs delivery. | Grantex | Email/SMS/passkey challenge, revocation, signed evidence. | Weak authorization. |
 | Policy simulator | Merchants need confidence. | Grantex | Preview policy by product/category/channel/amount. | Accidental capability exposure. |
-| Standards adapters | Major platforms need standard surfaces. | Grantex publishes; AgenticOrg consumes | C6J-C6M previews accepted; conformance and publication next. | Fragmented protocol state. |
-| Buyer channel launch | Buyers need easy entry. | AgenticOrg + Grantex approval | C6I channel-neutral response accepted; live channel adapters next. | Agentic commerce hard to use. |
-| Buyer UX | Buyers need understandable flow. | AgenticOrg | C6I read-only buyer session accepted; cart/consent/checkout UX remains future. | Confusing or unsafe agent behavior. |
+| Standards adapters | Major platforms need standard surfaces. | Grantex publishes; AgenticOrg consumes | C6J-C6M previews merged; conformance and publication next. | Fragmented protocol state. |
+| Buyer channel launch | Buyers need easy entry. | AgenticOrg + Grantex approval | C6I channel-neutral response merged; live channel adapters next. | Agentic commerce hard to use. |
+| Buyer UX | Buyers need understandable flow. | AgenticOrg | C6I read-only buyer session merged; cart/consent/checkout UX remains future. | Confusing or unsafe agent behavior. |
 | Merchant demo UX | Sellers need education. | AgenticOrg | Demo walkthroughs and blocked-path examples. | Misunderstanding production readiness. |
 | Evals/regressions | Guardrails must remain true. | AgenticOrg | No invention, no direct-provider, stale/refusal tests. | Regression risk. |
 | Ops/support dashboards | Teams need recovery. | Both | Policy denial, stale sync, stuck payment, webhook replay, support handoff. | Incidents are hard to resolve. |
@@ -455,30 +454,29 @@ in V1 form; others are future gaps.
 | --- | --- | --- | --- |
 | 1. Consolidated PRD and docs alignment | One source of truth. | This PRD, docs nav, overview links, AgenticOrg pointers. Status: merged. | Docs-only. |
 | 2. Seller sandbox onboarding | Merchant can prepare without engineers. | Workspace, profile, category, owner roles, checklist. Status: merged through C6G handoff. | No live enablement. |
-| 3. Catalog connector MVP | Merchant data enters Grantex. | CSV/manual readiness and C6N connector registry foundation accepted; real sync adapters pending. | No automatic live publish. |
-| 4. Public-safe preview | Merchant sees what agents can see. | Catalog/profile preview, schema.org draft, readiness score, protocol previews accepted or merged through C6J-C6M. | Fail-closed until approved. |
-| 5. Buyer web/mobile channel | First controllable buyer launch. | C6H merged and C6I accepted for channel-neutral read-only session; hosted widget/app pending. | Read-only first. |
-| 6. ChatGPT/Claude MCP | Major AI chat surfaces. | Channel-neutral response model accepted; remote MCP/app connector pending. | Respect platform write limits. |
-| 7. WhatsApp/Telegram | Messaging channels. | Channel-neutral response model accepted; bot/webhook adapters pending. | Secrets outside Git. |
-| 8. Gemini channel | Gemini-powered buyer sessions. | Channel-neutral response model accepted; function-calling wrapper pending. | Label native support accurately. |
+| 3. Catalog connector MVP | Merchant data enters Grantex. | CSV/manual readiness and C6N connector registry foundation merged; real sync adapters pending. | No automatic live publish. |
+| 4. Public-safe preview | Merchant sees what agents can see. | Catalog/profile preview, schema.org draft, readiness score, and protocol previews merged through C6J-C6M. | Fail-closed until approved. |
+| 5. Buyer web/mobile channel | First controllable buyer launch. | C6H and C6I merged for channel-neutral read-only session; hosted widget/app pending. | Read-only first. |
+| 6. ChatGPT/Claude MCP | Major AI chat surfaces. | Channel-neutral response model merged; remote MCP/app connector pending. | Respect platform write limits. |
+| 7. WhatsApp/Telegram | Messaging channels. | Channel-neutral response model merged; bot/webhook adapters pending. | Secrets outside Git. |
+| 8. Gemini channel | Gemini-powered buyer sessions. | Channel-neutral response model merged; function-calling wrapper pending. | Label native support accurately. |
 | 9. Inventory freshness and cart | Safe product selection. | Freshness TTL, stale refusal, exact-ID cart draft. | No checkout promise if stale. |
 | 10. Sandbox consent/checkout | Full rehearsal. | Consent, Passport, mock/provider-neutral checkout. | No live provider. |
 | 11. Order/fulfillment backbone | Operational paid flow. | Order, shipment, pickup/delivery, cancellation. | Required before broad checkout. |
 | 12. Return/refund request | Safe post-purchase support. | Request, eligibility, manual approval, audit. | No automatic refund execution. |
 | 13. Settlement/payout reporting | Seller finance visibility. | Reconciliation and payout read model. | No raw provider payloads. |
-| 14. Standards hardening | Platform interoperability. | C6J-C6M preview adapters and open-protocol packaging draft accepted as stacked draft work; public conformance pending. | No certification claims without evidence. |
+| 14. Standards hardening | Platform interoperability. | C6J-C6M preview adapters are merged and the open-protocol packaging draft is refreshed on merged C6I-C6N commits; public conformance pending. | No certification claims without evidence. |
 | 15. Controlled pilot | Minimal real launch. | One merchant, category, channel, provider, geography, rollback owner. | Separate explicit approval. |
 
 Current sequencing decision:
 
-1. Review and merge the accepted stacked product-chain PRs in dependency order:
-   AgenticOrg C6I, then Grantex C6J, C6K, C6L, C6M, C6N, and finally the
-   open-protocol packaging draft.
-2. After those PRs merge, update this PRD again from accepted draft to merged
-   status.
-3. Only then start the next runtime chain: public-safe conformance fixtures,
-   first real connector sync adapter, order/fulfillment backbone, and controlled
-   pilot planning.
+1. C6I-C6N are merged in dependency order across AgenticOrg and Grantex.
+2. The open-protocol packaging draft is refreshed on the actual merged commits
+   and remains internal, preview-only, non-publication, and non-certifying.
+3. The next runtime chain is C6O: public-safe conformance fixtures, the first
+   real connector sync adapter foundation, order/fulfillment backbone planning,
+   and controlled pilot readiness without enabling public discovery or live
+   checkout.
 
 ## 17. Release Acceptance Criteria
 
@@ -565,9 +563,8 @@ This PRD has been reviewed against the requested coverage:
 - documentation/navigation/workflow coverage covered;
 - next implementation sequencing covered.
 
-Remaining decision for the team: finish review and merge of the accepted
-stacked C6I-C6N and open-protocol packaging draft PRs before starting new
-runtime surfaces. The next implementation chain after merge should focus on
-conformance fixtures, one real connector sync adapter, order/fulfillment
-backbone, and controlled pilot readiness without enabling public discovery or
-live checkout.
+Remaining decision for the team: use the merged C6I-C6N base and internal
+open-protocol packaging draft to plan C6O. The next implementation chain should
+focus on conformance fixtures, one real connector sync adapter foundation,
+order/fulfillment backbone planning, and controlled pilot readiness without
+enabling public discovery or live checkout.

--- a/docs/guides/commerce-v1-agentic-commerce-prd.md
+++ b/docs/guides/commerce-v1-agentic-commerce-prd.md
@@ -91,31 +91,51 @@ AgenticOrg must not:
 
 ## 4. Current Implementation Snapshot
 
+Status as of 2026-06-07:
+
+- Grantex seller-control-plane work is implemented through the sandbox
+  read-only discovery handoff path: C5Z, C6A, C6B, C6C, C6D, C6E, C6F, and
+  C6G are merged on Grantex main.
+- AgenticOrg read-only buyer discovery consumer foundation is merged through
+  C6H. C6I buyer-session orchestration is accepted as a draft PR and remains
+  pending merge.
+- Grantex protocol-adapter and connector foundations C6J, C6K, C6L, C6M, and
+  C6N are accepted as stacked draft PRs and remain pending merge.
+- The open-protocol packaging draft is an internal docs-only stacked PR on top
+  of C6N. It is not public protocol publication, not certification, and not
+  production approval.
+- Public discovery, production Commerce V1, checkout/payment enablement, live
+  payments, live Plural, production allowlists, certification claims, provider
+  calls, and AgenticOrg direct merchant-system calls remain blocked.
+
 ### 4.1 Grantex Foundation
 
 | Capability | Current state | Gap |
 | --- | --- | --- |
-| Merchant/tenant control plane | Operator-led tenant and merchant foundations exist. | Full self-serve runtime onboarding is incomplete. |
-| Category presets | Preset/policy planning exists. | Merchant-facing preset checklist and required-field scoring need implementation hardening. |
-| Catalog and variants | Product/variant APIs, search/detail, bulk dry-run/upsert, patch/archive, CSV/JSON-oriented portal support exist. | Large async imports, connector sync, conflict handling, and rollback need hardening. |
+| Merchant/tenant control plane | Seller sandbox onboarding, category readiness, catalog readiness, public-safe agent preview, review request, operator decision, rollout proposal dry run, and AgenticOrg sandbox handoff are implemented through C6G. | Full self-serve production onboarding, KYB/KYC, live approval, and public discovery rollout remain blocked. |
+| Category presets | `electronics_appliances` readiness checklist and scoring exist for the sandbox path. | Multi-category presets and policy/eval defaults remain future work. |
+| Catalog and variants | Product/variant APIs, search/detail, bulk dry-run/upsert, patch/archive, CSV/JSON-oriented portal support, catalog readiness preview, and public-safe sample preview exist. | Large async imports, connector sync, conflict handling, rollback, richer price/offer models, and quantity inventory remain pending. |
 | Inventory | Variant availability and freshness exist. | Quantity, location, confidence, reservations, stock holds, and delivery feasibility are missing. |
-| Consent and Commerce Passport | Consent request/exchange/verify/revoke/challenge foundation exists. | Production challenge delivery and AP2-style signed mandate evidence are pending. |
-| Cart/payment intent | Cart draft and provider-neutral payment intent foundation exists. | Cart update/cancel/expire, fulfillment selection, and broad live checkout readiness are pending. |
+| Consent and Commerce Passport | Consent request/exchange/verify/revoke/challenge foundation exists. C6M AP2-style deterministic unsigned evidence preview is accepted as a draft PR. | Production challenge delivery, signed mandate evidence, independent AP2 conformance, and live payment approval are pending. |
+| Cart/payment intent | Cart draft and provider-neutral payment intent foundation exists. C6L ACP-style cart/checkout shape preview is accepted as a draft PR. | Cart update/cancel/expire, fulfillment selection, ACP conformance, and broad live checkout readiness are pending. |
 | Provider/webhooks | Provider credential and webhook intake/replay/reconciliation foundations exist. | Live Plural/provider approval, signature evidence, outage handling, and rollback proof remain gated. |
 | Merchant webhooks | Signed merchant webhook source and catalog update intake exist. | Inventory-only, price-only, order, fulfillment, support, return, and refund webhooks are pending. |
-| MCP/native surface | Read and checkout-oriented tools exist behind Grantex. | Public discovery remains fail-closed; standards conformance is not complete. |
-| Docs and CI | Commerce docs and docs-only workflow guard exist. | Keep consolidated PRD, overview, guides, and nav current as slices land. |
+| Existing-system connectors | C6N metadata-only connector registry, source precedence, sync health, stale/conflict blockers, and no-credential/no-execution guardrails are accepted as a draft PR. | Real Shopify/WooCommerce/Magento/ERP/OMS/WMS/logistics/support/payment sync adapters remain pending. |
+| Standards adapters | C6J schema.org JSON-LD preview, C6K UCP-style capability profile preview, C6L ACP-style checkout shape preview, and C6M AP2-style evidence preview are accepted as draft PRs. | Public publication, certification, conformance suites, live capability negotiation, and public discovery remain blocked. |
+| MCP/native surface | Read and checkout-oriented tools exist behind Grantex; C6G adds sandbox AgenticOrg buyer discovery handoff. | Public discovery remains fail-closed; public standards conformance is not complete. |
+| Docs and CI | Commerce docs, docs-only workflow guard, and internal open-protocol packaging draft exist. | Keep consolidated PRD, overview, guides, manifests, and nav current as stacked PRs merge. |
 
 ### 4.2 AgenticOrg Foundation
 
 | Capability | Current state | Gap |
 | --- | --- | --- |
-| Grantex-only connector aliases | Merchant profile, catalog search/detail, inventory, cart, consent, payment intent, checkout, and payment status aliases exist. | Order, fulfillment, support, return, refund, settlement, and payout aliases wait on Grantex APIs. |
-| Sales agent guardrails | Missing consent/passport, amount-cap breach, disabled merchant/agent, policy denial, and non-mock provider protections exist. | Guardrails must expand as Grantex adds more lifecycle capabilities. |
-| Demo/evals | Demo, golden evals, hosted smoke, and no-direct-provider regression foundations exist. | Channel-specific smoke and buyer UX evals are pending. |
+| Grantex-only connector aliases | Merchant profile, catalog search/detail, inventory, cart, consent, payment intent, checkout, payment status, and read-only buyer discovery preview aliases exist. | Order, fulfillment, support, return, refund, settlement, and payout aliases wait on Grantex APIs. |
+| Buyer discovery workflow | C6H read-only consumer foundation is merged. C6I channel-neutral buyer-session orchestration is accepted as a draft PR. | Live channel adapters and write-capable buyer flows remain blocked. |
+| Sales agent guardrails | Missing consent/passport, amount-cap breach, disabled merchant/agent, policy denial, no-direct-provider, and read-only buyer discovery refusal protections exist or are accepted in C6I. | Guardrails must expand as Grantex adds order, fulfillment, support, return, refund, settlement, and payout capabilities. |
+| Demo/evals | Demo, golden evals, hosted smoke, no-direct-provider regressions, and focused buyer discovery tests exist. | Channel-specific smoke and live buyer UX evals are pending. |
 | Public discovery | Fail-closed behind AgenticOrg public discovery flag. | Real merchant public discovery requires Grantex approval and AgenticOrg gating. |
 | Docs-only CI guard | Docs-only changes skip build/push/deploy-adjacent jobs. | Keep guard current, especially for workflow changes. |
-| Buyer channel launch | Planned in PRD. | ChatGPT, Claude, Gemini, WhatsApp, Telegram, web/mobile, and future adapters are not launch-ready yet. |
+| Buyer channel launch | Channel-neutral response model is accepted in C6I. | ChatGPT, Claude, Gemini, WhatsApp, Telegram, web/mobile, and future live adapters are not launch-ready yet. |
 
 ## 5. End-To-End Architecture
 
@@ -360,8 +380,8 @@ in V1 form; others are future gaps.
 | --- | --- | --- | --- |
 | CommerceTenant | Grantex | Tenant boundary. | Foundation exists. |
 | CommerceMerchant | Grantex | Seller identity and policy anchor. | Foundation exists. |
-| CommerceCategoryPreset | Grantex | Category-required fields and defaults. | Foundation exists/planned hardening. |
-| CommerceConnectorSource | Grantex | Existing-system connection and health. | Gap. |
+| CommerceCategoryPreset | Grantex | Category-required fields and defaults. | `electronics_appliances` readiness foundation exists. |
+| CommerceConnectorSource | Grantex | Existing-system connection and health. | C6N metadata-only registry accepted as draft; no credentials or outbound sync. |
 | CommerceImportJob | Grantex | Async import, dry-run, errors, rollback. | Gap. |
 | CommerceProduct | Grantex | Product truth. | Foundation exists. |
 | CommerceProductVariant | Grantex | SKU/variant/price/inventory anchor. | Foundation exists. |
@@ -378,7 +398,7 @@ in V1 form; others are future gaps.
 | CommerceRefundRequest | Grantex | Refund request and approval. | Gap. |
 | CommerceSettlement/Payout | Grantex | Seller payment reporting. | Gap. |
 | CommerceAuditEvent | Grantex | Append-only evidence. | Foundation exists. |
-| CommerceAgentSession | AgenticOrg/Grantex boundary | Buyer-agent session attribution and channel state. | Foundation/planning. |
+| CommerceAgentSession | AgenticOrg/Grantex boundary | Buyer-agent session attribution and channel state. | C6I channel-neutral session orchestration accepted as draft; live channels pending. |
 | ChannelAdapterConfig | AgenticOrg | Platform launch and capability limits. | Gap. |
 
 ## 14. Product Requirements By Surface
@@ -405,7 +425,7 @@ in V1 form; others are future gaps.
 | --- | --- | --- | --- | --- |
 | Self-serve merchant signup | Merchants need to join without engineering tickets. | Grantex | Sandbox workspace, roles, category, checklist. | Operator-only onboarding does not scale. |
 | Merchant verification | Real merchant identity must be trusted. | Grantex + reviewers | Private evidence refs and review workflow. | No live approval. |
-| Existing-system connectors | Merchants will not duplicate data manually. | Grantex | CSV/manual plus one priority connector. | Stale or manual-only launch. |
+| Existing-system connectors | Merchants will not duplicate data manually. | Grantex | C6N metadata-only connector registry accepted; real sync adapters next. | Stale or manual-only launch. |
 | Large catalog imports | Real sellers have many SKUs. | Grantex | Async import, dry-run, row errors, rollback. | Timeouts and silent data loss. |
 | Source-of-truth precedence | Systems can disagree. | Grantex | Conflict rules and sync timestamps. | Wrong price/stock/order facts. |
 | Inventory depth | Agents must not promise stock incorrectly. | Grantex | Quantity/location/freshness/reservation model. | Unsafe checkout promises. |
@@ -419,9 +439,9 @@ in V1 form; others are future gaps.
 | Live provider readiness | Payments need approval. | Grantex | Sandbox validation, live credential approval, webhook signatures. | Live provider risk. |
 | Commerce Passport production delivery | Real consent needs delivery. | Grantex | Email/SMS/passkey challenge, revocation, signed evidence. | Weak authorization. |
 | Policy simulator | Merchants need confidence. | Grantex | Preview policy by product/category/channel/amount. | Accidental capability exposure. |
-| Standards adapters | Major platforms need standard surfaces. | Grantex publishes; AgenticOrg consumes | UCP/ACP/MCP/schema.org/AP2 fixtures. | Fragmented protocol state. |
-| Buyer channel launch | Buyers need easy entry. | AgenticOrg + Grantex approval | Web/mobile, MCP, WhatsApp/Telegram, Gemini adapters. | Agentic commerce hard to use. |
-| Buyer UX | Buyers need understandable flow. | AgenticOrg | Grounded compare, cart, consent, checkout status, refusal copy. | Confusing or unsafe agent behavior. |
+| Standards adapters | Major platforms need standard surfaces. | Grantex publishes; AgenticOrg consumes | C6J-C6M previews accepted; conformance and publication next. | Fragmented protocol state. |
+| Buyer channel launch | Buyers need easy entry. | AgenticOrg + Grantex approval | C6I channel-neutral response accepted; live channel adapters next. | Agentic commerce hard to use. |
+| Buyer UX | Buyers need understandable flow. | AgenticOrg | C6I read-only buyer session accepted; cart/consent/checkout UX remains future. | Confusing or unsafe agent behavior. |
 | Merchant demo UX | Sellers need education. | AgenticOrg | Demo walkthroughs and blocked-path examples. | Misunderstanding production readiness. |
 | Evals/regressions | Guardrails must remain true. | AgenticOrg | No invention, no direct-provider, stale/refusal tests. | Regression risk. |
 | Ops/support dashboards | Teams need recovery. | Both | Policy denial, stale sync, stuck payment, webhook replay, support handoff. | Incidents are hard to resolve. |
@@ -433,21 +453,32 @@ in V1 form; others are future gaps.
 
 | Phase | Goal | Deliverables | Guardrail |
 | --- | --- | --- | --- |
-| 1. Consolidated PRD and docs alignment | One source of truth. | This PRD, docs nav, overview links, AgenticOrg pointers. | Docs-only. |
-| 2. Seller sandbox onboarding | Merchant can prepare without engineers. | Workspace, profile, category, owner roles, checklist. | No live enablement. |
-| 3. Catalog connector MVP | Merchant data enters Grantex. | CSV/manual plus one priority storefront connector; dry-run. | No automatic live publish. |
-| 4. Public-safe preview | Merchant sees what agents can see. | Catalog/profile preview, schema.org draft, readiness score. | Fail-closed until approved. |
-| 5. Buyer web/mobile channel | First controllable buyer launch. | AgenticOrg hosted session or widget. | Read-only first. |
-| 6. ChatGPT/Claude MCP | Major AI chat surfaces. | Remote MCP app/connector, auth, scopes, smoke. | Respect platform write limits. |
-| 7. WhatsApp/Telegram | Messaging channels. | Bot/webhook adapters, identity, consent link, opt-out. | Secrets outside Git. |
-| 8. Gemini channel | Gemini-powered buyer sessions. | Function-calling wrapper or approved native route. | Label native support accurately. |
+| 1. Consolidated PRD and docs alignment | One source of truth. | This PRD, docs nav, overview links, AgenticOrg pointers. Status: merged. | Docs-only. |
+| 2. Seller sandbox onboarding | Merchant can prepare without engineers. | Workspace, profile, category, owner roles, checklist. Status: merged through C6G handoff. | No live enablement. |
+| 3. Catalog connector MVP | Merchant data enters Grantex. | CSV/manual readiness and C6N connector registry foundation accepted; real sync adapters pending. | No automatic live publish. |
+| 4. Public-safe preview | Merchant sees what agents can see. | Catalog/profile preview, schema.org draft, readiness score, protocol previews accepted or merged through C6J-C6M. | Fail-closed until approved. |
+| 5. Buyer web/mobile channel | First controllable buyer launch. | C6H merged and C6I accepted for channel-neutral read-only session; hosted widget/app pending. | Read-only first. |
+| 6. ChatGPT/Claude MCP | Major AI chat surfaces. | Channel-neutral response model accepted; remote MCP/app connector pending. | Respect platform write limits. |
+| 7. WhatsApp/Telegram | Messaging channels. | Channel-neutral response model accepted; bot/webhook adapters pending. | Secrets outside Git. |
+| 8. Gemini channel | Gemini-powered buyer sessions. | Channel-neutral response model accepted; function-calling wrapper pending. | Label native support accurately. |
 | 9. Inventory freshness and cart | Safe product selection. | Freshness TTL, stale refusal, exact-ID cart draft. | No checkout promise if stale. |
 | 10. Sandbox consent/checkout | Full rehearsal. | Consent, Passport, mock/provider-neutral checkout. | No live provider. |
 | 11. Order/fulfillment backbone | Operational paid flow. | Order, shipment, pickup/delivery, cancellation. | Required before broad checkout. |
 | 12. Return/refund request | Safe post-purchase support. | Request, eligibility, manual approval, audit. | No automatic refund execution. |
 | 13. Settlement/payout reporting | Seller finance visibility. | Reconciliation and payout read model. | No raw provider payloads. |
-| 14. Standards hardening | Platform interoperability. | UCP/ACP/MCP/schema.org/AP2 fixtures. | No certification claims without evidence. |
+| 14. Standards hardening | Platform interoperability. | C6J-C6M preview adapters and open-protocol packaging draft accepted as stacked draft work; public conformance pending. | No certification claims without evidence. |
 | 15. Controlled pilot | Minimal real launch. | One merchant, category, channel, provider, geography, rollback owner. | Separate explicit approval. |
+
+Current sequencing decision:
+
+1. Review and merge the accepted stacked product-chain PRs in dependency order:
+   AgenticOrg C6I, then Grantex C6J, C6K, C6L, C6M, C6N, and finally the
+   open-protocol packaging draft.
+2. After those PRs merge, update this PRD again from accepted draft to merged
+   status.
+3. Only then start the next runtime chain: public-safe conformance fixtures,
+   first real connector sync adapter, order/fulfillment backbone, and controlled
+   pilot planning.
 
 ## 17. Release Acceptance Criteria
 
@@ -534,6 +565,9 @@ This PRD has been reviewed against the requested coverage:
 - documentation/navigation/workflow coverage covered;
 - next implementation sequencing covered.
 
-Remaining decision for the team: choose the first implementation slice from the
-fast-track roadmap. The recommended first slice is seller sandbox onboarding,
-followed by catalog connector MVP and read-only buyer discovery.
+Remaining decision for the team: finish review and merge of the accepted
+stacked C6I-C6N and open-protocol packaging draft PRs before starting new
+runtime surfaces. The next implementation chain after merge should focus on
+conformance fixtures, one real connector sync adapter, order/fulfillment
+backbone, and controlled pilot readiness without enabling public discovery or
+live checkout.

--- a/docs/internal/commerce-v1/commerce-v1-open-protocol-packaging-draft.md
+++ b/docs/internal/commerce-v1/commerce-v1-open-protocol-packaging-draft.md
@@ -4,8 +4,8 @@ Status: internal packaging draft only.
 
 Created: 2026-06-07.
 
-This draft packages the accepted Agentic Commerce C6I-C6N product-chain heads
-for internal open-protocol review. It is not public protocol publication, not
+This draft packages the merged Agentic Commerce C6I-C6N product-chain PRs for
+internal open-protocol review. It is not public protocol publication, not
 schema.org publication, not UCP certification, not ACP certification, not AP2
 certification, not provider certification, not production approval, not public
 discovery approval, and not checkout or payment approval.
@@ -15,18 +15,25 @@ configuration, touch secrets, enable public discovery, enable production
 Commerce V1, enable checkout or payment creation, enable live payments, call
 providers, call merchant private APIs, or claim certification.
 
-## Accepted Base
+## Merged Base
 
-The packaging draft is based only on these accepted PR heads:
+The packaging draft is based only on these reviewed and merged PRs. Where a
+slice was rebased or fixed during review, the table records the final merged PR
+head and the merge commit now present on the owning repository's `main` branch.
 
-| Slice | Repo | PR | Head SHA | Packaging role |
-| --- | --- | --- | --- | --- |
-| C6I buyer session orchestration | AgenticOrg | https://github.com/mishrasanjeev/agentic-org/pull/718 | `787b56c621ee5cb8d4ce4321056844ae25280fa0` | Buyer-agent read-only session wrapper, intent classification, channel-neutral response, grounded refusal model. |
-| C6J schema.org preview adapter | Grantex | https://github.com/mishrasanjeev/grantex/pull/511 | `ac90162ca0aee9a1e955fb70f388f6634b0e5d68` | Public-safe schema.org JSON-LD preview from canonical merchant/catalog/readiness state. |
-| C6K UCP-style capability profile preview | Grantex | https://github.com/mishrasanjeev/grantex/pull/512 | `cba0df34049217441fef8d8c378f5c2884fa165a` | Grantex-owned UCP-style preview metadata under `dev.grantex.commerce.discovery.preview`. |
-| C6L ACP-style checkout shape preview | Grantex | https://github.com/mishrasanjeev/grantex/pull/513 | `ab54a389167b1a57cb0bb975a5aabc193e1ca67c` | Sandbox-only cart and checkout shape mappings with explicit blockers. |
-| C6M AP2-style evidence preview | Grantex | https://github.com/mishrasanjeev/grantex/pull/514 | `aad06a1da39133170bbcd3e45fd0f5334b0351c7` | Deterministic unsigned AP2-style evidence preview from canonical consent, passport, policy, cart, payment, agent, and audit state. |
-| C6N connector foundation | Grantex | https://github.com/mishrasanjeev/grantex/pull/515 | `200f1e375fd771a3928397e75fa6195cb6cafc10` | Existing-system connector registry foundation, metadata-only, non-executing, tenant-scoped. |
+| Slice | Repo | PR | Final PR head SHA | Merge commit SHA | Packaging role |
+| --- | --- | --- | --- | --- | --- |
+| C6I buyer session orchestration | AgenticOrg | https://github.com/mishrasanjeev/agentic-org/pull/718 | `787b56c621ee5cb8d4ce4321056844ae25280fa0` | `d02657be67c4be256cd1f0b3d52d46e20c5de891` | Buyer-agent read-only session wrapper, intent classification, channel-neutral response, grounded refusal model. |
+| C6J schema.org preview adapter | Grantex | https://github.com/mishrasanjeev/grantex/pull/511 | `ac90162ca0aee9a1e955fb70f388f6634b0e5d68` | `54eca8eb43a3b196f9a15958567aa44f24fc0521` | Public-safe schema.org JSON-LD preview from canonical merchant/catalog/readiness state. |
+| C6K UCP-style capability profile preview | Grantex | https://github.com/mishrasanjeev/grantex/pull/512 | `c8eedb2dff57763bfc87c76009f849084f0f2abd` | `9d2a69b72756f28093c222796c8de822ab5ce0c3` | Grantex-owned UCP-style preview metadata under `dev.grantex.commerce.discovery.preview`. |
+| C6L ACP-style checkout shape preview | Grantex | https://github.com/mishrasanjeev/grantex/pull/513 | `cd0da84f6e08c4dd4d3d4e16dfb739c97f6da5ff` | `f606fc0963ba3622c7ab46b33b12637fa8d45485` | Sandbox-only cart and checkout shape mappings with explicit blockers. |
+| C6M AP2-style evidence preview | Grantex | https://github.com/mishrasanjeev/grantex/pull/514 | `d3a2e521b1fa7bb81f3629c61d0c3bc4554ed364` | `38af5020fa7a5e4b24cdedc49194d0a2894677d0` | Deterministic unsigned AP2-style evidence preview from canonical consent, passport, policy, cart, payment, agent, and audit state. |
+| C6N connector foundation | Grantex | https://github.com/mishrasanjeev/grantex/pull/515 | `50efe65b6806d03e7ed3896b1da418580769b4f6` | `488505e19a4283d875c3a88a760e8b752c288403` | Existing-system connector registry foundation, metadata-only, non-executing, tenant-scoped. |
+
+Repository tips after the merged product-chain stack:
+
+- AgenticOrg main after C6I: `d02657be67c4be256cd1f0b3d52d46e20c5de891`
+- Grantex main after C6N: `488505e19a4283d875c3a88a760e8b752c288403`
 
 ## Packaged Preview Surface
 
@@ -265,9 +272,9 @@ claims remain blocked.
 ## Next Remediation Prompt
 
 ```text
-Task: Review the Agentic Commerce open-protocol packaging draft for public-readiness gaps only.
+Task: Plan Agentic Commerce C6O conformance fixtures and first real connector sync adapter foundation.
 
-Do not deploy, merge, run cloud commands, create cloud resources, change production config, touch secrets, enable public discovery, enable production Commerce V1, enable checkout/payment creation, enable live payments, call providers, or claim certification.
+Do not deploy, run cloud commands, create cloud resources, change production config, touch secrets, enable public discovery, enable production Commerce V1, enable checkout/payment creation, enable live payments, call providers, call merchant private APIs from AgenticOrg, or claim certification.
 
-Review docs/internal/commerce-v1/commerce-v1-open-protocol-packaging-draft.md and docs/internal/commerce-v1/open-protocol-packaging-manifest.preview.json against AgenticOrg PR #718 and Grantex PRs #511-#515. Produce a public-readiness blocker list and exact remediation prompts. Do not publish anything.
+Use the merged C6I-C6N base: AgenticOrg PR #718 and Grantex PRs #511-#515. Define C6O reviewable slices for preview conformance fixtures, schema/manifest validators, and the first safe real connector sync adapter plan. Keep all artifacts sandbox-only, preview-only, non-live, non-publication, and non-certifying. For connector sync, start with metadata, dry-run, stale/conflict blockers, tenant boundaries, credential redaction, and test doubles before any live merchant-system call.
 ```

--- a/docs/internal/commerce-v1/commerce-v1-open-protocol-packaging-draft.md
+++ b/docs/internal/commerce-v1/commerce-v1-open-protocol-packaging-draft.md
@@ -1,0 +1,273 @@
+# Commerce V1 Open Protocol Packaging Draft
+
+Status: internal packaging draft only.
+
+Created: 2026-06-07.
+
+This draft packages the accepted Agentic Commerce C6I-C6N product-chain heads
+for internal open-protocol review. It is not public protocol publication, not
+schema.org publication, not UCP certification, not ACP certification, not AP2
+certification, not provider certification, not production approval, not public
+discovery approval, and not checkout or payment approval.
+
+This draft does not deploy, merge, create cloud resources, change production
+configuration, touch secrets, enable public discovery, enable production
+Commerce V1, enable checkout or payment creation, enable live payments, call
+providers, call merchant private APIs, or claim certification.
+
+## Accepted Base
+
+The packaging draft is based only on these accepted PR heads:
+
+| Slice | Repo | PR | Head SHA | Packaging role |
+| --- | --- | --- | --- | --- |
+| C6I buyer session orchestration | AgenticOrg | https://github.com/mishrasanjeev/agentic-org/pull/718 | `787b56c621ee5cb8d4ce4321056844ae25280fa0` | Buyer-agent read-only session wrapper, intent classification, channel-neutral response, grounded refusal model. |
+| C6J schema.org preview adapter | Grantex | https://github.com/mishrasanjeev/grantex/pull/511 | `ac90162ca0aee9a1e955fb70f388f6634b0e5d68` | Public-safe schema.org JSON-LD preview from canonical merchant/catalog/readiness state. |
+| C6K UCP-style capability profile preview | Grantex | https://github.com/mishrasanjeev/grantex/pull/512 | `cba0df34049217441fef8d8c378f5c2884fa165a` | Grantex-owned UCP-style preview metadata under `dev.grantex.commerce.discovery.preview`. |
+| C6L ACP-style checkout shape preview | Grantex | https://github.com/mishrasanjeev/grantex/pull/513 | `ab54a389167b1a57cb0bb975a5aabc193e1ca67c` | Sandbox-only cart and checkout shape mappings with explicit blockers. |
+| C6M AP2-style evidence preview | Grantex | https://github.com/mishrasanjeev/grantex/pull/514 | `aad06a1da39133170bbcd3e45fd0f5334b0351c7` | Deterministic unsigned AP2-style evidence preview from canonical consent, passport, policy, cart, payment, agent, and audit state. |
+| C6N connector foundation | Grantex | https://github.com/mishrasanjeev/grantex/pull/515 | `200f1e375fd771a3928397e75fa6195cb6cafc10` | Existing-system connector registry foundation, metadata-only, non-executing, tenant-scoped. |
+
+## Packaged Preview Surface
+
+### Buyer Session Envelope
+
+Source: AgenticOrg C6I.
+
+The buyer session surface is channel-neutral and may be adapted for ChatGPT,
+Claude, Gemini, WhatsApp, Telegram, web chat, and future channels. The package
+includes the response fields needed by all channels:
+
+- status
+- message
+- merchant preview
+- catalog samples
+- allowed capabilities
+- blocked capabilities
+- source reference
+- refusal code
+- evidence summary
+
+The buyer session is read-only. Checkout, payment, live-provider, fulfillment,
+refund, return, replacement, chargeback, and unsupported actions must return a
+refusal and must not call providers or merchant systems.
+
+### Grantex Schema.org JSON-LD Preview
+
+Source: Grantex C6J.
+
+The schema.org adapter is packaged as preview-only JSON-LD generated from
+canonical Grantex merchant, catalog, and readiness state. It may include only
+safe Product, Offer, MerchantReturnPolicy, and OfferShippingDetails fields when
+evidence exists.
+
+It must not expose tenant IDs, merchant IDs, product IDs, variant IDs, SKUs,
+private merchant data, secrets, provider metadata, raw payloads, allowlists, or
+production configuration.
+
+Publication remains blocked:
+
+- `schemaorg_publication_enabled: false`
+- `publication_status: not_published`
+- `certification_claims: []`
+
+### Grantex UCP-Style Capability Profile Preview
+
+Source: Grantex C6K.
+
+The UCP-style package uses Grantex-owned preview identifiers only. The namespace
+for services, capabilities, and transports is:
+
+`dev.grantex.commerce.discovery.preview`
+
+The package must not publish `dev.ucp.*`, must not claim UCP certification, and
+must not present preview metadata as certified external capability metadata.
+
+Controls remain blocked:
+
+- `ucp_publication_enabled: false`
+- `ucp_certification_claim: none`
+- `certified_ucp_namespace_published: false`
+- `certified_capabilities_published: false`
+- `commerce_v1_runtime_enabled_by_preview: false`
+
+### Grantex ACP-Style Cart And Checkout Shape Preview
+
+Source: Grantex C6L.
+
+The ACP-style package maps cart and checkout concepts to existing Grantex
+sandbox foundations. It is a shape preview only. It does not create payment
+intents, checkout links, public checkout sessions, provider calls, live payment
+flows, refunds, returns, or fulfillment actions.
+
+Controls remain blocked:
+
+- `acp_publication_enabled: false`
+- `acp_certification_claim: none`
+- `public_checkout_enabled: false`
+- `payment_intent_creation_enabled_by_preview: false`
+- `checkout_link_creation_enabled_by_preview: false`
+- `provider_call_enabled_by_preview: false`
+- `live_payment_enabled_by_preview: false`
+
+Missing consent, passport, policy, cart, or payment-intent evidence must appear
+as explicit blockers. Unsupported fields must remain explicit blockers.
+
+### Grantex AP2-Style Evidence Preview
+
+Source: Grantex C6M.
+
+The AP2-style package is deterministic and unsigned. It is an evidence preview
+from Commerce Passport, consent record, policy decision, cart hash, amount cap,
+merchant state, agent identity, audit reference, and idempotency/replay evidence
+where available.
+
+It is not AP2 certification, not AP2 publication, not payment-network
+submission, not a signed production mandate, and not a provider approval.
+
+Controls remain blocked:
+
+- `ap2_publication_enabled: false`
+- `ap2_certification_claim: none`
+- `ap2_signed_mandate_created: false`
+- `signed_production_mandate_created: false`
+- `signature_status: unsigned_preview`
+- `payment_network_submission_enabled: false`
+- `checkout_payment_creation_enabled_by_preview: false`
+
+### Merchant Existing-System Connector Registry
+
+Source: Grantex C6N.
+
+The connector package describes how merchants declare existing systems without
+letting AgenticOrg call those systems directly. Supported metadata connector
+types are:
+
+- manual
+- CSV
+- custom API
+- Shopify
+- WooCommerce
+- Magento
+- ERP
+- billing
+- OMS
+- WMS
+- logistics
+- CRM/support
+- payment provider
+
+The source precedence domains are:
+
+- catalog
+- price
+- inventory
+- order
+- fulfillment
+- refund
+- settlement
+- support
+
+The registry is metadata-only. It must not store credentials, call providers,
+call merchant private APIs, enable outbound sync, enable AgenticOrg direct
+execution, enable public discovery, write production configuration, or enable
+checkout/payment execution.
+
+Controls remain blocked:
+
+- `metadata_only_registry: true`
+- `credentials_stored_by_registry: false`
+- `outbound_sync_enabled_by_registry: false`
+- `agenticorg_direct_execution_allowed: false`
+- `provider_call_enabled_by_registry: false`
+- `checkout_payment_enabled_by_registry: false`
+- `live_payment_enabled_by_registry: false`
+- `public_discovery_enabled_by_registry: false`
+- `production_config_written_by_registry: false`
+
+## Cross-Protocol Contract
+
+Every packaged artifact must include or inherit these facts:
+
+- preview-only
+- sandbox-only where runtime state is involved
+- tenant-scoped
+- Grantex-grounded
+- non-publication
+- non-certifying
+- non-live
+- non-enabling
+- no provider calls
+- no merchant private API calls from AgenticOrg
+- no secrets, credentials, raw payloads, provider metadata, allowlists, or
+  production configuration
+
+## Publication Blockers
+
+Public publication is blocked until all of these have explicit approval:
+
+1. Governance accepts the final packaging PR or merged base.
+2. Legal/product/security approve public protocol publication.
+3. Public discovery rollout is separately approved.
+4. Production Commerce V1 enablement is separately approved.
+5. Checkout/payment creation is separately approved.
+6. Live-provider and live-payment approvals are separately granted.
+7. Certification claims are backed by independent conformance or certification
+   evidence.
+8. Merchant-specific public data has production approval and is not synthetic,
+   sandbox, demo, or private.
+9. AgenticOrg public discovery remains disabled until a future approved rollout.
+10. AgenticOrg continues to avoid direct calls to providers and merchant private
+    APIs.
+
+## Stop Conditions
+
+Stop packaging or publication work immediately if any future change:
+
+- sets `COMMERCE_PUBLIC_DISCOVERY_ENABLED`
+- sets `COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST`
+- sets production allowlists
+- enables AgenticOrg public discovery
+- enables production Commerce V1
+- enables checkout or payment creation in production
+- enables public checkout
+- enables live payment
+- enables live provider execution
+- stores real credentials in repository, logs, fixtures, docs, or examples
+- calls Plural, Stripe, Pine, a payment provider, or a merchant private API
+  directly from AgenticOrg
+- claims schema.org, UCP, ACP, AP2, MPP, A2A, provider, or production
+  certification
+- treats sandbox, demo, synthetic, or test data as production approval
+
+## Rollback Notes
+
+This package is documentation and preview manifest only. To roll it back, revert
+the packaging branch or remove:
+
+- `docs/internal/commerce-v1/commerce-v1-open-protocol-packaging-draft.md`
+- `docs/internal/commerce-v1/open-protocol-packaging-manifest.preview.json`
+
+No runtime flags, production configuration, provider credentials, merchant
+connector credentials, public discovery settings, or cloud resources are created
+by this package.
+
+## Readiness Result
+
+Internal packaging draft: GO.
+
+Public protocol publication: NO-GO.
+
+Production discovery, production checkout/payment, live providers, live
+payments, provider calls, merchant private API execution, and certification
+claims remain blocked.
+
+## Next Remediation Prompt
+
+```text
+Task: Review the Agentic Commerce open-protocol packaging draft for public-readiness gaps only.
+
+Do not deploy, merge, run cloud commands, create cloud resources, change production config, touch secrets, enable public discovery, enable production Commerce V1, enable checkout/payment creation, enable live payments, call providers, or claim certification.
+
+Review docs/internal/commerce-v1/commerce-v1-open-protocol-packaging-draft.md and docs/internal/commerce-v1/open-protocol-packaging-manifest.preview.json against AgenticOrg PR #718 and Grantex PRs #511-#515. Produce a public-readiness blocker list and exact remediation prompts. Do not publish anything.
+```

--- a/docs/internal/commerce-v1/open-protocol-packaging-manifest.preview.json
+++ b/docs/internal/commerce-v1/open-protocol-packaging-manifest.preview.json
@@ -9,13 +9,19 @@
   "non_live": true,
   "non_enabling": true,
   "certification_claims": [],
-  "accepted_heads": [
+  "merged_base": {
+    "agenticorg_main_tip_after_c6i": "d02657be67c4be256cd1f0b3d52d46e20c5de891",
+    "grantex_main_tip_after_c6n": "488505e19a4283d875c3a88a760e8b752c288403"
+  },
+  "merged_prs": [
     {
       "slice": "C6I",
       "repo": "agentic-org",
       "pr": 718,
       "url": "https://github.com/mishrasanjeev/agentic-org/pull/718",
-      "head_sha": "787b56c621ee5cb8d4ce4321056844ae25280fa0",
+      "final_head_sha": "787b56c621ee5cb8d4ce4321056844ae25280fa0",
+      "merge_commit_sha": "d02657be67c4be256cd1f0b3d52d46e20c5de891",
+      "merge_status": "merged",
       "role": "buyer_session_orchestration"
     },
     {
@@ -23,7 +29,9 @@
       "repo": "grantex",
       "pr": 511,
       "url": "https://github.com/mishrasanjeev/grantex/pull/511",
-      "head_sha": "ac90162ca0aee9a1e955fb70f388f6634b0e5d68",
+      "final_head_sha": "ac90162ca0aee9a1e955fb70f388f6634b0e5d68",
+      "merge_commit_sha": "54eca8eb43a3b196f9a15958567aa44f24fc0521",
+      "merge_status": "merged",
       "role": "schemaorg_jsonld_preview"
     },
     {
@@ -31,7 +39,9 @@
       "repo": "grantex",
       "pr": 512,
       "url": "https://github.com/mishrasanjeev/grantex/pull/512",
-      "head_sha": "cba0df34049217441fef8d8c378f5c2884fa165a",
+      "final_head_sha": "c8eedb2dff57763bfc87c76009f849084f0f2abd",
+      "merge_commit_sha": "9d2a69b72756f28093c222796c8de822ab5ce0c3",
+      "merge_status": "merged",
       "role": "ucp_style_capability_profile_preview"
     },
     {
@@ -39,7 +49,9 @@
       "repo": "grantex",
       "pr": 513,
       "url": "https://github.com/mishrasanjeev/grantex/pull/513",
-      "head_sha": "ab54a389167b1a57cb0bb975a5aabc193e1ca67c",
+      "final_head_sha": "cd0da84f6e08c4dd4d3d4e16dfb739c97f6da5ff",
+      "merge_commit_sha": "f606fc0963ba3622c7ab46b33b12637fa8d45485",
+      "merge_status": "merged",
       "role": "acp_style_checkout_shape_preview"
     },
     {
@@ -47,7 +59,9 @@
       "repo": "grantex",
       "pr": 514,
       "url": "https://github.com/mishrasanjeev/grantex/pull/514",
-      "head_sha": "aad06a1da39133170bbcd3e45fd0f5334b0351c7",
+      "final_head_sha": "d3a2e521b1fa7bb81f3629c61d0c3bc4554ed364",
+      "merge_commit_sha": "38af5020fa7a5e4b24cdedc49194d0a2894677d0",
+      "merge_status": "merged",
       "role": "ap2_style_evidence_preview"
     },
     {
@@ -55,7 +69,9 @@
       "repo": "grantex",
       "pr": 515,
       "url": "https://github.com/mishrasanjeev/grantex/pull/515",
-      "head_sha": "200f1e375fd771a3928397e75fa6195cb6cafc10",
+      "final_head_sha": "50efe65b6806d03e7ed3896b1da418580769b4f6",
+      "merge_commit_sha": "488505e19a4283d875c3a88a760e8b752c288403",
+      "merge_status": "merged",
       "role": "merchant_existing_system_connector_foundation"
     }
   ],
@@ -172,5 +188,5 @@
     "certification_claim_added",
     "sandbox_or_synthetic_data_treated_as_production_approval"
   ],
-  "next_review_prompt": "Review the Agentic Commerce open-protocol packaging draft for public-readiness gaps only. Do not deploy, merge, run cloud commands, create cloud resources, change production config, touch secrets, enable public discovery, enable production Commerce V1, enable checkout/payment creation, enable live payments, call providers, or claim certification."
+  "next_review_prompt": "Plan Agentic Commerce C6O conformance fixtures and first real connector sync adapter foundation. Do not deploy, run cloud commands, create cloud resources, change production config, touch secrets, enable public discovery, enable production Commerce V1, enable checkout/payment creation, enable live payments, call providers, call merchant private APIs from AgenticOrg, or claim certification. Use the merged C6I-C6N base: AgenticOrg PR #718 and Grantex PRs #511-#515. Define C6O reviewable slices for preview conformance fixtures, schema/manifest validators, and the first safe real connector sync adapter plan. Keep all artifacts sandbox-only, preview-only, non-live, non-publication, and non-certifying."
 }

--- a/docs/internal/commerce-v1/open-protocol-packaging-manifest.preview.json
+++ b/docs/internal/commerce-v1/open-protocol-packaging-manifest.preview.json
@@ -1,0 +1,176 @@
+{
+  "manifest_kind": "agentic_commerce_open_protocol_packaging_preview",
+  "manifest_version": "c6i_c6n_preview_2026_06_07",
+  "status": "internal_packaging_draft",
+  "created_at": "2026-06-07",
+  "publication_status": "not_published",
+  "preview_only": true,
+  "sandbox_only": true,
+  "non_live": true,
+  "non_enabling": true,
+  "certification_claims": [],
+  "accepted_heads": [
+    {
+      "slice": "C6I",
+      "repo": "agentic-org",
+      "pr": 718,
+      "url": "https://github.com/mishrasanjeev/agentic-org/pull/718",
+      "head_sha": "787b56c621ee5cb8d4ce4321056844ae25280fa0",
+      "role": "buyer_session_orchestration"
+    },
+    {
+      "slice": "C6J",
+      "repo": "grantex",
+      "pr": 511,
+      "url": "https://github.com/mishrasanjeev/grantex/pull/511",
+      "head_sha": "ac90162ca0aee9a1e955fb70f388f6634b0e5d68",
+      "role": "schemaorg_jsonld_preview"
+    },
+    {
+      "slice": "C6K",
+      "repo": "grantex",
+      "pr": 512,
+      "url": "https://github.com/mishrasanjeev/grantex/pull/512",
+      "head_sha": "cba0df34049217441fef8d8c378f5c2884fa165a",
+      "role": "ucp_style_capability_profile_preview"
+    },
+    {
+      "slice": "C6L",
+      "repo": "grantex",
+      "pr": 513,
+      "url": "https://github.com/mishrasanjeev/grantex/pull/513",
+      "head_sha": "ab54a389167b1a57cb0bb975a5aabc193e1ca67c",
+      "role": "acp_style_checkout_shape_preview"
+    },
+    {
+      "slice": "C6M",
+      "repo": "grantex",
+      "pr": 514,
+      "url": "https://github.com/mishrasanjeev/grantex/pull/514",
+      "head_sha": "aad06a1da39133170bbcd3e45fd0f5334b0351c7",
+      "role": "ap2_style_evidence_preview"
+    },
+    {
+      "slice": "C6N",
+      "repo": "grantex",
+      "pr": 515,
+      "url": "https://github.com/mishrasanjeev/grantex/pull/515",
+      "head_sha": "200f1e375fd771a3928397e75fa6195cb6cafc10",
+      "role": "merchant_existing_system_connector_foundation"
+    }
+  ],
+  "packaged_surfaces": {
+    "buyer_session": {
+      "owner": "AgenticOrg",
+      "source_slice": "C6I",
+      "channel_neutral": true,
+      "grounded_in_grantex": true,
+      "read_only_discovery": true,
+      "refuses_checkout_payment": true,
+      "refuses_live_provider": true,
+      "refuses_fulfillment": true,
+      "refuses_refund_return": true,
+      "agenticorg_direct_provider_calls_enabled": false,
+      "agenticorg_direct_merchant_api_calls_enabled": false
+    },
+    "schemaorg_jsonld_preview": {
+      "owner": "Grantex",
+      "source_slice": "C6J",
+      "schemaorg_publication_enabled": false,
+      "public_discovery_enabled": false,
+      "production_commerce_v1_enabled": false,
+      "checkout_payment_enabled": false,
+      "live_provider_enabled": false,
+      "provider_credentials_exposed": false,
+      "production_allowlist_written": false
+    },
+    "ucp_style_capability_profile_preview": {
+      "owner": "Grantex",
+      "source_slice": "C6K",
+      "namespace": "dev.grantex.commerce.discovery.preview",
+      "external_ucp_namespace_used": false,
+      "ucp_publication_enabled": false,
+      "ucp_certification_claim": "none",
+      "certified_ucp_namespace_published": false,
+      "certified_capabilities_published": false,
+      "commerce_v1_runtime_enabled_by_preview": false
+    },
+    "acp_style_checkout_shape_preview": {
+      "owner": "Grantex",
+      "source_slice": "C6L",
+      "acp_publication_enabled": false,
+      "acp_certification_claim": "none",
+      "public_checkout_enabled": false,
+      "payment_intent_creation_enabled_by_preview": false,
+      "checkout_link_creation_enabled_by_preview": false,
+      "provider_call_enabled_by_preview": false,
+      "live_payment_enabled_by_preview": false
+    },
+    "ap2_style_evidence_preview": {
+      "owner": "Grantex",
+      "source_slice": "C6M",
+      "ap2_publication_enabled": false,
+      "ap2_certification_claim": "none",
+      "deterministic_unsigned_preview": true,
+      "ap2_signed_mandate_created": false,
+      "signed_production_mandate_created": false,
+      "payment_network_submission_enabled": false,
+      "checkout_payment_creation_enabled_by_preview": false
+    },
+    "merchant_connector_registry": {
+      "owner": "Grantex",
+      "source_slice": "C6N",
+      "metadata_only_registry": true,
+      "credentials_stored_by_registry": false,
+      "outbound_sync_enabled_by_registry": false,
+      "agenticorg_direct_execution_allowed": false,
+      "provider_call_enabled_by_registry": false,
+      "checkout_payment_enabled_by_registry": false,
+      "live_payment_enabled_by_registry": false,
+      "public_discovery_enabled_by_registry": false,
+      "production_config_written_by_registry": false
+    }
+  },
+  "global_controls": {
+    "public_protocol_publication_approved": false,
+    "schemaorg_publication_enabled": false,
+    "commerce_public_discovery_enabled": false,
+    "agenticorg_public_discovery_enabled": false,
+    "production_commerce_v1_enabled": false,
+    "production_checkout_payment_creation_enabled": false,
+    "public_checkout_enabled": false,
+    "live_payment_enabled": false,
+    "live_provider_enabled": false,
+    "provider_calls_enabled": false,
+    "merchant_private_api_calls_from_agenticorg_enabled": false,
+    "provider_credentials_included": false,
+    "secrets_included": false,
+    "production_allowlists_written": false,
+    "cloud_resources_created": false,
+    "deployment_performed": false
+  },
+  "publication_blockers": [
+    "public_protocol_publication_not_approved",
+    "public_discovery_not_approved",
+    "production_commerce_v1_not_approved",
+    "production_checkout_payment_creation_not_approved",
+    "live_provider_not_approved",
+    "live_payment_not_approved",
+    "certification_evidence_missing",
+    "merchant_publication_approval_missing",
+    "agenticorg_public_discovery_not_enabled_by_approved_rollout"
+  ],
+  "stop_conditions": [
+    "public_discovery_flag_assignment",
+    "production_allowlist_assignment",
+    "production_commerce_v1_enablement",
+    "checkout_payment_enablement",
+    "live_payment_enablement",
+    "provider_call_enablement",
+    "merchant_private_api_call_from_agenticorg",
+    "secret_or_credential_material_added",
+    "certification_claim_added",
+    "sandbox_or_synthetic_data_treated_as_production_approval"
+  ],
+  "next_review_prompt": "Review the Agentic Commerce open-protocol packaging draft for public-readiness gaps only. Do not deploy, merge, run cloud commands, create cloud resources, change production config, touch secrets, enable public discovery, enable production Commerce V1, enable checkout/payment creation, enable live payments, call providers, or claim certification."
+}


### PR DESCRIPTION
Docs-only stacked packaging draft from accepted AgenticOrg PR #718 and Grantex PRs #511-#515 heads. Preview-only, sandbox-only, non-live, non-publication, non-certifying artifacts only. Does not deploy, merge, change config, enable public discovery, enable production Commerce V1, enable checkout/payment creation, enable live payments, call providers, or claim certification. Validation: JSON manifest parse, git diff --cached --check, Auth Service focused commerce tests/typecheck, AgenticOrg C6I focused pytest/ruff/mypy, focused guardrail scans.