### PR TITLE
test(commerce): add preview conformance ci gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,17 @@ on:
     branches: [main]
 
 jobs:
+  commerce-preview-conformance:
+    name: Commerce Preview Conformance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+      - name: Preview conformance gate (local only)
+        run: node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
+
   auth-service:
     name: Auth Service
     runs-on: ubuntu-latest

--- a/apps/auth-service/tests/commerce-c6oe-preview-gate.test.ts
+++ b/apps/auth-service/tests/commerce-c6oe-preview-gate.test.ts
@@ -1,0 +1,342 @@
+import { execFileSync } from 'node:child_process';
+import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..', '..', '..');
+const gatePath = join(repoRoot, 'scripts', 'commerce-c6oe-preview-conformance-gate.mjs');
+const fixtureDir = join(
+  repoRoot,
+  'docs',
+  'internal',
+  'commerce-v1',
+  'fixtures',
+  'c6oa-preview-conformance',
+);
+const ciWorkflowPath = join(repoRoot, '.github', 'workflows', 'ci.yml');
+const c6oeDocPath = join(
+  repoRoot,
+  'docs',
+  'internal',
+  'commerce-v1',
+  'commerce-v1-c6oe-preview-conformance-ci-release-gate.md',
+);
+
+const expectedSurfaces = [
+  'acp_style_checkout_shape_preview',
+  'ap2_style_evidence_preview',
+  'connector_registry_metadata_preview',
+  'schemaorg_jsonld_preview',
+  'ucp_style_capability_profile_preview',
+];
+
+const forbiddenOutputPatterns = [
+  /-----BEGIN [A-Z ]+PRIVATE KEY-----|sk_live_|pk_live_|whsec_|postgres:\/\/|postgresql:\/\/|redis:\/\/|bearer\s+[A-Za-z0-9._-]{20,}|client_secret\s*=|access_token\s*=|refresh_token\s*=|password\s*=|api[_-]?key\s*=/i,
+  /\b(?:ten|mch|cprd|cvar|cart|cpi|cconn|caud|jti)_[A-Z0-9][A-Za-z0-9]*/,
+  /"provider_metadata"\s*:\s*\{|"raw_payload"\s*:\s*\{/i,
+  /\bcertified\b|certification approved|production approved|public protocol publication approved|live payment approved/i,
+  /fetch\(|axios\.|got\(|undici/i,
+];
+
+function tempDir() {
+  return mkdtempSync(join(tmpdir(), 'commerce-c6oe-gate-'));
+}
+
+function runGate(args: string[]) {
+  return execFileSync(process.execPath, [gatePath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function parseSummary(output: string) {
+  const jsonStart = output.indexOf('{');
+  expect(jsonStart).toBeGreaterThanOrEqual(0);
+  return JSON.parse(output.slice(jsonStart)) as {
+    status: string;
+    mode: string;
+    fixture_validation: {
+      status: string;
+      fixtures_checked: number;
+      surfaces_checked: number;
+      scans_checked: number;
+    };
+    report: {
+      path: string;
+      status: string;
+      fixture_count: number;
+      surface_count: number;
+      scan_count: number;
+    };
+    status_page: {
+      path: string;
+      status: string;
+      badge: {
+        label: string;
+        message: string;
+        color: string;
+      };
+    };
+    work_dir: string;
+    artifacts_retained: boolean;
+  };
+}
+
+function readJson(path: string) {
+  return JSON.parse(readFileSync(path, 'utf8')) as Record<string, any>;
+}
+
+async function gateModule() {
+  return import(pathToFileURL(gatePath).href) as Promise<{
+    validateGateArtifacts: (input: {
+      fixtureDir?: string;
+      report: Record<string, any>;
+      status: Record<string, any>;
+      validationSummary: Record<string, any>;
+      reportSummary: Record<string, any>;
+      statusSummary: Record<string, any>;
+    }) => void;
+  }>;
+}
+
+function passingArtifacts() {
+  const dir = tempDir();
+  runGate(['--mode', 'release-review', '--work-dir', dir]);
+  const report = readJson(join(dir, 'open-protocol-preview-conformance.report.json'));
+  const status = readJson(join(dir, 'open-protocol-preview-conformance.status.json'));
+  const validationSummary = {
+    status: 'passed',
+    fixtures_checked: 10,
+    surfaces_checked: 5,
+    scans_checked: 104,
+  };
+  const reportSummary = {
+    status: 'passed',
+    fixtures_checked: 10,
+    surfaces_checked: 5,
+    scans_checked: 104,
+  };
+  const statusSummary = {
+    status: status.status,
+    fixture_count: 10,
+    surface_count: 5,
+    scan_count: 104,
+  };
+  return { dir, report, reportSummary, status, statusSummary, validationSummary };
+}
+
+describe('C6Oe preview conformance gate', () => {
+  it('passes in PR mode with the current C6Oa-C6Od chain', () => {
+    const output = runGate(['--mode', 'pr']);
+    const summary = parseSummary(output);
+
+    expect(output).toContain('commerce C6Oe preview conformance gate passed');
+    expect(summary).toMatchObject({
+      status: 'passed',
+      mode: 'pr',
+      artifacts_retained: false,
+      work_dir: 'temporary',
+      fixture_validation: {
+        status: 'passed',
+        fixtures_checked: 10,
+        surfaces_checked: 5,
+        scans_checked: 104,
+      },
+      report: {
+        status: 'passed',
+        fixture_count: 10,
+        surface_count: 5,
+        scan_count: 104,
+      },
+      status_page: {
+        status: 'passing',
+        badge: {
+          label: 'internal preview conformance',
+          message: 'passing',
+          color: 'green',
+        },
+      },
+    });
+  });
+
+  it('uses temp outputs in PR mode and does not create committed report or status files', () => {
+    runGate(['--mode', 'pr']);
+
+    expect(
+      existsSync(join(repoRoot, 'docs', 'internal', 'commerce-v1', 'reports', 'open-protocol-preview-conformance.report.json')),
+    ).toBe(false);
+    expect(
+      existsSync(join(repoRoot, 'docs', 'internal', 'commerce-v1', 'reports', 'open-protocol-preview-conformance.status.json')),
+    ).toBe(false);
+  });
+
+  it('writes release-review artifacts into the explicit work directory', () => {
+    const dir = tempDir();
+    try {
+      const output = runGate(['--mode', 'release-review', '--work-dir', dir]);
+      const summary = parseSummary(output);
+      const reportJson = join(dir, 'open-protocol-preview-conformance.report.json');
+      const reportMarkdown = join(dir, 'open-protocol-preview-conformance.report.md');
+      const statusJson = join(dir, 'open-protocol-preview-conformance.status.json');
+      const statusMarkdown = join(dir, 'open-protocol-preview-conformance.status.md');
+
+      expect(summary).toMatchObject({
+        status: 'passed',
+        mode: 'release-review',
+        artifacts_retained: true,
+      });
+      expect(existsSync(reportJson)).toBe(true);
+      expect(existsSync(reportMarkdown)).toBe(true);
+      expect(existsSync(statusJson)).toBe(true);
+      expect(existsSync(statusMarkdown)).toBe(true);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it('writes parseable release-review summaries for report and status artifacts', () => {
+    const dir = tempDir();
+    try {
+      runGate(['--mode', 'release-review', '--work-dir', dir]);
+      const report = readJson(join(dir, 'open-protocol-preview-conformance.report.json'));
+      const status = readJson(join(dir, 'open-protocol-preview-conformance.status.json'));
+      const reportMarkdown = readFileSync(join(dir, 'open-protocol-preview-conformance.report.md'), 'utf8');
+      const statusMarkdown = readFileSync(join(dir, 'open-protocol-preview-conformance.status.md'), 'utf8');
+
+      expect(report).toMatchObject({
+        status: 'passed',
+        fixture_count: 10,
+        surface_count: 5,
+        scan_count: 104,
+      });
+      expect(status).toMatchObject({
+        status: 'passing',
+        counts: {
+          fixture_count: 10,
+          surface_count: 5,
+          scan_count: 104,
+        },
+      });
+      expect(report.per_surface_results.map((surface: { surface: string }) => surface.surface).sort()).toEqual(
+        expectedSurfaces,
+      );
+      expect(status.per_surface_status.map((surface: { surface: string }) => surface.surface).sort()).toEqual(
+        expectedSurfaces,
+      );
+      expect(reportMarkdown).toContain('Open Protocol Preview Conformance Report');
+      expect(statusMarkdown).toContain('Open Protocol Preview Conformance Status');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it('detects failed report and status mismatch', async () => {
+    const { dir, report, reportSummary, status, statusSummary, validationSummary } = passingArtifacts();
+    try {
+      const { validateGateArtifacts } = await gateModule();
+      report.status = 'failed';
+      status.status = 'passing';
+      status.badge.message = 'passing';
+
+      expect(() => validateGateArtifacts({
+        report,
+        reportSummary,
+        status,
+        statusSummary,
+        validationSummary,
+      })).toThrow();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it('detects missing required surface', async () => {
+    const { dir, report, reportSummary, status, statusSummary, validationSummary } = passingArtifacts();
+    try {
+      const { validateGateArtifacts } = await gateModule();
+      report.per_surface_results = report.per_surface_results.filter(
+        (surface: { surface: string }) => surface.surface !== 'schemaorg_jsonld_preview',
+      );
+
+      expect(() => validateGateArtifacts({
+        report,
+        reportSummary,
+        status,
+        statusSummary,
+        validationSummary,
+      })).toThrow(/schemaorg_jsonld_preview/);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it('rejects unsafe publication, certification, or enabling posture', async () => {
+    const { dir, report, reportSummary, status, statusSummary, validationSummary } = passingArtifacts();
+    try {
+      const { validateGateArtifacts } = await gateModule();
+      status.safety_posture_summary.public_discovery_enabled = true;
+
+      expect(() => validateGateArtifacts({
+        report,
+        reportSummary,
+        status,
+        statusSummary,
+        validationSummary,
+      })).toThrow(/public discovery/);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it('keeps gate output free of secrets, private IDs, provider metadata, and raw payloads', () => {
+    const dir = tempDir();
+    try {
+      const output = runGate(['--mode', 'release-review', '--work-dir', dir]);
+      const combined = [
+        output,
+        readFileSync(join(dir, 'open-protocol-preview-conformance.report.json'), 'utf8'),
+        readFileSync(join(dir, 'open-protocol-preview-conformance.report.md'), 'utf8'),
+        readFileSync(join(dir, 'open-protocol-preview-conformance.status.json'), 'utf8'),
+        readFileSync(join(dir, 'open-protocol-preview-conformance.status.md'), 'utf8'),
+      ].join('\n');
+
+      for (const pattern of forbiddenOutputPatterns) {
+        expect(combined).not.toMatch(pattern);
+      }
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it('exits nonzero on validation failure', () => {
+    const dir = tempDir();
+    const copiedFixtureDir = join(dir, 'fixtures');
+    try {
+      cpSync(fixtureDir, copiedFixtureDir, { recursive: true });
+      const fixturePath = join(copiedFixtureDir, 'schemaorg-jsonld-preview.available.json');
+      const fixture = JSON.parse(readFileSync(fixturePath, 'utf8')) as { preview_only: boolean };
+      fixture.preview_only = false;
+      writeFileSync(fixturePath, `${JSON.stringify(fixture, null, 2)}\n`);
+
+      expect(() => runGate(['--mode', 'pr', '--fixture-dir', copiedFixtureDir])).toThrow();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it('documents the deterministic CI command', () => {
+    const workflow = readFileSync(ciWorkflowPath, 'utf8');
+    const docs = readFileSync(c6oeDocPath, 'utf8');
+    const command = 'node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr';
+
+    expect(workflow).toContain(command);
+    expect(docs).toContain(command);
+    expect(docs).toContain('--mode release-review --work-dir');
+    expect(docs).toContain('not public protocol publication');
+    expect(docs).toContain('not a certification artifact');
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6oe-preview-conformance-ci-release-gate.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6oe-preview-conformance-ci-release-gate.md
@@ -1,0 +1,160 @@
+# Commerce V1 C6Oe Preview Conformance CI Release Gate
+
+Status: implemented as local CI and release-review validation.
+
+Base:
+
+- Grantex main: `4cd9987ef0c72c075755ef3bafe74926e7297ae8`
+- C6Oa fixtures:
+  `docs/internal/commerce-v1/fixtures/c6oa-preview-conformance/`
+- C6Ob validator:
+  `scripts/commerce-c6oa-preview-conformance-validate.mjs`
+- C6Oc report generator:
+  `scripts/commerce-c6oa-preview-conformance-validate.mjs --write-report`
+- C6Od status renderer:
+  `scripts/commerce-c6od-preview-status-render.mjs`
+
+C6Oe adds a deterministic local gate that composes the C6Oa-C6Od chain. It is
+validation only. It does not add runtime APIs, routes, migrations, portal UI,
+production configuration, public discovery, checkout or payment behavior, live
+payment behavior, provider calls, merchant private API calls, public protocol
+publication, or certification claims.
+
+The gate is internal preview evidence only. It is not public protocol
+publication, not a certification artifact, and does not enable public discovery,
+production Commerce V1, checkout or payment creation, live payments, provider
+calls, merchant private API calls, production allowlists, secrets, credentials,
+or runtime connector execution.
+
+Public publication remains blocked: this is not public protocol publication and
+not a certification artifact.
+
+## PR CI Behavior
+
+PR CI runs the deterministic gate:
+
+```bash
+node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
+```
+
+This mode:
+
+- runs C6Ob fixture validation
+- generates C6Oc JSON and Markdown reports in a temporary directory
+- renders C6Od JSON and Markdown status artifacts in the same temporary
+  directory
+- parses the generated JSON artifacts
+- asserts fixture, surface, and scan counts
+- asserts all five preview surfaces are present
+- asserts report and status posture agree
+- asserts failed reports cannot produce passing status
+- asserts blocked fixtures include blocker evidence
+- asserts available fixtures preserve synthetic, sandbox-only, preview-only,
+  non-live, non-enabling, non-publication, and non-certifying posture
+- removes temporary artifacts before exiting
+
+The CI workflow job is named `Commerce Preview Conformance`. It does not
+authenticate to cloud, build or push Docker images, deploy, call providers, call
+merchant private APIs, use secrets, or create cloud resources.
+
+## Release-Review Behavior
+
+Release reviewers can generate local review artifacts explicitly:
+
+```bash
+node scripts/commerce-c6oe-preview-conformance-gate.mjs \
+  --mode release-review \
+  --work-dir <temp-or-review-dir>
+```
+
+This mode writes the following files inside the requested work directory only:
+
+- `open-protocol-preview-conformance.report.json`
+- `open-protocol-preview-conformance.report.md`
+- `open-protocol-preview-conformance.status.json`
+- `open-protocol-preview-conformance.status.md`
+
+The work directory is required, must be a directory, must not be the repository
+root, must not be a filesystem root, and must not be inside `.git`.
+
+Generated artifacts are local review evidence. Do not commit timestamped report
+or status artifacts unless a later approved release-packaging task explicitly
+requests a pinned artifact.
+
+## Required Surfaces
+
+The gate requires all five C6O preview surfaces:
+
+- schema.org JSON-LD preview
+- UCP-style capability profile preview
+- ACP-style checkout shape preview
+- AP2-style evidence preview
+- connector registry metadata preview
+
+## Failure Behavior
+
+The gate exits nonzero if:
+
+- fixture validation fails
+- report JSON or status JSON does not parse
+- fixture, surface, or scan counts differ from the expected corpus
+- any required surface is missing
+- report status and rendered status disagree
+- a failed report produces a passing status or badge
+- blocked fixture blocker evidence is missing
+- available fixtures lose non-production posture
+- internal preview, non-publication, non-certification, or non-enabling posture
+  is missing
+- generated artifacts contain secret markers, private commerce IDs, provider
+  metadata, raw payloads, concrete allowlist values, provider credential
+  markers, public discovery enablement, checkout/payment enablement, live
+  payment enablement, provider-call enablement, merchant private API enablement,
+  or certification/publication overclaims
+
+## Stop Conditions
+
+Stop and fix the fixture, validator, report, status renderer, gate, or docs if
+any output:
+
+- publishes public protocol materials or public status pages
+- enables Grantex or AgenticOrg public discovery
+- enables production Commerce V1
+- enables checkout, payment creation, public checkout, or live payments
+- enables live Plural or any live provider path
+- enables provider calls or merchant private API calls
+- includes secrets, credentials, DB URLs, raw payloads, provider metadata,
+  concrete private IDs, or concrete allowlist values
+- writes production configuration or production allowlists
+- claims UCP, ACP, AP2, schema.org, MPP, A2A, provider, protocol-publication, or
+  live-payment certification
+- treats sandbox, demo, synthetic, or test output as production approval
+
+## Validation
+
+C6Oe validation should include:
+
+- `node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr`
+- `node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode release-review --work-dir <temp>`
+- `npm --prefix apps/auth-service test -- commerce-c6oc-conformance-report.test.ts commerce-c6od-conformance-status.test.ts commerce-c6oe-preview-gate.test.ts`
+- `npm --prefix apps/auth-service run typecheck`
+- `git diff --check origin/main...HEAD`
+- focused guardrail scans for secrets/private details, production config and
+  allowlists, public discovery, checkout/payment enablement, live payment and
+  provider credentials, overclaims, direct provider calls, direct merchant
+  private API calls, and AgenticOrg direct execution enablement
+
+## Rollback
+
+This slice is local validation and CI gating only. To roll it back, remove:
+
+- `scripts/commerce-c6oe-preview-conformance-gate.mjs`
+- `apps/auth-service/tests/commerce-c6oe-preview-gate.test.ts`
+- `docs/internal/commerce-v1/commerce-v1-c6oe-preview-conformance-ci-release-gate.md`
+- the `Commerce Preview Conformance` job from `.github/workflows/ci.yml`
+- any local release-review artifacts generated under a reviewer-provided
+  directory
+
+No runtime flags, production configuration, provider credentials, connector
+credentials, public discovery settings, checkout/payment behavior, live-provider
+behavior, cloud resources, or deployment workflow changes are created by this
+slice.

--- a/scripts/commerce-c6oe-preview-conformance-gate.mjs
+++ b/scripts/commerce-c6oe-preview-conformance-gate.mjs
@@ -1,0 +1,452 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, parse, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptsDir, '..');
+const validatorPath = join(repoRoot, 'scripts', 'commerce-c6oa-preview-conformance-validate.mjs');
+const statusRendererPath = join(repoRoot, 'scripts', 'commerce-c6od-preview-status-render.mjs');
+const defaultFixtureDir = join(
+  repoRoot,
+  'docs',
+  'internal',
+  'commerce-v1',
+  'fixtures',
+  'c6oa-preview-conformance',
+);
+
+const expectedSurfaces = [
+  'schemaorg_jsonld_preview',
+  'ucp_style_capability_profile_preview',
+  'acp_style_checkout_shape_preview',
+  'ap2_style_evidence_preview',
+  'connector_registry_metadata_preview',
+];
+
+const expectedCounts = {
+  fixtures: 10,
+  surfaces: 5,
+  scans: 104,
+};
+
+const deterministicGeneratedAt = '2026-06-07T00:00:00.000Z';
+
+const forbiddenArtifactScans = [
+  {
+    name: 'secret or credential marker',
+    pattern: /-----BEGIN [A-Z ]+PRIVATE KEY-----|sk_live_|pk_live_|whsec_|postgres:\/\/|postgresql:\/\/|redis:\/\/|bearer\s+[A-Za-z0-9._-]{20,}|client_secret\s*=|access_token\s*=|refresh_token\s*=|password\s*=|api[_-]?key\s*=/i,
+  },
+  {
+    name: 'private commerce identifier',
+    pattern: /\b(?:ten|mch|cprd|cvar|cart|cpi|cconn|caud|jti)_[A-Z0-9][A-Za-z0-9]*/,
+  },
+  {
+    name: 'raw payload or provider metadata',
+    pattern: /"provider_metadata"\s*:\s*\{|"raw_payload"\s*:\s*\{/i,
+  },
+  {
+    name: 'public discovery or production config enablement',
+    pattern: /COMMERCE_PUBLIC_DISCOVERY_ENABLED\s*=\s*true|COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST\s*=|"production_allowlist[^"]*"\s*:\s*true|"(?:public_discovery_enabled|commerce_public_discovery_enabled|agenticorg_public_discovery_enabled|production_commerce_v1_enabled)"\s*:\s*true/i,
+  },
+  {
+    name: 'checkout or payment enablement',
+    pattern: /"(?:checkout|payment)[^"]*(?:enabled|creation|created|published)"\s*:\s*true|"enabled_by_preview"\s*:\s*true|"provider_call_enabled"\s*:\s*true|"provider_called"\s*:\s*true|"payment_enabled"\s*:\s*true/i,
+  },
+  {
+    name: 'live provider or provider credential enablement',
+    pattern: /"live_[^"]*"\s*:\s*true|live_plural|plural_enabled|"provider_credentials[^"]*"\s*:\s*true|"credentials_stored[^"]*"\s*:\s*true/i,
+  },
+  {
+    name: 'certification or publication overclaim',
+    pattern: /\b(?:certified|certification approved|production approved|public protocol publication approved|live payment approved|schema\.org certified|ucp certified|acp certified|ap2 certified|provider certified|protocol-publication certified)\b/i,
+  },
+  {
+    name: 'direct provider or merchant private API execution',
+    pattern: /fetch\(|axios\.|got\(|undici|provider_call_enabled[^:]*:\s*true|agenticorg_direct_execution_allowed[^:]*:\s*true|merchant_private_api_call_enabled[^:]*:\s*true|outbound_sync_enabled[^:]*:\s*true/i,
+  },
+  {
+    name: 'provider or checkout reference exposure',
+    pattern: /"(?:provider_payment_id|provider_order_id|checkout_url)"\s*:\s*"[^"{]/i,
+  },
+];
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function formatPath(path) {
+  const relativePath = relative(repoRoot, path).replace(/\\/g, '/');
+  if (relativePath && !relativePath.startsWith('..')) return relativePath;
+  return path.replace(/\\/g, '/');
+}
+
+function requireOptionValue(args, index, option) {
+  const value = args[index + 1];
+  assert.ok(value && !value.startsWith('--'), `${option} requires a value`);
+  return value;
+}
+
+function parseArgs(args) {
+  const options = {
+    fixtureDir: defaultFixtureDir,
+    generatedAt: deterministicGeneratedAt,
+    mode: null,
+    workDir: null,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case '--mode':
+        options.mode = requireOptionValue(args, index, arg);
+        index += 1;
+        break;
+      case '--work-dir':
+        options.workDir = resolve(repoRoot, requireOptionValue(args, index, arg));
+        index += 1;
+        break;
+      case '--fixture-dir':
+        options.fixtureDir = resolve(repoRoot, requireOptionValue(args, index, arg));
+        index += 1;
+        break;
+      case '--generated-at':
+        options.generatedAt = requireOptionValue(args, index, arg);
+        index += 1;
+        break;
+      case '--help':
+        console.log([
+          'Usage: node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode <pr|release-review> [options]',
+          '',
+          'Options:',
+          '  --mode pr                       Run deterministic PR gate with temporary artifacts.',
+          '  --mode release-review           Generate review artifacts in an explicit work directory.',
+          '  --work-dir <path>               Required with --mode release-review.',
+          '  --fixture-dir <path>            Optional fixture corpus override for local negative tests.',
+          '  --generated-at <iso-string>     Override deterministic generated_at value.',
+          '',
+          'The gate is local validation only. It does not publish artifacts, deploy, call providers, or enable runtime commerce behavior.',
+        ].join('\n'));
+        process.exit(0);
+        break;
+      default:
+        assert.fail(`Unknown option ${arg}`);
+    }
+  }
+
+  assert.ok(options.mode, '--mode is required');
+  assert.ok(['pr', 'release-review'].includes(options.mode), '--mode must be pr or release-review');
+  return options;
+}
+
+function assertSafeReleaseWorkDir(workDir) {
+  assert.ok(workDir, '--work-dir is required for release-review mode');
+  const parsed = parse(workDir);
+  assert.notEqual(workDir, parsed.root, 'work-dir must not be a filesystem root');
+  assert.notEqual(workDir, repoRoot, 'work-dir must not be the repository root');
+  assert.equal(
+    workDir.startsWith(join(repoRoot, '.git')),
+    false,
+    'work-dir must not be inside .git',
+  );
+  if (existsSync(workDir)) {
+    assert.equal(lstatSync(workDir).isDirectory(), true, 'work-dir must be a directory');
+  }
+}
+
+function prepareWorkDir(options) {
+  if (options.mode === 'pr') {
+    return {
+      cleanup: true,
+      path: mkdtempSync(join(tmpdir(), 'commerce-c6oe-preview-gate-')),
+    };
+  }
+
+  assertSafeReleaseWorkDir(options.workDir);
+  mkdirSync(options.workDir, { recursive: true });
+  return {
+    cleanup: false,
+    path: options.workDir,
+  };
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function parseSummary(output, label) {
+  const jsonStart = output.indexOf('{');
+  assert.ok(jsonStart >= 0, `${label} output must include JSON summary`);
+  return JSON.parse(output.slice(jsonStart));
+}
+
+function runNode(scriptPath, args) {
+  return execFileSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function runValidationOnly(options) {
+  const args = [];
+  if (options.fixtureDir !== defaultFixtureDir) {
+    args.push('--fixture-dir', options.fixtureDir);
+  }
+  const output = runNode(validatorPath, args);
+  return parseSummary(output, 'C6Ob validation');
+}
+
+function runReportGeneration(options, paths) {
+  const args = [
+    '--write-report',
+    '--json-report',
+    paths.reportJson,
+    '--markdown-report',
+    paths.reportMarkdown,
+    '--generated-at',
+    options.generatedAt,
+  ];
+  if (options.fixtureDir !== defaultFixtureDir) {
+    args.push('--fixture-dir', options.fixtureDir);
+  }
+  const output = runNode(validatorPath, args);
+  return parseSummary(output, 'C6Oc report generation');
+}
+
+function runStatusRendering(options, paths) {
+  const output = runNode(statusRendererPath, [
+    '--report',
+    paths.reportJson,
+    '--json-status',
+    paths.statusJson,
+    '--markdown-status',
+    paths.statusMarkdown,
+    '--generated-at',
+    options.generatedAt,
+  ]);
+  return parseSummary(output, 'C6Od status rendering');
+}
+
+function artifactPaths(workDir) {
+  return {
+    reportJson: join(workDir, 'open-protocol-preview-conformance.report.json'),
+    reportMarkdown: join(workDir, 'open-protocol-preview-conformance.report.md'),
+    statusJson: join(workDir, 'open-protocol-preview-conformance.status.json'),
+    statusMarkdown: join(workDir, 'open-protocol-preview-conformance.status.md'),
+  };
+}
+
+function assertCounts(summary, label, keyPrefix) {
+  const fixtureKey = keyPrefix === 'checked' ? 'fixtures_checked' : 'fixture_count';
+  const surfaceKey = keyPrefix === 'checked' ? 'surfaces_checked' : 'surface_count';
+  const scanKey = keyPrefix === 'checked' ? 'scans_checked' : 'scan_count';
+  assert.equal(summary[fixtureKey], expectedCounts.fixtures, `${label} fixture count`);
+  assert.equal(summary[surfaceKey], expectedCounts.surfaces, `${label} surface count`);
+  assert.equal(summary[scanKey], expectedCounts.scans, `${label} scan count`);
+}
+
+function assertSurfaces(results, label) {
+  assert.ok(Array.isArray(results), `${label} must be an array`);
+  const surfaces = new Set(results.map((result) => result.surface));
+  for (const surface of expectedSurfaces) {
+    assert.equal(surfaces.has(surface), true, `${label} must include ${surface}`);
+  }
+}
+
+function assertNoForbiddenValues(value, label) {
+  const serialized = typeof value === 'string' ? value : JSON.stringify(value);
+  for (const scan of forbiddenArtifactScans) {
+    assert.equal(scan.pattern.test(serialized), false, `${label} matched ${scan.name}`);
+  }
+}
+
+function assertSafetyPosture(report, status) {
+  const reportPosture = report.safety_posture_summary;
+  const statusPosture = status.safety_posture_summary;
+  assert.ok(isRecord(reportPosture), 'report safety posture must be present');
+  assert.ok(isRecord(statusPosture), 'status safety posture must be present');
+
+  for (const [label, posture] of [
+    ['report', reportPosture],
+    ['status', statusPosture],
+  ]) {
+    assert.equal(posture.preview_internal_only, true, `${label} preview_internal_only`);
+    assert.equal(posture.non_publication, true, `${label} non_publication`);
+    assert.equal(posture.non_certifying, true, `${label} non_certifying`);
+    assert.equal(posture.non_enabling, true, `${label} non_enabling`);
+    assert.equal(posture.public_discovery_enabled, false, `${label} public discovery`);
+    assert.equal(
+      posture.production_checkout_payment_creation_enabled,
+      false,
+      `${label} checkout/payment creation`,
+    );
+    assert.equal(posture.live_payment_enabled, false, `${label} live payment`);
+    assert.equal(posture.provider_calls_enabled, false, `${label} provider calls`);
+    assert.equal(posture.merchant_private_api_calls_enabled, false, `${label} merchant private API calls`);
+    assert.match(
+      posture.statement,
+      /not public protocol publication/i,
+      `${label} must include non-publication language`,
+    );
+    assert.match(
+      posture.statement,
+      /not a certification artifact/i,
+      `${label} must include non-certification language`,
+    );
+  }
+
+  const controls = status.non_enabling_control_summary;
+  assert.ok(isRecord(controls), 'status non-enabling controls must be present');
+  assert.equal(controls.all_guarded_controls_disabled, true, 'all guarded controls disabled');
+  assert.deepEqual(controls.enabled_guarded_controls ?? [], [], 'enabled guarded controls');
+  assert.equal(status.publication_status, 'not_published', 'status publication status');
+  assert.deepEqual(status.certification_claims, [], 'status certification claims');
+}
+
+function assertReportStatusAgreement(report, status) {
+  const expectedStatus = report.status === 'passed' ? 'passing' : 'failing';
+  assert.equal(status.status, expectedStatus, 'rendered status must match report status');
+  assert.equal(status.badge.message, expectedStatus, 'badge message must match report status');
+  if (report.status !== 'passed') {
+    assert.notEqual(status.badge.message, 'passing', 'failed report must not produce passing badge');
+    assert.equal(status.badge.color, 'red', 'failed report badge must be red');
+  } else {
+    assert.equal(status.badge.color, 'green', 'passing report badge must be green');
+  }
+}
+
+function assertBlockedFixtureEvidence(report) {
+  const blockedFixtures = report.per_fixture_results.filter(
+    (fixture) => fixture.scenario === 'blocked_refusal',
+  );
+  assert.equal(blockedFixtures.length, expectedCounts.surfaces, 'blocked fixture coverage');
+  for (const fixture of blockedFixtures) {
+    assert.equal(fixture.status, 'passed', `${fixture.path} status`);
+    assert.ok(fixture.expected_blockers.length > 0, `${fixture.path} expected blockers`);
+    assert.ok(
+      fixture.blocker_evidence_count >= fixture.expected_blockers.length,
+      `${fixture.path} blocker evidence`,
+    );
+  }
+}
+
+function assertAvailableFixturePosture(fixtureDir) {
+  const manifest = readJson(join(fixtureDir, 'manifest.json'));
+  const fixtures = manifest.fixtures.filter((fixture) => fixture.scenario === 'preview_available');
+  assert.equal(fixtures.length, expectedCounts.surfaces, 'available fixture coverage');
+
+  for (const entry of fixtures) {
+    const fixture = readJson(join(fixtureDir, entry.path));
+    assert.equal(fixture.synthetic, true, `${entry.path} synthetic`);
+    assert.equal(fixture.sandbox_only, true, `${entry.path} sandbox_only`);
+    assert.equal(fixture.preview_only, true, `${entry.path} preview_only`);
+    assert.equal(fixture.non_live, true, `${entry.path} non_live`);
+    assert.equal(fixture.non_enabling, true, `${entry.path} non_enabling`);
+    assert.equal(fixture.non_publication, true, `${entry.path} non_publication`);
+    assert.equal(fixture.non_certifying, true, `${entry.path} non_certifying`);
+    assert.equal(fixture.publication_status, 'not_published', `${entry.path} publication_status`);
+    assert.deepEqual(fixture.certification_claims, [], `${entry.path} certification_claims`);
+    assert.equal(fixture.payload.status, 'preview_only', `${entry.path} payload status`);
+    assert.equal(fixture.payload.preview_only, true, `${entry.path} payload preview_only`);
+    assertNoForbiddenValues(fixture, entry.path);
+  }
+}
+
+export function validateGateArtifacts({
+  fixtureDir = defaultFixtureDir,
+  report,
+  status,
+  validationSummary,
+  reportSummary,
+  statusSummary,
+}) {
+  assert.equal(validationSummary.status, 'passed', 'fixture validation summary status');
+  assert.equal(reportSummary.status, 'passed', 'report generation summary status');
+  assert.equal(statusSummary.status, status.status, 'status rendering summary status');
+
+  assertCounts(validationSummary, 'validation summary', 'checked');
+  assertCounts(reportSummary, 'report summary', 'checked');
+  assertCounts(statusSummary, 'status summary', 'count');
+  assertCounts(report, 'report artifact', 'count');
+  assertCounts(status.counts, 'status artifact', 'count');
+
+  assert.equal(report.status, 'passed', 'report artifact status');
+  assertSurfaces(report.per_surface_results, 'report surfaces');
+  assertSurfaces(status.per_surface_status, 'status surfaces');
+  assertReportStatusAgreement(report, status);
+  assertBlockedFixtureEvidence(report);
+  assertAvailableFixturePosture(fixtureDir);
+  assertSafetyPosture(report, status);
+  assertNoForbiddenValues(report, 'report artifact');
+  assertNoForbiddenValues(status, 'status artifact');
+}
+
+function runGate(options) {
+  const work = prepareWorkDir(options);
+  const paths = artifactPaths(work.path);
+
+  try {
+    const validationSummary = runValidationOnly(options);
+    const reportSummary = runReportGeneration(options, paths);
+    const statusSummary = runStatusRendering(options, paths);
+    const report = readJson(paths.reportJson);
+    const status = readJson(paths.statusJson);
+
+    validateGateArtifacts({
+      fixtureDir: options.fixtureDir,
+      report,
+      reportSummary,
+      status,
+      statusSummary,
+      validationSummary,
+    });
+
+    const summary = {
+      status: 'passed',
+      mode: options.mode,
+      fixture_validation: validationSummary,
+      report: {
+        path: options.mode === 'pr' ? 'temporary' : formatPath(paths.reportJson),
+        status: report.status,
+        fixture_count: report.fixture_count,
+        surface_count: report.surface_count,
+        scan_count: report.scan_count,
+      },
+      status_page: {
+        path: options.mode === 'pr' ? 'temporary' : formatPath(paths.statusJson),
+        status: status.status,
+        badge: status.badge,
+      },
+      work_dir: options.mode === 'pr' ? 'temporary' : formatPath(work.path),
+      artifacts_retained: options.mode === 'release-review',
+    };
+
+    console.log('commerce C6Oe preview conformance gate passed');
+    console.log(JSON.stringify(summary, null, 2));
+  } finally {
+    if (work.cleanup) {
+      rmSync(work.path, { force: true, recursive: true });
+    }
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    runGate(parseArgs(process.argv.slice(2)));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('commerce C6Oe preview conformance gate failed');
+    console.error(message);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a local C6Oe preview conformance gate that composes the C6Ob validator, C6Oc report generation, and C6Od status rendering.
- Adds deterministic `--mode pr` validation with temporary artifacts and explicit `--mode release-review --work-dir <path>` artifact generation.
- Adds a no-secret/no-cloud/no-provider-call CI job named `Commerce Preview Conformance`.
- Adds C6Oe tests and internal release-gate docs with stop conditions and rollback notes.

## Safety
- Internal preview validation only; not public protocol publication and not a certification artifact.
- No runtime APIs, routes, migrations, portal UI, production config, secrets, public discovery, checkout/payment behavior, live payment/live Plural behavior, provider calls, merchant private API calls, production allowlists, cloud actions, or certification claims.
- The gate fails closed on missing surfaces, failed validation, status/report mismatch, unsafe posture, blocker evidence gaps, or forbidden values.

## Validation
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode release-review --work-dir .tmp\\commerce-c6oe-validation
- npm --prefix apps/auth-service test -- commerce-c6oc-conformance-report.test.ts commerce-c6od-conformance-status.test.ts commerce-c6oe-preview-gate.test.ts
- npm --prefix apps/auth-service run typecheck
- git diff --check origin/main...HEAD
- Focused guardrail scans for secrets/private details, production config/allowlists, public discovery, checkout/payment enablement, live payment/live provider credentials, overclaims/certification claims, direct provider calls, and direct merchant private API calls
