### PR TITLE
test(commerce): cover source freshness projection

### DIFF
--- a/apps/auth-service/tests/commerce-c6u4-source-freshness-projection.test.ts
+++ b/apps/auth-service/tests/commerce-c6u4-source-freshness-projection.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeSandboxAgentFacingPreview,
+  computeSandboxCatalogReadiness,
+  computeSandboxOnboardingReadiness,
+  type SandboxOnboardingCatalogSummary,
+  type SandboxOnboardingMerchant,
+} from '../src/lib/commerce/sandbox-onboarding.js';
+
+const now = new Date('2026-06-09T00:00:00.000Z');
+
+function merchant(overrides: Partial<SandboxOnboardingMerchant> = {}): SandboxOnboardingMerchant {
+  return {
+    id: 'merchant_synthetic_c6u4',
+    tenant_id: 'tenant_synthetic_c6u4',
+    display_name: 'Synthetic Home Appliance Merchant',
+    category_preset: 'electronics_appliances',
+    environment: 'sandbox',
+    agentic_commerce_enabled: false,
+    default_currency: 'INR',
+    country_code: 'IN',
+    support_email: 'support@example.test',
+    support_url: null,
+    public_discovery_description_draft: 'Synthetic sandbox appliance catalog for internal buyer-agent review.',
+    provider_account_refs: null,
+    ...overrides,
+  };
+}
+
+function readyCatalogSummary(overrides: Partial<SandboxOnboardingCatalogSummary> = {}): SandboxOnboardingCatalogSummary {
+  return {
+    product_count: 1,
+    variant_count: 1,
+    products_with_image: 1,
+    products_with_public_safe_title: 1,
+    products_with_public_safe_description: 1,
+    products_with_category_mapping: 1,
+    products_with_unsafe_text: 0,
+    variants_with_sku: 1,
+    variants_with_price_currency: 1,
+    variants_with_warranty_summary: 1,
+    variants_with_return_policy_summary: 1,
+    variants_with_tax_metadata: 1,
+    variants_with_fresh_inventory: 1,
+    variants_with_known_availability: 1,
+    variants_with_unsafe_text: 0,
+    ...overrides,
+  };
+}
+
+describe('C6U4 source/freshness and buyer-safe fact projection contracts', () => {
+  it('keeps source freshness, tax, warranty, and return gaps visible in readiness checks', () => {
+    const readiness = computeSandboxCatalogReadiness(
+      merchant(),
+      readyCatalogSummary({
+        variants_with_fresh_inventory: 0,
+        variants_with_known_availability: 0,
+        variants_with_tax_metadata: 0,
+        variants_with_warranty_summary: 0,
+        variants_with_return_policy_summary: 0,
+      }),
+    );
+
+    expect(readiness.required_passed).toBe(true);
+    expect(readiness.items.find((item) => item.key === 'variants_availability_freshness'))
+      .toMatchObject({ status: 'fail', count: 0, total: 1 });
+    expect(readiness.items.find((item) => item.key === 'variants_tax_gst_metadata'))
+      .toMatchObject({ status: 'fail', count: 0, total: 1 });
+    expect(readiness.items.find((item) => item.key === 'variants_warranty_summary'))
+      .toMatchObject({ status: 'fail', count: 0, total: 1 });
+    expect(readiness.items.find((item) => item.key === 'variants_return_policy_summary'))
+      .toMatchObject({ status: 'fail', count: 0, total: 1 });
+  });
+
+  it('projects only public-safe preview facts and omits private source or final commercial claims', () => {
+    const readiness = computeSandboxOnboardingReadiness(merchant(), {}, readyCatalogSummary());
+    const preview = computeSandboxAgentFacingPreview(
+      merchant(),
+      readiness,
+      [{
+        title: 'Synthetic Mixer',
+        description: 'Synthetic appliance preview item.',
+        image_url: 'https://example.test/images/mixer.png',
+        category_preset: 'electronics_appliances',
+        variants: [{
+          sku: 'SKU-C6U4-MIXER',
+          variant_title: 'Warm finish',
+          price_amount: 1299,
+          currency: 'INR',
+          availability_status: 'in_stock',
+          warranty_summary: 'Synthetic one-year limited warranty summary.',
+          return_policy_summary: 'Synthetic seven-day unopened return summary.',
+          source_system: 'merchant-private-pim',
+          last_synced_at: '2026-06-09T00:00:00.000Z',
+          tax_rate: '0.18',
+          final_price_amount: 1533,
+          delivery_promise: 'tomorrow',
+          quantity_available: 25,
+        } as unknown as never],
+      }],
+      now,
+    );
+
+    expect(preview.preview_status).toBe('ready');
+    expect(preview.public_discovery_enabled).toBe(false);
+    expect(preview.checkout_payment_enabled).toBe(false);
+    expect(preview.live_provider_enabled).toBe(false);
+    expect(preview.sample_products[0]!.variants[0]).toMatchObject({
+      sku: 'SKU-C6U4-MIXER',
+      price_amount: 1299,
+      currency: 'INR',
+      availability_status: 'in_stock',
+      warranty_summary: 'Synthetic one-year limited warranty summary.',
+      return_policy_summary: 'Synthetic seven-day unopened return summary.',
+    });
+
+    const serialized = JSON.stringify(preview).toLowerCase();
+    expect(serialized).not.toContain('merchant-private-pim');
+    expect(serialized).not.toContain('last_synced_at');
+    expect(serialized).not.toContain('tax_rate');
+    expect(serialized).not.toContain('final_price');
+    expect(serialized).not.toContain('delivery_promise');
+    expect(serialized).not.toContain('quantity_available');
+  });
+
+  it('keeps unknown availability explicit instead of converting it into an in-stock promise', () => {
+    const readiness = computeSandboxOnboardingReadiness(merchant(), {}, readyCatalogSummary({
+      variants_with_fresh_inventory: 0,
+      variants_with_known_availability: 0,
+    }));
+    const preview = computeSandboxAgentFacingPreview(
+      merchant(),
+      readiness,
+      [{
+        title: 'Synthetic Lamp',
+        description: 'Synthetic appliance preview item with unknown availability.',
+        category_preset: 'electronics_appliances',
+        variants: [{
+          sku: 'SKU-C6U4-LAMP',
+          price_amount: 799,
+          currency: 'INR',
+          availability_status: 'unknown',
+        }],
+      }],
+      now,
+    );
+
+    expect(preview.sample_products[0]!.variants[0]!.availability_status).toBe('unknown');
+    expect(JSON.stringify(preview).toLowerCase()).not.toContain('guaranteed in stock');
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6u4-source-freshness-commercial-fact-projection.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6u4-source-freshness-commercial-fact-projection.md
@@ -1,0 +1,88 @@
+# C6U4 Source/Freshness and Buyer-Safe Commercial Fact Projection
+
+Status: internal implementation note only. This document does not approve production launch, real merchants, public discovery, checkout/payment, live providers, live Plural, production config, production allowlists, cloud resources, provider calls, merchant private API calls, protocol publication, external submission, certification, compliance, conformance, standardization, public-launch readiness, merchant approval, or production readiness.
+
+## Purpose
+
+C6U4 closes the C6U2/C6U3 mismatch where Grantex has richer source and freshness controls than AgenticOrg buyer-facing projection. The goal is to keep buyer agents from overstating price, inventory, tax, warranty, return, delivery, support, fulfillment, refund, settlement, payout, discount, coupon, or EMI facts.
+
+Grantex remains the source of truth for merchant profile, catalog, inventory, connector source, readiness, review, and audit facts. AgenticOrg may show only buyer-safe facts returned by Grantex and must qualify or refuse missing, stale, private, unapproved, or ambiguous facts.
+
+## Projection Model
+
+| Fact area | Grantex-owned source | Buyer-safe projection rule |
+| --- | --- | --- |
+| Merchant identity | Sandbox merchant profile and review/handoff state | Show only public display name, category, country, currency, and public-safe description. |
+| Product identity | Agent-facing preview sample products | Show public-safe title, brand/category when available, and capped sample references only. |
+| Preview price | Variant `price_amount` and `currency` | May be described only as preview price. It is not a final payable amount. |
+| Tax/GST | Catalog readiness and later tax fields | If missing, AgenticOrg must say tax is not confirmed. |
+| Warranty | Variant warranty summary | If missing, AgenticOrg must not invent warranty terms. |
+| Return/refund | Variant return summary and future refund contracts | If missing, AgenticOrg must not invent return, refund, replacement, or chargeback handling. |
+| Inventory | Availability bucket plus freshness checks | Unknown or stale inventory stays unknown/stale; no quantity or reservation is exposed. |
+| Delivery/support/fulfillment | Future order/support/fulfillment contracts | Refuse execution or promises until Grantex exposes source facts. |
+| Settlement/payout/reconciliation | Future payment/order operations contracts | Refuse buyer-facing claims; these are not buyer discovery facts. |
+| Source/freshness | Connector/source governance and readiness checks | Show only buyer-safe source labels and freshness status. Do not expose private system names, URLs, raw payloads, credentials, or internal IDs. |
+
+## Current Grantex Contract
+
+Grantex already enforces the following non-enabling controls:
+
+- Sandbox onboarding readiness requires public-safe profile, category, catalog, and non-enabling checks.
+- Catalog readiness tracks price/currency, warranty summary, return-policy summary, tax/GST metadata, availability freshness, known availability, and unsafe catalog text.
+- Agent-facing preview is capped and sanitized.
+- Preview flags stay false for public discovery, checkout/payment, live provider, live Plural, and production approval.
+- Preview variants expose only SKU, variant title, preview price amount, currency, availability bucket, warranty summary, and return-policy summary.
+- Preview variants do not expose source system names, raw connector payloads, private URLs, provider credentials, exact inventory quantity, final price, tax amount, delivery promises, settlement, payout, or refund execution.
+
+The C6U4 Grantex test pins that contract without adding runtime behavior.
+
+## AgenticOrg Projection Requirements
+
+AgenticOrg must:
+
+- Treat Grantex preview price as preview-only and not a final payable price.
+- Mark tax/GST, delivery, support, fulfillment, refund, settlement, payout, discount, coupon, and EMI as unknown or unsupported unless Grantex provides explicit buyer-safe facts.
+- Treat stale or unknown inventory as caution/refusal and never as an in-stock promise.
+- Redact private source labels, private URLs, raw connector payload markers, credentials, passport/JWT values, DB/Redis URLs, webhook secrets, and merchant-private identifiers.
+- Keep public discovery hidden unless both Grantex and AgenticOrg gates are explicitly approved in a later slice.
+- Refuse checkout/payment, live provider, live Plural, provider calls, and merchant private API calls.
+
+## Safe Wording
+
+Safe examples:
+
+- "Grantex shows a preview price for this sample, but final tax, fees, discounts, and checkout totals are not confirmed."
+- "Availability is unknown or stale, so I cannot confirm stock."
+- "Warranty terms are not confirmed by Grantex for this preview item."
+- "Delivery and refund handling are not enabled in this buyer discovery slice."
+
+Unsafe wording that must be refused or rewritten:
+
+- "This is the final price including all taxes."
+- "Guaranteed delivery tomorrow."
+- "Guaranteed refund is available."
+- "Guaranteed in stock with 25 units."
+- "I checked the merchant private system."
+- "The payment provider approved this checkout."
+
+## Stop Conditions
+
+Stop and do not merge a future C6U4 follow-up if any change:
+
+- Adds runtime routes, migrations, workflow changes, production config, secrets, cloud resources, provider calls, merchant private API calls, production allowlists, public discovery enablement, checkout/payment enablement, live provider enablement, or live Plural enablement.
+- Exposes private source labels, raw connector payloads, private URLs, credentials, internal tenant/merchant IDs, DB/Redis URLs, webhook secrets, or passport/JWT values.
+- Claims production launch, public launch, certification, compliance, conformance, standardization, merchant approval, or external standards approval.
+
+## Remaining Gaps
+
+- Shared public discovery state contract.
+- Consent/session/passport revocation propagation.
+- Channel-specific refusal packs.
+- Order, fulfillment, refund, support, settlement, and payout contracts.
+- Sandbox checkout E2E.
+- Live provider readiness.
+- AgenticOrg CI/CD cloud-build guard follow-up.
+
+## Validation
+
+C6U4 validation should include focused source/freshness projection tests, Commerce Preview Conformance gate, diff whitespace check, ASCII check, secret/private scan, production config/allowlist scan, public discovery/payment/live-provider enablement scan, direct provider/Plural scan, merchant private API scan, raw connector/private payload scan, and overclaim scan.


### PR DESCRIPTION
C6U4 Grantex source/freshness and buyer-safe commercial fact projection coverage. Adds an internal doc and focused auth-service tests proving readiness exposes source/freshness/tax/warranty/return gaps, preview facts remain non-enabling, private source/final commercial fields are omitted, and unknown availability is not converted into an in-stock promise. Validation: focused C6U4 test, C6U3/static preview tests, catalog/connector preview tests, auth-service typecheck, C6O preview conformance gate, diff checks, ASCII check, and guardrail scans. No runtime behavior, workflow, config, cloud, provider, merchant-private API, public discovery, checkout/payment, live provider, live Plural, allowlist, or protocol behavior added.