### PR TITLE
[codex] C6Sd connector dry-run evidence packet review

### DIFF
--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -1423,12 +1423,20 @@ describe('CommerceOnboarding', () => {
     expect(screen.getByText('Redacted evidence handoff')).toBeInTheDocument();
     expect(screen.getByText('internal sandbox only')).toBeInTheDocument();
     expect(screen.getByText('redacted summary')).toBeInTheDocument();
+    expect(screen.getByText('Sandbox follow-up readiness')).toBeInTheDocument();
+    expect(screen.getByText('Evidence packet review checklist')).toBeInTheDocument();
+    expect(screen.getAllByText('needs_operator_review').length).toBeGreaterThan(0);
+    expect(screen.getByText('Operator review requested')).toBeInTheDocument();
+    expect(screen.getByText('Schema: grantex.commerce.connector_dry_run.evidence_packet.v1')).toBeInTheDocument();
     expect(screen.getByText('Evidence JSON preview')).toBeInTheDocument();
     const evidenceJsonPreview = screen.getByText((_content, node) => (
       node?.tagName === 'PRE'
       && node.textContent?.includes('"evidence_type": "connector_dry_run_review_handoff"')
     ) ?? false);
     expect(evidenceJsonPreview).toBeInTheDocument();
+    expect(evidenceJsonPreview.textContent).toContain('"schema_version": "grantex.commerce.connector_dry_run.evidence_packet.v1"');
+    expect(evidenceJsonPreview.textContent).toContain('"packet_status": "needs_operator_review"');
+    expect(evidenceJsonPreview.textContent).toContain('"normalized_product_titles_included": false');
     expect(evidenceJsonPreview.textContent).not.toContain('rows_json');
     expect(evidenceJsonPreview.textContent).not.toContain('Portal Sandbox Fixture Product');
     expect(evidenceJsonPreview.textContent).toContain('"public_discovery_enabled": false');
@@ -1455,6 +1463,13 @@ describe('CommerceOnboarding', () => {
       decisionNote: 'Sandbox follow-up only.',
     }));
     expect(screen.getAllByText('caud_C6SB_DECISION').length).toBeGreaterThan(0);
+    await waitFor(() => expect(screen.getAllByText('ready_for_sandbox_followup').length).toBeGreaterThan(0));
+    const acceptedEvidenceJsonPreview = screen.getByText((_content, node) => (
+      node?.tagName === 'PRE'
+      && node.textContent?.includes('"packet_status": "ready_for_sandbox_followup"')
+    ) ?? false);
+    expect(acceptedEvidenceJsonPreview.textContent).toContain('"review_decision_audit_event_id": "caud_C6SB_DECISION"');
+    expect(acceptedEvidenceJsonPreview.textContent).not.toContain('Portal Sandbox Fixture Product');
     expect(screen.queryByText('production connector setup enabled')).not.toBeInTheDocument();
     anchorClick.mockRestore();
   });

--- a/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
+++ b/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
@@ -126,6 +126,18 @@ interface ConnectorRowsValidation {
   warnings: string[];
 }
 
+type ConnectorEvidencePacketCheckStatus = 'pass' | 'pending' | 'blocked';
+type ConnectorEvidencePacketStatus = 'ready_for_sandbox_followup' | 'needs_operator_review' | 'blocked';
+
+interface ConnectorEvidencePacketCheck {
+  key: string;
+  label: string;
+  status: ConnectorEvidencePacketCheckStatus;
+  detail: string;
+}
+
+const connectorEvidencePacketSchemaVersion = 'grantex.commerce.connector_dry_run.evidence_packet.v1';
+
 const connectorRowsPrivateFieldFragments = [
   'credential',
   'secret',
@@ -273,17 +285,178 @@ function connectorReviewSafeControls(review: CommerceConnectorDryRunReview | nul
   };
 }
 
+function packetCheck(
+  key: string,
+  label: string,
+  status: ConnectorEvidencePacketCheckStatus,
+  detail: string,
+): ConnectorEvidencePacketCheck {
+  return { key, label, status, detail };
+}
+
+function packetStatusVariant(status: ConnectorEvidencePacketCheckStatus | ConnectorEvidencePacketStatus): 'default' | 'success' | 'warning' | 'danger' {
+  if (status === 'pass' || status === 'ready_for_sandbox_followup') return 'success';
+  if (status === 'blocked') return 'danger';
+  return 'warning';
+}
+
+function buildConnectorEvidencePacketReview(
+  dryRun: CommerceConnectorDryRunResult,
+  review: CommerceConnectorDryRunReview | null,
+) {
+  const dryRunControls = connectorDryRunSafeControls(dryRun);
+  const reviewControls = connectorReviewSafeControls(review);
+  const disabledControlChecks = [
+    packetCheck(
+      'public_discovery_disabled',
+      'Public discovery disabled',
+      dryRunControls.public_discovery_enabled === false && reviewControls.public_discovery_enabled === false ? 'pass' : 'blocked',
+      'Evidence packet must not enable Grantex or AgenticOrg public commerce discovery.',
+    ),
+    packetCheck(
+      'checkout_payment_disabled',
+      'Checkout/payment disabled',
+      dryRunControls.checkout_payment_enabled === false && reviewControls.checkout_payment_enabled === false ? 'pass' : 'blocked',
+      'Evidence packet must not enable checkout/payment creation.',
+    ),
+    packetCheck(
+      'live_provider_disabled',
+      'Live provider disabled',
+      dryRunControls.live_provider_enabled === false && reviewControls.live_provider_enabled === false ? 'pass' : 'blocked',
+      'Evidence packet must not enable live providers or live Plural.',
+    ),
+    packetCheck(
+      'production_allowlist_not_written',
+      'Production allowlist not written',
+      dryRunControls.production_allowlist_written === false && reviewControls.production_allowlist_written === false ? 'pass' : 'blocked',
+      'Evidence packet must not write production allowlists.',
+    ),
+    packetCheck(
+      'connector_execution_not_approved',
+      'Connector execution not approved',
+      dryRunControls.outbound_sync_enabled === false
+        && dryRunControls.production_connector_setup === false
+        && dryRunControls.merchant_private_api_calls === false
+        && reviewControls.review_enables_connector_execution === false
+        ? 'pass'
+        : 'blocked',
+      'Evidence packet remains review-only and does not approve outbound sync or merchant private API execution.',
+    ),
+  ];
+
+  const checklist: ConnectorEvidencePacketCheck[] = [
+    packetCheck(
+      'schema_version_declared',
+      'Schema version declared',
+      'pass',
+      `${connectorEvidencePacketSchemaVersion} is attached to the local evidence packet.`,
+    ),
+    packetCheck(
+      'dry_run_passed',
+      'Dry-run passed',
+      dryRun.status === 'passed' ? 'pass' : 'blocked',
+      dryRun.status === 'passed' ? 'C6R dry-run passed.' : 'C6R dry-run is blocked.',
+    ),
+    packetCheck(
+      'dry_run_blockers_clear',
+      'Dry-run blockers clear',
+      dryRun.blockers.length === 0 ? 'pass' : 'blocked',
+      dryRun.blockers.length === 0 ? 'No dry-run blockers are present.' : `${dryRun.blockers.length} blocker(s) require remediation.`,
+    ),
+    packetCheck(
+      'dry_run_warnings_reviewed',
+      'Dry-run warnings reviewed',
+      dryRun.warnings.length === 0 ? 'pass' : 'pending',
+      dryRun.warnings.length === 0 ? 'No dry-run warnings are present.' : `${dryRun.warnings.length} warning(s) need operator review before sandbox follow-up.`,
+    ),
+    packetCheck(
+      'operator_review_requested',
+      'Operator review requested',
+      review ? 'pass' : 'pending',
+      review ? 'C6Sa review evidence exists.' : 'Request C6Sa operator review before sandbox follow-up readiness.',
+    ),
+    packetCheck(
+      'operator_review_accepted',
+      'Operator review accepted',
+      review?.status === 'accepted_for_sandbox_followup'
+        ? 'pass'
+        : review?.status === 'needs_changes' || review?.status === 'blocked'
+          ? 'blocked'
+          : 'pending',
+      review?.status === 'accepted_for_sandbox_followup'
+        ? 'Operator accepted this packet for sandbox follow-up only.'
+        : review
+          ? `Current review status is ${review.status}.`
+          : 'No operator decision has been recorded.',
+    ),
+    packetCheck(
+      'review_not_production_approval',
+      'Review is not production approval',
+      reviewControls.review_is_production_approval === false ? 'pass' : 'blocked',
+      'C6Sa decision must remain sandbox evidence only.',
+    ),
+    ...disabledControlChecks,
+    packetCheck(
+      'redaction_summary_attached',
+      'Redaction summary attached',
+      'pass',
+      'Packet excludes raw rows, normalized product titles, credentials, provider metadata, private URLs, checkout/payment artifacts, production config, allowlists, and customer data.',
+    ),
+  ];
+
+  const blocked = checklist.filter((check) => check.status === 'blocked');
+  const pending = checklist.filter((check) => check.status === 'pending');
+  const packetStatus: ConnectorEvidencePacketStatus = blocked.length
+    ? 'blocked'
+    : pending.length
+      ? 'needs_operator_review'
+      : 'ready_for_sandbox_followup';
+
+  return {
+    schema_version: connectorEvidencePacketSchemaVersion,
+    packet_status: packetStatus,
+    summary: packetStatus === 'ready_for_sandbox_followup'
+      ? 'Ready for sandbox follow-up review work only; not production launch or connector execution.'
+      : packetStatus === 'blocked'
+        ? 'Blocked for sandbox follow-up until packet blockers are remediated.'
+        : 'Needs operator review before sandbox follow-up readiness.',
+    checklist,
+    blocker_summary: blocked.map((check) => `${check.label}: ${check.detail}`),
+    pending_summary: pending.map((check) => `${check.label}: ${check.detail}`),
+    redaction_summary: {
+      raw_rows_included: false,
+      normalized_product_titles_included: false,
+      credentials_included: false,
+      provider_metadata_included: false,
+      private_api_urls_included: false,
+      checkout_payment_artifacts_included: false,
+      production_config_values_included: false,
+      concrete_allowlists_included: false,
+      customer_data_included: false,
+    },
+    audit_references: {
+      dry_run_requested_audit_event_id: dryRun.requested_audit_event_id,
+      dry_run_completed_or_blocked_audit_event_id: dryRun.audit_event_id,
+      review_requested_audit_event_id: review?.requested_audit_event_id ?? null,
+      review_decision_audit_event_id: review?.audit_event_id ?? null,
+    },
+  };
+}
+
 function buildConnectorEvidenceExport(
   merchantId: string,
   dryRun: CommerceConnectorDryRunResult,
   review: CommerceConnectorDryRunReview | null,
 ) {
+  const packetReview = buildConnectorEvidencePacketReview(dryRun, review);
   return {
     evidence_type: 'connector_dry_run_review_handoff',
+    schema_version: connectorEvidencePacketSchemaVersion,
     export_scope: 'internal_sandbox_preview_only',
     generated_by: 'grantex_portal_client',
     generated_at: 'client_side_on_demand',
     merchant_id: merchantId,
+    packet_review: packetReview,
     posture: {
       sandbox_only: true,
       not_live: true,
@@ -362,16 +535,21 @@ function formatMarkdownList(values: string[]): string {
 function buildConnectorEvidenceMarkdown(evidence: ReturnType<typeof buildConnectorEvidenceExport>): string {
   const blockers = evidence.dry_run.blockers.map((blocker) => `${blocker.code}: ${blocker.remediation}`);
   const warnings = evidence.dry_run.warnings.map((warning) => `${warning.code}: ${warning.message}`);
+  const packetChecklist = evidence.packet_review.checklist.map((check) => `${check.status} - ${check.label}: ${check.detail}`);
+  const redactionSummary = Object.entries(evidence.packet_review.redaction_summary).map(([key, value]) => `${key}: ${value}`);
   return [
     '# Connector Dry-Run Evidence Handoff',
     '',
     'Internal sandbox preview only. This is not public protocol publication, production approval, connector execution approval, checkout/payment approval, live-provider approval, or certification.',
     '',
+    `- Schema version: ${evidence.schema_version}`,
     `- Merchant ID: ${evidence.merchant_id}`,
     `- Dry-run ID: ${evidence.dry_run.dry_run_id}`,
     `- Dry-run status: ${evidence.dry_run.status}`,
     `- Review ID: ${evidence.review?.review_id ?? 'not_requested'}`,
     `- Review status: ${evidence.review?.status ?? 'not_requested'}`,
+    `- Packet status: ${evidence.packet_review.packet_status}`,
+    `- Packet summary: ${evidence.packet_review.summary}`,
     `- Rows received: ${evidence.dry_run.counts.rows_received}`,
     `- Products detected: ${evidence.dry_run.counts.products_detected}`,
     `- Variants detected: ${evidence.dry_run.counts.variants_detected}`,
@@ -394,6 +572,18 @@ function buildConnectorEvidenceMarkdown(evidence: ReturnType<typeof buildConnect
     `- production_allowlist_written: ${evidence.posture.production_allowlist_written}`,
     `- certification_claimed: ${evidence.posture.certification_claimed}`,
     '',
+    '## Operator Packet Review Checklist',
+    '',
+    formatMarkdownList(packetChecklist),
+    '',
+    '## Packet Blockers',
+    '',
+    formatMarkdownList(evidence.packet_review.blocker_summary),
+    '',
+    '## Packet Pending Items',
+    '',
+    formatMarkdownList(evidence.packet_review.pending_summary),
+    '',
     '## Blockers',
     '',
     formatMarkdownList(blockers),
@@ -408,6 +598,10 @@ function buildConnectorEvidenceMarkdown(evidence: ReturnType<typeof buildConnect
     `- Dry-run completed/blocked audit: ${evidence.dry_run.audit_references.completed_or_blocked_audit_event_id}`,
     `- Review requested audit: ${evidence.review?.audit_references.requested_audit_event_id ?? 'not_requested'}`,
     `- Review decision audit: ${evidence.review?.audit_references.decision_audit_event_id ?? 'not_recorded'}`,
+    '',
+    '## Redaction Summary',
+    '',
+    formatMarkdownList(redactionSummary),
     '',
     '## Redaction',
     '',
@@ -1948,6 +2142,34 @@ export function CommerceOnboarding() {
                   </div>
                 </div>
 
+                <div className="rounded-md border border-gx-border p-3">
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <div>
+                      <div className="text-sm font-medium text-gx-text">Sandbox follow-up readiness</div>
+                      <div className="mt-1 text-xs text-gx-muted">{connectorEvidence.packet_review.summary}</div>
+                    </div>
+                    <Badge variant={packetStatusVariant(connectorEvidence.packet_review.packet_status)}>
+                      {connectorEvidence.packet_review.packet_status}
+                    </Badge>
+                  </div>
+                  <div className="mt-2 text-xs text-gx-muted">Schema: {connectorEvidence.packet_review.schema_version}</div>
+                </div>
+
+                <div className="mt-3 rounded-md border border-gx-border p-3">
+                  <div className="text-sm font-medium text-gx-text">Evidence packet review checklist</div>
+                  <div className="mt-2 grid gap-2 md:grid-cols-2">
+                    {connectorEvidence.packet_review.checklist.map((check) => (
+                      <div key={check.key} className="rounded-md border border-gx-border p-2">
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <div className="text-xs font-medium text-gx-text">{check.label}</div>
+                          <Badge variant={packetStatusVariant(check.status)}>{check.status}</Badge>
+                        </div>
+                        <div className="mt-1 text-xs text-gx-muted">{check.detail}</div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
                 <div className="grid gap-2 md:grid-cols-4">
                   {[
                     { label: 'dry_run_id', value: connectorEvidence.dry_run.dry_run_id },
@@ -1971,6 +2193,18 @@ export function CommerceOnboarding() {
                       </Badge>
                     </div>
                   ))}
+                </div>
+
+                <div className="mt-3 rounded-md border border-gx-border p-3">
+                  <div className="text-sm font-medium text-gx-text">Redaction summary</div>
+                  <div className="mt-2 grid gap-2 md:grid-cols-3">
+                    {Object.entries(connectorEvidence.packet_review.redaction_summary).map(([label, value]) => (
+                      <div key={label} className="rounded-md border border-gx-border p-2">
+                        <div className="text-xs text-gx-muted">{label}</div>
+                        <Badge variant={value ? 'danger' : 'success'}>{String(value)}</Badge>
+                      </div>
+                    ))}
+                  </div>
                 </div>
 
                 <div className="mt-3 flex flex-wrap items-center gap-2">

--- a/docs/guides/commerce-v1-merchant-operator-guide.mdx
+++ b/docs/guides/commerce-v1-merchant-operator-guide.mdx
@@ -273,6 +273,24 @@ or downloaded handoff does not approve production launch, connector execution,
 public discovery, checkout/payment, live providers, public protocol
 publication, or certification.
 
+C6Sd adds a local evidence packet schema and operator packet review checklist
+to the C6Sc handoff. The packet includes a Grantex-owned schema version,
+checklist result, sandbox follow-up readiness summary, redaction summary, and
+audit references. The packet status can be `ready_for_sandbox_followup`,
+`needs_operator_review`, or `blocked`.
+
+`ready_for_sandbox_followup` means only that sandbox follow-up review work can
+continue after a passed dry-run, accepted C6Sa review, clear blockers, and fixed
+non-enabling controls. It is not production approval, connector execution
+approval, outbound sync approval, public discovery approval, checkout/payment
+approval, live provider approval, public protocol publication, or
+certification.
+
+C6Sd evidence packets remain local/internal review artifacts. They must not
+contain raw rows, normalized product titles, credentials, tokens, provider
+metadata, private API URLs, checkout URLs, payment identifiers, production
+config values, concrete allowlists, customer data, or secret material.
+
 ## Catalog And Inventory
 
 Catalog and inventory grounding is the first safety step. Agents must not invent

--- a/docs/internal/commerce-v1/commerce-v1-c6sd-connector-dry-run-evidence-packet-review.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6sd-connector-dry-run-evidence-packet-review.md
@@ -1,0 +1,150 @@
+# Commerce V1 C6Sd - Connector Dry-Run Evidence Packet Review
+
+C6Sd hardens the self-serve connector dry-run evidence packet that was added in
+C6Sc. It is portal, docs, and test work only. It remains internal preview,
+sandbox-only, non-live, non-publication, non-certifying, and non-enabling.
+
+C6Sd does not add backend routes, migrations, workflows, workers, credentials,
+outbound sync, production connector setup, public discovery, checkout/payment
+behavior, live payment behavior, provider calls, merchant private API calls,
+production allowlists, or certification claims.
+
+## Traceability Checklist
+
+| Requirement | Files | Tests | Guardrails | Status |
+| --- | --- | --- | --- | --- |
+| Evidence packet schema/version | `apps/portal/src/pages/commerce/CommerceOnboarding.tsx` | `CommerceDashboard.test.tsx` | Local packet schema only; no API contract or runtime route added | Implemented |
+| Operator packet review checklist | `CommerceOnboarding.tsx` | `CommerceDashboard.test.tsx` | Checklist is sandbox evidence review only | Implemented |
+| Sandbox follow-up readiness summary | `CommerceOnboarding.tsx` | `CommerceDashboard.test.tsx` | Ready means sandbox follow-up only, not launch or connector execution | Implemented |
+| Hardened JSON/Markdown export | `CommerceOnboarding.tsx` | `CommerceDashboard.test.tsx` | Excludes raw rows, normalized product titles, credentials, private URLs, provider metadata, checkout/payment artifacts, production config, allowlists, and customer data | Implemented |
+| Operator docs | This doc and merchant/operator guide | Doc review | Stop conditions, rollback, and retention remain explicit | Implemented |
+
+## Packet Schema
+
+Every C6Sd export carries the local schema version:
+
+`grantex.commerce.connector_dry_run.evidence_packet.v1`
+
+This schema is a Grantex portal evidence packet shape. It is not a public
+protocol schema, public publication artifact, provider approval, live-payment
+approval, or certification claim.
+
+## Packet Review Checklist
+
+The portal generates a local review checklist from already-returned C6R and
+C6Sa response summaries. The checklist covers:
+
+- schema version declaration;
+- dry-run passed status;
+- clear dry-run blockers;
+- dry-run warning review state;
+- C6Sa review request presence;
+- accepted sandbox-follow-up decision;
+- confirmation that the review is not production approval;
+- disabled public discovery, checkout/payment, live provider, live Plural,
+  production allowlist, outbound sync, production connector setup, and merchant
+  private API execution controls;
+- redaction summary presence.
+
+The checklist has three statuses: `pass`, `pending`, and `blocked`.
+
+## Sandbox Follow-Up Readiness
+
+The packet readiness summary has three values:
+
+- `ready_for_sandbox_followup`: dry-run passed, no blockers/warnings, C6Sa
+  review accepted for sandbox follow-up, and all non-enabling controls remain
+  disabled.
+- `needs_operator_review`: no blockers are present, but operator review or
+  warning review remains pending.
+- `blocked`: dry-run blockers, unsafe review status, or enabling controls are
+  present.
+
+`ready_for_sandbox_followup` does not mean production approval, production
+connector setup, outbound sync approval, public discovery approval,
+checkout/payment approval, live provider approval, public protocol publication,
+or certification.
+
+## Evidence Export Contents
+
+C6Sd JSON and Markdown exports include:
+
+- schema version;
+- packet status and summary;
+- operator packet review checklist;
+- packet blocker and pending summaries;
+- dry-run status and safe summary counts;
+- review status and safe review summary when present;
+- fixed non-enabling controls;
+- redaction summary;
+- requested/completed/review audit references.
+
+Exports exclude raw rows, raw files, raw merchant-system responses, normalized
+product titles, credentials, tokens, provider metadata, private API URLs,
+checkout URLs, payment identifiers, production config values, concrete
+allowlists, customer data, and secret material.
+
+## Evidence Retention
+
+Keep C6Sd exports in a local internal review directory only when a reviewer
+needs a packet. Delete temporary exports after review unless retention is
+explicitly required by an internal evidence process.
+
+Do not commit timestamped or merchant-specific exports unless a later approved
+work item says so.
+
+## Stop Conditions
+
+Stop and require a new approved work item if any follow-up:
+
+- adds credential entry, credential upload, secret storage, token storage, or
+  provider credential paths;
+- adds outbound sync, connector execution, worker schedules, background jobs, or
+  merchant private API calls;
+- connects to Shopify, WooCommerce, Magento, custom APIs, ERP, OMS, WMS,
+  logistics, CRM/support, payment providers, Plural, Stripe, Pine, or merchant
+  private APIs;
+- allows AgenticOrg to call merchant private APIs directly;
+- enables Grantex public discovery or AgenticOrg public commerce discovery;
+- enables production Commerce V1, checkout/payment creation, fulfillment,
+  refund execution, live payments, live Plural, or live providers;
+- writes production config or production allowlists;
+- claims production approval, public protocol publication, provider approval,
+  live-payment approval, or certification;
+- treats sandbox, demo, synthetic, fixture, dry-run, review, packet, export, or
+  rehearsal output as real merchant approval.
+
+## Rollback Notes
+
+C6Sd is portal/docs/test only. Roll back by removing:
+
+- the local packet schema, checklist, readiness summary, redaction summary, and
+  export additions in `CommerceOnboarding.tsx`;
+- the related `CommerceDashboard.test.tsx` assertions;
+- this internal note and the C6Sd guide section.
+
+No runtime API, route, migration, worker, production config, public discovery,
+checkout/payment, live payment, provider credential, production allowlist,
+cloud resource, or deploy workflow action is created by this slice.
+
+## Validation
+
+Focused validation for C6Sd:
+
+```bash
+npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
+npm --prefix apps/portal run typecheck
+npm --prefix apps/auth-service test -- commerce-connector-dry-run-c6r.test.ts commerce-connector-dry-run-review-c6sa.test.ts commerce-openapi.test.ts
+npm --prefix apps/auth-service run typecheck
+node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
+git diff --check origin/main...HEAD
+```
+
+Focused scans must cover secrets/private details, production config or allowlist
+assignments, public discovery enablement, checkout/payment enablement, live
+payment/live Plural/provider credential enablement, certification claims, direct
+provider calls, direct merchant private API calls, AgenticOrg direct execution,
+and outbound sync enablement.
+
+Expected scan hits should be limited to stop-condition text, denylist regex
+literals, negative assertions, or explicit disabled-control examples.


### PR DESCRIPTION
## Summary
- Add a local C6Sd evidence packet schema/version to the C6Sc connector dry-run handoff.
- Add an operator packet review checklist and sandbox-follow-up readiness verdict for dry-run evidence.
- Harden JSON/Markdown handoff exports with packet status, redaction summary, packet blockers/pending items, and audit references.
- Update merchant/operator and internal docs with C6Sd usage, stop conditions, rollback notes, and retention guidance.

## Safety
- Portal/docs/test only: no backend routes, migrations, workflows, workers, production config, secrets, credentials, outbound sync, production connector setup, provider calls, merchant private API calls, public discovery, checkout/payment creation, live payments, live Plural, production allowlists, or certification claims.
- Packet readiness means sandbox follow-up only; it is not production approval, connector execution approval, launch approval, public protocol publication, or certification.
- Exports exclude raw rows, normalized product titles, credentials, provider metadata, private API URLs, checkout/payment artifacts, production config values, concrete allowlists, customer data, and secret material.

## Validation
- npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
- npm --prefix apps/portal run typecheck
- npm --prefix apps/auth-service test -- commerce-connector-dry-run-c6r.test.ts commerce-connector-dry-run-review-c6sa.test.ts commerce-openapi.test.ts
- npm --prefix apps/auth-service run typecheck
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
- git diff --check origin/main...HEAD
- Focused added-line guardrail scans for secrets/private details, production config/allowlists, public discovery, checkout/payment enablement, live payment/live provider credentials, certification claims, provider calls, merchant private API calls, AgenticOrg direct execution, outbound sync, and true-valued enablement flags