### PR TITLE
C6Sie sandbox remediation follow-up closure gap assessment

### DIFF
--- a/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
+++ b/apps/portal/src/pages/__tests__/CommerceDashboard.test.tsx
@@ -1108,6 +1108,195 @@ const connectorRemediationTimelineStaleConflict = {
   },
 };
 
+const connectorRemediationFollowupReady = {
+  ...connectorRemediationTriaged,
+  status: 'followup_ready' as const,
+  triage: {
+    ...connectorRemediationTriaged.triage,
+    triage_status: 'ready_for_followup_review' as const,
+    merchant_followup_summary: 'Sandbox follow-up is ready for internal operator closure only.',
+    next_step: 'Review remaining launch blockers before any separate production approval request.',
+  },
+  updated_at: '2026-01-01T00:55:00Z',
+};
+
+const connectorRemediationTimelineFollowupReady = {
+  ...connectorRemediationTimelineTriaged,
+  remediation: connectorRemediationFollowupReady,
+  timeline: [
+    ...connectorRemediationTimelineTriaged.timeline,
+    {
+      sequence: 4,
+      key: 'followup_ready',
+      label: 'Sandbox follow-up ready',
+      status: 'complete' as const,
+      event_type: 'connector_dry_run_review_decision_recorded',
+      occurred_at: '2026-01-01T00:55:00Z',
+      audit_event_id: 'caud_C6SIE_FOLLOWUP_DECISION',
+      actor: { kind: null, id: null },
+      resource_references: {
+        remediation_id: 'cdrem_C6SG',
+        original_dry_run_id: 'cdry_C6SB',
+        original_review_id: 'cdrev_C6SB',
+        corrected_dry_run_id: 'cdry_C6SF_CORRECTED',
+        followup_review_id: 'cdrev_C6SF_FOLLOWUP',
+      },
+      evidence_summary: {
+        remediation_status: 'followup_ready',
+        followup_review_decision: 'accepted_for_sandbox_followup',
+        followup_ready_is_launch_approval: false,
+        production_approval_granted: false,
+      },
+      redaction: {
+        raw_connector_rows_included: false as const,
+        credentials_included: false as const,
+        provider_metadata_included: false as const,
+        merchant_private_api_payload_included: false as const,
+        production_config_values_included: false as const,
+      },
+    },
+  ],
+  operator_queue: {
+    ...connectorRemediationTimelineTriaged.operator_queue,
+    queue_status: 'followup_ready' as const,
+    requires_operator_followup: false,
+  },
+  merchant_status: {
+    ...connectorRemediationTimelineTriaged.merchant_status,
+    status: 'followup_ready' as const,
+    triage_status: 'ready_for_followup_review' as const,
+    merchant_followup_summary: 'Sandbox follow-up is ready for internal operator closure only.',
+    triage_next_step: 'Review remaining launch blockers before any separate production approval request.',
+    next_step: 'review_status_with_operator',
+  },
+};
+
+const connectorRemediationBlockedAgain = {
+  ...connectorRemediationFollowupReady,
+  status: 'blocked_again' as const,
+  triage: {
+    ...connectorRemediationFollowupReady.triage,
+    triage_status: 'blocked_for_sandbox_followup' as const,
+    merchant_followup_summary: 'Follow-up remains blocked in sandbox evidence.',
+    next_step: 'Correct the sandbox blocker and rerun the local dry-run.',
+  },
+  updated_at: '2026-01-01T00:56:00Z',
+};
+
+const connectorRemediationTimelineBlockedAgain = {
+  ...connectorRemediationTimelineFollowupReady,
+  remediation: connectorRemediationBlockedAgain,
+  timeline: [
+    ...connectorRemediationTimelineTriaged.timeline,
+    {
+      sequence: 4,
+      key: 'blocked_again',
+      label: 'Follow-up blocked or closed',
+      status: 'blocked' as const,
+      event_type: 'connector_dry_run_review_decision_recorded',
+      occurred_at: '2026-01-01T00:56:00Z',
+      audit_event_id: 'caud_C6SIE_BLOCKED_AGAIN_DECISION',
+      actor: { kind: null, id: null },
+      resource_references: {
+        remediation_id: 'cdrem_C6SG',
+        original_dry_run_id: 'cdry_C6SB',
+        original_review_id: 'cdrev_C6SB',
+        corrected_dry_run_id: 'cdry_C6SF_CORRECTED',
+        followup_review_id: 'cdrev_C6SF_FOLLOWUP',
+      },
+      evidence_summary: {
+        remediation_status: 'blocked_again',
+        followup_review_decision: 'blocked',
+        followup_ready_is_launch_approval: false,
+        production_approval_granted: false,
+      },
+      redaction: {
+        raw_connector_rows_included: false as const,
+        credentials_included: false as const,
+        provider_metadata_included: false as const,
+        merchant_private_api_payload_included: false as const,
+        production_config_values_included: false as const,
+      },
+    },
+  ],
+  operator_queue: {
+    ...connectorRemediationTimelineFollowupReady.operator_queue,
+    queue_status: 'blocked_again' as const,
+  },
+  merchant_status: {
+    ...connectorRemediationTimelineFollowupReady.merchant_status,
+    status: 'blocked_again' as const,
+    triage_status: 'blocked_for_sandbox_followup' as const,
+    merchant_followup_summary: 'Follow-up remains blocked in sandbox evidence.',
+    triage_next_step: 'Correct the sandbox blocker and rerun the local dry-run.',
+  },
+};
+
+const connectorRemediationClosedNoAction = {
+  ...connectorRemediationFollowupReady,
+  status: 'closed_no_action' as const,
+  audit_references: {
+    ...connectorRemediationFollowupReady.audit_references,
+    closed_or_blocked_audit_event_id: 'caud_C6SIE_CLOSED_NO_ACTION',
+  },
+  triage: {
+    ...connectorRemediationFollowupReady.triage,
+    triage_status: 'closed_no_action' as const,
+    merchant_followup_summary: 'Sandbox follow-up is closed with no production action.',
+    next_step: 'Open a new sandbox remediation if evidence changes.',
+  },
+  updated_at: '2026-01-01T00:57:00Z',
+};
+
+const connectorRemediationTimelineClosedNoAction = {
+  ...connectorRemediationTimelineFollowupReady,
+  remediation: connectorRemediationClosedNoAction,
+  timeline: [
+    ...connectorRemediationTimelineTriaged.timeline,
+    {
+      sequence: 4,
+      key: 'closed_no_action',
+      label: 'Follow-up blocked or closed',
+      status: 'blocked' as const,
+      event_type: 'connector_remediation_closed_or_blocked',
+      occurred_at: '2026-01-01T00:57:00Z',
+      audit_event_id: 'caud_C6SIE_CLOSED_NO_ACTION',
+      actor: { kind: null, id: null },
+      resource_references: {
+        remediation_id: 'cdrem_C6SG',
+        original_dry_run_id: 'cdry_C6SB',
+        original_review_id: 'cdrev_C6SB',
+        corrected_dry_run_id: 'cdry_C6SF_CORRECTED',
+        followup_review_id: 'cdrev_C6SF_FOLLOWUP',
+      },
+      evidence_summary: {
+        remediation_status: 'closed_no_action',
+        followup_review_decision: null,
+        followup_ready_is_launch_approval: false,
+        production_approval_granted: false,
+      },
+      redaction: {
+        raw_connector_rows_included: false as const,
+        credentials_included: false as const,
+        provider_metadata_included: false as const,
+        merchant_private_api_payload_included: false as const,
+        production_config_values_included: false as const,
+      },
+    },
+  ],
+  operator_queue: {
+    ...connectorRemediationTimelineFollowupReady.operator_queue,
+    queue_status: 'closed_no_action' as const,
+  },
+  merchant_status: {
+    ...connectorRemediationTimelineFollowupReady.merchant_status,
+    status: 'closed_no_action' as const,
+    triage_status: 'closed_no_action' as const,
+    merchant_followup_summary: 'Sandbox follow-up is closed with no production action.',
+    triage_next_step: 'Open a new sandbox remediation if evidence changes.',
+  },
+};
+
 const connectorDryRunCorrected = {
   ...connectorDryRun,
   dry_run_id: 'cdry_C6SF_CORRECTED',
@@ -2031,6 +2220,28 @@ describe('CommerceOnboarding', () => {
     const duplicateReconciliation = screen.getByTestId('connector-triage-reconciliation-summary');
     expect(within(duplicateReconciliation).getByText('aligned')).toBeInTheDocument();
     expect(within(duplicateReconciliation).getByText('none')).toBeInTheDocument();
+    const closureAssessment = screen.getByTestId('connector-followup-closure-gap-assessment');
+    expect(within(closureAssessment).getByText('Follow-up closure and launch-readiness gap assessment')).toBeInTheDocument();
+    expect(within(closureAssessment).getAllByText('waiting_for_operator_followup').length).toBeGreaterThan(0);
+    expect(within(closureAssessment).getByText('operator_closure_status_recorded')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('redacted_decision_audit_continuity')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('remaining_launch_blocker_matrix')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('launch_approval')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('public_discovery_approval')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('checkout_payment_approval')).toBeInTheDocument();
+    expect(within(closureAssessment).getAllByText('false').length).toBeGreaterThanOrEqual(4);
+    const launchBlockers = screen.getByTestId('connector-launch-blocker-matrix');
+    expect(within(launchBlockers).getByText('Grantex public discovery')).toBeInTheDocument();
+    expect(within(launchBlockers).getByText('AgenticOrg public commerce discovery')).toBeInTheDocument();
+    expect(within(launchBlockers).getByText('Production Commerce V1')).toBeInTheDocument();
+    expect(within(launchBlockers).getByText('Checkout/payment creation')).toBeInTheDocument();
+    expect(within(launchBlockers).getByText('Live providers, live Plural, and live payments')).toBeInTheDocument();
+    expect(within(launchBlockers).getByText('Connector credentials')).toBeInTheDocument();
+    expect(within(launchBlockers).getByText('Outbound connector sync')).toBeInTheDocument();
+    expect(within(launchBlockers).getByText('Merchant private API execution')).toBeInTheDocument();
+    expect(within(launchBlockers).getByText('Production allowlists')).toBeInTheDocument();
+    expect(within(launchBlockers).getByText('Public protocol publication')).toBeInTheDocument();
+    expect(within(launchBlockers).getByText('Certification claims')).toBeInTheDocument();
     expect(screen.queryByRole('textbox', { name: 'Credential' })).not.toBeInTheDocument();
     expect(screen.queryByText('production connector setup enabled')).not.toBeInTheDocument();
     expect(screen.queryByText('outbound connector sync enabled')).not.toBeInTheDocument();
@@ -2098,8 +2309,178 @@ describe('CommerceOnboarding', () => {
     expect(within(reconciliationSummary).getByText('production_approval')).toBeInTheDocument();
     expect(within(reconciliationSummary).getAllByText('false').length).toBeGreaterThanOrEqual(2);
     expect(within(reconciliationSummary).queryByText('Internal sandbox triage note must stay operator-only.')).not.toBeInTheDocument();
+    const closureAssessment = screen.getByTestId('connector-followup-closure-gap-assessment');
+    expect(within(closureAssessment).getAllByText('sandbox_blocker').length).toBeGreaterThan(0);
+    expect(within(closureAssessment).getByText('stale_conflict_closure_guidance')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('sandbox_blocker_only')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('Stale or conflicting closure guidance is a sandbox blocker only; it is not launch readiness.')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('connector_execution_enabled')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('production_approval')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('launch_approval')).toBeInTheDocument();
+    expect(within(closureAssessment).getAllByText('false').length).toBeGreaterThanOrEqual(3);
     expect(screen.queryByText('connector execution ready')).not.toBeInTheDocument();
     expect(screen.queryByText('production approval enabled')).not.toBeInTheDocument();
+    expect(screen.queryByRole('textbox', { name: 'Credential' })).not.toBeInTheDocument();
+  });
+
+  it('shows follow-up ready closure with launch blockers and no approval semantics', async () => {
+    mockListCommerceConnectorDryRunRemediations.mockResolvedValueOnce({
+      items: [{
+        ...connectorRemediationFollowupReady,
+        queue: {
+          operator_queue_status: 'followup_ready' as const,
+          merchant_visible_status: 'followup_ready' as const,
+          requires_corrected_dry_run: false,
+          requires_operator_followup: false,
+          timeline_available: true as const,
+          evidence_redacted: true as const,
+        },
+        summary: {
+          blocker_count: 0,
+          warning_count: 0,
+          corrected_dry_run_attached: true,
+          followup_review_requested: true,
+          last_audit_event_id: 'caud_C6SIE_FOLLOWUP_DECISION',
+        },
+      }],
+      next_cursor: null,
+      filters: { merchant_id: 'mch_1' },
+      controls: {
+        sandbox_only: true,
+        public_discovery_enabled: false,
+        checkout_payment_enabled: false,
+        live_provider_enabled: false,
+        live_plural_enabled: false,
+      },
+    });
+    mockGetCommerceConnectorDryRunRemediationTimeline.mockResolvedValueOnce({
+      data: connectorRemediationTimelineFollowupReady,
+    });
+    const user = userEvent.setup();
+    r(<CommerceOnboarding />);
+
+    await user.type(screen.getByLabelText('Merchant ID'), 'mch_1');
+    await user.click(screen.getByRole('button', { name: 'Load onboarding' }));
+    await waitFor(() => expect(screen.getByText('Persisted remediation queue')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: 'Load remediation queue' }));
+    await waitFor(() => expect(screen.getAllByText('followup_ready').length).toBeGreaterThan(0));
+    await user.click(screen.getByRole('button', { name: 'View timeline' }));
+    await waitFor(() => expect(screen.getByTestId('connector-followup-closure-gap-assessment')).toBeInTheDocument());
+
+    const closureAssessment = screen.getByTestId('connector-followup-closure-gap-assessment');
+    expect(within(closureAssessment).getAllByText('followup_closure_ready').length).toBeGreaterThan(0);
+    expect(within(closureAssessment).getByText('caud_C6SIE_FOLLOWUP_DECISION')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('redacted_decision_audit_continuity')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText((_content, node) => (
+      node?.textContent === 'Next step: Review remaining launch blockers before requesting any separate production approval.'
+    ))).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('launch_approval')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('public_discovery_approval')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('checkout_payment_approval')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('connector_execution_enabled')).toBeInTheDocument();
+    expect(within(closureAssessment).getAllByText('false').length).toBeGreaterThanOrEqual(4);
+    expect(within(closureAssessment).queryByText('Internal sandbox triage note must stay operator-only.')).not.toBeInTheDocument();
+    expect(screen.queryByText('launch approval enabled')).not.toBeInTheDocument();
+    expect(screen.queryByText('checkout payment approval enabled')).not.toBeInTheDocument();
+    expect(screen.queryByRole('textbox', { name: 'Credential' })).not.toBeInTheDocument();
+  });
+
+  it('shows blocked-again and closed-no-action closure states as non-enabling', async () => {
+    mockListCommerceConnectorDryRunRemediations.mockResolvedValueOnce({
+      items: [{
+        ...connectorRemediationBlockedAgain,
+        queue: {
+          operator_queue_status: 'blocked_again' as const,
+          merchant_visible_status: 'blocked_again' as const,
+          requires_corrected_dry_run: false,
+          requires_operator_followup: false,
+          timeline_available: true as const,
+          evidence_redacted: true as const,
+        },
+        summary: {
+          blocker_count: 1,
+          warning_count: 0,
+          corrected_dry_run_attached: true,
+          followup_review_requested: true,
+          last_audit_event_id: 'caud_C6SIE_BLOCKED_AGAIN_DECISION',
+        },
+      }],
+      next_cursor: null,
+      filters: { merchant_id: 'mch_1' },
+      controls: {
+        sandbox_only: true,
+        public_discovery_enabled: false,
+        checkout_payment_enabled: false,
+        live_provider_enabled: false,
+        live_plural_enabled: false,
+      },
+    });
+    mockGetCommerceConnectorDryRunRemediationTimeline.mockResolvedValueOnce({
+      data: connectorRemediationTimelineBlockedAgain,
+    });
+    const user = userEvent.setup();
+    r(<CommerceOnboarding />);
+
+    await user.type(screen.getByLabelText('Merchant ID'), 'mch_1');
+    await user.click(screen.getByRole('button', { name: 'Load onboarding' }));
+    await waitFor(() => expect(screen.getByText('Persisted remediation queue')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Load remediation queue' }));
+    await waitFor(() => expect(screen.getAllByText('blocked_again').length).toBeGreaterThan(0));
+    await user.click(screen.getByRole('button', { name: 'View timeline' }));
+    await waitFor(() => expect(screen.getByTestId('connector-followup-closure-gap-assessment')).toBeInTheDocument());
+    let closureAssessment = screen.getByTestId('connector-followup-closure-gap-assessment');
+    expect(within(closureAssessment).getAllByText('blocked_again').length).toBeGreaterThan(0);
+    expect(within(closureAssessment).getByText('caud_C6SIE_BLOCKED_AGAIN_DECISION')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('connector_execution_enabled')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('production_approval')).toBeInTheDocument();
+    expect(within(closureAssessment).getAllByText('false').length).toBeGreaterThanOrEqual(2);
+
+    mockListCommerceConnectorDryRunRemediations.mockResolvedValueOnce({
+      items: [{
+        ...connectorRemediationClosedNoAction,
+        queue: {
+          operator_queue_status: 'closed_no_action' as const,
+          merchant_visible_status: 'closed_no_action' as const,
+          requires_corrected_dry_run: false,
+          requires_operator_followup: false,
+          timeline_available: true as const,
+          evidence_redacted: true as const,
+        },
+        summary: {
+          blocker_count: 0,
+          warning_count: 0,
+          corrected_dry_run_attached: true,
+          followup_review_requested: true,
+          last_audit_event_id: 'caud_C6SIE_CLOSED_NO_ACTION',
+        },
+      }],
+      next_cursor: null,
+      filters: { merchant_id: 'mch_1' },
+      controls: {
+        sandbox_only: true,
+        public_discovery_enabled: false,
+        checkout_payment_enabled: false,
+        live_provider_enabled: false,
+        live_plural_enabled: false,
+      },
+    });
+    mockGetCommerceConnectorDryRunRemediationTimeline.mockResolvedValueOnce({
+      data: connectorRemediationTimelineClosedNoAction,
+    });
+    await user.click(screen.getByRole('button', { name: 'Load remediation queue' }));
+    await waitFor(() => expect(screen.getAllByText('closed_no_action').length).toBeGreaterThan(0));
+    await user.click(screen.getByRole('button', { name: 'View timeline' }));
+    await waitFor(() => expect(screen.getByText('caud_C6SIE_CLOSED_NO_ACTION')).toBeInTheDocument());
+    closureAssessment = screen.getByTestId('connector-followup-closure-gap-assessment');
+    expect(within(closureAssessment).getAllByText('closed_no_action').length).toBeGreaterThan(0);
+    expect(within(closureAssessment).getByText('Sandbox follow-up is closed with no production action.')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('launch_approval')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('public_discovery_approval')).toBeInTheDocument();
+    expect(within(closureAssessment).getByText('checkout_payment_approval')).toBeInTheDocument();
+    expect(within(closureAssessment).getAllByText('false').length).toBeGreaterThanOrEqual(4);
+    expect(screen.queryByText('production approval enabled')).not.toBeInTheDocument();
+    expect(screen.queryByText('connector execution ready')).not.toBeInTheDocument();
     expect(screen.queryByRole('textbox', { name: 'Credential' })).not.toBeInTheDocument();
   });
 

--- a/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
+++ b/apps/portal/src/pages/commerce/CommerceOnboarding.tsx
@@ -472,6 +472,12 @@ interface ConnectorTriageRehearsalStatus {
 }
 
 type ConnectorTriageReconciliationStatus = 'aligned' | 'warning' | 'blocked';
+type ConnectorFollowupClosureStatus =
+  | 'waiting_for_operator_followup'
+  | 'followup_closure_ready'
+  | 'blocked_again'
+  | 'closed_no_action'
+  | 'sandbox_blocker';
 
 interface ConnectorTriageReconciliationCheck {
   key: string;
@@ -502,6 +508,115 @@ interface ConnectorTriageEvidenceReconciliation {
   production_approval: false;
   connector_execution_enabled: false;
 }
+
+interface ConnectorFollowupClosureGapCheck {
+  key: string;
+  label: string;
+  status: 'pass' | 'warning' | 'blocked';
+  detail: string;
+}
+
+interface ConnectorLaunchReadinessBlocker {
+  key: string;
+  label: string;
+  status: 'blocked';
+  detail: string;
+}
+
+interface ConnectorFollowupClosureGapAssessment {
+  status: ConnectorFollowupClosureStatus;
+  remediation_id: string;
+  remediation_status: CommerceConnectorDryRunRemediationStatus;
+  triage_status: CommerceConnectorDryRunRemediationTriageStatus | null;
+  merchant_closure_summary: string;
+  merchant_next_step: string;
+  audit_references: {
+    requested_audit_event_id: string | null;
+    corrected_audit_event_id: string | null;
+    followup_audit_event_id: string | null;
+    triage_audit_event_id: string | null;
+    decision_or_closure_audit_event_id: string | null;
+  };
+  redacted_decision_audit_continuity: boolean;
+  stale_conflict_closure_guidance: boolean;
+  stale_conflict_handling: 'none' | 'sandbox_blocker_only';
+  checks: ConnectorFollowupClosureGapCheck[];
+  remaining_launch_blockers: ConnectorLaunchReadinessBlocker[];
+  production_approval: false;
+  launch_approval: false;
+  public_discovery_approval: false;
+  checkout_payment_approval: false;
+  connector_execution_enabled: false;
+}
+
+const connectorRemainingLaunchBlockers: ConnectorLaunchReadinessBlocker[] = [
+  {
+    key: 'public_discovery_blocked',
+    label: 'Grantex public discovery',
+    status: 'blocked',
+    detail: 'Requires a separate public discovery approval and remains off in this sandbox closure assessment.',
+  },
+  {
+    key: 'agenticorg_public_commerce_discovery_blocked',
+    label: 'AgenticOrg public commerce discovery',
+    status: 'blocked',
+    detail: 'AgenticOrg continues to consume Grantex preview surfaces only; public commerce discovery remains blocked.',
+  },
+  {
+    key: 'production_commerce_v1_blocked',
+    label: 'Production Commerce V1',
+    status: 'blocked',
+    detail: 'Sandbox remediation closure is not production Commerce V1 enablement.',
+  },
+  {
+    key: 'checkout_payment_blocked',
+    label: 'Checkout/payment creation',
+    status: 'blocked',
+    detail: 'Checkout and payment creation remain disabled and require separate approval.',
+  },
+  {
+    key: 'live_provider_blocked',
+    label: 'Live providers, live Plural, and live payments',
+    status: 'blocked',
+    detail: 'Live payment providers, live Plural, and live payment execution remain blocked.',
+  },
+  {
+    key: 'credentials_blocked',
+    label: 'Connector credentials',
+    status: 'blocked',
+    detail: 'No credential entry or credential storage is introduced by this closure assessment.',
+  },
+  {
+    key: 'outbound_sync_blocked',
+    label: 'Outbound connector sync',
+    status: 'blocked',
+    detail: 'Outbound sync and production connector setup remain blocked.',
+  },
+  {
+    key: 'merchant_private_api_execution_blocked',
+    label: 'Merchant private API execution',
+    status: 'blocked',
+    detail: 'Neither Grantex nor AgenticOrg may execute merchant private APIs from this sandbox evidence.',
+  },
+  {
+    key: 'production_allowlist_blocked',
+    label: 'Production allowlists',
+    status: 'blocked',
+    detail: 'Production allowlists and concrete production config assignments remain blocked.',
+  },
+  {
+    key: 'public_protocol_publication_blocked',
+    label: 'Public protocol publication',
+    status: 'blocked',
+    detail: 'Open protocol/public publication remains blocked by separate review gates.',
+  },
+  {
+    key: 'certification_blocked',
+    label: 'Certification claims',
+    status: 'blocked',
+    detail: 'No UCP, ACP, AP2, schema.org, provider, or live-payment certification is claimed.',
+  },
+];
 
 function buildConnectorTriageRehearsalStatus(
   remediation: CommerceConnectorDryRunRemediation,
@@ -679,6 +794,151 @@ function buildConnectorTriageEvidenceReconciliation(
     redacted_audit_reference_continuity: redactedAuditReferenceContinuity,
     checks,
     production_approval: false,
+    connector_execution_enabled: false,
+  };
+}
+
+function followupClosureStatusVariant(status: ConnectorFollowupClosureStatus | ConnectorFollowupClosureGapCheck['status']): 'default' | 'success' | 'warning' | 'danger' {
+  if (status === 'followup_closure_ready' || status === 'pass') return 'success';
+  if (status === 'sandbox_blocker' || status === 'blocked_again' || status === 'closed_no_action' || status === 'blocked') return 'danger';
+  return 'warning';
+}
+
+function connectorTerminalClosureEntry(timeline: CommerceConnectorDryRunRemediationTimeline) {
+  return timeline.timeline.find((entry) => (
+    entry.key === 'followup_ready'
+    || entry.key === 'blocked_again'
+    || entry.key === 'closed_no_action'
+  )) ?? null;
+}
+
+function buildConnectorFollowupClosureGapAssessment(
+  timeline: CommerceConnectorDryRunRemediationTimeline,
+  reconciliation: ConnectorTriageEvidenceReconciliation | null,
+): ConnectorFollowupClosureGapAssessment {
+  const remediation = timeline.remediation;
+  const terminalEntry = connectorTerminalClosureEntry(timeline);
+  const triageStatus = timeline.merchant_status.triage_status ?? remediation.triage?.triage_status ?? null;
+  const decisionOrClosureAudit = terminalEntry?.audit_event_id
+    ?? remediation.audit_references.closed_or_blocked_audit_event_id
+    ?? null;
+  const staleConflictClosureGuidance = reconciliation?.stale_conflict_followup_guidance
+    ?? containsStaleOrConflict(remediation, timeline);
+  const nonEnablingControlsPass = timeline.controls.public_discovery_enabled === false
+    && timeline.controls.checkout_payment_enabled === false
+    && timeline.controls.live_provider_enabled === false
+    && timeline.controls.live_plural_enabled === false
+    && timeline.controls.credential_entry_enabled === false
+    && timeline.controls.outbound_sync_enabled === false
+    && timeline.controls.production_connector_setup_enabled === false
+    && timeline.controls.provider_call_enabled === false
+    && timeline.controls.merchant_private_api_calls_enabled === false
+    && timeline.controls.production_allowlist_written === false
+    && timeline.controls.remediation_is_production_approval === false
+    && timeline.controls.remediation_enables_connector_execution === false
+    && timeline.controls.followup_ready_is_launch_approval === false;
+  const requiredAuditReferences = [
+    remediation.audit_references.requested_audit_event_id,
+    remediation.corrected_dry_run_id ? remediation.audit_references.corrected_audit_event_id : 'not_required',
+    remediation.followup_review_id ? remediation.audit_references.followup_audit_event_id : 'not_required',
+    triageStatus ? reconciliation?.audit_references.triage_audit_event_id ?? remediation.audit_references.triage_audit_event_id ?? 'not_recorded' : 'not_required',
+    terminalEntry ? decisionOrClosureAudit : 'not_required',
+  ];
+  const redactedDecisionAuditContinuity = requiredAuditReferences.every((value) => Boolean(value) && value !== 'not_recorded')
+    && timeline.timeline.every((entry) => (
+      entry.redaction.raw_connector_rows_included === false
+      && entry.redaction.credentials_included === false
+      && entry.redaction.provider_metadata_included === false
+      && entry.redaction.merchant_private_api_payload_included === false
+      && entry.redaction.production_config_values_included === false
+    ));
+  const status: ConnectorFollowupClosureStatus = !nonEnablingControlsPass || staleConflictClosureGuidance
+    ? 'sandbox_blocker'
+    : remediation.status === 'followup_ready'
+      ? 'followup_closure_ready'
+      : remediation.status === 'blocked_again'
+        ? 'blocked_again'
+        : remediation.status === 'closed_no_action' || triageStatus === 'closed_no_action'
+          ? 'closed_no_action'
+          : 'waiting_for_operator_followup';
+  const merchantClosureSummary = timeline.merchant_status.merchant_followup_summary
+    ?? remediation.triage?.merchant_followup_summary
+    ?? (status === 'followup_closure_ready'
+      ? 'Sandbox follow-up closure is ready for internal review only; launch blockers remain.'
+      : 'No public-safe closure guidance recorded.');
+  const merchantNextStep = staleConflictClosureGuidance
+    ? 'Refresh or correct sandbox evidence before any follow-up closure is considered.'
+    : status === 'followup_closure_ready'
+      ? 'Review remaining launch blockers before requesting any separate production approval.'
+      : timeline.merchant_status.triage_next_step
+        ?? remediation.triage?.next_step
+        ?? timeline.merchant_status.next_step;
+  const checks: ConnectorFollowupClosureGapCheck[] = [
+    {
+      key: 'operator_closure_status_recorded',
+      label: 'Operator closure status recorded',
+      status: status === 'waiting_for_operator_followup' ? 'warning' : status === 'sandbox_blocker' ? 'blocked' : 'pass',
+      detail: `remediation_status=${remediation.status} triage_status=${triageStatus ?? 'not_recorded'}`,
+    },
+    {
+      key: 'merchant_visible_closure_guidance_redacted',
+      label: 'Merchant-visible closure guidance redacted',
+      status: redactedDecisionAuditContinuity ? 'pass' : 'warning',
+      detail: 'Guidance uses public-safe summary and next-step fields only.',
+    },
+    {
+      key: 'decision_audit_reference_continuity',
+      label: 'Decision or closure audit continuity',
+      status: terminalEntry && !decisionOrClosureAudit ? 'warning' : redactedDecisionAuditContinuity ? 'pass' : 'warning',
+      detail: `requested=${remediation.audit_references.requested_audit_event_id ?? 'not_recorded'} corrected=${remediation.audit_references.corrected_audit_event_id ?? 'not_recorded'} followup=${remediation.audit_references.followup_audit_event_id ?? 'not_recorded'} triage=${reconciliation?.audit_references.triage_audit_event_id ?? remediation.audit_references.triage_audit_event_id ?? 'not_recorded'} decision_or_closure=${decisionOrClosureAudit ?? 'not_recorded'}`,
+    },
+    {
+      key: 'stale_conflict_closure_guidance',
+      label: 'Stale/conflict closure guidance',
+      status: staleConflictClosureGuidance ? 'blocked' : 'pass',
+      detail: staleConflictClosureGuidance
+        ? 'Stale or conflicting closure guidance is a sandbox blocker only; it is not launch readiness.'
+        : 'No stale or conflict closure blocker detected.',
+    },
+    {
+      key: 'remaining_launch_blocker_matrix',
+      label: 'Remaining launch blocker matrix',
+      status: connectorRemainingLaunchBlockers.every((blocker) => blocker.status === 'blocked') ? 'pass' : 'blocked',
+      detail: 'Every public, production, live, provider, allowlist, publication, and certification item remains blocked.',
+    },
+    {
+      key: 'fixed_non_enabling_controls',
+      label: 'Fixed non-enabling controls',
+      status: nonEnablingControlsPass ? 'pass' : 'blocked',
+      detail: nonEnablingControlsPass
+        ? 'Public discovery, checkout/payment, live providers, credentials, outbound sync, provider calls, merchant private API calls, production approval, and launch approval remain off.'
+        : 'One or more non-enabling control is not false/off.',
+    },
+  ];
+
+  return {
+    status,
+    remediation_id: remediation.remediation_id,
+    remediation_status: remediation.status,
+    triage_status: triageStatus,
+    merchant_closure_summary: merchantClosureSummary,
+    merchant_next_step: merchantNextStep,
+    audit_references: {
+      requested_audit_event_id: remediation.audit_references.requested_audit_event_id,
+      corrected_audit_event_id: remediation.audit_references.corrected_audit_event_id,
+      followup_audit_event_id: remediation.audit_references.followup_audit_event_id,
+      triage_audit_event_id: reconciliation?.audit_references.triage_audit_event_id ?? remediation.audit_references.triage_audit_event_id ?? null,
+      decision_or_closure_audit_event_id: decisionOrClosureAudit,
+    },
+    redacted_decision_audit_continuity: redactedDecisionAuditContinuity,
+    stale_conflict_closure_guidance: staleConflictClosureGuidance,
+    stale_conflict_handling: staleConflictClosureGuidance ? 'sandbox_blocker_only' : 'none',
+    checks,
+    remaining_launch_blockers: connectorRemainingLaunchBlockers,
+    production_approval: false,
+    launch_approval: false,
+    public_discovery_approval: false,
+    checkout_payment_approval: false,
     connector_execution_enabled: false,
   };
 }
@@ -2186,6 +2446,13 @@ export function CommerceOnboarding() {
       connectorTriageRehearsalStatus,
     );
   }, [connectorBackendRemediation, connectorRemediationQueue, connectorRemediationTimeline, connectorTriageRehearsalStatus]);
+  const connectorFollowupClosureGapAssessment = useMemo(() => {
+    if (!connectorRemediationTimeline) return null;
+    return buildConnectorFollowupClosureGapAssessment(
+      connectorRemediationTimeline,
+      connectorTriageReconciliation,
+    );
+  }, [connectorRemediationTimeline, connectorTriageReconciliation]);
   const connectorTriageControls = [
     { label: 'sandbox_only', value: true },
     { label: 'credential_entry_enabled', value: false },
@@ -3516,6 +3783,80 @@ export function CommerceOnboarding() {
                           <div className="mt-1 break-all text-xs text-gx-muted">{check.detail}</div>
                         </div>
                       ))}
+                    </div>
+                  </div>
+                ) : null}
+                {connectorFollowupClosureGapAssessment ? (
+                  <div data-testid="connector-followup-closure-gap-assessment" className="mt-3 rounded-md border border-gx-border p-3">
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <div>
+                        <div className="text-sm font-medium text-gx-text">Follow-up closure and launch-readiness gap assessment</div>
+                        <p className="mt-1 text-xs text-gx-muted">
+                          Summarizes sandbox follow-up closure status, redacted audit continuity, and remaining launch blockers without enabling production behavior.
+                        </p>
+                      </div>
+                      <Badge variant={followupClosureStatusVariant(connectorFollowupClosureGapAssessment.status)}>
+                        {connectorFollowupClosureGapAssessment.status}
+                      </Badge>
+                    </div>
+                    <div className="mt-3 grid gap-2 md:grid-cols-4">
+                      {[
+                        { label: 'remediation_status', value: connectorFollowupClosureGapAssessment.remediation_status },
+                        { label: 'operator_closure_status', value: connectorFollowupClosureGapAssessment.status },
+                        { label: 'triage_status', value: connectorFollowupClosureGapAssessment.triage_status ?? 'not_recorded' },
+                        { label: 'requested_audit', value: connectorFollowupClosureGapAssessment.audit_references.requested_audit_event_id ?? 'not_recorded' },
+                        { label: 'corrected_audit', value: connectorFollowupClosureGapAssessment.audit_references.corrected_audit_event_id ?? 'not_recorded' },
+                        { label: 'followup_audit', value: connectorFollowupClosureGapAssessment.audit_references.followup_audit_event_id ?? 'not_recorded' },
+                        { label: 'triage_audit', value: connectorFollowupClosureGapAssessment.audit_references.triage_audit_event_id ?? 'not_recorded' },
+                        { label: 'decision_or_closure_audit', value: connectorFollowupClosureGapAssessment.audit_references.decision_or_closure_audit_event_id ?? 'not_recorded' },
+                        { label: 'redacted_decision_audit_continuity', value: connectorFollowupClosureGapAssessment.redacted_decision_audit_continuity },
+                        { label: 'stale_conflict_handling', value: connectorFollowupClosureGapAssessment.stale_conflict_handling },
+                        { label: 'connector_execution_enabled', value: connectorFollowupClosureGapAssessment.connector_execution_enabled },
+                        { label: 'production_approval', value: connectorFollowupClosureGapAssessment.production_approval },
+                        { label: 'launch_approval', value: connectorFollowupClosureGapAssessment.launch_approval },
+                        { label: 'public_discovery_approval', value: connectorFollowupClosureGapAssessment.public_discovery_approval },
+                        { label: 'checkout_payment_approval', value: connectorFollowupClosureGapAssessment.checkout_payment_approval },
+                      ].map((item) => (
+                        <div key={item.label} className="rounded-md border border-gx-border p-2">
+                          <div className="text-xs text-gx-muted">{item.label}</div>
+                          <div className="break-all text-sm font-medium text-gx-text">{String(item.value)}</div>
+                        </div>
+                      ))}
+                    </div>
+                    <div data-testid="connector-closure-merchant-guidance" className="mt-3 rounded-md border border-gx-border p-2">
+                      <div className="text-xs font-medium text-gx-muted">Merchant-visible closure/gap guidance</div>
+                      <div className="mt-1 text-sm text-gx-text">{connectorFollowupClosureGapAssessment.merchant_closure_summary}</div>
+                      <div className="mt-1 text-xs text-gx-muted">Next step: {connectorFollowupClosureGapAssessment.merchant_next_step}</div>
+                      <div className="mt-1 text-xs text-gx-muted">
+                        Closure guidance is sandbox evidence only; it is not production approval, launch approval, public discovery approval, or checkout/payment approval.
+                      </div>
+                    </div>
+                    <div className="mt-3 grid gap-2 md:grid-cols-2">
+                      {connectorFollowupClosureGapAssessment.checks.map((check) => (
+                        <div key={check.key} className="rounded-md border border-gx-border p-2">
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <div className="text-xs font-medium text-gx-text">{check.label}</div>
+                            <Badge variant={followupClosureStatusVariant(check.status)}>{check.status}</Badge>
+                          </div>
+                          <div className="mt-1 text-xs text-gx-muted">{check.key}</div>
+                          <div className="mt-1 break-all text-xs text-gx-muted">{check.detail}</div>
+                        </div>
+                      ))}
+                    </div>
+                    <div data-testid="connector-launch-blocker-matrix" className="mt-3 rounded-md border border-gx-border p-3">
+                      <div className="text-sm font-medium text-gx-text">Remaining launch blocker matrix</div>
+                      <div className="mt-2 grid gap-2 md:grid-cols-2">
+                        {connectorFollowupClosureGapAssessment.remaining_launch_blockers.map((blocker) => (
+                          <div key={blocker.key} className="rounded-md border border-gx-border p-2">
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <div className="text-xs font-medium text-gx-text">{blocker.label}</div>
+                              <Badge variant="danger">{blocker.status}</Badge>
+                            </div>
+                            <div className="mt-1 text-xs text-gx-muted">{blocker.key}</div>
+                            <div className="mt-1 text-xs text-gx-muted">{blocker.detail}</div>
+                          </div>
+                        ))}
+                      </div>
                     </div>
                   </div>
                 ) : null}

--- a/docs/internal/commerce-v1/commerce-v1-c6sie-remediation-followup-closure-gap-assessment.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6sie-remediation-followup-closure-gap-assessment.md
@@ -1,0 +1,144 @@
+# Commerce V1 C6Sie - Remediation Follow-Up Closure Gap Assessment
+
+C6Sie adds a portal-only closure and launch-gap assessment for sandbox connector
+dry-run remediation follow-up. It uses existing C6Sg/C6Sh/C6Sia/C6Sid
+remediation, timeline, triage, and reconciliation evidence. It remains
+sandbox-only, credential-free, tenant-scoped, non-live, non-publication,
+non-certifying, and non-enabling.
+
+## Scope
+
+C6Sie displays a follow-up closure and launch-readiness gap panel in the
+existing connector remediation section. The panel reads existing state only:
+
+- persisted remediation status;
+- operator triage status;
+- merchant-visible public-safe follow-up summary;
+- redacted timeline audit references;
+- C6Sid operator/merchant reconciliation status;
+- fixed non-enabling controls.
+
+No backend route, migration, workflow, worker, portal credential entry,
+outbound sync, production connector setup, public discovery, checkout/payment,
+live provider, provider call, merchant private API call, production allowlist,
+or certification path is added.
+
+## Closure Statuses
+
+The portal maps existing sandbox evidence to these display-only closure states:
+
+- `waiting_for_operator_followup` when the remediation is still waiting for a
+  follow-up decision;
+- `followup_closure_ready` when existing remediation status is
+  `followup_ready`;
+- `blocked_again` when existing remediation status is `blocked_again`;
+- `closed_no_action` when remediation or triage status is `closed_no_action`;
+- `sandbox_blocker` when stale/conflicting guidance or non-enabling controls
+  fail closed.
+
+These states are internal sandbox evidence states. They are not production
+approval, launch approval, public discovery approval, checkout/payment approval,
+connector execution readiness, provider approval, public protocol publication,
+or certification.
+
+## Merchant-Visible Closure Guidance
+
+Merchant-visible closure/gap guidance is limited to public-safe summary and
+next-step fields from the persisted timeline and triage evidence. It must not
+include:
+
+- internal operator notes;
+- raw connector rows or raw merchant-system payloads;
+- private merchant details;
+- provider metadata;
+- credentials or secrets;
+- private API URLs;
+- checkout/payment identifiers or URLs;
+- production config values or concrete allowlists.
+
+Stale or conflicting closure guidance is shown only as
+`sandbox_blocker_only`. It directs the merchant to refresh or correct sandbox
+evidence and does not authorize connector execution or launch.
+
+## Audit Continuity
+
+C6Sie displays redacted audit continuity for:
+
+- remediation requested audit;
+- corrected dry-run attachment audit, when present;
+- follow-up review request audit, when present;
+- operator triage audit, when present;
+- decision or closure audit, when terminal status exists.
+
+The portal displays audit references only. It does not display raw rows, raw
+payloads, credentials, provider metadata, merchant private API payloads,
+production config values, or allowlists.
+
+## Remaining Launch Blockers
+
+The launch blocker matrix remains blocked after sandbox closure:
+
+- Grantex public discovery;
+- AgenticOrg public commerce discovery;
+- production Commerce V1;
+- checkout/payment creation;
+- live providers, live Plural, and live payments;
+- connector credentials;
+- outbound connector sync;
+- merchant private API execution;
+- production allowlists;
+- public protocol publication;
+- certification claims.
+
+Clearing C6Sie does not remove these blockers. Any future change that removes a
+blocker needs a separate approved work item and review.
+
+## Stop Conditions
+
+Stop and require a new approved work item if any follow-up:
+
+- adds or changes backend routes, migrations, workers, workflows, schedules, or
+  runtime connector execution;
+- adds credential entry, provider credentials, merchant private API URLs,
+  outbound sync, or production connector setup controls;
+- enables Grantex public discovery or AgenticOrg public commerce discovery;
+- enables production Commerce V1, checkout/payment creation, fulfillment,
+  refunds, live payments, live Plural, or live providers;
+- calls Shopify, WooCommerce, Magento, custom API, ERP, OMS, WMS, logistics,
+  CRM/support, payment providers, Plural, Stripe, Pine, or merchant private
+  APIs;
+- lets AgenticOrg call merchant private APIs directly;
+- writes production config or production allowlists;
+- claims production approval, launch approval, public discovery approval,
+  checkout/payment approval, live provider approval, public protocol
+  publication, provider approval, live-payment approval, or certification;
+- treats sandbox, demo, synthetic, fixture, dry-run, review, remediation,
+  triage, timeline, export, reconciliation, closure, or gap assessment output
+  as real merchant approval.
+
+## Rollback Notes
+
+C6Sie rollback removes the portal closure/gap assessment panel, its focused
+portal tests, and this internal note. Rollback does not require cloud action,
+secret rotation, production config changes, public discovery changes,
+checkout/payment changes, live provider changes, merchant private API changes,
+production allowlist changes, or certification work.
+
+## Validation
+
+Focused validation:
+
+```bash
+npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
+npm --prefix apps/portal run typecheck
+npm --prefix apps/auth-service test -- commerce-connector-remediation-triage-c6sia.test.ts commerce-openapi.test.ts
+npm --prefix apps/auth-service run typecheck
+node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
+git diff --check origin/main...HEAD
+```
+
+Focused scans must cover secrets/private details, production config or
+allowlist assignments, public discovery enablement, checkout/payment
+enablement, live payment/live Plural/provider credential enablement,
+certification claims, direct provider calls, direct merchant private API calls,
+AgenticOrg direct execution, and outbound sync enablement.


### PR DESCRIPTION
## Summary
- Adds a portal-only follow-up closure and launch-readiness gap assessment for persisted sandbox connector remediation evidence.
- Shows terminal states for followup_ready, blocked_again, closed_no_action, and triage closed_no_action without treating them as launch or production approval.
- Adds remaining launch blocker matrix and internal C6Sie docs.

## Safety
- Sandbox-only, credential-free, tenant-scoped, non-live, non-enabling.
- No backend routes, migrations, workflows, workers, production config, secrets, public discovery, checkout/payment, live providers, provider calls, merchant private API calls, allowlists, or certification claims.

## Validation
- npm --prefix apps/portal test -- src/api/__tests__/commerce.test.ts src/pages/__tests__/CommerceDashboard.test.tsx
- npm --prefix apps/auth-service test -- commerce-connector-remediation-triage-c6sia.test.ts commerce-openapi.test.ts
- npm --prefix apps/portal run typecheck
- npm --prefix apps/auth-service run typecheck
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
- git diff --cached --check
- focused guardrail scans