### PR TITLE
feat(commerce): add order handoff foundation

### DIFF
--- a/apps/auth-service/src/db/migrations/058_commerce_order_handoff_foundation.sql
+++ b/apps/auth-service/src/db/migrations/058_commerce_order_handoff_foundation.sql
@@ -1,0 +1,139 @@
+-- Grantex Commerce C6U8: order handoff contract foundation only.
+-- Handoff rows record tenant-scoped, buyer-safe source facts for future
+-- fulfillment, delivery, support, return, and refund status handling. They
+-- do not execute fulfillment, shipping, refunds, settlement, payout,
+-- checkout/payment, provider calls, or merchant private API calls.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conname = 'uq_commerce_orders_tenant_order_merchant'
+       AND conrelid = 'commerce_orders'::regclass
+  ) THEN
+    ALTER TABLE commerce_orders
+      ADD CONSTRAINT uq_commerce_orders_tenant_order_merchant UNIQUE (tenant_id, id, merchant_id);
+  END IF;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS commerce_order_handoffs (
+  id                         TEXT PRIMARY KEY, -- cohf_<ulid>
+  tenant_id                  TEXT NOT NULL REFERENCES commerce_tenants(id),
+  order_id                   TEXT NOT NULL,
+  merchant_id                TEXT NOT NULL,
+  buyer_principal_id         TEXT NOT NULL,
+  agent_id                   TEXT,
+  session_id                 TEXT,
+  handoff_type               TEXT NOT NULL,
+  status                     TEXT NOT NULL DEFAULT 'draft',
+  status_reason              TEXT,
+  handoff_snapshot           JSONB NOT NULL,
+  source_freshness_refs      JSONB NOT NULL DEFAULT '{}'::JSONB,
+  support_reference          JSONB NOT NULL DEFAULT '{"state":"handoff_support_not_enabled_by_c6u8"}'::JSONB,
+  audit_evidence_refs        JSONB NOT NULL DEFAULT '[]'::JSONB,
+  idempotency_scope          TEXT NOT NULL,
+  idempotency_key_hash       TEXT NOT NULL,
+  created_from               TEXT NOT NULL DEFAULT 'order_safe_source',
+  created_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_commerce_order_handoff_type CHECK (
+    handoff_type IN ('fulfillment','delivery','support','return','refund')
+  ),
+  CONSTRAINT chk_commerce_order_handoff_status CHECK (
+    status IN (
+      'draft',
+      'requested',
+      'acknowledged',
+      'blocked',
+      'rejected',
+      'expired',
+      'cancelled',
+      'manual_review_required',
+      'resolved_manually'
+    )
+  ),
+  CONSTRAINT chk_commerce_order_handoff_created_from CHECK (
+    created_from IN ('order_safe_source','merchant_safe_source','operator_record','manual_review')
+  ),
+  CONSTRAINT chk_commerce_order_handoff_idempotency_scope CHECK (
+    idempotency_scope IN (
+      'order.handoff.fulfillment.record',
+      'order.handoff.delivery.record',
+      'order.handoff.support.record',
+      'order.handoff.return.record',
+      'order.handoff.refund.record'
+    )
+  ),
+  CONSTRAINT chk_commerce_order_handoff_snapshot_object
+    CHECK (jsonb_typeof(handoff_snapshot) = 'object'),
+  CONSTRAINT chk_commerce_order_handoff_source_refs_object
+    CHECK (jsonb_typeof(source_freshness_refs) = 'object'),
+  CONSTRAINT chk_commerce_order_handoff_support_reference_object
+    CHECK (jsonb_typeof(support_reference) = 'object'),
+  CONSTRAINT chk_commerce_order_handoff_audit_refs_array
+    CHECK (jsonb_typeof(audit_evidence_refs) = 'array'),
+  CONSTRAINT fk_commerce_order_handoff_order
+    FOREIGN KEY (tenant_id, order_id, merchant_id)
+    REFERENCES commerce_orders(tenant_id, id, merchant_id),
+  CONSTRAINT fk_commerce_order_handoff_merchant
+    FOREIGN KEY (tenant_id, merchant_id)
+    REFERENCES commerce_merchants(tenant_id, id),
+  CONSTRAINT fk_commerce_order_handoff_agent
+    FOREIGN KEY (tenant_id, agent_id)
+    REFERENCES commerce_agents(tenant_id, id),
+  CONSTRAINT uq_commerce_order_handoffs_tenant_id UNIQUE (tenant_id, id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_commerce_order_handoffs_idempotency
+  ON commerce_order_handoffs(tenant_id, order_id, handoff_type, idempotency_scope, idempotency_key_hash);
+
+CREATE INDEX IF NOT EXISTS idx_commerce_order_handoffs_order_type
+  ON commerce_order_handoffs(tenant_id, order_id, handoff_type, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_commerce_order_handoffs_merchant_status
+  ON commerce_order_handoffs(tenant_id, merchant_id, status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_commerce_order_handoffs_buyer
+  ON commerce_order_handoffs(tenant_id, buyer_principal_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_commerce_order_handoffs_agent_session
+  ON commerce_order_handoffs(tenant_id, agent_id, session_id)
+  WHERE agent_id IS NOT NULL OR session_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION commerce_order_handoffs_block_immutable_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+     OR NEW.order_id IS DISTINCT FROM OLD.order_id
+     OR NEW.merchant_id IS DISTINCT FROM OLD.merchant_id
+     OR NEW.buyer_principal_id IS DISTINCT FROM OLD.buyer_principal_id
+     OR NEW.agent_id IS DISTINCT FROM OLD.agent_id
+     OR NEW.session_id IS DISTINCT FROM OLD.session_id
+     OR NEW.handoff_type IS DISTINCT FROM OLD.handoff_type
+     OR NEW.handoff_snapshot IS DISTINCT FROM OLD.handoff_snapshot
+     OR NEW.source_freshness_refs IS DISTINCT FROM OLD.source_freshness_refs
+     OR NEW.audit_evidence_refs IS DISTINCT FROM OLD.audit_evidence_refs
+     OR NEW.idempotency_scope IS DISTINCT FROM OLD.idempotency_scope
+     OR NEW.idempotency_key_hash IS DISTINCT FROM OLD.idempotency_key_hash
+     OR NEW.created_from IS DISTINCT FROM OLD.created_from
+     OR NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+    RAISE EXCEPTION 'commerce_order_handoffs immutable fields cannot be changed'
+      USING ERRCODE = 'invalid_column_reference';
+  END IF;
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS commerce_order_handoffs_immutable_fields ON commerce_order_handoffs;
+CREATE TRIGGER commerce_order_handoffs_immutable_fields
+  BEFORE UPDATE ON commerce_order_handoffs
+  FOR EACH ROW EXECUTE FUNCTION commerce_order_handoffs_block_immutable_update();
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'grantex_app') THEN
+    EXECUTE 'GRANT INSERT, SELECT, UPDATE ON commerce_order_handoffs TO grantex_app';
+    EXECUTE 'REVOKE DELETE, TRUNCATE ON commerce_order_handoffs FROM grantex_app';
+  END IF;
+END
+$$;

--- a/apps/auth-service/src/lib/commerce/ids.ts
+++ b/apps/auth-service/src/lib/commerce/ids.ts
@@ -14,6 +14,7 @@ export const newCommerceIdempotencyRecordId = (): string => `cidm_${ulid()}`;
 export const newCommerceCartId = (): string => `ccart_${ulid()}`;
 export const newCommercePaymentIntentId = (): string => `cpi_${ulid()}`;
 export const newCommerceOrderId = (): string => `cord_${ulid()}`;
+export const newCommerceOrderHandoffId = (): string => `cohf_${ulid()}`;
 export const newCommerceWebhookEventId = (): string => `cwh_${ulid()}`;
 export const newCommerceConnectorId = (): string => `cconn_${ulid()}`;
 export const newCommerceConnectorDryRunId = (): string => `cdry_${ulid()}`;

--- a/apps/auth-service/src/lib/commerce/order-handoff.ts
+++ b/apps/auth-service/src/lib/commerce/order-handoff.ts
@@ -1,0 +1,468 @@
+import { CommerceHttpError } from './errors.js';
+import { newCommerceOrderHandoffId } from './ids.js';
+
+export const COMMERCE_ORDER_HANDOFF_TYPES = [
+  'fulfillment',
+  'delivery',
+  'support',
+  'return',
+  'refund',
+] as const;
+
+export type CommerceOrderHandoffType = typeof COMMERCE_ORDER_HANDOFF_TYPES[number];
+
+export const COMMERCE_ORDER_HANDOFF_STATUSES = [
+  'draft',
+  'requested',
+  'acknowledged',
+  'blocked',
+  'rejected',
+  'expired',
+  'cancelled',
+  'manual_review_required',
+  'resolved_manually',
+] as const;
+
+export type CommerceOrderHandoffStatus = typeof COMMERCE_ORDER_HANDOFF_STATUSES[number];
+
+export const COMMERCE_ORDER_HANDOFF_UNKNOWN_MARKERS = [
+  'handoff_source_missing',
+  'fulfillment_source_missing',
+  'delivery_source_missing',
+  'support_source_missing',
+  'return_source_missing',
+  'refund_source_missing',
+] as const;
+
+export type CommerceOrderHandoffUnknownMarker = typeof COMMERCE_ORDER_HANDOFF_UNKNOWN_MARKERS[number];
+
+export interface CommerceOrderHandoffScopedRef {
+  label: string;
+  tenant_id: string;
+  order_id?: string | null;
+  merchant_id?: string | null;
+  buyer_principal_id?: string | null;
+}
+
+export interface CommerceOrderHandoffSourceRef {
+  source: 'order' | 'merchant_safe_source' | 'operator_record' | 'manual_review';
+  source_id: string;
+  checked_at?: string | null;
+  freshness?: 'fresh' | 'stale' | 'unknown';
+}
+
+export interface CommerceOrderHandoffSnapshotInput {
+  handoff_type: unknown;
+  summary?: string | null;
+  safe_fields?: Record<string, unknown>;
+  source_refs?: CommerceOrderHandoffSourceRef[];
+  unknown_markers?: CommerceOrderHandoffUnknownMarker[];
+}
+
+export interface CommerceOrderHandoffSnapshot {
+  handoff_type: CommerceOrderHandoffType;
+  summary: string;
+  safe_fields: Record<string, unknown>;
+  source_refs: CommerceOrderHandoffSourceRef[];
+  unknown_markers: CommerceOrderHandoffUnknownMarker[];
+}
+
+export interface CommerceOrderHandoffFoundationInput {
+  tenant_id: string;
+  order_id: string;
+  merchant_id: string;
+  buyer_principal_id: string;
+  agent_id?: string | null;
+  session_id?: string | null;
+  handoff_type: unknown;
+  handoff_snapshot: CommerceOrderHandoffSnapshotInput;
+  source_freshness_refs?: Record<string, unknown>;
+  audit_evidence_refs: Array<Record<string, string>>;
+  idempotency_key_hash: string;
+  created_from: 'order_safe_source' | 'merchant_safe_source' | 'operator_record' | 'manual_review';
+  scoped_refs?: CommerceOrderHandoffScopedRef[];
+  support_reference?: Record<string, unknown>;
+}
+
+export interface CommerceOrderHandoffFoundationDraft {
+  id: string;
+  tenant_id: string;
+  order_id: string;
+  merchant_id: string;
+  buyer_principal_id: string;
+  agent_id: string | null;
+  session_id: string | null;
+  handoff_type: CommerceOrderHandoffType;
+  status: CommerceOrderHandoffStatus;
+  handoff_snapshot: CommerceOrderHandoffSnapshot;
+  source_freshness_refs: Record<string, unknown>;
+  support_reference: Record<string, unknown>;
+  audit_evidence_refs: Array<Record<string, string>>;
+  idempotency_scope: CommerceOrderHandoffIdempotencyScope;
+  idempotency_key_hash: string;
+  created_from: CommerceOrderHandoffFoundationInput['created_from'];
+}
+
+export type CommerceOrderHandoffIdempotencyScope =
+  | 'order.handoff.fulfillment.record'
+  | 'order.handoff.delivery.record'
+  | 'order.handoff.support.record'
+  | 'order.handoff.return.record'
+  | 'order.handoff.refund.record';
+
+const HANDOFF_IDEMPOTENCY_SCOPE_BY_TYPE: Record<CommerceOrderHandoffType, CommerceOrderHandoffIdempotencyScope> = {
+  fulfillment: 'order.handoff.fulfillment.record',
+  delivery: 'order.handoff.delivery.record',
+  support: 'order.handoff.support.record',
+  return: 'order.handoff.return.record',
+  refund: 'order.handoff.refund.record',
+};
+
+const ALLOWED_HANDOFF_TRANSITIONS: Record<CommerceOrderHandoffStatus, CommerceOrderHandoffStatus[]> = {
+  draft: ['requested', 'blocked', 'cancelled', 'expired', 'manual_review_required'],
+  requested: ['acknowledged', 'blocked', 'rejected', 'cancelled', 'expired', 'manual_review_required'],
+  acknowledged: ['manual_review_required', 'resolved_manually', 'blocked', 'rejected', 'cancelled', 'expired'],
+  manual_review_required: ['resolved_manually', 'blocked', 'rejected', 'cancelled', 'expired'],
+  blocked: [],
+  rejected: [],
+  expired: [],
+  cancelled: [],
+  resolved_manually: [],
+};
+
+const FORBIDDEN_HANDOFF_EXECUTION_KEYS = new Set([
+  'carrier_api_key',
+  'carrier_execution_enabled',
+  'carrier_label_url',
+  'carrier_provider',
+  'carrier_request_id',
+  'carrier_tracking_url',
+  'checkout_payment_enabled',
+  'checkout_url',
+  'delivery_execution_enabled',
+  'fulfillment_execution_enabled',
+  'live_payment_provider_enabled',
+  'live_provider_enabled',
+  'merchant_private_api_key',
+  'merchant_private_api_url',
+  'payment_approval',
+  'private_api_key',
+  'private_api_url',
+  'provider_key',
+  'provider_metadata',
+  'provider_order_id',
+  'provider_payment_id',
+  'provider_raw_payload',
+  'raw_connector_payload',
+  'raw_payload',
+  'raw_provider_payload',
+  'refund_execution_enabled',
+  'refund_provider_id',
+  'refund_transaction_id',
+  'settlement_enabled',
+  'settlement_id',
+  'shipping_enabled',
+  'shipping_label_url',
+  'tracking_number',
+  'payout_enabled',
+  'payout_id',
+]);
+
+const PRIVATE_SUMMARY_KEYS = new Set([
+  'credential',
+  'credentials',
+  'db_url',
+  'evidence',
+  'jwt',
+  'merchant_private_url',
+  'passport',
+  'private_url',
+  'provider_credential',
+  'raw_connector_payload',
+  'raw_payload',
+  'raw_provider_payload',
+  'redis_url',
+  'secret',
+  'token',
+  'webhook_secret',
+]);
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function normalizeGuardKey(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[-\s]+/g, '_')
+    .toLowerCase();
+}
+
+function validationError(field: string, message: string): CommerceHttpError {
+  return new CommerceHttpError(422, 'validation_failed', 'Order handoff foundation input is invalid', {
+    retryable: false,
+    details: { fields: { [field]: message } },
+  });
+}
+
+export function assertCommerceOrderHandoffType(value: unknown): CommerceOrderHandoffType {
+  if (typeof value === 'string' && (COMMERCE_ORDER_HANDOFF_TYPES as readonly string[]).includes(value)) {
+    return value as CommerceOrderHandoffType;
+  }
+  throw validationError('handoff_type', 'must be one of fulfillment, delivery, support, return, refund');
+}
+
+export function assertCommerceOrderHandoffStatus(value: unknown): CommerceOrderHandoffStatus {
+  if (typeof value === 'string' && (COMMERCE_ORDER_HANDOFF_STATUSES as readonly string[]).includes(value)) {
+    return value as CommerceOrderHandoffStatus;
+  }
+  throw validationError('status', 'must be a fail-closed C6U8 handoff status');
+}
+
+export function commerceOrderHandoffIdempotencyScope(
+  handoffType: CommerceOrderHandoffType,
+): CommerceOrderHandoffIdempotencyScope {
+  return HANDOFF_IDEMPOTENCY_SCOPE_BY_TYPE[handoffType];
+}
+
+export function canTransitionCommerceOrderHandoffStatus(
+  from: CommerceOrderHandoffStatus,
+  to: CommerceOrderHandoffStatus,
+): boolean {
+  return ALLOWED_HANDOFF_TRANSITIONS[from].includes(to);
+}
+
+export function assertCommerceOrderHandoffStatusTransition(
+  from: CommerceOrderHandoffStatus,
+  to: CommerceOrderHandoffStatus,
+): void {
+  assertCommerceOrderHandoffStatus(from);
+  assertCommerceOrderHandoffStatus(to);
+  if (!canTransitionCommerceOrderHandoffStatus(from, to)) {
+    throw new CommerceHttpError(409, 'order_handoff_status_transition_refused',
+      'Order handoff status transition is not allowed by the C6U8 handoff foundation', {
+        retryable: false,
+        details: { from, to },
+      });
+  }
+}
+
+export function allowedCommerceOrderHandoffStatusTransitions(
+  from: CommerceOrderHandoffStatus,
+): CommerceOrderHandoffStatus[] {
+  assertCommerceOrderHandoffStatus(from);
+  return [...ALLOWED_HANDOFF_TRANSITIONS[from]];
+}
+
+export function assertCommerceOrderHandoffBoundary(input: {
+  tenant_id: string;
+  order_id: string;
+  merchant_id: string;
+  buyer_principal_id?: string;
+  refs?: CommerceOrderHandoffScopedRef[];
+}): void {
+  for (const ref of input.refs ?? []) {
+    if (ref.tenant_id !== input.tenant_id) {
+      throw new CommerceHttpError(403, 'order_handoff_tenant_mismatch',
+        'Order handoff source facts do not match this tenant', { retryable: false });
+    }
+    if (ref.order_id !== undefined && ref.order_id !== null && ref.order_id !== input.order_id) {
+      throw new CommerceHttpError(403, 'order_handoff_order_mismatch',
+        'Order handoff source facts do not match this order', { retryable: false });
+    }
+    if (ref.merchant_id !== undefined && ref.merchant_id !== null && ref.merchant_id !== input.merchant_id) {
+      throw new CommerceHttpError(403, 'order_handoff_merchant_mismatch',
+        'Order handoff source facts do not match this merchant', { retryable: false });
+    }
+    if (
+      input.buyer_principal_id !== undefined
+      && ref.buyer_principal_id !== undefined
+      && ref.buyer_principal_id !== null
+      && ref.buyer_principal_id !== input.buyer_principal_id
+    ) {
+      throw new CommerceHttpError(403, 'order_handoff_buyer_mismatch',
+        'Order handoff source facts do not match this buyer', { retryable: false });
+    }
+  }
+}
+
+export function assertNoCommerceOrderHandoffExecutionFields(value: unknown): void {
+  const stack: unknown[] = [value];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === null || current === undefined) continue;
+    if (Array.isArray(current)) {
+      stack.push(...current);
+      continue;
+    }
+    if (typeof current === 'object') {
+      for (const [key, child] of Object.entries(current as Record<string, unknown>)) {
+        if (FORBIDDEN_HANDOFF_EXECUTION_KEYS.has(normalizeGuardKey(key))) {
+          throw new CommerceHttpError(422, 'order_handoff_execution_fields_not_allowed',
+            'Order handoff cannot carry fulfillment, shipping, refund, provider, payment, payout, settlement, or private API execution fields', {
+              retryable: false,
+            });
+        }
+        stack.push(child);
+      }
+    }
+  }
+}
+
+export function redactCommerceOrderHandoffPrivateFields<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactCommerceOrderHandoffPrivateFields(item)) as T;
+  }
+  if (value !== null && typeof value === 'object') {
+    const output: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      output[key] = PRIVATE_SUMMARY_KEYS.has(normalizeGuardKey(key))
+        ? '[redacted]'
+        : redactCommerceOrderHandoffPrivateFields(child);
+    }
+    return output as T;
+  }
+  return value;
+}
+
+export function buildCommerceOrderHandoffSnapshot(
+  input: CommerceOrderHandoffSnapshotInput,
+): CommerceOrderHandoffSnapshot {
+  const handoffType = assertCommerceOrderHandoffType(input.handoff_type);
+  const unknownMarkers = new Set<CommerceOrderHandoffUnknownMarker>(input.unknown_markers ?? []);
+  if (!input.source_refs || input.source_refs.length === 0) {
+    unknownMarkers.add(`${handoffType}_source_missing` as CommerceOrderHandoffUnknownMarker);
+    unknownMarkers.add('handoff_source_missing');
+  }
+
+  const snapshot: CommerceOrderHandoffSnapshot = {
+    handoff_type: handoffType,
+    summary: isNonEmptyString(input.summary) ? input.summary : 'Handoff status requires Grantex safe source facts.',
+    safe_fields: redactCommerceOrderHandoffPrivateFields(cloneJson(input.safe_fields ?? {})),
+    source_refs: cloneJson(input.source_refs ?? []),
+    unknown_markers: [...unknownMarkers].sort(),
+  };
+  assertNoCommerceOrderHandoffExecutionFields(snapshot);
+  return snapshot;
+}
+
+export function buildCommerceOrderHandoffFoundationDraft(
+  input: CommerceOrderHandoffFoundationInput,
+): CommerceOrderHandoffFoundationDraft {
+  if (!isNonEmptyString(input.tenant_id)) throw validationError('tenant_id', 'is required');
+  if (!isNonEmptyString(input.order_id)) throw validationError('order_id', 'is required');
+  if (!isNonEmptyString(input.merchant_id)) throw validationError('merchant_id', 'is required');
+  if (!isNonEmptyString(input.buyer_principal_id)) throw validationError('buyer_principal_id', 'is required');
+  if (!isNonEmptyString(input.idempotency_key_hash)) {
+    throw validationError('idempotency_key_hash', 'is required');
+  }
+  if (input.audit_evidence_refs.length === 0) {
+    throw validationError('audit_evidence_refs', 'must contain at least one redacted audit reference');
+  }
+
+  const handoffType = assertCommerceOrderHandoffType(input.handoff_type);
+  assertCommerceOrderHandoffBoundary({
+    tenant_id: input.tenant_id,
+    order_id: input.order_id,
+    merchant_id: input.merchant_id,
+    buyer_principal_id: input.buyer_principal_id,
+    ...(input.scoped_refs === undefined ? {} : { refs: input.scoped_refs }),
+  });
+
+  const snapshot = buildCommerceOrderHandoffSnapshot({
+    ...input.handoff_snapshot,
+    handoff_type: handoffType,
+  });
+  const draft: CommerceOrderHandoffFoundationDraft = {
+    id: newCommerceOrderHandoffId(),
+    tenant_id: input.tenant_id,
+    order_id: input.order_id,
+    merchant_id: input.merchant_id,
+    buyer_principal_id: input.buyer_principal_id,
+    agent_id: input.agent_id ?? null,
+    session_id: input.session_id ?? null,
+    handoff_type: handoffType,
+    status: 'draft',
+    handoff_snapshot: snapshot,
+    source_freshness_refs: redactCommerceOrderHandoffPrivateFields(cloneJson(input.source_freshness_refs ?? {})),
+    support_reference: redactCommerceOrderHandoffPrivateFields(
+      cloneJson(input.support_reference ?? { state: 'handoff_support_not_enabled_by_c6u8' }),
+    ),
+    audit_evidence_refs: cloneJson(input.audit_evidence_refs),
+    idempotency_scope: commerceOrderHandoffIdempotencyScope(handoffType),
+    idempotency_key_hash: input.idempotency_key_hash,
+    created_from: input.created_from,
+  };
+  assertNoCommerceOrderHandoffExecutionFields(draft);
+  return draft;
+}
+
+export type CommerceOrderHandoffRefusalCode =
+  | 'order_handoff_source_facts_required'
+  | 'order_handoff_status_not_enabled_by_c6u8'
+  | 'order_handoff_support_not_enabled_by_c6u8'
+  | 'order_handoff_execution_not_enabled_by_c6u8'
+  | 'order_handoff_tenant_mismatch'
+  | 'order_handoff_order_mismatch'
+  | 'order_handoff_state_unknown';
+
+const PUBLIC_HANDOFF_REFUSALS: Record<CommerceOrderHandoffRefusalCode, string> = {
+  order_handoff_source_facts_required: 'Handoff status is unavailable until Grantex has safe source facts.',
+  order_handoff_status_not_enabled_by_c6u8: 'Handoff status is not available from Grantex for this request yet.',
+  order_handoff_support_not_enabled_by_c6u8: 'Support status is not available from Grantex for this order yet.',
+  order_handoff_execution_not_enabled_by_c6u8: 'Fulfillment, delivery, return, and refund execution are not enabled by the C6U8 handoff foundation.',
+  order_handoff_tenant_mismatch: 'Order handoff source facts do not match this tenant.',
+  order_handoff_order_mismatch: 'Order handoff source facts do not match this order.',
+  order_handoff_state_unknown: 'Handoff state is unknown. Refresh from Grantex before presenting status.',
+};
+
+export function publicCommerceOrderHandoffRefusal(code: CommerceOrderHandoffRefusalCode): {
+  code: CommerceOrderHandoffRefusalCode;
+  message: string;
+  retryable: boolean;
+} {
+  return {
+    code,
+    message: PUBLIC_HANDOFF_REFUSALS[code],
+    retryable: code === 'order_handoff_source_facts_required' || code === 'order_handoff_state_unknown',
+  };
+}
+
+export function publicCommerceOrderHandoffStatusSummary(input: {
+  handoff_type: CommerceOrderHandoffType;
+  status: CommerceOrderHandoffStatus;
+}): {
+  handoff_type: CommerceOrderHandoffType;
+  status: CommerceOrderHandoffStatus;
+  message: string;
+  retryable: boolean;
+} {
+  const status = assertCommerceOrderHandoffStatus(input.status);
+  const handoffType = assertCommerceOrderHandoffType(input.handoff_type);
+  if (status === 'draft' || status === 'manual_review_required') {
+    return {
+      handoff_type: handoffType,
+      status,
+      message: 'Handoff status requires Grantex safe source facts or manual review.',
+      retryable: true,
+    };
+  }
+  if (status === 'resolved_manually') {
+    return {
+      handoff_type: handoffType,
+      status,
+      message: 'Handoff status was recorded from a manual Grantex-safe source.',
+      retryable: false,
+    };
+  }
+  return {
+    handoff_type: handoffType,
+    status,
+    message: 'Handoff status is recorded without enabling live execution.',
+    retryable: false,
+  };
+}

--- a/apps/auth-service/tests/commerce-c6u8-order-handoff-foundation.test.ts
+++ b/apps/auth-service/tests/commerce-c6u8-order-handoff-foundation.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  allowedCommerceOrderHandoffStatusTransitions,
+  assertCommerceOrderHandoffBoundary,
+  assertCommerceOrderHandoffStatusTransition,
+  assertCommerceOrderHandoffType,
+  buildCommerceOrderHandoffFoundationDraft,
+  buildCommerceOrderHandoffSnapshot,
+  commerceOrderHandoffIdempotencyScope,
+  publicCommerceOrderHandoffRefusal,
+  publicCommerceOrderHandoffStatusSummary,
+  redactCommerceOrderHandoffPrivateFields,
+} from '../src/lib/commerce/order-handoff.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const MIGRATION_PATH = join(TEST_DIR, '../src/db/migrations/058_commerce_order_handoff_foundation.sql');
+const DOC_PATH = join(TEST_DIR, '../../../docs/internal/commerce-v1/commerce-v1-c6u8-fulfillment-delivery-support-return-refund-handoff.md');
+
+const TENANT = 'cten_C6U8';
+const MERCHANT = 'mch_C6U8';
+const ORDER = 'cord_C6U8';
+const BUYER = 'buyer_C6U8';
+const AGENT = 'cag_C6U8';
+const SESSION = 'buyer_session_C6U8';
+
+function baseDraftInput() {
+  return {
+    tenant_id: TENANT,
+    order_id: ORDER,
+    merchant_id: MERCHANT,
+    buyer_principal_id: BUYER,
+    agent_id: AGENT,
+    session_id: SESSION,
+    handoff_type: 'delivery',
+    handoff_snapshot: {
+      handoff_type: 'delivery',
+      summary: 'Delivery source facts pending from Grantex-safe source.',
+      safe_fields: { promised_window: null, current_state: 'source_facts_pending' },
+      source_refs: [{ source: 'order' as const, source_id: ORDER, checked_at: '2026-06-10T00:00:00.000Z', freshness: 'fresh' as const }],
+    },
+    source_freshness_refs: { order_checked_at: '2026-06-10T00:00:00.000Z' },
+    audit_evidence_refs: [{ audit_event_id: 'caud_C6U8_HANDOFF' }],
+    idempotency_key_hash: 'hash_handoff_idempotency',
+    created_from: 'order_safe_source' as const,
+    scoped_refs: [
+      { label: 'order', tenant_id: TENANT, order_id: ORDER, merchant_id: MERCHANT, buyer_principal_id: BUYER },
+    ],
+  };
+}
+
+describe('C6U8 commerce order handoff foundation', () => {
+  it('adds tenant-scoped order handoffs without execution fields or endpoints', () => {
+    const migration = readFileSync(MIGRATION_PATH, 'utf8');
+
+    expect(migration).toMatch(/CREATE TABLE IF NOT EXISTS commerce_order_handoffs/);
+    expect(migration).toMatch(/tenant_id\s+TEXT NOT NULL REFERENCES commerce_tenants\(id\)/);
+    expect(migration).toMatch(/order_id\s+TEXT NOT NULL/);
+    expect(migration).toMatch(/merchant_id\s+TEXT NOT NULL/);
+    expect(migration).toMatch(/buyer_principal_id\s+TEXT NOT NULL/);
+    expect(migration).toMatch(/handoff_type IN \('fulfillment','delivery','support','return','refund'\)/);
+    expect(migration).toMatch(/status IN \(/);
+    expect(migration).toMatch(/uq_commerce_order_handoffs_idempotency/);
+    expect(migration).toMatch(/fk_commerce_order_handoff_order/);
+    expect(migration).toMatch(/commerce_order_handoffs_block_immutable_update/);
+    expect(migration).toMatch(/commerce_order_handoffs immutable fields cannot be changed/);
+    expect(migration).toMatch(/uq_commerce_orders_tenant_order_merchant/);
+    expect(migration).not.toMatch(/provider_payment_id/);
+    expect(migration).not.toMatch(/checkout_url/);
+    expect(migration).not.toMatch(/carrier_tracking_url/);
+    expect(migration).not.toMatch(/refund_transaction_id/);
+    expect(migration).not.toMatch(/settlement_id/);
+    expect(migration).not.toMatch(/payout_id/);
+    expect(migration).not.toMatch(/merchant_private_api/);
+  });
+
+  it('builds immutable handoff snapshots and redacts private fields', () => {
+    const source = {
+      handoff_type: 'support',
+      summary: 'Support source facts pending.',
+      safe_fields: {
+        ticket_state: 'not_started',
+        jwt: 'private-token',
+        nested: { webhook_secret: 'private-secret' },
+      },
+      source_refs: [{ source: 'order' as const, source_id: ORDER, freshness: 'fresh' as const }],
+    };
+    const snapshot = buildCommerceOrderHandoffSnapshot(source);
+
+    source.safe_fields.ticket_state = 'mutated';
+
+    expect(snapshot).toMatchObject({
+      handoff_type: 'support',
+      summary: 'Support source facts pending.',
+    });
+    expect(snapshot.safe_fields).toMatchObject({
+      ticket_state: 'not_started',
+      jwt: '[redacted]',
+      nested: { webhook_secret: '[redacted]' },
+    });
+  });
+
+  it('builds draft records with tenant/order scoped idempotency', () => {
+    const draft = buildCommerceOrderHandoffFoundationDraft(baseDraftInput());
+
+    expect(draft.id).toMatch(/^cohf_/);
+    expect(draft.status).toBe('draft');
+    expect(draft.handoff_type).toBe('delivery');
+    expect(draft.idempotency_scope).toBe('order.handoff.delivery.record');
+    expect(commerceOrderHandoffIdempotencyScope('refund')).toBe('order.handoff.refund.record');
+    expect(draft.support_reference).toEqual({ state: 'handoff_support_not_enabled_by_c6u8' });
+  });
+
+  it('refuses mismatched tenant, order, merchant, and buyer source references fail closed', () => {
+    expect(() => assertCommerceOrderHandoffBoundary({
+      tenant_id: TENANT,
+      order_id: ORDER,
+      merchant_id: MERCHANT,
+      refs: [{ label: 'order', tenant_id: 'cten_OTHER', order_id: ORDER, merchant_id: MERCHANT }],
+    })).toThrow(/do not match this tenant/);
+
+    expect(() => assertCommerceOrderHandoffBoundary({
+      tenant_id: TENANT,
+      order_id: ORDER,
+      merchant_id: MERCHANT,
+      refs: [{ label: 'order', tenant_id: TENANT, order_id: 'cord_OTHER', merchant_id: MERCHANT }],
+    })).toThrow(/do not match this order/);
+
+    expect(() => assertCommerceOrderHandoffBoundary({
+      tenant_id: TENANT,
+      order_id: ORDER,
+      merchant_id: MERCHANT,
+      refs: [{ label: 'order', tenant_id: TENANT, order_id: ORDER, merchant_id: 'mch_OTHER' }],
+    })).toThrow(/do not match this merchant/);
+
+    expect(() => assertCommerceOrderHandoffBoundary({
+      tenant_id: TENANT,
+      order_id: ORDER,
+      merchant_id: MERCHANT,
+      buyer_principal_id: BUYER,
+      refs: [{ label: 'order', tenant_id: TENANT, order_id: ORDER, merchant_id: MERCHANT, buyer_principal_id: 'buyer_OTHER' }],
+    })).toThrow(/do not match this buyer/);
+  });
+
+  it('validates handoff types and fail-closed status transitions', () => {
+    expect(assertCommerceOrderHandoffType('fulfillment')).toBe('fulfillment');
+    expect(() => assertCommerceOrderHandoffType('settlement')).toThrow(/Order handoff foundation input is invalid/);
+    expect(allowedCommerceOrderHandoffStatusTransitions('draft')).toEqual([
+      'requested',
+      'blocked',
+      'cancelled',
+      'expired',
+      'manual_review_required',
+    ]);
+    expect(() => assertCommerceOrderHandoffStatusTransition('draft', 'requested')).not.toThrow();
+    expect(() => assertCommerceOrderHandoffStatusTransition('resolved_manually', 'requested')).toThrow(/not allowed/);
+    expect(() => assertCommerceOrderHandoffStatusTransition('requested', 'fulfilled' as never)).toThrow(/Order handoff foundation input is invalid/);
+  });
+
+  it('rejects provider, carrier, refund, private API, settlement, and payout execution fields', () => {
+    const forbiddenSamples = [
+      { carrierTrackingUrl: 'https://carrier.example.invalid/track/private' },
+      { refundTransactionId: 'refund_private' },
+      { merchantPrivateApiUrl: 'https://merchant-private.example.invalid/orders' },
+      { provider_payment_id: 'pay_private' },
+      { checkoutUrl: 'https://checkout.example.invalid' },
+      { settlementId: 'set_private' },
+      { payoutId: 'po_private' },
+      { raw_payload: { private: true } },
+    ];
+
+    for (const safe_fields of forbiddenSamples) {
+      expect(() => buildCommerceOrderHandoffSnapshot({
+        handoff_type: 'refund',
+        safe_fields,
+        source_refs: [{ source: 'order', source_id: ORDER }],
+      })).toThrow(/cannot carry/);
+    }
+  });
+
+  it('keeps buyer-facing handoff refusals and status summaries safe', () => {
+    const refusal = publicCommerceOrderHandoffRefusal('order_handoff_execution_not_enabled_by_c6u8');
+    const summary = publicCommerceOrderHandoffStatusSummary({ handoff_type: 'return', status: 'manual_review_required' });
+    const redacted = redactCommerceOrderHandoffPrivateFields({
+      raw_payload: { passport: 'private-passport' },
+      public_state: 'manual_review_required',
+    });
+    const serialized = JSON.stringify({ refusal, summary, redacted });
+
+    expect(refusal.retryable).toBe(false);
+    expect(summary.retryable).toBe(true);
+    expect(redacted).toMatchObject({
+      raw_payload: '[redacted]',
+      public_state: 'manual_review_required',
+    });
+    expect(serialized).not.toContain('private-passport');
+    expect(serialized).not.toContain('provider_payment_id');
+    expect(serialized).not.toContain('merchant-private');
+    expect(serialized).not.toContain('webhook_secret');
+  });
+
+  it('documents non-enabling scope and AgenticOrg refusal rules', () => {
+    const doc = readFileSync(DOC_PATH, 'utf8');
+
+    expect(doc).toContain('No endpoint or OpenAPI surface is added by C6U8');
+    expect(doc).toContain('AgenticOrg must refuse fulfillment, delivery, support, return, and refund status');
+    expect(doc).toContain('not a production launch, public discovery approval, checkout approval, payment approval, merchant approval, protocol publication, external submission');
+    expect(doc).toContain('Rollback requires care because migration 058 adds a composite uniqueness constraint to `commerce_orders`');
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6u8-fulfillment-delivery-support-return-refund-handoff.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6u8-fulfillment-delivery-support-return-refund-handoff.md
@@ -1,0 +1,125 @@
+# C6U8 Fulfillment, Delivery, Support, Return, And Refund Handoff
+
+Status: internal implementation note only. This is not a production launch, public discovery approval, checkout approval, payment approval, merchant approval, protocol publication, external submission, certification, compliance, conformance, standardization, public-launch readiness, production readiness, fulfillment enablement, refund enablement, settlement enablement, payout enablement, delivery enablement, or shipping enablement claim.
+
+This is not a production launch, public discovery approval, checkout approval, payment approval, merchant approval, fulfillment approval, refund approval, settlement approval, payout approval, or protocol publication.
+
+## Scope
+
+C6U8 adds a Grantex-owned handoff contract foundation for fulfillment, delivery, support, return, and refund status facts. It is schema/model/docs/test only in this slice. No endpoint or OpenAPI surface is added by C6U8 because no external or buyer-facing handoff API is exposed yet.
+
+The foundation can hold tenant-scoped, buyer-safe source facts tied to a Grantex order. It does not enable public discovery, production Commerce V1, checkout creation, payment creation, live payments, live Plural, provider calls, carrier calls, shipping integration, merchant private API calls, refund execution, fulfillment execution, delivery execution, support workflow execution, settlement, payout, production allowlists, cloud resources, or deploy behavior.
+
+## Handoff Contract Model
+
+Every handoff record is tenant-scoped, order-scoped, and merchant-scoped. The foundation keeps:
+
+- `tenant_id`
+- `order_id`
+- `merchant_id`
+- buyer principal reference
+- optional CommerceAgent reference
+- optional session reference
+- handoff type
+- fail-closed handoff status
+- immutable handoff snapshot
+- source freshness references
+- support placeholder
+- redacted audit evidence references
+- idempotency key hash scoped by tenant, order, handoff type, and handoff endpoint
+
+The handoff snapshot can include only buyer-safe facts returned by Grantex-safe sources. Unknown or absent facts must remain explicit instead of being inferred.
+
+## Handoff Types
+
+| Type | Meaning In C6U8 | Execution Status |
+| --- | --- | --- |
+| `fulfillment` | Safe facts about future fulfillment handoff state | Execution is blocked |
+| `delivery` | Safe facts about future delivery handoff state | Carrier and shipping integration are blocked |
+| `support` | Safe facts about future support handoff state | Support workflow execution is blocked |
+| `return` | Safe facts about future return handoff state | Return execution is blocked |
+| `refund` | Safe facts about future refund handoff state | Refund and provider execution are blocked |
+
+## Status Model
+
+C6U8 handoff status is fail-closed and non-execution-enabling. Supported states are:
+
+- `draft`
+- `requested`
+- `acknowledged`
+- `blocked`
+- `rejected`
+- `expired`
+- `cancelled`
+- `manual_review_required`
+- `resolved_manually`
+
+No status means live fulfillment, live delivery, carrier booking, shipping label creation, support workflow execution, return execution, refund execution, settlement, payout, checkout creation, or payment-provider action.
+
+## AgenticOrg Consumption Rule
+
+AgenticOrg must refuse fulfillment, delivery, support, return, and refund status when Grantex has not provided buyer-safe source facts. A cached AgenticOrg state cannot create, infer, or override handoff status. AgenticOrg can only display future handoff facts that are explicitly returned by Grantex as buyer-safe and scoped to the same tenant, merchant, order, buyer, and session.
+
+Buyer-safe wording examples:
+
+- "Handoff status is unavailable until Grantex has safe source facts."
+- "Support status is not available from Grantex for this order yet."
+- "Fulfillment, delivery, return, and refund execution are not enabled by C6U8."
+- "Handoff state is unknown. Refresh from Grantex before presenting status."
+
+Unsafe wording examples:
+
+- "Fulfillment is complete."
+- "Delivery is booked with the carrier."
+- "Refund has been processed."
+- "Settlement or payout is complete."
+- "Support case is resolved by the merchant system."
+
+Those examples are unsafe unless a later slice adds a Grantex-owned source, buyer-safe evidence contract, and explicit execution controls.
+
+## Audit And Evidence Expectations
+
+Handoff records must reference redacted audit evidence. They must not expose raw passports, JWTs, tokens, raw consent payloads, provider credentials, carrier credentials, raw provider payloads, raw carrier payloads, raw connector payloads, provider payment IDs, private merchant URLs, DB/Redis URLs, webhook secrets, production config values, concrete production allowlists, private incident evidence, settlement references, payout references, or refund execution references.
+
+Source freshness references must identify only safe source labels, source IDs, checked timestamps, and freshness state. Stale or unknown facts must remain visible as stale or unknown and must not be treated as successful execution.
+
+## Migration And Rollback Notes
+
+Migration 058 creates `commerce_order_handoffs` and adds `commerce_orders(tenant_id, id, merchant_id)` uniqueness so handoff rows can enforce tenant-safe order and merchant boundaries at the database layer. The added uniqueness is data-safe because `commerce_orders.id` is already the primary key, but adding the constraint may still take a table lock depending on table size and database behavior.
+
+Rollback requires care because migration 058 adds a composite uniqueness constraint to `commerce_orders` and creates dependent foreign keys from `commerce_order_handoffs`. This migration is forward-only under the V1 migration policy. If old code is restored, it remains compatible because the new table is additive and no existing nullable/runtime field is required by older code.
+
+## Stop Conditions
+
+C6U8 must stop if it adds any of the following:
+
+- endpoint, route, or OpenAPI exposure without a separate review
+- checkout or payment creation
+- live payment, live Plural, or provider calls
+- carrier calls or shipping integration
+- direct merchant private API calls
+- public discovery enablement
+- production Commerce V1 enablement
+- production config or production allowlists
+- cloud resources or deploy behavior
+- workflow changes
+- fulfillment, delivery, support, return, refund, settlement, payout, or shipping execution
+- protocol publication or external submission
+- certification, compliance, conformance, standardization, merchant approval, public-launch readiness, production readiness, checkout approval, payment approval, fulfillment enablement, delivery enablement, shipping enablement, refund enablement, settlement enablement, or payout enablement claims
+
+## Future Slices
+
+- AgenticOrg buyer-facing order/status consumption
+- fulfillment execution
+- carrier integration
+- refund execution
+- support workflow
+- settlement, payout, and reconciliation
+- sandbox checkout E2E
+- live provider readiness
+
+Each future slice needs its own source-of-truth, tenant-boundary, authorization, audit, redaction, rollback, and non-enablement review before any external surface is exposed.
+
+## Validation
+
+C6U8 validation should include focused handoff tests, nearby order/cart/payment/refusal tests, typecheck, whitespace diff check, ASCII check for new files, secret/private scan, passport/JWT/raw-token scan, production config/allowlist scan, public discovery enablement scan, checkout/payment/live-provider/live-Plural scan, direct provider/Plural scan, carrier/private API scan, raw connector/private payload scan, and overclaim scan.


### PR DESCRIPTION
Adds C6U8 Grantex-only order handoff foundation for fulfillment, delivery, support, return, and refund status contracts. Scope is migration/model/tests/docs only. No endpoint/OpenAPI/workflow/config changes. No checkout/payment/live provider/carrier/refund/settlement/payout/private API execution. Local validation passed: focused C6U8 tests, nearby commerce order/cart/payment/refusal tests, auth-service typecheck, internal preview gate, and git diff whitespace checks.