### PR TITLE
feat(commerce): add order foundation

### DIFF
--- a/apps/auth-service/src/db/migrations/057_commerce_order_foundation.sql
+++ b/apps/auth-service/src/db/migrations/057_commerce_order_foundation.sql
@@ -1,0 +1,133 @@
+-- Grantex Commerce C6U7: order foundation only.
+-- This table records tenant-scoped order facts derived from Grantex-safe
+-- source snapshots. It does not create checkout/payment, call providers,
+-- expose public discovery, or execute fulfillment/refunds/support.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conname = 'uq_payment_intents_tenant_id'
+       AND conrelid = 'commerce_payment_intents'::regclass
+  ) THEN
+    ALTER TABLE commerce_payment_intents
+      ADD CONSTRAINT uq_payment_intents_tenant_id UNIQUE (tenant_id, id);
+  END IF;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS commerce_orders (
+  id                         TEXT PRIMARY KEY, -- cord_<ulid>
+  tenant_id                  TEXT NOT NULL REFERENCES commerce_tenants(id),
+  merchant_id                TEXT NOT NULL,
+  buyer_principal_id         TEXT NOT NULL,
+  agent_id                   TEXT,
+  cart_id                    TEXT,
+  payment_intent_id          TEXT,
+  status                     TEXT NOT NULL DEFAULT 'pending_source_facts',
+  status_reason              TEXT,
+  line_items_snapshot        JSONB NOT NULL,
+  commercial_facts_snapshot  JSONB NOT NULL,
+  source_freshness_refs      JSONB NOT NULL DEFAULT '{}'::JSONB,
+  support_reference          JSONB NOT NULL DEFAULT '{"state":"support_status_not_enabled_by_c6u7"}'::JSONB,
+  audit_evidence_refs        JSONB NOT NULL DEFAULT '[]'::JSONB,
+  idempotency_scope          TEXT NOT NULL DEFAULT 'order.foundation.record',
+  idempotency_key_hash       TEXT NOT NULL,
+  created_from               TEXT NOT NULL DEFAULT 'cart_snapshot',
+  created_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_commerce_orders_status CHECK (
+    status IN (
+      'pending_source_facts',
+      'recorded',
+      'merchant_acknowledged',
+      'closed',
+      'cancelled',
+      'expired',
+      'blocked',
+      'unknown'
+    )
+  ),
+  CONSTRAINT chk_commerce_orders_created_from CHECK (
+    created_from IN ('cart_snapshot','payment_intent_snapshot','merchant_safe_source','operator_record')
+  ),
+  CONSTRAINT chk_commerce_orders_line_items_snapshot_array
+    CHECK (jsonb_typeof(line_items_snapshot) = 'array'),
+  CONSTRAINT chk_commerce_orders_commercial_facts_object
+    CHECK (jsonb_typeof(commercial_facts_snapshot) = 'object'),
+  CONSTRAINT chk_commerce_orders_source_refs_object
+    CHECK (jsonb_typeof(source_freshness_refs) = 'object'),
+  CONSTRAINT chk_commerce_orders_support_reference_object
+    CHECK (jsonb_typeof(support_reference) = 'object'),
+  CONSTRAINT chk_commerce_orders_audit_refs_array
+    CHECK (jsonb_typeof(audit_evidence_refs) = 'array'),
+  CONSTRAINT fk_commerce_orders_merchant
+    FOREIGN KEY (tenant_id, merchant_id)
+    REFERENCES commerce_merchants(tenant_id, id),
+  CONSTRAINT fk_commerce_orders_agent
+    FOREIGN KEY (tenant_id, agent_id)
+    REFERENCES commerce_agents(tenant_id, id),
+  CONSTRAINT fk_commerce_orders_cart
+    FOREIGN KEY (tenant_id, cart_id)
+    REFERENCES commerce_carts(tenant_id, id),
+  CONSTRAINT fk_commerce_orders_payment_intent
+    FOREIGN KEY (tenant_id, payment_intent_id)
+    REFERENCES commerce_payment_intents(tenant_id, id),
+  CONSTRAINT uq_commerce_orders_tenant_id UNIQUE (tenant_id, id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_orders_idempotency
+  ON commerce_orders(tenant_id, merchant_id, idempotency_scope, idempotency_key_hash);
+
+CREATE INDEX IF NOT EXISTS idx_commerce_orders_tenant_merchant_created
+  ON commerce_orders(tenant_id, merchant_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_commerce_orders_buyer
+  ON commerce_orders(tenant_id, buyer_principal_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_commerce_orders_cart
+  ON commerce_orders(tenant_id, cart_id)
+  WHERE cart_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_commerce_orders_payment_intent
+  ON commerce_orders(tenant_id, payment_intent_id)
+  WHERE payment_intent_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_commerce_orders_status
+  ON commerce_orders(tenant_id, merchant_id, status);
+
+CREATE OR REPLACE FUNCTION commerce_orders_block_immutable_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+     OR NEW.merchant_id IS DISTINCT FROM OLD.merchant_id
+     OR NEW.buyer_principal_id IS DISTINCT FROM OLD.buyer_principal_id
+     OR NEW.agent_id IS DISTINCT FROM OLD.agent_id
+     OR NEW.cart_id IS DISTINCT FROM OLD.cart_id
+     OR NEW.payment_intent_id IS DISTINCT FROM OLD.payment_intent_id
+     OR NEW.line_items_snapshot IS DISTINCT FROM OLD.line_items_snapshot
+     OR NEW.commercial_facts_snapshot IS DISTINCT FROM OLD.commercial_facts_snapshot
+     OR NEW.source_freshness_refs IS DISTINCT FROM OLD.source_freshness_refs
+     OR NEW.audit_evidence_refs IS DISTINCT FROM OLD.audit_evidence_refs
+     OR NEW.idempotency_scope IS DISTINCT FROM OLD.idempotency_scope
+     OR NEW.idempotency_key_hash IS DISTINCT FROM OLD.idempotency_key_hash
+     OR NEW.created_from IS DISTINCT FROM OLD.created_from
+     OR NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+    RAISE EXCEPTION 'commerce_orders immutable fields cannot be changed'
+      USING ERRCODE = 'invalid_column_reference';
+  END IF;
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS commerce_orders_immutable_fields ON commerce_orders;
+CREATE TRIGGER commerce_orders_immutable_fields
+  BEFORE UPDATE ON commerce_orders
+  FOR EACH ROW EXECUTE FUNCTION commerce_orders_block_immutable_update();
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'grantex_app') THEN
+    EXECUTE 'GRANT INSERT, SELECT, UPDATE ON commerce_orders TO grantex_app';
+    EXECUTE 'REVOKE DELETE, TRUNCATE ON commerce_orders FROM grantex_app';
+  END IF;
+END
+$$;

--- a/apps/auth-service/src/lib/commerce/ids.ts
+++ b/apps/auth-service/src/lib/commerce/ids.ts
@@ -13,6 +13,7 @@ export const newCommerceProviderCredentialId = (): string => `cpc_${ulid()}`;
 export const newCommerceIdempotencyRecordId = (): string => `cidm_${ulid()}`;
 export const newCommerceCartId = (): string => `ccart_${ulid()}`;
 export const newCommercePaymentIntentId = (): string => `cpi_${ulid()}`;
+export const newCommerceOrderId = (): string => `cord_${ulid()}`;
 export const newCommerceWebhookEventId = (): string => `cwh_${ulid()}`;
 export const newCommerceConnectorId = (): string => `cconn_${ulid()}`;
 export const newCommerceConnectorDryRunId = (): string => `cdry_${ulid()}`;

--- a/apps/auth-service/src/lib/commerce/order-foundation.ts
+++ b/apps/auth-service/src/lib/commerce/order-foundation.ts
@@ -1,0 +1,367 @@
+import { CommerceHttpError } from './errors.js';
+import { newCommerceOrderId } from './ids.js';
+
+export const COMMERCE_ORDER_STATUSES = [
+  'pending_source_facts',
+  'recorded',
+  'merchant_acknowledged',
+  'closed',
+  'cancelled',
+  'expired',
+  'blocked',
+  'unknown',
+] as const;
+
+export type CommerceOrderStatus = typeof COMMERCE_ORDER_STATUSES[number];
+
+export const COMMERCE_ORDER_UNKNOWN_MARKERS = [
+  'price_unknown',
+  'tax_unknown',
+  'final_price_unknown',
+  'source_reference_missing',
+] as const;
+
+export type CommerceOrderUnknownMarker = typeof COMMERCE_ORDER_UNKNOWN_MARKERS[number];
+
+export interface CommerceOrderScopedRef {
+  label: string;
+  tenant_id: string;
+  merchant_id?: string | null;
+  id?: string | null;
+}
+
+export interface CommerceOrderSourceRef {
+  source: 'cart' | 'payment_intent' | 'merchant_safe_source' | 'operator_record';
+  source_id: string;
+  checked_at?: string | null;
+  freshness?: 'fresh' | 'stale' | 'unknown';
+}
+
+export interface CommerceOrderLineItemFactInput {
+  product_id: string;
+  variant_id: string;
+  title: string;
+  sku: string;
+  quantity: number;
+  unit_price_minor_units?: number | null;
+  currency?: string | null;
+  tax_amount_minor_units?: number | null;
+  final_price_minor_units?: number | null;
+  source_refs?: CommerceOrderSourceRef[];
+  unknown_markers?: CommerceOrderUnknownMarker[];
+}
+
+export interface CommerceOrderLineItemSnapshot {
+  product_id: string;
+  variant_id: string;
+  title: string;
+  sku: string;
+  quantity: number;
+  unit_price_minor_units: number | null;
+  currency: string | null;
+  tax_amount_minor_units: number | null;
+  final_price_minor_units: number | null;
+  unknown_markers: CommerceOrderUnknownMarker[];
+  source_refs: CommerceOrderSourceRef[];
+}
+
+export interface CommerceOrderFoundationInput {
+  tenant_id: string;
+  merchant_id: string;
+  buyer_principal_id: string;
+  agent_id?: string | null;
+  cart_id?: string | null;
+  payment_intent_id?: string | null;
+  created_from: 'cart_snapshot' | 'payment_intent_snapshot' | 'merchant_safe_source' | 'operator_record';
+  idempotency_key_hash: string;
+  line_items: CommerceOrderLineItemFactInput[];
+  source_freshness_refs?: Record<string, unknown>;
+  audit_evidence_refs: Array<Record<string, string>>;
+  scoped_refs?: CommerceOrderScopedRef[];
+  support_reference?: Record<string, unknown>;
+}
+
+export interface CommerceOrderFoundationDraft {
+  id: string;
+  tenant_id: string;
+  merchant_id: string;
+  buyer_principal_id: string;
+  agent_id: string | null;
+  cart_id: string | null;
+  payment_intent_id: string | null;
+  status: CommerceOrderStatus;
+  line_items_snapshot: CommerceOrderLineItemSnapshot[];
+  commercial_facts_snapshot: {
+    line_items: CommerceOrderLineItemSnapshot[];
+    totals: {
+      currency: string | null;
+      subtotal_minor_units: number | null;
+      tax_minor_units: number | null;
+      final_minor_units: number | null;
+      unknown_markers: CommerceOrderUnknownMarker[];
+    };
+  };
+  source_freshness_refs: Record<string, unknown>;
+  support_reference: Record<string, unknown>;
+  audit_evidence_refs: Array<Record<string, string>>;
+  idempotency_scope: 'order.foundation.record';
+  idempotency_key_hash: string;
+  created_from: CommerceOrderFoundationInput['created_from'];
+}
+
+const ALLOWED_ORDER_TRANSITIONS: Record<CommerceOrderStatus, CommerceOrderStatus[]> = {
+  pending_source_facts: ['recorded', 'blocked', 'cancelled', 'expired', 'unknown'],
+  recorded: ['merchant_acknowledged', 'closed', 'blocked', 'cancelled', 'unknown'],
+  merchant_acknowledged: ['closed', 'blocked', 'cancelled', 'unknown'],
+  unknown: ['pending_source_facts', 'blocked'],
+  blocked: [],
+  cancelled: [],
+  expired: [],
+  closed: [],
+};
+
+const FORBIDDEN_PROVIDER_OR_PAYMENT_KEYS = new Set([
+  'checkout_url',
+  'checkout_payment_enabled',
+  'live_provider_enabled',
+  'provider_key',
+  'provider_metadata',
+  'provider_order_id',
+  'provider_payment_id',
+  'provider_raw_payload',
+  'raw_provider_payload',
+]);
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function validationError(field: string, message: string): CommerceHttpError {
+  return new CommerceHttpError(422, 'validation_failed', 'Order foundation input is invalid', {
+    retryable: false,
+    details: { fields: { [field]: message } },
+  });
+}
+
+function normalizeGuardKey(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[-\s]+/g, '_')
+    .toLowerCase();
+}
+
+export function canTransitionCommerceOrderStatus(
+  from: CommerceOrderStatus,
+  to: CommerceOrderStatus,
+): boolean {
+  return ALLOWED_ORDER_TRANSITIONS[from].includes(to);
+}
+
+export function assertCommerceOrderStatusTransition(
+  from: CommerceOrderStatus,
+  to: CommerceOrderStatus,
+): void {
+  if (!canTransitionCommerceOrderStatus(from, to)) {
+    throw new CommerceHttpError(409, 'order_status_transition_refused',
+      'Order status transition is not allowed by the C6U7 order foundation', {
+        retryable: false,
+        details: { from, to },
+      });
+  }
+}
+
+export function allowedCommerceOrderStatusTransitions(
+  from: CommerceOrderStatus,
+): CommerceOrderStatus[] {
+  return [...ALLOWED_ORDER_TRANSITIONS[from]];
+}
+
+export function assertCommerceOrderTenantBoundary(input: {
+  tenant_id: string;
+  merchant_id: string;
+  refs?: CommerceOrderScopedRef[];
+}): void {
+  for (const ref of input.refs ?? []) {
+    if (ref.tenant_id !== input.tenant_id) {
+      throw new CommerceHttpError(403, 'order_tenant_mismatch',
+        'Order source facts do not match this tenant', { retryable: false });
+    }
+    if (ref.merchant_id !== undefined && ref.merchant_id !== null && ref.merchant_id !== input.merchant_id) {
+      throw new CommerceHttpError(403, 'order_merchant_mismatch',
+        'Order source facts do not match this merchant', { retryable: false });
+    }
+  }
+}
+
+export function assertNoCommerceOrderProviderEnablement(value: unknown): void {
+  const stack: unknown[] = [value];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === null || current === undefined) continue;
+    if (Array.isArray(current)) {
+      stack.push(...current);
+      continue;
+    }
+    if (typeof current === 'object') {
+      for (const [key, child] of Object.entries(current as Record<string, unknown>)) {
+        if (FORBIDDEN_PROVIDER_OR_PAYMENT_KEYS.has(normalizeGuardKey(key))) {
+          throw new CommerceHttpError(422, 'order_provider_fields_not_allowed',
+            'Order foundation cannot carry live payment or provider execution fields', { retryable: false });
+        }
+        stack.push(child);
+      }
+    }
+  }
+}
+
+export function buildCommerceOrderLineItemSnapshot(
+  input: CommerceOrderLineItemFactInput,
+): CommerceOrderLineItemSnapshot {
+  if (!isNonEmptyString(input.product_id)) throw validationError('product_id', 'is required');
+  if (!isNonEmptyString(input.variant_id)) throw validationError('variant_id', 'is required');
+  if (!isNonEmptyString(input.title)) throw validationError('title', 'is required');
+  if (!isNonEmptyString(input.sku)) throw validationError('sku', 'is required');
+  if (!Number.isSafeInteger(input.quantity) || input.quantity <= 0) {
+    throw validationError('quantity', 'must be a positive integer');
+  }
+
+  const unknownMarkers = new Set<CommerceOrderUnknownMarker>(input.unknown_markers ?? []);
+  if (input.unit_price_minor_units === undefined || input.unit_price_minor_units === null || !input.currency) {
+    unknownMarkers.add('price_unknown');
+  }
+  if (input.tax_amount_minor_units === undefined || input.tax_amount_minor_units === null) {
+    unknownMarkers.add('tax_unknown');
+  }
+  if (input.final_price_minor_units === undefined || input.final_price_minor_units === null) {
+    unknownMarkers.add('final_price_unknown');
+  }
+  if (!input.source_refs || input.source_refs.length === 0) {
+    unknownMarkers.add('source_reference_missing');
+  }
+
+  const snapshot: CommerceOrderLineItemSnapshot = {
+    product_id: input.product_id,
+    variant_id: input.variant_id,
+    title: input.title,
+    sku: input.sku,
+    quantity: input.quantity,
+    unit_price_minor_units: input.unit_price_minor_units ?? null,
+    currency: input.currency ?? null,
+    tax_amount_minor_units: input.tax_amount_minor_units ?? null,
+    final_price_minor_units: input.final_price_minor_units ?? null,
+    unknown_markers: [...unknownMarkers].sort(),
+    source_refs: cloneJson(input.source_refs ?? []),
+  };
+  assertNoCommerceOrderProviderEnablement(snapshot);
+  return snapshot;
+}
+
+export function buildCommerceOrderFoundationDraft(
+  input: CommerceOrderFoundationInput,
+): CommerceOrderFoundationDraft {
+  if (!isNonEmptyString(input.tenant_id)) throw validationError('tenant_id', 'is required');
+  if (!isNonEmptyString(input.merchant_id)) throw validationError('merchant_id', 'is required');
+  if (!isNonEmptyString(input.buyer_principal_id)) throw validationError('buyer_principal_id', 'is required');
+  if (!isNonEmptyString(input.idempotency_key_hash)) {
+    throw validationError('idempotency_key_hash', 'is required');
+  }
+  if (input.line_items.length === 0) throw validationError('line_items', 'must contain at least one item');
+  if (input.audit_evidence_refs.length === 0) {
+    throw validationError('audit_evidence_refs', 'must contain at least one redacted audit reference');
+  }
+
+  assertCommerceOrderTenantBoundary({
+    tenant_id: input.tenant_id,
+    merchant_id: input.merchant_id,
+    ...(input.scoped_refs === undefined ? {} : { refs: input.scoped_refs }),
+  });
+
+  const lineItems = input.line_items.map(buildCommerceOrderLineItemSnapshot);
+  const totalMarkers = new Set<CommerceOrderUnknownMarker>();
+  let currency: string | null = null;
+  let subtotal = 0;
+  let tax = 0;
+  let final = 0;
+  for (const item of lineItems) {
+    for (const marker of item.unknown_markers) totalMarkers.add(marker);
+    if (item.currency) currency = currency ?? item.currency;
+    if (item.unit_price_minor_units === null) {
+      totalMarkers.add('price_unknown');
+    } else {
+      subtotal += item.unit_price_minor_units * item.quantity;
+    }
+    if (item.tax_amount_minor_units === null) {
+      totalMarkers.add('tax_unknown');
+    } else {
+      tax += item.tax_amount_minor_units * item.quantity;
+    }
+    if (item.final_price_minor_units === null) {
+      totalMarkers.add('final_price_unknown');
+    } else {
+      final += item.final_price_minor_units * item.quantity;
+    }
+  }
+
+  const draft: CommerceOrderFoundationDraft = {
+    id: newCommerceOrderId(),
+    tenant_id: input.tenant_id,
+    merchant_id: input.merchant_id,
+    buyer_principal_id: input.buyer_principal_id,
+    agent_id: input.agent_id ?? null,
+    cart_id: input.cart_id ?? null,
+    payment_intent_id: input.payment_intent_id ?? null,
+    status: 'pending_source_facts',
+    line_items_snapshot: cloneJson(lineItems),
+    commercial_facts_snapshot: {
+      line_items: cloneJson(lineItems),
+      totals: {
+        currency,
+        subtotal_minor_units: totalMarkers.has('price_unknown') ? null : subtotal,
+        tax_minor_units: totalMarkers.has('tax_unknown') ? null : tax,
+        final_minor_units: totalMarkers.has('final_price_unknown') ? null : final,
+        unknown_markers: [...totalMarkers].sort(),
+      },
+    },
+    source_freshness_refs: cloneJson(input.source_freshness_refs ?? {}),
+    support_reference: cloneJson(input.support_reference ?? { state: 'support_status_not_enabled_by_c6u7' }),
+    audit_evidence_refs: cloneJson(input.audit_evidence_refs),
+    idempotency_scope: 'order.foundation.record',
+    idempotency_key_hash: input.idempotency_key_hash,
+    created_from: input.created_from,
+  };
+  assertNoCommerceOrderProviderEnablement(draft);
+  return draft;
+}
+
+export type CommerceOrderRefusalCode =
+  | 'order_source_facts_required'
+  | 'order_status_not_enabled_by_c6u7'
+  | 'order_support_status_not_enabled_by_c6u7'
+  | 'order_payment_not_enabled_by_c6u7'
+  | 'order_tenant_mismatch'
+  | 'order_state_unknown';
+
+const PUBLIC_ORDER_REFUSALS: Record<CommerceOrderRefusalCode, string> = {
+  order_source_facts_required: 'Order status is unavailable until Grantex has safe source facts.',
+  order_status_not_enabled_by_c6u7: 'Order status is not available from Grantex for this request yet.',
+  order_support_status_not_enabled_by_c6u7: 'Support status is not available from Grantex for this order yet.',
+  order_payment_not_enabled_by_c6u7: 'Checkout and payment creation are not enabled by the C6U7 order foundation.',
+  order_tenant_mismatch: 'Order source facts do not match this tenant.',
+  order_state_unknown: 'Order state is unknown. Refresh from Grantex before presenting status.',
+};
+
+export function publicCommerceOrderRefusal(code: CommerceOrderRefusalCode): {
+  code: CommerceOrderRefusalCode;
+  message: string;
+  retryable: boolean;
+} {
+  return {
+    code,
+    message: PUBLIC_ORDER_REFUSALS[code],
+    retryable: code === 'order_source_facts_required' || code === 'order_state_unknown',
+  };
+}

--- a/apps/auth-service/tests/commerce-c6u7-order-foundation.test.ts
+++ b/apps/auth-service/tests/commerce-c6u7-order-foundation.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  allowedCommerceOrderStatusTransitions,
+  assertCommerceOrderStatusTransition,
+  assertCommerceOrderTenantBoundary,
+  buildCommerceOrderFoundationDraft,
+  buildCommerceOrderLineItemSnapshot,
+  publicCommerceOrderRefusal,
+} from '../src/lib/commerce/order-foundation.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const MIGRATION_PATH = join(TEST_DIR, '../src/db/migrations/057_commerce_order_foundation.sql');
+const DOC_PATH = join(TEST_DIR, '../../../docs/internal/commerce-v1/commerce-v1-c6u7-order-foundation.md');
+
+const TENANT = 'cten_C6U7';
+const MERCHANT = 'mch_C6U7';
+const AGENT = 'cag_C6U7';
+const CART = 'ccart_C6U7';
+const PAYMENT_INTENT = 'cpi_C6U7';
+
+function baseLineItem() {
+  return {
+    product_id: 'cprd_C6U7',
+    variant_id: 'cvar_C6U7',
+    title: 'Countertop Oven',
+    sku: 'OVEN-C6U7',
+    quantity: 2,
+    unit_price_minor_units: 125000,
+    currency: 'INR',
+    tax_amount_minor_units: null,
+    final_price_minor_units: null,
+    source_refs: [{ source: 'cart' as const, source_id: CART, checked_at: '2026-06-10T00:00:00.000Z', freshness: 'fresh' as const }],
+  };
+}
+
+describe('C6U7 commerce order foundation', () => {
+  it('adds a tenant-scoped order table without provider or checkout execution fields', () => {
+    const migration = readFileSync(MIGRATION_PATH, 'utf8');
+
+    expect(migration).toMatch(/CREATE TABLE IF NOT EXISTS commerce_orders/);
+    expect(migration).toMatch(/tenant_id\s+TEXT NOT NULL REFERENCES commerce_tenants\(id\)/);
+    expect(migration).toMatch(/buyer_principal_id\s+TEXT NOT NULL/);
+    expect(migration).toMatch(/line_items_snapshot\s+JSONB NOT NULL/);
+    expect(migration).toMatch(/commercial_facts_snapshot\s+JSONB NOT NULL/);
+    expect(migration).toMatch(/support_reference\s+JSONB NOT NULL/);
+    expect(migration).toMatch(/audit_evidence_refs\s+JSONB NOT NULL/);
+    expect(migration).toMatch(/uq_commerce_orders_idempotency/);
+    expect(migration).toMatch(/fk_commerce_orders_cart/);
+    expect(migration).toMatch(/fk_commerce_orders_payment_intent/);
+    expect(migration).toMatch(/commerce_orders_block_immutable_update/);
+    expect(migration).toMatch(/commerce_orders immutable fields cannot be changed/);
+    expect(migration).not.toMatch(/provider_payment_id/);
+    expect(migration).not.toMatch(/provider_order_id/);
+    expect(migration).not.toMatch(/checkout_url/);
+  });
+
+  it('builds immutable line-item and commercial fact snapshots with unknown tax/final-price markers', () => {
+    const sourceItem = baseLineItem();
+    const draft = buildCommerceOrderFoundationDraft({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      buyer_principal_id: 'buyer_C6U7',
+      agent_id: AGENT,
+      cart_id: CART,
+      payment_intent_id: PAYMENT_INTENT,
+      created_from: 'payment_intent_snapshot',
+      idempotency_key_hash: 'hash_idempotency',
+      line_items: [sourceItem],
+      source_freshness_refs: { cart_checked_at: '2026-06-10T00:00:00.000Z' },
+      audit_evidence_refs: [{ audit_event_id: 'caud_C6U7_CART' }],
+      scoped_refs: [
+        { label: 'cart', tenant_id: TENANT, merchant_id: MERCHANT, id: CART },
+        { label: 'payment_intent', tenant_id: TENANT, merchant_id: MERCHANT, id: PAYMENT_INTENT },
+      ],
+    });
+
+    sourceItem.title = 'Mutated title after snapshot';
+
+    expect(draft.id).toMatch(/^cord_/);
+    expect(draft.status).toBe('pending_source_facts');
+    expect(draft.line_items_snapshot[0]?.title).toBe('Countertop Oven');
+    expect(draft.commercial_facts_snapshot.totals).toMatchObject({
+      currency: 'INR',
+      subtotal_minor_units: 250000,
+      tax_minor_units: null,
+      final_minor_units: null,
+    });
+    expect(draft.commercial_facts_snapshot.totals.unknown_markers).toEqual([
+      'final_price_unknown',
+      'tax_unknown',
+    ]);
+    expect(draft.support_reference).toEqual({ state: 'support_status_not_enabled_by_c6u7' });
+  });
+
+  it('refuses mismatched tenant and merchant source references fail closed', () => {
+    expect(() => assertCommerceOrderTenantBoundary({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      refs: [{ label: 'cart', tenant_id: 'cten_OTHER', merchant_id: MERCHANT, id: CART }],
+    })).toThrow(/Order source facts do not match this tenant/);
+
+    expect(() => assertCommerceOrderTenantBoundary({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      refs: [{ label: 'payment_intent', tenant_id: TENANT, merchant_id: 'mch_OTHER', id: PAYMENT_INTENT }],
+    })).toThrow(/Order source facts do not match this merchant/);
+  });
+
+  it('keeps order status transitions fail-closed and non-payment-enabling', () => {
+    expect(allowedCommerceOrderStatusTransitions('pending_source_facts')).toEqual([
+      'recorded',
+      'blocked',
+      'cancelled',
+      'expired',
+      'unknown',
+    ]);
+    expect(() => assertCommerceOrderStatusTransition('pending_source_facts', 'recorded')).not.toThrow();
+    expect(() => assertCommerceOrderStatusTransition('closed', 'recorded')).toThrow(/not allowed/);
+    expect(() => assertCommerceOrderStatusTransition('recorded', 'paid' as never)).toThrow(/not allowed/);
+  });
+
+  it('rejects live payment/provider execution fields in order facts', () => {
+    expect(() => buildCommerceOrderLineItemSnapshot({
+      ...baseLineItem(),
+      source_refs: [{ source: 'cart', source_id: CART, provider_payment_id: 'pay_private' } as never],
+    })).toThrow(/live payment or provider execution fields/);
+
+    expect(() => buildCommerceOrderLineItemSnapshot({
+      ...baseLineItem(),
+      source_refs: [{ source: 'cart', source_id: CART, checkoutUrl: 'https://checkout.example.invalid' } as never],
+    })).toThrow(/live payment or provider execution fields/);
+  });
+
+  it('keeps public order refusals buyer-safe', () => {
+    const refusal = publicCommerceOrderRefusal('order_status_not_enabled_by_c6u7');
+    const serialized = JSON.stringify(refusal);
+
+    expect(refusal).toMatchObject({
+      code: 'order_status_not_enabled_by_c6u7',
+      retryable: false,
+    });
+    expect(serialized).not.toContain('passport');
+    expect(serialized).not.toContain('jwt');
+    expect(serialized).not.toContain('secret');
+    expect(serialized).not.toContain('provider_payment_id');
+    expect(serialized).not.toContain('merchant-private');
+    expect(serialized).not.toContain('raw_payload');
+  });
+
+  it('documents AgenticOrg refusal unless Grantex safe order facts exist', () => {
+    const doc = readFileSync(DOC_PATH, 'utf8');
+
+    expect(doc).toContain('AgenticOrg must refuse order or support status when Grantex has not provided buyer-safe source facts');
+    expect(doc).toContain('checkout/payment creation remains blocked by C6U7');
+    expect(doc).toContain('not a production launch, public discovery approval, checkout approval, payment approval, merchant approval, or protocol publication');
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6u7-order-foundation.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6u7-order-foundation.md
@@ -1,0 +1,77 @@
+# C6U7 Order Foundation
+
+Status: internal implementation note only. This is not a production launch, public discovery approval, checkout approval, payment approval, merchant approval, protocol publication, external submission, certification, compliance, conformance, standardization, public-launch readiness, or production readiness claim.
+
+This is not a production launch, public discovery approval, checkout approval, payment approval, merchant approval, or protocol publication.
+
+## Boundary
+
+C6U7 adds a Grantex-owned order foundation that can hold tenant-scoped order facts after Grantex has safe source data. It does not enable public discovery, production Commerce V1, checkout creation, payment creation, live payments, live Plural, provider calls, merchant private API calls, production allowlists, fulfillment execution, refund execution, settlement, payout, shipping integration, or support execution.
+
+The order foundation sits between cart/payment records and future post-purchase flows. It is schema/model only in this slice. No new endpoint is added by C6U7.
+
+## Required Order Facts
+
+Every order record is tenant-scoped and merchant-scoped. The foundation keeps:
+
+- `tenant_id`
+- `merchant_id`
+- buyer principal reference
+- optional CommerceAgent reference
+- optional Grantex cart reference
+- optional Grantex payment-intent reference
+- immutable line-item snapshot
+- commercial fact snapshot
+- source freshness references
+- support reference placeholder
+- redacted audit evidence references
+- idempotency key hash scoped by tenant, merchant, and order foundation endpoint
+
+Line-item snapshots include product ID, variant ID, title, SKU, quantity, price and currency when known, tax markers when tax is unknown, final-price markers when final price is unknown, and source/freshness references.
+
+## Status Model
+
+C6U7 order status is fail-closed and non-payment-enabling. Supported states are:
+
+- `pending_source_facts`
+- `recorded`
+- `merchant_acknowledged`
+- `closed`
+- `cancelled`
+- `expired`
+- `blocked`
+- `unknown`
+
+The model intentionally has no `paid` status and no provider payment status. Payment state remains owned by `commerce_payment_intents`. An order status must not imply checkout, payment creation, fulfillment, refund, or support execution.
+
+## AgenticOrg Consumption Rule
+
+AgenticOrg must refuse order or support status when Grantex has not provided buyer-safe source facts. A cached AgenticOrg state cannot create or override order status. AgenticOrg can only display future order/support facts that are explicitly returned by Grantex as buyer-safe and scoped to the same tenant, merchant, buyer, and session.
+
+Public-safe refusal examples:
+
+- "Order status is unavailable until Grantex has safe source facts."
+- "Support status is not available from Grantex for this order yet."
+- "checkout/payment creation remains blocked by C6U7."
+
+Do not expose raw passports, JWTs, tokens, raw consent payloads, provider credentials, raw provider payloads, provider payment IDs, merchant private URLs, DB/Redis URLs, webhook secrets, production config values, concrete production allowlists, raw connector payloads, or private incident evidence.
+
+## Explicit Non-Goals
+
+C6U7 must stop if it adds any of the following:
+
+- checkout or payment creation
+- live payment, live Plural, or provider calls
+- direct merchant private API calls
+- public discovery enablement
+- production Commerce V1 enablement
+- production config or production allowlists
+- cloud resources or deploy behavior
+- workflow changes
+- fulfillment, refund, settlement, payout, shipping, or support execution
+- protocol publication or external submission
+- certification, compliance, conformance, standardization, merchant approval, public-launch readiness, or production readiness claims
+
+## Validation
+
+C6U7 validation should include focused order-foundation tests, nearby cart/payment/idempotency tests when touched, typecheck, whitespace diff check, ASCII check for new files, secret/private scan, passport/JWT/raw-token scan, production config/allowlist scan, public discovery enablement scan, checkout/payment/live-provider/live-Plural scan, direct provider/Plural scan, merchant private API scan, raw connector/private payload scan, and overclaim scan.


### PR DESCRIPTION
C6U7 adds a Grantex-owned order foundation only. Scope: tenant-scoped commerce_orders migration, order-foundation model helpers, focused tests, and internal docs. No endpoint, OpenAPI, workflow, production config, checkout/payment creation, live provider, live Plural, provider call, merchant private API call, fulfillment, refund, settlement, payout, public discovery, allowlist, or external protocol behavior is added. Validation run locally: auth-service C6U7/cart/payment/C6U6 tests passed, auth-service typecheck passed, C6Oe preview gate passed, diff/ASCII/guardrail scans passed. Migration note: adds commerce_orders and a tenant/id unique constraint on commerce_payment_intents for composite FK support; human review requested before merge.