### PR TITLE
test(commerce): add preview conformance status page

### DIFF
--- a/apps/auth-service/tests/commerce-c6od-conformance-status.test.ts
+++ b/apps/auth-service/tests/commerce-c6od-conformance-status.test.ts
@@ -1,0 +1,246 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..', '..', '..');
+const validatorPath = join(repoRoot, 'scripts', 'commerce-c6oa-preview-conformance-validate.mjs');
+const rendererPath = join(repoRoot, 'scripts', 'commerce-c6od-preview-status-render.mjs');
+
+const expectedSurfaces = [
+  'acp_style_checkout_shape_preview',
+  'ap2_style_evidence_preview',
+  'connector_registry_metadata_preview',
+  'schemaorg_jsonld_preview',
+  'ucp_style_capability_profile_preview',
+];
+
+const forbiddenOutputPatterns = [
+  /-----BEGIN [A-Z ]+PRIVATE KEY-----|sk_live_|pk_live_|whsec_|postgres:\/\/|postgresql:\/\/|redis:\/\/|bearer\s+[A-Za-z0-9._-]{20,}|client_secret\s*=|access_token\s*=|refresh_token\s*=|password\s*=|api[_-]?key\s*=/i,
+  /\b(?:ten|mch|cprd|cvar|cart|cpi|cconn|caud|jti)_[A-Z0-9][A-Za-z0-9]*/,
+  /"provider_metadata"\s*:\s*\{|"raw_payload"\s*:\s*\{/i,
+  /\bcertified\b|certification approved|production approved|public protocol publication approved|live payment approved/i,
+  /fetch\(|axios\.|got\(|undici/i,
+];
+
+const forbiddenJsonEnablementPattern =
+  /"(?:public_discovery_enabled|production_checkout_payment_creation_enabled|live_payment_enabled|provider_call_enabled|merchant_private_api_call_enabled)"\s*:\s*true/i;
+
+const forbiddenMarkdownEnablementPattern =
+  /(?:Public discovery enabled|Production checkout\/payment creation enabled|Live payment enabled|Provider calls enabled|Merchant private API calls enabled): true/i;
+
+function tempDir() {
+  return mkdtempSync(join(tmpdir(), 'commerce-c6od-status-'));
+}
+
+function runNode(scriptPath: string, args: string[]) {
+  return execFileSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function generateReport(dir: string) {
+  const reportPath = join(dir, 'report.json');
+  const reportMarkdownPath = join(dir, 'report.md');
+  runNode(validatorPath, [
+    '--write-report',
+    '--json-report',
+    reportPath,
+    '--markdown-report',
+    reportMarkdownPath,
+    '--generated-at',
+    '2026-06-07T00:00:00.000Z',
+  ]);
+  return reportPath;
+}
+
+function renderStatus(reportPath: string, dir: string) {
+  const jsonStatusPath = join(dir, 'status.json');
+  const markdownStatusPath = join(dir, 'status.md');
+  const output = runNode(rendererPath, [
+    '--report',
+    reportPath,
+    '--json-status',
+    jsonStatusPath,
+    '--markdown-status',
+    markdownStatusPath,
+    '--generated-at',
+    '2026-06-07T00:00:00.000Z',
+  ]);
+  return { jsonStatusPath, markdownStatusPath, output };
+}
+
+function readStatus(path: string) {
+  return JSON.parse(readFileSync(path, 'utf8')) as {
+    status: string;
+    badge: {
+      label: string;
+      message: string;
+      color: string;
+      public_badge_publication_enabled: boolean;
+    };
+    counts: {
+      fixture_count: number;
+      surface_count: number;
+      scan_count: number;
+    };
+    per_surface_status: Array<{ surface: string; status: string }>;
+    blocker_summary: { blocked_fixture_count: number; expected_blocker_count: number };
+    forbidden_claim_scan_summary: { status: string; scans_checked: number; failure_count: number };
+    non_enabling_control_summary: {
+      status: string;
+      all_guarded_controls_disabled: boolean;
+      enabled_guarded_controls: string[];
+    };
+    safety_posture_summary: {
+      statement: string;
+      preview_internal_only: boolean;
+      sandbox_only: boolean;
+      non_live: boolean;
+      non_enabling: boolean;
+      non_publication: boolean;
+      non_certifying: boolean;
+      public_discovery_enabled: boolean;
+      production_checkout_payment_creation_enabled: boolean;
+      live_payment_enabled: boolean;
+      provider_calls_enabled: boolean;
+      merchant_private_api_calls_enabled: boolean;
+    };
+    failure_summary: { failure_count: number; failure_scopes: string[] };
+    publication_status: string;
+    certification_claims: string[];
+  };
+}
+
+describe('C6Od preview conformance status renderer', () => {
+  it('parses a valid C6Oc report and renders internal status artifacts', () => {
+    const dir = tempDir();
+    try {
+      const reportPath = generateReport(dir);
+      const { jsonStatusPath, markdownStatusPath, output } = renderStatus(reportPath, dir);
+      const status = readStatus(jsonStatusPath);
+      const markdown = readFileSync(markdownStatusPath, 'utf8');
+
+      expect(output).toContain('commerce C6Od preview conformance status rendered');
+      expect(status).toMatchObject({
+        status: 'passing',
+        counts: {
+          fixture_count: 10,
+          surface_count: 5,
+          scan_count: 104,
+        },
+      });
+      expect(status.badge).toMatchObject({
+        label: 'internal preview conformance',
+        message: 'passing',
+        color: 'green',
+        public_badge_publication_enabled: false,
+      });
+      expect(status.per_surface_status.map((surface) => surface.surface).sort()).toEqual(expectedSurfaces);
+      expect(status.blocker_summary.blocked_fixture_count).toBe(5);
+      expect(status.forbidden_claim_scan_summary.status).toBe('passed');
+      expect(status.non_enabling_control_summary.status).toBe('passed');
+      expect(markdown).toContain('# Open Protocol Preview Conformance Status');
+      expect(markdown).toContain('not public protocol publication');
+      expect(markdown).toContain('not a certification artifact');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it('does not write status files unless output paths are requested', () => {
+    const dir = tempDir();
+    try {
+      const reportPath = generateReport(dir);
+      const jsonStatusPath = join(dir, 'status.json');
+      const markdownStatusPath = join(dir, 'status.md');
+      const output = runNode(rendererPath, ['--report', reportPath]);
+
+      expect(output).toContain('commerce C6Od preview conformance status rendered');
+      expect(existsSync(jsonStatusPath)).toBe(false);
+      expect(existsSync(markdownStatusPath)).toBe(false);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it('renders failed report input as a failing badge and status', () => {
+    const dir = tempDir();
+    try {
+      const reportPath = generateReport(dir);
+      const report = JSON.parse(readFileSync(reportPath, 'utf8')) as {
+        status: string;
+        failures: Array<{ scope: string; message: string }>;
+        per_surface_results: Array<{ status: string; failed_fixtures: string[] }>;
+        forbidden_claim_scan_summary: { status: string; failures: Array<{ path: string; scan: string }> };
+      };
+      report.status = 'failed';
+      report.failures = [{ scope: 'fixture:synthetic-preview.blocked.json', message: 'synthetic failure' }];
+      report.per_surface_results[0]!.status = 'failed';
+      report.per_surface_results[0]!.failed_fixtures = ['synthetic-preview.blocked.json'];
+      report.forbidden_claim_scan_summary.status = 'failed';
+      report.forbidden_claim_scan_summary.failures = [{ path: 'synthetic-preview.blocked.json', scan: 'synthetic scan' }];
+      writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+
+      const { jsonStatusPath, markdownStatusPath } = renderStatus(reportPath, dir);
+      const status = readStatus(jsonStatusPath);
+      const markdown = readFileSync(markdownStatusPath, 'utf8');
+
+      expect(status.status).toBe('failing');
+      expect(status.badge).toMatchObject({
+        message: 'failing',
+        color: 'red',
+      });
+      expect(status.failure_summary).toMatchObject({
+        failure_count: 1,
+        failure_scopes: ['fixture:synthetic-preview.blocked.json'],
+      });
+      expect(status.forbidden_claim_scan_summary.failure_count).toBe(1);
+      expect(markdown).toContain('- Message: failing');
+      expect(markdown).not.toContain('- Message: passing');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it('keeps status output private-safe and non-enabling', () => {
+    const dir = tempDir();
+    try {
+      const reportPath = generateReport(dir);
+      const { jsonStatusPath, markdownStatusPath } = renderStatus(reportPath, dir);
+      const status = readStatus(jsonStatusPath);
+      const markdown = readFileSync(markdownStatusPath, 'utf8');
+      const combined = `${JSON.stringify(status)}\n${markdown}`;
+
+      for (const pattern of forbiddenOutputPatterns) {
+        expect(combined).not.toMatch(pattern);
+      }
+      expect(JSON.stringify(status)).not.toMatch(forbiddenJsonEnablementPattern);
+      expect(markdown).not.toMatch(forbiddenMarkdownEnablementPattern);
+      expect(status.safety_posture_summary).toMatchObject({
+        preview_internal_only: true,
+        sandbox_only: true,
+        non_live: true,
+        non_enabling: true,
+        non_publication: true,
+        non_certifying: true,
+        public_discovery_enabled: false,
+        production_checkout_payment_creation_enabled: false,
+        live_payment_enabled: false,
+        provider_calls_enabled: false,
+        merchant_private_api_calls_enabled: false,
+      });
+      expect(status.non_enabling_control_summary.all_guarded_controls_disabled).toBe(true);
+      expect(status.non_enabling_control_summary.enabled_guarded_controls).toEqual([]);
+      expect(status.publication_status).toBe('not_published');
+      expect(status.certification_claims).toEqual([]);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6od-preview-conformance-status-page.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6od-preview-conformance-status-page.md
@@ -1,0 +1,120 @@
+# Commerce V1 C6Od Preview Conformance Status Page
+
+Status: planned implementation as local internal status rendering.
+
+Base:
+
+- Grantex main: `80c16122f9d390f8982225fffb1bc418f3d5d145`
+- C6Oc report generator:
+  `scripts/commerce-c6oa-preview-conformance-validate.mjs`
+
+C6Od adds a local docs/test-only renderer for the C6Oc JSON conformance report.
+It produces internal-only status artifacts on request. It does not add runtime
+APIs, routes, migrations, portal UI, production configuration, public discovery,
+checkout or payment behavior, provider calls, merchant private API calls,
+published protocol materials, or certification claims.
+
+The status page is internal preview evidence only. It is not public protocol
+publication, not a certification artifact, and does not enable public discovery,
+production Commerce V1, checkout or payment creation, live payments, provider
+calls, merchant private API calls, production allowlists, secrets, credentials,
+or runtime connector execution.
+
+## Generate A Source Report
+
+Create a C6Oc report in a review or temporary directory:
+
+```bash
+node scripts/commerce-c6oa-preview-conformance-validate.mjs \
+  --write-report \
+  --json-report <temp-or-review-path>/report.json \
+  --markdown-report <temp-or-review-path>/report.md
+```
+
+## Render Internal Status
+
+Render internal status artifacts from the JSON report:
+
+```bash
+node scripts/commerce-c6od-preview-status-render.mjs \
+  --report <temp-or-review-path>/report.json \
+  --json-status <temp-or-review-path>/status.json \
+  --markdown-status <temp-or-review-path>/status.md
+```
+
+If `--json-status` and `--markdown-status` are omitted, the renderer validates
+the report and prints a summary without writing status files. This prevents
+timestamp churn during normal local validation.
+
+## Status Contents
+
+The JSON and Markdown status artifacts include:
+
+- internal preview status
+- internal preview conformance badge label, message, and color
+- fixture count
+- surface count
+- scan count
+- per-surface status
+- blocker summary
+- forbidden-claim scan summary
+- non-enabling control summary
+- safety posture summary
+- explicit internal preview, non-publication, and non-certification language
+
+The required surfaces are:
+
+- schema.org JSON-LD preview
+- UCP-style capability profile preview
+- ACP-style checkout shape preview
+- AP2-style evidence preview
+- connector registry metadata preview
+
+Passing reports render `internal preview conformance: passing`. Failed reports
+render `internal preview conformance: failing`; a failed source report must not
+produce a passing badge.
+
+## Stop Conditions
+
+Stop the slice if the renderer, generated status artifacts, or docs:
+
+- publish public protocol materials or public badge/status pages
+- enable public discovery or production Commerce V1
+- enable checkout, payment creation, public checkout, or live payment paths
+- enable live-provider behavior, provider calls, or provider credential use
+- allow AgenticOrg direct execution against merchant systems
+- include secrets, credentials, DB URLs, raw payloads, provider metadata,
+  concrete private IDs, or concrete allowlist values
+- write production configuration or production allowlists
+- claim UCP, ACP, AP2, schema.org, MPP, A2A, provider, or live-payment
+  certification
+- treat sandbox, demo, synthetic, or test output as production readiness
+  approval
+
+## Validation
+
+C6Od validation should include:
+
+- `node scripts/commerce-c6oa-preview-conformance-validate.mjs --write-report --json-report <temp>/report.json --markdown-report <temp>/report.md`
+- `node scripts/commerce-c6od-preview-status-render.mjs --report <temp>/report.json --json-status <temp>/status.json --markdown-status <temp>/status.md`
+- `npm --prefix apps/auth-service test -- commerce-c6oc-conformance-report.test.ts commerce-c6od-conformance-status.test.ts`
+- `npm --prefix apps/auth-service run typecheck`
+- `git diff --check origin/main...HEAD`
+- focused guardrail scans for secrets/private details, production config and
+  allowlists, public discovery, checkout/payment enablement, live payment and
+  provider credentials, overclaims, direct provider calls, direct merchant
+  private API calls, and AgenticOrg direct execution enablement
+
+## Rollback
+
+This slice is local status rendering only. To roll it back, remove:
+
+- `scripts/commerce-c6od-preview-status-render.mjs`
+- `apps/auth-service/tests/commerce-c6od-conformance-status.test.ts`
+- `docs/internal/commerce-v1/commerce-v1-c6od-preview-conformance-status-page.md`
+- any generated review status artifacts if a reviewer created them locally
+
+No runtime flags, production configuration, provider credentials, connector
+credentials, public discovery settings, checkout/payment behavior, live-provider
+behavior, cloud resources, or deployment workflow changes are created by this
+slice.

--- a/scripts/commerce-c6od-preview-status-render.mjs
+++ b/scripts/commerce-c6od-preview-status-render.mjs
@@ -1,0 +1,356 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptsDir, '..');
+
+const requiredSurfaces = [
+  'schemaorg_jsonld_preview',
+  'ucp_style_capability_profile_preview',
+  'acp_style_checkout_shape_preview',
+  'ap2_style_evidence_preview',
+  'connector_registry_metadata_preview',
+];
+
+const internalStatusStatement =
+  'Internal preview conformance status only. This is not public protocol publication, not a certification artifact, and does not enable public discovery, production checkout or payment creation, live payments, provider calls, or merchant private API calls.';
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function formatPath(path) {
+  const relativePath = relative(repoRoot, path).replace(/\\/g, '/');
+  if (relativePath && !relativePath.startsWith('..')) return relativePath;
+  return path.replace(/\\/g, '/');
+}
+
+function requireOptionValue(args, index, option) {
+  const value = args[index + 1];
+  assert.ok(value && !value.startsWith('--'), `${option} requires a path value`);
+  return value;
+}
+
+function parseArgs(args) {
+  const options = {
+    generatedAt: new Date().toISOString(),
+    jsonStatusPath: null,
+    markdownStatusPath: null,
+    reportPath: null,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case '--report':
+        options.reportPath = resolve(repoRoot, requireOptionValue(args, index, arg));
+        index += 1;
+        break;
+      case '--json-status':
+        options.jsonStatusPath = resolve(repoRoot, requireOptionValue(args, index, arg));
+        index += 1;
+        break;
+      case '--markdown-status':
+        options.markdownStatusPath = resolve(repoRoot, requireOptionValue(args, index, arg));
+        index += 1;
+        break;
+      case '--generated-at':
+        options.generatedAt = requireOptionValue(args, index, arg);
+        index += 1;
+        break;
+      case '--help':
+        console.log([
+          'Usage: node scripts/commerce-c6od-preview-status-render.mjs --report <path> [options]',
+          '',
+          'Options:',
+          '  --report <path>            C6Oc JSON conformance report to render.',
+          '  --json-status <path>       Optional JSON status summary output path.',
+          '  --markdown-status <path>   Optional Markdown status page output path.',
+          '  --generated-at <value>     Override status timestamp for deterministic review output.',
+          '',
+          'The renderer is local docs/test automation only. It does not publish status pages or enable runtime commerce behavior.',
+        ].join('\n'));
+        process.exit(0);
+        break;
+      default:
+        assert.fail(`Unknown option ${arg}`);
+    }
+  }
+
+  assert.ok(options.reportPath, '--report is required');
+  return options;
+}
+
+function parseJsonFile(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function asArray(value, label) {
+  assert.ok(Array.isArray(value), `${label} must be an array`);
+  return value;
+}
+
+function assertReportShape(report) {
+  assert.ok(isRecord(report), 'report must be an object');
+  assert.equal(
+    report.report_kind,
+    'agentic_commerce_open_protocol_preview_conformance_report',
+    'report_kind must be C6Oc preview conformance report',
+  );
+  assert.ok(['passed', 'failed'].includes(report.status), 'report.status must be passed or failed');
+  assert.equal(typeof report.generated_at, 'string', 'report.generated_at must be a string');
+  assert.equal(typeof report.source_manifest_path, 'string', 'report.source_manifest_path must be a string');
+  assert.equal(typeof report.fixture_corpus_version, 'string', 'report.fixture_corpus_version must be a string');
+  assert.equal(typeof report.fixture_count, 'number', 'report.fixture_count must be a number');
+  assert.equal(typeof report.surface_count, 'number', 'report.surface_count must be a number');
+  assert.equal(typeof report.scan_count, 'number', 'report.scan_count must be a number');
+  assert.ok(isRecord(report.blocker_summary), 'report.blocker_summary must be an object');
+  assert.ok(isRecord(report.forbidden_claim_scan_summary), 'report.forbidden_claim_scan_summary must be an object');
+  assert.ok(isRecord(report.non_enabling_control_summary), 'report.non_enabling_control_summary must be an object');
+  assert.ok(isRecord(report.safety_posture_summary), 'report.safety_posture_summary must be an object');
+
+  const surfaces = asArray(report.per_surface_results, 'report.per_surface_results');
+  const surfaceNames = new Set(surfaces.map((surface) => surface.surface));
+  for (const surface of requiredSurfaces) {
+    assert.equal(surfaceNames.has(surface), true, `report must include ${surface}`);
+  }
+}
+
+function statusFromReport(report) {
+  return report.status === 'passed' ? 'passing' : 'failing';
+}
+
+function badgeForStatus(status) {
+  return {
+    label: 'internal preview conformance',
+    message: status,
+    color: status === 'passing' ? 'green' : 'red',
+    public_badge_publication_enabled: false,
+  };
+}
+
+function summarizeSurfaces(report) {
+  return report.per_surface_results.map((surface) => ({
+    surface: surface.surface,
+    status: surface.status,
+    fixture_count: surface.fixture_count,
+    scenarios_present: Array.isArray(surface.scenarios_present) ? surface.scenarios_present : [],
+    missing_scenarios: Array.isArray(surface.missing_scenarios) ? surface.missing_scenarios : [],
+    failed_fixtures: Array.isArray(surface.failed_fixtures) ? surface.failed_fixtures : [],
+  }));
+}
+
+function summarizeFailures(report) {
+  const failures = Array.isArray(report.failures) ? report.failures : [];
+  return {
+    failure_count: failures.length,
+    failure_scopes: failures
+      .map((failure) => (isRecord(failure) && typeof failure.scope === 'string' ? failure.scope : 'unknown'))
+      .sort(),
+  };
+}
+
+function buildStatus(report, options) {
+  assertReportShape(report);
+  const status = statusFromReport(report);
+  const safetyPosture = report.safety_posture_summary;
+
+  return {
+    status_kind: 'agentic_commerce_open_protocol_preview_conformance_status',
+    status_version: 'c6od-preview-1',
+    generated_at: options.generatedAt,
+    source_report_path: formatPath(options.reportPath),
+    source_report: {
+      report_kind: report.report_kind,
+      report_version: report.report_version ?? 'unknown',
+      generated_at: report.generated_at,
+      source_manifest_path: report.source_manifest_path,
+      fixture_corpus_version: report.fixture_corpus_version,
+    },
+    status,
+    badge: badgeForStatus(status),
+    counts: {
+      fixture_count: report.fixture_count,
+      surface_count: report.surface_count,
+      scan_count: report.scan_count,
+    },
+    per_surface_status: summarizeSurfaces(report),
+    blocker_summary: report.blocker_summary,
+    forbidden_claim_scan_summary: {
+      status: report.forbidden_claim_scan_summary.status,
+      scans_checked: report.forbidden_claim_scan_summary.scans_checked,
+      scan_names: Array.isArray(report.forbidden_claim_scan_summary.scan_names)
+        ? report.forbidden_claim_scan_summary.scan_names
+        : [],
+      failure_count: Array.isArray(report.forbidden_claim_scan_summary.failures)
+        ? report.forbidden_claim_scan_summary.failures.length
+        : 0,
+    },
+    non_enabling_control_summary: {
+      status: report.non_enabling_control_summary.status,
+      all_guarded_controls_disabled: report.non_enabling_control_summary.all_guarded_controls_disabled === true,
+      enabled_guarded_controls: Array.isArray(report.non_enabling_control_summary.enabled_guarded_controls)
+        ? report.non_enabling_control_summary.enabled_guarded_controls
+        : [],
+      posture: isRecord(report.non_enabling_control_summary.posture)
+        ? report.non_enabling_control_summary.posture
+        : {},
+      controls: isRecord(report.non_enabling_control_summary.controls)
+        ? report.non_enabling_control_summary.controls
+        : {},
+    },
+    safety_posture_summary: {
+      statement: internalStatusStatement,
+      source_report_statement: typeof safetyPosture.statement === 'string' ? safetyPosture.statement : '',
+      preview_internal_only: true,
+      sandbox_only: safetyPosture.sandbox_only === true,
+      non_live: safetyPosture.non_live === true,
+      non_enabling: safetyPosture.non_enabling === true,
+      non_publication: safetyPosture.non_publication === true,
+      non_certifying: safetyPosture.non_certifying === true,
+      public_discovery_enabled: false,
+      production_checkout_payment_creation_enabled: false,
+      live_payment_enabled: false,
+      provider_calls_enabled: false,
+      merchant_private_api_calls_enabled: false,
+    },
+    failure_summary: summarizeFailures(report),
+    publication_status: 'not_published',
+    certification_claims: [],
+  };
+}
+
+function markdownList(items) {
+  if (items.length === 0) return '- None';
+  return items.map((item) => `- ${item}`).join('\n');
+}
+
+function renderMarkdownStatus(status) {
+  const surfaceRows = status.per_surface_status
+    .map((surface) => (
+      `| ${surface.surface} | ${surface.status} | ${surface.fixture_count} | ${surface.scenarios_present.join(', ')} | ${surface.failed_fixtures.join(', ') || 'none'} |`
+    ))
+    .join('\n');
+  const blockerRows = status.blocker_summary.by_surface
+    .map((surface) => (
+      `| ${surface.surface} | ${surface.blocked_fixture_count} | ${surface.expected_blocker_count} | ${surface.expected_blockers.join(', ') || 'none'} |`
+    ))
+    .join('\n');
+  const controlRows = Object.entries(status.non_enabling_control_summary.controls)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `| ${key} | ${String(value)} |`)
+    .join('\n');
+
+  return `${[
+    '# Open Protocol Preview Conformance Status',
+    '',
+    status.safety_posture_summary.statement,
+    '',
+    '## Badge',
+    '',
+    `- Label: ${status.badge.label}`,
+    `- Message: ${status.badge.message}`,
+    `- Color: ${status.badge.color}`,
+    `- Public badge publication enabled: ${status.badge.public_badge_publication_enabled}`,
+    '',
+    '## Summary',
+    '',
+    `- Status: ${status.status}`,
+    `- Generated at: ${status.generated_at}`,
+    `- Source report: ${status.source_report_path}`,
+    `- Fixture count: ${status.counts.fixture_count}`,
+    `- Surface count: ${status.counts.surface_count}`,
+    `- Scan count: ${status.counts.scan_count}`,
+    '',
+    '## Surface Status',
+    '',
+    '| Surface | Status | Fixtures | Scenarios present | Failed fixtures |',
+    '|---|---:|---:|---|---|',
+    surfaceRows,
+    '',
+    '## Blocker Summary',
+    '',
+    `- Blocked fixture count: ${status.blocker_summary.blocked_fixture_count}`,
+    `- Expected blocker count: ${status.blocker_summary.expected_blocker_count}`,
+    '',
+    '| Surface | Blocked fixtures | Expected blockers | Blockers |',
+    '|---|---:|---:|---|',
+    blockerRows,
+    '',
+    '## Forbidden-Claim Scan Summary',
+    '',
+    `- Status: ${status.forbidden_claim_scan_summary.status}`,
+    `- Scans checked: ${status.forbidden_claim_scan_summary.scans_checked}`,
+    `- Failure count: ${status.forbidden_claim_scan_summary.failure_count}`,
+    `- Scan names: ${status.forbidden_claim_scan_summary.scan_names.join(', ')}`,
+    '',
+    '## Non-Enabling Controls',
+    '',
+    `- Status: ${status.non_enabling_control_summary.status}`,
+    `- All guarded controls disabled: ${status.non_enabling_control_summary.all_guarded_controls_disabled}`,
+    `- Enabled guarded controls: ${status.non_enabling_control_summary.enabled_guarded_controls.join(', ') || 'none'}`,
+    '',
+    '| Control | Value |',
+    '|---|---:|',
+    controlRows,
+    '',
+    '## Safety Posture',
+    '',
+    `- Preview/internal only: ${status.safety_posture_summary.preview_internal_only}`,
+    `- Sandbox only: ${status.safety_posture_summary.sandbox_only}`,
+    `- Non-live: ${status.safety_posture_summary.non_live}`,
+    `- Non-enabling: ${status.safety_posture_summary.non_enabling}`,
+    `- Non-publication: ${status.safety_posture_summary.non_publication}`,
+    `- Non-certifying: ${status.safety_posture_summary.non_certifying}`,
+    `- Public discovery enabled: ${status.safety_posture_summary.public_discovery_enabled}`,
+    `- Production checkout/payment creation enabled: ${status.safety_posture_summary.production_checkout_payment_creation_enabled}`,
+    `- Live payment enabled: ${status.safety_posture_summary.live_payment_enabled}`,
+    `- Provider calls enabled: ${status.safety_posture_summary.provider_calls_enabled}`,
+    `- Merchant private API calls enabled: ${status.safety_posture_summary.merchant_private_api_calls_enabled}`,
+    `- Publication status: ${status.publication_status}`,
+    `- Certification claims: ${status.certification_claims.length}`,
+    '',
+    '## Failure Summary',
+    '',
+    `- Failure count: ${status.failure_summary.failure_count}`,
+    '',
+    markdownList(status.failure_summary.failure_scopes),
+  ].join('\n')}\n`;
+}
+
+function writeOutput(path, content) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+}
+
+function run(options) {
+  const report = parseJsonFile(options.reportPath);
+  const status = buildStatus(report, options);
+
+  if (options.jsonStatusPath) {
+    writeOutput(options.jsonStatusPath, `${JSON.stringify(status, null, 2)}\n`);
+  }
+  if (options.markdownStatusPath) {
+    writeOutput(options.markdownStatusPath, renderMarkdownStatus(status));
+  }
+
+  const summary = {
+    status: status.status,
+    fixture_count: status.counts.fixture_count,
+    surface_count: status.counts.surface_count,
+    scan_count: status.counts.scan_count,
+    source_report: status.source_report_path,
+  };
+  if (options.jsonStatusPath || options.markdownStatusPath) {
+    summary.outputs = {};
+    if (options.jsonStatusPath) summary.outputs.json_status = formatPath(options.jsonStatusPath);
+    if (options.markdownStatusPath) summary.outputs.markdown_status = formatPath(options.markdownStatusPath);
+  }
+
+  console.log('commerce C6Od preview conformance status rendered');
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+run(parseArgs(process.argv.slice(2)));


### PR DESCRIPTION
## Summary
- Adds a local docs/test-only C6Od status renderer for C6Oc JSON conformance reports.
- Renders internal-only JSON status summaries and Markdown status pages only when output paths are requested.
- Shows internal preview status, pass/fail badge, counts, per-surface status, blockers, scan summary, non-enabling controls, and safety posture.
- Adds internal docs with usage, stop conditions, validation, and rollback notes.

## Safety
- Internal preview evidence only; not public protocol publication and not a certification artifact.
- Does not add runtime APIs, routes, migrations, portal UI, production config, public discovery, checkout/payment behavior, live payment/live Plural behavior, provider calls, merchant private API calls, credentials, cloud actions, or certification claims.
- Failed C6Oc reports render failing status and cannot produce a passing badge.

## Validation
- node scripts/commerce-c6oa-preview-conformance-validate.mjs --write-report --json-report .tmp\\commerce-c6od-validation\\report.json --markdown-report .tmp\\commerce-c6od-validation\\report.md --generated-at 2026-06-07T00:00:00.000Z
- node scripts/commerce-c6od-preview-status-render.mjs --report .tmp\\commerce-c6od-validation\\report.json --json-status .tmp\\commerce-c6od-validation\\status.json --markdown-status .tmp\\commerce-c6od-validation\\status.md --generated-at 2026-06-07T00:00:00.000Z
- npm --prefix apps/auth-service test -- commerce-c6oc-conformance-report.test.ts commerce-c6od-conformance-status.test.ts
- npm --prefix apps/auth-service run typecheck
- git diff --check origin/main...HEAD
- Focused guardrail scans for secrets/private details, production config/allowlists, public discovery, checkout/payment enablement, live payment/live provider credentials, overclaims/certification claims, direct provider calls, and direct merchant private API calls
