### PR TITLE
feat(commerce): add connector dry-run portal foundation

### DIFF
--- a/apps/portal/src/api/__tests__/commerce.test.ts
+++ b/apps/portal/src/api/__tests__/commerce.test.ts
@@ -15,6 +15,8 @@ import {
   disableMerchantAgenticCommerce,
   evaluateCommercePolicy,
   getCommerceMerchant,
+  getCommerceConnectorDryRun,
+  getCommerceConnectorDryRunReview,
   getCommerceMerchantSchemaOrgJsonLdPreview,
   getCommerceMerchantSandboxOnboarding,
   getCommerceOpsHealth,
@@ -29,8 +31,11 @@ import {
   listCommercePaymentIntents,
   listCommerceProviderCredentials,
   reconcileCommercePaymentIntent,
+  recordCommerceConnectorDryRunReviewDecision,
   rotateCommerceWebhookSourceSecret,
+  requestCommerceConnectorDryRunReview,
   revokeCommercePassport,
+  runCommerceConnectorDryRun,
   transitionCommerceMerchantSandboxOnboarding,
   updateCommerceAgent,
   updateCommerceMerchant,
@@ -175,6 +180,82 @@ describe('commerce api', () => {
     });
     expect(mockFetch.mock.calls[4]![0]).toBe('http://localhost:3000/v1/commerce/catalog/products/bulk');
     expect(JSON.parse(mockFetch.mock.calls[4]![1].body).dry_run).toBe(true);
+  });
+
+  it('calls connector dry-run and review APIs without credential or enablement fields', async () => {
+    ok({ data: { dry_run_id: 'cdry/1', status: 'passed' }, audit_events: [] }, 201);
+    await runCommerceConnectorDryRun({
+      merchantId: 'mch/1',
+      connectorType: 'csv',
+      sourceLabel: 'portal_manual_fixture',
+      previewLimit: 3,
+      rows: [{ product_id: 'p1', title: 'Fixture product', sku: 'SKU-1', price_amount: 1000, currency: 'INR' }],
+    });
+    expect(mockFetch.mock.calls[0]![0]).toBe(
+      'http://localhost:3000/v1/commerce/merchants/mch%2F1/connectors/dry-run',
+    );
+    const dryRunBody = JSON.parse(mockFetch.mock.calls[0]![1].body);
+    expect(dryRunBody).toEqual({
+      connector_type: 'csv',
+      source_label: 'portal_manual_fixture',
+      preview_limit: 3,
+      rows: [{ product_id: 'p1', title: 'Fixture product', sku: 'SKU-1', price_amount: 1000, currency: 'INR' }],
+    });
+    const serializedDryRunBody = JSON.stringify(dryRunBody).toLowerCase();
+    for (const forbidden of [
+      'credential',
+      'secret',
+      'provider_metadata',
+      'public_discovery_enabled',
+      'checkout_payment_enabled',
+      'live_provider_enabled',
+      'live_plural_enabled',
+    ]) {
+      expect(serializedDryRunBody).not.toContain(forbidden);
+    }
+
+    ok({ data: { dry_run_id: 'cdry/1' } });
+    await getCommerceConnectorDryRun('mch/1', 'cdry/1');
+    expect(mockFetch.mock.calls[1]![0]).toBe(
+      'http://localhost:3000/v1/commerce/merchants/mch%2F1/connectors/dry-runs/cdry%2F1',
+    );
+
+    ok({ data: { review_id: 'cdrev/1' }, dry_run: { dry_run_id: 'cdry/1' }, audit_event_id: 'aud_1' });
+    await requestCommerceConnectorDryRunReview('mch/1', 'cdry/1', { requestNote: 'Public-safe sandbox evidence review.' });
+    expect(mockFetch.mock.calls[2]![0]).toBe(
+      'http://localhost:3000/v1/commerce/merchants/mch%2F1/connectors/dry-runs/cdry%2F1/review-request',
+    );
+    expect(JSON.parse(mockFetch.mock.calls[2]![1].body)).toEqual({ request_note: 'Public-safe sandbox evidence review.' });
+
+    ok({ data: { review_id: 'cdrev/1' }, dry_run: { dry_run_id: 'cdry/1' }, audit_event_id: 'aud_1' });
+    await getCommerceConnectorDryRunReview('mch/1', 'cdry/1');
+    expect(mockFetch.mock.calls[3]![0]).toBe(
+      'http://localhost:3000/v1/commerce/merchants/mch%2F1/connectors/dry-runs/cdry%2F1/review',
+    );
+
+    ok({ data: { review_id: 'cdrev/1', decision: 'accepted_for_sandbox_followup' }, dry_run: { dry_run_id: 'cdry/1' }, audit_event_id: 'aud_2' });
+    await recordCommerceConnectorDryRunReviewDecision('mch/1', 'cdry/1', {
+      decision: 'accepted_for_sandbox_followup',
+      decisionNote: 'Sandbox follow-up only.',
+    });
+    expect(mockFetch.mock.calls[4]![0]).toBe(
+      'http://localhost:3000/v1/commerce/merchants/mch%2F1/connectors/dry-runs/cdry%2F1/review/decision',
+    );
+    const decisionBody = JSON.parse(mockFetch.mock.calls[4]![1].body);
+    expect(decisionBody).toEqual({
+      decision: 'accepted_for_sandbox_followup',
+      decision_note: 'Sandbox follow-up only.',
+    });
+    const serializedDecisionBody = JSON.stringify(decisionBody).toLowerCase();
+    for (const forbidden of [
+      'approval',
+      'public_discovery_enabled',
+      'checkout_payment_enabled',
+      'live_provider_enabled',
+      'live_plural_enabled',
+    ]) {
+      expect(serializedDecisionBody).not.toContain(forbidden);
+    }
   });
 
   it('calls webhook source and policy endpoints without secret-like list output assumptions', async () => {

--- a/apps/portal/src/api/commerce.ts
+++ b/apps/portal/src/api/commerce.ts
@@ -220,6 +220,133 @@ export interface CommerceCatalogReadiness {
   };
 }
 
+export type CommerceConnectorDryRunType = 'manual' | 'csv';
+export type CommerceConnectorDryRunStatus = 'passed' | 'blocked';
+export type CommerceConnectorDryRunReviewStatus =
+  | 'pending_operator_review'
+  | 'accepted_for_sandbox_followup'
+  | 'needs_changes'
+  | 'blocked';
+export type CommerceConnectorDryRunReviewDecision =
+  | 'accepted_for_sandbox_followup'
+  | 'needs_changes'
+  | 'blocked';
+
+export interface CommerceConnectorDryRunPreviewVariant {
+  sku: string;
+  variant_title: string | null;
+  price_amount: number | string;
+  currency: string;
+  availability_status: 'in_stock' | 'out_of_stock' | 'pre_order' | 'back_order' | 'unknown';
+  warranty_summary: string | null;
+  return_policy_summary: string | null;
+}
+
+export interface CommerceConnectorDryRunPreviewProduct {
+  source_product_ref: string;
+  title: string;
+  brand: string | null;
+  description: string | null;
+  image_url: string | null;
+  category_preset: string;
+  variants: CommerceConnectorDryRunPreviewVariant[];
+}
+
+export interface CommerceConnectorDryRunBlocker {
+  code: string;
+  message: string;
+  row_index: number | null;
+  field: string | null;
+  remediation: string;
+}
+
+export interface CommerceConnectorDryRunWarning {
+  code: string;
+  message: string;
+  row_index: number | null;
+  field: string | null;
+}
+
+export interface CommerceConnectorDryRunResult {
+  dry_run_id: string;
+  tenant_id: string;
+  merchant_id: string;
+  connector_type: CommerceConnectorDryRunType;
+  source_label: string;
+  status: CommerceConnectorDryRunStatus;
+  sandbox_only: true;
+  not_live: true;
+  not_approved: true;
+  public_discovery_enabled: false;
+  checkout_payment_enabled: false;
+  live_provider_enabled: false;
+  live_plural_enabled: false;
+  rows_received: number;
+  products_detected: number;
+  variants_detected: number;
+  would_create_count: number;
+  would_update_count: number;
+  would_archive_count: number;
+  blocked_count: number;
+  warning_count: number;
+  normalized_preview: CommerceConnectorDryRunPreviewProduct[];
+  blockers: CommerceConnectorDryRunBlocker[];
+  warnings: CommerceConnectorDryRunWarning[];
+  requested_audit_event_id: string;
+  audit_event_id: string;
+  generated_at: string;
+  created_at: string;
+}
+
+export interface CommerceConnectorDryRunReview {
+  review_id: string;
+  tenant_id: string;
+  merchant_id: string;
+  dry_run_id: string;
+  status: CommerceConnectorDryRunReviewStatus;
+  decision: CommerceConnectorDryRunReviewDecision | null;
+  decision_note: string | null;
+  requested_by: {
+    kind: 'operator' | 'merchant';
+    id: string;
+  };
+  decided_by_operator_id: string | null;
+  dry_run_status: CommerceConnectorDryRunStatus;
+  dry_run_generated_at: string | null;
+  evidence_summary: Record<string, unknown>;
+  requested_audit_event_id: string;
+  audit_event_id: string | null;
+  controls: {
+    sandbox_only: true;
+    not_live: true;
+    not_approved: true;
+    public_discovery_enabled: false;
+    checkout_payment_enabled: false;
+    live_provider_enabled: false;
+    live_plural_enabled: false;
+    production_allowlist_written: false;
+    review_is_production_approval: false;
+    review_enables_connector_execution: false;
+  };
+  created_at: string | null;
+  updated_at: string | null;
+  decided_at: string | null;
+}
+
+export interface CommerceConnectorDryRunResponse {
+  data: CommerceConnectorDryRunResult;
+  audit_events: Array<{
+    event_type: 'connector_dry_run_requested' | 'connector_dry_run_completed' | 'connector_dry_run_blocked';
+    audit_event_id: string;
+  }>;
+}
+
+export interface CommerceConnectorDryRunReviewResponse {
+  data: CommerceConnectorDryRunReview;
+  dry_run: CommerceConnectorDryRunResult;
+  audit_event_id: string | null;
+}
+
 export interface CommerceAgentFacingPreviewProductVariant {
   sku: string;
   variant_title: string | null;
@@ -1188,6 +1315,74 @@ export function bulkIngestCommerceProducts(input: {
     dry_run: input.dryRun ?? true,
     products: input.products,
   });
+}
+
+export function runCommerceConnectorDryRun(input: {
+  merchantId: string;
+  connectorType: CommerceConnectorDryRunType;
+  sourceLabel: string;
+  sourceSnapshotAt?: string;
+  previewLimit?: number;
+  rows: Array<Record<string, unknown>>;
+}): Promise<CommerceConnectorDryRunResponse> {
+  return api.post<CommerceConnectorDryRunResponse>(
+    `/v1/commerce/merchants/${encodeURIComponent(input.merchantId)}/connectors/dry-run`,
+    {
+      connector_type: input.connectorType,
+      source_label: input.sourceLabel,
+      ...(input.sourceSnapshotAt ? { source_snapshot_at: input.sourceSnapshotAt } : {}),
+      ...(input.previewLimit ? { preview_limit: input.previewLimit } : {}),
+      rows: input.rows,
+    },
+  );
+}
+
+export function getCommerceConnectorDryRun(
+  merchantId: string,
+  dryRunId: string,
+): Promise<{ data: CommerceConnectorDryRunResult }> {
+  return api.get<{ data: CommerceConnectorDryRunResult }>(
+    `/v1/commerce/merchants/${encodeURIComponent(merchantId)}/connectors/dry-runs/${encodeURIComponent(dryRunId)}`,
+  );
+}
+
+export function requestCommerceConnectorDryRunReview(
+  merchantId: string,
+  dryRunId: string,
+  input: { requestNote?: string } = {},
+): Promise<CommerceConnectorDryRunReviewResponse> {
+  return api.post<CommerceConnectorDryRunReviewResponse>(
+    `/v1/commerce/merchants/${encodeURIComponent(merchantId)}/connectors/dry-runs/${encodeURIComponent(dryRunId)}/review-request`,
+    {
+      ...(input.requestNote ? { request_note: input.requestNote } : {}),
+    },
+  );
+}
+
+export function getCommerceConnectorDryRunReview(
+  merchantId: string,
+  dryRunId: string,
+): Promise<CommerceConnectorDryRunReviewResponse> {
+  return api.get<CommerceConnectorDryRunReviewResponse>(
+    `/v1/commerce/merchants/${encodeURIComponent(merchantId)}/connectors/dry-runs/${encodeURIComponent(dryRunId)}/review`,
+  );
+}
+
+export function recordCommerceConnectorDryRunReviewDecision(
+  merchantId: string,
+  dryRunId: string,
+  input: {
+    decision: CommerceConnectorDryRunReviewDecision;
+    decisionNote?: string;
+  },
+): Promise<CommerceConnectorDryRunReviewResponse> {
+  return api.post<CommerceConnectorDryRunReviewResponse>(
+    `/v1/commerce/merchants/${encodeURIComponent(merchantId)}/connectors/dry-runs/${encodeURIComponent(dryRunId)}/review/decision`,
+    {
+      decision: input.decision,
+      ...(input.decisionNote ? { decision_note: input.decisionNote } : {}),
+    },
+  );
 }
 
 export function listCommerceWebhookSources(params: {

--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -34,6 +34,9 @@ const mockGetCommerceMerchantAgenticOrgBuyerDiscoveryPreview = vi.fn();
 const mockGetCommerceMerchantSchemaOrgJsonLdPreview = vi.fn();
 const mockRequestCommerceMerchantAgenticOrgBuyerDiscoveryHandoff = vi.fn();
 const mockWithdrawCommerceMerchantAgenticOrgBuyerDiscoveryHandoff = vi.fn();
+const mockRunCommerceConnectorDryRun = vi.fn();
+const mockRequestCommerceConnectorDryRunReview = vi.fn();
+const mockRecordCommerceConnectorDryRunReviewDecision = vi.fn();
 const mockDisableMerchantAgenticCommerce = vi.fn();
 const mockEnableMerchantAgenticCommerce = vi.fn();
 const mockListCommerceAgents = vi.fn();
@@ -77,6 +80,9 @@ vi.mock('../../api/commerce', () => ({
   getCommerceMerchantSchemaOrgJsonLdPreview: (...a: unknown[]) => mockGetCommerceMerchantSchemaOrgJsonLdPreview(...a),
   requestCommerceMerchantAgenticOrgBuyerDiscoveryHandoff: (...a: unknown[]) => mockRequestCommerceMerchantAgenticOrgBuyerDiscoveryHandoff(...a),
   withdrawCommerceMerchantAgenticOrgBuyerDiscoveryHandoff: (...a: unknown[]) => mockWithdrawCommerceMerchantAgenticOrgBuyerDiscoveryHandoff(...a),
+  runCommerceConnectorDryRun: (...a: unknown[]) => mockRunCommerceConnectorDryRun(...a),
+  requestCommerceConnectorDryRunReview: (...a: unknown[]) => mockRequestCommerceConnectorDryRunReview(...a),
+  recordCommerceConnectorDryRunReviewDecision: (...a: unknown[]) => mockRecordCommerceConnectorDryRunReviewDecision(...a),
   disableMerchantAgenticCommerce: (...a: unknown[]) => mockDisableMerchantAgenticCommerce(...a),
   enableMerchantAgenticCommerce: (...a: unknown[]) => mockEnableMerchantAgenticCommerce(...a),
   listCommerceAgents: (...a: unknown[]) => mockListCommerceAgents(...a),
@@ -727,6 +733,95 @@ const schemaOrgPreview = {
   },
 };
 
+const connectorDryRun = {
+  dry_run_id: 'cdry_C6SB',
+  tenant_id: 'cten_1',
+  merchant_id: 'mch_1',
+  connector_type: 'csv' as const,
+  source_label: 'portal_manual_catalog_snapshot',
+  status: 'passed' as const,
+  sandbox_only: true as const,
+  not_live: true as const,
+  not_approved: true as const,
+  public_discovery_enabled: false as const,
+  checkout_payment_enabled: false as const,
+  live_provider_enabled: false as const,
+  live_plural_enabled: false as const,
+  rows_received: 1,
+  products_detected: 1,
+  variants_detected: 1,
+  would_create_count: 1,
+  would_update_count: 0,
+  would_archive_count: 0,
+  blocked_count: 0,
+  warning_count: 0,
+  normalized_preview: [{
+    source_product_ref: 'portal_fixture_001',
+    title: 'Portal Sandbox Fixture Product',
+    brand: 'Synthetic Fixture',
+    description: 'Public-safe local fixture row for connector dry-run rehearsal.',
+    image_url: null,
+    category_preset: 'electronics_appliances',
+    variants: [{
+      sku: 'PORTAL-FIXTURE-001',
+      variant_title: null,
+      price_amount: 1299,
+      currency: 'INR',
+      availability_status: 'in_stock' as const,
+      warranty_summary: 'Sandbox fixture warranty summary.',
+      return_policy_summary: 'Sandbox fixture return summary.',
+    }],
+  }],
+  blockers: [],
+  warnings: [],
+  requested_audit_event_id: 'caud_C6SB_REQUESTED',
+  audit_event_id: 'caud_C6SB_COMPLETED',
+  generated_at: '2026-01-01T00:40:00Z',
+  created_at: '2026-01-01T00:40:00Z',
+};
+
+const connectorReview = {
+  review_id: 'cdrev_C6SB',
+  tenant_id: 'cten_1',
+  merchant_id: 'mch_1',
+  dry_run_id: 'cdry_C6SB',
+  status: 'pending_operator_review' as const,
+  decision: null,
+  decision_note: null,
+  requested_by: { kind: 'operator' as const, id: 'dev_TEST' },
+  decided_by_operator_id: null,
+  dry_run_status: 'passed' as const,
+  dry_run_generated_at: '2026-01-01T00:40:00Z',
+  evidence_summary: { rows_received: 1, blocked_count: 0, warning_count: 0 },
+  requested_audit_event_id: 'caud_C6SB_REVIEW_REQUESTED',
+  audit_event_id: null,
+  controls: {
+    sandbox_only: true as const,
+    not_live: true as const,
+    not_approved: true as const,
+    public_discovery_enabled: false as const,
+    checkout_payment_enabled: false as const,
+    live_provider_enabled: false as const,
+    live_plural_enabled: false as const,
+    production_allowlist_written: false as const,
+    review_is_production_approval: false as const,
+    review_enables_connector_execution: false as const,
+  },
+  created_at: '2026-01-01T00:41:00Z',
+  updated_at: '2026-01-01T00:41:00Z',
+  decided_at: null,
+};
+
+const connectorReviewAccepted = {
+  ...connectorReview,
+  status: 'accepted_for_sandbox_followup' as const,
+  decision: 'accepted_for_sandbox_followup' as const,
+  decision_note: 'Sandbox follow-up only.',
+  decided_by_operator_id: 'dev_TEST',
+  audit_event_id: 'caud_C6SB_DECISION',
+  decided_at: '2026-01-01T00:42:00Z',
+};
+
 const credential = {
   id: 'cpcred_1',
   tenant_id: 'cten_1',
@@ -1140,6 +1235,23 @@ describe('CommerceOnboarding', () => {
       },
       audit_event_id: 'aud_agenticorg_withdraw',
     });
+    mockRunCommerceConnectorDryRun.mockResolvedValue({
+      data: connectorDryRun,
+      audit_events: [
+        { event_type: 'connector_dry_run_requested', audit_event_id: 'caud_C6SB_REQUESTED' },
+        { event_type: 'connector_dry_run_completed', audit_event_id: 'caud_C6SB_COMPLETED' },
+      ],
+    });
+    mockRequestCommerceConnectorDryRunReview.mockResolvedValue({
+      data: connectorReview,
+      dry_run: connectorDryRun,
+      audit_event_id: 'caud_C6SB_REVIEW_REQUESTED',
+    });
+    mockRecordCommerceConnectorDryRunReviewDecision.mockResolvedValue({
+      data: connectorReviewAccepted,
+      dry_run: connectorDryRun,
+      audit_event_id: 'caud_C6SB_DECISION',
+    });
     mockListCommerceAgents.mockResolvedValue({ items: [agent], next_cursor: null });
     mockListCommercePolicies.mockResolvedValue({ items: [{ id: 'cpol_1', status: 'active' }], next_cursor: null });
     mockListCommerceProducts.mockResolvedValue({ items: [product], next_cursor: null });
@@ -1253,6 +1365,68 @@ describe('CommerceOnboarding', () => {
     })));
     expect(screen.getByText('policy_allow')).toBeInTheDocument();
     expect(screen.queryByText(/passport_jwt/i)).not.toBeInTheDocument();
+  });
+
+  it('runs connector dry-run review evidence without credential entry or live execution controls', async () => {
+    const user = userEvent.setup();
+    r(<CommerceOnboarding />);
+
+    await user.type(screen.getByLabelText('Merchant ID'), 'mch_1');
+    await user.click(screen.getByRole('button', { name: 'Load onboarding' }));
+    await waitFor(() => expect(screen.getByText('Connector dry-run review')).toBeInTheDocument());
+
+    expect(screen.getAllByText((_content, node) => (
+      node?.textContent?.includes('Credential-free sandbox evidence') ?? false
+    )).length).toBeGreaterThan(0);
+    expect(screen.getByText('No credential entry')).toBeInTheDocument();
+    expect(screen.getByText('Outbound sync off')).toBeInTheDocument();
+    expect(screen.getByText('credential_entry_enabled')).toBeInTheDocument();
+    expect(screen.getByText('outbound_sync_enabled')).toBeInTheDocument();
+    expect(screen.getByText('production_connector_setup')).toBeInTheDocument();
+    expect(screen.getByText('merchant_private_api_calls')).toBeInTheDocument();
+    expect(screen.queryByRole('textbox', { name: 'Credential' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Run connector dry-run' }));
+    await waitFor(() => expect(mockRunCommerceConnectorDryRun).toHaveBeenCalledWith(expect.objectContaining({
+      merchantId: 'mch_1',
+      connectorType: 'csv',
+      sourceLabel: 'portal_manual_catalog_snapshot',
+      previewLimit: 5,
+    })));
+    const dryRunArgument = mockRunCommerceConnectorDryRun.mock.calls[0]![0];
+    const serializedDryRunArgument = JSON.stringify(dryRunArgument).toLowerCase();
+    for (const forbidden of [
+      'credential',
+      'secret',
+      'provider_metadata',
+      'public_discovery_enabled',
+      'checkout_payment_enabled',
+      'live_provider_enabled',
+      'live_plural_enabled',
+      'merchant_private_api',
+    ]) {
+      expect(serializedDryRunArgument).not.toContain(forbidden);
+    }
+    expect(screen.getByText('Portal Sandbox Fixture Product')).toBeInTheDocument();
+    expect(screen.getByText('would create')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText('Review request note'), 'Public-safe sandbox evidence.');
+    await user.click(screen.getByRole('button', { name: 'Request dry-run review' }));
+    await waitFor(() => expect(mockRequestCommerceConnectorDryRunReview).toHaveBeenCalledWith('mch_1', 'cdry_C6SB', {
+      requestNote: 'Public-safe sandbox evidence.',
+    }));
+    expect(screen.getByText('cdrev_C6SB')).toBeInTheDocument();
+    expect(screen.getByText('review_is_production_approval')).toBeInTheDocument();
+    expect(screen.getByText('review_enables_connector_execution')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText('Decision note'), 'Sandbox follow-up only.');
+    await user.click(screen.getByRole('button', { name: 'Record dry-run review decision' }));
+    await waitFor(() => expect(mockRecordCommerceConnectorDryRunReviewDecision).toHaveBeenCalledWith('mch_1', 'cdry_C6SB', {
+      decision: 'accepted_for_sandbox_followup',
+      decisionNote: 'Sandbox follow-up only.',
+    }));
+    expect(screen.getByText('caud_C6SB_DECISION')).toBeInTheDocument();
+    expect(screen.queryByText('production connector setup enabled')).not.toBeInTheDocument();
   });
 
   it('creates and dry-runs rollout proposal evidence from the operator flow', async () => {

--- a/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
+++ b/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
@@ -3,6 +3,7 @@ import {
   createCommerceMerchantReadOnlyDiscoveryRolloutProposal,
   dryRunCommerceMerchantReadOnlyDiscoveryRolloutProposal,
   evaluateCommercePolicy,
+  recordCommerceConnectorDryRunReviewDecision,
   getCommerceMerchantAgenticOrgBuyerDiscoveryPreview,
   getCommerceMerchantReadOnlyDiscoveryReview,
   getCommerceMerchantReadOnlyDiscoveryRolloutProposal,
@@ -14,14 +15,20 @@ import {
   listCommerceProducts,
   listCommerceProviderCredentials,
   listCommerceWebhookSources,
+  requestCommerceConnectorDryRunReview,
   recordCommerceReadOnlyDiscoveryReviewDecision,
   requestCommerceMerchantAgenticOrgBuyerDiscoveryHandoff,
   requestCommerceMerchantReadOnlyDiscoveryReview,
+  runCommerceConnectorDryRun,
   updateCommerceMerchantSandboxOnboarding,
   withdrawCommerceMerchantAgenticOrgBuyerDiscoveryHandoff,
   withdrawCommerceMerchantReadOnlyDiscoveryRolloutProposal,
   type CommerceAgent,
   type CommerceAgenticOrgBuyerDiscoveryPreview,
+  type CommerceConnectorDryRunResult,
+  type CommerceConnectorDryRunReview,
+  type CommerceConnectorDryRunReviewDecision,
+  type CommerceConnectorDryRunType,
   type CommerceReadOnlyDiscoveryOperatorDecision,
   type CommerceReadOnlyDiscoveryOperatorReview,
   type CommerceReadOnlyDiscoveryRolloutProposal,
@@ -70,6 +77,22 @@ const actionScopes = [
   'commerce:payment.status.read',
 ];
 
+const connectorDryRunRowsFixture = JSON.stringify([
+  {
+    product_id: 'portal_fixture_001',
+    title: 'Portal Sandbox Fixture Product',
+    brand: 'Synthetic Fixture',
+    description: 'Public-safe local fixture row for connector dry-run rehearsal.',
+    category_preset: 'electronics_appliances',
+    sku: 'PORTAL-FIXTURE-001',
+    price_amount: 1299,
+    currency: 'INR',
+    availability_status: 'in_stock',
+    warranty_summary: 'Sandbox fixture warranty summary.',
+    return_policy_summary: 'Sandbox fixture return summary.',
+  },
+], null, 2);
+
 function readinessVariant(status: string): 'default' | 'success' | 'warning' | 'danger' {
   if (status === 'pass') return 'success';
   if (status === 'fail' || status === 'not_applicable' || status === 'recommended') return 'warning';
@@ -101,6 +124,8 @@ export function CommerceOnboarding() {
   const [rolloutProposal, setRolloutProposal] = useState<CommerceReadOnlyDiscoveryRolloutProposal | null>(null);
   const [agenticOrgPreview, setAgenticOrgPreview] = useState<CommerceAgenticOrgBuyerDiscoveryPreview | null>(null);
   const [schemaOrgPreview, setSchemaOrgPreview] = useState<CommerceSchemaOrgJsonLdPreview | null>(null);
+  const [connectorDryRun, setConnectorDryRun] = useState<CommerceConnectorDryRunResult | null>(null);
+  const [connectorReview, setConnectorReview] = useState<CommerceConnectorDryRunReview | null>(null);
   const [merchantForm, setMerchantForm] = useState<MerchantPatchForm>(defaultPatch);
   const [agents, setAgents] = useState<CommerceAgent[]>([]);
   const [activePolicyCount, setActivePolicyCount] = useState(0);
@@ -116,6 +141,24 @@ export function CommerceOnboarding() {
   const [proposalNote, setProposalNote] = useState('');
   const [agenticOrgSubmitting, setAgenticOrgSubmitting] = useState(false);
   const [agenticOrgNote, setAgenticOrgNote] = useState('');
+  const [connectorSubmitting, setConnectorSubmitting] = useState(false);
+  const [connectorReviewSubmitting, setConnectorReviewSubmitting] = useState(false);
+  const [connectorDecisionSubmitting, setConnectorDecisionSubmitting] = useState(false);
+  const [connectorForm, setConnectorForm] = useState<{
+    connector_type: CommerceConnectorDryRunType;
+    source_label: string;
+    rows_json: string;
+    request_note: string;
+    decision: CommerceConnectorDryRunReviewDecision;
+    decision_note: string;
+  }>({
+    connector_type: 'csv',
+    source_label: 'portal_manual_catalog_snapshot',
+    rows_json: connectorDryRunRowsFixture,
+    request_note: '',
+    decision: 'accepted_for_sandbox_followup',
+    decision_note: '',
+  });
   const [decisionForm, setDecisionForm] = useState<{
     decision: CommerceReadOnlyDiscoveryOperatorDecision;
     reason: string;
@@ -163,6 +206,8 @@ export function CommerceOnboarding() {
       setRolloutProposal(proposalRes?.data ?? null);
       setAgenticOrgPreview(agenticOrgRes?.data ?? null);
       setSchemaOrgPreview(schemaOrgRes?.data ?? null);
+      setConnectorDryRun(null);
+      setConnectorReview(null);
       setProposalNote(proposalRes?.data.proposal_note ?? '');
       setAgenticOrgNote('');
       setMerchantForm({
@@ -357,6 +402,82 @@ export function CommerceOnboarding() {
     }
   }
 
+  function parseConnectorRows(): Array<Record<string, unknown>> | null {
+    try {
+      const parsed = JSON.parse(connectorForm.rows_json) as unknown;
+      if (!Array.isArray(parsed) || parsed.some((row) => row === null || typeof row !== 'object' || Array.isArray(row))) {
+        show('Connector dry-run rows must be a JSON array of objects', 'error');
+        return null;
+      }
+      return parsed as Array<Record<string, unknown>>;
+    } catch {
+      show('Connector dry-run rows must be valid JSON', 'error');
+      return null;
+    }
+  }
+
+  async function runConnectorDryRun() {
+    if (!merchant) return;
+    const rows = parseConnectorRows();
+    if (!rows) return;
+    setConnectorSubmitting(true);
+    setConnectorReview(null);
+    try {
+      const res = await runCommerceConnectorDryRun({
+        merchantId: merchant.merchant_id,
+        connectorType: connectorForm.connector_type,
+        sourceLabel: connectorForm.source_label.trim(),
+        previewLimit: 5,
+        rows,
+      });
+      setConnectorDryRun(res.data);
+      show(res.data.status === 'passed' ? 'Connector dry-run passed' : 'Connector dry-run blocked', res.data.status === 'passed' ? 'success' : 'error');
+    } catch {
+      show('Connector dry-run request is blocked', 'error');
+    } finally {
+      setConnectorSubmitting(false);
+    }
+  }
+
+  async function requestConnectorReview() {
+    if (!merchant || !connectorDryRun) return;
+    setConnectorReviewSubmitting(true);
+    try {
+      const res = await requestCommerceConnectorDryRunReview(merchant.merchant_id, connectorDryRun.dry_run_id, {
+        requestNote: connectorForm.request_note.trim() || undefined,
+      });
+      setConnectorReview(res.data);
+      setConnectorDryRun(res.dry_run);
+      show('Connector dry-run review requested', 'success');
+    } catch {
+      show('Connector dry-run review request is blocked', 'error');
+    } finally {
+      setConnectorReviewSubmitting(false);
+    }
+  }
+
+  async function recordConnectorDecision() {
+    if (!merchant || !connectorDryRun || !connectorReview) return;
+    setConnectorDecisionSubmitting(true);
+    try {
+      const res = await recordCommerceConnectorDryRunReviewDecision(
+        merchant.merchant_id,
+        connectorDryRun.dry_run_id,
+        {
+          decision: connectorForm.decision,
+          decisionNote: connectorForm.decision_note.trim() || undefined,
+        },
+      );
+      setConnectorReview(res.data);
+      setConnectorDryRun(res.dry_run);
+      show('Connector dry-run review decision recorded', 'success');
+    } catch {
+      show('Connector dry-run review decision is blocked', 'error');
+    } finally {
+      setConnectorDecisionSubmitting(false);
+    }
+  }
+
   async function simulatePolicy() {
     if (!merchant) return;
     setSimulating(true);
@@ -448,6 +569,35 @@ export function CommerceOnboarding() {
     || agenticOrgStatus !== 'sandbox_handoff_requested';
   const agenticOrgJson = agenticOrgPreview ? JSON.stringify(agenticOrgPreview, null, 2) : '';
   const schemaOrgJson = schemaOrgPreview ? JSON.stringify(schemaOrgPreview.jsonld, null, 2) : '';
+  const connectorDryRunControls = connectorDryRun ? [
+    { label: 'sandbox_only', value: connectorDryRun.sandbox_only },
+    { label: 'not_live', value: connectorDryRun.not_live },
+    { label: 'not_approved', value: connectorDryRun.not_approved },
+    { label: 'public_discovery_enabled', value: connectorDryRun.public_discovery_enabled },
+    { label: 'checkout_payment_enabled', value: connectorDryRun.checkout_payment_enabled },
+    { label: 'live_provider_enabled', value: connectorDryRun.live_provider_enabled },
+    { label: 'live_plural_enabled', value: connectorDryRun.live_plural_enabled },
+  ] : [];
+  const connectorReviewControls = connectorReview ? [
+    { label: 'sandbox_only', value: connectorReview.controls.sandbox_only },
+    { label: 'not_live', value: connectorReview.controls.not_live },
+    { label: 'not_approved', value: connectorReview.controls.not_approved },
+    { label: 'review_is_production_approval', value: connectorReview.controls.review_is_production_approval },
+    { label: 'review_enables_connector_execution', value: connectorReview.controls.review_enables_connector_execution },
+    { label: 'public_discovery_enabled', value: connectorReview.controls.public_discovery_enabled },
+    { label: 'checkout_payment_enabled', value: connectorReview.controls.checkout_payment_enabled },
+    { label: 'live_provider_enabled', value: connectorReview.controls.live_provider_enabled },
+    { label: 'live_plural_enabled', value: connectorReview.controls.live_plural_enabled },
+    { label: 'production_allowlist_written', value: connectorReview.controls.production_allowlist_written },
+  ] : [];
+  const connectorReviewRequestDisabled = connectorReviewSubmitting
+    || !connectorDryRun
+    || connectorDryRun.status !== 'passed';
+  const connectorDecisionDisabled = connectorDecisionSubmitting
+    || !connectorReview
+    || connectorReview.status !== 'pending_operator_review'
+    || ((connectorForm.decision === 'needs_changes' || connectorForm.decision === 'blocked') && !connectorForm.decision_note.trim())
+    || (connectorForm.decision === 'accepted_for_sandbox_followup' && connectorReview?.dry_run_status !== 'passed');
 
   return (
     <div>
@@ -1198,6 +1348,263 @@ export function CommerceOnboarding() {
                 {schemaOrgJson}
               </pre>
             </details>
+          </Card>
+
+          <Card className="xl:col-span-2">
+            <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h2 className="text-base font-semibold text-gx-text">Connector dry-run review</h2>
+                <p className="mt-1 text-xs text-gx-muted">
+                  Credential-free sandbox evidence for manual/CSV connector mapping; this does not run outbound sync, production connector setup, public discovery, checkout, payment, live provider, or merchant-system execution.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Badge variant={connectorDryRun?.status === 'passed' ? 'success' : connectorDryRun?.status === 'blocked' ? 'danger' : 'warning'}>
+                  {connectorDryRun?.status ?? 'not_run'}
+                </Badge>
+                <Badge variant="warning">sandbox_only</Badge>
+                <Badge variant="danger">not_live</Badge>
+                <Badge variant="danger">not_approved</Badge>
+                <Badge variant="success">No credential entry</Badge>
+                <Badge variant="success">Outbound sync off</Badge>
+              </div>
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-[180px_minmax(0,1fr)]">
+              <label className="text-sm font-medium text-gx-text">
+                Connector type
+                <select
+                  className="mt-1.5 w-full rounded-md border border-gx-border bg-gx-bg px-3 py-2 text-sm text-gx-text focus:border-gx-accent focus:outline-none"
+                  value={connectorForm.connector_type}
+                  onChange={(e) => setConnectorForm({ ...connectorForm, connector_type: e.target.value as CommerceConnectorDryRunType })}
+                >
+                  <option value="csv">csv</option>
+                  <option value="manual">manual</option>
+                </select>
+              </label>
+              <Input
+                id="connector-source-label"
+                label="Source label"
+                value={connectorForm.source_label}
+                onChange={(e) => setConnectorForm({ ...connectorForm, source_label: e.target.value })}
+              />
+            </div>
+
+            <div className="mt-3">
+              <label htmlFor="connector-rows-json" className="mb-1.5 block text-sm font-medium text-gx-text">
+                Sandbox catalog rows JSON
+              </label>
+              <textarea
+                id="connector-rows-json"
+                value={connectorForm.rows_json}
+                onChange={(e) => setConnectorForm({ ...connectorForm, rows_json: e.target.value })}
+                rows={8}
+                className="w-full rounded-md border border-gx-border bg-gx-bg px-3 py-2 font-mono text-xs text-gx-text focus:border-gx-accent focus:outline-none"
+              />
+            </div>
+
+            <div className="mt-4 flex flex-wrap gap-2">
+              <Button
+                variant="secondary"
+                onClick={runConnectorDryRun}
+                disabled={connectorSubmitting || !connectorForm.source_label.trim() || !connectorForm.rows_json.trim()}
+              >
+                {connectorSubmitting ? 'Running' : 'Run connector dry-run'}
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={requestConnectorReview}
+                disabled={connectorReviewRequestDisabled}
+                title={connectorDryRun?.status === 'blocked' ? 'Blocked dry-runs cannot be accepted for sandbox follow-up.' : 'Request sandbox-only dry-run review.'}
+              >
+                {connectorReviewSubmitting ? 'Requesting' : connectorReview ? 'Review requested' : 'Request dry-run review'}
+              </Button>
+            </div>
+
+            <div className="mt-4 grid gap-2 md:grid-cols-4">
+              {[
+                { label: 'credential_entry_enabled', value: false },
+                { label: 'outbound_sync_enabled', value: false },
+                { label: 'production_connector_setup', value: false },
+                { label: 'merchant_private_api_calls', value: false },
+              ].map(({ label, value }) => (
+                <div key={label} className="rounded-md border border-gx-border p-3">
+                  <div className="text-xs text-gx-muted">{label}</div>
+                  <Badge variant={value ? 'danger' : 'success'}>{value ? 'true' : 'false'}</Badge>
+                </div>
+              ))}
+            </div>
+
+            {connectorDryRun ? (
+              <>
+                <div className="mt-4 grid gap-2 md:grid-cols-4">
+                  {[
+                    { label: 'rows received', value: connectorDryRun.rows_received },
+                    { label: 'products detected', value: connectorDryRun.products_detected },
+                    { label: 'variants detected', value: connectorDryRun.variants_detected },
+                    { label: 'blocked rows', value: connectorDryRun.blocked_count },
+                    { label: 'would create', value: connectorDryRun.would_create_count },
+                    { label: 'would update', value: connectorDryRun.would_update_count },
+                    { label: 'would archive', value: connectorDryRun.would_archive_count },
+                    { label: 'warnings', value: connectorDryRun.warning_count },
+                  ].map((item) => (
+                    <div key={item.label} className="rounded-md border border-gx-border p-3">
+                      <div className="text-xs text-gx-muted">{item.label}</div>
+                      <div className="text-sm font-medium text-gx-text">{item.value}</div>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="mt-4 grid gap-2 md:grid-cols-4">
+                  {connectorDryRunControls.map(({ label, value }) => (
+                    <div key={label} className="rounded-md border border-gx-border p-3">
+                      <div className="text-xs text-gx-muted">{label}</div>
+                      <Badge variant={value === true && !label.endsWith('_enabled') ? 'success' : value ? 'danger' : 'success'}>
+                        {value ? 'true' : 'false'}
+                      </Badge>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="mt-4 grid gap-3 md:grid-cols-2">
+                  <div className="rounded-md border border-gx-border p-3">
+                    <div className="text-sm font-medium text-gx-text">Normalized preview</div>
+                    {connectorDryRun.normalized_preview.length ? (
+                      <div className="mt-2 grid gap-2">
+                        {connectorDryRun.normalized_preview.map((item) => (
+                          <div key={item.source_product_ref} className="rounded-md border border-gx-border p-2">
+                            <div className="text-sm font-medium text-gx-text">{item.title}</div>
+                            <div className="mt-1 text-xs text-gx-muted">{item.category_preset}</div>
+                            <div className="mt-2 flex flex-wrap gap-2">
+                              {item.variants.map((variant) => (
+                                <Badge key={variant.sku} variant="default">
+                                  {variant.sku} {variant.price_amount} {variant.currency}
+                                </Badge>
+                              ))}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="mt-2 text-sm text-gx-muted">No normalized preview rows available.</p>
+                    )}
+                  </div>
+                  <div className="rounded-md border border-gx-border p-3">
+                    <div className="text-sm font-medium text-gx-text">Blockers and warnings</div>
+                    <div className="mt-2 grid gap-2">
+                      {connectorDryRun.blockers.map((blocker) => (
+                        <div key={`${blocker.code}-${blocker.row_index ?? 'all'}`} className="text-xs text-gx-warning">
+                          {blocker.code}: {blocker.remediation}
+                        </div>
+                      ))}
+                      {connectorDryRun.warnings.map((warning) => (
+                        <div key={`${warning.code}-${warning.row_index ?? 'all'}`} className="text-xs text-gx-muted">
+                          {warning.code}: {warning.message}
+                        </div>
+                      ))}
+                      {!connectorDryRun.blockers.length && !connectorDryRun.warnings.length ? (
+                        <p className="text-sm text-gx-muted">No blockers or warnings in the latest dry-run.</p>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              </>
+            ) : null}
+
+            <div className="mt-4 grid gap-3 md:grid-cols-2">
+              <div>
+                <label htmlFor="connector-review-note" className="mb-1.5 block text-sm font-medium text-gx-text">
+                  Review request note
+                </label>
+                <textarea
+                  id="connector-review-note"
+                  value={connectorForm.request_note}
+                  onChange={(e) => setConnectorForm({ ...connectorForm, request_note: e.target.value })}
+                  rows={3}
+                  className="w-full rounded-md border border-gx-border bg-gx-bg px-3 py-2 text-sm text-gx-text focus:border-gx-accent focus:outline-none"
+                />
+              </div>
+              <div>
+                <label htmlFor="connector-decision-note" className="mb-1.5 block text-sm font-medium text-gx-text">
+                  Decision note
+                </label>
+                <textarea
+                  id="connector-decision-note"
+                  value={connectorForm.decision_note}
+                  onChange={(e) => setConnectorForm({ ...connectorForm, decision_note: e.target.value })}
+                  rows={3}
+                  className="w-full rounded-md border border-gx-border bg-gx-bg px-3 py-2 text-sm text-gx-text focus:border-gx-accent focus:outline-none"
+                />
+              </div>
+            </div>
+
+            <div className="mt-3 grid gap-3 md:grid-cols-[260px_auto] md:items-end">
+              <label className="text-sm font-medium text-gx-text">
+                Review decision
+                <select
+                  className="mt-1.5 w-full rounded-md border border-gx-border bg-gx-bg px-3 py-2 text-sm text-gx-text focus:border-gx-accent focus:outline-none"
+                  value={connectorForm.decision}
+                  onChange={(e) => setConnectorForm({ ...connectorForm, decision: e.target.value as CommerceConnectorDryRunReviewDecision })}
+                >
+                  <option value="accepted_for_sandbox_followup">accepted_for_sandbox_followup</option>
+                  <option value="needs_changes">needs_changes</option>
+                  <option value="blocked">blocked</option>
+                </select>
+              </label>
+              <Button
+                variant="secondary"
+                onClick={recordConnectorDecision}
+                disabled={connectorDecisionDisabled}
+                title={connectorReview?.status === 'pending_operator_review' ? 'Record sandbox evidence review only.' : 'A pending connector dry-run review is required.'}
+              >
+                {connectorDecisionSubmitting ? 'Recording' : 'Record dry-run review decision'}
+              </Button>
+            </div>
+
+            {connectorReview ? (
+              <div className="mt-4 rounded-md border border-gx-border p-3">
+                <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <div className="text-sm font-medium text-gx-text">Review evidence</div>
+                    <div className="text-xs text-gx-muted">{connectorReview.review_id}</div>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Badge variant={connectorReview.status === 'accepted_for_sandbox_followup' ? 'success' : connectorReview.status === 'pending_operator_review' ? 'warning' : 'danger'}>
+                      {connectorReview.status}
+                    </Badge>
+                    <Badge variant="warning">sandbox evidence only</Badge>
+                  </div>
+                </div>
+                <div className="grid gap-2 md:grid-cols-4">
+                  {connectorReviewControls.map(({ label, value }) => (
+                    <div key={label} className="rounded-md border border-gx-border p-3">
+                      <div className="text-xs text-gx-muted">{label}</div>
+                      <Badge variant={value === true && !label.endsWith('_enabled') && !label.includes('approval') && !label.includes('execution') ? 'success' : value ? 'danger' : 'success'}>
+                        {value ? 'true' : 'false'}
+                      </Badge>
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-3 grid gap-3 text-sm md:grid-cols-4">
+                  <div>
+                    <div className="text-xs text-gx-muted">Requested by</div>
+                    <div className="text-gx-text">{connectorReview.requested_by.kind}</div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-gx-muted">Dry-run status</div>
+                    <div className="text-gx-text">{connectorReview.dry_run_status}</div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-gx-muted">Decision</div>
+                    <div className="text-gx-text">{connectorReview.decision ?? 'none'}</div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-gx-muted">Audit event</div>
+                    <div className="text-gx-text">{connectorReview.audit_event_id ?? connectorReview.requested_audit_event_id}</div>
+                  </div>
+                </div>
+              </div>
+            ) : null}
           </Card>
 
           <Card>

--- a/docs/guides/commerce-v1-merchant-operator-guide.mdx
+++ b/docs/guides/commerce-v1-merchant-operator-guide.mdx
@@ -233,6 +233,26 @@ keys, production config values, concrete allowlist values, checkout URLs,
 payment identifiers, customer data, live-provider claims, launch claims, or
 certification claims into review evidence.
 
+C6Sb adds the credential-free portal foundation for C6R dry-runs and C6Sa
+review evidence. Merchants and operators can use the Commerce onboarding portal
+to paste or select local sandbox manual/CSV catalog rows, run the tenant-scoped
+dry-run, review counts and capped normalized preview rows, request operator
+review, and record a sandbox evidence decision.
+
+The C6Sb portal panel is not production connector setup. It does not include
+credential entry, outbound sync controls, private API URL execution, provider
+setup, live merchant-system execution, public discovery controls,
+checkout/payment controls, live payment controls, live Plural controls, or
+production allowlist controls. It displays fixed safety controls such as
+`credential_entry_enabled: false`, `outbound_sync_enabled: false`,
+`production_connector_setup: false`, and `merchant_private_api_calls: false`.
+
+Operators should treat C6Sb output as internal sandbox evidence only. A passing
+dry-run or `accepted_for_sandbox_followup` review decision is not merchant
+approval, production approval, connector execution approval, public discovery
+approval, checkout/payment approval, live provider approval, public protocol
+publication, or certification.
+
 ## Catalog And Inventory
 
 Catalog and inventory grounding is the first safety step. Agents must not invent

--- a/docs/internal/commerce-v1/commerce-v1-c6sb-connector-dry-run-portal-foundation.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6sb-connector-dry-run-portal-foundation.md
@@ -1,0 +1,148 @@
+# Commerce V1 C6Sb - Credential-Free Connector Dry-Run Portal Foundation
+
+This document is an internal implementation note for the portal UX that sits on
+top of the C6R connector dry-run and C6Sa operator review APIs. C6Sb is
+sandbox-only, non-live, non-publication, non-certifying, and non-enabling.
+
+It does not collect credentials, run outbound sync, create production connector
+setup, call merchant systems, call providers, enable public discovery, enable
+AgenticOrg public commerce discovery, enable production Commerce V1, create
+checkout/payment objects, enable live payments, enable live Plural, set
+production allowlists, or approve launch.
+
+## Traceability Checklist
+
+| Requirement | Files | Tests | Guardrails | Status |
+| --- | --- | --- | --- | --- |
+| Portal API client for C6R/C6Sa routes | `apps/portal/src/api/commerce.ts` | `apps/portal/src/api/__tests__/commerce.test.ts` | Request bodies omit credential, provider, discovery, checkout, payment, and live-enable fields | Implemented |
+| Credential-free portal panel | `apps/portal/src/pages/commerce/CommerceOnboarding.tsx` | `CommerceDashboard.test.tsx` | No credential entry UI, no outbound sync control, no production connector setup | Implemented |
+| Dry-run evidence display | `CommerceOnboarding.tsx` | UI dry-run test | Shows counts, blockers, warnings, capped normalized preview, and non-enabling controls | Implemented |
+| Operator review evidence display | `CommerceOnboarding.tsx` | UI review request/decision test | Review remains sandbox evidence only, not production approval | Implemented |
+| Layman/operator docs | `docs/guides/commerce-v1-merchant-operator-guide.mdx` | Doc review | AgenticOrg boundary and stop conditions remain explicit | Implemented |
+
+## Portal Flow
+
+1. The merchant or operator loads a tenant-scoped sandbox merchant in the
+   Commerce onboarding portal.
+2. The user selects `csv` or `manual` connector type and enters a source label.
+3. The user pastes local sandbox catalog rows as JSON. This is a manual snapshot
+   flow; it is not a live connector and it does not call a merchant system.
+4. The portal calls the C6R dry-run route and displays safe summary counts,
+   fixed controls, blockers, warnings, and capped normalized preview rows.
+5. The user can request C6Sa operator review for the dry-run evidence.
+6. An operator can record a sandbox-only review decision:
+   `accepted_for_sandbox_followup`, `needs_changes`, or `blocked`.
+
+The portal labels the surface as credential-free sandbox evidence. It shows
+explicit controls for:
+
+- `credential_entry_enabled: false`
+- `outbound_sync_enabled: false`
+- `production_connector_setup: false`
+- `merchant_private_api_calls: false`
+
+## API Client Scope
+
+The portal client calls only the existing tenant-scoped C6R/C6Sa APIs:
+
+- `POST /v1/commerce/merchants/{merchantId}/connectors/dry-run`
+- `GET /v1/commerce/merchants/{merchantId}/connectors/dry-runs/{dryRunId}`
+- `POST /v1/commerce/merchants/{merchantId}/connectors/dry-runs/{dryRunId}/review-request`
+- `GET /v1/commerce/merchants/{merchantId}/connectors/dry-runs/{dryRunId}/review`
+- `POST /v1/commerce/merchants/{merchantId}/connectors/dry-runs/{dryRunId}/review/decision`
+
+The dry-run request body includes only:
+
+- connector type;
+- source label;
+- optional source snapshot timestamp;
+- optional preview limit;
+- local rows.
+
+It does not send credentials, secrets, provider metadata, private API URLs,
+public discovery flags, checkout/payment flags, live provider flags, live
+Plural flags, production config values, or allowlists.
+
+## Evidence Display
+
+C6Sb displays redacted evidence already produced by Grantex:
+
+- dry-run status;
+- row, product, variant, would-create, would-update, would-archive, blocker,
+  and warning counts;
+- capped normalized product/variant preview rows;
+- blocker and warning codes;
+- review ID, review status, requester kind, decision, and audit reference;
+- fixed controls showing sandbox-only, not-live, not-approved, public discovery
+  off, checkout/payment off, live provider off, live Plural off, no production
+  allowlist writing, no production approval, and no connector execution
+  approval.
+
+C6Sb does not render or store raw connector files, raw merchant-system
+responses, credentials, private URLs, provider metadata, customer data,
+checkout URLs, payment identifiers, production config values, concrete
+allowlists, or secret material.
+
+## AgenticOrg Boundary
+
+AgenticOrg does not call merchant private APIs directly. This portal panel is a
+Grantex operator/merchant evidence surface only. AgenticOrg continues to consume
+only Grantex-owned preview and buyer discovery payloads after Grantex records
+the required sandbox evidence.
+
+## Stop Conditions
+
+Stop and require a new approved work item if any follow-up:
+
+- adds credential entry, credential upload, secret storage, token storage, or
+  provider credential paths;
+- adds outbound sync, connector execution, worker schedules, background jobs, or
+  merchant private API calls;
+- connects to Shopify, WooCommerce, Magento, custom APIs, ERP, OMS, WMS,
+  logistics, CRM/support, payment providers, Plural, Stripe, Pine, or merchant
+  private APIs;
+- allows AgenticOrg to call merchant private APIs directly;
+- enables Grantex public discovery or AgenticOrg public commerce discovery;
+- enables production Commerce V1, checkout/payment creation, fulfillment,
+  refund execution, live payments, live Plural, or live providers;
+- writes production config or production allowlists;
+- claims production approval, public protocol publication, provider approval,
+  live-payment approval, or certification;
+- treats sandbox, demo, synthetic, fixture, dry-run, review, or rehearsal output
+  as real merchant approval.
+
+## Rollback Notes
+
+C6Sb is portal and docs only. Roll back by removing:
+
+- C6Sb portal API client helpers in `apps/portal/src/api/commerce.ts`;
+- the Connector dry-run review panel in
+  `apps/portal/src/pages/commerce/CommerceOnboarding.tsx`;
+- C6Sb portal/API tests;
+- this internal note and the C6Sb guide section.
+
+No runtime API, route, migration, worker, production config, public discovery,
+checkout/payment, live payment, provider credential, production allowlist,
+cloud resource, or deploy workflow action is created by this slice.
+
+## Validation
+
+Focused validation for C6Sb:
+
+```bash
+npm --prefix apps/auth-service test -- commerce-connector-dry-run-c6r.test.ts commerce-connector-dry-run-review-c6sa.test.ts commerce-openapi.test.ts
+npm --prefix apps/auth-service run typecheck
+npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
+npm --prefix apps/portal run typecheck
+node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
+git diff --check origin/main...HEAD
+```
+
+Focused scans must cover secrets/private details, production config or allowlist
+assignments, public discovery enablement, checkout/payment enablement, live
+payment/live Plural/provider credential enablement, certification claims, direct
+provider calls, direct merchant private API calls, AgenticOrg direct execution,
+and outbound sync enablement.
+
+Expected scan hits should be limited to stop-condition text, denylist regex
+literals, negative assertions, or explicit disabled-control examples.


### PR DESCRIPTION
## Summary
- adds portal API client helpers for C6R connector dry-run and C6Sa review routes
- adds a credential-free Commerce onboarding panel for sandbox connector dry-run evidence, review requests, and sandbox review decisions
- documents C6Sb as internal sandbox evidence only, with no credential entry, outbound sync, production connector setup, public discovery, checkout/payment, live provider, merchant private API, allowlist, or certification behavior

## Validation
- npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
- npm --prefix apps/portal run typecheck
- npm --prefix apps/auth-service test -- commerce-connector-dry-run-c6r.test.ts commerce-connector-dry-run-review-c6sa.test.ts commerce-openapi.test.ts
- npm --prefix apps/auth-service run typecheck
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
- git diff --check origin/main...HEAD
- local portal dev server smoke: HTTP 200 at http://127.0.0.1:5173/dashboard/commerce/onboarding

## Guardrails
- no deploy, cloud command, production config, secret, public discovery, production Commerce V1, checkout/payment creation, live payment, provider call, merchant private API call, production allowlist, or certification claim
- focused scan hits are limited to existing provider/webhook tests, denylist assertions, disabled-control labels, and stop-condition documentation