### PR TITLE
docs(commerce): add public-safe standards example corpus

### DIFF
--- a/docs/internal/commerce-v1/commerce-v1-c6tc-public-safe-example-corpus.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6tc-public-safe-example-corpus.md
@@ -1,0 +1,205 @@
+# Commerce V1 C6Tc - Public-Safe Standards Example Corpus
+
+Status: internal draft-preparation note only.
+
+Created: 2026-06-09.
+
+C6Tc creates an internal public-safe example corpus for future Agentic Commerce
+IETF and NIST draft preparation. The examples are generic, synthetic,
+non-live, non-enabling, and stripped of private implementation identifiers,
+real merchant data, provider details, production configuration, and
+certification claims.
+
+This package is not an IETF submission, not a NIST submission, not public
+protocol publication, not public guidance, not certification, not conformance,
+not compliance, not production authorization, not public discovery
+authorization, not checkout/payment authorization, not provider authorization,
+and not live-payment authorization.
+
+This package does not deploy, merge, create cloud resources, change production
+configuration, touch secrets, enable public discovery, enable production
+Commerce V1, enable checkout or payment creation, enable live payments, enable
+live Plural, call payment providers, call merchant private APIs, set production
+allowlists, or claim certification.
+
+## Scope
+
+C6Tc adds a docs-only and fixture-only corpus under:
+
+- `docs/internal/commerce-v1/standards/examples/`;
+- `docs/internal/commerce-v1/commerce-v1-c6tc-public-safe-example-corpus.md`.
+
+No runtime files, routes, migrations, portal UI, workflows, jobs, provider
+adapters, production configuration, cloud resources, public documentation
+publication, public discovery settings, checkout/payment behavior,
+live-provider behavior, merchant private API behavior, production allowlists, or
+external submissions are added.
+
+## Why Public-Safe Examples Are Needed
+
+The C6T standards-preparation plan identified a gap: future IETF and NIST
+drafts need examples that explain agentic commerce concepts without carrying
+private implementation state. Internal preview fixtures are useful evidence,
+but they may contain product-specific names, repo-specific states, or
+implementation labels that should not become public draft examples.
+
+C6Tc provides a small sanitized corpus that reviewers can use to reason about:
+
+- read-only discovery success;
+- checkout/payment refusal;
+- capability profiles;
+- consent and evidence envelopes;
+- connector source metadata and source precedence;
+- schema.org-style public-safe product and offer previews;
+- ACP-style blocked checkout shapes;
+- AP2-style unsigned evidence previews.
+
+These examples are for internal draft preparation only. Future public use
+requires separate public-safe review, legal review, security review, and
+explicit approval to submit or publish.
+
+## Public-Safe Transformation Rules
+
+The corpus is derived from internal preview fixture concepts, not copied from
+private payloads. C6Tc applies these transformations:
+
+| Source concern | Public-safe transformation |
+| --- | --- |
+| Real merchant data | Replaced with `Example Home Goods Merchant`. |
+| Private merchant, tenant, product, session, payment, and evidence IDs | Replaced with synthetic IDs such as `mer_example_home_001`, `item_example_lamp_001`, `variant_example_lamp_warm_001`, `buyer_session_example_001`, and `evidence_example_001`. |
+| Provider-specific status or metadata | Replaced with generic provider-boundary refusal or not-invoked states. |
+| Private connector payloads | Replaced with source health, freshness, precedence, and redaction summaries only. |
+| Production config and allowlists | Omitted; every example marks production approval and public discovery as false. |
+| Certification or approval language | Omitted; every example uses empty `certification_claims`. |
+| Checkout/payment behavior | Represented only as blocked or not enabled. |
+| Live provider behavior | Represented only as disabled or not invoked. |
+
+## Required Example Markers
+
+Every JSON example includes:
+
+- `internal_example_only: true`;
+- `synthetic_data: true`;
+- `public_submission_status: "not_submitted"`;
+- `certification_claims: []`;
+- `production_approval: false`;
+- `public_discovery_enabled: false`;
+- `checkout_payment_enabled: false`;
+- `live_provider_enabled: false`.
+
+The manifest also repeats these markers as global corpus controls.
+
+## Corpus Inventory
+
+| File | Purpose |
+| --- | --- |
+| `agentic-commerce-example-corpus.manifest.json` | Indexes corpus controls, files, scenarios, and required refusal coverage. |
+| `buyer-session.discovery.available.json` | Shows internal read-only discovery success without public discovery or checkout enablement. |
+| `buyer-session.checkout-refused.json` | Shows checkout/payment refusal with required refusal reasons. |
+| `capability-profile.read-only.json` | Shows a read-only capability profile with browse-only state. |
+| `capability-profile.blocked.json` | Shows blocked discovery and checkout capability state. |
+| `evidence-envelope.consent-preview.json` | Shows a redacted consent/evidence preview without tokens, credentials, raw payloads, or provider metadata. |
+| `connector-source-metadata.dry-run.json` | Shows connector source metadata, freshness, dry-run, and source precedence without private source payloads. |
+| `schemaorg-product-offer.preview.json` | Shows schema.org-style public-safe product/offer preview fields without publication. |
+| `acp-style-checkout-shape.blocked.json` | Shows ACP-style checkout shape mapping with checkout blocked. |
+| `ap2-style-evidence.unsigned-preview.json` | Shows AP2-style unsigned evidence preview with no mandate, token, provider call, or payment enablement. |
+
+## Refusal Coverage
+
+The corpus includes blocked/refusal examples for:
+
+- `consent_required`;
+- `public_discovery_disabled`;
+- `checkout_not_enabled`;
+- `live_payment_not_enabled`;
+- `merchant_private_api_not_allowed`;
+- `provider_call_not_allowed`;
+- `stale_inventory`.
+
+Refusal details are safe for draft review and do not expose private merchant
+policy, provider metadata, private URLs, credentials, raw payloads, production
+configuration, or concrete allowlists.
+
+## Future IETF and NIST Use
+
+Future IETF or NIST drafts may reference this corpus only after:
+
+1. public-safe review confirms no private implementation details remain;
+2. legal review confirms the examples can be reused externally;
+3. security review confirms no sensitive identifiers, secrets, raw payloads, or
+   production configuration are present;
+4. product review confirms the examples do not imply production approval,
+   certification, conformance, compliance, provider approval, or live-payment
+   readiness;
+5. separate explicit approval authorizes external submission or publication.
+
+C6Tc itself does not grant any of those approvals.
+
+## Stop Conditions
+
+Stop and require a new explicitly authorized work item if any follow-up:
+
+- submits material to IETF;
+- submits material to NIST;
+- submits a NIST public comment, project description, collaborator request, or
+  NCCoE package;
+- publishes public protocol materials or public guidance;
+- claims IETF submission, RFC status, NIST approval, NCCoE acceptance, UCP
+  certification, ACP certification, AP2 certification, schema.org
+  certification, MPP approval, A2A approval, provider certification,
+  conformance, compliance, or live-payment certification;
+- includes real merchant names, real addresses, real phone numbers, real
+  emails, PAN, GST, tax IDs, production IDs, provider credentials, tokens,
+  JWTs, passports, idempotency keys, webhook secrets, DB/Redis URLs, private
+  keys, raw payload dumps, production config values, concrete allowlists, real
+  provider references, or platform-private tenant/merchant IDs;
+- enables public discovery, production Commerce V1, checkout/payment creation,
+  live payments, live Plural, provider calls, merchant private API calls, cloud
+  resources, production config, routes, migrations, portal UI, workflows, or
+  production allowlists;
+- treats synthetic, sandbox, preview, dry-run, remediation, triage, or rehearsal
+  output as production approval.
+
+## Validation
+
+C6Tc validation must include:
+
+```bash
+git diff --check origin/main...HEAD
+```
+
+Every JSON example must parse. Focused scans must cover:
+
+- secrets, credentials, tokens, private URLs, raw payloads, provider metadata,
+  real merchant details, production identifiers, and production config values;
+- production config, production allowlists, public discovery,
+  checkout/payment, live provider, live Plural, provider calls, and merchant
+  private API enablement;
+- IETF, NIST, RFC, NCCoE, certification, conformance, compliance, provider,
+  public guidance, public-comment, public publication, or live-payment
+  overclaims;
+- real merchant names, private data, private URLs, provider credentials, raw
+  payloads, concrete allowlists, and production identifiers;
+- Grantex-private IDs and provider-specific references.
+
+## Rollback
+
+C6Tc is docs/fixture-only. Roll back by removing:
+
+- `docs/internal/commerce-v1/commerce-v1-c6tc-public-safe-example-corpus.md`;
+- `docs/internal/commerce-v1/standards/examples/agentic-commerce-example-corpus.manifest.json`;
+- `docs/internal/commerce-v1/standards/examples/buyer-session.discovery.available.json`;
+- `docs/internal/commerce-v1/standards/examples/buyer-session.checkout-refused.json`;
+- `docs/internal/commerce-v1/standards/examples/capability-profile.read-only.json`;
+- `docs/internal/commerce-v1/standards/examples/capability-profile.blocked.json`;
+- `docs/internal/commerce-v1/standards/examples/evidence-envelope.consent-preview.json`;
+- `docs/internal/commerce-v1/standards/examples/connector-source-metadata.dry-run.json`;
+- `docs/internal/commerce-v1/standards/examples/schemaorg-product-offer.preview.json`;
+- `docs/internal/commerce-v1/standards/examples/acp-style-checkout-shape.blocked.json`;
+- `docs/internal/commerce-v1/standards/examples/ap2-style-evidence.unsigned-preview.json`.
+
+No cloud action, deployment action, secret rotation, migration, route removal,
+production configuration change, public discovery change, checkout/payment
+change, live-provider change, merchant private API change, production allowlist
+change, external submission, public publication, certification action, or
+NIST/NCCoE engagement action is required.

--- a/docs/internal/commerce-v1/standards/draft-mishra-agentic-commerce-trust-architecture-00.md
+++ b/docs/internal/commerce-v1/standards/draft-mishra-agentic-commerce-trust-architecture-00.md
@@ -589,6 +589,8 @@ References are placeholders for later public-safe review.
   citation.
 - AP2-style evidence references, if public-safe and cleared for citation.
 - MCP/native API references, if public-safe and cleared for citation.
+- C6Tc public-safe example corpus references, if legal/security review clears
+  them for future external draft use.
 
 ## Appendix A. Internal Draft-Preparation Checklist
 

--- a/docs/internal/commerce-v1/standards/examples/acp-style-checkout-shape.blocked.json
+++ b/docs/internal/commerce-v1/standards/examples/acp-style-checkout-shape.blocked.json
@@ -1,0 +1,48 @@
+{
+  "example_id": "acp_checkout_shape_example_blocked_001",
+  "example_kind": "acp_style_checkout_shape",
+  "scenario": "blocked_checkout",
+  "status": "internal_example_only",
+  "internal_example_only": true,
+  "synthetic_data": true,
+  "public_submission_status": "not_submitted",
+  "certification_claims": [],
+  "production_approval": false,
+  "public_discovery_enabled": false,
+  "checkout_payment_enabled": false,
+  "live_provider_enabled": false,
+  "checkout_shape": {
+    "checkout_reference": "checkout_example_blocked_001",
+    "merchant_reference": "mer_example_home_001",
+    "buyer_session_reference": "buyer_session_example_001",
+    "line_items": [
+      {
+        "item_id": "item_example_lamp_001",
+        "variant_id": "variant_example_lamp_warm_001",
+        "quantity": 1,
+        "inventory_state": "stale"
+      }
+    ],
+    "cart_total": {
+      "amount": "49.00",
+      "currency": "USD"
+    },
+    "checkout_state": "blocked",
+    "payment_state": "not_created"
+  },
+  "refusal": {
+    "reason_codes": [
+      "consent_required",
+      "checkout_not_enabled",
+      "stale_inventory",
+      "live_payment_not_enabled"
+    ],
+    "safe_message": "Checkout is blocked in this synthetic internal example."
+  },
+  "blocked_controls": {
+    "checkout_creation_enabled": false,
+    "payment_creation_enabled": false,
+    "provider_call_enabled": false,
+    "live_payment_enabled": false
+  }
+}

--- a/docs/internal/commerce-v1/standards/examples/agentic-commerce-example-corpus.manifest.json
+++ b/docs/internal/commerce-v1/standards/examples/agentic-commerce-example-corpus.manifest.json
@@ -1,0 +1,138 @@
+{
+  "manifest_kind": "agentic_commerce_public_safe_example_corpus_manifest",
+  "manifest_version": "c6tc-public-safe-1",
+  "created_at": "2026-06-09T00:00:00.000Z",
+  "status": "internal_draft_preparation_only",
+  "internal_example_only": true,
+  "synthetic_data": true,
+  "public_submission_status": "not_submitted",
+  "certification_claims": [],
+  "production_approval": false,
+  "public_discovery_enabled": false,
+  "checkout_payment_enabled": false,
+  "live_provider_enabled": false,
+  "non_live": true,
+  "non_enabling": true,
+  "non_publication": true,
+  "non_certifying": true,
+  "global_controls": {
+    "ietf_submission": false,
+    "nist_submission": false,
+    "nccoe_acceptance": false,
+    "public_protocol_publication": false,
+    "public_guidance_publication": false,
+    "production_commerce_v1_enabled": false,
+    "checkout_payment_creation_enabled": false,
+    "live_payment_enabled": false,
+    "live_plural_enabled": false,
+    "provider_call_enabled": false,
+    "merchant_private_api_call_enabled": false,
+    "production_allowlists_set": false,
+    "cloud_resources_created": false,
+    "production_config_changed": false,
+    "secrets_included": false,
+    "credentials_included": false,
+    "raw_payloads_included": false,
+    "real_provider_references_included": false,
+    "real_merchant_data_included": false
+  },
+  "synthetic_identifiers": {
+    "merchant_id": "mer_example_home_001",
+    "merchant_name": "Example Home Goods Merchant",
+    "item_id": "item_example_lamp_001",
+    "variant_id": "variant_example_lamp_warm_001",
+    "buyer_session_id": "buyer_session_example_001",
+    "evidence_id": "evidence_example_001",
+    "connector_source_id": "source_example_catalog_001",
+    "policy_id": "policy_example_v1"
+  },
+  "examples": [
+    {
+      "path": "buyer-session.discovery.available.json",
+      "surface": "buyer_session",
+      "scenario": "read_only_discovery_success"
+    },
+    {
+      "path": "buyer-session.checkout-refused.json",
+      "surface": "buyer_session",
+      "scenario": "checkout_payment_refused"
+    },
+    {
+      "path": "capability-profile.read-only.json",
+      "surface": "capability_profile",
+      "scenario": "read_only"
+    },
+    {
+      "path": "capability-profile.blocked.json",
+      "surface": "capability_profile",
+      "scenario": "blocked"
+    },
+    {
+      "path": "evidence-envelope.consent-preview.json",
+      "surface": "evidence_envelope",
+      "scenario": "consent_preview"
+    },
+    {
+      "path": "connector-source-metadata.dry-run.json",
+      "surface": "connector_source_metadata",
+      "scenario": "dry_run_source_precedence"
+    },
+    {
+      "path": "schemaorg-product-offer.preview.json",
+      "surface": "schemaorg_style_product_offer_preview",
+      "scenario": "public_safe_preview"
+    },
+    {
+      "path": "acp-style-checkout-shape.blocked.json",
+      "surface": "acp_style_checkout_shape",
+      "scenario": "blocked_checkout"
+    },
+    {
+      "path": "ap2-style-evidence.unsigned-preview.json",
+      "surface": "ap2_style_evidence_preview",
+      "scenario": "unsigned_preview"
+    }
+  ],
+  "required_refusal_codes_covered": [
+    "consent_required",
+    "public_discovery_disabled",
+    "checkout_not_enabled",
+    "live_payment_not_enabled",
+    "merchant_private_api_not_allowed",
+    "provider_call_not_allowed",
+    "stale_inventory"
+  ],
+  "forbidden_content": [
+    "real_merchant_names",
+    "real_addresses",
+    "real_phone_numbers",
+    "real_emails",
+    "pan_gst_or_tax_ids",
+    "provider_credentials",
+    "tokens_jwts_or_passports",
+    "idempotency_keys",
+    "webhook_secrets",
+    "db_or_redis_urls",
+    "private_keys",
+    "raw_payload_dumps",
+    "production_config_values",
+    "concrete_allowlist_values",
+    "real_provider_references",
+    "real_platform_tenant_or_merchant_ids"
+  ],
+  "stop_conditions": [
+    "external_submission",
+    "public_protocol_publication",
+    "public_guidance_publication",
+    "certification_claim_added",
+    "conformance_or_compliance_claim_added",
+    "real_merchant_or_private_data_added",
+    "provider_specific_reference_added",
+    "production_config_or_allowlist_added",
+    "public_discovery_enablement",
+    "checkout_payment_enablement",
+    "live_payment_enablement",
+    "provider_call_enablement",
+    "merchant_private_api_call_enablement"
+  ]
+}

--- a/docs/internal/commerce-v1/standards/examples/ap2-style-evidence.unsigned-preview.json
+++ b/docs/internal/commerce-v1/standards/examples/ap2-style-evidence.unsigned-preview.json
@@ -1,0 +1,42 @@
+{
+  "example_id": "ap2_evidence_example_unsigned_001",
+  "example_kind": "ap2_style_evidence_preview",
+  "scenario": "unsigned_preview",
+  "status": "internal_example_only",
+  "internal_example_only": true,
+  "synthetic_data": true,
+  "public_submission_status": "not_submitted",
+  "certification_claims": [],
+  "production_approval": false,
+  "public_discovery_enabled": false,
+  "checkout_payment_enabled": false,
+  "live_provider_enabled": false,
+  "evidence_preview": {
+    "evidence_reference": "evidence_example_001",
+    "merchant_reference": "mer_example_home_001",
+    "buyer_reference": "buyer_example_001",
+    "buyer_agent_reference": "agent_example_home_001",
+    "requested_action": "payment_authority_preview",
+    "consent_state": "not_granted",
+    "policy_reference": "policy_example_v1",
+    "amount_limit": {
+      "amount": "50.00",
+      "currency": "USD"
+    },
+    "signature_state": "unsigned_internal_preview",
+    "provider_state": "not_invoked",
+    "payment_state": "not_created"
+  },
+  "blocked_reasons": [
+    "consent_required",
+    "provider_call_not_allowed",
+    "live_payment_not_enabled"
+  ],
+  "redaction": {
+    "token_material_included": false,
+    "private_key_material_included": false,
+    "provider_credentials_included": false,
+    "raw_payment_payload_included": false,
+    "real_provider_reference_included": false
+  }
+}

--- a/docs/internal/commerce-v1/standards/examples/buyer-session.checkout-refused.json
+++ b/docs/internal/commerce-v1/standards/examples/buyer-session.checkout-refused.json
@@ -1,0 +1,61 @@
+{
+  "example_id": "buyer_session_example_checkout_refused_001",
+  "example_kind": "buyer_session",
+  "scenario": "checkout_payment_refused",
+  "status": "internal_example_only",
+  "internal_example_only": true,
+  "synthetic_data": true,
+  "public_submission_status": "not_submitted",
+  "certification_claims": [],
+  "production_approval": false,
+  "public_discovery_enabled": false,
+  "checkout_payment_enabled": false,
+  "live_provider_enabled": false,
+  "merchant": {
+    "merchant_id": "mer_example_home_001",
+    "display_name": "Example Home Goods Merchant",
+    "environment": "internal_preview"
+  },
+  "buyer_session": {
+    "buyer_session_id": "buyer_session_example_001",
+    "buyer_agent_id": "agent_example_home_001",
+    "agent_platform_id": "platform_example_001",
+    "requested_capability": "checkout.payment.request",
+    "authority_state": "not_authorized_for_payment"
+  },
+  "requested_item": {
+    "item_id": "item_example_lamp_001",
+    "variant_id": "variant_example_lamp_warm_001",
+    "quantity": 1,
+    "inventory_freshness": "stale"
+  },
+  "refusal": {
+    "result_state": "refused",
+    "primary_reason": "consent_required",
+    "safe_buyer_message": "This request cannot continue because checkout and payment are not enabled for this internal example.",
+    "operator_safe_detail": "Synthetic example only; no provider call, private merchant API call, live payment, or public discovery action is permitted.",
+    "reason_codes": [
+      "consent_required",
+      "checkout_not_enabled",
+      "live_payment_not_enabled",
+      "merchant_private_api_not_allowed",
+      "provider_call_not_allowed",
+      "stale_inventory"
+    ]
+  },
+  "blocked_actions": {
+    "checkout_create": true,
+    "payment_create": true,
+    "live_payment": true,
+    "provider_call": true,
+    "merchant_private_api_call": true
+  },
+  "redaction": {
+    "tokens_included": false,
+    "jwts_included": false,
+    "passports_included": false,
+    "idempotency_keys_included": false,
+    "provider_references_included": false,
+    "raw_payloads_included": false
+  }
+}

--- a/docs/internal/commerce-v1/standards/examples/buyer-session.discovery.available.json
+++ b/docs/internal/commerce-v1/standards/examples/buyer-session.discovery.available.json
@@ -1,0 +1,61 @@
+{
+  "example_id": "buyer_session_example_001",
+  "example_kind": "buyer_session",
+  "scenario": "read_only_discovery_success",
+  "status": "internal_example_only",
+  "internal_example_only": true,
+  "synthetic_data": true,
+  "public_submission_status": "not_submitted",
+  "certification_claims": [],
+  "production_approval": false,
+  "public_discovery_enabled": false,
+  "checkout_payment_enabled": false,
+  "live_provider_enabled": false,
+  "merchant": {
+    "merchant_id": "mer_example_home_001",
+    "display_name": "Example Home Goods Merchant",
+    "merchant_category": "home_goods",
+    "environment": "internal_preview"
+  },
+  "buyer_session": {
+    "buyer_session_id": "buyer_session_example_001",
+    "buyer_agent_id": "agent_example_home_001",
+    "agent_platform_id": "platform_example_001",
+    "channel": "internal_review_channel",
+    "requested_capability": "catalog.discovery.read",
+    "authority_state": "read_only"
+  },
+  "discovery_result": {
+    "result_state": "available_for_internal_read_only_preview",
+    "public_safe_fields_only": true,
+    "items": [
+      {
+        "item_id": "item_example_lamp_001",
+        "title": "Example Table Lamp",
+        "variant_id": "variant_example_lamp_warm_001",
+        "availability": "available_for_preview",
+        "inventory_freshness": "fresh_for_internal_preview",
+        "price": {
+          "amount": "49.00",
+          "currency": "USD",
+          "tax_identifier_included": false
+        }
+      }
+    ]
+  },
+  "blocked_actions": [
+    "checkout.create",
+    "payment.create",
+    "provider.call",
+    "merchant_private_api.call",
+    "public_discovery.publish"
+  ],
+  "redaction": {
+    "real_merchant_data_included": false,
+    "private_urls_included": false,
+    "provider_credentials_included": false,
+    "raw_payloads_included": false,
+    "production_config_values_included": false,
+    "concrete_allowlists_included": false
+  }
+}

--- a/docs/internal/commerce-v1/standards/examples/capability-profile.blocked.json
+++ b/docs/internal/commerce-v1/standards/examples/capability-profile.blocked.json
@@ -1,0 +1,53 @@
+{
+  "example_id": "capability_profile_example_blocked_001",
+  "example_kind": "capability_profile",
+  "scenario": "blocked",
+  "status": "internal_example_only",
+  "internal_example_only": true,
+  "synthetic_data": true,
+  "public_submission_status": "not_submitted",
+  "certification_claims": [],
+  "production_approval": false,
+  "public_discovery_enabled": false,
+  "checkout_payment_enabled": false,
+  "live_provider_enabled": false,
+  "merchant": {
+    "merchant_id": "mer_example_home_001",
+    "display_name": "Example Home Goods Merchant",
+    "environment": "internal_preview"
+  },
+  "profile_state": "blocked",
+  "blocked_capabilities": [
+    {
+      "capability": "public_discovery.publish",
+      "reason_code": "public_discovery_disabled"
+    },
+    {
+      "capability": "checkout.create",
+      "reason_code": "checkout_not_enabled"
+    },
+    {
+      "capability": "payment.create",
+      "reason_code": "live_payment_not_enabled"
+    },
+    {
+      "capability": "merchant_private_api.call",
+      "reason_code": "merchant_private_api_not_allowed"
+    },
+    {
+      "capability": "provider.call",
+      "reason_code": "provider_call_not_allowed"
+    }
+  ],
+  "safe_remediation": [
+    "keep_profile_internal",
+    "complete_public_safe_review_before_external_use",
+    "do_not_treat_synthetic_example_as_production_approval"
+  ],
+  "redaction": {
+    "private_policy_details_included": false,
+    "private_source_details_included": false,
+    "provider_metadata_included": false,
+    "production_allowlist_values_included": false
+  }
+}

--- a/docs/internal/commerce-v1/standards/examples/capability-profile.read-only.json
+++ b/docs/internal/commerce-v1/standards/examples/capability-profile.read-only.json
@@ -1,0 +1,58 @@
+{
+  "example_id": "capability_profile_example_read_only_001",
+  "example_kind": "capability_profile",
+  "scenario": "read_only",
+  "status": "internal_example_only",
+  "internal_example_only": true,
+  "synthetic_data": true,
+  "public_submission_status": "not_submitted",
+  "certification_claims": [],
+  "production_approval": false,
+  "public_discovery_enabled": false,
+  "checkout_payment_enabled": false,
+  "live_provider_enabled": false,
+  "merchant": {
+    "merchant_id": "mer_example_home_001",
+    "display_name": "Example Home Goods Merchant",
+    "environment": "internal_preview"
+  },
+  "capabilities": [
+    {
+      "capability": "merchant.profile.read",
+      "state": "available_for_internal_preview",
+      "requires_consent": false
+    },
+    {
+      "capability": "catalog.search.read",
+      "state": "available_for_internal_preview",
+      "requires_consent": false
+    },
+    {
+      "capability": "inventory.status.read",
+      "state": "available_for_internal_preview",
+      "requires_consent": false
+    },
+    {
+      "capability": "checkout.create",
+      "state": "blocked",
+      "requires_consent": true,
+      "refusal_code": "checkout_not_enabled"
+    },
+    {
+      "capability": "payment.create",
+      "state": "blocked",
+      "requires_consent": true,
+      "refusal_code": "live_payment_not_enabled"
+    }
+  ],
+  "source_constraints": {
+    "source_precedence_required": true,
+    "fresh_inventory_required": true,
+    "private_source_payloads_exposed": false
+  },
+  "publication_controls": {
+    "public_protocol_publication": false,
+    "public_guidance_publication": false,
+    "external_submission": false
+  }
+}

--- a/docs/internal/commerce-v1/standards/examples/connector-source-metadata.dry-run.json
+++ b/docs/internal/commerce-v1/standards/examples/connector-source-metadata.dry-run.json
@@ -1,0 +1,44 @@
+{
+  "example_id": "connector_source_example_001",
+  "example_kind": "connector_source_metadata",
+  "scenario": "dry_run_source_precedence",
+  "status": "internal_example_only",
+  "internal_example_only": true,
+  "synthetic_data": true,
+  "public_submission_status": "not_submitted",
+  "certification_claims": [],
+  "production_approval": false,
+  "public_discovery_enabled": false,
+  "checkout_payment_enabled": false,
+  "live_provider_enabled": false,
+  "merchant": {
+    "merchant_id": "mer_example_home_001",
+    "display_name": "Example Home Goods Merchant"
+  },
+  "connector_source": {
+    "source_id": "source_example_catalog_001",
+    "source_kind": "generic_catalog_source",
+    "source_mode": "dry_run_only",
+    "source_precedence": 10,
+    "source_of_truth_for": [
+      "catalog_title",
+      "price",
+      "inventory_status"
+    ],
+    "last_dry_run_result": "blocked_due_to_stale_inventory",
+    "private_payloads_exposed": false,
+    "credentials_included": false,
+    "outbound_sync_enabled": false
+  },
+  "item_state": {
+    "item_id": "item_example_lamp_001",
+    "variant_id": "variant_example_lamp_warm_001",
+    "inventory_state": "stale",
+    "refusal_code": "stale_inventory"
+  },
+  "operator_summary": {
+    "safe_detail": "Synthetic dry-run metadata only; no private source payload or merchant private API call is included.",
+    "merchant_private_api_call_enabled": false,
+    "provider_call_enabled": false
+  }
+}

--- a/docs/internal/commerce-v1/standards/examples/evidence-envelope.consent-preview.json
+++ b/docs/internal/commerce-v1/standards/examples/evidence-envelope.consent-preview.json
@@ -1,0 +1,45 @@
+{
+  "example_id": "evidence_example_001",
+  "example_kind": "evidence_envelope",
+  "scenario": "consent_preview",
+  "status": "internal_example_only",
+  "internal_example_only": true,
+  "synthetic_data": true,
+  "public_submission_status": "not_submitted",
+  "certification_claims": [],
+  "production_approval": false,
+  "public_discovery_enabled": false,
+  "checkout_payment_enabled": false,
+  "live_provider_enabled": false,
+  "evidence_envelope": {
+    "evidence_id": "evidence_example_001",
+    "evidence_type": "consent_and_policy_preview",
+    "buyer_reference": "buyer_example_001",
+    "buyer_agent_reference": "agent_example_home_001",
+    "merchant_reference": "mer_example_home_001",
+    "policy_reference": "policy_example_v1",
+    "requested_capability": "checkout.payment.request",
+    "consent_state": "required_not_granted",
+    "policy_decision": "requires_user_consent",
+    "amount_cap": {
+      "amount": "50.00",
+      "currency": "USD"
+    },
+    "action_result": "blocked"
+  },
+  "redaction": {
+    "tokens_included": false,
+    "jwts_included": false,
+    "passports_included": false,
+    "credentials_included": false,
+    "raw_payloads_included": false,
+    "private_urls_included": false,
+    "provider_metadata_included": false,
+    "production_config_values_included": false
+  },
+  "signature_state": "unsigned_internal_preview",
+  "safe_reason_codes": [
+    "consent_required",
+    "checkout_not_enabled"
+  ]
+}

--- a/docs/internal/commerce-v1/standards/examples/schemaorg-product-offer.preview.json
+++ b/docs/internal/commerce-v1/standards/examples/schemaorg-product-offer.preview.json
@@ -1,0 +1,47 @@
+{
+  "example_id": "schemaorg_product_offer_example_001",
+  "example_kind": "schemaorg_style_product_offer_preview",
+  "scenario": "public_safe_preview",
+  "status": "internal_example_only",
+  "internal_example_only": true,
+  "synthetic_data": true,
+  "public_submission_status": "not_submitted",
+  "certification_claims": [],
+  "production_approval": false,
+  "public_discovery_enabled": false,
+  "checkout_payment_enabled": false,
+  "live_provider_enabled": false,
+  "schemaorg_style": {
+    "context_label": "schema_org_context_placeholder_public_safe",
+    "type": "Product",
+    "identifier": "item_example_lamp_001",
+    "name": "Example Table Lamp",
+    "brand": "Example Home Goods Merchant",
+    "description": "Synthetic public-safe product preview for internal standards draft preparation.",
+    "image_included": false,
+    "offer": {
+      "type": "Offer",
+      "identifier": "offer_example_lamp_001",
+      "price": "49.00",
+      "price_currency": "USD",
+      "availability": "preview_available",
+      "seller": "Example Home Goods Merchant",
+      "checkout_url_included": false
+    }
+  },
+  "excluded_fields": [
+    "real_product_url",
+    "real_image_url",
+    "real_address",
+    "real_phone",
+    "real_email",
+    "tax_id",
+    "provider_reference",
+    "production_config"
+  ],
+  "publication_controls": {
+    "schemaorg_publication_enabled": false,
+    "public_protocol_publication": false,
+    "external_submission": false
+  }
+}

--- a/docs/internal/commerce-v1/standards/nist-agentic-commerce-security-reference-architecture.md
+++ b/docs/internal/commerce-v1/standards/nist-agentic-commerce-security-reference-architecture.md
@@ -554,6 +554,8 @@ References are placeholders for later public-safe review.
 - Public-safe capability profile references, if cleared.
 - Public-safe checkout-shape references, if cleared.
 - Public-safe evidence references, if cleared.
+- C6Tc public-safe example corpus references, if legal/security review clears
+  them for future external draft use.
 
 ## Appendix A. Internal Draft-Preparation Checklist
 


### PR DESCRIPTION
## Summary

- Adds the internal C6Tc public-safe Agentic Commerce example corpus for future IETF/NIST draft preparation.
- Adds a manifest and synthetic JSON examples for read-only discovery, checkout refusal, capability profiles, consent/evidence, connector source metadata, schema.org-style preview, ACP-style blocked checkout, and AP2-style unsigned evidence.
- Adds short internal references from the C6Ta/C6Tb draft skeletons to the C6Tc corpus, gated on future legal/security review.

## Safety posture

Docs/fixture-only and internal draft-preparation only. This is not an IETF submission, not a NIST submission, not public protocol publication, not public guidance, not certification, not conformance, not compliance, not production authorization, not public discovery authorization, not checkout/payment authorization, not provider authorization, and not live-payment authorization.

No deploy, cloud command, production config, secrets, public discovery, production Commerce V1, checkout/payment creation, live payments, live Plural, provider calls, merchant private API calls, production allowlists, runtime behavior, external submission, public publication, or certification claims are added.

## Validation

- Every JSON example parses.
- JSON marker validation passed for `internal_example_only`, `synthetic_data`, `public_submission_status`, `certification_claims`, `production_approval`, `public_discovery_enabled`, `checkout_payment_enabled`, and `live_provider_enabled`.
- `git diff --check origin/main...HEAD`: passed
- focused secret/private-detail scan: no unsafe findings; broad hits are negative guardrails, redaction flags, and stop conditions
- focused production config / allowlist / public discovery / checkout-payment / live-provider scan: no unsafe findings; broad hits are false flags and blocked-state examples
- focused IETF/NIST/RFC/NCCoE/certification/conformance overclaim scan: no unsafe positive claims; broad hits are internal-only status and stop-condition language
- focused real merchant/private-data scan: no real merchant/private data; broad hits are forbidden-content labels and negative live-provider guardrails only
- focused Grantex-private-ID/provider-specific scan: strict counts are zero