### PR TITLE
C6U6 Agentic Commerce consent session revocation propagation

### DIFF
--- a/apps/auth-service/tests/commerce-c6u6-consent-session-revocation-propagation.test.ts
+++ b/apps/auth-service/tests/commerce-c6u6-consent-session-revocation-propagation.test.ts
@@ -1,0 +1,202 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..', '..', '..');
+const mcpRoutePath = join(repoRoot, 'apps', 'auth-service', 'src', 'routes', 'commerce-mcp.ts');
+const publicDiscoveryContractPath = join(
+  repoRoot,
+  'docs',
+  'internal',
+  'commerce-v1',
+  'commerce-v1-c6u5-public-discovery-state-contract.md',
+);
+
+const now = new Date('2026-06-09T00:00:00.000Z');
+
+interface AuthorityEvidence {
+  consent_status?: string;
+  passport_status?: string;
+  session_status?: string;
+  merchant_status?: string;
+  agent_status?: string;
+  policy_decision?: string;
+  authority_checked_at?: string;
+  passport_expires_at?: string;
+  consent_expires_at?: string;
+  revoked_at?: string | null;
+  expected_merchant_id?: string;
+  actual_merchant_id?: string;
+  expected_agent_id?: string;
+  actual_agent_id?: string;
+  expected_buyer_id?: string;
+  actual_buyer_id?: string;
+  expected_session_id?: string;
+  actual_session_id?: string;
+}
+
+interface AuthorityDecision {
+  protected_action_allowed: false;
+  public_discovery_enabled: false;
+  checkout_payment_enabled: false;
+  live_provider_enabled: false;
+  refusal_code: string;
+  blockers: string[];
+  audit_required: boolean;
+}
+
+function baseAuthority(overrides: Partial<AuthorityEvidence> = {}): AuthorityEvidence {
+  return {
+    consent_status: 'granted',
+    passport_status: 'valid',
+    session_status: 'active',
+    merchant_status: 'enabled',
+    agent_status: 'trusted',
+    policy_decision: 'allow',
+    authority_checked_at: '2026-06-08T23:59:00.000Z',
+    passport_expires_at: '2026-06-09T00:10:00.000Z',
+    consent_expires_at: '2026-06-09T00:10:00.000Z',
+    revoked_at: null,
+    expected_merchant_id: 'merchant_synthetic_c6u6',
+    actual_merchant_id: 'merchant_synthetic_c6u6',
+    expected_agent_id: 'agent_synthetic_c6u6',
+    actual_agent_id: 'agent_synthetic_c6u6',
+    expected_buyer_id: 'buyer_synthetic_c6u6',
+    actual_buyer_id: 'buyer_synthetic_c6u6',
+    expected_session_id: 'buyer_session_synthetic_c6u6',
+    actual_session_id: 'buyer_session_synthetic_c6u6',
+    ...overrides,
+  };
+}
+
+function classifyGrantexAuthority(evidence: AuthorityEvidence): AuthorityDecision {
+  const blockers: string[] = [];
+  const consent = evidence.consent_status ?? '';
+  const passport = evidence.passport_status ?? '';
+  const session = evidence.session_status ?? '';
+  const merchant = evidence.merchant_status ?? '';
+  const agent = evidence.agent_status ?? '';
+  const policy = evidence.policy_decision ?? '';
+
+  if (!consent) blockers.push('consent_missing');
+  if (['denied', 'revoked', 'withdrawn', 'expired'].includes(consent)) blockers.push(`consent_${consent}`);
+  if (!passport) blockers.push('passport_missing');
+  if (['revoked', 'expired', 'not_yet_valid'].includes(passport)) blockers.push(`passport_${passport}`);
+  if (!session) blockers.push('session_missing');
+  if (['revoked', 'expired', 'disabled'].includes(session)) blockers.push(`session_${session}`);
+  if (['disabled', 'blocked', 'suspended', 'inactive'].includes(merchant)) blockers.push('merchant_disabled');
+  if (['disabled', 'blocked', 'suspended', 'inactive', 'untrusted'].includes(agent)) blockers.push('agent_disabled');
+  if (['deny', 'denied', 'blocked', 'rejected'].includes(policy)) blockers.push('policy_denied');
+  if (!evidence.authority_checked_at) blockers.push('authority_freshness_missing');
+  if (evidence.authority_checked_at && Date.parse(evidence.authority_checked_at) <= now.getTime() - 5 * 60 * 1000) {
+    blockers.push('authority_stale');
+  }
+  if (evidence.passport_expires_at && Date.parse(evidence.passport_expires_at) <= now.getTime()) {
+    blockers.push('passport_expired');
+  }
+  if (evidence.consent_expires_at && Date.parse(evidence.consent_expires_at) <= now.getTime()) {
+    blockers.push('consent_expired');
+  }
+  if (evidence.revoked_at) blockers.push('passport_revoked');
+
+  for (const [label, expected, actual] of [
+    ['merchant', evidence.expected_merchant_id, evidence.actual_merchant_id],
+    ['agent', evidence.expected_agent_id, evidence.actual_agent_id],
+    ['buyer', evidence.expected_buyer_id, evidence.actual_buyer_id],
+    ['session', evidence.expected_session_id, evidence.actual_session_id],
+  ] as const) {
+    if (expected && actual && expected !== actual) blockers.push(`${label}_mismatch`);
+  }
+
+  return {
+    protected_action_allowed: false,
+    public_discovery_enabled: false,
+    checkout_payment_enabled: false,
+    live_provider_enabled: false,
+    refusal_code: blockers[0] ?? 'checkout_payment_not_enabled_by_c6u6',
+    blockers: [...new Set(blockers)],
+    audit_required: true,
+  };
+}
+
+describe('C6U6 Grantex consent/session/passport authority contract', () => {
+  it.each([
+    ['missing consent', { consent_status: '' }, 'consent_missing'],
+    ['missing passport', { passport_status: '' }, 'passport_missing'],
+    ['expired passport', { passport_status: 'expired' }, 'passport_expired'],
+    ['revoked passport', { passport_status: 'revoked' }, 'passport_revoked'],
+    ['expired passport time', { passport_expires_at: '2026-06-08T23:59:00.000Z' }, 'passport_expired'],
+    ['revoked timestamp', { revoked_at: '2026-06-08T23:55:00.000Z' }, 'passport_revoked'],
+    ['disabled merchant', { merchant_status: 'disabled' }, 'merchant_disabled'],
+    ['disabled agent', { agent_status: 'disabled' }, 'agent_disabled'],
+    ['policy denial', { policy_decision: 'deny' }, 'policy_denied'],
+    ['stale authority', { authority_checked_at: '2026-06-08T23:40:00.000Z' }, 'authority_stale'],
+    ['merchant mismatch', { actual_merchant_id: 'merchant_other' }, 'merchant_mismatch'],
+    ['agent mismatch', { actual_agent_id: 'agent_other' }, 'agent_mismatch'],
+    ['buyer mismatch', { actual_buyer_id: 'buyer_other' }, 'buyer_mismatch'],
+    ['session mismatch', { actual_session_id: 'buyer_session_other' }, 'session_mismatch'],
+  ])('fails closed for %s', (_label, overrides, refusalCode) => {
+    const decision = classifyGrantexAuthority(baseAuthority(overrides));
+
+    expect(decision.protected_action_allowed).toBe(false);
+    expect(decision.public_discovery_enabled).toBe(false);
+    expect(decision.checkout_payment_enabled).toBe(false);
+    expect(decision.live_provider_enabled).toBe(false);
+    expect(decision.blockers).toContain(refusalCode);
+    expect(decision.audit_required).toBe(true);
+  });
+
+  it('keeps even fresh authority non-enabling in C6U6', () => {
+    const decision = classifyGrantexAuthority(baseAuthority());
+
+    expect(decision).toMatchObject({
+      protected_action_allowed: false,
+      public_discovery_enabled: false,
+      checkout_payment_enabled: false,
+      live_provider_enabled: false,
+      refusal_code: 'checkout_payment_not_enabled_by_c6u6',
+      blockers: [],
+      audit_required: true,
+    });
+  });
+
+  it('pins Commerce MCP passport verification and mismatch gates to Grantex authority', () => {
+    const route = readFileSync(mcpRoutePath, 'utf8');
+
+    expect(route).toContain('async function requireAgentPassportScope');
+    expect(route).toContain('expectedTenantId: input.tenantId');
+    expect(route).toContain('expectedMerchantId: input.merchantId');
+    expect(route).toContain("throw new CommerceHttpError(403, 'agent_mismatch'");
+    expect(route).toContain("throw new CommerceHttpError(403, 'passport_scope_missing'");
+    expect(route).toContain("revocation_unavailable: 'revocation_unavailable'");
+    expect(route).toContain("revoked: 'passport_revoked'");
+    expect(route).toContain("expired: 'passport_expired'");
+  });
+
+  it('keeps the public discovery contract hidden and future-public inactive', () => {
+    const doc = readFileSync(publicDiscoveryContractPath, 'utf8');
+
+    expect(doc).toContain('buyer-facing public discovery hidden or refused');
+    expect(doc).toContain('future_public_enabled');
+    expect(doc).toContain('not active');
+    expect(doc).toContain('not a production or merchant approval');
+  });
+
+  it('does not expose private evidence in authority decisions', () => {
+    const decision = classifyGrantexAuthority(baseAuthority({
+      passport_status: 'revoked',
+      revoked_at: '2026-06-08T23:55:00.000Z',
+    }));
+    const serialized = JSON.stringify(decision).toLowerCase();
+
+    expect(serialized).not.toContain('passport.jwt');
+    expect(serialized).not.toContain('jwt=');
+    expect(serialized).not.toContain('secret');
+    expect(serialized).not.toContain('postgres://');
+    expect(serialized).not.toContain('redis://');
+    expect(serialized).not.toContain('merchant-private');
+    expect(serialized).not.toContain('raw_payload');
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6u6-consent-session-passport-revocation-propagation.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6u6-consent-session-passport-revocation-propagation.md
@@ -1,0 +1,122 @@
+# C6U6 Consent, Session, and Passport Revocation Propagation
+
+Status: internal implementation note only. This document does not approve production launch, real merchants, public discovery, checkout/payment, live providers, live Plural, production config, production allowlists, cloud resources, provider calls, merchant private API calls, protocol publication, external submission, certification, compliance, conformance, standardization, public-launch readiness, merchant approval, or production readiness.
+
+## Executive Summary
+
+C6U6 defines the authority boundary for buyer-agent sessions. Grantex remains the authority for consent, Commerce Passport issuance and verification, revocation, merchant status, agent status, policy evaluation, and audit evidence. AgenticOrg may consume only buyer-safe authority summaries and must fail closed when authority is missing, stale, expired, revoked, disabled, mismatched, ambiguous, or unsupported.
+
+This slice does not enable checkout, payment creation, live payment, live Plural, provider calls, merchant private API calls, public discovery, production allowlists, or production launch.
+
+## Grantex Authority Model
+
+Grantex owns:
+- Consent request, grant, denial, expiry, and revocation state.
+- Commerce Passport signing, verification, scope checks, expiry checks, tenant checks, merchant checks, agent checks, and revocation checks.
+- Merchant enablement, emergency disable, and production approval state.
+- Commerce agent registration, trust, suspension, and disablement state.
+- Policy decisions for protected actions.
+- Audit events for consent, passport issue, verify, revoke, policy denial, merchant disable, agent disable, checkout refusal, and payment refusal.
+
+Protected actions include checkout creation, payment intent creation, payment status reads for agent callers, and any future payment-affecting action. A protected action must not proceed unless Grantex can verify fresh consent, a valid Commerce Passport, matching tenant, matching merchant, matching agent, required scopes, merchant eligibility, agent eligibility, policy allow, and non-revoked state.
+
+## AgenticOrg Session-Consumption Model
+
+AgenticOrg may cache only a buyer-safe summary of Grantex authority. It must not cache or expose raw Commerce Passport JWTs, raw consent payloads, raw provider payloads, provider credentials, merchant private payloads, private URLs, DB/Redis URLs, webhook secrets, production config values, or concrete allowlist values.
+
+If AgenticOrg has no fresh authority summary, it must either re-check with Grantex through a Grantex-owned contract or refuse the protected action. Cached state cannot override a Grantex revoked, expired, disabled, denied, or stale state.
+
+## Required Authority Fields
+
+Future Grantex-to-AgenticOrg authority summaries should include only buyer-safe values:
+- `consent_status`
+- `passport_status`
+- `session_status`
+- `merchant_status`
+- `agent_status`
+- `policy_decision`
+- `authority_checked_at`
+- `passport_expires_at`
+- `consent_expires_at`
+- `revocation_status` or redacted revocation reference
+- `merchant_reference` or scoped merchant handle
+- `agent_reference` or scoped agent handle
+- `buyer_session_reference`
+- `audit_event_id`
+- `decision_id`
+
+Raw IDs should be avoided where a scoped reference is enough. Raw JWTs and raw private evidence must not be included.
+
+## Revocation Propagation
+
+Revocation can originate from buyer consent withdrawal, passport revocation, merchant disablement, commerce-agent disablement, policy denial, incident response, fraud/abuse moderation, or operator rollback. Once Grantex records revocation or disablement, AgenticOrg must treat any cached buyer session as invalid for protected actions until Grantex returns a fresh allowed authority summary.
+
+Revocation propagation is fail-closed:
+- Missing consent means no protected action.
+- Missing passport means no protected action.
+- Expired passport means refused.
+- Revoked passport means refused.
+- Disabled merchant means refused.
+- Disabled commerce agent means refused.
+- Policy denial means refused.
+- Mismatched merchant, agent, buyer, or session means refused.
+- Stale authority means refresh or refuse.
+- Ambiguous authority means refuse.
+
+## Freshness and Staleness
+
+AgenticOrg should treat authority as stale when `authority_checked_at` is missing, older than the configured short TTL, or contradicted by any expiration or revocation marker. Payment-affecting flows should use a short TTL and prefer an online Grantex verification path. C6U6 does not define a production TTL or enable a production path.
+
+## Mismatch Handling
+
+The tenant, merchant, agent, buyer principal, session, and passport must refer to the same scoped authority chain. Any mismatch must refuse. A Grantex-only approval does not authorize AgenticOrg exposure. An AgenticOrg-only cached session does not authorize Grantex commerce.
+
+## Buyer-Safe Refusal Wording
+
+Safe wording:
+- "I need fresh Grantex consent before continuing."
+- "The Commerce Passport is no longer valid. Please request fresh consent through Grantex."
+- "The merchant or agent is not enabled for this commerce action."
+- "Grantex policy did not allow this action."
+- "The buyer session authority is stale, so I cannot continue."
+
+Unsafe wording:
+- "Here is the passport JWT."
+- "The private provider payload says..."
+- "The merchant private endpoint returned..."
+- "Checkout/payment is approved."
+- "Live provider or live Plural is available."
+
+## Private-Only Fields
+
+Keep private: raw passports, JWTs, tokens, provider credentials, raw consent payloads, raw connector payloads, merchant private URLs, provider internals, DB/Redis URLs, webhook secrets, production config values, concrete production allowlists, raw reviewer notes, and private incident evidence.
+
+## Audit and Evidence Requirements
+
+Every protected-action decision should have an audit trail that can answer:
+- Which consent record was checked.
+- Which Commerce Passport or redacted passport reference was checked.
+- Which merchant and agent status were checked.
+- Which policy decision was checked.
+- Whether revocation was checked online or from a fresh summary.
+- Whether the action was refused, why, and by which owner.
+
+Audit evidence must be redacted before it is shared with AgenticOrg or a buyer channel.
+
+## Stop Conditions
+
+Stop C6U6 work if it adds public discovery enablement, checkout/payment enablement, live payment, live Plural, provider calls, merchant private API calls, production config, production allowlists, cloud resources, secrets, workflow changes, migrations, protocol publication, external submission, certification, compliance, conformance, standardization, merchant approval, public-launch readiness, or production readiness claims.
+
+## Remaining Gaps
+
+- Channel-specific refusal packs.
+- Order, fulfillment, refund, support, settlement, and payout contracts.
+- Sandbox checkout E2E.
+- Live provider readiness.
+- AgenticOrg CI/CD cloud-build guard follow-up.
+- Shared production-grade revocation TTL policy.
+- Buyer-facing consent UX and revocation UX.
+
+## Validation
+
+C6U6 validation should run focused consent/session/passport revocation propagation tests, nearby commerce consent/passport/policy/no-Plural/public-discovery tests, Commerce Preview Conformance gate, typecheck where touched, whitespace diff check, ASCII check, secret/private scan, passport/JWT/raw-token scan, production config/allowlist scan, public discovery enablement scan, checkout/payment/live-provider scan, direct provider/Plural scan, merchant private API scan, raw connector/private payload scan, and overclaim scan.


### PR DESCRIPTION
Docs/test-only C6U6 authority contract coverage for Grantex. Keeps public discovery, checkout/payment, live provider, live Plural, provider calls, merchant private APIs, production config, allowlists, and standards claims blocked.