### PR TITLE
docs(commerce): prepare IETF and NIST publication tracks

### DIFF
--- a/docs/guides/commerce-v1-agentic-commerce-prd.md
+++ b/docs/guides/commerce-v1-agentic-commerce-prd.md
@@ -91,7 +91,7 @@ AgenticOrg must not:
 
 ## 4. Current Implementation Snapshot
 
-Status as of 2026-06-07:
+Status as of 2026-06-09:
 
 - Grantex seller-control-plane work is implemented through the sandbox
   read-only discovery handoff path: C5Z, C6A, C6B, C6C, C6D, C6E, C6F, and
@@ -100,9 +100,17 @@ Status as of 2026-06-07:
   C6H. C6I buyer-session orchestration is merged on AgenticOrg main.
 - Grantex protocol-adapter and connector foundations C6J, C6K, C6L, C6M, and
   C6N are merged on Grantex main.
+- Grantex C6O preview conformance fixtures, validation, reporting, status,
+  release gate, runbook, and launch-gap assessment are merged.
+- Grantex C6P-C6Si connector dry-run, review, portal, evidence packet,
+  remediation, persistence, queue, timeline, and operator triage foundations
+  are in progress or merged as sandbox-only, non-live, non-enabling work.
 - The open-protocol packaging draft is an internal docs-only PR refreshed on
   the merged C6I-C6N base. It is not public protocol publication, not
   certification, and not production approval.
+- C6T adds an IETF/NIST publication-preparation track. It is not an IETF
+  submission, not a NIST submission, not public protocol publication, and not
+  standards approval.
 - Public discovery, production Commerce V1, checkout/payment enablement, live
   payments, live Plural, production allowlists, certification claims, provider
   calls, and AgenticOrg direct merchant-system calls remain blocked.
@@ -370,6 +378,28 @@ Do not claim certified UCP, ACP, AP2, A2A, MPP, schema.org production, or live
 provider readiness until implementation, conformance tests, approvals, and
 release evidence exist.
 
+### 12.1 IETF And NIST Publication Tracks
+
+The external standards strategy is split into two preparation tracks:
+
+| Track | Intended artifact | Current posture | Required before external submission |
+| --- | --- | --- | --- |
+| IETF | Individual Internet-Draft candidate for an agentic commerce trust architecture. | C6T internal outline only; not submitted, not adopted, not an RFC, and not a standard. | Public-safe draft text, IPR/legal review, security/privacy considerations, non-Grantex-specific examples, and explicit approval to submit. |
+| NIST | Security and risk reference-architecture whitepaper candidate. | C6T internal outline only; not submitted to NIST, not accepted by NCCoE, and not NIST-approved. | Threat model, NIST AI RMF/CSF control mapping, public-safe architecture, collaborator/project path, and explicit approval to engage. |
+
+The IETF track should focus on protocol engineering: roles, message envelopes,
+capability profiles, consent, policy, evidence, refusal semantics, and
+interoperability with existing protocol surfaces.
+
+The NIST track should focus on risk management: threat model, trust boundaries,
+AI RMF mapping, cybersecurity controls, payment-provider boundary controls,
+connector governance, audit evidence, privacy, incident response, and rollback.
+
+Both tracks must describe Grantex and AgenticOrg as implementation experience
+only. They must not make Grantex-specific APIs mandatory, must not claim
+external certification, and must not describe sandbox evidence as production
+approval.
+
 ## 13. Conceptual Data Model
 
 The implementation should preserve these conceptual records. Some already exist
@@ -438,7 +468,7 @@ in V1 form; others are future gaps.
 | Live provider readiness | Payments need approval. | Grantex | Sandbox validation, live credential approval, webhook signatures. | Live provider risk. |
 | Commerce Passport production delivery | Real consent needs delivery. | Grantex | Email/SMS/passkey challenge, revocation, signed evidence. | Weak authorization. |
 | Policy simulator | Merchants need confidence. | Grantex | Preview policy by product/category/channel/amount. | Accidental capability exposure. |
-| Standards adapters | Major platforms need standard surfaces. | Grantex publishes; AgenticOrg consumes | C6J-C6M previews merged; conformance and publication next. | Fragmented protocol state. |
+| Standards adapters | Major platforms need standard surfaces. | Grantex publishes; AgenticOrg consumes | C6J-C6M previews, C6O conformance, and C6T IETF/NIST preparation are in place or in review; external publication remains blocked. | Fragmented protocol state or premature external claims. |
 | Buyer channel launch | Buyers need easy entry. | AgenticOrg + Grantex approval | C6I channel-neutral response merged; live channel adapters next. | Agentic commerce hard to use. |
 | Buyer UX | Buyers need understandable flow. | AgenticOrg | C6I read-only buyer session merged; cart/consent/checkout UX remains future. | Confusing or unsafe agent behavior. |
 | Merchant demo UX | Sellers need education. | AgenticOrg | Demo walkthroughs and blocked-path examples. | Misunderstanding production readiness. |
@@ -465,7 +495,7 @@ in V1 form; others are future gaps.
 | 11. Order/fulfillment backbone | Operational paid flow. | Order, shipment, pickup/delivery, cancellation. | Required before broad checkout. |
 | 12. Return/refund request | Safe post-purchase support. | Request, eligibility, manual approval, audit. | No automatic refund execution. |
 | 13. Settlement/payout reporting | Seller finance visibility. | Reconciliation and payout read model. | No raw provider payloads. |
-| 14. Standards hardening | Platform interoperability. | C6J-C6M preview adapters are merged and the open-protocol packaging draft is refreshed on merged C6I-C6N commits; public conformance pending. | No certification claims without evidence. |
+| 14. Standards hardening | Platform interoperability. | C6J-C6M preview adapters, C6O preview conformance, and C6T IETF/NIST publication-preparation outlines exist or are in review. | No submission, publication, or certification claims without explicit approval and evidence. |
 | 15. Controlled pilot | Minimal real launch. | One merchant, category, channel, provider, geography, rollback owner. | Separate explicit approval. |
 
 Current sequencing decision:
@@ -473,10 +503,10 @@ Current sequencing decision:
 1. C6I-C6N are merged in dependency order across AgenticOrg and Grantex.
 2. The open-protocol packaging draft is refreshed on the actual merged commits
    and remains internal, preview-only, non-publication, and non-certifying.
-3. The next runtime chain is C6O: public-safe conformance fixtures, the first
-   real connector sync adapter foundation, order/fulfillment backbone planning,
-   and controlled pilot readiness without enabling public discovery or live
-   checkout.
+3. C6O conformance and C6P-C6Si connector dry-run/remediation foundations are
+   the current runtime-hardening chain.
+4. C6T starts the standards-publication preparation track for IETF and NIST
+   without external submission, public publication, or certification claims.
 
 ## 17. Release Acceptance Criteria
 
@@ -563,8 +593,8 @@ This PRD has been reviewed against the requested coverage:
 - documentation/navigation/workflow coverage covered;
 - next implementation sequencing covered.
 
-Remaining decision for the team: use the merged C6I-C6N base and internal
-open-protocol packaging draft to plan C6O. The next implementation chain should
-focus on conformance fixtures, one real connector sync adapter foundation,
-order/fulfillment backbone planning, and controlled pilot readiness without
-enabling public discovery or live checkout.
+Remaining decision for the team: continue the C6P-C6Si connector
+dry-run/remediation chain for real merchant readiness while C6T prepares
+public-safe IETF and NIST draft materials. The next implementation chain should
+avoid external submission, public protocol publication, certification claims,
+public discovery, and live checkout until explicit approvals and evidence exist.

--- a/docs/guides/compliance-matrix.mdx
+++ b/docs/guides/compliance-matrix.mdx
@@ -3,7 +3,10 @@ title: "Compliance Matrix"
 description: "How Grantex maps to OWASP Agentic Top 10, EU AI Act, and NIST AI RMF requirements for AI agent security and authorization."
 ---
 
-Grantex provides technical controls that map directly to the three major regulatory frameworks governing AI agent security. This page documents each requirement and the corresponding Grantex feature.
+Grantex provides technical controls that can be mapped to widely used AI agent
+security and risk-management frameworks. This page documents current mapping
+posture and the corresponding Grantex feature areas without claiming formal
+third-party attestation unless separately stated.
 
 ## OWASP Agentic Security Top 10
 
@@ -28,7 +31,8 @@ Binding August 2026 — the world's first comprehensive AI regulation.
 
 ## NIST AI Risk Management Framework
 
-Active now — required for US government agencies and federal contractors per Executive Order 14110.
+Active now as voluntary risk-management guidance; useful for US government and
+federal-contractor alignment where applicable.
 
 | Control | Requirement | Grantex Control | Implementation |
 |---------|------------|----------------|----------------|
@@ -77,6 +81,6 @@ The evidence pack includes:
 ## Evidence And Standards Mappings
 
 - **SOC 2** — readiness control mapping published; formal third-party attestation is not published. [View mapping](/security/soc2-report)
-- **IETF Internet-Draft** — submitted. [View submission](/community/ietf-draft)
-- **NIST AI RMF** — public comment submitted. [View comment](/community/nist-comment)
+- **IETF Internet-Draft** — preparation track only; no IETF submission, working-group adoption, RFC approval, or standards status is claimed. Internal Commerce V1 C6T materials define the draft outline and review gates.
+- **NIST AI RMF** — mapping and whitepaper preparation track only; no NIST submission, public comment submission, NCCoE acceptance, or NIST approval is claimed. Internal Commerce V1 C6T materials define the candidate reference architecture and control-map outline.
 - **OpenID AuthZEN** — conformance mapping complete. [View mapping](/community/authzen-mapping)

--- a/docs/internal/commerce-v1/commerce-v1-c6t-ietf-nist-publication-readiness.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6t-ietf-nist-publication-readiness.md
@@ -1,0 +1,289 @@
+# Commerce V1 C6T - IETF And NIST Publication Readiness Plan
+
+Status: internal publication-readiness plan only.
+
+Created: 2026-06-09.
+
+This C6T plan turns the existing Agentic Commerce open-protocol work into two
+reviewable external-facing tracks:
+
+- an IETF Internet-Draft candidate for the protocol-level trust architecture;
+- a NIST-facing security and risk reference-architecture whitepaper candidate.
+
+This plan is not an IETF submission, not a NIST submission, not public protocol
+publication, not certification, not production approval, not public discovery
+approval, and not checkout or payment approval.
+
+This plan does not deploy, merge, create cloud resources, change production
+configuration, touch secrets, enable public discovery, enable production
+Commerce V1, enable checkout or payment creation, enable live payments, call
+providers, call merchant private APIs, or claim certification.
+
+## External Process Facts
+
+These facts shape the publication path:
+
+- IETF Internet-Drafts are working documents for review and comment. They have
+  no formal standing unless adopted by an IETF working group or approved as an
+  RFC. Source: https://www.ietf.org/how/ids/
+- Anyone can author and submit an Internet-Draft. If the goal is an Internet
+  Standard RFC, the work must follow the IETF standards process and find the
+  appropriate IETF community path. Source:
+  https://www.ietf.org/process/new-work/
+- IETF standards work usually starts as an Internet-Draft and may progress only
+  if there is consensus and sustained community interest. Source:
+  https://www.ietf.org/process/process/
+- NIST's AI Risk Management Framework is voluntary guidance for managing risks
+  associated with AI systems, including generative AI profile guidance. Source:
+  https://www.nist.gov/itl/ai-risk-management-framework
+- NIST NCCoE work is collaborative, public, and often starts with a project
+  description, public comment, collaborator assembly, and a repeatable reference
+  architecture or practice guide. Source:
+  https://www.nccoe.nist.gov/our-approach/how-we-work
+
+## Publication Framing
+
+The recommended external framing is:
+
+> Agentic Commerce Trust Architecture defines a merchant-controlled trust,
+> consent, policy, audit, and evidence layer for agent-mediated commerce. It
+> maps to existing commerce and agent protocols through adapters rather than
+> replacing them.
+
+Use this framing:
+
+- protocol trust layer;
+- consent and scoped authority;
+- merchant policy and capability exposure;
+- audit evidence envelope;
+- buyer-agent session and refusal semantics;
+- adapter mappings to schema.org, UCP-style discovery, ACP-style checkout
+  shapes, AP2-style mandate evidence, MCP/native APIs, and merchant system
+  connector metadata.
+
+Do not use this framing:
+
+- "standard";
+- "certified";
+- "NIST-approved";
+- "IETF-approved";
+- "AP2-compliant";
+- "ACP-compliant";
+- "UCP-certified";
+- "schema.org-certified";
+- "providers can skip other protocols";
+- "production-ready";
+- "live payment-ready".
+
+## Current Evidence Base
+
+| Area | Current evidence | Publication posture |
+| --- | --- | --- |
+| Buyer-agent envelope | AgenticOrg C6I buyer session orchestration is merged. | Good for IETF terminology and message-flow draft sections. |
+| schema.org preview | Grantex C6J preview adapter is merged. | Good for adapter-mapping examples only; not public publication. |
+| UCP-style preview | Grantex C6K preview adapter is merged. | Use as "UCP-style" internal mapping only; do not claim UCP compliance. |
+| ACP-style preview | Grantex C6L checkout shape preview is merged. | Use as checkout-shape mapping only; do not claim ACP compliance. |
+| AP2-style preview | Grantex C6M unsigned evidence preview is merged. | Use as mandate-evidence inspiration only; do not claim AP2 compliance. |
+| Connector foundation | Grantex C6N-C6Si chain is building metadata, dry-run, review, remediation, and triage evidence. | Good for merchant-system connector governance sections; no outbound sync or credentials yet. |
+| Conformance fixtures | C6Oa-C6Oe preview fixtures and gate are merged. | Good internal conformance evidence; not external certification. |
+| Release rehearsal | C6Of-C6Og runbook and gap assessment are merged. | Good no-go matrix and blocker source. |
+
+## IETF Track
+
+Recommended working title:
+
+`draft-mishra-agentic-commerce-trust-architecture-00`
+
+Goal:
+
+Define an application-layer protocol architecture and JSON/HTTP message model
+for safe agent-mediated commerce. The draft should be general enough that it is
+not Grantex-specific, Pine/Plural-specific, or AgenticOrg-specific.
+
+Expected draft sections:
+
+1. Abstract.
+2. Status of This Memo and IETF boilerplate.
+3. Introduction.
+4. Terminology.
+5. Roles:
+   - buyer;
+   - buyer agent;
+   - merchant;
+   - merchant control plane;
+   - agent platform;
+   - payment provider;
+   - connector source;
+   - auditor/operator.
+6. Architecture overview.
+7. Discovery and capability profile.
+8. Buyer-agent session envelope.
+9. Consent and scoped authority.
+10. Merchant policy evaluation.
+11. Cart and checkout safety preconditions.
+12. Evidence envelope.
+13. Connector source metadata and source-of-truth precedence.
+14. Error and refusal semantics.
+15. Interoperability with existing surfaces.
+16. Security considerations.
+17. Privacy considerations.
+18. Operational considerations.
+19. IANA considerations.
+20. Implementation status.
+21. References.
+
+Initial likely IETF community path:
+
+- submit as individual Internet-Draft only after public-safe review;
+- discuss with application/security dispatch communities before asking for
+  working-group adoption;
+- avoid requesting standards-track status until at least two independent
+  implementers or serious implementer interest exists.
+
+IETF blockers:
+
+- no public-safe Internet-Draft text exists yet;
+- no external implementer feedback;
+- no IPR review;
+- no consensus venue selected;
+- no independent interoperability evidence;
+- no public conformance suite;
+- protocol examples still reference Grantex-specific preview states unless
+  generalized.
+
+## NIST Track
+
+Recommended working title:
+
+`Securing Agentic Commerce: Reference Architecture for Consent, Merchant
+Policy, Audit Evidence, and Payment Safety`
+
+Goal:
+
+Present a NIST-aligned security and risk reference architecture for agentic
+commerce. The whitepaper should focus on risk management, controls, assurance,
+and repeatable implementation guidance rather than protocol standardization.
+
+Expected whitepaper sections:
+
+1. Executive summary.
+2. Problem statement.
+3. Reference architecture.
+4. Threat model.
+5. Trust boundaries.
+6. Actor and asset inventory.
+7. Control objectives.
+8. NIST AI RMF mapping.
+9. NIST Cybersecurity Framework mapping.
+10. Identity, consent, and authorization controls.
+11. Merchant policy and capability governance.
+12. Connector and source-of-truth controls.
+13. Payment safety and provider-boundary controls.
+14. Audit evidence and evidence retention.
+15. Privacy and data minimization.
+16. Incident response and rollback.
+17. Conformance and test evidence.
+18. Open questions for industry collaboration.
+19. Appendix: implementation lessons from Grantex and AgenticOrg.
+
+NIST/NCCoE collaboration path:
+
+- first publish an internal/public-safe whitepaper draft;
+- map it to NIST AI RMF and cybersecurity control families;
+- prepare a project-description style proposal for "Securing Agentic
+  Commerce";
+- seek collaborators only after the scope is generalized beyond Grantex and
+  AgenticOrg;
+- do not claim NIST acceptance, endorsement, approval, or publication.
+
+NIST blockers:
+
+- no public-safe NIST whitepaper draft exists yet;
+- no complete threat model matrix;
+- no formal AI RMF control mapping for agentic commerce;
+- no NCCoE-style project description;
+- no external collaborator list or CRADA/LOI path;
+- no official NIST engagement evidence;
+- no approved public language.
+
+## Cross-Track Guardrails
+
+Every external-facing artifact must preserve these facts:
+
+- internal preview evidence is not public protocol publication;
+- preview conformance is not certification;
+- sandbox data is not production approval;
+- Grantex examples are implementation examples, not the protocol boundary;
+- AgenticOrg must not call payment providers or merchant private APIs directly;
+- live payments and live providers remain blocked until separate approvals
+  exist;
+- protocol adapters map from canonical merchant state and must not duplicate
+  source-of-truth data;
+- payment-affecting actions require consent, policy, scope, idempotency,
+  revocation check, and audit evidence.
+
+## Deliverable Plan
+
+| Slice | Output | Scope | Stop condition |
+| --- | --- | --- | --- |
+| C6Ta | IETF draft skeleton and terminology alignment | Markdown/xml2rfc-ready outline, examples, no public submission | Claims IETF acceptance or certification |
+| C6Tb | NIST whitepaper skeleton and control map | NIST AI RMF/CSF mapping, threat model outline | Claims NIST approval or submission |
+| C6Tc | Public-safe example corpus | Generic examples derived from fixtures with Grantex/private IDs removed | Includes real merchant/private data |
+| C6Td | Conformance profile split | Internal preview conformance vs public draft conformance matrix | Claims independent conformance |
+| C6Te | Standards outreach packet | Mailing-list/community questions, IPR checklist, legal review checklist | Submits externally without approval |
+
+## Publication Readiness Matrix
+
+| Track | Current status | Readiness | Next required evidence |
+| --- | --- | --- | --- |
+| IETF individual Internet-Draft | Not drafted, not submitted | Preparing | Public-safe Internet-Draft text and IPR/legal review |
+| IETF working-group adoption | Not started | Blocked | Community interest and appropriate venue |
+| IETF RFC | Not started | Blocked | IETF consensus or Independent Stream review |
+| NIST-aligned whitepaper | Not drafted | Preparing | NIST AI RMF/CSF mapping and threat model |
+| NCCoE project proposal | Not started | Blocked | Generalized project description and collaborators |
+| Official NIST publication | Not started | Blocked | NIST project sponsorship/process |
+
+## Stop Conditions
+
+Stop and require a new approved work item if any C6T follow-up:
+
+- submits an IETF Internet-Draft;
+- submits a NIST comment, project description, or collaborator request;
+- claims IETF, RFC, NIST, NCCoE, UCP, ACP, AP2, schema.org, MPP, A2A,
+  provider, or live-payment approval;
+- publishes public protocol materials;
+- exposes real merchant data, private artifacts, secrets, credentials, raw
+  payloads, concrete allowlist values, production config, or provider metadata;
+- enables public discovery, production Commerce V1, checkout/payment creation,
+  live payments, live Plural, live providers, provider calls, merchant private
+  API calls, or production allowlists;
+- treats sandbox, demo, synthetic, fixture, dry-run, remediation, triage, or
+  rehearsal output as production approval.
+
+## Validation
+
+C6T validation should include:
+
+- `git diff --check origin/main...HEAD`;
+- focused scan for standards overclaims;
+- focused scan for secrets/private artifacts;
+- focused scan for production config, allowlist, public discovery, checkout,
+  payment, live provider, direct provider call, and merchant private API
+  enablement;
+- manual review that all IETF/NIST statements are framed as preparation, not
+  submission or approval.
+
+## Rollback
+
+C6T is docs-only. Roll back by removing:
+
+- `docs/internal/commerce-v1/commerce-v1-c6t-ietf-nist-publication-readiness.md`;
+- `docs/internal/commerce-v1/commerce-v1-ietf-agentic-commerce-trust-architecture-draft-outline.md`;
+- `docs/internal/commerce-v1/commerce-v1-nist-agentic-commerce-security-reference-architecture-outline.md`;
+- the C6T PRD/compliance wording updates.
+
+No runtime flags, production configuration, provider credentials, connector
+credentials, public discovery settings, checkout/payment behavior,
+live-provider behavior, production allowlists, cloud resources, migrations,
+routes, portal UI changes, public docs publication, external submission, or
+deployment workflow changes are created by this package.

--- a/docs/internal/commerce-v1/commerce-v1-ietf-agentic-commerce-trust-architecture-draft-outline.md
+++ b/docs/internal/commerce-v1/commerce-v1-ietf-agentic-commerce-trust-architecture-draft-outline.md
@@ -1,0 +1,237 @@
+# IETF Candidate Outline - Agentic Commerce Trust Architecture
+
+Status: internal Internet-Draft outline only.
+
+Created: 2026-06-09.
+
+Candidate filename:
+
+`draft-mishra-agentic-commerce-trust-architecture-00`
+
+This outline prepares an IETF Internet-Draft candidate. It has not been
+submitted to IETF, has not been adopted by an IETF working group, has not been
+approved as an RFC, and must not be cited as a standard.
+
+## Intended Abstract
+
+This document describes a trust architecture for agent-mediated commerce. It
+defines roles, message envelopes, consent and authorization requirements,
+merchant capability exposure, policy checks, audit evidence, refusal semantics,
+and interoperability considerations for buyer agents, merchant control planes,
+agent platforms, payment providers, and connector sources.
+
+The architecture is designed to let agents discover and request commerce
+actions without bypassing merchant policy, buyer consent, scoped authority,
+provider boundaries, or audit evidence.
+
+## Draft Goals
+
+- Define a protocol-neutral trust architecture for agentic commerce.
+- Provide JSON/HTTP-oriented examples that can map to multiple transports.
+- Keep payment providers behind merchant-control-plane authorization.
+- Keep merchant private systems behind merchant-control-plane connectors.
+- Define refusal/error semantics for unsafe, stale, unapproved, or unsupported
+  commerce actions.
+- Describe evidence envelopes suitable for consent, policy, and audit review.
+- Describe how existing protocol surfaces can consume canonical commerce state.
+
+## Non-Goals
+
+- No payment-provider standardization.
+- No card-data or bank-account credential handling.
+- No settlement, refund, chargeback, or tax standardization.
+- No schema.org, UCP, ACP, AP2, MCP, MPP, A2A, or provider certification claim.
+- No Grantex-specific API requirement.
+- No AgenticOrg-specific agent implementation requirement.
+- No autonomous live payment delegation requirement.
+
+## Terminology
+
+| Term | Draft meaning |
+| --- | --- |
+| Buyer | Human or organization seeking to discover or purchase goods or services. |
+| Buyer Agent | AI or software agent acting for a buyer within declared scope. |
+| Merchant | Seller offering goods or services. |
+| Merchant Control Plane | System that owns merchant identity, catalog, policy, consent, evidence, and provider boundaries. |
+| Agent Platform | Runtime or channel that hosts buyer-agent interaction. |
+| Connector Source | Merchant-owned or merchant-authorized system of record for catalog, price, inventory, order, fulfillment, refund, settlement, or support state. |
+| Commerce Capability | Bounded action or data surface that may be exposed to agents. |
+| Consent Grant | Buyer authorization for a scoped commerce action. |
+| Evidence Envelope | Redacted, signed or unsigned structured evidence of consent, policy, state, and audit references. |
+| Refusal | Structured denial of an action with a safe reason code and optional remediation. |
+
+## Candidate Table Of Contents
+
+1. Introduction.
+2. Terminology.
+3. Roles and trust boundaries.
+4. Architecture overview.
+5. Merchant capability discovery.
+6. Buyer-agent session envelope.
+7. Consent and scoped authority.
+8. Merchant policy evaluation.
+9. Cart, checkout, and payment safety preconditions.
+10. Connector source metadata and source-of-truth precedence.
+11. Evidence envelope.
+12. Refusal and error semantics.
+13. Interoperability with existing protocol surfaces.
+14. Security considerations.
+15. Privacy considerations.
+16. Operational considerations.
+17. IANA considerations.
+18. Implementation status.
+19. References.
+
+## Core Message Concepts
+
+### Capability Profile
+
+The capability profile describes what an agent may read or request. It must
+distinguish:
+
+- read-only capabilities;
+- consent-required capabilities;
+- merchant-review-required capabilities;
+- checkout/payment-capable states;
+- blocked capabilities;
+- environment restrictions;
+- freshness requirements;
+- channel restrictions.
+
+### Buyer Session Envelope
+
+The buyer session envelope should contain:
+
+- session identifier;
+- buyer-agent identifier;
+- channel identifier;
+- requested action;
+- merchant reference;
+- capability snapshot reference;
+- consent requirement;
+- refusal code when blocked;
+- redacted evidence reference.
+
+### Evidence Envelope
+
+The evidence envelope should contain:
+
+- evidence type;
+- actor identifiers;
+- merchant reference;
+- capability reference;
+- policy version;
+- consent reference;
+- cart or request hash where applicable;
+- amount cap where applicable;
+- idempotency reference where applicable;
+- audit references;
+- generated timestamp;
+- signature status.
+
+Evidence examples must use synthetic identifiers only.
+
+## Refusal Semantics
+
+Refusals are first-class protocol results. Refusal reasons should include:
+
+- merchant_not_approved;
+- public_discovery_disabled;
+- channel_not_enabled;
+- capability_not_enabled;
+- consent_required;
+- consent_denied;
+- policy_denied;
+- stale_catalog;
+- stale_inventory;
+- price_changed;
+- checkout_not_enabled;
+- payment_provider_not_ready;
+- live_payment_not_enabled;
+- connector_source_blocked;
+- merchant_private_api_not_allowed;
+- provider_call_not_allowed;
+- unsupported_action.
+
+## Interoperability Mapping
+
+| Surface | Mapping posture |
+| --- | --- |
+| schema.org JSON-LD | Public-safe product/offer/return/shipping metadata generated from approved canonical state. |
+| UCP-style capability profile | Capability discovery view generated from canonical merchant policy and channel state. |
+| ACP-style checkout shape | Cart/checkout state shape generated only when consent and provider prerequisites exist. |
+| AP2-style evidence | Consent, scope, policy, audit, amount, and cart evidence that may later support signed mandate flows. |
+| MCP/native API | Tool calls backed by merchant-control-plane policy, tenant boundary, and audit. |
+| Merchant connectors | Metadata and governed sync state, never direct agent execution of private merchant APIs. |
+
+## Security Considerations Draft Notes
+
+The draft must discuss:
+
+- malicious or compromised buyer agents;
+- prompt injection from merchant/catalog content;
+- stale catalog, price, and inventory;
+- overbroad consent;
+- replay and idempotency;
+- cross-tenant access;
+- capability overexposure;
+- credential leakage;
+- provider boundary bypass;
+- audit tampering;
+- direct merchant private API execution by agents;
+- public-discovery misconfiguration.
+
+## Privacy Considerations Draft Notes
+
+The draft must discuss:
+
+- data minimization;
+- separation of public merchant fields from private artifacts;
+- redacted evidence;
+- raw payload avoidance;
+- buyer consent records;
+- retention and deletion policy dependencies;
+- channel identity binding;
+- sensitive category restrictions.
+
+## IANA Considerations Draft Notes
+
+Initial draft posture:
+
+No IANA action is requested in the first individual Internet-Draft. Future
+versions may request registries only after the message shapes stabilize.
+
+## Implementation Status Draft Notes
+
+The implementation status section may cite Grantex and AgenticOrg only as
+non-normative implementation experience. It must say:
+
+- implementation is internal/preview unless separately approved;
+- conformance fixtures are preview-only;
+- no public protocol publication has occurred;
+- no certification is claimed;
+- live payment/provider execution remains separately gated.
+
+## Pre-Submission Checklist
+
+- Public-safe examples use synthetic identifiers only.
+- All Grantex-specific names are examples, not protocol requirements.
+- All IETF boilerplate is correct.
+- IPR/legal review complete.
+- Security considerations are substantive.
+- Privacy considerations are substantive.
+- No certification, approval, or standards status is claimed.
+- No production configs, allowlists, credentials, or private merchant details
+  appear in examples.
+- External submission is explicitly approved before using IETF Datatracker.
+
+## Stop Conditions
+
+Stop drafting if any change:
+
+- claims IETF adoption, RFC approval, or standards-track status;
+- submits externally without approval;
+- exposes real merchant/private data;
+- enables public discovery, checkout/payment, live provider, or production
+  allowlist behavior;
+- treats Grantex implementation details as mandatory protocol requirements.

--- a/docs/internal/commerce-v1/commerce-v1-nist-agentic-commerce-security-reference-architecture-outline.md
+++ b/docs/internal/commerce-v1/commerce-v1-nist-agentic-commerce-security-reference-architecture-outline.md
@@ -1,0 +1,184 @@
+# NIST Candidate Outline - Securing Agentic Commerce
+
+Status: internal NIST-facing whitepaper outline only.
+
+Created: 2026-06-09.
+
+Candidate title:
+
+`Securing Agentic Commerce: Reference Architecture for Consent, Merchant
+Policy, Audit Evidence, and Payment Safety`
+
+This outline prepares a NIST-aligned security and risk reference architecture.
+It has not been submitted to NIST, has not been accepted by NIST, has not been
+accepted by NCCoE, and must not be described as NIST-approved.
+
+## Intended Abstract
+
+Agentic commerce introduces new risks because AI agents can discover products,
+reason about offers, request carts, initiate consent flows, and request
+checkout or payment actions. This paper proposes a reference architecture for
+managing those risks through merchant-controlled capability exposure, scoped
+buyer consent, policy enforcement, provider boundaries, connector governance,
+redacted audit evidence, refusal behavior, and rollback.
+
+## Whitepaper Goals
+
+- Define a repeatable security architecture for agent-mediated commerce.
+- Map technical controls to NIST AI RMF and cybersecurity risk-management
+  concepts.
+- Show how merchants can participate without exposing private systems directly
+  to agents.
+- Keep payment providers behind governed merchant-control-plane boundaries.
+- Make audit evidence and refusal behavior explicit.
+- Identify residual risk and launch gates.
+
+## Non-Goals
+
+- No claim of NIST endorsement.
+- No claim of formal NIST publication.
+- No live payment approval.
+- No provider certification.
+- No protocol certification.
+- No replacement for legal, compliance, payment-network, or provider approval.
+
+## Candidate Table Of Contents
+
+1. Executive summary.
+2. Problem statement.
+3. Scope and assumptions.
+4. Reference architecture.
+5. Threat model.
+6. Actor and asset inventory.
+7. Trust boundaries.
+8. Control objectives.
+9. NIST AI RMF mapping.
+10. Cybersecurity control mapping.
+11. Identity, consent, and authorization controls.
+12. Merchant policy and capability governance.
+13. Connector governance and source-of-truth controls.
+14. Payment safety and provider-boundary controls.
+15. Audit evidence and evidence retention.
+16. Privacy and data minimization.
+17. Incident response and rollback.
+18. Assurance and conformance evidence.
+19. Deployment patterns.
+20. Open questions for industry collaboration.
+21. Appendix: implementation lessons.
+
+## Reference Architecture
+
+```mermaid
+flowchart TB
+  buyer["Buyer"]
+  channel["Buyer channel"]
+  agent["Buyer agent / Agent platform"]
+  control["Merchant control plane"]
+  policy["Policy and consent engine"]
+  evidence["Audit evidence ledger"]
+  connector["Connector governance layer"]
+  systems["Merchant systems"]
+  provider["Payment provider"]
+  ops["Operator / reviewer"]
+
+  buyer --> channel
+  channel --> agent
+  agent --> control
+  control --> policy
+  control --> evidence
+  control --> connector
+  connector --> systems
+  control --> provider
+  ops --> control
+```
+
+Core boundary:
+
+Agents request commerce actions through the merchant control plane. Agents do
+not directly call payment providers or merchant private systems.
+
+## Threat Model
+
+| Threat | Example | Control objective |
+| --- | --- | --- |
+| Agent goal hijacking | Agent tries to buy outside requested scope. | Scope and policy verification before protected actions. |
+| Prompt injection | Product content instructs agent to bypass rules. | Treat merchant/catalog content as untrusted input. |
+| Stale commerce facts | Agent promises unavailable stock or old price. | Freshness checks and refusal behavior. |
+| Overbroad consent | Buyer approves more than intended. | Narrow scopes, amount caps, expiry, revocation. |
+| Provider boundary bypass | Agent calls payment provider directly. | Provider credentials and calls stay in merchant control plane. |
+| Merchant private API exposure | Agent calls ERP or storefront private APIs. | Connector mediation and no direct agent execution. |
+| Cross-tenant data leak | One merchant sees another merchant's data. | Tenant-boundary filtering and tests. |
+| Audit tampering | Protected action lacks durable evidence. | Append-only audit and redacted evidence references. |
+| Unsafe public discovery | Unapproved merchant or synthetic data appears public. | Approval gates and allowlist controls. |
+
+## NIST AI RMF Mapping Draft
+
+| AI RMF function | Agentic commerce control theme | Evidence to collect |
+| --- | --- | --- |
+| Govern | Roles, responsibilities, policy owners, launch approvals. | Owner records, approval references, policy versions. |
+| Map | Context, actors, channels, merchant systems, data flows. | Architecture diagrams, system inventory, trust boundaries. |
+| Measure | Guardrail tests, refusal evals, stale-data checks, conformance scans. | Test results, conformance reports, scan outputs. |
+| Manage | Rollback, disablement, incident response, revocation, monitoring. | Runbooks, audit events, alert/rollback evidence. |
+
+## Cybersecurity Control Themes
+
+| Theme | Control expectation |
+| --- | --- |
+| Identity and access | Agent, buyer, merchant, and operator identities are attributable. |
+| Least privilege | Capabilities are scoped by merchant, channel, product, amount, and environment. |
+| Data minimization | Public views exclude private merchant artifacts, raw payloads, and credentials. |
+| Credential protection | Provider and connector credentials are never stored in docs, logs, fixtures, or agent systems. |
+| Auditability | Protected actions are not acknowledged without durable evidence. |
+| Integrity | Cart, amount, policy, and consent evidence is hashable or otherwise verifiable. |
+| Availability and resilience | Stale or unavailable sources fail closed with safe refusal. |
+| Incident response | Disablement, rollback, and revocation paths are documented and tested. |
+
+## Agentic Commerce Control Objectives
+
+1. Agents discover only approved merchant capabilities.
+2. Agents do not invent products, prices, inventory, delivery, refunds, or
+   payment outcomes.
+3. Payment-affecting actions require scoped buyer consent.
+4. Merchant policy can block or require human review.
+5. Merchant private systems are accessed only through governed connectors.
+6. Payment providers are accessed only through governed provider adapters.
+7. Evidence is redacted, durable, and reviewable.
+8. Public discovery and live payment require separate explicit approvals.
+
+## Assurance Evidence
+
+Expected evidence categories:
+
+- conformance fixture results;
+- refusal and no-invention tests;
+- tenant-boundary tests;
+- secret/private-data scans;
+- public-safe preview reviews;
+- connector dry-run and remediation evidence;
+- audit event tests;
+- rollback and disablement rehearsal;
+- payment-provider sandbox evidence when available;
+- live readiness approval when applicable.
+
+## NIST/NCCoE Engagement Plan
+
+1. Complete internal whitepaper draft.
+2. Remove all private repo, merchant, and provider-specific details.
+3. Map controls to AI RMF and cybersecurity risk-management categories.
+4. Draft a project-description style summary for "Securing Agentic Commerce".
+5. Identify external collaborators only after public-safe scope approval.
+6. Seek review without claiming NIST approval.
+
+## Stop Conditions
+
+Stop drafting if any change:
+
+- claims NIST approval, NIST publication, NCCoE acceptance, or public comment
+  submission;
+- includes private merchant artifacts, secrets, credentials, raw payloads,
+  production config, concrete allowlists, or provider metadata;
+- enables public discovery, production Commerce V1, checkout/payment creation,
+  live provider, live Plural, provider calls, merchant private API calls, or
+  production allowlists;
+- treats sandbox evidence as production readiness;
+- omits payment-provider, merchant-system, or buyer-consent threat boundaries.


### PR DESCRIPTION
## Summary

- Adds C6T IETF/NIST publication-readiness plan for Agentic Commerce.
- Adds internal IETF Internet-Draft candidate outline for an agentic commerce trust architecture.
- Adds internal NIST-facing security/reference-architecture whitepaper outline.
- Updates the consolidated Agentic Commerce PRD status to track C6O-C6T and the IETF/NIST preparation tracks.
- Softens public compliance wording so the docs no longer claim IETF submission or NIST public-comment submission.

## Safety posture

This is docs-only preparation. It is not an IETF submission, not a NIST submission, not public protocol publication, not certification, not production approval, not public discovery approval, and not checkout/payment approval.

No deploy, cloud command, production config, secrets, public discovery, production Commerce V1, checkout/payment creation, live payments, live Plural, provider calls, merchant private API calls, production allowlists, or certification claims are added.

## Validation

- git diff --cached --check: passed before commit
- focused secret/private scan: clean
- focused production config / allowlist / public discovery / checkout-payment / live-provider enablement scan: clean
- standards overclaim scan: only negative guardrail wording such as not approved / do not claim