### PR TITLE
[codex] C6Se connector dry-run handoff remediation workflow

### DIFF
--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -822,6 +822,16 @@ const connectorReviewAccepted = {
   decided_at: '2026-01-01T00:42:00Z',
 };
 
+const connectorReviewNeedsChanges = {
+  ...connectorReview,
+  status: 'needs_changes' as const,
+  decision: 'needs_changes' as const,
+  decision_note: 'Fix category mapping and rerun the local sandbox dry-run.',
+  decided_by_operator_id: 'dev_TEST',
+  audit_event_id: 'caud_C6SB_NEEDS_CHANGES',
+  decided_at: '2026-01-01T00:43:00Z',
+};
+
 const credential = {
   id: 'cpcred_1',
   tenant_id: 'cten_1',
@@ -1424,9 +1434,13 @@ describe('CommerceOnboarding', () => {
     expect(screen.getByText('internal sandbox only')).toBeInTheDocument();
     expect(screen.getByText('redacted summary')).toBeInTheDocument();
     expect(screen.getByText('Sandbox follow-up readiness')).toBeInTheDocument();
+    expect(screen.getByText('Operator sandbox handoff')).toBeInTheDocument();
+    expect(screen.getByText('Self-serve remediation workflow')).toBeInTheDocument();
     expect(screen.getByText('Evidence packet review checklist')).toBeInTheDocument();
     expect(screen.getAllByText('needs_operator_review').length).toBeGreaterThan(0);
-    expect(screen.getByText('Operator review requested')).toBeInTheDocument();
+    expect(screen.getAllByText('merchant_or_operator').length).toBeGreaterThan(0);
+    expect(screen.getByText('Request operator review')).toBeInTheDocument();
+    expect(screen.getAllByText('Operator review requested').length).toBeGreaterThan(0);
     expect(screen.getByText('Schema: grantex.commerce.connector_dry_run.evidence_packet.v1')).toBeInTheDocument();
     expect(screen.getByText('Evidence JSON preview')).toBeInTheDocument();
     const evidenceJsonPreview = screen.getByText((_content, node) => (
@@ -1436,6 +1450,10 @@ describe('CommerceOnboarding', () => {
     expect(evidenceJsonPreview).toBeInTheDocument();
     expect(evidenceJsonPreview.textContent).toContain('"schema_version": "grantex.commerce.connector_dry_run.evidence_packet.v1"');
     expect(evidenceJsonPreview.textContent).toContain('"packet_status": "needs_operator_review"');
+    expect(evidenceJsonPreview.textContent).toContain('"operator_handoff"');
+    expect(evidenceJsonPreview.textContent).toContain('"handoff_status": "needs_operator_review"');
+    expect(evidenceJsonPreview.textContent).toContain('"remediation_workflow"');
+    expect(evidenceJsonPreview.textContent).toContain('"workflow_status": "pending_operator_review"');
     expect(evidenceJsonPreview.textContent).toContain('"normalized_product_titles_included": false');
     expect(evidenceJsonPreview.textContent).not.toContain('rows_json');
     expect(evidenceJsonPreview.textContent).not.toContain('Portal Sandbox Fixture Product');
@@ -1469,9 +1487,62 @@ describe('CommerceOnboarding', () => {
       && node.textContent?.includes('"packet_status": "ready_for_sandbox_followup"')
     ) ?? false);
     expect(acceptedEvidenceJsonPreview.textContent).toContain('"review_decision_audit_event_id": "caud_C6SB_DECISION"');
+    expect(acceptedEvidenceJsonPreview.textContent).toContain('"handoff_status": "ready"');
+    expect(acceptedEvidenceJsonPreview.textContent).toContain('"workflow_status": "complete"');
+    expect(acceptedEvidenceJsonPreview.textContent).toContain('"blocked_next_steps"');
     expect(acceptedEvidenceJsonPreview.textContent).not.toContain('Portal Sandbox Fixture Product');
+    expect(screen.getByText('Review the redacted evidence packet with the merchant in a sandbox-only follow-up.')).toBeInTheDocument();
+    expect(screen.getByText('No remediation actions remain before sandbox follow-up.')).toBeInTheDocument();
     expect(screen.queryByText('production connector setup enabled')).not.toBeInTheDocument();
     anchorClick.mockRestore();
+  });
+
+  it('renders self-serve remediation for needs-changes connector dry-run decisions', async () => {
+    mockRecordCommerceConnectorDryRunReviewDecision.mockResolvedValueOnce({
+      data: connectorReviewNeedsChanges,
+      dry_run: connectorDryRun,
+      audit_event_id: 'caud_C6SB_NEEDS_CHANGES',
+    });
+    const user = userEvent.setup();
+    r(<CommerceOnboarding />);
+
+    await user.type(screen.getByLabelText('Merchant ID'), 'mch_1');
+    await user.click(screen.getByRole('button', { name: 'Load onboarding' }));
+    await waitFor(() => expect(screen.getByText('Connector dry-run review')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: 'Run connector dry-run' }));
+    await waitFor(() => expect(mockRunCommerceConnectorDryRun).toHaveBeenCalled());
+    await user.type(screen.getByLabelText('Review request note'), 'Public-safe sandbox evidence.');
+    await user.click(screen.getByRole('button', { name: 'Request dry-run review' }));
+    await waitFor(() => expect(mockRequestCommerceConnectorDryRunReview).toHaveBeenCalled());
+
+    await user.selectOptions(screen.getByLabelText('Review decision'), 'needs_changes');
+    await user.type(screen.getByLabelText('Decision note'), 'Fix category mapping and rerun the local sandbox dry-run.');
+    await user.click(screen.getByRole('button', { name: 'Record dry-run review decision' }));
+    await waitFor(() => expect(mockRecordCommerceConnectorDryRunReviewDecision).toHaveBeenCalledWith('mch_1', 'cdry_C6SB', {
+      decision: 'needs_changes',
+      decisionNote: 'Fix category mapping and rerun the local sandbox dry-run.',
+    }));
+
+    expect(screen.getByText('Operator requested changes')).toBeInTheDocument();
+    expect(screen.getAllByText('blocked').length).toBeGreaterThan(0);
+    expect(screen.getAllByText((_content, node) => (
+      node?.textContent?.includes('Owner: merchant') ?? false
+    )).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Fix category mapping and rerun the local sandbox dry-run.').length).toBeGreaterThan(0);
+    const remediationEvidenceJsonPreview = screen.getByText((_content, node) => (
+      node?.tagName === 'PRE'
+      && node.textContent?.includes('"workflow_status": "blocked"')
+    ) ?? false);
+    expect(remediationEvidenceJsonPreview.textContent).toContain('"handoff_status": "blocked"');
+    expect(remediationEvidenceJsonPreview.textContent).toContain('"requires_rerun": true');
+    expect(remediationEvidenceJsonPreview.textContent).toContain('"operator_requested_changes"');
+    expect(remediationEvidenceJsonPreview.textContent).toContain('"production_approval": false');
+    expect(remediationEvidenceJsonPreview.textContent).toContain('"public_discovery_approval": false');
+    expect(remediationEvidenceJsonPreview.textContent).not.toContain('rows_json');
+    expect(remediationEvidenceJsonPreview.textContent).not.toContain('Portal Sandbox Fixture Product');
+    expect(screen.queryByRole('textbox', { name: 'Credential' })).not.toBeInTheDocument();
+    expect(screen.queryByText('outbound connector sync enabled')).not.toBeInTheDocument();
   });
 
   it('validates, clears, and resets connector rows before dry-run submission', async () => {

--- a/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
+++ b/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
@@ -128,12 +128,24 @@ interface ConnectorRowsValidation {
 
 type ConnectorEvidencePacketCheckStatus = 'pass' | 'pending' | 'blocked';
 type ConnectorEvidencePacketStatus = 'ready_for_sandbox_followup' | 'needs_operator_review' | 'blocked';
+type ConnectorOperatorHandoffStatus = 'ready' | 'needs_operator_review' | 'blocked';
+type ConnectorRemediationWorkflowStatus = 'complete' | 'pending_operator_review' | 'blocked';
+type ConnectorRemediationStepStatus = 'complete' | 'pending' | 'blocked';
 
 interface ConnectorEvidencePacketCheck {
   key: string;
   label: string;
   status: ConnectorEvidencePacketCheckStatus;
   detail: string;
+}
+
+interface ConnectorRemediationStep {
+  key: string;
+  label: string;
+  status: ConnectorRemediationStepStatus;
+  owner: 'merchant' | 'operator' | 'grantex';
+  action: string;
+  evidence_source: string;
 }
 
 const connectorEvidencePacketSchemaVersion = 'grantex.commerce.connector_dry_run.evidence_packet.v1';
@@ -300,6 +312,18 @@ function packetStatusVariant(status: ConnectorEvidencePacketCheckStatus | Connec
   return 'warning';
 }
 
+function handoffStatusVariant(status: ConnectorOperatorHandoffStatus): 'default' | 'success' | 'warning' | 'danger' {
+  if (status === 'ready') return 'success';
+  if (status === 'blocked') return 'danger';
+  return 'warning';
+}
+
+function remediationStatusVariant(status: ConnectorRemediationWorkflowStatus | ConnectorRemediationStepStatus): 'default' | 'success' | 'warning' | 'danger' {
+  if (status === 'complete') return 'success';
+  if (status === 'blocked') return 'danger';
+  return 'warning';
+}
+
 function buildConnectorEvidencePacketReview(
   dryRun: CommerceConnectorDryRunResult,
   review: CommerceConnectorDryRunReview | null,
@@ -443,12 +467,192 @@ function buildConnectorEvidencePacketReview(
   };
 }
 
+function buildConnectorOperatorHandoff(
+  dryRun: CommerceConnectorDryRunResult,
+  review: CommerceConnectorDryRunReview | null,
+  packetReview: ReturnType<typeof buildConnectorEvidencePacketReview>,
+) {
+  const handoffStatus: ConnectorOperatorHandoffStatus = packetReview.packet_status === 'ready_for_sandbox_followup'
+    ? 'ready'
+    : packetReview.packet_status === 'blocked'
+      ? 'blocked'
+      : 'needs_operator_review';
+  return {
+    handoff_type: 'sandbox_connector_dry_run_followup',
+    handoff_status: handoffStatus,
+    summary: handoffStatus === 'ready'
+      ? 'Ready for operator sandbox follow-up only; this is not approval to execute connectors or launch commerce.'
+      : handoffStatus === 'blocked'
+        ? 'Blocked until the dry-run, review, or packet evidence issues below are remediated.'
+        : 'Needs C6Sa operator review before sandbox follow-up handoff.',
+    next_actor: handoffStatus === 'ready' ? 'operator' : 'merchant_or_operator',
+    packet_status: packetReview.packet_status,
+    dry_run_id: dryRun.dry_run_id,
+    review_id: review?.review_id ?? null,
+    allowed_next_steps: handoffStatus === 'ready'
+      ? [
+        'Review the redacted evidence packet with the merchant in a sandbox-only follow-up.',
+        'Plan another local dry-run using sanitized manual or CSV rows if more catalog evidence is needed.',
+      ]
+      : [],
+    blocked_next_steps: [
+      'production_merchant_approval',
+      'outbound_connector_sync',
+      'merchant_private_api_execution',
+      'public_discovery_enablement',
+      'checkout_payment_creation',
+      'live_payment_or_provider_enablement',
+      'production_allowlist_assignment',
+      'public_protocol_publication_or_certification',
+    ],
+    non_approval: {
+      production_approval: false,
+      connector_execution_approval: false,
+      public_discovery_approval: false,
+      checkout_payment_approval: false,
+      live_provider_approval: false,
+      public_protocol_publication: false,
+      certification: false,
+    },
+    audit_references: packetReview.audit_references,
+  };
+}
+
+function remediationStep(
+  key: string,
+  label: string,
+  status: ConnectorRemediationStepStatus,
+  owner: ConnectorRemediationStep['owner'],
+  action: string,
+  evidenceSource: string,
+): ConnectorRemediationStep {
+  return {
+    key,
+    label,
+    status,
+    owner,
+    action,
+    evidence_source: evidenceSource,
+  };
+}
+
+function buildConnectorRemediationWorkflow(
+  dryRun: CommerceConnectorDryRunResult,
+  review: CommerceConnectorDryRunReview | null,
+  packetReview: ReturnType<typeof buildConnectorEvidencePacketReview>,
+) {
+  const steps: ConnectorRemediationStep[] = [];
+
+  dryRun.blockers.forEach((blocker, index) => {
+    steps.push(remediationStep(
+      `dry_run_blocker_${index}_${blocker.code}`,
+      `Dry-run blocker: ${blocker.code}`,
+      'blocked',
+      'merchant',
+      blocker.remediation,
+      blocker.field ? `C6R dry-run blocker field ${blocker.field}` : 'C6R dry-run blocker summary',
+    ));
+  });
+
+  dryRun.warnings.forEach((warning, index) => {
+    steps.push(remediationStep(
+      `dry_run_warning_${index}_${warning.code}`,
+      `Dry-run warning: ${warning.code}`,
+      'pending',
+      'operator',
+      `Review warning before sandbox follow-up: ${warning.message}`,
+      warning.field ? `C6R dry-run warning field ${warning.field}` : 'C6R dry-run warning summary',
+    ));
+  });
+
+  packetReview.checklist
+    .filter((check) => check.status !== 'pass')
+    .forEach((check) => {
+      steps.push(remediationStep(
+        `packet_check_${check.key}`,
+        check.label,
+        check.status === 'blocked' ? 'blocked' : 'pending',
+        check.key.includes('operator_review') || check.key.includes('warning') ? 'operator' : 'merchant',
+        check.detail,
+        'C6Sd evidence packet checklist',
+      ));
+    });
+
+  if (!review) {
+    steps.push(remediationStep(
+      'request_operator_review',
+      'Request operator review',
+      'pending',
+      'operator',
+      'Request C6Sa operator review after a passing dry-run before sandbox follow-up handoff.',
+      'C6Sa review state',
+    ));
+  } else if (review.status === 'pending_operator_review') {
+    steps.push(remediationStep(
+      'record_operator_decision',
+      'Record operator decision',
+      'pending',
+      'operator',
+      'Record an accepted, needs-changes, or blocked sandbox evidence decision.',
+      'C6Sa review state',
+    ));
+  } else if (review.status === 'needs_changes') {
+    steps.push(remediationStep(
+      'operator_requested_changes',
+      'Operator requested changes',
+      'blocked',
+      'merchant',
+      review.decision_note || 'Address the operator requested changes and rerun the local sandbox dry-run.',
+      'C6Sa review decision',
+    ));
+  } else if (review.status === 'blocked') {
+    steps.push(remediationStep(
+      'operator_blocked_followup',
+      'Operator blocked sandbox follow-up',
+      'blocked',
+      'merchant',
+      review.decision_note || 'Resolve the operator blocker before requesting another sandbox evidence review.',
+      'C6Sa review decision',
+    ));
+  }
+
+  const blocked = steps.filter((step) => step.status === 'blocked');
+  const pending = steps.filter((step) => step.status === 'pending');
+  const workflowStatus: ConnectorRemediationWorkflowStatus = blocked.length
+    ? 'blocked'
+    : pending.length
+      ? 'pending_operator_review'
+      : 'complete';
+
+  return {
+    workflow_type: 'self_serve_connector_dry_run_remediation',
+    workflow_status: workflowStatus,
+    summary: workflowStatus === 'complete'
+      ? 'No self-serve remediation steps remain before sandbox follow-up handoff.'
+      : workflowStatus === 'blocked'
+        ? 'Resolve blocked dry-run, review, or packet evidence items before sandbox follow-up.'
+        : 'Complete pending operator review items before sandbox follow-up.',
+    requires_rerun: dryRun.blockers.length > 0 || review?.status === 'needs_changes' || review?.status === 'blocked',
+    step_count: steps.length,
+    blocked_count: blocked.length,
+    pending_count: pending.length,
+    steps,
+    evidence_sources: [
+      'C6R dry-run summary',
+      'C6Sa review summary',
+      'C6Sd evidence packet checklist',
+    ],
+  };
+}
+
 function buildConnectorEvidenceExport(
   merchantId: string,
   dryRun: CommerceConnectorDryRunResult,
   review: CommerceConnectorDryRunReview | null,
 ) {
   const packetReview = buildConnectorEvidencePacketReview(dryRun, review);
+  const operatorHandoff = buildConnectorOperatorHandoff(dryRun, review, packetReview);
+  const remediationWorkflow = buildConnectorRemediationWorkflow(dryRun, review, packetReview);
   return {
     evidence_type: 'connector_dry_run_review_handoff',
     schema_version: connectorEvidencePacketSchemaVersion,
@@ -457,6 +661,8 @@ function buildConnectorEvidenceExport(
     generated_at: 'client_side_on_demand',
     merchant_id: merchantId,
     packet_review: packetReview,
+    operator_handoff: operatorHandoff,
+    remediation_workflow: remediationWorkflow,
     posture: {
       sandbox_only: true,
       not_live: true,
@@ -536,6 +742,11 @@ function buildConnectorEvidenceMarkdown(evidence: ReturnType<typeof buildConnect
   const blockers = evidence.dry_run.blockers.map((blocker) => `${blocker.code}: ${blocker.remediation}`);
   const warnings = evidence.dry_run.warnings.map((warning) => `${warning.code}: ${warning.message}`);
   const packetChecklist = evidence.packet_review.checklist.map((check) => `${check.status} - ${check.label}: ${check.detail}`);
+  const allowedNextSteps = evidence.operator_handoff.allowed_next_steps;
+  const blockedNextSteps = evidence.operator_handoff.blocked_next_steps;
+  const remediationSteps = evidence.remediation_workflow.steps.map((step) => (
+    `${step.status} - ${step.label} (${step.owner}): ${step.action}`
+  ));
   const redactionSummary = Object.entries(evidence.packet_review.redaction_summary).map(([key, value]) => `${key}: ${value}`);
   return [
     '# Connector Dry-Run Evidence Handoff',
@@ -550,6 +761,8 @@ function buildConnectorEvidenceMarkdown(evidence: ReturnType<typeof buildConnect
     `- Review status: ${evidence.review?.status ?? 'not_requested'}`,
     `- Packet status: ${evidence.packet_review.packet_status}`,
     `- Packet summary: ${evidence.packet_review.summary}`,
+    `- Operator handoff status: ${evidence.operator_handoff.handoff_status}`,
+    `- Remediation workflow status: ${evidence.remediation_workflow.workflow_status}`,
     `- Rows received: ${evidence.dry_run.counts.rows_received}`,
     `- Products detected: ${evidence.dry_run.counts.products_detected}`,
     `- Variants detected: ${evidence.dry_run.counts.variants_detected}`,
@@ -583,6 +796,31 @@ function buildConnectorEvidenceMarkdown(evidence: ReturnType<typeof buildConnect
     '## Packet Pending Items',
     '',
     formatMarkdownList(evidence.packet_review.pending_summary),
+    '',
+    '## Operator Sandbox Handoff',
+    '',
+    `- Handoff type: ${evidence.operator_handoff.handoff_type}`,
+    `- Handoff status: ${evidence.operator_handoff.handoff_status}`,
+    `- Next actor: ${evidence.operator_handoff.next_actor}`,
+    `- Summary: ${evidence.operator_handoff.summary}`,
+    '',
+    '### Allowed Sandbox Follow-Up Steps',
+    '',
+    formatMarkdownList(allowedNextSteps),
+    '',
+    '### Blocked Next Steps',
+    '',
+    formatMarkdownList(blockedNextSteps),
+    '',
+    '## Self-Serve Remediation Workflow',
+    '',
+    `- Workflow status: ${evidence.remediation_workflow.workflow_status}`,
+    `- Summary: ${evidence.remediation_workflow.summary}`,
+    `- Requires rerun: ${evidence.remediation_workflow.requires_rerun}`,
+    `- Blocked count: ${evidence.remediation_workflow.blocked_count}`,
+    `- Pending count: ${evidence.remediation_workflow.pending_count}`,
+    '',
+    formatMarkdownList(remediationSteps),
     '',
     '## Blockers',
     '',
@@ -2156,6 +2394,52 @@ export function CommerceOnboarding() {
                 </div>
 
                 <div className="mt-3 rounded-md border border-gx-border p-3">
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <div>
+                      <div className="text-sm font-medium text-gx-text">Operator sandbox handoff</div>
+                      <div className="mt-1 text-xs text-gx-muted">{connectorEvidence.operator_handoff.summary}</div>
+                    </div>
+                    <Badge variant={handoffStatusVariant(connectorEvidence.operator_handoff.handoff_status)}>
+                      {connectorEvidence.operator_handoff.handoff_status}
+                    </Badge>
+                  </div>
+                  <div className="mt-2 grid gap-2 md:grid-cols-3">
+                    <div className="rounded-md border border-gx-border p-2">
+                      <div className="text-xs text-gx-muted">next_actor</div>
+                      <div className="text-sm font-medium text-gx-text">{connectorEvidence.operator_handoff.next_actor}</div>
+                    </div>
+                    <div className="rounded-md border border-gx-border p-2">
+                      <div className="text-xs text-gx-muted">dry_run_id</div>
+                      <div className="break-all text-sm font-medium text-gx-text">{connectorEvidence.operator_handoff.dry_run_id}</div>
+                    </div>
+                    <div className="rounded-md border border-gx-border p-2">
+                      <div className="text-xs text-gx-muted">review_id</div>
+                      <div className="break-all text-sm font-medium text-gx-text">{connectorEvidence.operator_handoff.review_id ?? 'not_requested'}</div>
+                    </div>
+                  </div>
+                  <div className="mt-3 grid gap-2 md:grid-cols-2">
+                    <div>
+                      <div className="text-xs font-medium text-gx-muted">Allowed sandbox follow-up</div>
+                      <ul className="mt-1 list-disc space-y-1 pl-4 text-xs text-gx-muted">
+                        {connectorEvidence.operator_handoff.allowed_next_steps.length ? connectorEvidence.operator_handoff.allowed_next_steps.map((step) => (
+                          <li key={step}>{step}</li>
+                        )) : (
+                          <li>Complete remediation before any sandbox handoff.</li>
+                        )}
+                      </ul>
+                    </div>
+                    <div>
+                      <div className="text-xs font-medium text-gx-muted">Blocked next steps</div>
+                      <ul className="mt-1 list-disc space-y-1 pl-4 text-xs text-gx-muted">
+                        {connectorEvidence.operator_handoff.blocked_next_steps.map((step) => (
+                          <li key={step}>{step}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mt-3 rounded-md border border-gx-border p-3">
                   <div className="text-sm font-medium text-gx-text">Evidence packet review checklist</div>
                   <div className="mt-2 grid gap-2 md:grid-cols-2">
                     {connectorEvidence.packet_review.checklist.map((check) => (
@@ -2167,6 +2451,48 @@ export function CommerceOnboarding() {
                         <div className="mt-1 text-xs text-gx-muted">{check.detail}</div>
                       </div>
                     ))}
+                  </div>
+                </div>
+
+                <div className="mt-3 rounded-md border border-gx-border p-3">
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <div>
+                      <div className="text-sm font-medium text-gx-text">Self-serve remediation workflow</div>
+                      <div className="mt-1 text-xs text-gx-muted">{connectorEvidence.remediation_workflow.summary}</div>
+                    </div>
+                    <Badge variant={remediationStatusVariant(connectorEvidence.remediation_workflow.workflow_status)}>
+                      {connectorEvidence.remediation_workflow.workflow_status}
+                    </Badge>
+                  </div>
+                  <div className="mt-2 grid gap-2 md:grid-cols-3">
+                    <div className="rounded-md border border-gx-border p-2">
+                      <div className="text-xs text-gx-muted">blocked_count</div>
+                      <div className="text-sm font-medium text-gx-text">{connectorEvidence.remediation_workflow.blocked_count}</div>
+                    </div>
+                    <div className="rounded-md border border-gx-border p-2">
+                      <div className="text-xs text-gx-muted">pending_count</div>
+                      <div className="text-sm font-medium text-gx-text">{connectorEvidence.remediation_workflow.pending_count}</div>
+                    </div>
+                    <div className="rounded-md border border-gx-border p-2">
+                      <div className="text-xs text-gx-muted">requires_rerun</div>
+                      <Badge variant={connectorEvidence.remediation_workflow.requires_rerun ? 'warning' : 'success'}>
+                        {String(connectorEvidence.remediation_workflow.requires_rerun)}
+                      </Badge>
+                    </div>
+                  </div>
+                  <div className="mt-3 grid gap-2">
+                    {connectorEvidence.remediation_workflow.steps.length ? connectorEvidence.remediation_workflow.steps.map((step) => (
+                      <div key={step.key} className="rounded-md border border-gx-border p-2">
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <div className="text-xs font-medium text-gx-text">{step.label}</div>
+                          <Badge variant={remediationStatusVariant(step.status)}>{step.status}</Badge>
+                        </div>
+                        <div className="mt-1 text-xs text-gx-muted">{step.action}</div>
+                        <div className="mt-1 text-xs text-gx-muted">Owner: {step.owner} | Source: {step.evidence_source}</div>
+                      </div>
+                    )) : (
+                      <p className="text-sm text-gx-muted">No remediation actions remain before sandbox follow-up.</p>
+                    )}
                   </div>
                 </div>
 

--- a/docs/guides/commerce-v1-merchant-operator-guide.mdx
+++ b/docs/guides/commerce-v1-merchant-operator-guide.mdx
@@ -291,6 +291,26 @@ contain raw rows, normalized product titles, credentials, tokens, provider
 metadata, private API URLs, checkout URLs, payment identifiers, production
 config values, concrete allowlists, customer data, or secret material.
 
+C6Se adds a local operator handoff and self-serve remediation workflow to the
+same redacted evidence packet. A `ready` handoff means an operator can continue
+an internal sandbox follow-up conversation with the merchant. It is not
+production approval, connector execution approval, outbound sync approval,
+public discovery approval, checkout/payment approval, live provider approval,
+public protocol publication, or certification.
+
+If a packet is pending or blocked, the remediation workflow points merchants
+and operators back to the relevant C6R dry-run blockers/warnings, C6Sd packet
+checks, and C6Sa review decisions. `needs_changes` and `blocked` decisions keep
+the handoff blocked and require local snapshot remediation plus another
+sandbox dry-run before follow-up can continue.
+
+C6Se exports are still local/internal evidence only. They include handoff and
+remediation summaries, non-enabling controls, and audit references, and they
+exclude raw rows, raw merchant-system payloads, normalized product titles,
+credentials, tokens, provider metadata, private API URLs, checkout URLs,
+payment identifiers, production config values, concrete allowlists, customer
+data, and secret material.
+
 ## Catalog And Inventory
 
 Catalog and inventory grounding is the first safety step. Agents must not invent

--- a/docs/internal/commerce-v1/commerce-v1-c6se-connector-dry-run-operator-handoff-remediation.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6se-connector-dry-run-operator-handoff-remediation.md
@@ -1,0 +1,127 @@
+# Commerce V1 C6Se - Connector Dry-Run Operator Handoff And Remediation
+
+C6Se extends the C6Sc/C6Sd portal evidence packet with a local operator handoff
+summary and a self-serve remediation workflow. It is portal, docs, and test
+work only. It remains internal preview, sandbox-only, non-live,
+non-publication, non-certifying, and non-enabling.
+
+C6Se does not add backend routes, migrations, workflows, workers, credentials,
+outbound sync, production connector setup, public discovery, checkout/payment
+behavior, live payment behavior, provider calls, merchant private API calls,
+production allowlists, or certification claims.
+
+## Traceability Checklist
+
+| Requirement | Files | Tests | Guardrails | Status |
+| --- | --- | --- | --- | --- |
+| Local operator sandbox handoff summary | `apps/portal/src/pages/commerce/CommerceOnboarding.tsx` | `CommerceDashboard.test.tsx` | Derived only from C6R dry-run, C6Sa review, and C6Sd packet summaries | Implemented |
+| Self-serve remediation workflow | `CommerceOnboarding.tsx` | `CommerceDashboard.test.tsx` | Pending/blocked items do not enable connectors or approve launch | Implemented |
+| Redacted JSON/Markdown export content | `CommerceOnboarding.tsx` | `CommerceDashboard.test.tsx` | Export excludes raw rows, product titles, credentials, private URLs, provider metadata, checkout/payment artifacts, production config, allowlists, and customer data | Implemented |
+| Merchant/operator guide update | `docs/guides/commerce-v1-merchant-operator-guide.mdx` | Doc review | Handoff and remediation remain local/internal evidence only | Implemented |
+
+## Operator Handoff
+
+The portal derives an `operator_handoff` section when a connector dry-run
+evidence packet exists. The handoff has three statuses:
+
+- `ready`: the C6Sd packet is `ready_for_sandbox_followup`.
+- `needs_operator_review`: operator review or warning review is still pending.
+- `blocked`: dry-run blockers, unsafe packet checks, or a blocked review status
+  must be remediated first.
+
+A `ready` handoff only permits an internal sandbox follow-up conversation. It
+does not approve production launch, outbound connector sync, merchant private
+API execution, public discovery, checkout/payment creation, live providers,
+live Plural, production allowlists, public protocol publication, or
+certification.
+
+## Self-Serve Remediation Workflow
+
+The portal derives a `remediation_workflow` from:
+
+- C6R dry-run blockers and warnings;
+- C6Sd packet checklist items with `pending` or `blocked` status;
+- C6Sa review states, including `pending_operator_review`, `needs_changes`,
+  and `blocked`.
+
+The workflow status is:
+
+- `complete`: no local remediation items remain before sandbox follow-up.
+- `pending_operator_review`: operator review or warning review is still needed.
+- `blocked`: dry-run, packet, or review blockers require remediation.
+
+When an operator records `needs_changes` or `blocked`, the portal keeps the
+handoff blocked and marks `requires_rerun` so the merchant can adjust the local
+manual/CSV snapshot and rerun the sandbox dry-run. This is still a dry-run
+workflow; it does not create or update a live catalog.
+
+## Export Contents
+
+C6Se JSON and Markdown exports include:
+
+- operator handoff status, next actor, allowed sandbox follow-up steps, blocked
+  next steps, and audit references;
+- self-serve remediation workflow status, counts, steps, owners, and evidence
+  sources;
+- fixed non-enabling controls and non-approval statements.
+
+Exports remain redacted. They exclude raw rows, raw files, raw merchant-system
+responses, normalized product titles, credentials, tokens, provider metadata,
+private API URLs, checkout URLs, payment identifiers, production config values,
+concrete allowlists, customer data, and secret material.
+
+## Stop Conditions
+
+Stop and require a new approved work item if any follow-up:
+
+- adds credential entry, credential upload, secret storage, token storage, or
+  provider credential paths;
+- adds outbound sync, connector execution, worker schedules, background jobs, or
+  merchant private API calls;
+- connects to Shopify, WooCommerce, Magento, custom APIs, ERP, OMS, WMS,
+  logistics, CRM/support, payment providers, Plural, Stripe, Pine, or merchant
+  private APIs;
+- allows AgenticOrg to call merchant private APIs directly;
+- enables Grantex public discovery or AgenticOrg public commerce discovery;
+- enables production Commerce V1, checkout/payment creation, fulfillment,
+  refund execution, live payments, live Plural, or live providers;
+- writes production config or production allowlists;
+- claims production approval, public protocol publication, provider approval,
+  live-payment approval, or certification;
+- treats sandbox, demo, synthetic, fixture, dry-run, review, packet, handoff,
+  remediation, export, or rehearsal output as real merchant approval.
+
+## Rollback Notes
+
+C6Se is portal/docs/test only. Roll back by removing:
+
+- the local `operator_handoff` and `remediation_workflow` additions in
+  `CommerceOnboarding.tsx`;
+- the related `CommerceDashboard.test.tsx` assertions;
+- this internal note and the C6Se guide section.
+
+No runtime API, route, migration, worker, production config, public discovery,
+checkout/payment, live payment, provider credential, production allowlist,
+cloud resource, or deploy workflow action is created by this slice.
+
+## Validation
+
+Focused validation for C6Se:
+
+```bash
+npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
+npm --prefix apps/portal run typecheck
+npm --prefix apps/auth-service test -- commerce-connector-dry-run-c6r.test.ts commerce-connector-dry-run-review-c6sa.test.ts commerce-openapi.test.ts
+npm --prefix apps/auth-service run typecheck
+node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
+git diff --check origin/main...HEAD
+```
+
+Focused scans must cover secrets/private details, production config or allowlist
+assignments, public discovery enablement, checkout/payment enablement, live
+payment/live Plural/provider credential enablement, certification claims, direct
+provider calls, direct merchant private API calls, AgenticOrg direct execution,
+and outbound sync enablement.
+
+Expected scan hits should be limited to stop-condition text, denylist regex
+literals, negative assertions, or explicit disabled-control examples.


### PR DESCRIPTION
Adds portal-only C6Se operator sandbox handoff and self-serve remediation workflow for C6Sd evidence packets. Extends the existing redacted JSON/Markdown export with handoff status, remediation steps, non-approval statements, non-enabling controls, and audit references. Updates the merchant/operator guide and adds the internal C6Se note. Validation: portal tests, portal typecheck, auth connector/OpenAPI tests, auth typecheck, C6Oe PR conformance gate, git diff --check, and focused guardrail scans. Guardrails: no backend routes, migrations, workflows, workers, credentials, outbound sync, production connector setup, public discovery, checkout/payment behavior, live provider behavior, provider calls, merchant private API calls, production allowlists, or certification claims.