### PR TITLE
docs(commerce): add conformance release review runbook

### DIFF
--- a/apps/auth-service/tests/commerce-c6of-release-review-runbook.test.ts
+++ b/apps/auth-service/tests/commerce-c6of-release-review-runbook.test.ts
@@ -1,0 +1,202 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..', '..', '..');
+const runbookPath = join(
+  repoRoot,
+  'docs',
+  'internal',
+  'commerce-v1',
+  'commerce-v1-c6of-conformance-release-review-runbook.md',
+);
+const gatePath = join(repoRoot, 'scripts', 'commerce-c6oe-preview-conformance-gate.mjs');
+const reportsDir = join(repoRoot, 'docs', 'internal', 'commerce-v1', 'reports');
+
+const releaseReviewCommand =
+  'node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode release-review --work-dir <local-review-dir>';
+
+const expectedArtifacts = [
+  'open-protocol-preview-conformance.report.json',
+  'open-protocol-preview-conformance.report.md',
+  'open-protocol-preview-conformance.status.json',
+  'open-protocol-preview-conformance.status.md',
+];
+
+const expectedSurfaces = [
+  'ACP-style checkout shape preview',
+  'AP2-style evidence preview',
+  'connector registry metadata preview',
+  'schema.org JSON-LD preview',
+  'UCP-style capability profile preview',
+];
+
+function readRunbook() {
+  return readFileSync(runbookPath, 'utf8');
+}
+
+function parseSummary(output: string) {
+  const jsonStart = output.indexOf('{');
+  expect(jsonStart).toBeGreaterThanOrEqual(0);
+  return JSON.parse(output.slice(jsonStart)) as {
+    status: string;
+    mode: string;
+    report: {
+      status: string;
+      fixture_count: number;
+      surface_count: number;
+      scan_count: number;
+    };
+    status_page: {
+      status: string;
+      badge: {
+        message: string;
+        color: string;
+      };
+    };
+    artifacts_retained: boolean;
+  };
+}
+
+describe('C6Of conformance release-review runbook', () => {
+  it('documents the C6Oe release-review command', () => {
+    const runbook = readRunbook();
+
+    expect(runbook).toContain(releaseReviewCommand);
+    expect(runbook).toContain('--mode release-review --work-dir');
+    expect(runbook).toContain('scripts/commerce-c6oe-preview-conformance-gate.mjs');
+  });
+
+  it('documents expected release-review artifacts', () => {
+    const runbook = readRunbook();
+
+    for (const artifact of expectedArtifacts) {
+      expect(runbook).toContain(artifact);
+    }
+  });
+
+  it('documents reviewer checklist, pass/fail criteria, stop conditions, and rollback notes', () => {
+    const runbook = readRunbook();
+
+    expect(runbook).toContain('## Reviewer Checklist');
+    expect(runbook).toContain('## Pass Criteria');
+    expect(runbook).toContain('## Fail Criteria');
+    expect(runbook).toContain('## Stop Conditions');
+    expect(runbook).toContain('## Rollback');
+    expect(runbook).toContain('fixtures_checked: 10');
+    expect(runbook).toContain('surfaces_checked: 5');
+    expect(runbook).toContain('scans_checked: 104');
+
+    for (const surface of expectedSurfaces) {
+      expect(runbook).toContain(surface);
+    }
+  });
+
+  it('keeps evidence retention local/internal with no committed timestamped artifacts', () => {
+    const runbook = readRunbook();
+
+    expect(runbook).toContain('## Evidence Retention');
+    expect(runbook).toContain('local/internal evidence only');
+    expect(runbook).toContain('Do not commit generated timestamped report or status artifacts');
+    expect(runbook).toContain('not public publication and not certification');
+  });
+
+  it('does not include public publication, certification, or production approval claims', () => {
+    const runbook = readRunbook();
+
+    expect(runbook).toContain('not public protocol publication');
+    expect(runbook).toContain('not a certification artifact');
+    expect(runbook).not.toMatch(
+      /\b(certified|certification approved|production approved|public protocol publication approved|live payment approved|schema\.org certified|ucp certified|acp certified|ap2 certified|provider certified|protocol-publication certified)\b/i,
+    );
+    expect(runbook).not.toMatch(/COMMERCE_PUBLIC_DISCOVERY_ENABLED\s*=\s*true/i);
+    expect(runbook).not.toMatch(/COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST\s*=\s*[^<\s]/i);
+  });
+
+  it('runs the first gated release rehearsal into an explicit local work directory', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'commerce-c6of-runbook-'));
+    try {
+      const output = execFileSync(
+        process.execPath,
+        [gatePath, '--mode', 'release-review', '--work-dir', dir],
+        {
+          cwd: repoRoot,
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      );
+      const summary = parseSummary(output);
+
+      expect(output).toContain('commerce C6Oe preview conformance gate passed');
+      expect(summary).toMatchObject({
+        status: 'passed',
+        mode: 'release-review',
+        artifacts_retained: true,
+        report: {
+          status: 'passed',
+          fixture_count: 10,
+          surface_count: 5,
+          scan_count: 104,
+        },
+        status_page: {
+          status: 'passing',
+          badge: {
+            message: 'passing',
+            color: 'green',
+          },
+        },
+      });
+
+      const actualArtifacts = readdirSync(dir).sort();
+      expect(actualArtifacts).toEqual([...expectedArtifacts].sort());
+
+      const report = JSON.parse(
+        readFileSync(join(dir, 'open-protocol-preview-conformance.report.json'), 'utf8'),
+      ) as {
+        status: string;
+        fixture_count: number;
+        surface_count: number;
+        scan_count: number;
+      };
+      const status = JSON.parse(
+        readFileSync(join(dir, 'open-protocol-preview-conformance.status.json'), 'utf8'),
+      ) as {
+        status: string;
+        counts: {
+          fixture_count: number;
+          surface_count: number;
+          scan_count: number;
+        };
+      };
+
+      expect(report).toMatchObject({
+        status: 'passed',
+        fixture_count: 10,
+        surface_count: 5,
+        scan_count: 104,
+      });
+      expect(status).toMatchObject({
+        status: 'passing',
+        counts: {
+          fixture_count: 10,
+          surface_count: 5,
+          scan_count: 104,
+        },
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it('does not rely on committed generated report or status artifacts', () => {
+    const committedArtifactPaths = expectedArtifacts.map((artifact) => join(reportsDir, artifact));
+
+    for (const artifactPath of committedArtifactPaths) {
+      expect(existsSync(artifactPath)).toBe(false);
+    }
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6of-conformance-release-review-runbook.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6of-conformance-release-review-runbook.md
@@ -1,0 +1,203 @@
+# Commerce V1 C6Of Conformance Release Review Runbook
+
+Status: implemented as an internal release-review runbook and first gated
+release rehearsal.
+
+Base:
+
+- Grantex main: `c72a16e523cd2545c234fd144835aeca350ef36d`
+- C6Oa fixtures:
+  `docs/internal/commerce-v1/fixtures/c6oa-preview-conformance/`
+- C6Ob validator:
+  `scripts/commerce-c6oa-preview-conformance-validate.mjs`
+- C6Oc report generator:
+  `scripts/commerce-c6oa-preview-conformance-validate.mjs --write-report`
+- C6Od status renderer:
+  `scripts/commerce-c6od-preview-status-render.mjs`
+- C6Oe gate:
+  `scripts/commerce-c6oe-preview-conformance-gate.mjs`
+
+C6Of defines the human release-review process for the C6Oa-C6Oe conformance
+chain. The process is internal preview evidence only. It is sandbox-only,
+non-live, non-enabling, not public protocol publication, and not a certification
+artifact. It does not enable public discovery, production Commerce V1, checkout
+or payment creation, live payments, live Plural, provider calls, merchant
+private API calls, production allowlists, secrets, credentials, or runtime
+connector execution.
+
+The result is not a certification artifact.
+
+Evidence status: not public publication and not certification.
+
+## First Gated Release Rehearsal
+
+Run the rehearsal from a clean local checkout:
+
+```bash
+node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode release-review --work-dir <local-review-dir>
+```
+
+Use an explicit local work directory such as:
+
+```bash
+node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode release-review --work-dir .tmp/commerce-c6of-release-review
+```
+
+The work directory is local reviewer evidence. Do not use the repository root, a
+filesystem root, `.git`, or a shared/public publishing directory. Do not commit
+generated timestamped report or status artifacts unless a later approved
+release-packaging task explicitly requests a pinned artifact.
+
+Expected artifacts written under `<local-review-dir>`:
+
+- `open-protocol-preview-conformance.report.json`
+- `open-protocol-preview-conformance.report.md`
+- `open-protocol-preview-conformance.status.json`
+- `open-protocol-preview-conformance.status.md`
+
+## Reviewer Checklist
+
+- Confirm the reviewed branch or release candidate is based on the intended
+  Grantex main commit.
+- Confirm no manual deploy, deploy workflow trigger, cloud command, cloud
+  resource creation, production config write, secret access, provider call, or
+  merchant private API call is part of the review.
+- Run the release-review command with an explicit local work directory.
+- Confirm the command exits zero and prints `commerce C6Oe preview conformance
+  gate passed`.
+- Parse `open-protocol-preview-conformance.report.json` and
+  `open-protocol-preview-conformance.status.json`.
+- Confirm the report says `status: passed` and the status output says
+  `status: passing`.
+- Confirm the expected counts remain `fixtures_checked: 10`,
+  `surfaces_checked: 5`, and `scans_checked: 104`.
+- Confirm all five surfaces are present:
+  schema.org JSON-LD preview, UCP-style capability profile preview, ACP-style
+  checkout shape preview, AP2-style evidence preview, and connector registry
+  metadata preview.
+- Confirm blocked fixtures include blocker and remediation evidence.
+- Confirm available fixtures preserve synthetic, sandbox-only, preview-only,
+  non-live, non-enabling, non-publication, and non-certifying posture.
+- Confirm the Markdown report and Markdown status page include blocker summary,
+  forbidden-claim scan summary, non-enabling controls, safety posture, and
+  preview/internal-only language.
+- Confirm generated artifacts stay under the explicit local work directory and
+  no generated report or status files are staged for commit.
+- Run the focused guardrail scans listed below before approving release-review
+  evidence.
+
+## Required Surface Labels
+
+- schema.org JSON-LD preview
+- UCP-style capability profile preview
+- ACP-style checkout shape preview
+- AP2-style evidence preview
+- connector registry metadata preview
+
+## Pass Criteria
+
+The rehearsal passes only when all of the following are true:
+
+- the C6Oe gate exits zero in `--mode release-review`
+- exactly the four expected report and status artifacts are present under the
+  explicit work directory
+- report and status JSON parse successfully
+- report and status agree on passing posture
+- fixture count is 10, surface count is 5, and scan count is 104
+- all five preview surfaces are present
+- blocked fixtures include blocker and remediation evidence
+- available fixtures preserve non-production posture
+- public discovery, checkout/payment creation, live payments, live Plural,
+  provider calls, merchant private API calls, production allowlists, production
+  config writes, secrets, provider credentials, raw payloads, private commerce
+  IDs, and certification/publication overclaims are absent
+- the evidence is retained as local/internal review material only
+
+## Fail Criteria
+
+The rehearsal fails if any of the following occur:
+
+- the C6Oe gate exits nonzero
+- an expected artifact is missing or an unexpected generated artifact appears in
+  the repository tree
+- report or status JSON fails to parse
+- report and rendered status disagree
+- a failed report produces a passing status or passing badge
+- fixture, surface, or scan counts differ from the expected corpus
+- any required preview surface is missing
+- blocked fixture blocker evidence is missing
+- available fixtures lose synthetic, sandbox-only, preview-only, non-live,
+  non-enabling, non-publication, or non-certifying posture
+- any output enables or implies public discovery, checkout/payment creation,
+  live payment, live Plural, provider calls, merchant private API calls,
+  production allowlists, production config writes, secrets, credentials, raw
+  payloads, private IDs, public publication approval, production approval, or
+  certification approval
+
+## Stop Conditions
+
+Stop the release review and fix the underlying fixture, validator, report,
+status renderer, gate, docs, or tests if any evidence:
+
+- publishes public protocol materials or public status pages
+- enables Grantex public discovery or AgenticOrg public commerce discovery
+- enables production Commerce V1
+- enables checkout, payment creation, public checkout, live payments, or live
+  Plural
+- calls or enables payment providers, provider APIs, or merchant private APIs
+- stores or exposes secrets, credentials, DB URLs, raw payloads, provider
+  metadata, private commerce IDs, or concrete allowlist values
+- writes production configuration or production allowlists
+- claims UCP, ACP, AP2, schema.org, MPP, A2A, provider, protocol-publication, or
+  live-payment certification
+- treats sandbox, demo, synthetic, or test data as production approval
+- requires cloud commands, cloud resources, manual deploys, or manual deploy
+  workflow triggers
+
+## Evidence Retention
+
+Release-review artifacts are local/internal evidence only. Retain them in the
+explicit local work directory for the reviewer session, or move them to an
+approved internal evidence store only after a separate review policy allows it.
+
+Do not commit generated timestamped report or status artifacts. Do not publish
+the generated Markdown status page or JSON report as public protocol material.
+Do not attach artifacts containing secrets, private merchant data, provider
+metadata, raw payloads, production config, provider credentials, concrete
+allowlists, or private commerce IDs.
+
+If the review needs a durable reference, record the reviewed commit, command,
+work-directory name, report status, status badge, fixture count, surface count,
+scan count, reviewer, and review date in the internal review tracker. Keep that
+tracker entry explicit that the result is preview/internal evidence only, not
+public publication and not certification.
+
+## Focused Guardrail Scans
+
+Run or confirm focused scans for:
+
+- secrets and private details
+- production config and allowlist assignments
+- public discovery enablement
+- checkout/payment enablement
+- live payment, live Plural, and provider credential enablement
+- overclaims, public protocol publication claims, and certification claims
+- direct provider calls
+- direct merchant private API calls
+- generated report or status artifacts staged for commit
+
+Expected scan hits in tests or scripts should be limited to denylist regex
+literals, negative assertions, or explicit stop-condition text.
+
+## Rollback
+
+C6Of is docs and tests only. To roll it back, remove:
+
+- `docs/internal/commerce-v1/commerce-v1-c6of-conformance-release-review-runbook.md`
+- `apps/auth-service/tests/commerce-c6of-release-review-runbook.test.ts`
+
+Delete any local `<local-review-dir>` generated during rehearsal. There are no
+runtime flags, production config changes, provider credentials, connector
+credentials, public discovery settings, checkout/payment behavior, live-provider
+behavior, cloud resources, migrations, routes, portal UI changes, or deployment
+workflow changes to roll back.


### PR DESCRIPTION
## Summary
- Add C6Of internal release-review runbook for the C6Oa-C6Oe preview conformance chain.
- Document the first gated release rehearsal command and expected local artifacts.
- Add focused tests for runbook coverage and temp-dir rehearsal behavior.

## Safety
- Docs/test-only; no runtime APIs, routes, migrations, portal UI, production config, public discovery, checkout/payment behavior, live payment, provider calls, merchant private API calls, secrets, or certification claims.
- Generated report/status artifacts are local-only and not committed.

## Validation
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode release-review --work-dir .tmp/commerce-c6of-validation-postcommit
- npm --prefix apps/auth-service test -- commerce-c6oe-preview-gate.test.ts commerce-c6of-release-review-runbook.test.ts
- npm --prefix apps/auth-service run typecheck
- git diff --check origin/main...HEAD
- Focused guardrail scans for secrets/private details, production config/allowlists, public discovery, checkout/payment, live provider credentials, overclaims, and direct provider/merchant API semantics