### PR TITLE
docs(commerce): add release rehearsal status gap assessment

### DIFF
--- a/apps/auth-service/tests/commerce-c6og-release-rehearsal-status.test.ts
+++ b/apps/auth-service/tests/commerce-c6og-release-rehearsal-status.test.ts
@@ -38,6 +38,17 @@ const remainingBlockers = [
   'Production allowlists',
 ];
 
+const realMerchantLaunchBlockers = [
+  'no approved real merchant source-system scope or source-of-truth map',
+  'no reviewed first real connector dry-run adapter plan',
+  'no approved credential intake, storage, rotation, and redaction process',
+  'no tenant-boundary evidence for real merchant connector configuration',
+  'no stale-source, conflict, and source-precedence evidence',
+  'no dry-run audit evidence showing connector metadata',
+  'no approved rollback and disablement procedure',
+  'no production readiness approval',
+];
+
 function readAssessment() {
   return readFileSync(assessmentPath, 'utf8');
 }
@@ -95,6 +106,28 @@ describe('C6Og release rehearsal status and launch gap assessment', () => {
       expect(assessment).toContain(blocker);
     }
     expect(assessment).toContain('No-go for public or production launch');
+  });
+
+  it('documents real merchant launch blockers', () => {
+    const assessment = readAssessment();
+
+    expect(assessment).toContain('## Real Merchant Launch Blockers');
+    expect(assessment).toContain('C6Og does not approve real merchant launch');
+    for (const blocker of realMerchantLaunchBlockers) {
+      expect(assessment).toContain(blocker);
+    }
+  });
+
+  it('documents the next recommended runtime chain as C6P connector planning', () => {
+    const assessment = readAssessment();
+
+    expect(assessment).toContain('## Next Recommended Runtime Chain');
+    expect(assessment).toContain('C6P first real connector sync adapter planning');
+    expect(assessment).toContain('metadata, dry-run behavior');
+    expect(assessment).toContain('test doubles only');
+    expect(assessment).toContain('keep AgenticOrg from directly executing merchant private API calls');
+    expect(assessment).toContain('credential redaction');
+    expect(assessment).toContain('audit evidence');
   });
 
   it('keeps evidence retention internal preview only and non-enabling', () => {

--- a/apps/auth-service/tests/commerce-c6og-release-rehearsal-status.test.ts
+++ b/apps/auth-service/tests/commerce-c6og-release-rehearsal-status.test.ts
@@ -1,0 +1,170 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..', '..', '..');
+const assessmentPath = join(
+  repoRoot,
+  'docs',
+  'internal',
+  'commerce-v1',
+  'commerce-v1-c6og-release-rehearsal-status-launch-gap-assessment.md',
+);
+const gatePath = join(repoRoot, 'scripts', 'commerce-c6oe-preview-conformance-gate.mjs');
+const reportsDir = join(repoRoot, 'docs', 'internal', 'commerce-v1', 'reports');
+
+const releaseReviewCommand =
+  'node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode release-review --work-dir <local-review-dir>';
+
+const expectedArtifacts = [
+  'open-protocol-preview-conformance.report.json',
+  'open-protocol-preview-conformance.report.md',
+  'open-protocol-preview-conformance.status.json',
+  'open-protocol-preview-conformance.status.md',
+];
+
+const remainingBlockers = [
+  'Public protocol publication',
+  'UCP/ACP/AP2/schema.org/MPP/A2A/provider/live-payment certification',
+  'Grantex public discovery',
+  'AgenticOrg public commerce discovery',
+  'Production Commerce V1',
+  'Production checkout/payment creation',
+  'Live payments/live Plural/live providers',
+  'Production allowlists',
+];
+
+function readAssessment() {
+  return readFileSync(assessmentPath, 'utf8');
+}
+
+function parseSummary(output: string) {
+  const jsonStart = output.indexOf('{');
+  expect(jsonStart).toBeGreaterThanOrEqual(0);
+  return JSON.parse(output.slice(jsonStart)) as {
+    status: string;
+    mode: string;
+    report: {
+      status: string;
+      fixture_count: number;
+      surface_count: number;
+      scan_count: number;
+    };
+    status_page: {
+      status: string;
+      badge: {
+        message: string;
+        color: string;
+      };
+    };
+    artifacts_retained: boolean;
+  };
+}
+
+describe('C6Og release rehearsal status and launch gap assessment', () => {
+  it('records the C6Of rehearsal command, status, and counts', () => {
+    const assessment = readAssessment();
+
+    expect(assessment).toContain(releaseReviewCommand);
+    expect(assessment).toContain('| Release-review gate | passed |');
+    expect(assessment).toContain('| Fixture count | 10 |');
+    expect(assessment).toContain('| Surface count | 5 |');
+    expect(assessment).toContain('| Scan count | 104 |');
+    expect(assessment).toContain('| Rendered status | passing |');
+    expect(assessment).toContain('| Badge status | passing |');
+  });
+
+  it('documents expected local report and status artifacts without committing them', () => {
+    const assessment = readAssessment();
+
+    for (const artifact of expectedArtifacts) {
+      expect(assessment).toContain(artifact);
+      expect(existsSync(join(reportsDir, artifact))).toBe(false);
+    }
+  });
+
+  it('documents all remaining launch blockers', () => {
+    const assessment = readAssessment();
+
+    expect(assessment).toContain('## Remaining Launch Gap Matrix');
+    for (const blocker of remainingBlockers) {
+      expect(assessment).toContain(blocker);
+    }
+    expect(assessment).toContain('No-go for public or production launch');
+  });
+
+  it('keeps evidence retention internal preview only and non-enabling', () => {
+    const assessment = readAssessment();
+
+    expect(assessment).toContain('internal preview evidence only');
+    expect(assessment).toContain('sandbox-only');
+    expect(assessment).toContain('non-live');
+    expect(assessment).toContain('non-enabling');
+    expect(assessment).toContain('not public publication and not certification');
+    expect(assessment).toContain('local/internal only');
+    expect(assessment).toContain('must not be committed under `docs/internal/commerce-v1/reports`');
+  });
+
+  it('does not claim public publication, certification, live, checkout, provider, config, or allowlist enablement', () => {
+    const assessment = readAssessment();
+
+    expect(assessment).toContain('not public protocol publication');
+    expect(assessment).toContain('not a certification artifact');
+    expect(assessment).not.toMatch(
+      /\b(certified|certification approved|production approved|public protocol publication approved|live payment approved|schema\.org certified|ucp certified|acp certified|ap2 certified|provider certified|protocol-publication certified)\b/i,
+    );
+    expect(assessment).not.toMatch(/COMMERCE_PUBLIC_DISCOVERY_ENABLED\s*=\s*true/i);
+    expect(assessment).not.toMatch(/COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST\s*=\s*[^<\s]/i);
+    expect(assessment).not.toMatch(/public_discovery_enabled\s*[:=]\s*true/i);
+    expect(assessment).not.toMatch(/checkout[^.\n]*(enabled|creation|created|published)\s*[:=]\s*true/i);
+    expect(assessment).not.toMatch(/payment_enabled\s*[:=]\s*true/i);
+    expect(assessment).not.toMatch(/live_[A-Za-z0-9_]*\s*[:=]\s*true/i);
+    expect(assessment).not.toMatch(/provider_call_enabled\s*[:=]\s*true/i);
+    expect(assessment).not.toMatch(/merchant_private_api_call_enabled\s*[:=]\s*true/i);
+    expect(assessment).not.toMatch(/production_allowlist[^.\n]*\s*[:=]\s*true/i);
+  });
+
+  it('verifies temp-dir rehearsal behavior and removes generated artifacts after validation', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'commerce-c6og-rehearsal-'));
+    try {
+      const output = execFileSync(
+        process.execPath,
+        [gatePath, '--mode', 'release-review', '--work-dir', dir],
+        {
+          cwd: repoRoot,
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      );
+      const summary = parseSummary(output);
+
+      expect(summary).toMatchObject({
+        status: 'passed',
+        mode: 'release-review',
+        artifacts_retained: true,
+        report: {
+          status: 'passed',
+          fixture_count: 10,
+          surface_count: 5,
+          scan_count: 104,
+        },
+        status_page: {
+          status: 'passing',
+          badge: {
+            message: 'passing',
+            color: 'green',
+          },
+        },
+      });
+      expect(readdirSync(dir).sort()).toEqual([...expectedArtifacts].sort());
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+
+    expect(existsSync(dir)).toBe(false);
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6og-release-rehearsal-status-launch-gap-assessment.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6og-release-rehearsal-status-launch-gap-assessment.md
@@ -115,6 +115,50 @@ No-go for public or production launch:
 - live payments, live Plural, or live providers
 - production allowlists
 
+## Real Merchant Launch Blockers
+
+Real merchant launch remains blocked until a separate approved runtime chain
+proves safe connector behavior with reviewed evidence. C6Og does not approve
+real merchant launch.
+
+Real merchant launch status: C6Og does not approve real merchant launch.
+
+Current real merchant launch blockers:
+
+- no approved real merchant source-system scope or source-of-truth map
+- no reviewed first real connector dry-run adapter plan
+- no approved credential intake, storage, rotation, and redaction process
+- no tenant-boundary evidence for real merchant connector configuration
+- no stale-source, conflict, and source-precedence evidence for catalog, price,
+  inventory, order, fulfillment, refund, settlement, and support data
+- no dry-run audit evidence showing connector metadata and sync planning without
+  outbound merchant private API execution
+- no approved rollback and disablement procedure for connector scheduling,
+  stale-state blockers, conflict blockers, or credential revocation
+- no production readiness approval for public discovery, production Commerce V1,
+  checkout/payment creation, live payments, live Plural, live providers, or
+  production allowlists
+
+## Next Recommended Runtime Chain
+
+The next recommended runtime chain is C6P first real connector sync adapter
+planning.
+
+Next runtime chain: C6P first real connector sync adapter planning.
+
+C6P should remain planning and safe-foundation work unless a later approved task
+explicitly expands scope. The expected C6P starting point is:
+
+- define the first connector sync adapter plan using metadata, dry-run behavior,
+  and test doubles only
+- keep AgenticOrg from directly executing merchant private API calls
+- keep Grantex connector work non-live until explicit approval exists
+- prove source precedence, stale/conflict blockers, tenant boundaries,
+  credential redaction, and audit evidence before any real sync execution
+- document stop conditions for public discovery, production Commerce V1,
+  checkout/payment creation, live payments, live Plural, provider calls,
+  merchant private API calls, and production allowlists
+
 ## Stop Conditions
 
 Stop and require a new approved work item if any C6Og follow-up:

--- a/docs/internal/commerce-v1/commerce-v1-c6og-release-rehearsal-status-launch-gap-assessment.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6og-release-rehearsal-status-launch-gap-assessment.md
@@ -1,0 +1,169 @@
+# Commerce V1 C6Og Release Rehearsal Status And Launch Gap Assessment
+
+Status: implemented as an internal release-rehearsal status summary and
+remaining launch-gap assessment.
+
+Base:
+
+- Grantex main: `b0317fc42b69024d2a938cab11f10b05ae97152c`
+- C6Of runbook:
+  `docs/internal/commerce-v1/commerce-v1-c6of-conformance-release-review-runbook.md`
+- C6Oe release-review gate:
+  `scripts/commerce-c6oe-preview-conformance-gate.mjs`
+
+C6Og summarizes the first gated release rehearsal for the C6Oa-C6Of conformance
+chain and records the remaining launch gaps. This is internal preview evidence
+only. It is sandbox-only, non-live, non-enabling, not public protocol
+publication, and not a certification artifact. It does not enable public
+discovery, production Commerce V1, checkout or payment creation, live payments,
+live Plural, provider calls, merchant private API calls, production allowlists,
+secrets, credentials, or runtime connector execution.
+
+Evidence status: not public publication and not certification.
+
+Review posture: internal preview evidence only.
+
+Publication posture: not public protocol publication.
+
+## Rehearsal Command
+
+Run the C6Of rehearsal with the C6Oe release-review gate:
+
+```bash
+node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode release-review --work-dir <local-review-dir>
+```
+
+The work directory must be an explicit local temp or review directory. Generated
+report and status artifacts must stay in that local work directory, must not be
+published, and must not be committed as timestamped artifacts.
+
+## First Rehearsal Status
+
+| Check | Result |
+| --- | --- |
+| Release-review gate | passed |
+| Fixture count | 10 |
+| Surface count | 5 |
+| Scan count | 104 |
+| Rendered status | passing |
+| Badge status | passing |
+| Report/status artifacts | generated only in local temp/review directory |
+| Committed generated artifacts | none |
+| Evidence retention | local/internal only |
+
+The rehearsal generated the expected local files:
+
+- `open-protocol-preview-conformance.report.json`
+- `open-protocol-preview-conformance.report.md`
+- `open-protocol-preview-conformance.status.json`
+- `open-protocol-preview-conformance.status.md`
+
+Those files are release-review evidence only. They must be removed after local
+validation or retained only in an approved internal review location. They must
+not be committed under `docs/internal/commerce-v1/reports` unless a later
+approved packaging task explicitly requests sanitized pinned artifacts.
+
+Artifact retention rule: must not be committed under `docs/internal/commerce-v1/reports`.
+
+## Surface Coverage
+
+The passing rehearsal covered all five preview surfaces:
+
+- schema.org JSON-LD preview
+- UCP-style capability profile preview
+- ACP-style checkout shape preview
+- AP2-style evidence preview
+- connector registry metadata preview
+
+This coverage confirms the preview conformance chain can validate fixture
+shape, report generation, status rendering, blocked fixture evidence, available
+fixture non-production posture, forbidden-claim scans, and non-enabling controls.
+It does not approve public launch, live providers, production checkout/payment,
+public discovery, production allowlists, or any certification claim.
+
+## Remaining Launch Gap Matrix
+
+| Area | Current status | Launch blocker | Required next evidence |
+| --- | --- | --- | --- |
+| Public protocol publication | blocked | No explicit publication approval or public-docs release process exists for these preview materials. | Approved publication owner, public-safe content review, legal/standards review, and rollback plan. |
+| UCP/ACP/AP2/schema.org/MPP/A2A/provider/live-payment certification | blocked | The chain is preview-only and makes no certification claim. | Formal external certification or attestation process, approved language, and evidence package. |
+| Grantex public discovery | blocked | Public discovery remains outside the preview conformance gate. | Approved rollout plan, safe allowlist process, monitoring, rollback, and production-readiness approval. |
+| AgenticOrg public commerce discovery | blocked | AgenticOrg discovery stays read-only and gated; public commerce discovery is not enabled by this chain. | Cross-repo approval, grounded-response review, monitoring, rollback, and public-discovery authorization. |
+| Production Commerce V1 | blocked | C6Oa-C6Of validates preview fixtures and local reports only. | Production readiness review, operator approval, risk acceptance, and production config change control. |
+| Production checkout/payment creation | blocked | ACP-style and AP2-style artifacts remain sandbox/non-live and non-enabling. | Consent/passport/policy evidence, payment risk review, provider approval, payment-creation controls, and rollback. |
+| Live payments/live Plural/live providers | blocked | No live provider path is exercised or enabled. | Provider approvals, credential handling review, live-payment controls, audit evidence, and incident rollback. |
+| Production allowlists | blocked | No concrete production allowlist values are set or approved. | Allowlist owner approval, tenant scope review, expiry/rollback policy, and config-change review. |
+
+## Go/No-Go Summary
+
+Go for internal preview release rehearsal evidence:
+
+- C6Oe release-review gate passes.
+- C6Of runbook defines the manual review process.
+- C6Og records the passing status and remaining blockers.
+- Evidence remains local/internal, preview-only, sandbox-only, non-live,
+  non-publication, non-certifying, and non-enabling.
+
+No-go for public or production launch:
+
+- public protocol publication
+- UCP, ACP, AP2, schema.org, MPP, A2A, provider, or live-payment certification
+- Grantex public discovery
+- AgenticOrg public commerce discovery
+- production Commerce V1
+- production checkout or payment creation
+- live payments, live Plural, or live providers
+- production allowlists
+
+## Stop Conditions
+
+Stop and require a new approved work item if any C6Og follow-up:
+
+- publishes public protocol materials or public status pages
+- turns on Grantex public discovery or AgenticOrg public commerce discovery
+- turns on production Commerce V1
+- turns on checkout/payment creation, public checkout, live payments, live
+  Plural, or live providers
+- calls payment providers, provider APIs, or merchant private APIs
+- stores or exposes secrets, credentials, DB URLs, raw payloads, provider
+  metadata, private commerce IDs, concrete allowlist values, or production
+  config values
+- writes production configuration or production allowlists
+- claims UCP, ACP, AP2, schema.org, MPP, A2A, provider, protocol-publication, or
+  live-payment certification
+- treats sandbox, demo, synthetic, fixture, or rehearsal output as production
+  approval
+- requires cloud commands, cloud resources, manual deploys, or manual deploy
+  workflow triggers
+
+## Validation
+
+C6Og validation should include:
+
+- `node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode release-review --work-dir <temp>`
+- `npm --prefix apps/auth-service test -- commerce-c6of-release-review-runbook.test.ts commerce-c6og-release-rehearsal-status.test.ts`
+- `npm --prefix apps/auth-service run typecheck`
+- `git diff --check origin/main...HEAD`
+- focused guardrail scans for secrets/private details, production config and
+  allowlists, public discovery, checkout/payment enablement, live payment and
+  provider credentials, overclaims and certification claims, direct provider
+  calls, direct merchant private API calls, and generated artifacts staged for
+  commit
+
+Expected scan hits should be limited to stop-condition text, denylist regex
+literals, negative assertions, or disabled-control statements in temporary
+generated output.
+
+## Rollback
+
+C6Og is docs and tests only. To roll it back, remove:
+
+- `docs/internal/commerce-v1/commerce-v1-c6og-release-rehearsal-status-launch-gap-assessment.md`
+- `apps/auth-service/tests/commerce-c6og-release-rehearsal-status.test.ts`
+
+Delete any local `<local-review-dir>` generated during validation. There are no
+runtime flags, production config changes, provider credentials, connector
+credentials, public discovery settings, checkout/payment behavior, live-provider
+behavior, production allowlists, cloud resources, migrations, routes, portal UI
+changes, public docs publication changes, or deployment workflow changes to roll
+back.


### PR DESCRIPTION
## Summary
- Add C6Og internal release rehearsal status and launch-gap assessment.
- Record the C6Of release-review gate status: passed, 10 fixtures, 5 surfaces, 104 scans, passing status.
- Add blocker matrix for publication, certification, public discovery, production Commerce V1, production checkout/payment, live providers, and production allowlists.
- Add focused tests for rehearsal status, blockers, local/internal evidence retention, no committed generated artifacts, and non-enabling posture.

## Safety
- Docs/test-only; no runtime APIs, routes, migrations, portal UI, public docs publication, production config, secrets, public discovery, checkout/payment behavior, live payment behavior, provider calls, merchant private API calls, allowlists, or certification claims.
- Generated report/status artifacts are local-only and not committed.

## Validation
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode release-review --work-dir .tmp/commerce-c6og-postcommit
- npm --prefix apps/auth-service test -- commerce-c6of-release-review-runbook.test.ts commerce-c6og-release-rehearsal-status.test.ts
- npm --prefix apps/auth-service run typecheck
- git diff --check origin/main...HEAD
- Focused guardrail scans for secrets/private details, production config/allowlists, public discovery, checkout/payment, live provider credentials, overclaims/certification claims, and direct provider/merchant API semantics