### PR TITLE
docs(commerce): draft nist agentic commerce reference architecture

### DIFF
--- a/docs/internal/commerce-v1/commerce-v1-c6tb-nist-security-reference-architecture.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6tb-nist-security-reference-architecture.md
@@ -1,0 +1,228 @@
+# Commerce V1 C6Tb - NIST Security Reference Architecture Skeleton
+
+Status: internal draft-preparation note only.
+
+Created: 2026-06-09.
+
+C6Tb creates the first internal NIST-aligned whitepaper skeleton for `Securing
+Agentic Commerce: Reference Architecture for Consent, Merchant Policy, Audit
+Evidence, and Payment Safety`. It uses the C6T publication-readiness plan, the
+C6T NIST candidate outline, the C6Ta IETF trust-architecture skeleton, the
+consolidated Commerce V1 PRD, and the Commerce V1 build spec as source
+material.
+
+This package is not a NIST submission, not an IETF submission, not accepted by
+NCCoE, not NIST-approved, not public guidance, not public protocol publication,
+not certification, not production authorization, not public discovery
+authorization, not checkout/payment authorization, not provider authorization,
+and not live-payment authorization.
+
+This package does not deploy, merge, create cloud resources, change production
+configuration, touch secrets, enable public discovery, enable production
+Commerce V1, enable checkout or payment creation, enable live payments, enable
+live Plural, call payment providers, call merchant private APIs, set production
+allowlists, or claim certification.
+
+## Scope
+
+C6Tb adds two docs-only artifacts:
+
+- `docs/internal/commerce-v1/standards/nist-agentic-commerce-security-reference-architecture.md`;
+- `docs/internal/commerce-v1/commerce-v1-c6tb-nist-security-reference-architecture.md`.
+
+No runtime files, routes, migrations, workflows, jobs, provider adapters,
+tests, portal UI, secrets, production configuration, public documentation
+publication, cloud resources, discovery settings, checkout/payment behavior,
+live-provider behavior, or production allowlists are added.
+
+## Source Traceability
+
+| Source | C6Tb use |
+| --- | --- |
+| `commerce-v1-c6t-ietf-nist-publication-readiness.md` | Uses C6T NIST track, publication framing, evidence base, cross-track guardrails, stop conditions, and rollback posture. |
+| `commerce-v1-nist-agentic-commerce-security-reference-architecture-outline.md` | Expands the candidate NIST whitepaper outline into a first internal reference-architecture skeleton. |
+| `standards/draft-mishra-agentic-commerce-trust-architecture-00.md` | Reuses generic role, trust-boundary, consent, policy, provider-boundary, connector-source, evidence, refusal, and adapter concepts. |
+| `commerce-v1-agentic-commerce-prd.md` | Aligns standards posture, launch blockers, Grantex/AgenticOrg responsibility split, direct-provider bans, and no-certification language. |
+| `GRANTEX_COMMERCE_PRD.md` | Preserves long-range agentic commerce context while keeping this package internal and preparation-only. |
+| `GRANTEX_COMMERCE_V1_BUILD_SPEC.md` | Preserves V1 safety controls for consent, policy, tenant boundary, audit, provider-neutral boundaries, no direct provider calls, no direct merchant private API calls, and no live-payment enablement. |
+
+## Traceability Matrix
+
+| Requirement | Artifact coverage | Status |
+| --- | --- | --- |
+| Status statement | Standard skeleton header says internal draft only, not submitted to NIST, not accepted by NCCoE, not NIST-approved, not public guidance, and not certification. | Complete |
+| Executive summary | Standard skeleton section `1. Executive Summary`. | Complete |
+| Problem statement | Standard skeleton section `2. Problem Statement`. | Complete |
+| Scope and assumptions | Standard skeleton section `3. Scope and Assumptions`. | Complete |
+| Reference architecture with Mermaid diagram | Standard skeleton section `4. Reference Architecture`. | Complete |
+| Actor and asset inventory | Standard skeleton section `5. Actor and Asset Inventory`. | Complete |
+| Trust boundaries | Standard skeleton section `6. Trust Boundaries`. | Complete |
+| Threat model | Standard skeleton section `7. Threat Model` covers malicious/compromised buyer agents, prompt injection, stale catalog/price/inventory, overbroad consent, cross-tenant exposure, provider-boundary bypass, merchant private API exposure, audit tampering, unsafe public discovery, and synthetic/demo evidence treated as approval. | Complete |
+| Control objectives | Standard skeleton section `8. Control Objectives`. | Complete |
+| NIST AI RMF mapping | Standard skeleton section `9. NIST AI RMF Mapping` covers Govern, Map, Measure, and Manage. | Complete |
+| Cybersecurity control themes | Standard skeleton section `10. Cybersecurity Control Themes` covers identity/access, least privilege, data minimization, credential protection, auditability, integrity, resilience, and incident response. | Complete |
+| Agentic Commerce safety controls | Standard skeleton section `11. Agentic Commerce Safety Controls`. | Complete |
+| Payment safety and provider-boundary controls | Standard skeleton section `12. Payment Safety and Provider-Boundary Controls`. | Complete |
+| Privacy and data minimization | Standard skeleton section `13. Privacy and Data Minimization`. | Complete |
+| Audit evidence and evidence retention | Standard skeleton section `14. Audit Evidence and Evidence Retention`. | Complete |
+| Incident response and rollback | Standard skeleton section `15. Incident Response and Rollback`. | Complete |
+| Assurance evidence | Standard skeleton section `16. Assurance Evidence`. | Complete |
+| Residual risks and blocked production gates | Standard skeleton section `17. Residual Risks and Blocked Production Gates`. | Complete |
+| NIST/NCCoE engagement plan | Standard skeleton section `18. NIST/NCCoE Engagement Plan`. | Complete |
+| Open questions for external collaboration | Standard skeleton section `19. Open Questions for External Collaboration`. | Complete |
+| References placeholder | Standard skeleton section `20. References Placeholder`. | Complete |
+
+## NIST Reference Architecture Summary
+
+The skeleton frames agentic commerce as a governed security architecture with
+distinct buyer, buyer-agent, agent-platform, merchant-control-plane,
+connector-source, payment-provider, reviewer/operator, and audit/evidence-store
+boundaries.
+
+The reference architecture keeps protected commerce actions behind a merchant
+control plane. Agent platforms request actions and receive safe results or
+refusals; they do not become the merchant source of truth, do not call payment
+providers directly, and do not call merchant private APIs directly.
+
+The Mermaid diagram shows buyer-agent requests flowing through an agent
+platform into a merchant control plane, where consent/passport verification,
+merchant policy, connector governance, provider-boundary controls, and audit
+evidence mediate the action.
+
+## Threat Model Summary
+
+The threat model covers:
+
+- malicious or compromised buyer agents;
+- prompt injection through product, support, connector, or channel content;
+- stale catalog, price, inventory, delivery, refund, or support facts;
+- overbroad or ambiguous consent;
+- cross-tenant and cross-merchant data exposure;
+- provider-boundary bypass;
+- merchant private API exposure;
+- audit tampering or missing evidence;
+- unsafe public discovery;
+- synthetic, demo, sandbox, dry-run, remediation, or rehearsal evidence treated
+  as production approval.
+
+Each threat maps to a control objective, such as scoped consent, tenant
+isolation, connector source governance, direct-provider bans, direct-private-API
+bans, append-only or durable evidence patterns, discovery approval gates, and
+explicit production blockers.
+
+## NIST AI RMF and Control Mapping Summary
+
+The AI RMF alignment is internal and preparatory:
+
+- Govern: owner roles, stop conditions, production gates, policy authority, and
+  rollback ownership;
+- Map: actor inventory, asset inventory, trust boundaries, data flows, source
+  systems, providers, and channels;
+- Measure: C6O conformance gate, refusal tests, tenant-boundary tests,
+  secret/private scans, connector dry-run/remediation evidence, and audit
+  tests;
+- Manage: incident response, revocation, emergency disable, discovery rollback,
+  connector quarantine, residual risk tracking, and rollback rehearsal.
+
+The cybersecurity control themes cover identity/access, least privilege, data
+minimization, credential protection, auditability, integrity, resilience, and
+incident response.
+
+## Standards and Engagement Posture
+
+C6Tb remains preparation-only:
+
+- no NIST submission;
+- no NIST public-comment submission;
+- no NCCoE acceptance;
+- no NIST approval;
+- no public guidance publication;
+- no IETF submission;
+- no public protocol publication;
+- no certification, conformance, or compliance claim;
+- no provider approval;
+- no live-payment approval;
+- no production approval.
+
+Grantex and AgenticOrg appear only as non-normative implementation examples.
+The skeleton does not describe them as mandatory architecture participants,
+certified implementations, official NIST participants, or external approval
+sources.
+
+## Private Data and Synthetic Example Policy
+
+The C6Tb skeleton does not include real merchant names, production identifiers,
+private URLs, secrets, credentials, raw payloads, provider metadata, concrete
+allowlists, or production config values.
+
+Where examples are needed, use synthetic identifiers only, such as:
+
+- `merchant.example.001`;
+- `buyer_example_001`;
+- `agent_example_001`;
+- `platform_example_001`;
+- `source_example_001`;
+- `policy_example_v1`;
+- `evidence_example_001`.
+
+The standard skeleton currently avoids concrete payload examples and instead
+uses tables, control objectives, and review checklists.
+
+## Stop Conditions
+
+Stop and require a new explicitly authorized work item if any follow-up:
+
+- submits material to NIST;
+- submits a NIST public comment, project description, collaborator request, or
+  NCCoE package;
+- submits material to IETF;
+- publishes public protocol materials or public guidance;
+- claims NIST approval, NIST publication, NIST public-comment submission,
+  NCCoE acceptance, IETF approval, RFC status, UCP certification, ACP
+  certification, AP2 certification, schema.org certification, MPP approval, A2A
+  approval, provider certification, live-payment certification, conformance, or
+  compliance;
+- treats Grantex or AgenticOrg behavior as mandatory security architecture
+  behavior;
+- exposes real merchant data, private artifacts, secrets, credentials, raw
+  payloads, private URLs, concrete allowlists, production config values, or
+  provider metadata;
+- enables public discovery, production Commerce V1, checkout/payment creation,
+  live payments, live Plural, provider calls, merchant private API calls,
+  production allowlists, cloud resources, deployments, production config,
+  routes, migrations, portal UI, workflows, or runtime behavior;
+- treats sandbox, demo, synthetic, fixture, dry-run, remediation, triage, or
+  rehearsal output as production approval.
+
+## Validation Plan
+
+C6Tb validation:
+
+```bash
+git diff --check origin/main...HEAD
+```
+
+Focused scans must cover:
+
+- secrets, credentials, tokens, private URLs, raw payloads, provider metadata,
+  real merchant details, production identifiers, and production config values;
+- production config, production allowlists, public discovery,
+  checkout/payment, live provider, live Plural, provider calls, and merchant
+  private API enablement;
+- NIST, NCCoE, certification, conformance, compliance, provider, public
+  guidance, public-comment, public publication, or live-payment overclaims;
+- real merchant names, private data, private URLs, provider credentials, raw
+  payloads, concrete allowlists, and production identifiers.
+
+## Rollback
+
+C6Tb is docs-only. Roll back by removing:
+
+- `docs/internal/commerce-v1/standards/nist-agentic-commerce-security-reference-architecture.md`;
+- `docs/internal/commerce-v1/commerce-v1-c6tb-nist-security-reference-architecture.md`.
+
+No cloud action, deployment action, secret rotation, migration, route removal,
+production configuration change, public discovery change, checkout/payment
+change, live-provider change, merchant private API change, production allowlist
+change, external submission, public publication, certification action, or
+NIST/NCCoE engagement action is required.

--- a/docs/internal/commerce-v1/standards/nist-agentic-commerce-security-reference-architecture.md
+++ b/docs/internal/commerce-v1/standards/nist-agentic-commerce-security-reference-architecture.md
@@ -1,0 +1,575 @@
+# Securing Agentic Commerce: Reference Architecture for Consent, Merchant Policy, Audit Evidence, and Payment Safety
+
+Status: internal draft-preparation artifact only.
+
+Created: 2026-06-09.
+
+This document is an internal NIST-aligned whitepaper skeleton. It has not been
+submitted to NIST, has not been accepted by NCCoE, is not NIST-approved, is not
+public guidance, and is not certification. It is not an IETF submission, public
+protocol publication, production approval, public discovery authorization,
+checkout/payment authorization, provider authorization, or live-payment
+authorization.
+
+This skeleton uses public-safe but internal language for security architecture
+review. Grantex and AgenticOrg appear only as non-normative implementation
+examples. This document does not define a Grantex-specific requirement,
+AgenticOrg-specific requirement, payment-provider requirement, production
+configuration, allowlist, credential, secret, merchant private API, live-payment
+behavior, or runtime enablement.
+
+## 1. Executive Summary
+
+Agentic commerce allows buyer agents and agent platforms to discover merchant
+capabilities, assist buyer decisions, request carts, initiate consent flows, and
+coordinate checkout-related actions. These workflows create useful automation,
+but they also introduce security and safety risks when agents can influence
+commerce actions across buyer, merchant, connector, provider, and operator
+boundaries.
+
+This internal skeleton outlines a NIST-aligned security reference architecture
+for agentic commerce. It focuses on consent, merchant policy, audit evidence,
+connector source governance, payment safety, refusal behavior, and rollback.
+The architecture is intended to help reviewers reason about control objectives,
+threats, evidence, residual risks, and production blockers before any external
+engagement or public publication is considered.
+
+The central security claim is:
+
+> A protected commerce action should advance only when buyer consent, scoped
+> authority, merchant policy, tenant boundary, source freshness, provider
+> boundary, and audit evidence controls all permit the action.
+
+This skeleton is not a product launch approval, standards claim, provider
+approval, or certification claim.
+
+## 2. Problem Statement
+
+Traditional ecommerce assumes that a buyer interacts directly with a merchant
+site, app, marketplace, or support channel. Agentic commerce adds software and
+AI agents that can read merchant capability data, interpret product content,
+assemble carts, request consent, or ask a merchant control plane to progress
+toward payment.
+
+Without explicit controls, an agentic commerce system can:
+
+- let a malicious or compromised agent exceed buyer intent;
+- treat product or connector content as trusted instructions;
+- expose stale price, catalog, inventory, delivery, refund, or support facts;
+- overexpose merchant capabilities through discovery profiles;
+- blur the boundary between agent-facing surfaces and merchant private systems;
+- bypass payment-provider controls;
+- leak tenant, merchant, buyer, credential, or private source data;
+- accept synthetic, demo, or sandbox evidence as production approval;
+- lack durable evidence for refusal, consent, policy, payment, and rollback
+  decisions.
+
+The architecture in this skeleton frames those risks as control objectives and
+assurance evidence rather than as protocol certification or public guidance.
+
+## 3. Scope and Assumptions
+
+This skeleton covers the security architecture for agent-mediated commerce
+where a merchant-authorized control plane mediates requests from buyer agents or
+agent platforms.
+
+In scope:
+
+- actor and asset inventory;
+- trust boundaries;
+- threat model;
+- control objectives;
+- NIST AI RMF mapping;
+- cybersecurity control themes;
+- agentic commerce safety controls;
+- payment safety and provider-boundary controls;
+- privacy and data minimization;
+- audit evidence and evidence retention;
+- incident response and rollback;
+- assurance evidence;
+- residual risks and blocked production gates;
+- NIST/NCCoE engagement planning.
+
+Out of scope:
+
+- NIST submission;
+- NCCoE acceptance or collaborator request;
+- IETF submission;
+- public protocol publication;
+- public guidance publication;
+- certification, conformance, or compliance claim;
+- production Commerce V1 enablement;
+- public discovery enablement;
+- checkout/payment creation enablement;
+- live payment enablement;
+- live Plural enablement;
+- payment-provider calls;
+- merchant private API calls;
+- production allowlists;
+- cloud resources, deployments, migrations, routes, workflows, configs, portal
+  UI, or runtime behavior.
+
+Assumptions:
+
+- merchants remain responsible for authorizing capability exposure and private
+  system access;
+- buyer consent is separate from agent authentication;
+- agent platforms do not become the merchant source of truth;
+- provider credentials and provider execution stay behind governed merchant
+  control-plane boundaries;
+- connector source data is mediated, freshness-checked, and governed by
+  source-of-truth precedence;
+- unsafe states fail closed with structured refusal behavior;
+- internal preview, sandbox, synthetic, dry-run, remediation, or rehearsal
+  evidence is not production approval.
+
+## 4. Reference Architecture
+
+The reference architecture separates buyer-facing, agent-facing,
+merchant-control, connector-source, provider, and audit/operator boundaries.
+Protected actions pass through consent, policy, source, provider, and evidence
+checks before they advance.
+
+```mermaid
+flowchart TB
+  buyer["Buyer"]
+  agent["Buyer agent"]
+  platform["Agent platform\n(AgenticOrg as non-normative example)"]
+  discovery["Capability and discovery view"]
+  control["Merchant control plane\n(Grantex as non-normative example)"]
+  consent["Consent and Commerce Passport verifier"]
+  policy["Merchant policy evaluator"]
+  connectors["Connector source governance"]
+  sources["Merchant-authorized source systems"]
+  provider["Payment provider boundary"]
+  evidence["Audit / evidence store"]
+  ops["Reviewer / operator"]
+
+  buyer --> agent
+  agent --> platform
+  platform --> discovery
+  platform --> control
+  control --> consent
+  control --> policy
+  control --> connectors
+  connectors --> sources
+  control --> provider
+  control --> evidence
+  ops --> control
+  ops --> evidence
+```
+
+Core design rules:
+
+- buyer agents request actions through governed merchant-control-plane
+  interfaces;
+- agent platforms do not directly call payment providers;
+- agent platforms do not directly call merchant private APIs;
+- public-safe discovery is not checkout/payment authorization;
+- cart, checkout, and payment-affecting actions require consent, policy,
+  scope, tenant, source, provider, idempotency, and audit checks;
+- audit and evidence stores receive redacted decision references rather than
+  secrets, credentials, raw private payloads, concrete production configuration
+  values, or concrete allowlist values.
+
+## 5. Actor and Asset Inventory
+
+| Actor or asset | Security role | Sensitive or governed assets |
+| --- | --- | --- |
+| Buyer | Source of buyer-specific authorization and revocation. | Consent decisions, identity binding, amount and scope limits. |
+| Buyer agent | Acts for the buyer within declared scope. | Session context, requested actions, refusal handling. |
+| Merchant | Owns capability exposure, readiness, policy, source-of-truth, and rollback. | Merchant identity, catalog, price, inventory, policy, approvals. |
+| Merchant control plane | Mediates agent-facing requests and protected commerce actions. | Policy decisions, consent verification, cart and payment references, audit references. |
+| AgenticOrg / agent platform | Hosts or mediates the buyer-agent experience as an implementation example. | Channel identity, session attribution, tool-call requests, refusal display. |
+| Connector sources | Supply merchant-authorized data or metadata. | Source health, source precedence, freshness, conflict state, import results. |
+| Payment provider | Performs payment-provider functions behind governed boundaries. | Provider references, checkout status, webhook events, reconciliation state. |
+| Reviewer/operator | Reviews blockers, evidence, incidents, and rollback state. | Readiness notes, review decisions, incident records, remediation actions. |
+| Audit/evidence store | Preserves durable redacted evidence for protected decisions. | Consent references, policy versions, event references, hashes, timestamps. |
+
+Grantex and AgenticOrg are examples of possible implementation experience only.
+They do not define mandatory NIST, NCCoE, protocol, provider, or ecosystem
+requirements in this skeleton.
+
+## 6. Trust Boundaries
+
+Buyer to buyer agent:
+
+: The agent may assist but does not replace buyer consent. Buyer intent should
+  be represented as scoped, revocable authority before protected actions.
+
+Buyer agent to agent platform:
+
+: The platform mediates requests and displays results. It should not silently
+  expand scope, suppress refusal, or treat prompt context as payment authority.
+
+Agent platform to merchant control plane:
+
+: The merchant control plane is the enforcement boundary for capabilities,
+  consent, policy, tenant scope, source state, provider boundary, and evidence.
+
+Merchant control plane to connector sources:
+
+: Connectors supply governed data or metadata. Agents should not directly
+  execute against private merchant source systems.
+
+Merchant control plane to payment provider:
+
+: Provider access occurs through governed provider-boundary controls. Provider
+  credentials, provider-specific payloads, and provider calls stay outside
+  agent systems.
+
+Merchant control plane to audit/evidence store:
+
+: Evidence should be durable, redacted, attributable, and reviewable. Protected
+  actions should not be acknowledged without the required evidence.
+
+Operator to control and evidence planes:
+
+: Operators can inspect, disable, roll back, and remediate. Operator review does
+  not imply public discovery approval, production approval, provider approval,
+  or live-payment approval.
+
+## 7. Threat Model
+
+| Threat | Risk scenario | Control objectives |
+| --- | --- | --- |
+| Malicious or compromised buyer agent | Agent attempts to buy outside buyer intent, manipulate scope, or suppress refusal. | Bind protected actions to scoped consent, agent identity, expiry, revocation, amount caps, and audit evidence. |
+| Prompt injection | Product, support, connector, or channel content instructs the agent to bypass rules. | Treat untrusted content as data, not instruction; require policy and provider-boundary checks outside the model context. |
+| Stale catalog, price, or inventory | Agent promises an unavailable item, wrong price, or unsupported delivery state. | Enforce freshness checks, source precedence, conflict handling, and refusal on stale or conflicting data. |
+| Overbroad consent | Buyer authorizes more action than intended or cannot revoke authority. | Use narrow scopes, merchant binding, amount caps, short expiry, revocation, and clear consent records. |
+| Cross-tenant data exposure | Data or authority from one tenant or merchant is visible to another. | Require tenant filtering, tenant-bound keys, tenant-bound audit, and negative tenant-boundary tests. |
+| Provider boundary bypass | Agent platform or buyer agent calls provider APIs or handles provider credentials. | Keep provider credentials and provider execution in merchant control plane; reject direct provider paths. |
+| Merchant private API exposure | Agent or agent platform directly calls ERP, PIM, storefront, OMS, support, or payment systems. | Mediate private systems through governed connectors and expose only public-safe or channel-safe views. |
+| Audit tampering | Protected action lacks durable evidence or evidence can be edited after the fact. | Use append-only evidence patterns, redacted references, immutable timestamps, and compensating events for corrections. |
+| Unsafe public discovery | Unapproved merchant, sandbox capability, or blocked channel appears discoverable. | Separate discovery readiness, approval, environment, and allowlist controls; fail closed when unclear. |
+| Synthetic or demo data treated as approval | Internal examples, fixtures, dry-runs, or demos are interpreted as production readiness. | Label synthetic/demo evidence clearly and require separate production gates, legal/provider approval, and rollback ownership. |
+
+## 8. Control Objectives
+
+1. Attribute each protected action to buyer, buyer agent, agent platform,
+   merchant, tenant, and policy context.
+2. Separate agent authentication from buyer consent.
+3. Require scoped, revocable, short-lived authority for protected actions.
+4. Enforce merchant policy before cart, checkout, payment, or private-state
+   progression.
+5. Preserve tenant and merchant isolation across every request and evidence
+   reference.
+6. Keep provider credentials and provider calls behind governed
+   merchant-control-plane boundaries.
+7. Keep merchant private APIs behind connector governance and source precedence.
+8. Minimize public-safe and buyer-facing data to the fields needed for the
+   action.
+9. Fail closed when source freshness, consent, policy, provider readiness,
+   environment, or audit evidence is missing.
+10. Emit durable, redacted evidence for protected decisions and refusals.
+11. Treat sandbox, synthetic, demo, dry-run, or remediation evidence as
+   assurance input only, not production approval.
+12. Maintain incident response, disablement, and rollback paths for capability,
+   connector, provider, and discovery mistakes.
+
+## 9. NIST AI RMF Mapping
+
+This mapping is an internal alignment aid. It is not NIST approval, NIST
+publication, NIST public-comment submission, NCCoE acceptance, certification,
+or compliance.
+
+| AI RMF function | Agentic commerce interpretation | Candidate evidence |
+| --- | --- | --- |
+| Govern | Define owners, responsibilities, policy authority, production gates, stop conditions, and review workflows. | Role inventory, policy owner records, launch blocker matrix, review decisions, rollback ownership. |
+| Map | Identify context, actors, assets, data flows, trust boundaries, source systems, provider paths, channels, and impacted users. | Architecture diagram, actor and asset inventory, trust-boundary analysis, data-flow notes, threat model. |
+| Measure | Evaluate controls, refusals, tenant boundaries, stale-state behavior, public-safe previews, secret exposure, and connector dry-runs. | C6O conformance results, refusal tests, tenant-boundary tests, secret/private scans, dry-run evidence, audit tests. |
+| Manage | Operate controls, respond to incidents, revoke authority, disable capabilities, roll back discovery, and track residual risks. | Runbooks, incident records, revocation evidence, emergency disable evidence, rollback rehearsal, residual risk register. |
+
+## 10. Cybersecurity Control Themes
+
+| Theme | Control expectation |
+| --- | --- |
+| Identity and access | Buyer, agent, merchant, tenant, platform, provider-boundary, and operator identities are attributable where relevant. |
+| Least privilege | Capabilities are constrained by merchant, channel, tenant, agent trust, product, amount, scope, environment, and expiry. |
+| Data minimization | Public-safe and buyer-facing views exclude private merchant artifacts, raw payloads, credentials, and production configuration values. |
+| Credential protection | Provider and connector credentials are not placed in docs, logs, fixtures, examples, agent systems, or public-safe outputs. |
+| Auditability | Protected actions and significant refusals produce durable redacted evidence with policy and consent references. |
+| Integrity | Cart, amount, currency, policy, consent, source freshness, and evidence references can be validated or compared. |
+| Resilience | Stale, unavailable, conflicting, or disabled sources fail closed with safe refusal and operator visibility. |
+| Incident response | Discovery, connector, provider, consent, audit, and cross-tenant mistakes have disablement, rollback, and review paths. |
+
+## 11. Agentic Commerce Safety Controls
+
+Grantex-only commerce facts:
+
+: In the Grantex/AgenticOrg implementation example, buyer-facing agent answers
+  and commerce actions should be based on Grantex-approved capability and
+  commerce facts, not invented channel state or direct source-system access.
+
+No AgenticOrg direct provider calls:
+
+: AgenticOrg is an implementation example of an agent platform and should not
+  hold payment-provider credentials or call payment providers directly.
+
+No AgenticOrg direct merchant private API calls:
+
+: Agent platforms should use governed merchant-control-plane tools or public-safe
+  capability views, not direct private merchant APIs.
+
+Consent, passport, policy, and audit for protected actions:
+
+: Protected actions should require consent/passport context, merchant policy,
+  scope checks, amount and currency checks, revocation handling, tenant
+  boundary checks, idempotency, and audit evidence.
+
+Public-safe preview boundaries:
+
+: Preview, discovery, and standards-adapter materials should not include real
+  merchant private artifacts, credentials, production identifiers, raw payloads,
+  concrete allowlists, or production configuration.
+
+Connector source governance:
+
+: Connector metadata should include source type, source health, freshness,
+  precedence, conflict state, dry-run evidence, and remediation state without
+  exposing private payloads to unauthorized agent surfaces.
+
+Refusal behavior:
+
+: Refusals should be first-class results with safe reason codes. Agents should
+  refuse or ask for review when consent, policy, freshness, source, provider,
+  tenant, environment, or evidence checks fail.
+
+## 12. Payment Safety and Provider-Boundary Controls
+
+Payment safety depends on keeping payment progression behind governed merchant
+control-plane checks.
+
+Candidate controls:
+
+- payment-affecting actions require buyer consent and merchant policy approval;
+- consent is scoped by merchant, capability, amount, currency, expiry, and
+  revocation state;
+- checkout/payment progression is blocked if catalog price, inventory, tax,
+  delivery, or source data is stale or conflicting;
+- idempotency keys prevent duplicate payment-affecting progression;
+- provider credentials are stored and used only within governed
+  merchant-control-plane boundaries;
+- agent platforms do not hold provider credentials;
+- agent platforms and buyer agents do not call provider APIs directly;
+- provider errors are normalized before reaching buyer-facing or agent-facing
+  surfaces;
+- provider-specific payloads and metadata are redacted from public-safe views;
+- provider outages, webhook failures, reconciliation gaps, and invalid state
+  transitions produce refusal, audit, and operator-visible evidence;
+- live payment and live provider paths remain blocked until separate legal,
+  provider, data-residency, operational, and rollback approvals exist.
+
+This skeleton does not enable checkout/payment creation, live payments, live
+Plural, direct payment-provider calls, or production Commerce V1 behavior.
+
+## 13. Privacy and Data Minimization
+
+Privacy controls should reduce collection, disclosure, and retention to the
+minimum needed for safe commerce decisions.
+
+Candidate practices:
+
+- separate public-safe merchant fields from private merchant artifacts;
+- avoid exposing raw connector payloads to buyers, public docs, or agent
+  platforms;
+- use redacted evidence references instead of private record disclosure;
+- avoid storing secrets, raw credentials, private URLs, or private payloads in
+  examples, logs, documentation, or public-safe previews;
+- bind buyer consent to a specific scope, merchant, amount, currency, expiry,
+  and revocation path;
+- keep channel identity binding proportionate to the action;
+- avoid cross-channel or cross-tenant tracking unless needed for security,
+  consent, support, or legal obligations;
+- define retention and deletion dependencies for consent records, audit
+  references, source evidence, and payment-related records;
+- restrict sensitive category data and regulated-offer details to authorized
+  surfaces.
+
+## 14. Audit Evidence and Evidence Retention
+
+Audit evidence should make protected actions and refusals reviewable without
+leaking private artifacts.
+
+Evidence should capture:
+
+- buyer, buyer-agent, merchant, tenant, and platform references where
+  appropriate;
+- consent/passport reference, scope, expiry, revocation state, and amount cap;
+- merchant policy version and decision reference;
+- cart, price, currency, source freshness, and source precedence references;
+- provider-boundary readiness or refusal state;
+- idempotency reference for payment-affecting actions;
+- refusal code and safe remediation guidance;
+- operator/reviewer decision references where used;
+- timestamps and correlation identifiers using synthetic or redacted values in
+  examples.
+
+Evidence should avoid:
+
+- secrets;
+- raw credentials;
+- provider credentials;
+- raw private connector payloads;
+- private URLs;
+- concrete production configuration values;
+- concrete allowlist values;
+- real merchant names or production identifiers in internal draft examples.
+
+Retention planning should identify which evidence is needed for buyer support,
+merchant support, incident response, legal review, provider dispute handling,
+security investigation, rollback, and deletion/export workflows.
+
+## 15. Incident Response and Rollback
+
+Incident response should assume mistakes can happen in discovery, consent,
+policy, connector, provider, evidence, tenant-boundary, or agent-channel
+behavior.
+
+Candidate incident scenarios:
+
+- unapproved merchant appears discoverable;
+- stale or conflicting source data reaches an agent-facing view;
+- consent scope is ambiguous or too broad;
+- policy blocks are not displayed clearly;
+- cross-tenant data exposure is suspected;
+- provider-boundary checks fail or are bypassed;
+- merchant private source data appears in an unauthorized surface;
+- audit evidence is missing or incomplete;
+- synthetic/demo data is mistaken for approval;
+- live mode, live provider, or public discovery appears enabled without
+  approval.
+
+Candidate response controls:
+
+- emergency disable for merchant, capability, channel, connector source, or
+  provider path;
+- revocation for consent/passport authority;
+- capability downgrade to read-only or blocked;
+- public discovery rollback;
+- connector source disablement or freshness quarantine;
+- refusal reason updates;
+- evidence export for review;
+- compensating audit events for corrections;
+- post-incident review with residual risk updates.
+
+## 16. Assurance Evidence
+
+Assurance evidence is internal evidence for readiness review. It is not
+certification, conformance, NIST approval, NCCoE acceptance, provider approval,
+or production approval.
+
+Expected evidence categories:
+
+- C6O conformance gate results for internal preview expectations;
+- refusal tests for denied consent, missing consent, stale inventory, disabled
+  merchant, disabled agent, amount cap breach, unsupported offer, and payment
+  status polling;
+- tenant-boundary tests for cross-tenant negative cases;
+- secret/private scans for docs, examples, fixtures, logs, and evidence
+  packets;
+- connector dry-run and remediation evidence for source health, freshness,
+  precedence, redaction, operator review, and blocked launch states;
+- audit tests showing protected actions and refusals emit durable evidence;
+- rollback rehearsal for discovery, connector, provider, and capability
+  exposure mistakes.
+
+## 17. Residual Risks and Blocked Production Gates
+
+Residual risks remain until separate evidence, approvals, and operational
+readiness exist.
+
+Blocked gates include:
+
+- NIST submission or NCCoE engagement without explicit approval;
+- public publication without public-safe review and approval;
+- certification or conformance claims without a reviewed external program and
+  evidence;
+- public discovery without merchant, legal, operator, source, and rollback
+  approval;
+- production Commerce V1 without release-gate evidence;
+- checkout/payment creation without consent, policy, idempotency, source,
+  provider-readiness, audit, and rollback evidence;
+- live payments and live Plural without legal, provider, data-residency,
+  webhook, outage, reconciliation, and rollback approval;
+- provider calls from agent platforms or buyer agents;
+- merchant private API calls from agent platforms or buyer agents;
+- concrete production allowlists or production configuration changes without
+  separate approval;
+- treating synthetic, sandbox, demo, fixture, dry-run, remediation, triage, or
+  rehearsal output as production approval.
+
+## 18. NIST/NCCoE Engagement Plan
+
+This plan is internal and preparatory. It is not a NIST submission, public
+comment submission, NCCoE acceptance, NIST approval, or public guidance.
+
+Candidate steps:
+
+1. Complete internal whitepaper skeleton and security-review pass.
+2. Remove or generalize implementation-specific details that are not
+   public-safe.
+3. Confirm no real merchant names, production identifiers, secrets, private
+   URLs, provider credentials, raw payloads, concrete allowlists, or production
+   config values are present.
+4. Map control objectives to NIST AI RMF functions and selected cybersecurity
+   control themes.
+5. Prepare a generalized project-description concept for possible external
+   collaboration.
+6. Identify possible collaborator categories only after public-safe scope
+   approval.
+7. Seek legal, security, product, provider, and executive review before any
+   external engagement.
+
+## 19. Open Questions for External Collaboration
+
+- Which agentic commerce risk scenarios are common across merchant platforms,
+  agent platforms, providers, and marketplaces?
+- What minimum evidence should a merchant control plane retain for protected
+  agent-mediated actions?
+- How should public-safe discovery distinguish read-only browsing from
+  checkout/payment authorization?
+- What refusal code families are useful across agent platforms without leaking
+  private merchant policy?
+- How should connector source freshness and source precedence be represented in
+  public-safe capability views?
+- What provider-boundary evidence is useful without exposing provider
+  credentials or private payloads?
+- What assurance evidence should be required before pilot, production, and live
+  payment stages?
+- Which aspects are best handled by voluntary security guidance rather than
+  protocol specifications?
+
+## 20. References Placeholder
+
+References are placeholders for later public-safe review.
+
+- NIST AI Risk Management Framework.
+- NIST Cybersecurity Framework.
+- NIST Privacy Framework.
+- NCCoE project-description and practice-guide process references.
+- Secure software development and incident response references.
+- Agentic commerce trust architecture draft skeleton.
+- Public-safe commerce metadata references, if cleared.
+- Public-safe capability profile references, if cleared.
+- Public-safe checkout-shape references, if cleared.
+- Public-safe evidence references, if cleared.
+
+## Appendix A. Internal Draft-Preparation Checklist
+
+- Status says internal draft only.
+- Status says not submitted to NIST.
+- Status says not accepted by NCCoE.
+- Status says not NIST-approved.
+- Status says not public guidance.
+- Status says not certification.
+- Grantex and AgenticOrg appear only as non-normative implementation examples.
+- No real merchant names, production identifiers, secrets, private URLs,
+  provider credentials, raw payloads, concrete allowlists, or production config
+  values are included.
+- No route, migration, portal UI, workflow, config, test, runtime behavior,
+  cloud resource, deployment, public discovery, checkout/payment creation, live
+  payment, provider call, merchant private API call, or production allowlist is
+  added by this document.
+- External submission or public publication requires separate explicit
+  authorization.


### PR DESCRIPTION
## Summary

- Adds the first internal NIST-aligned Agentic Commerce security reference architecture skeleton.
- Adds the C6Tb implementation note with source traceability, threat model summary, AI RMF/control mapping summary, stop conditions, validation plan, and rollback note.

## Safety posture

Docs-only and internal draft-preparation only. This is not submitted to NIST, not accepted by NCCoE, not NIST-approved, not public guidance, not an IETF submission, not public protocol publication, not certification, not conformance, not production authorization, not public discovery authorization, not checkout/payment authorization, not provider authorization, and not live-payment authorization.

No deploy, cloud command, production config, secrets, public discovery, production Commerce V1, checkout/payment creation, live payments, live Plural, provider calls, merchant private API calls, production allowlists, runtime behavior, or certification claims are added.

## Validation

- `git diff --check origin/main...HEAD`: passed
- focused secret/private-detail scan: no unsafe findings; broad hits are negative guardrails and stop conditions
- focused production config / allowlist / public discovery / checkout-payment / live-provider scan: no unsafe findings; broad hits are negative guardrails and stop conditions
- focused NIST/NCCoE/certification overclaim scan: no unsafe positive claims; broad hits are internal-only status and stop-condition language
- focused real merchant/private-data scan: no real merchant/private data; broad hits are negative live-Plural/provider guardrails only