### PR TITLE
[codex] C6Sf connector dry-run remediation loop

### DIFF
--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -832,6 +832,35 @@ const connectorReviewNeedsChanges = {
   decided_at: '2026-01-01T00:43:00Z',
 };
 
+const connectorDryRunCorrected = {
+  ...connectorDryRun,
+  dry_run_id: 'cdry_C6SF_CORRECTED',
+  requested_audit_event_id: 'caud_C6SF_CORRECTED_REQUESTED',
+  audit_event_id: 'caud_C6SF_CORRECTED_COMPLETED',
+  generated_at: '2026-01-01T00:50:00Z',
+  created_at: '2026-01-01T00:50:00Z',
+};
+
+const connectorReviewFollowup = {
+  ...connectorReview,
+  review_id: 'cdrev_C6SF_FOLLOWUP',
+  dry_run_id: 'cdry_C6SF_CORRECTED',
+  dry_run_generated_at: '2026-01-01T00:50:00Z',
+  requested_audit_event_id: 'caud_C6SF_FOLLOWUP_REQUESTED',
+  created_at: '2026-01-01T00:51:00Z',
+  updated_at: '2026-01-01T00:51:00Z',
+};
+
+const connectorReviewFollowupAccepted = {
+  ...connectorReviewFollowup,
+  status: 'accepted_for_sandbox_followup' as const,
+  decision: 'accepted_for_sandbox_followup' as const,
+  decision_note: 'Corrected sandbox follow-up only.',
+  decided_by_operator_id: 'dev_TEST',
+  audit_event_id: 'caud_C6SF_FOLLOWUP_DECISION',
+  decided_at: '2026-01-01T00:52:00Z',
+};
+
 const credential = {
   id: 'cpcred_1',
   tenant_id: 'cten_1',
@@ -1543,6 +1572,106 @@ describe('CommerceOnboarding', () => {
     expect(remediationEvidenceJsonPreview.textContent).not.toContain('Portal Sandbox Fixture Product');
     expect(screen.queryByRole('textbox', { name: 'Credential' })).not.toBeInTheDocument();
     expect(screen.queryByText('outbound connector sync enabled')).not.toBeInTheDocument();
+  });
+
+  it('rehearses remediation loop from needs-changes to corrected sandbox follow-up', async () => {
+    mockRunCommerceConnectorDryRun
+      .mockResolvedValueOnce({
+        data: connectorDryRun,
+        audit_events: [
+          { event_type: 'connector_dry_run_requested', audit_event_id: 'caud_C6SB_REQUESTED' },
+          { event_type: 'connector_dry_run_completed', audit_event_id: 'caud_C6SB_COMPLETED' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        data: connectorDryRunCorrected,
+        audit_events: [
+          { event_type: 'connector_dry_run_requested', audit_event_id: 'caud_C6SF_CORRECTED_REQUESTED' },
+          { event_type: 'connector_dry_run_completed', audit_event_id: 'caud_C6SF_CORRECTED_COMPLETED' },
+        ],
+      });
+    mockRequestCommerceConnectorDryRunReview
+      .mockResolvedValueOnce({
+        data: connectorReview,
+        dry_run: connectorDryRun,
+        audit_event_id: 'caud_C6SB_REVIEW_REQUESTED',
+      })
+      .mockResolvedValueOnce({
+        data: connectorReviewFollowup,
+        dry_run: connectorDryRunCorrected,
+        audit_event_id: 'caud_C6SF_FOLLOWUP_REQUESTED',
+      });
+    mockRecordCommerceConnectorDryRunReviewDecision
+      .mockResolvedValueOnce({
+        data: connectorReviewNeedsChanges,
+        dry_run: connectorDryRun,
+        audit_event_id: 'caud_C6SB_NEEDS_CHANGES',
+      })
+      .mockResolvedValueOnce({
+        data: connectorReviewFollowupAccepted,
+        dry_run: connectorDryRunCorrected,
+        audit_event_id: 'caud_C6SF_FOLLOWUP_DECISION',
+      });
+    const user = userEvent.setup();
+    r(<CommerceOnboarding />);
+
+    await user.type(screen.getByLabelText('Merchant ID'), 'mch_1');
+    await user.click(screen.getByRole('button', { name: 'Load onboarding' }));
+    await waitFor(() => expect(screen.getByText('Connector dry-run review')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: 'Run connector dry-run' }));
+    await waitFor(() => expect(mockRunCommerceConnectorDryRun).toHaveBeenCalledTimes(1));
+    await user.type(screen.getByLabelText('Review request note'), 'Public-safe sandbox evidence.');
+    await user.click(screen.getByRole('button', { name: 'Request dry-run review' }));
+    await waitFor(() => expect(mockRequestCommerceConnectorDryRunReview).toHaveBeenCalledTimes(1));
+
+    await user.selectOptions(screen.getByLabelText('Review decision'), 'needs_changes');
+    fireEvent.change(screen.getByLabelText('Decision note'), { target: { value: 'Fix category mapping and rerun the local sandbox dry-run.' } });
+    await user.click(screen.getByRole('button', { name: 'Record dry-run review decision' }));
+    await waitFor(() => expect(mockRecordCommerceConnectorDryRunReviewDecision).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('Remediation loop rehearsal')).toBeInTheDocument();
+    expect(screen.getAllByText('issue_captured').length).toBeGreaterThan(0);
+    expect(screen.getByText('previous_review_status')).toBeInTheDocument();
+    expect(screen.getAllByText('needs_changes').length).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole('button', { name: 'Reset sample' }));
+    await user.click(screen.getByRole('button', { name: 'Run connector dry-run' }));
+    await waitFor(() => expect(mockRunCommerceConnectorDryRun).toHaveBeenCalledTimes(2));
+    expect(screen.getAllByText('corrected_dry_run_ready').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('cdry_C6SF_CORRECTED').length).toBeGreaterThan(0);
+    expect(screen.getByText('operator_followup_status')).toBeInTheDocument();
+    expect(screen.getAllByText('not_requested').length).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole('button', { name: 'Request dry-run review' }));
+    await waitFor(() => expect(mockRequestCommerceConnectorDryRunReview).toHaveBeenCalledTimes(2));
+    expect(screen.getAllByText('operator_followup_requested').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('pending_operator_review').length).toBeGreaterThan(0);
+
+    await user.selectOptions(screen.getByLabelText('Review decision'), 'accepted_for_sandbox_followup');
+    fireEvent.change(screen.getByLabelText('Decision note'), { target: { value: 'Corrected sandbox follow-up only.' } });
+    await user.click(screen.getByRole('button', { name: 'Record dry-run review decision' }));
+    await waitFor(() => expect(mockRecordCommerceConnectorDryRunReviewDecision).toHaveBeenCalledTimes(2));
+    expect(screen.getAllByText('followup_ready').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('accepted_for_sandbox_followup').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('caud_C6SF_FOLLOWUP_DECISION').length).toBeGreaterThan(0);
+
+    const loopEvidenceJsonPreview = screen.getByText((_content, node) => (
+      node?.tagName === 'PRE'
+      && node.textContent?.includes('"loop_status": "followup_ready"')
+    ) ?? false);
+    expect(loopEvidenceJsonPreview.textContent).toContain('"remediation_loop"');
+    expect(loopEvidenceJsonPreview.textContent).toContain('"previous_issue"');
+    expect(loopEvidenceJsonPreview.textContent).toContain('"corrected_dry_run"');
+    expect(loopEvidenceJsonPreview.textContent).toContain('"operator_followup"');
+    expect(loopEvidenceJsonPreview.textContent).toContain('"credential_entry_enabled": false');
+    expect(loopEvidenceJsonPreview.textContent).toContain('"outbound_sync_enabled": false');
+    expect(loopEvidenceJsonPreview.textContent).toContain('"public_discovery_enabled": false');
+    expect(loopEvidenceJsonPreview.textContent).toContain('"checkout_payment_enabled": false');
+    expect(loopEvidenceJsonPreview.textContent).toContain('"merchant_private_api_calls": false');
+    expect(loopEvidenceJsonPreview.textContent).not.toContain('rows_json');
+    expect(loopEvidenceJsonPreview.textContent).not.toContain('Portal Sandbox Fixture Product');
+    expect(screen.queryByRole('textbox', { name: 'Credential' })).not.toBeInTheDocument();
+    expect(screen.queryByText('production connector setup enabled')).not.toBeInTheDocument();
   });
 
   it('validates, clears, and resets connector rows before dry-run submission', async () => {

--- a/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
+++ b/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
@@ -131,6 +131,18 @@ type ConnectorEvidencePacketStatus = 'ready_for_sandbox_followup' | 'needs_opera
 type ConnectorOperatorHandoffStatus = 'ready' | 'needs_operator_review' | 'blocked';
 type ConnectorRemediationWorkflowStatus = 'complete' | 'pending_operator_review' | 'blocked';
 type ConnectorRemediationStepStatus = 'complete' | 'pending' | 'blocked';
+type ConnectorRemediationLoopStatus =
+  | 'issue_captured'
+  | 'corrected_dry_run_ready'
+  | 'operator_followup_requested'
+  | 'followup_ready'
+  | 'blocked_again';
+type ConnectorOperatorFollowupStatus =
+  | 'not_requested'
+  | 'pending_operator_review'
+  | 'accepted_for_sandbox_followup'
+  | 'needs_changes'
+  | 'blocked';
 
 interface ConnectorEvidencePacketCheck {
   key: string;
@@ -146,6 +158,54 @@ interface ConnectorRemediationStep {
   owner: 'merchant' | 'operator' | 'grantex';
   action: string;
   evidence_source: string;
+}
+
+interface ConnectorRemediationLoopState {
+  loop_type: 'local_connector_dry_run_remediation_loop_rehearsal';
+  loop_status: ConnectorRemediationLoopStatus;
+  previous_issue: {
+    dry_run_id: string;
+    review_id: string;
+    review_status: 'needs_changes' | 'blocked';
+    decision: CommerceConnectorDryRunReviewDecision | null;
+    decision_note: string | null;
+    packet_status: ConnectorEvidencePacketStatus;
+    remediation_workflow_status: ConnectorRemediationWorkflowStatus;
+    blocked_count: number;
+    pending_count: number;
+    blocker_summary: string[];
+    pending_summary: string[];
+    audit_references: ReturnType<typeof buildConnectorEvidencePacketReview>['audit_references'];
+  };
+  corrected_dry_run: {
+    dry_run_id: string;
+    status: CommerceConnectorDryRunResult['status'];
+    rows_received: number;
+    products_detected: number;
+    variants_detected: number;
+    blocked_count: number;
+    warning_count: number;
+    audit_references: {
+      requested_audit_event_id: string;
+      completed_or_blocked_audit_event_id: string;
+    };
+  } | null;
+  refreshed_packet: {
+    packet_status: ConnectorEvidencePacketStatus;
+    handoff_status: ConnectorOperatorHandoffStatus;
+    remediation_workflow_status: ConnectorRemediationWorkflowStatus;
+    blocker_summary: string[];
+    pending_summary: string[];
+  } | null;
+  operator_followup: {
+    followup_status: ConnectorOperatorFollowupStatus;
+    review_id: string | null;
+    decision: CommerceConnectorDryRunReviewDecision | null;
+    audit_references: {
+      review_requested_audit_event_id: string | null;
+      review_decision_audit_event_id: string | null;
+    };
+  };
 }
 
 const connectorEvidencePacketSchemaVersion = 'grantex.commerce.connector_dry_run.evidence_packet.v1';
@@ -321,6 +381,12 @@ function handoffStatusVariant(status: ConnectorOperatorHandoffStatus): 'default'
 function remediationStatusVariant(status: ConnectorRemediationWorkflowStatus | ConnectorRemediationStepStatus): 'default' | 'success' | 'warning' | 'danger' {
   if (status === 'complete') return 'success';
   if (status === 'blocked') return 'danger';
+  return 'warning';
+}
+
+function remediationLoopStatusVariant(status: ConnectorRemediationLoopStatus | ConnectorOperatorFollowupStatus): 'default' | 'success' | 'warning' | 'danger' {
+  if (status === 'followup_ready' || status === 'accepted_for_sandbox_followup') return 'success';
+  if (status === 'blocked_again' || status === 'blocked' || status === 'needs_changes') return 'danger';
   return 'warning';
 }
 
@@ -645,10 +711,126 @@ function buildConnectorRemediationWorkflow(
   };
 }
 
+function buildConnectorRemediationLoopIssue(
+  dryRun: CommerceConnectorDryRunResult,
+  review: CommerceConnectorDryRunReview,
+): ConnectorRemediationLoopState {
+  const packetReview = buildConnectorEvidencePacketReview(dryRun, review);
+  const remediationWorkflow = buildConnectorRemediationWorkflow(dryRun, review, packetReview);
+  return {
+    loop_type: 'local_connector_dry_run_remediation_loop_rehearsal',
+    loop_status: 'issue_captured',
+    previous_issue: {
+      dry_run_id: dryRun.dry_run_id,
+      review_id: review.review_id,
+      review_status: review.status === 'blocked' ? 'blocked' : 'needs_changes',
+      decision: review.decision,
+      decision_note: review.decision_note,
+      packet_status: packetReview.packet_status,
+      remediation_workflow_status: remediationWorkflow.workflow_status,
+      blocked_count: remediationWorkflow.blocked_count,
+      pending_count: remediationWorkflow.pending_count,
+      blocker_summary: packetReview.blocker_summary,
+      pending_summary: packetReview.pending_summary,
+      audit_references: packetReview.audit_references,
+    },
+    corrected_dry_run: null,
+    refreshed_packet: null,
+    operator_followup: {
+      followup_status: 'not_requested',
+      review_id: null,
+      decision: null,
+      audit_references: {
+        review_requested_audit_event_id: null,
+        review_decision_audit_event_id: null,
+      },
+    },
+  };
+}
+
+function applyCorrectedConnectorDryRunToLoop(
+  loop: ConnectorRemediationLoopState,
+  dryRun: CommerceConnectorDryRunResult,
+): ConnectorRemediationLoopState {
+  const packetReview = buildConnectorEvidencePacketReview(dryRun, null);
+  const operatorHandoff = buildConnectorOperatorHandoff(dryRun, null, packetReview);
+  const remediationWorkflow = buildConnectorRemediationWorkflow(dryRun, null, packetReview);
+  return {
+    ...loop,
+    loop_status: dryRun.status === 'passed' ? 'corrected_dry_run_ready' : 'blocked_again',
+    corrected_dry_run: {
+      dry_run_id: dryRun.dry_run_id,
+      status: dryRun.status,
+      rows_received: dryRun.rows_received,
+      products_detected: dryRun.products_detected,
+      variants_detected: dryRun.variants_detected,
+      blocked_count: dryRun.blocked_count,
+      warning_count: dryRun.warning_count,
+      audit_references: {
+        requested_audit_event_id: dryRun.requested_audit_event_id,
+        completed_or_blocked_audit_event_id: dryRun.audit_event_id,
+      },
+    },
+    refreshed_packet: {
+      packet_status: packetReview.packet_status,
+      handoff_status: operatorHandoff.handoff_status,
+      remediation_workflow_status: remediationWorkflow.workflow_status,
+      blocker_summary: packetReview.blocker_summary,
+      pending_summary: packetReview.pending_summary,
+    },
+    operator_followup: {
+      followup_status: 'not_requested',
+      review_id: null,
+      decision: null,
+      audit_references: {
+        review_requested_audit_event_id: null,
+        review_decision_audit_event_id: null,
+      },
+    },
+  };
+}
+
+function applyConnectorFollowupReviewToLoop(
+  loop: ConnectorRemediationLoopState,
+  dryRun: CommerceConnectorDryRunResult,
+  review: CommerceConnectorDryRunReview,
+): ConnectorRemediationLoopState {
+  const packetReview = buildConnectorEvidencePacketReview(dryRun, review);
+  const operatorHandoff = buildConnectorOperatorHandoff(dryRun, review, packetReview);
+  const remediationWorkflow = buildConnectorRemediationWorkflow(dryRun, review, packetReview);
+  const followupStatus = review.status as ConnectorOperatorFollowupStatus;
+  const loopStatus: ConnectorRemediationLoopStatus = review.status === 'accepted_for_sandbox_followup'
+    ? 'followup_ready'
+    : review.status === 'pending_operator_review'
+      ? 'operator_followup_requested'
+      : 'blocked_again';
+  return {
+    ...loop,
+    loop_status: loopStatus,
+    refreshed_packet: {
+      packet_status: packetReview.packet_status,
+      handoff_status: operatorHandoff.handoff_status,
+      remediation_workflow_status: remediationWorkflow.workflow_status,
+      blocker_summary: packetReview.blocker_summary,
+      pending_summary: packetReview.pending_summary,
+    },
+    operator_followup: {
+      followup_status: followupStatus,
+      review_id: review.review_id,
+      decision: review.decision,
+      audit_references: {
+        review_requested_audit_event_id: review.requested_audit_event_id,
+        review_decision_audit_event_id: review.audit_event_id,
+      },
+    },
+  };
+}
+
 function buildConnectorEvidenceExport(
   merchantId: string,
   dryRun: CommerceConnectorDryRunResult,
   review: CommerceConnectorDryRunReview | null,
+  remediationLoop: ConnectorRemediationLoopState | null = null,
 ) {
   const packetReview = buildConnectorEvidencePacketReview(dryRun, review);
   const operatorHandoff = buildConnectorOperatorHandoff(dryRun, review, packetReview);
@@ -663,6 +845,22 @@ function buildConnectorEvidenceExport(
     packet_review: packetReview,
     operator_handoff: operatorHandoff,
     remediation_workflow: remediationWorkflow,
+    remediation_loop: remediationLoop ? {
+      ...remediationLoop,
+      posture: {
+        internal_sandbox_only: true,
+        credential_entry_enabled: false,
+        outbound_sync_enabled: false,
+        production_connector_setup: false,
+        public_discovery_enabled: false,
+        checkout_payment_enabled: false,
+        live_provider_enabled: false,
+        live_plural_enabled: false,
+        merchant_private_api_calls: false,
+        production_allowlist_written: false,
+        certification_claimed: false,
+      },
+    } : null,
     posture: {
       sandbox_only: true,
       not_live: true,
@@ -747,6 +945,21 @@ function buildConnectorEvidenceMarkdown(evidence: ReturnType<typeof buildConnect
   const remediationSteps = evidence.remediation_workflow.steps.map((step) => (
     `${step.status} - ${step.label} (${step.owner}): ${step.action}`
   ));
+  const remediationLoop = evidence.remediation_loop;
+  const remediationLoopLines = remediationLoop ? [
+    `Loop status: ${remediationLoop.loop_status}`,
+    `Previous dry-run: ${remediationLoop.previous_issue.dry_run_id}`,
+    `Previous review: ${remediationLoop.previous_issue.review_id}`,
+    `Previous review status: ${remediationLoop.previous_issue.review_status}`,
+    `Previous packet status: ${remediationLoop.previous_issue.packet_status}`,
+    `Previous blocked count: ${remediationLoop.previous_issue.blocked_count}`,
+    `Previous pending count: ${remediationLoop.previous_issue.pending_count}`,
+    `Corrected dry-run: ${remediationLoop.corrected_dry_run?.dry_run_id ?? 'not_recorded'}`,
+    `Corrected dry-run status: ${remediationLoop.corrected_dry_run?.status ?? 'not_recorded'}`,
+    `Refreshed packet status: ${remediationLoop.refreshed_packet?.packet_status ?? 'not_recorded'}`,
+    `Operator follow-up status: ${remediationLoop.operator_followup.followup_status}`,
+    `Operator follow-up review: ${remediationLoop.operator_followup.review_id ?? 'not_requested'}`,
+  ] : ['none'];
   const redactionSummary = Object.entries(evidence.packet_review.redaction_summary).map(([key, value]) => `${key}: ${value}`);
   return [
     '# Connector Dry-Run Evidence Handoff',
@@ -822,6 +1035,10 @@ function buildConnectorEvidenceMarkdown(evidence: ReturnType<typeof buildConnect
     '',
     formatMarkdownList(remediationSteps),
     '',
+    '## Local Remediation Loop Rehearsal',
+    '',
+    formatMarkdownList(remediationLoopLines),
+    '',
     '## Blockers',
     '',
     formatMarkdownList(blockers),
@@ -869,6 +1086,7 @@ export function CommerceOnboarding() {
   const [schemaOrgPreview, setSchemaOrgPreview] = useState<CommerceSchemaOrgJsonLdPreview | null>(null);
   const [connectorDryRun, setConnectorDryRun] = useState<CommerceConnectorDryRunResult | null>(null);
   const [connectorReview, setConnectorReview] = useState<CommerceConnectorDryRunReview | null>(null);
+  const [connectorRemediationLoop, setConnectorRemediationLoop] = useState<ConnectorRemediationLoopState | null>(null);
   const [merchantForm, setMerchantForm] = useState<MerchantPatchForm>(defaultPatch);
   const [agents, setAgents] = useState<CommerceAgent[]>([]);
   const [activePolicyCount, setActivePolicyCount] = useState(0);
@@ -955,6 +1173,7 @@ export function CommerceOnboarding() {
       setSchemaOrgPreview(schemaOrgRes?.data ?? null);
       setConnectorDryRun(null);
       setConnectorReview(null);
+      setConnectorRemediationLoop(null);
       setProposalNote(proposalRes?.data.proposal_note ?? '');
       setAgenticOrgNote('');
       setMerchantForm({
@@ -1181,6 +1400,7 @@ export function CommerceOnboarding() {
     setConnectorForm((prev) => ({ ...prev, rows_json: '' }));
     setConnectorDryRun(null);
     setConnectorReview(null);
+    setConnectorRemediationLoop(null);
     show('Sandbox connector rows cleared', 'success');
   }
 
@@ -1199,6 +1419,11 @@ export function CommerceOnboarding() {
         rows,
       });
       setConnectorDryRun(res.data);
+      setConnectorRemediationLoop((prev) => (
+        prev && prev.loop_status !== 'followup_ready'
+          ? applyCorrectedConnectorDryRunToLoop(prev, res.data)
+          : prev
+      ));
       show(res.data.status === 'passed' ? 'Connector dry-run passed' : 'Connector dry-run blocked', res.data.status === 'passed' ? 'success' : 'error');
     } catch {
       show('Connector dry-run request is blocked', 'error');
@@ -1216,6 +1441,11 @@ export function CommerceOnboarding() {
       });
       setConnectorReview(res.data);
       setConnectorDryRun(res.dry_run);
+      setConnectorRemediationLoop((prev) => (
+        prev?.corrected_dry_run?.dry_run_id === res.dry_run.dry_run_id
+          ? applyConnectorFollowupReviewToLoop(prev, res.dry_run, res.data)
+          : prev
+      ));
       show('Connector dry-run review requested', 'success');
     } catch {
       show('Connector dry-run review request is blocked', 'error');
@@ -1238,6 +1468,15 @@ export function CommerceOnboarding() {
       );
       setConnectorReview(res.data);
       setConnectorDryRun(res.dry_run);
+      setConnectorRemediationLoop((prev) => {
+        if (res.data.status === 'needs_changes' || res.data.status === 'blocked') {
+          return buildConnectorRemediationLoopIssue(res.dry_run, res.data);
+        }
+        if (prev?.corrected_dry_run?.dry_run_id === res.dry_run.dry_run_id) {
+          return applyConnectorFollowupReviewToLoop(prev, res.dry_run, res.data);
+        }
+        return prev;
+      });
       show('Connector dry-run review decision recorded', 'success');
     } catch {
       show('Connector dry-run review decision is blocked', 'error');
@@ -1408,7 +1647,7 @@ export function CommerceOnboarding() {
         ? 'Connector dry-run is being submitted.'
         : 'Dry-run is local snapshot validation only.';
   const connectorEvidence = merchant && connectorDryRun
-    ? buildConnectorEvidenceExport(merchant.merchant_id, connectorDryRun, connectorReview)
+    ? buildConnectorEvidenceExport(merchant.merchant_id, connectorDryRun, connectorReview, connectorRemediationLoop)
     : null;
   const connectorEvidenceJson = connectorEvidence ? JSON.stringify(connectorEvidence, null, 2) : '';
   const connectorEvidenceMarkdown = connectorEvidence ? buildConnectorEvidenceMarkdown(connectorEvidence) : '';
@@ -2495,6 +2734,58 @@ export function CommerceOnboarding() {
                     )}
                   </div>
                 </div>
+
+                {connectorEvidence.remediation_loop ? (
+                  <div className="mt-3 rounded-md border border-gx-border p-3">
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <div>
+                        <div className="text-sm font-medium text-gx-text">Remediation loop rehearsal</div>
+                        <div className="mt-1 text-xs text-gx-muted">
+                          Local-only loop from prior operator issue through corrected dry-run and sandbox follow-up status.
+                        </div>
+                      </div>
+                      <Badge variant={remediationLoopStatusVariant(connectorEvidence.remediation_loop.loop_status)}>
+                        {connectorEvidence.remediation_loop.loop_status}
+                      </Badge>
+                    </div>
+                    <div className="mt-3 grid gap-2 md:grid-cols-4">
+                      {[
+                        { label: 'previous_review_status', value: connectorEvidence.remediation_loop.previous_issue.review_status },
+                        { label: 'corrected_dry_run', value: connectorEvidence.remediation_loop.corrected_dry_run?.dry_run_id ?? 'not_recorded' },
+                        { label: 'refreshed_packet', value: connectorEvidence.remediation_loop.refreshed_packet?.packet_status ?? 'not_recorded' },
+                        { label: 'operator_followup_status', value: connectorEvidence.remediation_loop.operator_followup.followup_status },
+                      ].map((item) => (
+                        <div key={item.label} className="rounded-md border border-gx-border p-2">
+                          <div className="text-xs text-gx-muted">{item.label}</div>
+                          <div className="break-all text-sm font-medium text-gx-text">{item.value}</div>
+                        </div>
+                      ))}
+                    </div>
+                    <div className="mt-3 grid gap-2 md:grid-cols-2">
+                      <div className="rounded-md border border-gx-border p-2">
+                        <div className="text-xs font-medium text-gx-muted">Previous issue summary</div>
+                        <div className="mt-1 text-xs text-gx-muted">Dry-run: {connectorEvidence.remediation_loop.previous_issue.dry_run_id}</div>
+                        <div className="text-xs text-gx-muted">Review: {connectorEvidence.remediation_loop.previous_issue.review_id}</div>
+                        <div className="text-xs text-gx-muted">Blocked: {connectorEvidence.remediation_loop.previous_issue.blocked_count}</div>
+                        <div className="text-xs text-gx-muted">Pending: {connectorEvidence.remediation_loop.previous_issue.pending_count}</div>
+                      </div>
+                      <div className="rounded-md border border-gx-border p-2">
+                        <div className="text-xs font-medium text-gx-muted">Operator follow-up</div>
+                        <Badge variant={remediationLoopStatusVariant(connectorEvidence.remediation_loop.operator_followup.followup_status)}>
+                          {connectorEvidence.remediation_loop.operator_followup.followup_status}
+                        </Badge>
+                        <div className="mt-1 text-xs text-gx-muted">
+                          Review: {connectorEvidence.remediation_loop.operator_followup.review_id ?? 'not_requested'}
+                        </div>
+                        <div className="text-xs text-gx-muted">
+                          Audit: {connectorEvidence.remediation_loop.operator_followup.audit_references.review_decision_audit_event_id
+                            ?? connectorEvidence.remediation_loop.operator_followup.audit_references.review_requested_audit_event_id
+                            ?? 'not_recorded'}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
 
                 <div className="grid gap-2 md:grid-cols-4">
                   {[

--- a/docs/guides/commerce-v1-merchant-operator-guide.mdx
+++ b/docs/guides/commerce-v1-merchant-operator-guide.mdx
@@ -311,6 +311,19 @@ credentials, tokens, provider metadata, private API URLs, checkout URLs,
 payment identifiers, production config values, concrete allowlists, customer
 data, and secret material.
 
+C6Sf rehearses the remediation loop locally in the portal. After a
+`needs_changes` or `blocked` C6Sa connector review decision, the portal can
+show the previous issue summary, a corrected sandbox dry-run, the refreshed
+packet status, and the operator follow-up status. This is only a local
+review-aid for sandbox evidence; it does not persist follow-up approval or
+enable connector execution.
+
+C6Sf `followup_ready` means only that a corrected dry-run has an accepted
+sandbox follow-up decision in the local evidence packet. It is not production
+approval, connector execution approval, outbound sync approval, public
+discovery approval, checkout/payment approval, live provider approval, public
+protocol publication, or certification.
+
 ## Catalog And Inventory
 
 Catalog and inventory grounding is the first safety step. Agents must not invent

--- a/docs/internal/commerce-v1/commerce-v1-c6sf-connector-dry-run-remediation-loop.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6sf-connector-dry-run-remediation-loop.md
@@ -1,0 +1,122 @@
+# Commerce V1 C6Sf - Connector Dry-Run Remediation Loop Rehearsal
+
+C6Sf hardens the local portal rehearsal loop after C6Se. It lets a reviewer
+see how a `needs_changes` or `blocked` connector dry-run evidence decision
+moves through corrected sandbox rows, a refreshed dry-run packet, and an
+operator follow-up status. It is portal, docs, and test work only. It remains
+internal preview, sandbox-only, non-live, non-publication, non-certifying, and
+non-enabling.
+
+C6Sf does not add backend routes, migrations, workflows, workers, credentials,
+outbound sync, production connector setup, public discovery, checkout/payment
+behavior, live payment behavior, provider calls, merchant private API calls,
+production allowlists, or certification claims.
+
+## Traceability Checklist
+
+| Requirement | Files | Tests | Guardrails | Status |
+| --- | --- | --- | --- | --- |
+| Capture prior operator issue | `apps/portal/src/pages/commerce/CommerceOnboarding.tsx` | `CommerceDashboard.test.tsx` | Local state only; no persistence or backend route | Implemented |
+| Corrected sandbox dry-run status | `CommerceOnboarding.tsx` | `CommerceDashboard.test.tsx` | Uses existing C6R dry-run response shape only | Implemented |
+| Refreshed packet handoff status | `CommerceOnboarding.tsx` | `CommerceDashboard.test.tsx` | Derived from C6Sd/C6Se packet helpers; no publication or enablement | Implemented |
+| Operator follow-up status | `CommerceOnboarding.tsx` | `CommerceDashboard.test.tsx` | Accepted means sandbox follow-up only | Implemented |
+| Redacted JSON/Markdown export | `CommerceOnboarding.tsx` | `CommerceDashboard.test.tsx` | Excludes raw rows, product titles, credentials, private URLs, provider metadata, checkout/payment artifacts, production config, allowlists, and customer data | Implemented |
+| Merchant/operator guide update | `docs/guides/commerce-v1-merchant-operator-guide.mdx` | Doc review | Loop rehearsal remains local/internal evidence only | Implemented |
+
+## Local Remediation Loop
+
+The portal maintains a local `remediation_loop` section after an operator
+records `needs_changes` or `blocked` for a connector dry-run review. The loop
+captures only safe summary evidence:
+
+- previous dry-run ID and review ID;
+- previous review status and packet status;
+- previous blocked and pending counts;
+- corrected dry-run ID, status, counts, and audit references;
+- refreshed packet status, handoff status, and remediation workflow status;
+- operator follow-up review ID, status, decision, and audit references;
+- fixed non-enabling posture.
+
+The loop statuses are:
+
+- `issue_captured`: a `needs_changes` or `blocked` operator decision has been
+  captured locally.
+- `corrected_dry_run_ready`: a later sandbox dry-run passed and refreshed the
+  packet locally.
+- `operator_followup_requested`: a C6Sa follow-up review request exists for the
+  corrected dry-run.
+- `followup_ready`: the corrected dry-run has an accepted sandbox follow-up
+  decision.
+- `blocked_again`: the corrected dry-run or follow-up decision is blocked.
+
+`followup_ready` is not production approval, connector execution approval,
+outbound sync approval, public discovery approval, checkout/payment approval,
+live provider approval, public protocol publication, or certification.
+
+## Evidence Export
+
+C6Sf extends the existing C6Se JSON and Markdown export with a
+`remediation_loop` section. The section is local/internal review evidence only.
+It is intended to help reviewers compare the previous issue with the refreshed
+packet and operator follow-up state.
+
+The export excludes raw rows, raw files, raw merchant-system responses,
+normalized product titles, credentials, tokens, provider metadata, private API
+URLs, checkout URLs, payment identifiers, production config values, concrete
+allowlists, customer data, and secret material.
+
+## Stop Conditions
+
+Stop and require a new approved work item if any follow-up:
+
+- adds credential entry, credential upload, secret storage, token storage, or
+  provider credential paths;
+- adds outbound sync, connector execution, worker schedules, background jobs, or
+  merchant private API calls;
+- connects to Shopify, WooCommerce, Magento, custom APIs, ERP, OMS, WMS,
+  logistics, CRM/support, payment providers, Plural, Stripe, Pine, or merchant
+  private APIs;
+- allows AgenticOrg to call merchant private APIs directly;
+- enables Grantex public discovery or AgenticOrg public commerce discovery;
+- enables production Commerce V1, checkout/payment creation, fulfillment,
+  refund execution, live payments, live Plural, or live providers;
+- writes production config or production allowlists;
+- claims production approval, public protocol publication, provider approval,
+  live-payment approval, or certification;
+- treats sandbox, demo, synthetic, fixture, dry-run, review, packet, handoff,
+  remediation, export, or rehearsal output as real merchant approval.
+
+## Rollback Notes
+
+C6Sf is portal/docs/test only. Roll back by removing:
+
+- the local `remediation_loop` state and export additions in
+  `CommerceOnboarding.tsx`;
+- the related `CommerceDashboard.test.tsx` assertions;
+- this internal note and the C6Sf guide section.
+
+No runtime API, route, migration, worker, production config, public discovery,
+checkout/payment, live payment, provider credential, production allowlist,
+cloud resource, or deploy workflow action is created by this slice.
+
+## Validation
+
+Focused validation for C6Sf:
+
+```bash
+npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
+npm --prefix apps/portal run typecheck
+npm --prefix apps/auth-service test -- commerce-connector-dry-run-c6r.test.ts commerce-connector-dry-run-review-c6sa.test.ts commerce-openapi.test.ts
+npm --prefix apps/auth-service run typecheck
+node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
+git diff --check origin/main...HEAD
+```
+
+Focused scans must cover secrets/private details, production config or allowlist
+assignments, public discovery enablement, checkout/payment enablement, live
+payment/live Plural/provider credential enablement, certification claims, direct
+provider calls, direct merchant private API calls, AgenticOrg direct execution,
+and outbound sync enablement.
+
+Expected scan hits should be limited to stop-condition text, denylist regex
+literals, negative assertions, or explicit disabled-control examples.


### PR DESCRIPTION
Adds portal-only C6Sf remediation-loop rehearsal for connector dry-run evidence. The portal now captures a local needs_changes/blocked issue, advances through a corrected sandbox dry-run, shows refreshed packet status, and records operator follow-up status in the redacted evidence export. Updates the merchant/operator guide and adds the internal C6Sf note. Validation: portal tests, portal typecheck, auth connector/OpenAPI tests, auth typecheck, C6Oe PR conformance gate, git diff --check, and focused guardrail scans. Guardrails: no backend routes, migrations, workflows, workers, credentials, outbound sync, production connector setup, public discovery, checkout/payment behavior, live provider behavior, provider calls, merchant private API calls, production allowlists, or certification claims.