### PR TITLE
C6Sic sandbox connector remediation triage workflow rehearsal

### DIFF
--- a/apps/portal/src/api/__tests__/commerce.test.ts
+++ b/apps/portal/src/api/__tests__/commerce.test.ts
@@ -366,6 +366,71 @@ describe('commerce api', () => {
     }
   });
 
+  it('reuses the same public-safe triage request shape for duplicate-current submissions', async () => {
+    const response = {
+      data: {
+        remediation_id: 'cdrem/1',
+        triage: {
+          triage_status: 'waiting_on_merchant',
+          merchant_followup_summary: 'Rerun the sandbox dry-run after fixing category mapping.',
+          next_step: 'Attach corrected sandbox evidence.',
+          triage_audit_event_id: 'aud_triage',
+        },
+      },
+      audit_event_id: 'aud_triage',
+      controls: {
+        sandbox_only: true,
+        credential_entry_enabled: false,
+        outbound_sync_enabled: false,
+        production_connector_setup_enabled: false,
+        provider_call_enabled: false,
+        merchant_private_api_calls_enabled: false,
+        triage_is_production_approval: false,
+        triage_enables_connector_execution: false,
+      },
+    };
+    ok(response);
+    ok(response);
+
+    const input = {
+      triageStatus: 'waiting_on_merchant' as const,
+      assignedOperatorId: 'ops.c6sic',
+      triageNote: 'Internal sandbox triage note remains operator-only.',
+      merchantFollowupSummary: 'Rerun the sandbox dry-run after fixing category mapping.',
+      nextStep: 'Attach corrected sandbox evidence.',
+    };
+    await recordCommerceConnectorDryRunRemediationTriage('mch/1', 'cdrem/1', input);
+    await recordCommerceConnectorDryRunRemediationTriage('mch/1', 'cdrem/1', input);
+
+    expect(mockFetch.mock.calls).toHaveLength(2);
+    for (const call of mockFetch.mock.calls) {
+      expect(call[0]).toBe('http://localhost:3000/v1/commerce/merchants/mch%2F1/connectors/remediations/cdrem%2F1/triage');
+      const body = JSON.parse(call[1].body);
+      expect(body).toEqual({
+        triage_status: 'waiting_on_merchant',
+        assigned_operator_id: 'ops.c6sic',
+        triage_note: 'Internal sandbox triage note remains operator-only.',
+        merchant_followup_summary: 'Rerun the sandbox dry-run after fixing category mapping.',
+        next_step: 'Attach corrected sandbox evidence.',
+      });
+      const serialized = JSON.stringify(body).toLowerCase();
+      for (const forbidden of [
+        'credential',
+        'secret',
+        'provider_metadata',
+        'raw_payload',
+        'public_discovery_enabled',
+        'checkout_payment_enabled',
+        'live_provider_enabled',
+        'live_plural_enabled',
+        'production_allowlist',
+        'certification',
+      ]) {
+        expect(serialized).not.toContain(forbidden);
+      }
+    }
+  });
+
   it('calls webhook source and policy endpoints without secret-like list output assumptions', async () => {
     ok({ items: [] });
     await listCommerceWebhookSources({ merchantId: 'mch_1', status: 'active' });

--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import type { ReactNode } from 'react';
@@ -1899,6 +1899,7 @@ describe('CommerceOnboarding', () => {
   it('loads persisted remediation queue and redacted timeline without connector execution controls', async () => {
     mockGetCommerceConnectorDryRunRemediationTimeline
       .mockResolvedValueOnce({ data: connectorRemediationTimeline })
+      .mockResolvedValueOnce({ data: connectorRemediationTimelineTriaged })
       .mockResolvedValueOnce({ data: connectorRemediationTimelineTriaged });
     const user = userEvent.setup();
     r(<CommerceOnboarding />);
@@ -1953,12 +1954,37 @@ describe('CommerceOnboarding', () => {
     )).length).toBeGreaterThan(0);
     expect(screen.getAllByText('waiting_on_merchant').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Please rerun the sandbox dry-run after fixing category mapping.').length).toBeGreaterThan(0);
+    const merchantGuidance = screen.getByTestId('connector-merchant-followup-guidance');
+    expect(within(merchantGuidance).getByText('Merchant-visible follow-up guidance')).toBeInTheDocument();
+    expect(within(merchantGuidance).getByText('Please rerun the sandbox dry-run after fixing category mapping.')).toBeInTheDocument();
+    expect(within(merchantGuidance).getByText('Next step: Attach the corrected sandbox dry-run evidence.')).toBeInTheDocument();
+    expect(within(merchantGuidance).queryByText('Internal sandbox triage note must stay operator-only.')).not.toBeInTheDocument();
     expect(screen.getByText('triage_is_production_approval')).toBeInTheDocument();
     expect(screen.getAllByText((_content, node) => (
       node?.textContent?.includes('triage_enables_connector_execution: false') === true
       && node.childElementCount === 0
     )).length).toBeGreaterThan(0);
+    const rehearsalStatus = screen.getByTestId('connector-triage-rehearsal-status');
+    expect(within(rehearsalStatus).getByText('Triage workflow rehearsal status')).toBeInTheDocument();
+    expect(within(rehearsalStatus).getByText('saved_or_already_current')).toBeInTheDocument();
+    expect(within(rehearsalStatus).getByText('reuse_existing_state')).toBeInTheDocument();
+    expect(within(rehearsalStatus).getByText('redacted_timeline_continuity')).toBeInTheDocument();
+    expect(within(rehearsalStatus).getAllByText('true').length).toBeGreaterThan(0);
+    expect(within(rehearsalStatus).getByText('internal_notes_in_merchant_guidance')).toBeInTheDocument();
+    expect(within(rehearsalStatus).getByText('connector_execution_enabled')).toBeInTheDocument();
+    expect(within(rehearsalStatus).getByText('production_approval')).toBeInTheDocument();
+    expect(within(rehearsalStatus).getAllByText('false').length).toBeGreaterThanOrEqual(3);
+    expect(within(rehearsalStatus).queryByText('Internal sandbox triage note must stay operator-only.')).not.toBeInTheDocument();
     expect(mockShow).toHaveBeenCalledWith('Connector triage saved or already current', 'success');
+
+    await user.click(screen.getByRole('button', { name: 'Record operator triage' }));
+    await waitFor(() => expect(mockRecordCommerceConnectorDryRunRemediationTriage).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockGetCommerceConnectorDryRunRemediationTimeline).toHaveBeenCalledTimes(3));
+    const duplicateStatus = screen.getByTestId('connector-triage-rehearsal-status');
+    expect(within(duplicateStatus).getByText('reuse_existing_state')).toBeInTheDocument();
+    expect(within(duplicateStatus).getByText('saved_or_already_current')).toBeInTheDocument();
+    expect(within(duplicateStatus).getByText('caud_C6SIA_TRIAGE_RECORDED')).toBeInTheDocument();
+    expect(within(duplicateStatus).queryByText('Internal sandbox triage note must stay operator-only.')).not.toBeInTheDocument();
     expect(screen.queryByRole('textbox', { name: 'Credential' })).not.toBeInTheDocument();
     expect(screen.queryByText('production connector setup enabled')).not.toBeInTheDocument();
     expect(screen.queryByText('outbound connector sync enabled')).not.toBeInTheDocument();

--- a/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
+++ b/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
@@ -449,6 +449,51 @@ function triageFormFromRemediation(remediation: CommerceConnectorDryRunRemediati
   };
 }
 
+interface ConnectorTriageRehearsalStatus {
+  result: 'saved_or_already_current';
+  remediation_id: string;
+  triage_status: CommerceConnectorDryRunRemediationTriageStatus | null;
+  audit_reference: string | null;
+  merchant_followup_summary: string;
+  merchant_next_step: string;
+  timeline_entries: number;
+  redacted_timeline_continuity: boolean;
+  duplicate_handling: 'reuse_existing_state';
+  internal_notes_in_merchant_guidance: false;
+  production_approval: false;
+  connector_execution_enabled: false;
+}
+
+function buildConnectorTriageRehearsalStatus(
+  remediation: CommerceConnectorDryRunRemediation,
+  timeline: CommerceConnectorDryRunRemediationTimeline,
+): ConnectorTriageRehearsalStatus {
+  return {
+    result: 'saved_or_already_current',
+    remediation_id: remediation.remediation_id,
+    triage_status: remediation.triage?.triage_status ?? null,
+    audit_reference: remediation.triage?.triage_audit_event_id ?? remediation.audit_references.triage_audit_event_id ?? null,
+    merchant_followup_summary: timeline.merchant_status.merchant_followup_summary
+      ?? remediation.triage?.merchant_followup_summary
+      ?? 'not_recorded',
+    merchant_next_step: timeline.merchant_status.triage_next_step
+      ?? remediation.triage?.next_step
+      ?? timeline.merchant_status.next_step,
+    timeline_entries: timeline.timeline.length,
+    redacted_timeline_continuity: timeline.timeline.every((entry) => (
+      entry.redaction.raw_connector_rows_included === false
+      && entry.redaction.credentials_included === false
+      && entry.redaction.provider_metadata_included === false
+      && entry.redaction.merchant_private_api_payload_included === false
+      && entry.redaction.production_config_values_included === false
+    )),
+    duplicate_handling: 'reuse_existing_state',
+    internal_notes_in_merchant_guidance: false,
+    production_approval: false,
+    connector_execution_enabled: false,
+  };
+}
+
 function buildConnectorEvidencePacketReview(
   dryRun: CommerceConnectorDryRunResult,
   review: CommerceConnectorDryRunReview | null,
@@ -1221,6 +1266,7 @@ export function CommerceOnboarding() {
   const [connectorQueueLoading, setConnectorQueueLoading] = useState(false);
   const [connectorTimelineLoading, setConnectorTimelineLoading] = useState(false);
   const [connectorTriageSubmitting, setConnectorTriageSubmitting] = useState(false);
+  const [connectorTriageRehearsalStatus, setConnectorTriageRehearsalStatus] = useState<ConnectorTriageRehearsalStatus | null>(null);
   const [connectorForm, setConnectorForm] = useState<{
     connector_type: CommerceConnectorDryRunType;
     source_label: string;
@@ -1295,6 +1341,7 @@ export function CommerceOnboarding() {
       setConnectorRemediationQueue([]);
       setConnectorRemediationTimeline(null);
       setConnectorTriageForm(triageFormFromRemediation(null));
+      setConnectorTriageRehearsalStatus(null);
       setProposalNote(proposalRes?.data.proposal_note ?? '');
       setAgenticOrgNote('');
       setMerchantForm({
@@ -1712,6 +1759,11 @@ export function CommerceOnboarding() {
       setConnectorRemediationTimeline(res.data);
       setConnectorBackendRemediation(res.data.remediation);
       setConnectorTriageForm(triageFormFromRemediation(res.data.remediation));
+      setConnectorTriageRehearsalStatus(
+        res.data.remediation.triage?.triage_status
+          ? buildConnectorTriageRehearsalStatus(res.data.remediation, res.data)
+          : null,
+      );
       show('Connector remediation timeline loaded', 'success');
     } catch {
       show('Connector remediation timeline is unavailable', 'error');
@@ -1752,6 +1804,7 @@ export function CommerceOnboarding() {
         res.data.remediation_id,
       );
       setConnectorRemediationTimeline(timelineRes.data);
+      setConnectorTriageRehearsalStatus(buildConnectorTriageRehearsalStatus(res.data, timelineRes.data));
       show('Connector triage saved or already current', 'success');
     } catch {
       show('Connector triage is blocked for sandbox safety', 'error');
@@ -3056,6 +3109,18 @@ export function CommerceOnboarding() {
                       </div>
                     ))}
                   </div>
+                  <div data-testid="connector-merchant-followup-guidance" className="mt-3 rounded-md border border-gx-border p-2">
+                    <div className="text-xs font-medium text-gx-muted">Merchant-visible follow-up guidance</div>
+                    <div className="mt-1 text-sm text-gx-text">
+                      {connectorRemediationTimeline.merchant_status.merchant_followup_summary ?? 'No merchant-visible follow-up summary recorded.'}
+                    </div>
+                    <div className="mt-1 text-xs text-gx-muted">
+                      Next step: {connectorRemediationTimeline.merchant_status.triage_next_step ?? connectorRemediationTimeline.merchant_status.next_step}
+                    </div>
+                    <div className="mt-1 text-xs text-gx-muted">
+                      Internal notes, raw connector rows, provider metadata, credentials, and merchant private API payloads are excluded.
+                    </div>
+                  </div>
                   <div className="mt-3 grid gap-2">
                     {connectorRemediationTimeline.timeline.map((entry) => (
                       <div key={`${entry.sequence}-${entry.key}`} className="rounded-md border border-gx-border p-2">
@@ -3166,6 +3231,42 @@ export function CommerceOnboarding() {
                     </div>
                   ))}
                 </div>
+                {connectorTriageRehearsalStatus ? (
+                  <div data-testid="connector-triage-rehearsal-status" className="mt-3 rounded-md border border-gx-border p-3">
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <div>
+                        <div className="text-sm font-medium text-gx-text">Triage workflow rehearsal status</div>
+                        <p className="mt-1 text-xs text-gx-muted">
+                          Current triage state is persisted for sandbox follow-up only. Duplicate identical submissions reuse existing state and do not approve connector execution.
+                        </p>
+                      </div>
+                      <Badge variant="success">{connectorTriageRehearsalStatus.result}</Badge>
+                    </div>
+                    <div className="mt-3 grid gap-2 md:grid-cols-4">
+                      {[
+                        { label: 'remediation_id', value: connectorTriageRehearsalStatus.remediation_id },
+                        { label: 'triage_status', value: connectorTriageRehearsalStatus.triage_status ?? 'not_recorded' },
+                        { label: 'audit_reference', value: connectorTriageRehearsalStatus.audit_reference ?? 'not_recorded' },
+                        { label: 'duplicate_handling', value: connectorTriageRehearsalStatus.duplicate_handling },
+                        { label: 'timeline_entries', value: connectorTriageRehearsalStatus.timeline_entries },
+                        { label: 'redacted_timeline_continuity', value: connectorTriageRehearsalStatus.redacted_timeline_continuity },
+                        { label: 'internal_notes_in_merchant_guidance', value: connectorTriageRehearsalStatus.internal_notes_in_merchant_guidance },
+                        { label: 'connector_execution_enabled', value: connectorTriageRehearsalStatus.connector_execution_enabled },
+                        { label: 'production_approval', value: connectorTriageRehearsalStatus.production_approval },
+                      ].map((item) => (
+                        <div key={item.label} className="rounded-md border border-gx-border p-2">
+                          <div className="text-xs text-gx-muted">{item.label}</div>
+                          <div className="break-all text-sm font-medium text-gx-text">{String(item.value)}</div>
+                        </div>
+                      ))}
+                    </div>
+                    <div data-testid="connector-triage-rehearsal-guidance" className="mt-3 rounded-md border border-gx-border p-2">
+                      <div className="text-xs font-medium text-gx-muted">Redacted merchant guidance in current state</div>
+                      <div className="mt-1 text-sm text-gx-text">{connectorTriageRehearsalStatus.merchant_followup_summary}</div>
+                      <div className="mt-1 text-xs text-gx-muted">Next step: {connectorTriageRehearsalStatus.merchant_next_step}</div>
+                    </div>
+                  </div>
+                ) : null}
               </div>
             </div>
 

--- a/docs/internal/commerce-v1/commerce-v1-c6sic-remediation-triage-workflow-rehearsal.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6sic-remediation-triage-workflow-rehearsal.md
@@ -1,0 +1,121 @@
+# Commerce V1 C6Sic - Remediation Triage Workflow Rehearsal
+
+C6Sic hardens the C6Sib portal rehearsal for persisted sandbox connector
+remediation triage. It is portal, docs, and test work only. It remains
+sandbox-only, credential-free, tenant-scoped, non-live, non-publication,
+non-certifying, and non-enabling.
+
+## Scope
+
+C6Sic rehearses the local operator workflow after C6Sia and C6Sib are in place:
+
+1. Load the tenant-scoped remediation queue.
+2. Filter by remediation status and operator triage status.
+3. Open the redacted remediation timeline.
+4. Record operator triage metadata.
+5. Confirm duplicate identical triage submissions are shown as already-current
+   state.
+6. Confirm merchant-visible follow-up guidance contains only public-safe summary
+   and next-step fields.
+7. Confirm redacted audit timeline continuity remains intact.
+
+The rehearsal does not add backend routes, migrations, workflows, workers,
+runtime connector execution, credential entry, outbound sync, production
+connector setup, public discovery, checkout/payment, live providers, provider
+calls, merchant private API calls, production allowlists, or certification
+claims.
+
+## Merchant-Visible Follow-Up
+
+The portal shows a dedicated merchant-visible guidance panel. That panel may
+include:
+
+- remediation status;
+- merchant follow-up summary;
+- next sandbox evidence step;
+- redacted audit/timeline continuity indicators.
+
+The panel must not include:
+
+- internal operator triage notes;
+- raw connector rows or raw merchant-system payloads;
+- private merchant details;
+- provider metadata;
+- credentials or secrets;
+- private API URLs;
+- checkout/payment identifiers or URLs;
+- production config values or concrete allowlists.
+
+## Duplicate Triage Handling
+
+Duplicate identical triage submissions are treated as existing/current sandbox
+state. They must reuse the persisted triage state and audit reference returned
+by Grantex. They are not a new production approval, connector execution
+authorization, public discovery approval, checkout/payment approval, live
+provider approval, or certification.
+
+## Redacted Timeline Continuity
+
+The portal derives the rehearsal status from the redacted timeline response. A
+passing rehearsal requires every timeline entry to keep these redaction flags
+false:
+
+- raw connector rows included;
+- credentials included;
+- provider metadata included;
+- merchant private API payload included;
+- production config values included.
+
+The rehearsal summary may show remediation IDs, triage status, audit reference,
+timeline entry count, merchant-visible summary, next step, and fixed
+non-enabling controls.
+
+## Stop Conditions
+
+Stop and require a new approved work item if any follow-up:
+
+- adds or changes backend routes, migrations, workers, workflows, schedules, or
+  runtime connector execution;
+- adds credential entry, provider credentials, merchant private API URLs, or
+  outbound sync controls;
+- enables Grantex public discovery or AgenticOrg public commerce discovery;
+- enables production Commerce V1, checkout/payment creation, fulfillment,
+  refunds, live payments, live Plural, or live providers;
+- calls Shopify, WooCommerce, Magento, custom API, ERP, OMS, WMS, logistics,
+  CRM/support, payment providers, Plural, Stripe, Pine, or merchant private
+  APIs;
+- lets AgenticOrg call merchant private APIs directly;
+- writes production config or production allowlists;
+- claims production approval, public discovery approval, checkout/payment
+  approval, live provider approval, public protocol publication, provider
+  approval, live-payment approval, or certification;
+- treats sandbox, demo, synthetic, fixture, dry-run, review, remediation,
+  triage, timeline, export, or rehearsal output as real merchant approval.
+
+## Rollback Notes
+
+C6Sic rollback removes the portal rehearsal status panel, the dedicated
+merchant-visible guidance hardening, the duplicate-current portal/API tests, and
+this internal note. Rollback does not require cloud action, secret rotation,
+production config changes, public discovery changes, checkout/payment changes,
+live provider changes, merchant private API changes, production allowlist
+changes, or certification work.
+
+## Validation
+
+Focused validation:
+
+```bash
+npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
+npm --prefix apps/portal run typecheck
+npm --prefix apps/auth-service test -- commerce-connector-remediation-triage-c6sia.test.ts commerce-openapi.test.ts
+npm --prefix apps/auth-service run typecheck
+node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
+git diff --check origin/main...HEAD
+```
+
+Focused scans must cover secrets/private details, production config or
+allowlist assignments, public discovery enablement, checkout/payment
+enablement, live payment/live Plural/provider credential enablement,
+certification claims, direct provider calls, direct merchant private API calls,
+AgenticOrg direct execution, and outbound sync enablement.


### PR DESCRIPTION
## Summary
- Adds a C6Sic portal rehearsal status for sandbox connector remediation triage, including duplicate-current handling and redacted timeline continuity indicators.
- Hardens merchant-visible follow-up guidance so the dedicated panel shows only public-safe summary and next-step fields.
- Adds portal/API-client regression coverage for duplicate triage requests, redaction, non-enabling controls, and internal docs for usage/stop conditions.

## Safety
- Portal/docs/test only.
- No backend routes, migrations, workflows, workers, runtime connector execution, credential entry, outbound sync, production connector setup, public discovery, checkout/payment, live providers, provider calls, merchant private API calls, production allowlists, or certification claims.
- Duplicate triage responses are treated as existing/current sandbox state, not approval or enablement.

## Validation
- npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
- npm --prefix apps/portal run typecheck
- npm --prefix apps/auth-service test -- commerce-connector-remediation-triage-c6sia.test.ts commerce-openapi.test.ts
- npm --prefix apps/auth-service run typecheck
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
- git diff --check origin/main...HEAD
- focused guardrail scans for secrets/private details, production config/allowlists, public discovery, checkout/payment, live providers, provider calls, merchant private API calls, and certification claims