### PR TITLE
[codex] C6Sh connector remediation queue timeline

### DIFF
--- a/apps/auth-service/src/routes/commerce-connectors.ts
+++ b/apps/auth-service/src/routes/commerce-connectors.ts
@@ -985,9 +985,14 @@ function timelineEntry(input: {
   };
 }
 
-function toDryRunRemediationTimeline(row: ConnectorDryRunRemediationRow): Record<string, unknown> {
+function toDryRunRemediationTimeline(
+  row: ConnectorDryRunRemediationRow,
+  followupReview: ConnectorDryRunReviewRow | null = null,
+): Record<string, unknown> {
   const blockerSummary = safeArray(row.blocker_summary);
   const warningSummary = safeArray(row.warning_summary);
+  const followupDecisionAuditEventId = followupReview?.decision_audit_event_id ?? null;
+  const followupDecidedAt = followupReview?.decided_at ?? null;
   const entries: Array<Record<string, unknown>> = [
     timelineEntry({
       sequence: 1,
@@ -1075,8 +1080,10 @@ function toDryRunRemediationTimeline(row: ConnectorDryRunRemediationRow): Record
       eventType: row.status === 'closed_no_action'
         ? 'connector_remediation_closed_or_blocked'
         : 'connector_dry_run_review_decision_recorded',
-      occurredAt: row.updated_at,
-      auditEventId: row.closed_or_blocked_audit_event_id ?? row.followup_audit_event_id,
+      occurredAt: row.status === 'closed_no_action' ? row.updated_at : followupDecidedAt,
+      auditEventId: row.status === 'closed_no_action'
+        ? row.closed_or_blocked_audit_event_id
+        : followupDecisionAuditEventId,
       actorKind: null,
       actorId: null,
       resourceReferences: {
@@ -1088,6 +1095,7 @@ function toDryRunRemediationTimeline(row: ConnectorDryRunRemediationRow): Record
       },
       evidenceSummary: {
         remediation_status: row.status,
+        followup_review_decision: followupReview?.decision ?? null,
         followup_ready_is_launch_approval: false,
         production_approval_granted: false,
       },
@@ -2630,7 +2638,14 @@ export async function commerceConnectorRoutes(app: FastifyInstance): Promise<voi
       throw new CommerceHttpError(404, 'connector_remediation_not_found',
         'Connector dry-run remediation was not found in this tenant and merchant');
     }
-    return reply.status(200).send({ data: toDryRunRemediationTimeline(remediation) });
+    const followupReview = remediation.followup_review_id
+      ? await readDryRunReviewById(sql, tenantId, merchantId, remediation.followup_review_id)
+      : null;
+    if (remediation.followup_review_id && !followupReview) {
+      throw new CommerceHttpError(404, 'connector_dry_run_review_not_found',
+        'Connector remediation follow-up review was not found in this tenant and merchant');
+    }
+    return reply.status(200).send({ data: toDryRunRemediationTimeline(remediation, followupReview) });
   });
 
   app.post<{

--- a/apps/auth-service/src/routes/commerce-connectors.ts
+++ b/apps/auth-service/src/routes/commerce-connectors.ts
@@ -120,6 +120,15 @@ interface ConnectorDryRunRemediationParams {
   remediationId?: string;
 }
 
+interface ConnectorDryRunRemediationListQuery {
+  merchant_id?: string;
+  status?: string;
+  original_decision?: string;
+  has_corrected_dry_run?: string;
+  has_followup_review?: string;
+  limit?: string;
+}
+
 interface ConnectorDryRunReviewDecisionBody {
   decision?: unknown;
   decision_note?: unknown;
@@ -260,6 +269,16 @@ type ConnectorDryRunRemediationStatus =
   | 'blocked_again'
   | 'closed_no_action';
 
+const REMEDIATION_STATUS_VALUES: ConnectorDryRunRemediationStatus[] = [
+  'remediation_requested',
+  'waiting_for_corrected_dry_run',
+  'corrected_dry_run_attached',
+  'followup_review_requested',
+  'followup_ready',
+  'blocked_again',
+  'closed_no_action',
+];
+
 const CONNECTOR_KEY_RE = /^[a-z0-9_-]{3,64}$/;
 const CONNECTOR_TYPES: ConnectorType[] = [
   'manual',
@@ -328,6 +347,8 @@ const REVIEW_DECISIONS = new Set<ConnectorDryRunReviewDecision>([
   'needs_changes',
   'blocked',
 ]);
+const REMEDIATION_STATUSES = new Set<ConnectorDryRunRemediationStatus>(REMEDIATION_STATUS_VALUES);
+const REMEDIATION_ORIGINAL_DECISIONS = new Set(['needs_changes', 'blocked']);
 const SENSITIVE_FIELD_RE =
   /(^|_)(secret|token|api_key|apikey|password|credential|credentials|private_key|client_secret|access_token|refresh_token|raw_payload|authorization|bearer)(_|$)/i;
 const SENSITIVE_VALUE_RE =
@@ -376,6 +397,42 @@ function rowDateOrNull(value: Date | string | null | undefined): string | null {
 function safeList(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.filter((item): item is string => typeof item === 'string' && /^[a-z0-9_.:-]{1,96}$/.test(item));
+}
+
+function safeArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function parseQueryBoolean(
+  value: string | undefined,
+  fieldName: string,
+  fields: Record<string, string>,
+): boolean | null {
+  if (value === undefined) return null;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  fields[fieldName] = 'must be true or false';
+  return null;
+}
+
+function parseQueryLimit(
+  value: string | undefined,
+  fieldName: string,
+  fields: Record<string, string>,
+  fallback: number,
+  max: number,
+): number {
+  if (value === undefined) return fallback;
+  if (!/^\d+$/.test(value)) {
+    fields[fieldName] = `must be an integer between 1 and ${max}`;
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (parsed < 1 || parsed > max) {
+    fields[fieldName] = `must be an integer between 1 and ${max}`;
+    return fallback;
+  }
+  return parsed;
 }
 
 function normalizeSourceDomains(value: unknown, fields: Record<string, string>): SourceDomain[] {
@@ -485,6 +542,28 @@ function merchantIdForConnectorRequest(request: FastifyRequest, rawMerchantId: u
   }
   throw new CommerceHttpError(403, 'caller_not_authorized',
     'Connector registry management requires operator or owning merchant caller');
+}
+
+function merchantFilterForRemediationQueue(request: FastifyRequest, rawMerchantId: unknown): string | null {
+  const caller = request.commerceCaller as CommerceCaller;
+  if (caller.kind === 'merchant') {
+    if (rawMerchantId !== undefined && rawMerchantId !== caller.merchantId) {
+      throw new CommerceHttpError(403, 'merchant_scope_violation',
+        'Merchant callers may only list connector remediation evidence for their own merchant');
+    }
+    return caller.merchantId;
+  }
+  if (caller.kind === 'operator') {
+    if (rawMerchantId !== undefined && !isString(rawMerchantId)) {
+      throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+        details: { fields: { merchant_id: 'must be a string when provided' } },
+        retryable: false,
+      });
+    }
+    return isString(rawMerchantId) ? rawMerchantId : null;
+  }
+  throw new CommerceHttpError(403, 'caller_not_authorized',
+    'Connector remediation queue requires operator or owning merchant caller');
 }
 
 function connectorReviewActor(request: FastifyRequest): { kind: 'operator' | 'merchant'; id: string } {
@@ -820,6 +899,239 @@ function toDryRunRemediation(row: ConnectorDryRunRemediationRow): Record<string,
   };
 }
 
+function dryRunRemediationControls(row: ConnectorDryRunRemediationRow): Record<string, unknown> {
+  return {
+    sandbox_only: row.sandbox_only,
+    not_live: row.not_live,
+    not_approved: row.not_approved,
+    public_discovery_enabled: row.public_discovery_enabled,
+    checkout_payment_enabled: row.checkout_payment_enabled,
+    live_provider_enabled: row.live_provider_enabled,
+    [PROVIDER_SPECIFIC_LIVE_DISABLED_KEY]: row.provider_specific_live_enabled,
+    production_allowlist_written: row.production_allowlist_written,
+    credential_entry_enabled: false,
+    outbound_sync_enabled: false,
+    production_connector_setup_enabled: false,
+    provider_call_enabled: false,
+    merchant_private_api_calls_enabled: false,
+    remediation_is_production_approval: false,
+    remediation_enables_connector_execution: false,
+    followup_ready_is_launch_approval: false,
+  };
+}
+
+function toDryRunRemediationQueueItem(row: ConnectorDryRunRemediationRow): Record<string, unknown> {
+  const blockerSummary = safeArray(row.blocker_summary);
+  const warningSummary = safeArray(row.warning_summary);
+  return {
+    ...toDryRunRemediation(row),
+    queue: {
+      operator_queue_status: row.status,
+      merchant_visible_status: row.status,
+      requires_corrected_dry_run: row.corrected_dry_run_id === null
+        && (row.status === 'remediation_requested' || row.status === 'waiting_for_corrected_dry_run'),
+      requires_operator_followup: row.status === 'corrected_dry_run_attached'
+        || row.status === 'followup_review_requested',
+      timeline_available: true,
+      evidence_redacted: true,
+    },
+    summary: {
+      blocker_count: blockerSummary.length,
+      warning_count: warningSummary.length,
+      corrected_dry_run_attached: row.corrected_dry_run_id !== null,
+      followup_review_requested: row.followup_review_id !== null,
+      last_audit_event_id: row.followup_audit_event_id
+        ?? row.corrected_audit_event_id
+        ?? row.closed_or_blocked_audit_event_id
+        ?? row.requested_audit_event_id,
+    },
+  };
+}
+
+function timelineEntry(input: {
+  sequence: number;
+  key: string;
+  label: string;
+  status: 'complete' | 'pending' | 'blocked';
+  eventType: string;
+  occurredAt: Date | string | null;
+  auditEventId: string | null;
+  actorKind: 'operator' | 'merchant' | null;
+  actorId: string | null;
+  resourceReferences: Record<string, string | null>;
+  evidenceSummary: Record<string, unknown>;
+}): Record<string, unknown> {
+  return {
+    sequence: input.sequence,
+    key: input.key,
+    label: input.label,
+    status: input.status,
+    event_type: input.eventType,
+    occurred_at: rowDateOrNull(input.occurredAt),
+    audit_event_id: input.auditEventId,
+    actor: {
+      kind: input.actorKind,
+      id: input.actorId,
+    },
+    resource_references: input.resourceReferences,
+    evidence_summary: input.evidenceSummary,
+    redaction: {
+      raw_connector_rows_included: false,
+      credentials_included: false,
+      provider_metadata_included: false,
+      merchant_private_api_payload_included: false,
+      production_config_values_included: false,
+    },
+  };
+}
+
+function toDryRunRemediationTimeline(row: ConnectorDryRunRemediationRow): Record<string, unknown> {
+  const blockerSummary = safeArray(row.blocker_summary);
+  const warningSummary = safeArray(row.warning_summary);
+  const entries: Array<Record<string, unknown>> = [
+    timelineEntry({
+      sequence: 1,
+      key: 'remediation_requested',
+      label: 'Remediation requested',
+      status: 'complete',
+      eventType: 'connector_remediation_requested',
+      occurredAt: row.created_at,
+      auditEventId: row.requested_audit_event_id,
+      actorKind: row.requested_by_kind,
+      actorId: row.requested_by_id,
+      resourceReferences: {
+        remediation_id: row.id,
+        original_dry_run_id: row.original_dry_run_id,
+        original_review_id: row.original_review_id,
+        corrected_dry_run_id: row.corrected_dry_run_id,
+        followup_review_id: row.followup_review_id,
+      },
+      evidenceSummary: {
+        original_decision: row.original_decision,
+        blocker_count: blockerSummary.length,
+        warning_count: warningSummary.length,
+        public_safe_note_present: row.public_safe_note !== null,
+      },
+    }),
+  ];
+
+  if (row.corrected_dry_run_id) {
+    entries.push(timelineEntry({
+      sequence: entries.length + 1,
+      key: 'corrected_dry_run_attached',
+      label: 'Corrected dry-run attached',
+      status: 'complete',
+      eventType: 'connector_remediation_corrected_dry_run_attached',
+      occurredAt: row.updated_at,
+      auditEventId: row.corrected_audit_event_id,
+      actorKind: null,
+      actorId: null,
+      resourceReferences: {
+        remediation_id: row.id,
+        original_dry_run_id: row.original_dry_run_id,
+        original_review_id: row.original_review_id,
+        corrected_dry_run_id: row.corrected_dry_run_id,
+        followup_review_id: row.followup_review_id,
+      },
+      evidenceSummary: {
+        corrected_dry_run_attached: true,
+        corrected_dry_run_id: row.corrected_dry_run_id,
+      },
+    }));
+  }
+
+  if (row.followup_review_id) {
+    entries.push(timelineEntry({
+      sequence: entries.length + 1,
+      key: 'followup_review_requested',
+      label: 'Follow-up review requested',
+      status: 'complete',
+      eventType: 'connector_remediation_followup_review_requested',
+      occurredAt: row.updated_at,
+      auditEventId: row.followup_audit_event_id,
+      actorKind: null,
+      actorId: null,
+      resourceReferences: {
+        remediation_id: row.id,
+        original_dry_run_id: row.original_dry_run_id,
+        original_review_id: row.original_review_id,
+        corrected_dry_run_id: row.corrected_dry_run_id,
+        followup_review_id: row.followup_review_id,
+      },
+      evidenceSummary: {
+        followup_review_requested: true,
+        followup_review_id: row.followup_review_id,
+        followup_ready_is_launch_approval: false,
+      },
+    }));
+  }
+
+  if (row.status === 'followup_ready' || row.status === 'blocked_again' || row.status === 'closed_no_action') {
+    entries.push(timelineEntry({
+      sequence: entries.length + 1,
+      key: row.status,
+      label: row.status === 'followup_ready' ? 'Sandbox follow-up ready' : 'Follow-up blocked or closed',
+      status: row.status === 'followup_ready' ? 'complete' : 'blocked',
+      eventType: row.status === 'closed_no_action'
+        ? 'connector_remediation_closed_or_blocked'
+        : 'connector_dry_run_review_decision_recorded',
+      occurredAt: row.updated_at,
+      auditEventId: row.closed_or_blocked_audit_event_id ?? row.followup_audit_event_id,
+      actorKind: null,
+      actorId: null,
+      resourceReferences: {
+        remediation_id: row.id,
+        original_dry_run_id: row.original_dry_run_id,
+        original_review_id: row.original_review_id,
+        corrected_dry_run_id: row.corrected_dry_run_id,
+        followup_review_id: row.followup_review_id,
+      },
+      evidenceSummary: {
+        remediation_status: row.status,
+        followup_ready_is_launch_approval: false,
+        production_approval_granted: false,
+      },
+    }));
+  }
+
+  return {
+    remediation: toDryRunRemediation(row),
+    timeline: entries,
+    operator_queue: {
+      queue_status: row.status,
+      visible_to_operator: true,
+      evidence_redacted: true,
+      requires_corrected_dry_run: row.corrected_dry_run_id === null
+        && (row.status === 'remediation_requested' || row.status === 'waiting_for_corrected_dry_run'),
+      requires_operator_followup: row.status === 'corrected_dry_run_attached'
+        || row.status === 'followup_review_requested',
+    },
+    merchant_status: {
+      visible_to_merchant: true,
+      status: row.status,
+      corrected_dry_run_id: row.corrected_dry_run_id,
+      followup_review_id: row.followup_review_id,
+      next_step: row.status === 'remediation_requested' || row.status === 'waiting_for_corrected_dry_run'
+        ? 'attach_corrected_sandbox_dry_run'
+        : row.status === 'corrected_dry_run_attached'
+          ? 'request_operator_followup_review'
+          : row.status === 'followup_review_requested'
+            ? 'wait_for_operator_decision'
+            : 'review_status_with_operator',
+    },
+    redaction_summary: {
+      blocker_summary_count: blockerSummary.length,
+      warning_summary_count: warningSummary.length,
+      raw_connector_rows_included: false,
+      credentials_included: false,
+      provider_metadata_included: false,
+      merchant_private_api_payload_included: false,
+      production_config_values_included: false,
+    },
+    controls: dryRunRemediationControls(row),
+  };
+}
+
 async function readMerchantForDryRun(sql: Sql, tenantId: string, merchantId: string): Promise<MerchantDryRunRow | null> {
   const rows = await sql<MerchantDryRunRow[]>`
     SELECT id, environment, verification_status, disabled_at
@@ -955,6 +1267,47 @@ async function readDryRunRemediationForOriginal(
      LIMIT 1
   `;
   return rows[0] ?? null;
+}
+
+async function readDryRunRemediationQueue(
+  sql: Sql,
+  input: {
+    tenantId: string;
+    merchantId: string | null;
+    status: ConnectorDryRunRemediationStatus | null;
+    originalDecision: 'needs_changes' | 'blocked' | null;
+    hasCorrectedDryRun: boolean | null;
+    hasFollowupReview: boolean | null;
+    limit: number;
+  },
+): Promise<ConnectorDryRunRemediationRow[]> {
+  return sql<ConnectorDryRunRemediationRow[]>`
+    SELECT id, tenant_id, merchant_id, original_dry_run_id,
+           original_review_id, original_decision, status, public_safe_note,
+           blocker_summary, warning_summary, corrected_dry_run_id,
+           followup_review_id, requested_by_kind, requested_by_id,
+           requested_audit_event_id, corrected_audit_event_id,
+           followup_audit_event_id, closed_or_blocked_audit_event_id,
+           sandbox_only, not_live, not_approved, public_discovery_enabled,
+           checkout_payment_enabled, live_provider_enabled,
+           provider_specific_live_enabled, production_allowlist_written,
+           created_at, updated_at
+      FROM commerce_connector_dry_run_remediations
+     WHERE tenant_id = ${input.tenantId}
+       AND (${input.merchantId}::text IS NULL OR merchant_id = ${input.merchantId})
+       AND (${input.status}::text IS NULL OR status = ${input.status})
+       AND (${input.originalDecision}::text IS NULL OR original_decision = ${input.originalDecision})
+       AND (
+         ${input.hasCorrectedDryRun}::boolean IS NULL
+         OR (corrected_dry_run_id IS NOT NULL) = ${input.hasCorrectedDryRun}
+       )
+       AND (
+         ${input.hasFollowupReview}::boolean IS NULL
+         OR (followup_review_id IS NOT NULL) = ${input.hasFollowupReview}
+       )
+     ORDER BY updated_at DESC, created_at DESC, id DESC
+     LIMIT ${input.limit}
+  `;
 }
 
 async function existingDryRunProductIds(
@@ -2174,6 +2527,82 @@ export async function commerceConnectorRoutes(app: FastifyInstance): Promise<voi
     });
   });
 
+  app.get<{ Querystring: ConnectorDryRunRemediationListQuery }>('/connectors/remediations', async (request, reply) => {
+    const fields: Record<string, string> = {};
+    const merchantId = merchantFilterForRemediationQueue(request, request.query.merchant_id);
+    const rawStatus = request.query.status;
+    const status = rawStatus && REMEDIATION_STATUSES.has(rawStatus as ConnectorDryRunRemediationStatus)
+      ? rawStatus as ConnectorDryRunRemediationStatus
+      : null;
+    if (rawStatus !== undefined && status === null) {
+      fields['status'] = `must be one of: ${REMEDIATION_STATUS_VALUES.join(', ')}`;
+    }
+    const rawOriginalDecision = request.query.original_decision;
+    const originalDecision = rawOriginalDecision && REMEDIATION_ORIGINAL_DECISIONS.has(rawOriginalDecision)
+      ? rawOriginalDecision as 'needs_changes' | 'blocked'
+      : null;
+    if (rawOriginalDecision !== undefined && originalDecision === null) {
+      fields['original_decision'] = 'must be needs_changes or blocked';
+    }
+    const hasCorrectedDryRun = parseQueryBoolean(
+      request.query.has_corrected_dry_run,
+      'has_corrected_dry_run',
+      fields,
+    );
+    const hasFollowupReview = parseQueryBoolean(
+      request.query.has_followup_review,
+      'has_followup_review',
+      fields,
+    );
+    const limit = parseQueryLimit(request.query.limit, 'limit', fields, 25, 100);
+    if (Object.keys(fields).length > 0) {
+      throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+        details: { fields },
+        retryable: false,
+      });
+    }
+
+    const tenantId = request.commerceTenantId;
+    const sql = getSql();
+    if (merchantId !== null) await assertMerchantInTenant(sql, tenantId, merchantId);
+    const rows = await readDryRunRemediationQueue(sql, {
+      tenantId,
+      merchantId,
+      status,
+      originalDecision,
+      hasCorrectedDryRun,
+      hasFollowupReview,
+      limit,
+    });
+    return reply.status(200).send({
+      items: rows.map(toDryRunRemediationQueueItem),
+      next_cursor: null,
+      filters: {
+        merchant_id: merchantId,
+        status,
+        original_decision: originalDecision,
+        has_corrected_dry_run: hasCorrectedDryRun,
+        has_followup_review: hasFollowupReview,
+        limit,
+      },
+      controls: {
+        sandbox_only: true,
+        not_live: true,
+        not_approved: true,
+        public_discovery_enabled: false,
+        checkout_payment_enabled: false,
+        live_provider_enabled: false,
+        [PROVIDER_SPECIFIC_LIVE_DISABLED_KEY]: false,
+        credential_entry_enabled: false,
+        outbound_sync_enabled: false,
+        production_connector_setup_enabled: false,
+        provider_call_enabled: false,
+        merchant_private_api_calls_enabled: false,
+        production_allowlist_written: false,
+      },
+    });
+  });
+
   app.get<{
     Params: Required<Pick<ConnectorDryRunRemediationParams, 'merchantId' | 'remediationId'>>;
   }>('/merchants/:merchantId/connectors/remediations/:remediationId', async (request, reply) => {
@@ -2187,6 +2616,21 @@ export async function commerceConnectorRoutes(app: FastifyInstance): Promise<voi
         'Connector dry-run remediation was not found in this tenant and merchant');
     }
     return reply.status(200).send({ data: toDryRunRemediation(remediation) });
+  });
+
+  app.get<{
+    Params: Required<Pick<ConnectorDryRunRemediationParams, 'merchantId' | 'remediationId'>>;
+  }>('/merchants/:merchantId/connectors/remediations/:remediationId/timeline', async (request, reply) => {
+    const merchantId = merchantIdForConnectorRequest(request, request.params.merchantId);
+    const tenantId = request.commerceTenantId;
+    const sql = getSql();
+    await assertMerchantInTenant(sql, tenantId, merchantId);
+    const remediation = await readDryRunRemediationById(sql, tenantId, merchantId, request.params.remediationId);
+    if (!remediation) {
+      throw new CommerceHttpError(404, 'connector_remediation_not_found',
+        'Connector dry-run remediation was not found in this tenant and merchant');
+    }
+    return reply.status(200).send({ data: toDryRunRemediationTimeline(remediation) });
   });
 
   app.post<{

--- a/apps/auth-service/tests/commerce-connector-remediation-queue-c6sh.test.ts
+++ b/apps/auth-service/tests/commerce-connector-remediation-queue-c6sh.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { authHeader, buildTestApp, sqlMock } from './helpers.js';
+import { seedCommerceContext, TEST_COMMERCE_TENANT_ID } from './commerce-helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..', '..', '..');
+const openapiPath = join(repoRoot, 'docs', 'api', 'grantex-commerce-v1.openapi.yaml');
+const guidePath = join(repoRoot, 'docs', 'guides', 'commerce-v1-merchant-operator-guide.mdx');
+const docPath = join(
+  repoRoot,
+  'docs',
+  'internal',
+  'commerce-v1',
+  'commerce-v1-c6sh-connector-remediation-queue-timeline.md',
+);
+const NOW = '2026-06-08T00:00:00.000Z';
+const MERCHANT = 'mch_C6SH';
+const OTHER_MERCHANT = 'mch_OTHER_C6SH';
+const MERCHANT_TOKEN = ['grtx', 'sk', 'sandbox', 'c6shmmmmmmmmmmmmmmmmmmmmmmmm'].join('_');
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+function bearer(token: string): Record<string, string> {
+  return { authorization: ['Bearer', token].join(' ') };
+}
+
+function remediationDbRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'cdrem_C6SH',
+    tenant_id: TEST_COMMERCE_TENANT_ID,
+    merchant_id: MERCHANT,
+    original_dry_run_id: 'cdry_C6SH_ORIGINAL',
+    original_review_id: 'cdrev_C6SH_ORIGINAL',
+    original_decision: 'needs_changes',
+    status: 'remediation_requested',
+    public_safe_note: 'Correct local sandbox rows only.',
+    blocker_summary: [{ code: 'missing_category', remediation: 'Add a sandbox category mapping.' }],
+    warning_summary: [{ code: 'operator_review_recommended', message: 'Review warning summary.' }],
+    corrected_dry_run_id: null,
+    followup_review_id: null,
+    requested_by_kind: 'operator',
+    requested_by_id: 'dev_TEST',
+    requested_audit_event_id: 'caud_C6SH_REMEDIATION_REQUESTED',
+    corrected_audit_event_id: null,
+    followup_audit_event_id: null,
+    closed_or_blocked_audit_event_id: null,
+    sandbox_only: true,
+    not_live: true,
+    not_approved: true,
+    public_discovery_enabled: false,
+    checkout_payment_enabled: false,
+    live_provider_enabled: false,
+    provider_specific_live_enabled: false,
+    production_allowlist_written: false,
+    created_at: NOW,
+    updated_at: NOW,
+    ...overrides,
+  };
+}
+
+function seedMerchantCaller(merchantId = MERCHANT): void {
+  sqlMock.mockResolvedValueOnce([{
+    id: 'mkey_C6SH',
+    tenant_id: TEST_COMMERCE_TENANT_ID,
+    merchant_id: merchantId,
+    environment: 'sandbox',
+    tenant_status: 'active',
+  }]);
+  sqlMock.mockResolvedValueOnce([]);
+}
+
+function sqlText(): string {
+  return sqlMock.mock.calls
+    .map((call) => {
+      const tpl = call[0] as unknown;
+      return Array.isArray(tpl) ? tpl.join(' ') : '';
+    })
+    .join('\n');
+}
+
+function fullSqlCalls(): string {
+  return JSON.stringify(sqlMock.mock.calls);
+}
+
+describe('C6Sh connector remediation queue and timeline routes', () => {
+  it('lists tenant-scoped operator queue entries with filters and non-enabling controls', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([{ id: MERCHANT }]);
+    sqlMock.mockResolvedValueOnce([remediationDbRow({
+      status: 'corrected_dry_run_attached',
+      corrected_dry_run_id: 'cdry_C6SH_CORRECTED',
+      corrected_audit_event_id: 'caud_C6SH_CORRECTED_ATTACHED',
+    })]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/v1/commerce/connectors/remediations?merchant_id=${MERCHANT}&status=corrected_dry_run_attached&has_corrected_dry_run=true&has_followup_review=false&limit=10`,
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      items: Array<Record<string, unknown>>;
+      filters: Record<string, unknown>;
+      controls: Record<string, unknown>;
+    }>();
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0]).toMatchObject({
+      remediation_id: 'cdrem_C6SH',
+      status: 'corrected_dry_run_attached',
+      queue: {
+        operator_queue_status: 'corrected_dry_run_attached',
+        merchant_visible_status: 'corrected_dry_run_attached',
+        requires_operator_followup: true,
+        timeline_available: true,
+        evidence_redacted: true,
+      },
+      summary: {
+        blocker_count: 1,
+        warning_count: 1,
+        corrected_dry_run_attached: true,
+        followup_review_requested: false,
+        last_audit_event_id: 'caud_C6SH_CORRECTED_ATTACHED',
+      },
+      controls: {
+        sandbox_only: true,
+        not_live: true,
+        not_approved: true,
+        public_discovery_enabled: false,
+        checkout_payment_enabled: false,
+        live_provider_enabled: false,
+        live_plural_enabled: false,
+        remediation_is_production_approval: false,
+        remediation_enables_connector_execution: false,
+      },
+    });
+    expect(body.filters).toMatchObject({
+      merchant_id: MERCHANT,
+      status: 'corrected_dry_run_attached',
+      has_corrected_dry_run: true,
+      has_followup_review: false,
+      limit: 10,
+    });
+    expect(body.controls).toMatchObject({
+      sandbox_only: true,
+      public_discovery_enabled: false,
+      checkout_payment_enabled: false,
+      live_provider_enabled: false,
+      live_plural_enabled: false,
+      credential_entry_enabled: false,
+      outbound_sync_enabled: false,
+      production_connector_setup_enabled: false,
+      provider_call_enabled: false,
+      merchant_private_api_calls_enabled: false,
+      production_allowlist_written: false,
+    });
+    expect(sqlText()).toContain('FROM commerce_connector_dry_run_remediations');
+    expect(sqlText()).not.toMatch(/\b(INSERT|UPDATE|DELETE)\b|commerce_audit_events|checkout_links|payment_intents/i);
+  });
+
+  it('lets merchant callers see only their own remediation queue', async () => {
+    seedMerchantCaller(MERCHANT);
+    sqlMock.mockResolvedValueOnce([{ id: MERCHANT }]);
+    sqlMock.mockResolvedValueOnce([remediationDbRow()]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/connectors/remediations',
+      headers: bearer(MERCHANT_TOKEN),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ filters: Record<string, unknown>; items: unknown[] }>())
+      .toMatchObject({ filters: { merchant_id: MERCHANT }, items: [expect.any(Object)] });
+
+    sqlMock.mockClear();
+    seedMerchantCaller(MERCHANT);
+    const crossScope = await app.inject({
+      method: 'GET',
+      url: `/v1/commerce/connectors/remediations?merchant_id=${OTHER_MERCHANT}`,
+      headers: bearer(MERCHANT_TOKEN),
+    });
+    expect(crossScope.statusCode).toBe(403);
+    expect(fullSqlCalls()).not.toContain('commerce_connector_dry_run_remediations');
+  });
+
+  it('renders a redacted remediation timeline without runtime enablement semantics', async () => {
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([{ id: MERCHANT }]);
+    sqlMock.mockResolvedValueOnce([remediationDbRow({
+      status: 'followup_ready',
+      corrected_dry_run_id: 'cdry_C6SH_CORRECTED',
+      followup_review_id: 'cdrev_C6SH_FOLLOWUP',
+      corrected_audit_event_id: 'caud_C6SH_CORRECTED_ATTACHED',
+      followup_audit_event_id: 'caud_C6SH_FOLLOWUP_REQUESTED',
+      updated_at: '2026-06-08T00:05:00.000Z',
+    })]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/v1/commerce/merchants/${MERCHANT}/connectors/remediations/cdrem_C6SH/timeline`,
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const bodyText = res.body.toLowerCase();
+    const body = res.json<{ data: Record<string, unknown> }>();
+    expect(body.data).toMatchObject({
+      operator_queue: {
+        queue_status: 'followup_ready',
+        visible_to_operator: true,
+        evidence_redacted: true,
+      },
+      merchant_status: {
+        visible_to_merchant: true,
+        status: 'followup_ready',
+        corrected_dry_run_id: 'cdry_C6SH_CORRECTED',
+        followup_review_id: 'cdrev_C6SH_FOLLOWUP',
+      },
+      redaction_summary: {
+        raw_connector_rows_included: false,
+        credentials_included: false,
+        provider_metadata_included: false,
+        merchant_private_api_payload_included: false,
+        production_config_values_included: false,
+      },
+      controls: {
+        sandbox_only: true,
+        not_live: true,
+        not_approved: true,
+        public_discovery_enabled: false,
+        checkout_payment_enabled: false,
+        live_provider_enabled: false,
+        live_plural_enabled: false,
+        credential_entry_enabled: false,
+        outbound_sync_enabled: false,
+        production_connector_setup_enabled: false,
+        provider_call_enabled: false,
+        merchant_private_api_calls_enabled: false,
+        followup_ready_is_launch_approval: false,
+      },
+    });
+    const timeline = body.data['timeline'] as Array<Record<string, unknown>>;
+    expect(timeline.map((entry) => entry['key'])).toEqual([
+      'remediation_requested',
+      'corrected_dry_run_attached',
+      'followup_review_requested',
+      'followup_ready',
+    ]);
+    expect(bodyText).toContain('caud_c6sh_remediation_requested');
+    expect(bodyText).toContain('caud_c6sh_corrected_attached');
+    expect(bodyText).not.toMatch(/secret_value|access_token|checkout_url|payment_intent_id|provider_metadata"\s*:\s*\{|merchant_private_api_payload"\s*:\s*\{/);
+    expect(sqlText()).not.toMatch(/\b(INSERT|UPDATE|DELETE)\b|checkout_links|payment_intents/i);
+  });
+
+  it('rejects invalid queue filters fail-closed', async () => {
+    seedCommerceContext();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/connectors/remediations?status=live&has_corrected_dry_run=yes&limit=500',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(422);
+    const serialized = JSON.stringify(res.json());
+    expect(serialized).toContain('status');
+    expect(serialized).toContain('has_corrected_dry_run');
+    expect(serialized).toContain('limit');
+    expect(fullSqlCalls()).not.toContain('commerce_connector_dry_run_remediations');
+  });
+});
+
+describe('C6Sh docs and OpenAPI drift guards', () => {
+  it('documents remediation queue and timeline as sandbox-only evidence visibility', () => {
+    const doc = readFileSync(docPath, 'utf8');
+    const guide = readFileSync(guidePath, 'utf8');
+    expect(doc).toContain('Traceability Checklist');
+    expect(doc).toContain('tenant-scoped operator queue');
+    expect(doc.toLowerCase()).toContain('redacted remediation timeline');
+    expect(doc.toLowerCase()).toContain('merchant self-serve status visibility');
+    expect(doc).toMatch(/AgenticOrg never directly executes\s+merchant private API calls/);
+    expect(guide).toContain('C6Sh adds a tenant-scoped remediation queue and redacted evidence timeline');
+    expect(`${doc}\n${guide}`).not.toMatch(/certification approved|production approved|public protocol publication approved|live payment approved/i);
+  });
+
+  it('declares C6Sh queue and timeline APIs in OpenAPI as non-enabling', () => {
+    const content = readFileSync(openapiPath, 'utf8');
+    expect(content).toContain('/v1/commerce/connectors/remediations');
+    expect(content).toContain('/v1/commerce/merchants/{merchant_id}/connectors/remediations/{remediation_id}/timeline');
+    expect(content).toMatch(/operationId:\s*listCommerceConnectorDryRunRemediations/);
+    expect(content).toMatch(/operationId:\s*getCommerceConnectorDryRunRemediationTimeline/);
+    expect(content).toMatch(/x-milestone:\s*C6Sh/);
+    expect(content).toMatch(/CommerceConnectorDryRunRemediationTimeline:/);
+    expect(content).toMatch(/merchant_private_api_calls_enabled:\s*\{\s*type:\s*boolean,\s*const:\s*false\s*\}/);
+    expect(content).toMatch(/followup_ready_is_launch_approval:\s*\{\s*type:\s*boolean,\s*const:\s*false\s*\}/);
+  });
+});

--- a/apps/auth-service/tests/commerce-connector-remediation-queue-c6sh.test.ts
+++ b/apps/auth-service/tests/commerce-connector-remediation-queue-c6sh.test.ts
@@ -66,6 +66,38 @@ function remediationDbRow(overrides: Record<string, unknown> = {}): Record<strin
   };
 }
 
+function followupReviewDbRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'cdrev_C6SH_FOLLOWUP',
+    tenant_id: TEST_COMMERCE_TENANT_ID,
+    merchant_id: MERCHANT,
+    dry_run_id: 'cdry_C6SH_CORRECTED',
+    status: 'accepted_for_sandbox_followup',
+    decision: 'accepted_for_sandbox_followup',
+    decision_note: 'Sandbox follow-up evidence is ready for operator review.',
+    requested_by_kind: 'operator',
+    requested_by_id: 'dev_TEST',
+    decided_by_operator_id: 'dev_TEST_OPERATOR',
+    dry_run_status: 'passed',
+    dry_run_generated_at: '2026-06-08T00:03:00.000Z',
+    evidence_summary: { blocked_count: 0, warning_count: 0 },
+    requested_audit_event_id: 'caud_C6SH_FOLLOWUP_REVIEW_REQUESTED',
+    decision_audit_event_id: 'caud_C6SH_FOLLOWUP_DECISION',
+    sandbox_only: true,
+    not_live: true,
+    not_approved: true,
+    public_discovery_enabled: false,
+    checkout_payment_enabled: false,
+    live_provider_enabled: false,
+    provider_specific_live_enabled: false,
+    production_allowlist_written: false,
+    created_at: '2026-06-08T00:04:00.000Z',
+    updated_at: '2026-06-08T00:07:00.000Z',
+    decided_at: '2026-06-08T00:07:00.000Z',
+    ...overrides,
+  };
+}
+
 function seedMerchantCaller(merchantId = MERCHANT): void {
   sqlMock.mockResolvedValueOnce([{
     id: 'mkey_C6SH',
@@ -201,8 +233,9 @@ describe('C6Sh connector remediation queue and timeline routes', () => {
       followup_review_id: 'cdrev_C6SH_FOLLOWUP',
       corrected_audit_event_id: 'caud_C6SH_CORRECTED_ATTACHED',
       followup_audit_event_id: 'caud_C6SH_FOLLOWUP_REQUESTED',
-      updated_at: '2026-06-08T00:05:00.000Z',
+      updated_at: '2026-06-08T00:08:00.000Z',
     })]);
+    sqlMock.mockResolvedValueOnce([followupReviewDbRow()]);
 
     const res = await app.inject({
       method: 'GET',
@@ -255,8 +288,24 @@ describe('C6Sh connector remediation queue and timeline routes', () => {
       'followup_review_requested',
       'followup_ready',
     ]);
+    expect(timeline[2]).toMatchObject({
+      key: 'followup_review_requested',
+      audit_event_id: 'caud_C6SH_FOLLOWUP_REQUESTED',
+    });
+    expect(timeline[3]).toMatchObject({
+      key: 'followup_ready',
+      event_type: 'connector_dry_run_review_decision_recorded',
+      occurred_at: '2026-06-08T00:07:00.000Z',
+      audit_event_id: 'caud_C6SH_FOLLOWUP_DECISION',
+      evidence_summary: {
+        followup_review_decision: 'accepted_for_sandbox_followup',
+        followup_ready_is_launch_approval: false,
+        production_approval_granted: false,
+      },
+    });
     expect(bodyText).toContain('caud_c6sh_remediation_requested');
     expect(bodyText).toContain('caud_c6sh_corrected_attached');
+    expect(bodyText).toContain('caud_c6sh_followup_decision');
     expect(bodyText).not.toMatch(/secret_value|access_token|checkout_url|payment_intent_id|provider_metadata"\s*:\s*\{|merchant_private_api_payload"\s*:\s*\{/);
     expect(sqlText()).not.toMatch(/\b(INSERT|UPDATE|DELETE)\b|checkout_links|payment_intents/i);
   });

--- a/apps/portal/src/api/__tests__/commerce.test.ts
+++ b/apps/portal/src/api/__tests__/commerce.test.ts
@@ -20,6 +20,7 @@ import {
   getCommerceConnectorDryRun,
   getCommerceConnectorDryRunReview,
   getCommerceConnectorDryRunRemediation,
+  getCommerceConnectorDryRunRemediationTimeline,
   getCommerceMerchantSchemaOrgJsonLdPreview,
   getCommerceMerchantSandboxOnboarding,
   getCommerceOpsHealth,
@@ -27,6 +28,7 @@ import {
   listCommerceAgents,
   listCommercePolicies,
   listCommerceProducts,
+  listCommerceConnectorDryRunRemediations,
   listCommerceWebhookSources,
   listCommerceProviderWebhookEvents,
   listCommerceAuditEvents,
@@ -277,15 +279,36 @@ describe('commerce api', () => {
       'http://localhost:3000/v1/commerce/merchants/mch%2F1/connectors/remediations/cdrem%2F1',
     );
 
+    ok({ items: [{ remediation_id: 'cdrem/1' }], next_cursor: null, filters: {}, controls: {} });
+    await listCommerceConnectorDryRunRemediations({
+      merchantId: 'mch/1',
+      status: 'corrected_dry_run_attached',
+      originalDecision: 'needs_changes',
+      hasCorrectedDryRun: true,
+      hasFollowupReview: false,
+      limit: 10,
+    });
+    expect(mockFetch.mock.calls[7]![0]).toBe(
+      'http://localhost:3000/v1/commerce/connectors/remediations?merchant_id=mch%2F1&status=corrected_dry_run_attached&original_decision=needs_changes&has_corrected_dry_run=true&has_followup_review=false&limit=10',
+    );
+    expect(mockFetch.mock.calls[7]![1]?.body).toBeUndefined();
+
+    ok({ data: { timeline: [], controls: { sandbox_only: true } } });
+    await getCommerceConnectorDryRunRemediationTimeline('mch/1', 'cdrem/1');
+    expect(mockFetch.mock.calls[8]![0]).toBe(
+      'http://localhost:3000/v1/commerce/merchants/mch%2F1/connectors/remediations/cdrem%2F1/timeline',
+    );
+    expect(mockFetch.mock.calls[8]![1]?.body).toBeUndefined();
+
     ok({ data: { remediation_id: 'cdrem/1' }, corrected_dry_run: { dry_run_id: 'cdry/2' }, audit_event_id: 'aud_4' });
     await attachCommerceConnectorRemediationCorrectedDryRun('mch/1', 'cdrem/1', {
       correctedDryRunId: 'cdry/2',
       publicSafeNote: 'Corrected sandbox evidence only.',
     });
-    expect(mockFetch.mock.calls[7]![0]).toBe(
+    expect(mockFetch.mock.calls[9]![0]).toBe(
       'http://localhost:3000/v1/commerce/merchants/mch%2F1/connectors/remediations/cdrem%2F1/corrected-dry-run',
     );
-    const correctedBody = JSON.parse(mockFetch.mock.calls[7]![1].body);
+    const correctedBody = JSON.parse(mockFetch.mock.calls[9]![1].body);
     expect(correctedBody).toEqual({
       corrected_dry_run_id: 'cdry/2',
       public_safe_note: 'Corrected sandbox evidence only.',
@@ -295,10 +318,10 @@ describe('commerce api', () => {
     await requestCommerceConnectorRemediationFollowUpReview('mch/1', 'cdrem/1', {
       requestNote: 'Follow-up sandbox evidence review.',
     });
-    expect(mockFetch.mock.calls[8]![0]).toBe(
+    expect(mockFetch.mock.calls[10]![0]).toBe(
       'http://localhost:3000/v1/commerce/merchants/mch%2F1/connectors/remediations/cdrem%2F1/follow-up-review',
     );
-    const followupBody = JSON.parse(mockFetch.mock.calls[8]![1].body);
+    const followupBody = JSON.parse(mockFetch.mock.calls[10]![1].body);
     expect(followupBody).toEqual({ request_note: 'Follow-up sandbox evidence review.' });
     for (const body of [remediationBody, correctedBody, followupBody]) {
       const serialized = JSON.stringify(body).toLowerCase();

--- a/apps/portal/src/api/commerce.ts
+++ b/apps/portal/src/api/commerce.ts
@@ -381,6 +381,93 @@ export interface CommerceConnectorDryRunRemediation {
   updated_at: string | null;
 }
 
+export interface CommerceConnectorDryRunRemediationQueueItem extends CommerceConnectorDryRunRemediation {
+  queue: {
+    operator_queue_status: CommerceConnectorDryRunRemediationStatus;
+    merchant_visible_status: CommerceConnectorDryRunRemediationStatus;
+    requires_corrected_dry_run: boolean;
+    requires_operator_followup: boolean;
+    timeline_available: true;
+    evidence_redacted: true;
+  };
+  summary: {
+    blocker_count: number;
+    warning_count: number;
+    corrected_dry_run_attached: boolean;
+    followup_review_requested: boolean;
+    last_audit_event_id: string | null;
+  };
+}
+
+export interface CommerceConnectorDryRunRemediationTimelineEntry {
+  sequence: number;
+  key: string;
+  label: string;
+  status: 'complete' | 'pending' | 'blocked';
+  event_type: string;
+  occurred_at: string | null;
+  audit_event_id: string | null;
+  actor: {
+    kind: 'operator' | 'merchant' | null;
+    id: string | null;
+  };
+  resource_references: Record<string, string | null>;
+  evidence_summary: Record<string, unknown>;
+  redaction: {
+    raw_connector_rows_included: false;
+    credentials_included: false;
+    provider_metadata_included: false;
+    merchant_private_api_payload_included: false;
+    production_config_values_included: false;
+  };
+}
+
+export interface CommerceConnectorDryRunRemediationTimeline {
+  remediation: CommerceConnectorDryRunRemediation;
+  timeline: CommerceConnectorDryRunRemediationTimelineEntry[];
+  operator_queue: {
+    queue_status: CommerceConnectorDryRunRemediationStatus;
+    visible_to_operator: true;
+    evidence_redacted: true;
+    requires_corrected_dry_run: boolean;
+    requires_operator_followup: boolean;
+  };
+  merchant_status: {
+    visible_to_merchant: true;
+    status: CommerceConnectorDryRunRemediationStatus;
+    corrected_dry_run_id: string | null;
+    followup_review_id: string | null;
+    next_step: string;
+  };
+  redaction_summary: {
+    blocker_summary_count: number;
+    warning_summary_count: number;
+    raw_connector_rows_included: false;
+    credentials_included: false;
+    provider_metadata_included: false;
+    merchant_private_api_payload_included: false;
+    production_config_values_included: false;
+  };
+  controls: {
+    sandbox_only: true;
+    not_live: true;
+    not_approved: true;
+    public_discovery_enabled: false;
+    checkout_payment_enabled: false;
+    live_provider_enabled: false;
+    live_plural_enabled: false;
+    production_allowlist_written: false;
+    credential_entry_enabled: false;
+    outbound_sync_enabled: false;
+    production_connector_setup_enabled: false;
+    provider_call_enabled: false;
+    merchant_private_api_calls_enabled: false;
+    remediation_is_production_approval: false;
+    remediation_enables_connector_execution: false;
+    followup_ready_is_launch_approval: false;
+  };
+}
+
 export interface CommerceConnectorDryRunResponse {
   data: CommerceConnectorDryRunResult;
   audit_events: Array<{
@@ -1044,7 +1131,7 @@ export interface CommerceWellKnownProfile {
   capabilities: string[];
 }
 
-function qs(params: Record<string, string | number | null | undefined>): string {
+function qs(params: Record<string, string | number | boolean | null | undefined>): string {
   const q = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
     if (value !== undefined && value !== null && String(value).length > 0) {
@@ -1472,6 +1559,43 @@ export function getCommerceConnectorDryRunRemediation(
 ): Promise<{ data: CommerceConnectorDryRunRemediation }> {
   return api.get<{ data: CommerceConnectorDryRunRemediation }>(
     `/v1/commerce/merchants/${encodeURIComponent(merchantId)}/connectors/remediations/${encodeURIComponent(remediationId)}`,
+  );
+}
+
+export function listCommerceConnectorDryRunRemediations(params: {
+  merchantId?: string;
+  status?: CommerceConnectorDryRunRemediationStatus;
+  originalDecision?: 'needs_changes' | 'blocked';
+  hasCorrectedDryRun?: boolean;
+  hasFollowupReview?: boolean;
+  limit?: number;
+} = {}): Promise<{
+  items: CommerceConnectorDryRunRemediationQueueItem[];
+  next_cursor: string | null;
+  filters: Record<string, unknown>;
+  controls: Record<string, unknown>;
+}> {
+  return api.get<{
+    items: CommerceConnectorDryRunRemediationQueueItem[];
+    next_cursor: string | null;
+    filters: Record<string, unknown>;
+    controls: Record<string, unknown>;
+  }>(`/v1/commerce/connectors/remediations${qs({
+    merchant_id: params.merchantId,
+    status: params.status,
+    original_decision: params.originalDecision,
+    has_corrected_dry_run: params.hasCorrectedDryRun,
+    has_followup_review: params.hasFollowupReview,
+    limit: params.limit,
+  })}`);
+}
+
+export function getCommerceConnectorDryRunRemediationTimeline(
+  merchantId: string,
+  remediationId: string,
+): Promise<{ data: CommerceConnectorDryRunRemediationTimeline }> {
+  return api.get<{ data: CommerceConnectorDryRunRemediationTimeline }>(
+    `/v1/commerce/merchants/${encodeURIComponent(merchantId)}/connectors/remediations/${encodeURIComponent(remediationId)}/timeline`,
   );
 }
 

--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -40,6 +40,8 @@ const mockRecordCommerceConnectorDryRunReviewDecision = vi.fn();
 const mockCreateCommerceConnectorDryRunRemediation = vi.fn();
 const mockAttachCommerceConnectorRemediationCorrectedDryRun = vi.fn();
 const mockRequestCommerceConnectorRemediationFollowUpReview = vi.fn();
+const mockListCommerceConnectorDryRunRemediations = vi.fn();
+const mockGetCommerceConnectorDryRunRemediationTimeline = vi.fn();
 const mockDisableMerchantAgenticCommerce = vi.fn();
 const mockEnableMerchantAgenticCommerce = vi.fn();
 const mockListCommerceAgents = vi.fn();
@@ -89,6 +91,8 @@ vi.mock('../../api/commerce', () => ({
   createCommerceConnectorDryRunRemediation: (...a: unknown[]) => mockCreateCommerceConnectorDryRunRemediation(...a),
   attachCommerceConnectorRemediationCorrectedDryRun: (...a: unknown[]) => mockAttachCommerceConnectorRemediationCorrectedDryRun(...a),
   requestCommerceConnectorRemediationFollowUpReview: (...a: unknown[]) => mockRequestCommerceConnectorRemediationFollowUpReview(...a),
+  listCommerceConnectorDryRunRemediations: (...a: unknown[]) => mockListCommerceConnectorDryRunRemediations(...a),
+  getCommerceConnectorDryRunRemediationTimeline: (...a: unknown[]) => mockGetCommerceConnectorDryRunRemediationTimeline(...a),
   disableMerchantAgenticCommerce: (...a: unknown[]) => mockDisableMerchantAgenticCommerce(...a),
   enableMerchantAgenticCommerce: (...a: unknown[]) => mockEnableMerchantAgenticCommerce(...a),
   listCommerceAgents: (...a: unknown[]) => mockListCommerceAgents(...a),
@@ -897,6 +901,103 @@ const connectorRemediationFollowup = {
   updated_at: '2026-01-01T00:51:30Z',
 };
 
+const connectorRemediationTimeline = {
+  remediation: connectorRemediationFollowup,
+  timeline: [
+    {
+      sequence: 1,
+      key: 'remediation_requested',
+      label: 'Remediation requested',
+      status: 'complete' as const,
+      event_type: 'connector_remediation_requested',
+      occurred_at: '2026-01-01T00:44:00Z',
+      audit_event_id: 'caud_C6SG_REMEDIATION_REQUESTED',
+      actor: { kind: 'operator' as const, id: 'dev_TEST' },
+      resource_references: {
+        remediation_id: 'cdrem_C6SG',
+        original_dry_run_id: 'cdry_C6SB',
+        original_review_id: 'cdrev_C6SB',
+        corrected_dry_run_id: 'cdry_C6SF_CORRECTED',
+        followup_review_id: 'cdrev_C6SF_FOLLOWUP',
+      },
+      evidence_summary: { blocker_count: 0, warning_count: 0 },
+      redaction: {
+        raw_connector_rows_included: false as const,
+        credentials_included: false as const,
+        provider_metadata_included: false as const,
+        merchant_private_api_payload_included: false as const,
+        production_config_values_included: false as const,
+      },
+    },
+    {
+      sequence: 2,
+      key: 'followup_review_requested',
+      label: 'Follow-up review requested',
+      status: 'complete' as const,
+      event_type: 'connector_remediation_followup_review_requested',
+      occurred_at: '2026-01-01T00:51:30Z',
+      audit_event_id: 'caud_C6SG_FOLLOWUP_REQUESTED',
+      actor: { kind: null, id: null },
+      resource_references: {
+        remediation_id: 'cdrem_C6SG',
+        original_dry_run_id: 'cdry_C6SB',
+        original_review_id: 'cdrev_C6SB',
+        corrected_dry_run_id: 'cdry_C6SF_CORRECTED',
+        followup_review_id: 'cdrev_C6SF_FOLLOWUP',
+      },
+      evidence_summary: { followup_ready_is_launch_approval: false },
+      redaction: {
+        raw_connector_rows_included: false as const,
+        credentials_included: false as const,
+        provider_metadata_included: false as const,
+        merchant_private_api_payload_included: false as const,
+        production_config_values_included: false as const,
+      },
+    },
+  ],
+  operator_queue: {
+    queue_status: 'followup_review_requested' as const,
+    visible_to_operator: true as const,
+    evidence_redacted: true as const,
+    requires_corrected_dry_run: false,
+    requires_operator_followup: true,
+  },
+  merchant_status: {
+    visible_to_merchant: true as const,
+    status: 'followup_review_requested' as const,
+    corrected_dry_run_id: 'cdry_C6SF_CORRECTED',
+    followup_review_id: 'cdrev_C6SF_FOLLOWUP',
+    next_step: 'wait_for_operator_decision',
+  },
+  redaction_summary: {
+    blocker_summary_count: 0,
+    warning_summary_count: 0,
+    raw_connector_rows_included: false as const,
+    credentials_included: false as const,
+    provider_metadata_included: false as const,
+    merchant_private_api_payload_included: false as const,
+    production_config_values_included: false as const,
+  },
+  controls: {
+    sandbox_only: true as const,
+    not_live: true as const,
+    not_approved: true as const,
+    public_discovery_enabled: false as const,
+    checkout_payment_enabled: false as const,
+    live_provider_enabled: false as const,
+    live_plural_enabled: false as const,
+    production_allowlist_written: false as const,
+    credential_entry_enabled: false as const,
+    outbound_sync_enabled: false as const,
+    production_connector_setup_enabled: false as const,
+    provider_call_enabled: false as const,
+    merchant_private_api_calls_enabled: false as const,
+    remediation_is_production_approval: false as const,
+    remediation_enables_connector_execution: false as const,
+    followup_ready_is_launch_approval: false as const,
+  },
+};
+
 const connectorDryRunCorrected = {
   ...connectorDryRun,
   dry_run_id: 'cdry_C6SF_CORRECTED',
@@ -1373,6 +1474,38 @@ describe('CommerceOnboarding', () => {
       followup_review: connectorReviewFollowup,
       audit_event_id: 'caud_C6SG_FOLLOWUP_REQUESTED',
     });
+    mockListCommerceConnectorDryRunRemediations.mockResolvedValue({
+      items: [{
+        ...connectorRemediationFollowup,
+        queue: {
+          operator_queue_status: 'followup_review_requested' as const,
+          merchant_visible_status: 'followup_review_requested' as const,
+          requires_corrected_dry_run: false,
+          requires_operator_followup: true,
+          timeline_available: true as const,
+          evidence_redacted: true as const,
+        },
+        summary: {
+          blocker_count: 0,
+          warning_count: 0,
+          corrected_dry_run_attached: true,
+          followup_review_requested: true,
+          last_audit_event_id: 'caud_C6SG_FOLLOWUP_REQUESTED',
+        },
+      }],
+      next_cursor: null,
+      filters: { merchant_id: 'mch_1' },
+      controls: {
+        sandbox_only: true,
+        public_discovery_enabled: false,
+        checkout_payment_enabled: false,
+        live_provider_enabled: false,
+        live_plural_enabled: false,
+      },
+    });
+    mockGetCommerceConnectorDryRunRemediationTimeline.mockResolvedValue({
+      data: connectorRemediationTimeline,
+    });
     mockListCommerceAgents.mockResolvedValue({ items: [agent], next_cursor: null });
     mockListCommercePolicies.mockResolvedValue({ items: [{ id: 'cpol_1', status: 'active' }], next_cursor: null });
     mockListCommerceProducts.mockResolvedValue({ items: [product], next_cursor: null });
@@ -1661,6 +1794,41 @@ describe('CommerceOnboarding', () => {
     expect(remediationEvidenceJsonPreview.textContent).not.toContain('rows_json');
     expect(remediationEvidenceJsonPreview.textContent).not.toContain('Portal Sandbox Fixture Product');
     expect(screen.queryByRole('textbox', { name: 'Credential' })).not.toBeInTheDocument();
+    expect(screen.queryByText('outbound connector sync enabled')).not.toBeInTheDocument();
+  });
+
+  it('loads persisted remediation queue and redacted timeline without connector execution controls', async () => {
+    const user = userEvent.setup();
+    r(<CommerceOnboarding />);
+
+    await user.type(screen.getByLabelText('Merchant ID'), 'mch_1');
+    await user.click(screen.getByRole('button', { name: 'Load onboarding' }));
+    await waitFor(() => expect(screen.getByText('Persisted remediation queue')).toBeInTheDocument());
+
+    await user.selectOptions(screen.getByLabelText('Remediation status filter'), 'followup_review_requested');
+    await user.click(screen.getByRole('button', { name: 'Load remediation queue' }));
+    await waitFor(() => expect(mockListCommerceConnectorDryRunRemediations).toHaveBeenCalledWith({
+      merchantId: 'mch_1',
+      status: 'followup_review_requested',
+      limit: 10,
+    }));
+    expect(screen.getAllByText('cdrem_C6SG').length).toBeGreaterThan(0);
+    expect(screen.getByText('operator_followup_required')).toBeInTheDocument();
+    expect(screen.getAllByText('public_discovery_enabled').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('checkout_payment_enabled').length).toBeGreaterThan(0);
+    expect(screen.getByText('merchant_private_api_calls_enabled')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'View timeline' }));
+    await waitFor(() => expect(mockGetCommerceConnectorDryRunRemediationTimeline).toHaveBeenCalledWith('mch_1', 'cdrem_C6SG'));
+    expect(screen.getByText('Redacted remediation timeline')).toBeInTheDocument();
+    expect(screen.getByText('merchant_next_step')).toBeInTheDocument();
+    expect(screen.getByText('wait_for_operator_decision')).toBeInTheDocument();
+    expect(screen.getByText('raw_rows_included')).toBeInTheDocument();
+    expect(screen.getByText('followup_ready_is_launch_approval')).toBeInTheDocument();
+    expect(screen.getByText('connector_remediation_requested')).toBeInTheDocument();
+    expect(screen.getByText('connector_remediation_followup_review_requested')).toBeInTheDocument();
+    expect(screen.queryByRole('textbox', { name: 'Credential' })).not.toBeInTheDocument();
+    expect(screen.queryByText('production connector setup enabled')).not.toBeInTheDocument();
     expect(screen.queryByText('outbound connector sync enabled')).not.toBeInTheDocument();
   });
 

--- a/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
+++ b/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
@@ -6,6 +6,7 @@ import {
   dryRunCommerceMerchantReadOnlyDiscoveryRolloutProposal,
   evaluateCommercePolicy,
   recordCommerceConnectorDryRunReviewDecision,
+  getCommerceConnectorDryRunRemediationTimeline,
   getCommerceMerchantAgenticOrgBuyerDiscoveryPreview,
   getCommerceMerchantReadOnlyDiscoveryReview,
   getCommerceMerchantReadOnlyDiscoveryRolloutProposal,
@@ -13,6 +14,7 @@ import {
   getCommerceMerchantSchemaOrgJsonLdPreview,
   getCommerceWellKnownProfile,
   listCommerceAgents,
+  listCommerceConnectorDryRunRemediations,
   listCommercePolicies,
   listCommerceProducts,
   listCommerceProviderCredentials,
@@ -30,6 +32,9 @@ import {
   type CommerceAgenticOrgBuyerDiscoveryPreview,
   type CommerceConnectorDryRunResult,
   type CommerceConnectorDryRunRemediation,
+  type CommerceConnectorDryRunRemediationQueueItem,
+  type CommerceConnectorDryRunRemediationStatus,
+  type CommerceConnectorDryRunRemediationTimeline,
   type CommerceConnectorDryRunReview,
   type CommerceConnectorDryRunReviewDecision,
   type CommerceConnectorDryRunType,
@@ -213,6 +218,16 @@ interface ConnectorRemediationLoopState {
 }
 
 const connectorEvidencePacketSchemaVersion = 'grantex.commerce.connector_dry_run.evidence_packet.v1';
+
+const connectorRemediationStatusOptions: CommerceConnectorDryRunRemediationStatus[] = [
+  'remediation_requested',
+  'waiting_for_corrected_dry_run',
+  'corrected_dry_run_attached',
+  'followup_review_requested',
+  'followup_ready',
+  'blocked_again',
+  'closed_no_action',
+];
 
 const connectorRowsPrivateFieldFragments = [
   'credential',
@@ -1148,6 +1163,9 @@ export function CommerceOnboarding() {
   const [connectorReview, setConnectorReview] = useState<CommerceConnectorDryRunReview | null>(null);
   const [connectorRemediationLoop, setConnectorRemediationLoop] = useState<ConnectorRemediationLoopState | null>(null);
   const [connectorBackendRemediation, setConnectorBackendRemediation] = useState<CommerceConnectorDryRunRemediation | null>(null);
+  const [connectorRemediationQueue, setConnectorRemediationQueue] = useState<CommerceConnectorDryRunRemediationQueueItem[]>([]);
+  const [connectorRemediationTimeline, setConnectorRemediationTimeline] = useState<CommerceConnectorDryRunRemediationTimeline | null>(null);
+  const [connectorQueueStatusFilter, setConnectorQueueStatusFilter] = useState<CommerceConnectorDryRunRemediationStatus | ''>('');
   const [merchantForm, setMerchantForm] = useState<MerchantPatchForm>(defaultPatch);
   const [agents, setAgents] = useState<CommerceAgent[]>([]);
   const [activePolicyCount, setActivePolicyCount] = useState(0);
@@ -1166,6 +1184,8 @@ export function CommerceOnboarding() {
   const [connectorSubmitting, setConnectorSubmitting] = useState(false);
   const [connectorReviewSubmitting, setConnectorReviewSubmitting] = useState(false);
   const [connectorDecisionSubmitting, setConnectorDecisionSubmitting] = useState(false);
+  const [connectorQueueLoading, setConnectorQueueLoading] = useState(false);
+  const [connectorTimelineLoading, setConnectorTimelineLoading] = useState(false);
   const [connectorForm, setConnectorForm] = useState<{
     connector_type: CommerceConnectorDryRunType;
     source_label: string;
@@ -1236,6 +1256,8 @@ export function CommerceOnboarding() {
       setConnectorReview(null);
       setConnectorRemediationLoop(null);
       setConnectorBackendRemediation(null);
+      setConnectorRemediationQueue([]);
+      setConnectorRemediationTimeline(null);
       setProposalNote(proposalRes?.data.proposal_note ?? '');
       setAgenticOrgNote('');
       setMerchantForm({
@@ -1455,6 +1477,8 @@ export function CommerceOnboarding() {
     setConnectorForm((prev) => ({ ...prev, rows_json: connectorDryRunRowsFixture }));
     setConnectorDryRun(null);
     setConnectorReview(null);
+    setConnectorRemediationQueue([]);
+    setConnectorRemediationTimeline(null);
     show('Sandbox sample rows restored', 'success');
   }
 
@@ -1464,6 +1488,8 @@ export function CommerceOnboarding() {
     setConnectorReview(null);
     setConnectorRemediationLoop(null);
     setConnectorBackendRemediation(null);
+    setConnectorRemediationQueue([]);
+    setConnectorRemediationTimeline(null);
     show('Sandbox connector rows cleared', 'success');
   }
 
@@ -1497,6 +1523,7 @@ export function CommerceOnboarding() {
           },
         );
         setConnectorBackendRemediation(remediationRes.data);
+        setConnectorRemediationTimeline(null);
       }
       setConnectorRemediationLoop((prev) => (
         prev && prev.loop_status !== 'followup_ready'
@@ -1526,6 +1553,7 @@ export function CommerceOnboarding() {
           { requestNote },
         );
         setConnectorBackendRemediation(res.data);
+        setConnectorRemediationTimeline(null);
         setConnectorReview(res.followup_review);
         setConnectorDryRun(res.corrected_dry_run);
         setConnectorRemediationLoop((prev) => (
@@ -1583,6 +1611,7 @@ export function CommerceOnboarding() {
           { publicSafeNote: res.data.decision_note ?? undefined },
         );
         setConnectorBackendRemediation(remediationRes.data);
+        setConnectorRemediationTimeline(null);
       } else if (connectorBackendRemediation?.followup_review_id === res.data.review_id) {
         setConnectorBackendRemediation((prev) => prev ? {
           ...prev,
@@ -1592,12 +1621,50 @@ export function CommerceOnboarding() {
             followup_audit_event_id: prev.audit_references.followup_audit_event_id ?? res.data.audit_event_id,
           },
         } : prev);
+        setConnectorRemediationTimeline(null);
       }
       show('Connector dry-run review decision recorded', 'success');
     } catch {
       show('Connector dry-run review decision is blocked', 'error');
     } finally {
       setConnectorDecisionSubmitting(false);
+    }
+  }
+
+  async function loadConnectorRemediationQueue() {
+    if (!merchant) return;
+    setConnectorQueueLoading(true);
+    try {
+      const res = await listCommerceConnectorDryRunRemediations({
+        merchantId: merchant.merchant_id,
+        status: connectorQueueStatusFilter || undefined,
+        limit: 10,
+      });
+      setConnectorRemediationQueue(res.items);
+      show('Connector remediation queue loaded', 'success');
+    } catch {
+      show('Connector remediation queue is unavailable', 'error');
+    } finally {
+      setConnectorQueueLoading(false);
+    }
+  }
+
+  async function loadConnectorRemediationTimeline(remediationId?: string) {
+    if (!merchant) return;
+    const id = remediationId ?? connectorBackendRemediation?.remediation_id;
+    if (!id) {
+      show('Select a remediation record before loading its timeline', 'error');
+      return;
+    }
+    setConnectorTimelineLoading(true);
+    try {
+      const res = await getCommerceConnectorDryRunRemediationTimeline(merchant.merchant_id, id);
+      setConnectorRemediationTimeline(res.data);
+      show('Connector remediation timeline loaded', 'success');
+    } catch {
+      show('Connector remediation timeline is unavailable', 'error');
+    } finally {
+      setConnectorTimelineLoading(false);
     }
   }
 
@@ -2572,6 +2639,8 @@ export function CommerceOnboarding() {
                   setConnectorReview(null);
                   setConnectorRemediationLoop(null);
                   setConnectorBackendRemediation(null);
+                  setConnectorRemediationQueue([]);
+                  setConnectorRemediationTimeline(null);
                 }}
                 rows={8}
                 className="w-full rounded-md border border-gx-border bg-gx-bg px-3 py-2 font-mono text-xs text-gx-text focus:border-gx-accent focus:outline-none"
@@ -2720,6 +2789,150 @@ export function CommerceOnboarding() {
                 </div>
               </>
             ) : null}
+
+            <div className="mt-4 rounded-md border border-gx-border p-3">
+              <div className="mb-3 flex flex-wrap items-start justify-between gap-2">
+                <div>
+                  <div className="text-sm font-medium text-gx-text">Persisted remediation queue</div>
+                  <p className="mt-1 text-xs text-gx-muted">
+                    Tenant-scoped sandbox remediation status and redacted timeline visibility; this does not approve production launch, outbound sync, public discovery, checkout, payment, or live providers.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="warning">sandbox_only</Badge>
+                  <Badge variant="success">credential-free</Badge>
+                  <Badge variant="success">read-only timeline</Badge>
+                </div>
+              </div>
+              <div className="grid gap-3 md:grid-cols-[260px_auto_auto] md:items-end">
+                <label className="text-sm font-medium text-gx-text">
+                  Remediation status filter
+                  <select
+                    className="mt-1.5 w-full rounded-md border border-gx-border bg-gx-bg px-3 py-2 text-sm text-gx-text focus:border-gx-accent focus:outline-none"
+                    value={connectorQueueStatusFilter}
+                    onChange={(e) => setConnectorQueueStatusFilter(e.target.value as CommerceConnectorDryRunRemediationStatus | '')}
+                  >
+                    <option value="">all sandbox statuses</option>
+                    {connectorRemediationStatusOptions.map((status) => (
+                      <option key={status} value={status}>{status}</option>
+                    ))}
+                  </select>
+                </label>
+                <Button
+                  variant="secondary"
+                  onClick={loadConnectorRemediationQueue}
+                  disabled={connectorQueueLoading}
+                >
+                  {connectorQueueLoading ? 'Loading queue' : 'Load remediation queue'}
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={() => loadConnectorRemediationTimeline()}
+                  disabled={connectorTimelineLoading || !connectorBackendRemediation}
+                  title={connectorBackendRemediation ? 'Load timeline for the persisted remediation evidence.' : 'Create or select persisted remediation evidence first.'}
+                >
+                  {connectorTimelineLoading ? 'Loading timeline' : 'Load current timeline'}
+                </Button>
+              </div>
+              <div className="mt-3 grid gap-2 md:grid-cols-4">
+                {[
+                  { label: 'public_discovery_enabled', value: false },
+                  { label: 'checkout_payment_enabled', value: false },
+                  { label: 'live_provider_enabled', value: false },
+                  { label: 'merchant_private_api_calls_enabled', value: false },
+                ].map((item) => (
+                  <div key={item.label} className="rounded-md border border-gx-border p-2">
+                    <div className="text-xs text-gx-muted">{item.label}</div>
+                    <Badge variant={item.value ? 'danger' : 'success'}>{String(item.value)}</Badge>
+                  </div>
+                ))}
+              </div>
+              {connectorRemediationQueue.length ? (
+                <div className="mt-3 grid gap-2">
+                  {connectorRemediationQueue.map((item) => (
+                    <div key={item.remediation_id} className="rounded-md border border-gx-border p-2">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div>
+                          <div className="break-all text-sm font-medium text-gx-text">{item.remediation_id}</div>
+                          <div className="mt-1 text-xs text-gx-muted">
+                            Original dry-run {item.original_dry_run_id} | original decision {item.original_decision}
+                          </div>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge variant={backendRemediationStatusVariant(item.status)}>{item.status}</Badge>
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            onClick={() => loadConnectorRemediationTimeline(item.remediation_id)}
+                            disabled={connectorTimelineLoading}
+                          >
+                            View timeline
+                          </Button>
+                        </div>
+                      </div>
+                      <div className="mt-2 grid gap-2 md:grid-cols-4">
+                        {[
+                          { label: 'blockers', value: item.summary.blocker_count },
+                          { label: 'warnings', value: item.summary.warning_count },
+                          { label: 'corrected_attached', value: item.summary.corrected_dry_run_attached },
+                          { label: 'operator_followup_required', value: item.queue.requires_operator_followup },
+                        ].map((summary) => (
+                          <div key={summary.label} className="rounded-md border border-gx-border p-2">
+                            <div className="text-xs text-gx-muted">{summary.label}</div>
+                            <div className="text-sm font-medium text-gx-text">{String(summary.value)}</div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="mt-3 text-sm text-gx-muted">No persisted remediation queue entries loaded.</p>
+              )}
+
+              {connectorRemediationTimeline ? (
+                <div className="mt-3 rounded-md border border-gx-border p-3">
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <div>
+                      <div className="text-sm font-medium text-gx-text">Redacted remediation timeline</div>
+                      <div className="mt-1 text-xs text-gx-muted">
+                        Merchant-visible and operator-visible status from Grantex-persisted sandbox evidence only.
+                      </div>
+                    </div>
+                    <Badge variant={backendRemediationStatusVariant(connectorRemediationTimeline.merchant_status.status)}>
+                      {connectorRemediationTimeline.merchant_status.status}
+                    </Badge>
+                  </div>
+                  <div className="mt-2 grid gap-2 md:grid-cols-4">
+                    {[
+                      { label: 'merchant_next_step', value: connectorRemediationTimeline.merchant_status.next_step },
+                      { label: 'queue_status', value: connectorRemediationTimeline.operator_queue.queue_status },
+                      { label: 'raw_rows_included', value: connectorRemediationTimeline.redaction_summary.raw_connector_rows_included },
+                      { label: 'followup_ready_is_launch_approval', value: connectorRemediationTimeline.controls.followup_ready_is_launch_approval },
+                    ].map((item) => (
+                      <div key={item.label} className="rounded-md border border-gx-border p-2">
+                        <div className="text-xs text-gx-muted">{item.label}</div>
+                        <div className="break-all text-sm font-medium text-gx-text">{String(item.value)}</div>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-3 grid gap-2">
+                    {connectorRemediationTimeline.timeline.map((entry) => (
+                      <div key={`${entry.sequence}-${entry.key}`} className="rounded-md border border-gx-border p-2">
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <div className="text-xs font-medium text-gx-text">{entry.sequence}. {entry.label}</div>
+                          <Badge variant={entry.status === 'complete' ? 'success' : entry.status === 'blocked' ? 'danger' : 'warning'}>
+                            {entry.status}
+                          </Badge>
+                        </div>
+                        <div className="mt-1 text-xs text-gx-muted">{entry.event_type}</div>
+                        <div className="mt-1 break-all text-xs text-gx-muted">Audit: {entry.audit_event_id ?? 'not_recorded'}</div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
 
             {connectorEvidence ? (
               <div className="mt-4 rounded-md border border-gx-border p-3">

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -3057,6 +3057,190 @@ components:
         created_at: { type: string, format: date-time, nullable: true }
         updated_at: { type: string, format: date-time, nullable: true }
 
+    CommerceConnectorDryRunRemediationQueueItem:
+      allOf:
+        - { $ref: "#/components/schemas/CommerceConnectorDryRunRemediation" }
+        - type: object
+          description: >-
+            C6Sh operator queue and merchant self-serve status projection for
+            persisted sandbox remediation evidence. It is read-only, redacted,
+            sandbox-only, non-live, non-public, non-enabling, and not
+            production approval or certification.
+          properties:
+            queue:
+              type: object
+              additionalProperties: false
+              properties:
+                operator_queue_status:
+                  type: string
+                  enum:
+                    - remediation_requested
+                    - waiting_for_corrected_dry_run
+                    - corrected_dry_run_attached
+                    - followup_review_requested
+                    - followup_ready
+                    - blocked_again
+                    - closed_no_action
+                merchant_visible_status:
+                  type: string
+                  enum:
+                    - remediation_requested
+                    - waiting_for_corrected_dry_run
+                    - corrected_dry_run_attached
+                    - followup_review_requested
+                    - followup_ready
+                    - blocked_again
+                    - closed_no_action
+                requires_corrected_dry_run: { type: boolean }
+                requires_operator_followup: { type: boolean }
+                timeline_available: { type: boolean, const: true }
+                evidence_redacted: { type: boolean, const: true }
+            summary:
+              type: object
+              additionalProperties: false
+              properties:
+                blocker_count: { type: integer, minimum: 0 }
+                warning_count: { type: integer, minimum: 0 }
+                corrected_dry_run_attached: { type: boolean }
+                followup_review_requested: { type: boolean }
+                last_audit_event_id: { type: string, nullable: true }
+
+    CommerceConnectorDryRunRemediationListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/CommerceConnectorDryRunRemediationQueueItem" }
+        next_cursor: { type: string, nullable: true }
+        filters:
+          type: object
+          additionalProperties: true
+        controls:
+          type: object
+          additionalProperties: false
+          properties:
+            sandbox_only: { type: boolean, const: true }
+            not_live: { type: boolean, const: true }
+            not_approved: { type: boolean, const: true }
+            public_discovery_enabled: { type: boolean, const: false }
+            checkout_payment_enabled: { type: boolean, const: false }
+            live_provider_enabled: { type: boolean, const: false }
+            live_plural_enabled: { type: boolean, const: false }
+            credential_entry_enabled: { type: boolean, const: false }
+            outbound_sync_enabled: { type: boolean, const: false }
+            production_connector_setup_enabled: { type: boolean, const: false }
+            provider_call_enabled: { type: boolean, const: false }
+            merchant_private_api_calls_enabled: { type: boolean, const: false }
+            production_allowlist_written: { type: boolean, const: false }
+
+    CommerceConnectorDryRunRemediationTimelineEntry:
+      type: object
+      description: >-
+        Redacted timeline entry synthesized from C6Sg remediation state and
+        audit references. It excludes raw connector rows, credentials, provider
+        metadata, merchant private API payloads, production config, allowlists,
+        checkout/payment artifacts, and certification claims.
+      properties:
+        sequence: { type: integer, minimum: 1 }
+        key: { type: string }
+        label: { type: string }
+        status: { type: string, enum: [complete, pending, blocked] }
+        event_type: { type: string }
+        occurred_at: { type: string, format: date-time, nullable: true }
+        audit_event_id: { type: string, nullable: true }
+        actor:
+          type: object
+          additionalProperties: false
+          properties:
+            kind: { type: string, enum: [operator, merchant], nullable: true }
+            id: { type: string, nullable: true }
+        resource_references:
+          type: object
+          additionalProperties:
+            type: string
+            nullable: true
+        evidence_summary:
+          type: object
+          additionalProperties: true
+        redaction:
+          type: object
+          additionalProperties: false
+          properties:
+            raw_connector_rows_included: { type: boolean, const: false }
+            credentials_included: { type: boolean, const: false }
+            provider_metadata_included: { type: boolean, const: false }
+            merchant_private_api_payload_included: { type: boolean, const: false }
+            production_config_values_included: { type: boolean, const: false }
+
+    CommerceConnectorDryRunRemediationTimeline:
+      type: object
+      description: >-
+        C6Sh read-only remediation timeline for sandbox connector dry-run
+        evidence. It makes operator queue and merchant self-serve status
+        visible without adding credential entry, outbound sync, public
+        discovery, checkout/payment creation, live providers, provider calls,
+        merchant private API calls, production allowlists, publication, or
+        certification.
+      properties:
+        remediation: { $ref: "#/components/schemas/CommerceConnectorDryRunRemediation" }
+        timeline:
+          type: array
+          items: { $ref: "#/components/schemas/CommerceConnectorDryRunRemediationTimelineEntry" }
+        operator_queue:
+          type: object
+          additionalProperties: false
+          properties:
+            queue_status: { type: string }
+            visible_to_operator: { type: boolean, const: true }
+            evidence_redacted: { type: boolean, const: true }
+            requires_corrected_dry_run: { type: boolean }
+            requires_operator_followup: { type: boolean }
+        merchant_status:
+          type: object
+          additionalProperties: false
+          properties:
+            visible_to_merchant: { type: boolean, const: true }
+            status: { type: string }
+            corrected_dry_run_id: { type: string, nullable: true }
+            followup_review_id: { type: string, nullable: true }
+            next_step: { type: string }
+        redaction_summary:
+          type: object
+          additionalProperties: false
+          properties:
+            blocker_summary_count: { type: integer, minimum: 0 }
+            warning_summary_count: { type: integer, minimum: 0 }
+            raw_connector_rows_included: { type: boolean, const: false }
+            credentials_included: { type: boolean, const: false }
+            provider_metadata_included: { type: boolean, const: false }
+            merchant_private_api_payload_included: { type: boolean, const: false }
+            production_config_values_included: { type: boolean, const: false }
+        controls:
+          type: object
+          additionalProperties: false
+          properties:
+            sandbox_only: { type: boolean, const: true }
+            not_live: { type: boolean, const: true }
+            not_approved: { type: boolean, const: true }
+            public_discovery_enabled: { type: boolean, const: false }
+            checkout_payment_enabled: { type: boolean, const: false }
+            live_provider_enabled: { type: boolean, const: false }
+            live_plural_enabled: { type: boolean, const: false }
+            production_allowlist_written: { type: boolean, const: false }
+            credential_entry_enabled: { type: boolean, const: false }
+            outbound_sync_enabled: { type: boolean, const: false }
+            production_connector_setup_enabled: { type: boolean, const: false }
+            provider_call_enabled: { type: boolean, const: false }
+            merchant_private_api_calls_enabled: { type: boolean, const: false }
+            remediation_is_production_approval: { type: boolean, const: false }
+            remediation_enables_connector_execution: { type: boolean, const: false }
+            followup_ready_is_launch_approval: { type: boolean, const: false }
+
+    CommerceConnectorDryRunRemediationTimelineResponse:
+      type: object
+      properties:
+        data: { $ref: "#/components/schemas/CommerceConnectorDryRunRemediationTimeline" }
+
     CommerceConnectorDryRunRemediationResponse:
       type: object
       properties:
@@ -6004,6 +6188,53 @@ paths:
         "409": { description: Review is not pending, dry-run evidence is unsafe, or blocked dry-run cannot be accepted }
         "422": { $ref: "#/components/responses/ValidationFailed" }
 
+  /v1/commerce/connectors/remediations:
+    get:
+      tags: [Connectors]
+      summary: List sandbox connector dry-run remediation queue
+      operationId: listCommerceConnectorDryRunRemediations
+      x-implemented: true
+      x-milestone: C6Sh
+      description: >-
+        Operator or owning merchant endpoint. Lists tenant-scoped persisted
+        remediation evidence created by C6Sg with C6Sh queue/status filters.
+        Operators may list tenant queue entries; merchant callers are scoped to
+        their own merchant. The response is read-only, redacted, sandbox-only,
+        non-live, not approved, non-public, non-enabling, and not certification
+        evidence. It does not add credential entry, outbound sync, production
+        connector setup, public discovery, checkout/payment creation, live
+        providers, provider calls, merchant private API calls, production
+        allowlists, public protocol publication, or certification.
+      parameters:
+        - { in: query, name: merchant_id, required: false, schema: { type: string } }
+        - in: query
+          name: status
+          required: false
+          schema:
+            type: string
+            enum:
+              - remediation_requested
+              - waiting_for_corrected_dry_run
+              - corrected_dry_run_attached
+              - followup_review_requested
+              - followup_ready
+              - blocked_again
+              - closed_no_action
+        - { in: query, name: original_decision, required: false, schema: { type: string, enum: [needs_changes, blocked] } }
+        - { in: query, name: has_corrected_dry_run, required: false, schema: { type: boolean } }
+        - { in: query, name: has_followup_review, required: false, schema: { type: boolean } }
+        - { in: query, name: limit, required: false, schema: { type: integer, minimum: 1, maximum: 100, default: 25 } }
+      responses:
+        "200":
+          description: Redacted sandbox remediation queue
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/CommerceConnectorDryRunRemediationListResponse" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Agent caller or cross-merchant caller is denied }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "422": { $ref: "#/components/responses/ValidationFailed" }
+
   /v1/commerce/merchants/{merchant_id}/connectors/dry-runs/{dry_run_id}/remediation:
     parameters:
       - { in: path, name: merchant_id, required: true, schema: { type: string } }
@@ -6066,6 +6297,33 @@ paths:
                 type: object
                 properties:
                   data: { $ref: "#/components/schemas/CommerceConnectorDryRunRemediation" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: Agent caller or cross-merchant caller is denied }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /v1/commerce/merchants/{merchant_id}/connectors/remediations/{remediation_id}/timeline:
+    parameters:
+      - { in: path, name: merchant_id, required: true, schema: { type: string } }
+      - { in: path, name: remediation_id, required: true, schema: { type: string } }
+    get:
+      tags: [Connectors]
+      summary: Read redacted sandbox connector remediation timeline
+      operationId: getCommerceConnectorDryRunRemediationTimeline
+      x-implemented: true
+      x-milestone: C6Sh
+      description: >-
+        Reads a redacted C6Sh remediation timeline synthesized from persisted
+        C6Sg remediation state and audit references. The timeline is
+        operator-visible and merchant-visible sandbox follow-up status only. It
+        is not production approval, connector execution approval, public
+        discovery approval, checkout/payment approval, live provider approval,
+        public protocol publication, or certification.
+      responses:
+        "200":
+          description: Redacted sandbox remediation timeline
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/CommerceConnectorDryRunRemediationTimelineResponse" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { description: Agent caller or cross-merchant caller is denied }
         "404": { $ref: "#/components/responses/NotFound" }

--- a/docs/guides/commerce-v1-merchant-operator-guide.mdx
+++ b/docs/guides/commerce-v1-merchant-operator-guide.mdx
@@ -346,6 +346,20 @@ connector execution approval, outbound sync approval, public discovery approval,
 checkout/payment approval, live provider approval, public protocol publication,
 or certification.
 
+C6Sh adds a tenant-scoped remediation queue and redacted evidence timeline for
+the persisted C6Sg loop. Operators can filter sandbox remediation records by
+merchant, status, original decision, corrected dry-run attachment, and follow-up
+review request. Merchants can see their own sandbox remediation status and the
+next safe step in the portal.
+
+The C6Sh timeline is redacted evidence visibility only. It shows remediation
+status, audit references, corrected dry-run and follow-up review links, and
+fixed non-enabling controls. It does not store or display raw connector rows,
+credentials, provider metadata, private API payloads, production config values,
+or concrete allowlists. It does not approve production launch, connector
+execution, outbound sync, public discovery, checkout/payment, live providers,
+public protocol publication, or certification.
+
 ## Catalog And Inventory
 
 Catalog and inventory grounding is the first safety step. Agents must not invent

--- a/docs/internal/commerce-v1/commerce-v1-c6sh-connector-remediation-queue-timeline.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6sh-connector-remediation-queue-timeline.md
@@ -1,0 +1,151 @@
+# Commerce V1 C6Sh - Connector Remediation Queue And Timeline
+
+C6Sh makes persisted C6Sg remediation evidence operational through a
+tenant-scoped operator queue, merchant-visible status filters, and a redacted
+timeline. It remains internal, sandbox-only, non-live, non-publication,
+non-certifying, and non-enabling.
+
+C6Sh does not add credential entry, outbound sync, production connector setup,
+public discovery, checkout/payment behavior, live payment behavior, provider
+calls, merchant private API calls, production allowlists, production config, or
+certification claims.
+
+## Traceability Checklist
+
+| Requirement | Files | Tests | Guardrails | Status |
+| --- | --- | --- | --- | --- |
+| Tenant-scoped operator queue | `commerce-connectors.ts` | `commerce-connector-remediation-queue-c6sh.test.ts` | Operators can filter tenant evidence; merchant callers are self-scoped | Implemented |
+| Status filters | `commerce-connectors.ts`, portal API | route and API client tests | Filters are read-only and fail closed on invalid values | Implemented |
+| Redacted remediation timeline | `commerce-connectors.ts`, `CommerceOnboarding.tsx` | route and portal tests | Timeline is synthesized from remediation state and audit references only | Implemented |
+| Merchant self-serve status visibility | portal API/UI | `CommerceDashboard.test.tsx` | Shows next step without production approval or connector execution controls | Implemented |
+| OpenAPI coverage | `docs/api/grantex-commerce-v1.openapi.yaml` | OpenAPI drift guard | Routes marked C6Sh, sandbox-only, non-enabling | Implemented |
+| Docs and stop conditions | this note, operator guide | docs drift guard | Keeps launch, discovery, checkout/payment, live provider, and certification blockers explicit | Implemented |
+
+## What Merchants See
+
+Merchants can load their own persisted remediation queue and timeline after a
+C6Sa review returns `needs_changes` or `blocked`. The portal shows the current
+sandbox status, the corrected dry-run link if present, follow-up review link if
+present, redacted blocker/warning counts, and the next safe step.
+
+The merchant-visible status is not production approval. It does not permit live
+connector execution, outbound sync, public discovery, checkout/payment creation,
+live providers, production allowlists, or public protocol publication.
+
+## What Operators See
+
+Operators can list tenant-scoped remediation records and filter by:
+
+- merchant ID;
+- remediation status;
+- original decision;
+- whether a corrected dry-run is attached;
+- whether a follow-up review is requested;
+- result limit.
+
+The queue is a review worklist only. It helps operators find remediation loops
+that need corrected evidence or follow-up review. It does not approve real
+merchant launch, production Commerce V1, public discovery, checkout/payment, or
+live providers.
+
+## Redacted Timeline
+
+The timeline includes:
+
+- remediation request;
+- corrected dry-run attachment, when present;
+- follow-up review request, when present;
+- terminal follow-up status, when present;
+- audit references;
+- IDs for the remediation, original dry-run, original review, corrected dry-run,
+  and follow-up review;
+- fixed non-enabling controls.
+
+The timeline excludes raw connector rows, raw files, raw merchant-system
+payloads, credentials, tokens, provider metadata, private API URLs, checkout
+URLs, payment identifiers, production config values, concrete allowlists,
+customer data, and secret material.
+
+## API
+
+C6Sh adds:
+
+- `GET /v1/commerce/connectors/remediations`
+- `GET /v1/commerce/merchants/{merchant_id}/connectors/remediations/{remediation_id}/timeline`
+
+Both routes are tenant scoped. Merchant callers can read only their own
+merchant remediation evidence. Operator callers can list the tenant queue.
+CommerceAgent callers remain denied, and AgenticOrg never directly executes
+merchant private API calls.
+
+## Portal Behavior
+
+The portal adds a credential-free remediation queue and redacted timeline panel
+inside the existing sandbox connector dry-run review card. The panel provides:
+
+- status filter;
+- queue load action;
+- current remediation timeline load action;
+- per-row timeline action;
+- blocker and warning counts;
+- corrected/follow-up flags;
+- audit references;
+- explicit disabled controls for public discovery, checkout/payment, live
+  providers, and merchant private API execution.
+
+No credential entry, production connector setup, outbound sync, public discovery
+control, checkout/payment control, live provider control, allowlist control, or
+certification control is added.
+
+## Stop Conditions
+
+Stop and require a new approved work item if any follow-up:
+
+- accepts or stores real connector credentials;
+- adds outbound sync workers, connector execution, private API URLs, schedules,
+  background jobs, or real merchant-system calls;
+- calls Shopify, WooCommerce, Magento, custom API, ERP, OMS, WMS, logistics,
+  CRM/support, payment providers, Plural, Stripe, Pine, or merchant private
+  APIs;
+- allows AgenticOrg to call merchant private APIs directly;
+- enables Grantex public discovery or AgenticOrg public commerce discovery;
+- enables production Commerce V1, checkout/payment creation, fulfillment,
+  refund execution, live payments, live Plural, or live providers;
+- writes production config or production allowlists;
+- claims production approval, public protocol publication, provider approval,
+  live-payment approval, or certification;
+- treats sandbox, demo, synthetic, fixture, dry-run, review, packet, handoff,
+  remediation, export, timeline, or rehearsal output as real merchant approval.
+
+## Rollback Notes
+
+C6Sh rollback removes:
+
+- C6Sh read-only route additions in `apps/auth-service/src/routes/commerce-connectors.ts`;
+- `apps/auth-service/tests/commerce-connector-remediation-queue-c6sh.test.ts`;
+- portal API and UI additions for remediation queue and timeline visibility;
+- OpenAPI C6Sh path/schema additions;
+- this internal note and the C6Sh guide section.
+
+No migration, runtime connector execution, public discovery, checkout/payment,
+live payment, live Plural, provider credential, production config, production
+allowlist, cloud resource, or deploy workflow action is created by this slice.
+
+## Validation
+
+Focused validation for C6Sh:
+
+```bash
+npm --prefix apps/auth-service test -- commerce-connector-dry-run-c6r.test.ts commerce-connector-dry-run-review-c6sa.test.ts commerce-connector-remediation-c6sg.test.ts commerce-connector-remediation-queue-c6sh.test.ts commerce-openapi.test.ts
+npm --prefix apps/auth-service run typecheck
+npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
+npm --prefix apps/portal run typecheck
+node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
+git diff --check origin/main...HEAD
+```
+
+Focused scans must cover secrets/private details, production config or allowlist
+assignments, public discovery enablement, checkout/payment enablement, live
+payment/live Plural/provider credential enablement, certification claims, direct
+provider calls, direct merchant private API calls, AgenticOrg direct execution,
+and outbound sync enablement.


### PR DESCRIPTION
## Summary
- Adds C6Sh read-only connector remediation queue and redacted timeline APIs for persisted C6Sg evidence.
- Adds credential-free portal queue/timeline visibility for operators and merchant self-serve status.
- Updates OpenAPI, operator guide, internal C6Sh docs, and focused backend/portal tests.

## Safety
- Sandbox-only, non-live, not approved, non-public, and non-enabling.
- No credential entry, outbound sync, production connector setup, public discovery, checkout/payment creation, live providers, provider calls, merchant private API calls, production allowlists, or certification claims.

## Validation
- npm --prefix apps/auth-service test -- commerce-connector-dry-run-c6r.test.ts commerce-connector-dry-run-review-c6sa.test.ts commerce-connector-remediation-c6sg.test.ts commerce-connector-remediation-queue-c6sh.test.ts commerce-openapi.test.ts
- npm --prefix apps/auth-service run typecheck
- npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
- npm --prefix apps/portal run typecheck
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
- git diff --check origin/main...HEAD
- focused guardrail scans for secrets/private details, production config/allowlists, public discovery, checkout/payment/live provider enablement, overclaims, and direct provider/merchant API execution