### PR TITLE
C6Sid sandbox connector remediation triage evidence reconciliation

### DIFF
--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -1083,6 +1083,31 @@ const connectorRemediationTimelineTriaged = {
   },
 };
 
+const connectorRemediationStaleConflict = {
+  ...connectorRemediationTriaged,
+  warning_summary: [
+    {
+      code: 'last_sync_stale',
+      message: 'Stale source conflict detected in sandbox evidence.',
+    },
+  ],
+  triage: {
+    ...connectorRemediationTriaged.triage,
+    merchant_followup_summary: 'Resolve stale source conflict in sandbox evidence before follow-up.',
+    next_step: 'Refresh the local sandbox snapshot and rerun the dry-run.',
+  },
+};
+
+const connectorRemediationTimelineStaleConflict = {
+  ...connectorRemediationTimelineTriaged,
+  remediation: connectorRemediationStaleConflict,
+  merchant_status: {
+    ...connectorRemediationTimelineTriaged.merchant_status,
+    merchant_followup_summary: 'Resolve stale source conflict in sandbox evidence before follow-up.',
+    triage_next_step: 'Refresh the local sandbox snapshot and rerun the dry-run.',
+  },
+};
+
 const connectorDryRunCorrected = {
   ...connectorDryRun,
   dry_run_id: 'cdry_C6SF_CORRECTED',
@@ -1975,6 +2000,24 @@ describe('CommerceOnboarding', () => {
     expect(within(rehearsalStatus).getByText('production_approval')).toBeInTheDocument();
     expect(within(rehearsalStatus).getAllByText('false').length).toBeGreaterThanOrEqual(3);
     expect(within(rehearsalStatus).queryByText('Internal sandbox triage note must stay operator-only.')).not.toBeInTheDocument();
+    const reconciliationSummary = screen.getByTestId('connector-triage-reconciliation-summary');
+    expect(within(reconciliationSummary).getByText('Operator/merchant evidence reconciliation')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('aligned')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('queue_timeline_triage_status')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('backend_timeline_triage_status')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('rehearsal_timeline_triage_status')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('merchant_guidance_consistency')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getAllByText('redacted_audit_reference_continuity').length).toBeGreaterThan(0);
+    expect(within(reconciliationSummary).getByText('stale_conflict_followup_guidance')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('none')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('caud_C6SG_REMEDIATION_REQUESTED')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('caud_C6SG_CORRECTED_ATTACHED')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('caud_C6SG_FOLLOWUP_REQUESTED')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('caud_C6SIA_TRIAGE_RECORDED')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('connector_execution_enabled')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('production_approval')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getAllByText('false').length).toBeGreaterThanOrEqual(2);
+    expect(within(reconciliationSummary).queryByText('Internal sandbox triage note must stay operator-only.')).not.toBeInTheDocument();
     expect(mockShow).toHaveBeenCalledWith('Connector triage saved or already current', 'success');
 
     await user.click(screen.getByRole('button', { name: 'Record operator triage' }));
@@ -1985,10 +2028,79 @@ describe('CommerceOnboarding', () => {
     expect(within(duplicateStatus).getByText('saved_or_already_current')).toBeInTheDocument();
     expect(within(duplicateStatus).getByText('caud_C6SIA_TRIAGE_RECORDED')).toBeInTheDocument();
     expect(within(duplicateStatus).queryByText('Internal sandbox triage note must stay operator-only.')).not.toBeInTheDocument();
+    const duplicateReconciliation = screen.getByTestId('connector-triage-reconciliation-summary');
+    expect(within(duplicateReconciliation).getByText('aligned')).toBeInTheDocument();
+    expect(within(duplicateReconciliation).getByText('none')).toBeInTheDocument();
     expect(screen.queryByRole('textbox', { name: 'Credential' })).not.toBeInTheDocument();
     expect(screen.queryByText('production connector setup enabled')).not.toBeInTheDocument();
     expect(screen.queryByText('outbound connector sync enabled')).not.toBeInTheDocument();
     expect(screen.queryByText('public discovery enabled')).not.toBeInTheDocument();
+  }, 10000);
+
+  it('flags stale or conflicting follow-up guidance as a sandbox blocker only', async () => {
+    mockGetCommerceConnectorDryRunRemediationTimeline.mockReset();
+    mockListCommerceConnectorDryRunRemediations.mockResolvedValueOnce({
+      items: [{
+        ...connectorRemediationStaleConflict,
+        queue: {
+          operator_queue_status: 'followup_review_requested' as const,
+          merchant_visible_status: 'followup_review_requested' as const,
+          requires_corrected_dry_run: false,
+          requires_operator_followup: true,
+          timeline_available: true as const,
+          evidence_redacted: true as const,
+        },
+        summary: {
+          blocker_count: 0,
+          warning_count: 1,
+          corrected_dry_run_attached: true,
+          followup_review_requested: true,
+          last_audit_event_id: 'caud_C6SIA_TRIAGE_RECORDED',
+        },
+      }],
+      next_cursor: null,
+      filters: { merchant_id: 'mch_1' },
+      controls: {
+        sandbox_only: true,
+        public_discovery_enabled: false,
+        checkout_payment_enabled: false,
+        live_provider_enabled: false,
+        live_plural_enabled: false,
+      },
+    });
+    mockGetCommerceConnectorDryRunRemediationTimeline.mockResolvedValueOnce({
+      data: connectorRemediationTimelineStaleConflict,
+    });
+    const user = userEvent.setup();
+    r(<CommerceOnboarding />);
+
+    await user.type(screen.getByLabelText('Merchant ID'), 'mch_1');
+    await user.click(screen.getByRole('button', { name: 'Load onboarding' }));
+    await waitFor(() => expect(screen.getByText('Persisted remediation queue')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: 'Load remediation queue' }));
+    await waitFor(() => expect(screen.getByText('Resolve stale source conflict in sandbox evidence before follow-up.')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'View timeline' }));
+    await waitFor(() => expect(mockGetCommerceConnectorDryRunRemediationTimeline).toHaveBeenCalledWith('mch_1', 'cdrem_C6SG'));
+
+    const merchantGuidance = screen.getByTestId('connector-merchant-followup-guidance');
+    expect(within(merchantGuidance).getByText('Resolve stale source conflict in sandbox evidence before follow-up.')).toBeInTheDocument();
+    expect(within(merchantGuidance).getByText('Next step: Refresh the local sandbox snapshot and rerun the dry-run.')).toBeInTheDocument();
+    expect(within(merchantGuidance).queryByText('Internal sandbox triage note must stay operator-only.')).not.toBeInTheDocument();
+
+    const reconciliationSummary = screen.getByTestId('connector-triage-reconciliation-summary');
+    expect(within(reconciliationSummary).getByText('Operator/merchant evidence reconciliation')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getAllByText('blocked').length).toBeGreaterThan(0);
+    expect(within(reconciliationSummary).getByText('stale_conflict_followup_guidance')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('sandbox_blocker_only')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('Stale or conflicting follow-up guidance is a sandbox blocker only; it is not approval or connector execution readiness.')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('connector_execution_enabled')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getByText('production_approval')).toBeInTheDocument();
+    expect(within(reconciliationSummary).getAllByText('false').length).toBeGreaterThanOrEqual(2);
+    expect(within(reconciliationSummary).queryByText('Internal sandbox triage note must stay operator-only.')).not.toBeInTheDocument();
+    expect(screen.queryByText('connector execution ready')).not.toBeInTheDocument();
+    expect(screen.queryByText('production approval enabled')).not.toBeInTheDocument();
+    expect(screen.queryByRole('textbox', { name: 'Credential' })).not.toBeInTheDocument();
   });
 
   it('rehearses remediation loop from needs-changes to corrected sandbox follow-up', async () => {

--- a/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
+++ b/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
@@ -433,6 +433,13 @@ function triageStatusVariant(status: CommerceConnectorDryRunRemediationTriageSta
   return 'default';
 }
 
+function reconciliationStatusVariant(status: ConnectorTriageReconciliationStatus | ConnectorTriageReconciliationCheck['status']): 'default' | 'success' | 'warning' | 'danger' {
+  if (status === 'aligned' || status === 'pass') return 'success';
+  if (status === 'blocked') return 'danger';
+  if (status === 'warning') return 'warning';
+  return 'default';
+}
+
 function triageFormFromRemediation(remediation: CommerceConnectorDryRunRemediation | null): {
   triage_status: CommerceConnectorDryRunRemediationTriageStatus;
   assigned_operator_id: string;
@@ -464,6 +471,38 @@ interface ConnectorTriageRehearsalStatus {
   connector_execution_enabled: false;
 }
 
+type ConnectorTriageReconciliationStatus = 'aligned' | 'warning' | 'blocked';
+
+interface ConnectorTriageReconciliationCheck {
+  key: string;
+  label: string;
+  status: 'pass' | 'warning' | 'blocked';
+  detail: string;
+}
+
+interface ConnectorTriageEvidenceReconciliation {
+  status: ConnectorTriageReconciliationStatus;
+  remediation_id: string;
+  queue_triage_status: CommerceConnectorDryRunRemediationTriageStatus | null;
+  timeline_triage_status: CommerceConnectorDryRunRemediationTriageStatus | null;
+  backend_triage_status: CommerceConnectorDryRunRemediationTriageStatus | null;
+  rehearsal_triage_status: CommerceConnectorDryRunRemediationTriageStatus | null;
+  merchant_followup_summary: string;
+  merchant_next_step: string;
+  audit_references: {
+    requested_audit_event_id: string | null;
+    corrected_audit_event_id: string | null;
+    followup_audit_event_id: string | null;
+    triage_audit_event_id: string | null;
+  };
+  stale_conflict_followup_guidance: boolean;
+  stale_conflict_handling: 'none' | 'sandbox_blocker_only';
+  redacted_audit_reference_continuity: boolean;
+  checks: ConnectorTriageReconciliationCheck[];
+  production_approval: false;
+  connector_execution_enabled: false;
+}
+
 function buildConnectorTriageRehearsalStatus(
   remediation: CommerceConnectorDryRunRemediation,
   timeline: CommerceConnectorDryRunRemediationTimeline,
@@ -489,6 +528,156 @@ function buildConnectorTriageRehearsalStatus(
     )),
     duplicate_handling: 'reuse_existing_state',
     internal_notes_in_merchant_guidance: false,
+    production_approval: false,
+    connector_execution_enabled: false,
+  };
+}
+
+function safeSummaryText(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function containsStaleOrConflict(remediation: CommerceConnectorDryRunRemediation, timeline: CommerceConnectorDryRunRemediationTimeline): boolean {
+  const candidateText = [
+    remediation.public_safe_note,
+    remediation.triage?.merchant_followup_summary,
+    remediation.triage?.next_step,
+    timeline.merchant_status.merchant_followup_summary,
+    timeline.merchant_status.triage_next_step,
+    timeline.merchant_status.next_step,
+    ...remediation.blocker_summary.map(safeSummaryText),
+    ...remediation.warning_summary.map(safeSummaryText),
+  ].join(' ').toLowerCase();
+  return candidateText.includes('stale') || candidateText.includes('conflict');
+}
+
+function buildConnectorTriageEvidenceReconciliation(
+  timeline: CommerceConnectorDryRunRemediationTimeline,
+  queueItem: CommerceConnectorDryRunRemediationQueueItem | null,
+  backendRemediation: CommerceConnectorDryRunRemediation | null,
+  rehearsalStatus: ConnectorTriageRehearsalStatus | null,
+): ConnectorTriageEvidenceReconciliation {
+  const remediation = timeline.remediation;
+  const queueTriageStatus = queueItem?.triage?.triage_status ?? null;
+  const timelineTriageStatus = timeline.merchant_status.triage_status ?? remediation.triage?.triage_status ?? null;
+  const backendTriageStatus = backendRemediation?.triage?.triage_status ?? remediation.triage?.triage_status ?? null;
+  const rehearsalTriageStatus = rehearsalStatus?.triage_status ?? null;
+  const merchantFollowupSummary = timeline.merchant_status.merchant_followup_summary
+    ?? remediation.triage?.merchant_followup_summary
+    ?? rehearsalStatus?.merchant_followup_summary
+    ?? 'not_recorded';
+  const merchantNextStep = timeline.merchant_status.triage_next_step
+    ?? remediation.triage?.next_step
+    ?? rehearsalStatus?.merchant_next_step
+    ?? timeline.merchant_status.next_step;
+  const triageAuditReference = remediation.triage?.triage_audit_event_id
+    ?? remediation.audit_references.triage_audit_event_id
+    ?? rehearsalStatus?.audit_reference
+    ?? null;
+  const requiredAuditReferences = [
+    remediation.audit_references.requested_audit_event_id,
+    remediation.corrected_dry_run_id ? remediation.audit_references.corrected_audit_event_id : 'not_required',
+    remediation.followup_review_id ? remediation.audit_references.followup_audit_event_id : 'not_required',
+    timelineTriageStatus ? triageAuditReference : 'not_required',
+  ];
+  const redactedAuditReferenceContinuity = requiredAuditReferences.every(Boolean)
+    && timeline.timeline.every((entry) => (
+      entry.redaction.raw_connector_rows_included === false
+      && entry.redaction.credentials_included === false
+      && entry.redaction.provider_metadata_included === false
+      && entry.redaction.merchant_private_api_payload_included === false
+      && entry.redaction.production_config_values_included === false
+    ));
+  const staleConflictFollowupGuidance = containsStaleOrConflict(remediation, timeline);
+  const nonEnablingControlsPass = timeline.controls.public_discovery_enabled === false
+    && timeline.controls.checkout_payment_enabled === false
+    && timeline.controls.live_provider_enabled === false
+    && timeline.controls.live_plural_enabled === false
+    && timeline.controls.provider_call_enabled === false
+    && timeline.controls.merchant_private_api_calls_enabled === false
+    && timeline.controls.remediation_is_production_approval === false
+    && timeline.controls.remediation_enables_connector_execution === false
+    && timeline.controls.followup_ready_is_launch_approval === false;
+  const checks: ConnectorTriageReconciliationCheck[] = [
+    {
+      key: 'queue_timeline_triage_status',
+      label: 'Queue and timeline triage status',
+      status: !queueTriageStatus || queueTriageStatus === timelineTriageStatus ? 'pass' : 'warning',
+      detail: `queue=${queueTriageStatus ?? 'not_recorded'} timeline=${timelineTriageStatus ?? 'not_recorded'}`,
+    },
+    {
+      key: 'backend_timeline_triage_status',
+      label: 'Backend and timeline triage status',
+      status: !backendTriageStatus || backendTriageStatus === timelineTriageStatus ? 'pass' : 'warning',
+      detail: `backend=${backendTriageStatus ?? 'not_recorded'} timeline=${timelineTriageStatus ?? 'not_recorded'}`,
+    },
+    {
+      key: 'rehearsal_timeline_triage_status',
+      label: 'Rehearsal and timeline triage status',
+      status: !rehearsalTriageStatus || rehearsalTriageStatus === timelineTriageStatus ? 'pass' : 'warning',
+      detail: `rehearsal=${rehearsalTriageStatus ?? 'not_recorded'} timeline=${timelineTriageStatus ?? 'not_recorded'}`,
+    },
+    {
+      key: 'merchant_guidance_consistency',
+      label: 'Merchant-visible guidance consistency',
+      status: [queueItem?.triage?.merchant_followup_summary, remediation.triage?.merchant_followup_summary, rehearsalStatus?.merchant_followup_summary]
+        .filter(Boolean)
+        .every((summary) => summary === merchantFollowupSummary) ? 'pass' : 'warning',
+      detail: merchantFollowupSummary,
+    },
+    {
+      key: 'redacted_audit_reference_continuity',
+      label: 'Redacted audit reference continuity',
+      status: redactedAuditReferenceContinuity ? 'pass' : 'warning',
+      detail: `requested=${remediation.audit_references.requested_audit_event_id ?? 'not_recorded'} corrected=${remediation.audit_references.corrected_audit_event_id ?? 'not_recorded'} followup=${remediation.audit_references.followup_audit_event_id ?? 'not_recorded'} triage=${triageAuditReference ?? 'not_recorded'}`,
+    },
+    {
+      key: 'stale_conflict_followup_guidance',
+      label: 'Stale/conflict follow-up handling',
+      status: staleConflictFollowupGuidance ? 'blocked' : 'pass',
+      detail: staleConflictFollowupGuidance
+        ? 'Stale or conflicting follow-up guidance is a sandbox blocker only; it is not approval or connector execution readiness.'
+        : 'No stale or conflict follow-up blocker detected.',
+    },
+    {
+      key: 'non_enabling_controls',
+      label: 'Fixed non-enabling controls',
+      status: nonEnablingControlsPass ? 'pass' : 'blocked',
+      detail: nonEnablingControlsPass
+        ? 'Public discovery, checkout/payment, live provider, provider calls, merchant private API calls, and approval controls remain disabled.'
+        : 'One or more non-enabling controls is not false/off.',
+    },
+  ];
+  const status = checks.some((check) => check.status === 'blocked')
+    ? 'blocked'
+    : checks.some((check) => check.status === 'warning')
+      ? 'warning'
+      : 'aligned';
+  return {
+    status,
+    remediation_id: remediation.remediation_id,
+    queue_triage_status: queueTriageStatus,
+    timeline_triage_status: timelineTriageStatus,
+    backend_triage_status: backendTriageStatus,
+    rehearsal_triage_status: rehearsalTriageStatus,
+    merchant_followup_summary: merchantFollowupSummary,
+    merchant_next_step: merchantNextStep,
+    audit_references: {
+      requested_audit_event_id: remediation.audit_references.requested_audit_event_id,
+      corrected_audit_event_id: remediation.audit_references.corrected_audit_event_id,
+      followup_audit_event_id: remediation.audit_references.followup_audit_event_id,
+      triage_audit_event_id: triageAuditReference,
+    },
+    stale_conflict_followup_guidance: staleConflictFollowupGuidance,
+    stale_conflict_handling: staleConflictFollowupGuidance ? 'sandbox_blocker_only' : 'none',
+    redacted_audit_reference_continuity: redactedAuditReferenceContinuity,
+    checks,
     production_approval: false,
     connector_execution_enabled: false,
   };
@@ -1987,6 +2176,16 @@ export function CommerceOnboarding() {
       : connectorTriageSubmitting
         ? 'Connector triage is being recorded.'
         : 'Record sandbox-only operator triage; this does not approve launch or connector execution.';
+  const connectorTriageReconciliation = useMemo(() => {
+    if (!connectorRemediationTimeline) return null;
+    const queueItem = connectorRemediationQueue.find((item) => item.remediation_id === connectorRemediationTimeline.remediation.remediation_id) ?? null;
+    return buildConnectorTriageEvidenceReconciliation(
+      connectorRemediationTimeline,
+      queueItem,
+      connectorBackendRemediation,
+      connectorTriageRehearsalStatus,
+    );
+  }, [connectorBackendRemediation, connectorRemediationQueue, connectorRemediationTimeline, connectorTriageRehearsalStatus]);
   const connectorTriageControls = [
     { label: 'sandbox_only', value: true },
     { label: 'credential_entry_enabled', value: false },
@@ -3264,6 +3463,59 @@ export function CommerceOnboarding() {
                       <div className="text-xs font-medium text-gx-muted">Redacted merchant guidance in current state</div>
                       <div className="mt-1 text-sm text-gx-text">{connectorTriageRehearsalStatus.merchant_followup_summary}</div>
                       <div className="mt-1 text-xs text-gx-muted">Next step: {connectorTriageRehearsalStatus.merchant_next_step}</div>
+                    </div>
+                  </div>
+                ) : null}
+                {connectorTriageReconciliation ? (
+                  <div data-testid="connector-triage-reconciliation-summary" className="mt-3 rounded-md border border-gx-border p-3">
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <div>
+                        <div className="text-sm font-medium text-gx-text">Operator/merchant evidence reconciliation</div>
+                        <p className="mt-1 text-xs text-gx-muted">
+                          Compares queue state, redacted timeline state, backend remediation state, and rehearsal state without enabling connector execution.
+                        </p>
+                      </div>
+                      <Badge variant={reconciliationStatusVariant(connectorTriageReconciliation.status)}>
+                        {connectorTriageReconciliation.status}
+                      </Badge>
+                    </div>
+                    <div className="mt-3 grid gap-2 md:grid-cols-4">
+                      {[
+                        { label: 'queue_triage_status', value: connectorTriageReconciliation.queue_triage_status ?? 'not_recorded' },
+                        { label: 'timeline_triage_status', value: connectorTriageReconciliation.timeline_triage_status ?? 'not_recorded' },
+                        { label: 'backend_triage_status', value: connectorTriageReconciliation.backend_triage_status ?? 'not_recorded' },
+                        { label: 'rehearsal_triage_status', value: connectorTriageReconciliation.rehearsal_triage_status ?? 'not_recorded' },
+                        { label: 'requested_audit', value: connectorTriageReconciliation.audit_references.requested_audit_event_id ?? 'not_recorded' },
+                        { label: 'corrected_audit', value: connectorTriageReconciliation.audit_references.corrected_audit_event_id ?? 'not_recorded' },
+                        { label: 'followup_audit', value: connectorTriageReconciliation.audit_references.followup_audit_event_id ?? 'not_recorded' },
+                        { label: 'triage_audit', value: connectorTriageReconciliation.audit_references.triage_audit_event_id ?? 'not_recorded' },
+                        { label: 'redacted_audit_reference_continuity', value: connectorTriageReconciliation.redacted_audit_reference_continuity },
+                        { label: 'stale_conflict_handling', value: connectorTriageReconciliation.stale_conflict_handling },
+                        { label: 'connector_execution_enabled', value: connectorTriageReconciliation.connector_execution_enabled },
+                        { label: 'production_approval', value: connectorTriageReconciliation.production_approval },
+                      ].map((item) => (
+                        <div key={item.label} className="rounded-md border border-gx-border p-2">
+                          <div className="text-xs text-gx-muted">{item.label}</div>
+                          <div className="break-all text-sm font-medium text-gx-text">{String(item.value)}</div>
+                        </div>
+                      ))}
+                    </div>
+                    <div data-testid="connector-triage-reconciliation-guidance" className="mt-3 rounded-md border border-gx-border p-2">
+                      <div className="text-xs font-medium text-gx-muted">Reconciled merchant-visible guidance</div>
+                      <div className="mt-1 text-sm text-gx-text">{connectorTriageReconciliation.merchant_followup_summary}</div>
+                      <div className="mt-1 text-xs text-gx-muted">Next step: {connectorTriageReconciliation.merchant_next_step}</div>
+                    </div>
+                    <div className="mt-3 grid gap-2 md:grid-cols-2">
+                      {connectorTriageReconciliation.checks.map((check) => (
+                        <div key={check.key} className="rounded-md border border-gx-border p-2">
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <div className="text-xs font-medium text-gx-text">{check.label}</div>
+                            <Badge variant={reconciliationStatusVariant(check.status)}>{check.status}</Badge>
+                          </div>
+                          <div className="mt-1 text-xs text-gx-muted">{check.key}</div>
+                          <div className="mt-1 break-all text-xs text-gx-muted">{check.detail}</div>
+                        </div>
+                      ))}
                     </div>
                   </div>
                 ) : null}

--- a/docs/internal/commerce-v1/commerce-v1-c6sid-remediation-triage-evidence-reconciliation.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6sid-remediation-triage-evidence-reconciliation.md
@@ -1,0 +1,130 @@
+# Commerce V1 C6Sid - Remediation Triage Evidence Reconciliation
+
+C6Sid reconciles the operator and merchant views of persisted sandbox connector
+remediation triage. It is portal, docs, and test work only. It remains
+sandbox-only, credential-free, tenant-scoped, non-live, non-publication,
+non-certifying, and non-enabling.
+
+## Scope
+
+C6Sid adds a portal reconciliation summary across existing C6S surfaces:
+
+- persisted remediation queue item;
+- redacted remediation timeline;
+- backend remediation evidence already loaded by the portal;
+- C6Sic triage workflow rehearsal status.
+
+The reconciliation summary checks whether the queue triage status, timeline
+merchant status, backend triage status, rehearsal status, merchant-visible
+summary, next step, and redacted audit references agree.
+
+No backend route, migration, worker, workflow, connector execution path,
+credential entry, outbound sync, production connector setup, public discovery,
+checkout/payment, live provider, provider call, merchant private API call,
+production allowlist, or certification path is added.
+
+## Reconciliation Checks
+
+The portal summary includes:
+
+- queue and timeline triage status;
+- backend and timeline triage status;
+- rehearsal and timeline triage status;
+- merchant-visible guidance consistency;
+- requested, corrected, follow-up, and triage audit references;
+- redacted audit timeline continuity;
+- stale/conflict follow-up handling;
+- fixed non-enabling controls.
+
+`aligned` means the loaded sandbox views agree. `warning` means the views are
+loaded but not fully aligned. `blocked` means the loaded evidence contains a
+sandbox blocker such as stale or conflicting follow-up guidance. None of these
+states are production approval.
+
+## Merchant-Visible Guidance
+
+Merchant-visible guidance remains limited to public-safe summary and next-step
+fields. It must not expose:
+
+- internal operator notes;
+- raw connector rows or raw merchant-system payloads;
+- private merchant details;
+- provider metadata;
+- credentials or secrets;
+- private API URLs;
+- checkout/payment identifiers or URLs;
+- production config values or concrete allowlists.
+
+## Stale Or Conflicting Evidence
+
+If stale or conflicting follow-up guidance appears in the loaded remediation
+evidence, the portal marks it as `sandbox_blocker_only`. This means:
+
+- the merchant should refresh or correct sandbox evidence;
+- the operator should not treat the state as follow-up ready;
+- the state does not authorize connector execution;
+- the state does not approve public discovery, checkout/payment, live provider
+  use, production allowlists, or production launch.
+
+## Audit Reference Continuity
+
+The portal validates redacted audit reference continuity for:
+
+- remediation requested audit;
+- corrected dry-run attachment audit, when a corrected dry-run exists;
+- follow-up review request audit, when a follow-up review exists;
+- triage audit, when triage is recorded.
+
+The summary displays audit references only. It does not display raw connector
+files, raw payloads, provider metadata, private merchant artifacts, credentials,
+or secrets.
+
+## Stop Conditions
+
+Stop and require a new approved work item if any follow-up:
+
+- adds or changes backend routes, migrations, workers, workflows, schedules, or
+  runtime connector execution;
+- adds credential entry, provider credentials, merchant private API URLs, or
+  outbound sync controls;
+- enables Grantex public discovery or AgenticOrg public commerce discovery;
+- enables production Commerce V1, checkout/payment creation, fulfillment,
+  refunds, live payments, live Plural, or live providers;
+- calls Shopify, WooCommerce, Magento, custom API, ERP, OMS, WMS, logistics,
+  CRM/support, payment providers, Plural, Stripe, Pine, or merchant private
+  APIs;
+- lets AgenticOrg call merchant private APIs directly;
+- writes production config or production allowlists;
+- claims production approval, public discovery approval, checkout/payment
+  approval, live provider approval, public protocol publication, provider
+  approval, live-payment approval, or certification;
+- treats sandbox, demo, synthetic, fixture, dry-run, review, remediation,
+  triage, timeline, export, reconciliation, or rehearsal output as real
+  merchant approval.
+
+## Rollback Notes
+
+C6Sid rollback removes the portal reconciliation summary, the stale/conflict
+reconciliation tests, and this internal note. Rollback does not require cloud
+action, secret rotation, production config changes, public discovery changes,
+checkout/payment changes, live provider changes, merchant private API changes,
+production allowlist changes, or certification work.
+
+## Validation
+
+Focused validation:
+
+```bash
+npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
+npm --prefix apps/portal run typecheck
+npm --prefix apps/auth-service test -- commerce-connector-remediation-triage-c6sia.test.ts commerce-openapi.test.ts
+npm --prefix apps/auth-service run typecheck
+node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
+git diff --check origin/main...HEAD
+```
+
+Focused scans must cover secrets/private details, production config or
+allowlist assignments, public discovery enablement, checkout/payment
+enablement, live payment/live Plural/provider credential enablement,
+certification claims, direct provider calls, direct merchant private API calls,
+AgenticOrg direct execution, and outbound sync enablement.


### PR DESCRIPTION
## Summary
- Adds a portal-only reconciliation summary for C6Sid across remediation queue, redacted timeline, backend remediation evidence, and C6Sic rehearsal state.
- Validates triage status agreement, merchant-visible follow-up guidance consistency, redacted audit reference continuity, stale/conflict handling, and fixed non-enabling controls.
- Adds portal tests for aligned reconciliation and stale/conflicting guidance as sandbox blockers, plus internal C6Sid docs.

## Safety
- Portal/docs/test only.
- No backend routes, migrations, workflows, workers, runtime connector execution, credential entry, outbound sync, production connector setup, public discovery, checkout/payment, live providers, provider calls, merchant private API calls, production allowlists, or certification claims.
- Stale/conflict guidance renders as `sandbox_blocker_only`, not approval or connector execution readiness.

## Validation
- npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
- npm --prefix apps/auth-service test -- commerce-connector-remediation-triage-c6sia.test.ts commerce-openapi.test.ts
- npm --prefix apps/portal run typecheck
- npm --prefix apps/auth-service run typecheck
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
- git diff --check origin/main...HEAD
- focused guardrail scans for secrets/private details, production config/allowlists, public discovery, checkout/payment, live providers, provider calls, merchant private API calls, and certification claims