### PR TITLE
C6Sib sandbox connector remediation operator triage portal controls

### DIFF
--- a/apps/portal/src/api/__tests__/commerce.test.ts
+++ b/apps/portal/src/api/__tests__/commerce.test.ts
@@ -37,6 +37,7 @@ import {
   listCommerceProviderCredentials,
   reconcileCommercePaymentIntent,
   recordCommerceConnectorDryRunReviewDecision,
+  recordCommerceConnectorDryRunRemediationTriage,
   rotateCommerceWebhookSourceSecret,
   requestCommerceConnectorDryRunReview,
   requestCommerceConnectorRemediationFollowUpReview,
@@ -283,13 +284,14 @@ describe('commerce api', () => {
     await listCommerceConnectorDryRunRemediations({
       merchantId: 'mch/1',
       status: 'corrected_dry_run_attached',
+      triageStatus: 'ready_for_followup_review',
       originalDecision: 'needs_changes',
       hasCorrectedDryRun: true,
       hasFollowupReview: false,
       limit: 10,
     });
     expect(mockFetch.mock.calls[7]![0]).toBe(
-      'http://localhost:3000/v1/commerce/connectors/remediations?merchant_id=mch%2F1&status=corrected_dry_run_attached&original_decision=needs_changes&has_corrected_dry_run=true&has_followup_review=false&limit=10',
+      'http://localhost:3000/v1/commerce/connectors/remediations?merchant_id=mch%2F1&status=corrected_dry_run_attached&triage_status=ready_for_followup_review&original_decision=needs_changes&has_corrected_dry_run=true&has_followup_review=false&limit=10',
     );
     expect(mockFetch.mock.calls[7]![1]?.body).toBeUndefined();
 
@@ -300,15 +302,39 @@ describe('commerce api', () => {
     );
     expect(mockFetch.mock.calls[8]![1]?.body).toBeUndefined();
 
+    ok({ data: { remediation_id: 'cdrem/1', triage: { triage_status: 'waiting_on_merchant' } }, audit_event_id: 'aud_triage', controls: { sandbox_only: true } });
+    await recordCommerceConnectorDryRunRemediationTriage('mch/1', 'cdrem/1', {
+      triageStatus: 'waiting_on_merchant',
+      assignedOperatorId: 'ops.c6sib',
+      triageNote: 'Review corrected sandbox category mapping after rerun.',
+      merchantFollowupSummary: 'Rerun the sandbox dry-run after fixing category mapping.',
+      nextStep: 'Attach corrected sandbox evidence.',
+    });
+    expect(mockFetch.mock.calls[9]![0]).toBe(
+      'http://localhost:3000/v1/commerce/merchants/mch%2F1/connectors/remediations/cdrem%2F1/triage',
+    );
+    const triageBody = JSON.parse(mockFetch.mock.calls[9]![1].body);
+    expect(triageBody).toEqual({
+      triage_status: 'waiting_on_merchant',
+      assigned_operator_id: 'ops.c6sib',
+      triage_note: 'Review corrected sandbox category mapping after rerun.',
+      merchant_followup_summary: 'Rerun the sandbox dry-run after fixing category mapping.',
+      next_step: 'Attach corrected sandbox evidence.',
+    });
+    expect(JSON.stringify(triageBody).toLowerCase()).not.toContain('credential');
+    expect(JSON.stringify(triageBody).toLowerCase()).not.toContain('public_discovery_enabled');
+    expect(JSON.stringify(triageBody).toLowerCase()).not.toContain('checkout_payment_enabled');
+    expect(JSON.stringify(triageBody).toLowerCase()).not.toContain('live_provider_enabled');
+
     ok({ data: { remediation_id: 'cdrem/1' }, corrected_dry_run: { dry_run_id: 'cdry/2' }, audit_event_id: 'aud_4' });
     await attachCommerceConnectorRemediationCorrectedDryRun('mch/1', 'cdrem/1', {
       correctedDryRunId: 'cdry/2',
       publicSafeNote: 'Corrected sandbox evidence only.',
     });
-    expect(mockFetch.mock.calls[9]![0]).toBe(
+    expect(mockFetch.mock.calls[10]![0]).toBe(
       'http://localhost:3000/v1/commerce/merchants/mch%2F1/connectors/remediations/cdrem%2F1/corrected-dry-run',
     );
-    const correctedBody = JSON.parse(mockFetch.mock.calls[9]![1].body);
+    const correctedBody = JSON.parse(mockFetch.mock.calls[10]![1].body);
     expect(correctedBody).toEqual({
       corrected_dry_run_id: 'cdry/2',
       public_safe_note: 'Corrected sandbox evidence only.',
@@ -318,12 +344,12 @@ describe('commerce api', () => {
     await requestCommerceConnectorRemediationFollowUpReview('mch/1', 'cdrem/1', {
       requestNote: 'Follow-up sandbox evidence review.',
     });
-    expect(mockFetch.mock.calls[10]![0]).toBe(
+    expect(mockFetch.mock.calls[11]![0]).toBe(
       'http://localhost:3000/v1/commerce/merchants/mch%2F1/connectors/remediations/cdrem%2F1/follow-up-review',
     );
-    const followupBody = JSON.parse(mockFetch.mock.calls[10]![1].body);
+    const followupBody = JSON.parse(mockFetch.mock.calls[11]![1].body);
     expect(followupBody).toEqual({ request_note: 'Follow-up sandbox evidence review.' });
-    for (const body of [remediationBody, correctedBody, followupBody]) {
+    for (const body of [remediationBody, triageBody, correctedBody, followupBody]) {
       const serialized = JSON.stringify(body).toLowerCase();
       for (const forbidden of [
         'credential',

--- a/apps/portal/src/api/commerce.ts
+++ b/apps/portal/src/api/commerce.ts
@@ -239,6 +239,12 @@ export type CommerceConnectorDryRunRemediationStatus =
   | 'followup_ready'
   | 'blocked_again'
   | 'closed_no_action';
+export type CommerceConnectorDryRunRemediationTriageStatus =
+  | 'triage_in_progress'
+  | 'waiting_on_merchant'
+  | 'ready_for_followup_review'
+  | 'blocked_for_sandbox_followup'
+  | 'closed_no_action';
 
 export interface CommerceConnectorDryRunPreviewVariant {
   sku: string;
@@ -363,6 +369,19 @@ export interface CommerceConnectorDryRunRemediation {
     corrected_audit_event_id: string | null;
     followup_audit_event_id: string | null;
     closed_or_blocked_audit_event_id: string | null;
+    triage_audit_event_id?: string | null;
+  };
+  triage?: {
+    triage_status: CommerceConnectorDryRunRemediationTriageStatus | null;
+    assigned_operator_id: string | null;
+    triage_note: string | null;
+    merchant_followup_summary: string | null;
+    next_step: string | null;
+    triaged_by_operator_id: string | null;
+    triaged_at: string | null;
+    triage_audit_event_id: string | null;
+    triage_is_production_approval: false;
+    triage_enables_connector_execution: false;
   };
   controls: {
     sandbox_only: true;
@@ -376,6 +395,8 @@ export interface CommerceConnectorDryRunRemediation {
     remediation_is_production_approval: false;
     remediation_enables_connector_execution: false;
     followup_ready_is_launch_approval: false;
+    triage_is_production_approval?: false;
+    triage_enables_connector_execution?: false;
   };
   created_at: string | null;
   updated_at: string | null;
@@ -435,6 +456,9 @@ export interface CommerceConnectorDryRunRemediationTimeline {
   merchant_status: {
     visible_to_merchant: true;
     status: CommerceConnectorDryRunRemediationStatus;
+    triage_status?: CommerceConnectorDryRunRemediationTriageStatus | null;
+    merchant_followup_summary?: string | null;
+    triage_next_step?: string | null;
     corrected_dry_run_id: string | null;
     followup_review_id: string | null;
     next_step: string;
@@ -500,6 +524,20 @@ export interface CommerceConnectorDryRunFollowUpReviewResponse {
   corrected_dry_run: CommerceConnectorDryRunResult;
   followup_review: CommerceConnectorDryRunReview;
   audit_event_id: string | null;
+}
+
+export interface CommerceConnectorDryRunRemediationTriageResponse {
+  data: CommerceConnectorDryRunRemediation;
+  audit_event_id: string | null;
+  controls: CommerceConnectorDryRunRemediation['controls'] & {
+    credential_entry_enabled: false;
+    outbound_sync_enabled: false;
+    production_connector_setup_enabled: false;
+    provider_call_enabled: false;
+    merchant_private_api_calls_enabled: false;
+    triage_is_production_approval: false;
+    triage_enables_connector_execution: false;
+  };
 }
 
 export interface CommerceAgentFacingPreviewProductVariant {
@@ -1565,6 +1603,7 @@ export function getCommerceConnectorDryRunRemediation(
 export function listCommerceConnectorDryRunRemediations(params: {
   merchantId?: string;
   status?: CommerceConnectorDryRunRemediationStatus;
+  triageStatus?: CommerceConnectorDryRunRemediationTriageStatus;
   originalDecision?: 'needs_changes' | 'blocked';
   hasCorrectedDryRun?: boolean;
   hasFollowupReview?: boolean;
@@ -1583,6 +1622,7 @@ export function listCommerceConnectorDryRunRemediations(params: {
   }>(`/v1/commerce/connectors/remediations${qs({
     merchant_id: params.merchantId,
     status: params.status,
+    triage_status: params.triageStatus,
     original_decision: params.originalDecision,
     has_corrected_dry_run: params.hasCorrectedDryRun,
     has_followup_review: params.hasFollowupReview,
@@ -1596,6 +1636,29 @@ export function getCommerceConnectorDryRunRemediationTimeline(
 ): Promise<{ data: CommerceConnectorDryRunRemediationTimeline }> {
   return api.get<{ data: CommerceConnectorDryRunRemediationTimeline }>(
     `/v1/commerce/merchants/${encodeURIComponent(merchantId)}/connectors/remediations/${encodeURIComponent(remediationId)}/timeline`,
+  );
+}
+
+export function recordCommerceConnectorDryRunRemediationTriage(
+  merchantId: string,
+  remediationId: string,
+  input: {
+    triageStatus: CommerceConnectorDryRunRemediationTriageStatus;
+    assignedOperatorId?: string;
+    triageNote?: string;
+    merchantFollowupSummary?: string;
+    nextStep?: string;
+  },
+): Promise<CommerceConnectorDryRunRemediationTriageResponse> {
+  return api.post<CommerceConnectorDryRunRemediationTriageResponse>(
+    `/v1/commerce/merchants/${encodeURIComponent(merchantId)}/connectors/remediations/${encodeURIComponent(remediationId)}/triage`,
+    {
+      triage_status: input.triageStatus,
+      ...(input.assignedOperatorId ? { assigned_operator_id: input.assignedOperatorId } : {}),
+      ...(input.triageNote ? { triage_note: input.triageNote } : {}),
+      ...(input.merchantFollowupSummary ? { merchant_followup_summary: input.merchantFollowupSummary } : {}),
+      ...(input.nextStep ? { next_step: input.nextStep } : {}),
+    },
   );
 }
 

--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -40,6 +40,7 @@ const mockRecordCommerceConnectorDryRunReviewDecision = vi.fn();
 const mockCreateCommerceConnectorDryRunRemediation = vi.fn();
 const mockAttachCommerceConnectorRemediationCorrectedDryRun = vi.fn();
 const mockRequestCommerceConnectorRemediationFollowUpReview = vi.fn();
+const mockRecordCommerceConnectorDryRunRemediationTriage = vi.fn();
 const mockListCommerceConnectorDryRunRemediations = vi.fn();
 const mockGetCommerceConnectorDryRunRemediationTimeline = vi.fn();
 const mockDisableMerchantAgenticCommerce = vi.fn();
@@ -91,6 +92,7 @@ vi.mock('../../api/commerce', () => ({
   createCommerceConnectorDryRunRemediation: (...a: unknown[]) => mockCreateCommerceConnectorDryRunRemediation(...a),
   attachCommerceConnectorRemediationCorrectedDryRun: (...a: unknown[]) => mockAttachCommerceConnectorRemediationCorrectedDryRun(...a),
   requestCommerceConnectorRemediationFollowUpReview: (...a: unknown[]) => mockRequestCommerceConnectorRemediationFollowUpReview(...a),
+  recordCommerceConnectorDryRunRemediationTriage: (...a: unknown[]) => mockRecordCommerceConnectorDryRunRemediationTriage(...a),
   listCommerceConnectorDryRunRemediations: (...a: unknown[]) => mockListCommerceConnectorDryRunRemediations(...a),
   getCommerceConnectorDryRunRemediationTimeline: (...a: unknown[]) => mockGetCommerceConnectorDryRunRemediationTimeline(...a),
   disableMerchantAgenticCommerce: (...a: unknown[]) => mockDisableMerchantAgenticCommerce(...a),
@@ -861,6 +863,19 @@ const connectorRemediation = {
     corrected_audit_event_id: null,
     followup_audit_event_id: null,
     closed_or_blocked_audit_event_id: null,
+    triage_audit_event_id: null,
+  },
+  triage: {
+    triage_status: null,
+    assigned_operator_id: null,
+    triage_note: null,
+    merchant_followup_summary: null,
+    next_step: null,
+    triaged_by_operator_id: null,
+    triaged_at: null,
+    triage_audit_event_id: null,
+    triage_is_production_approval: false as const,
+    triage_enables_connector_execution: false as const,
   },
   controls: {
     sandbox_only: true as const,
@@ -874,6 +889,8 @@ const connectorRemediation = {
     remediation_is_production_approval: false as const,
     remediation_enables_connector_execution: false as const,
     followup_ready_is_launch_approval: false as const,
+    triage_is_production_approval: false as const,
+    triage_enables_connector_execution: false as const,
   },
   created_at: '2026-01-01T00:44:00Z',
   updated_at: '2026-01-01T00:44:00Z',
@@ -899,6 +916,27 @@ const connectorRemediationFollowup = {
     followup_audit_event_id: 'caud_C6SG_FOLLOWUP_REQUESTED',
   },
   updated_at: '2026-01-01T00:51:30Z',
+};
+
+const connectorRemediationTriaged = {
+  ...connectorRemediationFollowup,
+  audit_references: {
+    ...connectorRemediationFollowup.audit_references,
+    triage_audit_event_id: 'caud_C6SIA_TRIAGE_RECORDED',
+  },
+  triage: {
+    triage_status: 'waiting_on_merchant' as const,
+    assigned_operator_id: 'ops.c6sib',
+    triage_note: 'Internal sandbox triage note must stay operator-only.',
+    merchant_followup_summary: 'Please rerun the sandbox dry-run after fixing category mapping.',
+    next_step: 'Attach the corrected sandbox dry-run evidence.',
+    triaged_by_operator_id: 'dev_TEST',
+    triaged_at: '2026-01-01T00:52:30Z',
+    triage_audit_event_id: 'caud_C6SIA_TRIAGE_RECORDED',
+    triage_is_production_approval: false as const,
+    triage_enables_connector_execution: false as const,
+  },
+  updated_at: '2026-01-01T00:52:30Z',
 };
 
 const connectorRemediationTimeline = {
@@ -995,6 +1033,53 @@ const connectorRemediationTimeline = {
     remediation_is_production_approval: false as const,
     remediation_enables_connector_execution: false as const,
     followup_ready_is_launch_approval: false as const,
+  },
+};
+
+const connectorRemediationTimelineTriaged = {
+  ...connectorRemediationTimeline,
+  remediation: connectorRemediationTriaged,
+  timeline: [
+    ...connectorRemediationTimeline.timeline,
+    {
+      sequence: 3,
+      key: 'operator_triage_recorded',
+      label: 'Operator triage recorded',
+      status: 'complete' as const,
+      event_type: 'connector_remediation_triage_recorded',
+      occurred_at: '2026-01-01T00:52:30Z',
+      audit_event_id: 'caud_C6SIA_TRIAGE_RECORDED',
+      actor: { kind: 'operator' as const, id: 'dev_TEST' },
+      resource_references: {
+        remediation_id: 'cdrem_C6SG',
+        original_dry_run_id: 'cdry_C6SB',
+        original_review_id: 'cdrev_C6SB',
+        corrected_dry_run_id: 'cdry_C6SF_CORRECTED',
+        followup_review_id: 'cdrev_C6SF_FOLLOWUP',
+      },
+      evidence_summary: {
+        triage_status: 'waiting_on_merchant',
+        assigned_operator_id_present: true,
+        triage_note_present: true,
+        merchant_followup_summary_present: true,
+        next_step_present: true,
+        triage_is_production_approval: false,
+        triage_enables_connector_execution: false,
+      },
+      redaction: {
+        raw_connector_rows_included: false as const,
+        credentials_included: false as const,
+        provider_metadata_included: false as const,
+        merchant_private_api_payload_included: false as const,
+        production_config_values_included: false as const,
+      },
+    },
+  ],
+  merchant_status: {
+    ...connectorRemediationTimeline.merchant_status,
+    triage_status: 'waiting_on_merchant' as const,
+    merchant_followup_summary: 'Please rerun the sandbox dry-run after fixing category mapping.',
+    triage_next_step: 'Attach the corrected sandbox dry-run evidence.',
   },
 };
 
@@ -1474,6 +1559,20 @@ describe('CommerceOnboarding', () => {
       followup_review: connectorReviewFollowup,
       audit_event_id: 'caud_C6SG_FOLLOWUP_REQUESTED',
     });
+    mockRecordCommerceConnectorDryRunRemediationTriage.mockResolvedValue({
+      data: connectorRemediationTriaged,
+      audit_event_id: 'caud_C6SIA_TRIAGE_RECORDED',
+      controls: {
+        sandbox_only: true,
+        credential_entry_enabled: false,
+        outbound_sync_enabled: false,
+        production_connector_setup_enabled: false,
+        provider_call_enabled: false,
+        merchant_private_api_calls_enabled: false,
+        triage_is_production_approval: false,
+        triage_enables_connector_execution: false,
+      },
+    });
     mockListCommerceConnectorDryRunRemediations.mockResolvedValue({
       items: [{
         ...connectorRemediationFollowup,
@@ -1639,9 +1738,9 @@ describe('CommerceOnboarding', () => {
     )).length).toBeGreaterThan(0);
     expect(screen.getByText('No credential entry')).toBeInTheDocument();
     expect(screen.getByText('Outbound sync off')).toBeInTheDocument();
-    expect(screen.getByText('credential_entry_enabled')).toBeInTheDocument();
-    expect(screen.getByText('outbound_sync_enabled')).toBeInTheDocument();
-    expect(screen.getByText('production_connector_setup')).toBeInTheDocument();
+    expect(screen.getAllByText('credential_entry_enabled').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('outbound_sync_enabled').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('production_connector_setup').length).toBeGreaterThan(0);
     expect(screen.getByText('merchant_private_api_calls')).toBeInTheDocument();
     expect(screen.queryByRole('textbox', { name: 'Credential' })).not.toBeInTheDocument();
     expect(screen.getByText('Rows parsed: 1')).toBeInTheDocument();
@@ -1798,6 +1897,9 @@ describe('CommerceOnboarding', () => {
   });
 
   it('loads persisted remediation queue and redacted timeline without connector execution controls', async () => {
+    mockGetCommerceConnectorDryRunRemediationTimeline
+      .mockResolvedValueOnce({ data: connectorRemediationTimeline })
+      .mockResolvedValueOnce({ data: connectorRemediationTimelineTriaged });
     const user = userEvent.setup();
     r(<CommerceOnboarding />);
 
@@ -1806,17 +1908,19 @@ describe('CommerceOnboarding', () => {
     await waitFor(() => expect(screen.getByText('Persisted remediation queue')).toBeInTheDocument());
 
     await user.selectOptions(screen.getByLabelText('Remediation status filter'), 'followup_review_requested');
+    await user.selectOptions(screen.getByLabelText('Triage status filter'), 'waiting_on_merchant');
     await user.click(screen.getByRole('button', { name: 'Load remediation queue' }));
     await waitFor(() => expect(mockListCommerceConnectorDryRunRemediations).toHaveBeenCalledWith({
       merchantId: 'mch_1',
       status: 'followup_review_requested',
+      triageStatus: 'waiting_on_merchant',
       limit: 10,
     }));
     expect(screen.getAllByText('cdrem_C6SG').length).toBeGreaterThan(0);
     expect(screen.getByText('operator_followup_required')).toBeInTheDocument();
     expect(screen.getAllByText('public_discovery_enabled').length).toBeGreaterThan(0);
     expect(screen.getAllByText('checkout_payment_enabled').length).toBeGreaterThan(0);
-    expect(screen.getByText('merchant_private_api_calls_enabled')).toBeInTheDocument();
+    expect(screen.getAllByText('merchant_private_api_calls_enabled').length).toBeGreaterThan(0);
 
     await user.click(screen.getByRole('button', { name: 'View timeline' }));
     await waitFor(() => expect(mockGetCommerceConnectorDryRunRemediationTimeline).toHaveBeenCalledWith('mch_1', 'cdrem_C6SG'));
@@ -1827,9 +1931,38 @@ describe('CommerceOnboarding', () => {
     expect(screen.getByText('followup_ready_is_launch_approval')).toBeInTheDocument();
     expect(screen.getByText('connector_remediation_requested')).toBeInTheDocument();
     expect(screen.getByText('connector_remediation_followup_review_requested')).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText('Triage status'), 'waiting_on_merchant');
+    await user.type(screen.getByLabelText('Assigned operator reference'), 'ops.c6sib');
+    await user.type(screen.getByLabelText('Internal triage note'), 'Internal sandbox triage note must stay operator-only.');
+    await user.type(screen.getByLabelText('Merchant-visible follow-up summary'), 'Please rerun the sandbox dry-run after fixing category mapping.');
+    await user.type(screen.getByLabelText('Triage next step'), 'Attach the corrected sandbox dry-run evidence.');
+    await user.click(screen.getByRole('button', { name: 'Record operator triage' }));
+    await waitFor(() => expect(mockRecordCommerceConnectorDryRunRemediationTriage).toHaveBeenCalledWith('mch_1', 'cdrem_C6SG', {
+      triageStatus: 'waiting_on_merchant',
+      assignedOperatorId: 'ops.c6sib',
+      triageNote: 'Internal sandbox triage note must stay operator-only.',
+      merchantFollowupSummary: 'Please rerun the sandbox dry-run after fixing category mapping.',
+      nextStep: 'Attach the corrected sandbox dry-run evidence.',
+    }));
+    await waitFor(() => expect(mockGetCommerceConnectorDryRunRemediationTimeline).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('connector_remediation_triage_recorded')).toBeInTheDocument();
+    expect(screen.getAllByText((_content, node) => (
+      node?.textContent?.includes('caud_C6SIA_TRIAGE_RECORDED') === true
+      && node.childElementCount === 0
+    )).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('waiting_on_merchant').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Please rerun the sandbox dry-run after fixing category mapping.').length).toBeGreaterThan(0);
+    expect(screen.getByText('triage_is_production_approval')).toBeInTheDocument();
+    expect(screen.getAllByText((_content, node) => (
+      node?.textContent?.includes('triage_enables_connector_execution: false') === true
+      && node.childElementCount === 0
+    )).length).toBeGreaterThan(0);
+    expect(mockShow).toHaveBeenCalledWith('Connector triage saved or already current', 'success');
     expect(screen.queryByRole('textbox', { name: 'Credential' })).not.toBeInTheDocument();
     expect(screen.queryByText('production connector setup enabled')).not.toBeInTheDocument();
     expect(screen.queryByText('outbound connector sync enabled')).not.toBeInTheDocument();
+    expect(screen.queryByText('public discovery enabled')).not.toBeInTheDocument();
   });
 
   it('rehearses remediation loop from needs-changes to corrected sandbox follow-up', async () => {

--- a/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
+++ b/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
@@ -21,6 +21,7 @@ import {
   listCommerceWebhookSources,
   requestCommerceConnectorDryRunReview,
   requestCommerceConnectorRemediationFollowUpReview,
+  recordCommerceConnectorDryRunRemediationTriage,
   recordCommerceReadOnlyDiscoveryReviewDecision,
   requestCommerceMerchantAgenticOrgBuyerDiscoveryHandoff,
   requestCommerceMerchantReadOnlyDiscoveryReview,
@@ -34,6 +35,7 @@ import {
   type CommerceConnectorDryRunRemediation,
   type CommerceConnectorDryRunRemediationQueueItem,
   type CommerceConnectorDryRunRemediationStatus,
+  type CommerceConnectorDryRunRemediationTriageStatus,
   type CommerceConnectorDryRunRemediationTimeline,
   type CommerceConnectorDryRunReview,
   type CommerceConnectorDryRunReviewDecision,
@@ -229,6 +231,14 @@ const connectorRemediationStatusOptions: CommerceConnectorDryRunRemediationStatu
   'closed_no_action',
 ];
 
+const connectorRemediationTriageStatusOptions: CommerceConnectorDryRunRemediationTriageStatus[] = [
+  'triage_in_progress',
+  'waiting_on_merchant',
+  'ready_for_followup_review',
+  'blocked_for_sandbox_followup',
+  'closed_no_action',
+];
+
 const connectorRowsPrivateFieldFragments = [
   'credential',
   'secret',
@@ -414,6 +424,29 @@ function backendRemediationStatusVariant(status: CommerceConnectorDryRunRemediat
   if (status === 'blocked_again' || status === 'closed_no_action') return 'danger';
   if (status === 'remediation_requested' || status === 'waiting_for_corrected_dry_run') return 'warning';
   return 'default';
+}
+
+function triageStatusVariant(status: CommerceConnectorDryRunRemediationTriageStatus | null | undefined): 'default' | 'success' | 'warning' | 'danger' {
+  if (status === 'ready_for_followup_review') return 'success';
+  if (status === 'blocked_for_sandbox_followup' || status === 'closed_no_action') return 'danger';
+  if (status === 'waiting_on_merchant' || status === 'triage_in_progress') return 'warning';
+  return 'default';
+}
+
+function triageFormFromRemediation(remediation: CommerceConnectorDryRunRemediation | null): {
+  triage_status: CommerceConnectorDryRunRemediationTriageStatus;
+  assigned_operator_id: string;
+  triage_note: string;
+  merchant_followup_summary: string;
+  next_step: string;
+} {
+  return {
+    triage_status: remediation?.triage?.triage_status ?? 'triage_in_progress',
+    assigned_operator_id: remediation?.triage?.assigned_operator_id ?? '',
+    triage_note: remediation?.triage?.triage_note ?? '',
+    merchant_followup_summary: remediation?.triage?.merchant_followup_summary ?? '',
+    next_step: remediation?.triage?.next_step ?? '',
+  };
 }
 
 function buildConnectorEvidencePacketReview(
@@ -1166,6 +1199,7 @@ export function CommerceOnboarding() {
   const [connectorRemediationQueue, setConnectorRemediationQueue] = useState<CommerceConnectorDryRunRemediationQueueItem[]>([]);
   const [connectorRemediationTimeline, setConnectorRemediationTimeline] = useState<CommerceConnectorDryRunRemediationTimeline | null>(null);
   const [connectorQueueStatusFilter, setConnectorQueueStatusFilter] = useState<CommerceConnectorDryRunRemediationStatus | ''>('');
+  const [connectorQueueTriageStatusFilter, setConnectorQueueTriageStatusFilter] = useState<CommerceConnectorDryRunRemediationTriageStatus | ''>('');
   const [merchantForm, setMerchantForm] = useState<MerchantPatchForm>(defaultPatch);
   const [agents, setAgents] = useState<CommerceAgent[]>([]);
   const [activePolicyCount, setActivePolicyCount] = useState(0);
@@ -1186,6 +1220,7 @@ export function CommerceOnboarding() {
   const [connectorDecisionSubmitting, setConnectorDecisionSubmitting] = useState(false);
   const [connectorQueueLoading, setConnectorQueueLoading] = useState(false);
   const [connectorTimelineLoading, setConnectorTimelineLoading] = useState(false);
+  const [connectorTriageSubmitting, setConnectorTriageSubmitting] = useState(false);
   const [connectorForm, setConnectorForm] = useState<{
     connector_type: CommerceConnectorDryRunType;
     source_label: string;
@@ -1201,6 +1236,7 @@ export function CommerceOnboarding() {
     decision: 'accepted_for_sandbox_followup',
     decision_note: '',
   });
+  const [connectorTriageForm, setConnectorTriageForm] = useState(triageFormFromRemediation(null));
   const [decisionForm, setDecisionForm] = useState<{
     decision: CommerceReadOnlyDiscoveryOperatorDecision;
     reason: string;
@@ -1258,6 +1294,7 @@ export function CommerceOnboarding() {
       setConnectorBackendRemediation(null);
       setConnectorRemediationQueue([]);
       setConnectorRemediationTimeline(null);
+      setConnectorTriageForm(triageFormFromRemediation(null));
       setProposalNote(proposalRes?.data.proposal_note ?? '');
       setAgenticOrgNote('');
       setMerchantForm({
@@ -1479,6 +1516,7 @@ export function CommerceOnboarding() {
     setConnectorReview(null);
     setConnectorRemediationQueue([]);
     setConnectorRemediationTimeline(null);
+    setConnectorTriageForm(triageFormFromRemediation(null));
     show('Sandbox sample rows restored', 'success');
   }
 
@@ -1490,6 +1528,7 @@ export function CommerceOnboarding() {
     setConnectorBackendRemediation(null);
     setConnectorRemediationQueue([]);
     setConnectorRemediationTimeline(null);
+    setConnectorTriageForm(triageFormFromRemediation(null));
     show('Sandbox connector rows cleared', 'success');
   }
 
@@ -1523,6 +1562,7 @@ export function CommerceOnboarding() {
           },
         );
         setConnectorBackendRemediation(remediationRes.data);
+        setConnectorTriageForm(triageFormFromRemediation(remediationRes.data));
         setConnectorRemediationTimeline(null);
       }
       setConnectorRemediationLoop((prev) => (
@@ -1553,6 +1593,7 @@ export function CommerceOnboarding() {
           { requestNote },
         );
         setConnectorBackendRemediation(res.data);
+        setConnectorTriageForm(triageFormFromRemediation(res.data));
         setConnectorRemediationTimeline(null);
         setConnectorReview(res.followup_review);
         setConnectorDryRun(res.corrected_dry_run);
@@ -1611,16 +1652,24 @@ export function CommerceOnboarding() {
           { publicSafeNote: res.data.decision_note ?? undefined },
         );
         setConnectorBackendRemediation(remediationRes.data);
+        setConnectorTriageForm(triageFormFromRemediation(remediationRes.data));
         setConnectorRemediationTimeline(null);
       } else if (connectorBackendRemediation?.followup_review_id === res.data.review_id) {
-        setConnectorBackendRemediation((prev) => prev ? {
-          ...prev,
-          status: res.data.status === 'accepted_for_sandbox_followup' ? 'followup_ready' : 'blocked_again',
-          audit_references: {
-            ...prev.audit_references,
-            followup_audit_event_id: prev.audit_references.followup_audit_event_id ?? res.data.audit_event_id,
-          },
-        } : prev);
+        const followupStatus: CommerceConnectorDryRunRemediationStatus = res.data.status === 'accepted_for_sandbox_followup'
+          ? 'followup_ready'
+          : 'blocked_again';
+        setConnectorBackendRemediation((prev) => {
+          const updated = prev ? {
+            ...prev,
+            status: followupStatus,
+            audit_references: {
+              ...prev.audit_references,
+              followup_audit_event_id: prev.audit_references.followup_audit_event_id ?? res.data.audit_event_id,
+            },
+          } : prev;
+          if (updated) setConnectorTriageForm(triageFormFromRemediation(updated));
+          return updated;
+        });
         setConnectorRemediationTimeline(null);
       }
       show('Connector dry-run review decision recorded', 'success');
@@ -1638,6 +1687,7 @@ export function CommerceOnboarding() {
       const res = await listCommerceConnectorDryRunRemediations({
         merchantId: merchant.merchant_id,
         status: connectorQueueStatusFilter || undefined,
+        triageStatus: connectorQueueTriageStatusFilter || undefined,
         limit: 10,
       });
       setConnectorRemediationQueue(res.items);
@@ -1660,11 +1710,53 @@ export function CommerceOnboarding() {
     try {
       const res = await getCommerceConnectorDryRunRemediationTimeline(merchant.merchant_id, id);
       setConnectorRemediationTimeline(res.data);
+      setConnectorBackendRemediation(res.data.remediation);
+      setConnectorTriageForm(triageFormFromRemediation(res.data.remediation));
       show('Connector remediation timeline loaded', 'success');
     } catch {
       show('Connector remediation timeline is unavailable', 'error');
     } finally {
       setConnectorTimelineLoading(false);
+    }
+  }
+
+  async function recordConnectorRemediationTriage() {
+    if (!merchant) return;
+    const remediation = connectorRemediationTimeline?.remediation ?? connectorBackendRemediation;
+    if (!remediation) {
+      show('Select a remediation record before recording triage', 'error');
+      return;
+    }
+    setConnectorTriageSubmitting(true);
+    try {
+      const res = await recordCommerceConnectorDryRunRemediationTriage(
+        merchant.merchant_id,
+        remediation.remediation_id,
+        {
+          triageStatus: connectorTriageForm.triage_status,
+          assignedOperatorId: connectorTriageForm.assigned_operator_id.trim() || undefined,
+          triageNote: connectorTriageForm.triage_note.trim() || undefined,
+          merchantFollowupSummary: connectorTriageForm.merchant_followup_summary.trim() || undefined,
+          nextStep: connectorTriageForm.next_step.trim() || undefined,
+        },
+      );
+      setConnectorBackendRemediation(res.data);
+      setConnectorTriageForm(triageFormFromRemediation(res.data));
+      setConnectorRemediationQueue((prev) => prev.map((item) => (
+        item.remediation_id === res.data.remediation_id
+          ? { ...item, ...res.data }
+          : item
+      )));
+      const timelineRes = await getCommerceConnectorDryRunRemediationTimeline(
+        merchant.merchant_id,
+        res.data.remediation_id,
+      );
+      setConnectorRemediationTimeline(timelineRes.data);
+      show('Connector triage saved or already current', 'success');
+    } catch {
+      show('Connector triage is blocked for sandbox safety', 'error');
+    } finally {
+      setConnectorTriageSubmitting(false);
     }
   }
 
@@ -1829,6 +1921,29 @@ export function CommerceOnboarding() {
       : connectorSubmitting
         ? 'Connector dry-run is being submitted.'
         : 'Dry-run is local snapshot validation only.';
+  const activeConnectorRemediation = connectorRemediationTimeline?.remediation ?? connectorBackendRemediation;
+  const connectorTriageNeedsMerchantSummary = connectorTriageForm.triage_status === 'waiting_on_merchant'
+    || connectorTriageForm.triage_status === 'blocked_for_sandbox_followup';
+  const connectorTriageDisabled = connectorTriageSubmitting
+    || !activeConnectorRemediation
+    || (connectorTriageNeedsMerchantSummary && !connectorTriageForm.merchant_followup_summary.trim());
+  const connectorTriageDisabledReason = !activeConnectorRemediation
+    ? 'Select a persisted remediation record before recording operator triage.'
+    : connectorTriageNeedsMerchantSummary && !connectorTriageForm.merchant_followup_summary.trim()
+      ? 'Waiting or blocked triage requires merchant-visible follow-up guidance.'
+      : connectorTriageSubmitting
+        ? 'Connector triage is being recorded.'
+        : 'Record sandbox-only operator triage; this does not approve launch or connector execution.';
+  const connectorTriageControls = [
+    { label: 'sandbox_only', value: true },
+    { label: 'credential_entry_enabled', value: false },
+    { label: 'outbound_sync_enabled', value: false },
+    { label: 'public_discovery_enabled', value: false },
+    { label: 'checkout_payment_enabled', value: false },
+    { label: 'live_provider_enabled', value: false },
+    { label: 'merchant_private_api_calls_enabled', value: false },
+    { label: 'triage_is_production_approval', value: false },
+  ];
   const connectorEvidence = merchant && connectorDryRun
     ? buildConnectorEvidenceExport(merchant.merchant_id, connectorDryRun, connectorReview, connectorRemediationLoop, connectorBackendRemediation)
     : null;
@@ -2804,7 +2919,7 @@ export function CommerceOnboarding() {
                   <Badge variant="success">read-only timeline</Badge>
                 </div>
               </div>
-              <div className="grid gap-3 md:grid-cols-[260px_auto_auto] md:items-end">
+              <div className="grid gap-3 md:grid-cols-[220px_220px_auto_auto] md:items-end">
                 <label className="text-sm font-medium text-gx-text">
                   Remediation status filter
                   <select
@@ -2814,6 +2929,19 @@ export function CommerceOnboarding() {
                   >
                     <option value="">all sandbox statuses</option>
                     {connectorRemediationStatusOptions.map((status) => (
+                      <option key={status} value={status}>{status}</option>
+                    ))}
+                  </select>
+                </label>
+                <label className="text-sm font-medium text-gx-text">
+                  Triage status filter
+                  <select
+                    className="mt-1.5 w-full rounded-md border border-gx-border bg-gx-bg px-3 py-2 text-sm text-gx-text focus:border-gx-accent focus:outline-none"
+                    value={connectorQueueTriageStatusFilter}
+                    onChange={(e) => setConnectorQueueTriageStatusFilter(e.target.value as CommerceConnectorDryRunRemediationTriageStatus | '')}
+                  >
+                    <option value="">all triage statuses</option>
+                    {connectorRemediationTriageStatusOptions.map((status) => (
                       <option key={status} value={status}>{status}</option>
                     ))}
                   </select>
@@ -2860,6 +2988,9 @@ export function CommerceOnboarding() {
                         </div>
                         <div className="flex flex-wrap items-center gap-2">
                           <Badge variant={backendRemediationStatusVariant(item.status)}>{item.status}</Badge>
+                          <Badge variant={triageStatusVariant(item.triage?.triage_status)}>
+                            {item.triage?.triage_status ?? 'triage_not_recorded'}
+                          </Badge>
                           <Button
                             variant="secondary"
                             size="sm"
@@ -2883,6 +3014,12 @@ export function CommerceOnboarding() {
                           </div>
                         ))}
                       </div>
+                      {item.triage?.merchant_followup_summary ? (
+                        <div className="mt-2 rounded-md border border-gx-border p-2">
+                          <div className="text-xs text-gx-muted">merchant_followup_summary</div>
+                          <div className="mt-1 text-sm text-gx-text">{item.triage.merchant_followup_summary}</div>
+                        </div>
+                      ) : null}
                     </div>
                   ))}
                 </div>
@@ -2906,6 +3043,9 @@ export function CommerceOnboarding() {
                   <div className="mt-2 grid gap-2 md:grid-cols-4">
                     {[
                       { label: 'merchant_next_step', value: connectorRemediationTimeline.merchant_status.next_step },
+                      { label: 'merchant_followup_summary', value: connectorRemediationTimeline.merchant_status.merchant_followup_summary ?? 'not_recorded' },
+                      { label: 'triage_status', value: connectorRemediationTimeline.merchant_status.triage_status ?? 'not_recorded' },
+                      { label: 'triage_next_step', value: connectorRemediationTimeline.merchant_status.triage_next_step ?? 'not_recorded' },
                       { label: 'queue_status', value: connectorRemediationTimeline.operator_queue.queue_status },
                       { label: 'raw_rows_included', value: connectorRemediationTimeline.redaction_summary.raw_connector_rows_included },
                       { label: 'followup_ready_is_launch_approval', value: connectorRemediationTimeline.controls.followup_ready_is_launch_approval },
@@ -2927,11 +3067,106 @@ export function CommerceOnboarding() {
                         </div>
                         <div className="mt-1 text-xs text-gx-muted">{entry.event_type}</div>
                         <div className="mt-1 break-all text-xs text-gx-muted">Audit: {entry.audit_event_id ?? 'not_recorded'}</div>
+                        {entry.key === 'operator_triage_recorded' ? (
+                          <div className="mt-2 grid gap-1 text-xs text-gx-muted md:grid-cols-2">
+                            <div>triage_status: {String(entry.evidence_summary.triage_status ?? 'not_recorded')}</div>
+                            <div>merchant_summary_present: {String(entry.evidence_summary.merchant_followup_summary_present ?? false)}</div>
+                            <div>triage_is_production_approval: {String(entry.evidence_summary.triage_is_production_approval ?? false)}</div>
+                            <div>triage_enables_connector_execution: {String(entry.evidence_summary.triage_enables_connector_execution ?? false)}</div>
+                          </div>
+                        ) : null}
                       </div>
                     ))}
                   </div>
                 </div>
               ) : null}
+
+              <div className="mt-3 rounded-md border border-gx-border p-3">
+                <div className="mb-3 flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <div className="text-sm font-medium text-gx-text">Operator triage controls</div>
+                    <p className="mt-1 text-xs text-gx-muted">
+                      Records C6Sia sandbox triage metadata for the selected remediation record only. Duplicate identical submissions return the existing audit reference and are not production approval.
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Badge variant="warning">operator-only</Badge>
+                    <Badge variant="success">tenant-scoped</Badge>
+                    <Badge variant="success">redacted guidance</Badge>
+                  </div>
+                </div>
+                <div className="grid gap-3 md:grid-cols-2">
+                  <label className="text-sm font-medium text-gx-text">
+                    Triage status
+                    <select
+                      className="mt-1.5 w-full rounded-md border border-gx-border bg-gx-bg px-3 py-2 text-sm text-gx-text focus:border-gx-accent focus:outline-none"
+                      value={connectorTriageForm.triage_status}
+                      onChange={(e) => setConnectorTriageForm({ ...connectorTriageForm, triage_status: e.target.value as CommerceConnectorDryRunRemediationTriageStatus })}
+                    >
+                      {connectorRemediationTriageStatusOptions.map((status) => (
+                        <option key={status} value={status}>{status}</option>
+                      ))}
+                    </select>
+                  </label>
+                  <Input
+                    id="connector-triage-assigned-operator"
+                    label="Assigned operator reference"
+                    value={connectorTriageForm.assigned_operator_id}
+                    onChange={(e) => setConnectorTriageForm({ ...connectorTriageForm, assigned_operator_id: e.target.value })}
+                  />
+                  <div>
+                    <label htmlFor="connector-triage-note" className="mb-1.5 block text-sm font-medium text-gx-text">
+                      Internal triage note
+                    </label>
+                    <textarea
+                      id="connector-triage-note"
+                      value={connectorTriageForm.triage_note}
+                      onChange={(e) => setConnectorTriageForm({ ...connectorTriageForm, triage_note: e.target.value })}
+                      rows={3}
+                      className="w-full rounded-md border border-gx-border bg-gx-bg px-3 py-2 text-sm text-gx-text focus:border-gx-accent focus:outline-none"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="connector-triage-merchant-summary" className="mb-1.5 block text-sm font-medium text-gx-text">
+                      Merchant-visible follow-up summary
+                    </label>
+                    <textarea
+                      id="connector-triage-merchant-summary"
+                      value={connectorTriageForm.merchant_followup_summary}
+                      onChange={(e) => setConnectorTriageForm({ ...connectorTriageForm, merchant_followup_summary: e.target.value })}
+                      rows={3}
+                      className="w-full rounded-md border border-gx-border bg-gx-bg px-3 py-2 text-sm text-gx-text focus:border-gx-accent focus:outline-none"
+                    />
+                  </div>
+                  <Input
+                    id="connector-triage-next-step"
+                    label="Triage next step"
+                    value={connectorTriageForm.next_step}
+                    onChange={(e) => setConnectorTriageForm({ ...connectorTriageForm, next_step: e.target.value })}
+                  />
+                  <div className="flex flex-col justify-end">
+                    <Button
+                      variant="secondary"
+                      onClick={recordConnectorRemediationTriage}
+                      disabled={connectorTriageDisabled}
+                      title={connectorTriageDisabledReason}
+                    >
+                      {connectorTriageSubmitting ? 'Recording triage' : 'Record operator triage'}
+                    </Button>
+                    <div className="mt-2 text-xs text-gx-muted">Triage action: {connectorTriageDisabledReason}</div>
+                  </div>
+                </div>
+                <div className="mt-3 grid gap-2 md:grid-cols-4">
+                  {connectorTriageControls.map((item) => (
+                    <div key={item.label} className="rounded-md border border-gx-border p-2">
+                      <div className="text-xs text-gx-muted">{item.label}</div>
+                      <Badge variant={item.value && item.label === 'sandbox_only' ? 'success' : item.value ? 'danger' : 'success'}>
+                        {String(item.value)}
+                      </Badge>
+                    </div>
+                  ))}
+                </div>
+              </div>
             </div>
 
             {connectorEvidence ? (

--- a/docs/internal/commerce-v1/commerce-v1-c6sib-remediation-operator-triage-portal.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6sib-remediation-operator-triage-portal.md
@@ -1,0 +1,110 @@
+# Commerce V1 C6Sib - Connector Remediation Operator Triage Portal
+
+C6Sib adds portal controls for the C6Sia backend operator triage route. The
+portal lets an operator view persisted sandbox connector remediation records,
+filter by triage status, record public-safe triage metadata, and show
+merchant-visible follow-up guidance from the redacted timeline.
+
+C6Sib is portal, docs, and tests only. It remains sandbox-only,
+credential-free, non-live, non-publication, non-certifying, and non-enabling.
+
+## Operator Workflow
+
+1. Load the merchant's Commerce Onboarding page.
+2. Load the persisted connector remediation queue.
+3. Optionally filter by remediation status and C6Sia `triage_status`.
+4. Open the redacted remediation timeline for a selected remediation record.
+5. Record operator triage with:
+   - triage status;
+   - public-safe operator assignment reference;
+   - public-safe internal triage note;
+   - merchant-visible follow-up summary;
+   - public-safe next step.
+6. Reopen the refreshed redacted timeline and continue the sandbox-only
+   corrected dry-run or follow-up review flow when existing C6R/C6Sg/C6Sa
+   controls allow it.
+
+Duplicate identical triage submissions are displayed as already-current state.
+They must not be treated as a new production approval or new connector
+execution authorization.
+
+## Merchant-Visible Guidance
+
+Merchant-visible guidance is limited to remediation status, a short follow-up
+summary, and the next sandbox evidence step. It must not expose internal
+operator notes, raw connector rows, raw merchant-system payloads, customer data,
+credentials, provider metadata, private API URLs, checkout URLs, payment
+identifiers, production config values, concrete allowlists, or secrets.
+
+## Non-Enabling Controls
+
+The portal continues to show fixed false/off controls for:
+
+- credential entry;
+- outbound sync;
+- production connector setup;
+- public discovery;
+- checkout/payment;
+- live provider and live Plural;
+- provider calls;
+- merchant private API calls;
+- production allowlists;
+- production approval;
+- connector execution approval;
+- certification.
+
+## Stop Conditions
+
+Stop and require a new approved work item if any change:
+
+- adds backend routes, migrations, workers, workflows, schedules, or runtime
+  connector execution;
+- adds credential entry, provider credentials, merchant private API URLs, or
+  outbound sync controls;
+- enables Grantex public discovery or AgenticOrg public commerce discovery;
+- enables production Commerce V1, checkout/payment creation, fulfillment,
+  refunds, live payments, live Plural, or live providers;
+- calls Shopify, WooCommerce, Magento, custom API, ERP, OMS, WMS, logistics,
+  CRM/support, payment providers, Plural, Stripe, Pine, or merchant private
+  APIs;
+- lets AgenticOrg call merchant private APIs directly;
+- writes production config or production allowlists;
+- claims production approval, public discovery approval, checkout/payment
+  approval, live provider approval, public protocol publication, provider
+  approval, live-payment approval, or certification;
+- treats sandbox, demo, synthetic, fixture, dry-run, review, remediation,
+  triage, timeline, export, or rehearsal output as real merchant approval.
+
+## Rollback Notes
+
+C6Sib rollback removes:
+
+- the portal API client helper for the C6Sia triage route;
+- portal triage status filtering and operator triage controls;
+- redacted triage timeline presentation;
+- the C6Sib portal tests;
+- this internal note.
+
+Rollback does not require cloud action, secret rotation, production config
+changes, public discovery changes, checkout/payment changes, live provider
+changes, merchant private API changes, production allowlist changes, or
+certification work.
+
+## Validation
+
+Focused validation:
+
+```bash
+npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
+npm --prefix apps/portal run typecheck
+npm --prefix apps/auth-service test -- commerce-connector-remediation-triage-c6sia.test.ts commerce-openapi.test.ts
+npm --prefix apps/auth-service run typecheck
+node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
+git diff --check origin/main...HEAD
+```
+
+Focused scans must cover secrets/private details, production config or
+allowlist assignments, public discovery enablement, checkout/payment
+enablement, live payment/live Plural/provider credential enablement,
+certification claims, direct provider calls, direct merchant private API calls,
+AgenticOrg direct execution, and outbound sync enablement.


### PR DESCRIPTION
## Summary
- add portal API types and client support for the existing C6Sia connector remediation triage route and triage_status queue filter
- add sandbox-only operator triage controls, merchant-visible follow-up guidance, and redacted triage timeline/audit display to Commerce Onboarding
- add focused portal API/UI tests and an internal C6Sib operator guide with stop conditions and rollback notes

## Safety posture
- portal/docs/test only; no backend routes, migrations, workers, workflows, or runtime connector execution added
- credential-free, sandbox-only, tenant-scoped, non-live, non-enabling behavior preserved
- no public discovery, checkout/payment, live provider, live Plural, production allowlist, provider call, merchant private API call, or certification behavior enabled
- duplicate/idempotent triage responses are presented as already-current state, not approval

## Validation
- npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
- npm --prefix apps/portal run typecheck
- npm --prefix apps/auth-service test -- commerce-connector-remediation-triage-c6sia.test.ts commerce-openapi.test.ts
- npm --prefix apps/auth-service run typecheck
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
- git diff --check origin/main...HEAD
- focused guardrail scans for secrets/private details, production config/allowlists, public discovery, checkout/payment, live payment/live provider, provider credentials, certification claims, direct provider calls, and direct merchant private API calls