### PR TITLE
C6U9 sandbox checkout E2E foundation

### DIFF
--- a/apps/auth-service/src/lib/commerce/sandbox-checkout-e2e.ts
+++ b/apps/auth-service/src/lib/commerce/sandbox-checkout-e2e.ts
@@ -1,0 +1,727 @@
+import { CommerceHttpError } from './errors.js';
+import { hashRequestBody } from './idempotency.js';
+import {
+  buildCommerceOrderFoundationDraft,
+  publicCommerceOrderRefusal,
+  type CommerceOrderFoundationDraft,
+  type CommerceOrderLineItemFactInput,
+} from './order-foundation.js';
+import {
+  buildCommerceOrderHandoffFoundationDraft,
+  publicCommerceOrderHandoffRefusal,
+  type CommerceOrderHandoffFoundationDraft,
+} from './order-handoff.js';
+
+export const COMMERCE_SANDBOX_CHECKOUT_STATUSES = [
+  'draft',
+  'authority_checked',
+  'order_linked',
+  'handoff_linked',
+  'synthetic_outcome_recorded',
+  'refused',
+  'blocked',
+] as const;
+
+export type CommerceSandboxCheckoutStatus = typeof COMMERCE_SANDBOX_CHECKOUT_STATUSES[number];
+
+export const COMMERCE_SANDBOX_SYNTHETIC_PAYMENT_OUTCOMES = [
+  'not_attempted',
+  'synthetic_authorized',
+  'synthetic_pending',
+  'synthetic_succeeded',
+  'synthetic_declined',
+  'synthetic_expired',
+  'synthetic_cancelled',
+] as const;
+
+export type CommerceSandboxSyntheticPaymentOutcome =
+  typeof COMMERCE_SANDBOX_SYNTHETIC_PAYMENT_OUTCOMES[number];
+
+export type CommerceSandboxCheckoutRefusalCode =
+  | 'sandbox_checkout_tenant_context_required'
+  | 'sandbox_checkout_merchant_context_required'
+  | 'sandbox_checkout_buyer_context_required'
+  | 'sandbox_checkout_agent_context_required'
+  | 'sandbox_checkout_session_context_required'
+  | 'sandbox_checkout_cart_required'
+  | 'sandbox_checkout_cart_facts_required'
+  | 'sandbox_checkout_consent_required'
+  | 'sandbox_checkout_passport_required'
+  | 'sandbox_checkout_passport_expired'
+  | 'sandbox_checkout_passport_revoked'
+  | 'sandbox_checkout_passport_mismatch'
+  | 'sandbox_checkout_passport_unknown'
+  | 'sandbox_checkout_checkout_passport_required'
+  | 'sandbox_checkout_scope_required'
+  | 'sandbox_checkout_environment_refused'
+  | 'sandbox_checkout_public_discovery_not_available'
+  | 'sandbox_checkout_audit_evidence_required'
+  | 'sandbox_checkout_idempotency_required';
+
+export interface CommerceSandboxCheckoutAuthority {
+  consent_granted?: boolean | null;
+  passport_status?: 'valid' | 'missing' | 'expired' | 'revoked' | 'mismatched' | 'unknown' | null;
+  passport_type?: 'checkout' | 'browse' | 'support' | 'unknown' | null;
+  tenant_id?: string | null;
+  merchant_id?: string | null;
+  agent_id?: string | null;
+  buyer_principal_id?: string | null;
+  session_id?: string | null;
+  environment?: 'sandbox' | 'live' | 'unknown' | null;
+  scopes?: string[] | null;
+}
+
+export interface CommerceSandboxCheckoutCartInput {
+  cart_id?: string | null;
+  line_items?: CommerceOrderLineItemFactInput[] | null;
+  source_checked_at?: string | null;
+}
+
+export interface CommerceSandboxCheckoutE2EInput {
+  tenant_id?: string | null;
+  merchant_id?: string | null;
+  buyer_principal_id?: string | null;
+  agent_id?: string | null;
+  session_id?: string | null;
+  environment?: 'sandbox' | 'live' | 'unknown' | null;
+  public_discovery_state?: 'hidden' | 'disabled' | 'enabled' | 'unknown' | null;
+  cart?: CommerceSandboxCheckoutCartInput | null;
+  payment_intent_id?: string | null;
+  synthetic_payment_outcome?: CommerceSandboxSyntheticPaymentOutcome | null;
+  authority?: CommerceSandboxCheckoutAuthority | null;
+  source_freshness_refs?: Record<string, unknown> | null;
+  buyer_safe_context?: Record<string, unknown> | null;
+  audit_evidence_refs?: Array<Record<string, string>> | null;
+  idempotency_key_hash?: string | null;
+}
+
+export interface CommerceSandboxCheckoutSyntheticPaymentSummary {
+  payment_intent_id: string | null;
+  outcome: CommerceSandboxSyntheticPaymentOutcome;
+  mode: 'local_sandbox_contract_only';
+  live_mode: false;
+  provider_call: false;
+  partner_payment_rail_call: false;
+  carrier_call: false;
+  merchant_private_api_call: false;
+  production_checkout_enabled: false;
+}
+
+export interface CommerceSandboxCheckoutReadyResult {
+  status: 'synthetic_outcome_recorded';
+  tenant_id: string;
+  merchant_id: string;
+  buyer_principal_id: string;
+  agent_id: string;
+  session_id: string;
+  environment: 'sandbox';
+  buyer_facing_checkout_surface: 'not_exposed';
+  public_discovery_state: 'hidden' | 'disabled';
+  idempotency_scope: 'sandbox.checkout.e2e.contract';
+  idempotency_key_hash: string;
+  request_body_hash: string;
+  order: CommerceOrderFoundationDraft;
+  handoff: CommerceOrderHandoffFoundationDraft;
+  synthetic_payment: CommerceSandboxCheckoutSyntheticPaymentSummary;
+  buyer_safe_context: Record<string, unknown>;
+  audit_evidence_refs: Array<Record<string, string>>;
+  non_enablement: {
+    production_checkout: false;
+    live_payment: false;
+    live_partner_payment_rail: false;
+    provider_call: false;
+    partner_payment_rail_call: false;
+    carrier_call: false;
+    merchant_private_api_call: false;
+    public_discovery: false;
+  };
+  sequence: Array<{
+    step: string;
+    status: CommerceSandboxCheckoutStatus;
+    message: string;
+  }>;
+}
+
+export interface CommerceSandboxCheckoutRefusedResult {
+  status: 'refused';
+  refusal: {
+    code: CommerceSandboxCheckoutRefusalCode;
+    message: string;
+    retryable: boolean;
+  };
+  buyer_facing_checkout_surface: 'not_exposed';
+  public_discovery_state: 'hidden' | 'disabled' | 'enabled' | 'unknown';
+  non_enablement: CommerceSandboxCheckoutReadyResult['non_enablement'];
+  sequence: Array<{
+    step: string;
+    status: 'refused';
+    message: string;
+  }>;
+}
+
+export type CommerceSandboxCheckoutE2EResult =
+  | CommerceSandboxCheckoutReadyResult
+  | CommerceSandboxCheckoutRefusedResult;
+
+export interface CommerceSandboxCheckoutPriorResult {
+  tenant_id: string;
+  merchant_id: string;
+  idempotency_scope: 'sandbox.checkout.e2e.contract';
+  idempotency_key_hash: string;
+  request_body_hash: string;
+  response: CommerceSandboxCheckoutE2EResult;
+}
+
+export type CommerceSandboxCheckoutReplayResult =
+  | { kind: 'new'; request_body_hash: string }
+  | { kind: 'replay'; response: CommerceSandboxCheckoutE2EResult }
+  | { kind: 'conflict'; expected_body_hash: string; actual_body_hash: string };
+
+const ALLOWED_SANDBOX_CHECKOUT_TRANSITIONS: Record<CommerceSandboxCheckoutStatus, CommerceSandboxCheckoutStatus[]> = {
+  draft: ['authority_checked', 'refused', 'blocked'],
+  authority_checked: ['order_linked', 'refused', 'blocked'],
+  order_linked: ['handoff_linked', 'blocked'],
+  handoff_linked: ['synthetic_outcome_recorded', 'blocked'],
+  synthetic_outcome_recorded: [],
+  refused: [],
+  blocked: [],
+};
+
+const FORBIDDEN_SANDBOX_CHECKOUT_KEYS = new Set([
+  'carrier_api_key',
+  'carrier_call',
+  'carrier_execution_enabled',
+  'carrier_label_url',
+  'carrier_provider',
+  'carrier_request_id',
+  'carrier_tracking_url',
+  'checkout_payment_enabled',
+  'checkout_url',
+  'delivery_execution_enabled',
+  'fulfillment_execution_enabled',
+  'live_payment_enabled',
+  'live_payment_provider_enabled',
+  'live_provider_enabled',
+  ['live_plu', 'ral_enabled'].join(''),
+  'merchant_private_api_call',
+  'merchant_private_api_key',
+  'merchant_private_api_url',
+  'payment_provider_call',
+  ['plu', 'ral_call'].join(''),
+  'private_api_key',
+  'private_api_url',
+  'production_allowlist',
+  'production_checkout_enabled',
+  'provider_call',
+  'provider_key',
+  'provider_metadata',
+  'provider_order_id',
+  'provider_payment_id',
+  'provider_raw_payload',
+  'raw_connector_payload',
+  'raw_payload',
+  'raw_provider_payload',
+  'refund_execution_enabled',
+  'refund_provider_id',
+  'refund_transaction_id',
+  'settlement_enabled',
+  'settlement_id',
+  'shipping_enabled',
+  'shipping_label_url',
+  'tracking_number',
+  'payout_enabled',
+  'payout_id',
+]);
+
+const PRIVATE_SANDBOX_CHECKOUT_KEYS = new Set([
+  'access_token',
+  'api_key',
+  'authorization',
+  'bearer',
+  'credential',
+  'credentials',
+  'db_url',
+  'evidence',
+  'jwt',
+  'merchant_private_url',
+  'passport',
+  'private_url',
+  'provider_credential',
+  'raw_consent_payload',
+  'redis_url',
+  'refresh_token',
+  'secret',
+  'token',
+  'webhook_secret',
+]);
+
+const PUBLIC_SANDBOX_CHECKOUT_REFUSALS: Record<CommerceSandboxCheckoutRefusalCode, {
+  message: string;
+  retryable: boolean;
+}> = {
+  sandbox_checkout_tenant_context_required: {
+    message: 'Sandbox checkout requires a tenant-bound Grantex context.',
+    retryable: false,
+  },
+  sandbox_checkout_merchant_context_required: {
+    message: 'Sandbox checkout requires a merchant-bound Grantex context.',
+    retryable: false,
+  },
+  sandbox_checkout_buyer_context_required: {
+    message: 'Sandbox checkout requires a buyer or session principal.',
+    retryable: false,
+  },
+  sandbox_checkout_agent_context_required: {
+    message: 'Sandbox checkout requires a registered CommerceAgent context.',
+    retryable: false,
+  },
+  sandbox_checkout_session_context_required: {
+    message: 'Sandbox checkout requires a buyer session context.',
+    retryable: false,
+  },
+  sandbox_checkout_cart_required: {
+    message: 'Sandbox checkout requires a Grantex cart reference.',
+    retryable: false,
+  },
+  sandbox_checkout_cart_facts_required: {
+    message: 'Sandbox checkout requires safe cart facts before an order foundation can be represented.',
+    retryable: true,
+  },
+  sandbox_checkout_consent_required: {
+    message: 'Sandbox checkout requires user consent before protected sequencing can continue.',
+    retryable: true,
+  },
+  sandbox_checkout_passport_required: {
+    message: 'Sandbox checkout requires Commerce Passport authority before protected sequencing can continue.',
+    retryable: true,
+  },
+  sandbox_checkout_passport_expired: {
+    message: 'Sandbox checkout authority has expired. Refresh consent before continuing.',
+    retryable: true,
+  },
+  sandbox_checkout_passport_revoked: {
+    message: 'Sandbox checkout authority has been revoked.',
+    retryable: false,
+  },
+  sandbox_checkout_passport_mismatch: {
+    message: 'Sandbox checkout authority does not match this tenant, merchant, buyer, session, or agent.',
+    retryable: false,
+  },
+  sandbox_checkout_passport_unknown: {
+    message: 'Sandbox checkout authority is unknown. Refresh from Grantex before continuing.',
+    retryable: true,
+  },
+  sandbox_checkout_checkout_passport_required: {
+    message: 'Sandbox checkout requires checkout-scoped Commerce Passport authority.',
+    retryable: true,
+  },
+  sandbox_checkout_scope_required: {
+    message: 'Sandbox checkout requires checkout and payment initiation scopes.',
+    retryable: true,
+  },
+  sandbox_checkout_environment_refused: {
+    message: 'Sandbox checkout E2E refuses live or unknown payment environments.',
+    retryable: false,
+  },
+  sandbox_checkout_public_discovery_not_available: {
+    message: 'Buyer-facing checkout remains unavailable while public discovery is not enabled for this slice.',
+    retryable: false,
+  },
+  sandbox_checkout_audit_evidence_required: {
+    message: 'Sandbox checkout requires redacted audit evidence references.',
+    retryable: true,
+  },
+  sandbox_checkout_idempotency_required: {
+    message: 'Sandbox checkout requires a hashed idempotency key reference.',
+    retryable: false,
+  },
+};
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function normalizeGuardKey(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[-\s]+/g, '_')
+    .toLowerCase();
+}
+
+function safeDiscoveryState(
+  state: CommerceSandboxCheckoutE2EInput['public_discovery_state'],
+): 'hidden' | 'disabled' | 'enabled' | 'unknown' {
+  if (state === 'hidden' || state === 'disabled' || state === 'enabled') return state;
+  return 'unknown';
+}
+
+function normalizeSyntheticOutcome(
+  outcome: CommerceSandboxCheckoutE2EInput['synthetic_payment_outcome'],
+): CommerceSandboxSyntheticPaymentOutcome {
+  if (
+    typeof outcome === 'string'
+    && (COMMERCE_SANDBOX_SYNTHETIC_PAYMENT_OUTCOMES as readonly string[]).includes(outcome)
+  ) {
+    return outcome as CommerceSandboxSyntheticPaymentOutcome;
+  }
+  return 'not_attempted';
+}
+
+function publicRefusal(code: CommerceSandboxCheckoutRefusalCode): CommerceSandboxCheckoutRefusedResult['refusal'] {
+  const refusal = PUBLIC_SANDBOX_CHECKOUT_REFUSALS[code];
+  return {
+    code,
+    message: refusal.message,
+    retryable: refusal.retryable,
+  };
+}
+
+function refusalResult(
+  input: CommerceSandboxCheckoutE2EInput,
+  code: CommerceSandboxCheckoutRefusalCode,
+): CommerceSandboxCheckoutRefusedResult {
+  const refusal = publicRefusal(code);
+  return {
+    status: 'refused',
+    refusal,
+    buyer_facing_checkout_surface: 'not_exposed',
+    public_discovery_state: safeDiscoveryState(input.public_discovery_state),
+    non_enablement: {
+      production_checkout: false,
+      live_payment: false,
+      live_partner_payment_rail: false,
+      provider_call: false,
+      partner_payment_rail_call: false,
+      carrier_call: false,
+      merchant_private_api_call: false,
+      public_discovery: false,
+    },
+    sequence: [{
+      step: 'fail_closed_refusal',
+      status: 'refused',
+      message: refusal.message,
+    }],
+  };
+}
+
+export function canTransitionCommerceSandboxCheckoutStatus(
+  from: CommerceSandboxCheckoutStatus,
+  to: CommerceSandboxCheckoutStatus,
+): boolean {
+  return ALLOWED_SANDBOX_CHECKOUT_TRANSITIONS[from].includes(to);
+}
+
+export function assertCommerceSandboxCheckoutStatusTransition(
+  from: CommerceSandboxCheckoutStatus,
+  to: CommerceSandboxCheckoutStatus,
+): void {
+  if (!canTransitionCommerceSandboxCheckoutStatus(from, to)) {
+    throw new CommerceHttpError(409, 'sandbox_checkout_status_transition_refused',
+      'Sandbox checkout status transition is not allowed by the C6U9 foundation', {
+        retryable: false,
+        details: { from, to },
+      });
+  }
+}
+
+export function allowedCommerceSandboxCheckoutStatusTransitions(
+  from: CommerceSandboxCheckoutStatus,
+): CommerceSandboxCheckoutStatus[] {
+  return [...ALLOWED_SANDBOX_CHECKOUT_TRANSITIONS[from]];
+}
+
+export function assertNoCommerceSandboxCheckoutExecutionFields(value: unknown): void {
+  const stack: unknown[] = [value];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === null || current === undefined) continue;
+    if (Array.isArray(current)) {
+      stack.push(...current);
+      continue;
+    }
+    if (typeof current === 'object') {
+      for (const [key, child] of Object.entries(current as Record<string, unknown>)) {
+        if (FORBIDDEN_SANDBOX_CHECKOUT_KEYS.has(normalizeGuardKey(key))) {
+          throw new CommerceHttpError(422, 'sandbox_checkout_execution_fields_not_allowed',
+            'Sandbox checkout cannot carry production checkout, live payment, provider, partner rail, carrier, private API, raw payload, settlement, payout, fulfillment, or refund execution fields', {
+              retryable: false,
+            });
+        }
+        stack.push(child);
+      }
+    }
+  }
+}
+
+export function redactCommerceSandboxCheckoutPrivateFields<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactCommerceSandboxCheckoutPrivateFields(item)) as T;
+  }
+  if (value !== null && typeof value === 'object') {
+    const output: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      output[key] = PRIVATE_SANDBOX_CHECKOUT_KEYS.has(normalizeGuardKey(key))
+        ? '[redacted]'
+        : redactCommerceSandboxCheckoutPrivateFields(child);
+    }
+    return output as T;
+  }
+  return value;
+}
+
+export function publicCommerceSandboxCheckoutRefusal(code: CommerceSandboxCheckoutRefusalCode): {
+  code: CommerceSandboxCheckoutRefusalCode;
+  message: string;
+  retryable: boolean;
+} {
+  return publicRefusal(code);
+}
+
+export function evaluateCommerceSandboxCheckoutReadiness(
+  input: CommerceSandboxCheckoutE2EInput,
+): CommerceSandboxCheckoutRefusalCode | null {
+  if (!isNonEmptyString(input.tenant_id)) return 'sandbox_checkout_tenant_context_required';
+  if (!isNonEmptyString(input.merchant_id)) return 'sandbox_checkout_merchant_context_required';
+  if (!isNonEmptyString(input.buyer_principal_id)) return 'sandbox_checkout_buyer_context_required';
+  if (!isNonEmptyString(input.agent_id)) return 'sandbox_checkout_agent_context_required';
+  if (!isNonEmptyString(input.session_id)) return 'sandbox_checkout_session_context_required';
+  if (input.environment !== 'sandbox') return 'sandbox_checkout_environment_refused';
+  if (input.public_discovery_state !== 'hidden' && input.public_discovery_state !== 'disabled') {
+    return 'sandbox_checkout_public_discovery_not_available';
+  }
+  if (!isNonEmptyString(input.cart?.cart_id)) return 'sandbox_checkout_cart_required';
+  if (!input.cart?.line_items || input.cart.line_items.length === 0) {
+    return 'sandbox_checkout_cart_facts_required';
+  }
+  if (!input.audit_evidence_refs || input.audit_evidence_refs.length === 0) {
+    return 'sandbox_checkout_audit_evidence_required';
+  }
+  if (!isNonEmptyString(input.idempotency_key_hash)) return 'sandbox_checkout_idempotency_required';
+
+  const authority = input.authority;
+  if (!authority?.consent_granted) return 'sandbox_checkout_consent_required';
+  if (authority.passport_status === 'missing' || !authority.passport_status) return 'sandbox_checkout_passport_required';
+  if (authority.passport_status === 'expired') return 'sandbox_checkout_passport_expired';
+  if (authority.passport_status === 'revoked') return 'sandbox_checkout_passport_revoked';
+  if (authority.passport_status === 'unknown') return 'sandbox_checkout_passport_unknown';
+  if (authority.passport_status === 'mismatched') return 'sandbox_checkout_passport_mismatch';
+  if (authority.environment !== 'sandbox') return 'sandbox_checkout_environment_refused';
+  if (
+    authority.tenant_id !== input.tenant_id
+    || authority.merchant_id !== input.merchant_id
+    || authority.agent_id !== input.agent_id
+    || authority.buyer_principal_id !== input.buyer_principal_id
+    || authority.session_id !== input.session_id
+  ) {
+    return 'sandbox_checkout_passport_mismatch';
+  }
+  if (authority.passport_type !== 'checkout') return 'sandbox_checkout_checkout_passport_required';
+
+  const scopes = new Set(authority.scopes ?? []);
+  if (!scopes.has('commerce:checkout.create') || !scopes.has('commerce:payment.initiate')) {
+    return 'sandbox_checkout_scope_required';
+  }
+
+  return null;
+}
+
+export function hashCommerceSandboxCheckoutRequest(input: CommerceSandboxCheckoutE2EInput): string {
+  return hashRequestBody({
+    tenant_id: input.tenant_id ?? null,
+    merchant_id: input.merchant_id ?? null,
+    buyer_principal_id: input.buyer_principal_id ?? null,
+    agent_id: input.agent_id ?? null,
+    session_id: input.session_id ?? null,
+    environment: input.environment ?? null,
+    public_discovery_state: input.public_discovery_state ?? null,
+    cart: {
+      cart_id: input.cart?.cart_id ?? null,
+      line_items: input.cart?.line_items ?? [],
+      source_checked_at: input.cart?.source_checked_at ?? null,
+    },
+    payment_intent_id: input.payment_intent_id ?? null,
+    synthetic_payment_outcome: normalizeSyntheticOutcome(input.synthetic_payment_outcome),
+    authority: {
+      consent_granted: input.authority?.consent_granted ?? false,
+      passport_status: input.authority?.passport_status ?? null,
+      passport_type: input.authority?.passport_type ?? null,
+      tenant_id: input.authority?.tenant_id ?? null,
+      merchant_id: input.authority?.merchant_id ?? null,
+      agent_id: input.authority?.agent_id ?? null,
+      buyer_principal_id: input.authority?.buyer_principal_id ?? null,
+      session_id: input.authority?.session_id ?? null,
+      environment: input.authority?.environment ?? null,
+      scopes: [...(input.authority?.scopes ?? [])].sort(),
+    },
+  });
+}
+
+export function compareCommerceSandboxCheckoutReplay(
+  input: CommerceSandboxCheckoutE2EInput,
+  previous?: CommerceSandboxCheckoutPriorResult | null,
+): CommerceSandboxCheckoutReplayResult {
+  const actual = hashCommerceSandboxCheckoutRequest(input);
+  if (!previous) return { kind: 'new', request_body_hash: actual };
+  if (
+    previous.tenant_id !== input.tenant_id
+    || previous.merchant_id !== input.merchant_id
+    || previous.idempotency_scope !== 'sandbox.checkout.e2e.contract'
+    || previous.idempotency_key_hash !== input.idempotency_key_hash
+  ) {
+    return { kind: 'new', request_body_hash: actual };
+  }
+  if (previous.request_body_hash !== actual) {
+    return {
+      kind: 'conflict',
+      expected_body_hash: previous.request_body_hash,
+      actual_body_hash: actual,
+    };
+  }
+  return { kind: 'replay', response: previous.response };
+}
+
+export function buildCommerceSandboxCheckoutE2EPlan(
+  input: CommerceSandboxCheckoutE2EInput,
+): CommerceSandboxCheckoutE2EResult {
+  assertNoCommerceSandboxCheckoutExecutionFields(input);
+
+  const readinessRefusal = evaluateCommerceSandboxCheckoutReadiness(input);
+  if (readinessRefusal) return refusalResult(input, readinessRefusal);
+
+  const tenantId = input.tenant_id as string;
+  const merchantId = input.merchant_id as string;
+  const buyerPrincipalId = input.buyer_principal_id as string;
+  const agentId = input.agent_id as string;
+  const sessionId = input.session_id as string;
+  const cartId = input.cart?.cart_id as string;
+  const idempotencyKeyHash = input.idempotency_key_hash as string;
+  const auditEvidenceRefs = cloneJson(input.audit_evidence_refs ?? []);
+  const requestBodyHash = hashCommerceSandboxCheckoutRequest(input);
+
+  const order = buildCommerceOrderFoundationDraft({
+    tenant_id: tenantId,
+    merchant_id: merchantId,
+    buyer_principal_id: buyerPrincipalId,
+    agent_id: agentId,
+    cart_id: cartId,
+    payment_intent_id: input.payment_intent_id ?? null,
+    created_from: 'cart_snapshot',
+    idempotency_key_hash: idempotencyKeyHash,
+    line_items: cloneJson(input.cart?.line_items ?? []),
+    source_freshness_refs: redactCommerceSandboxCheckoutPrivateFields(cloneJson(input.source_freshness_refs ?? {})),
+    audit_evidence_refs: auditEvidenceRefs,
+    scoped_refs: [
+      { label: 'cart', tenant_id: tenantId, merchant_id: merchantId, id: cartId },
+      ...(input.payment_intent_id
+        ? [{ label: 'synthetic_payment_intent', tenant_id: tenantId, merchant_id: merchantId, id: input.payment_intent_id }]
+        : []),
+    ],
+    support_reference: { state: 'support_status_not_enabled_by_c6u9_sandbox' },
+  });
+
+  const handoff = buildCommerceOrderHandoffFoundationDraft({
+    tenant_id: tenantId,
+    order_id: order.id,
+    merchant_id: merchantId,
+    buyer_principal_id: buyerPrincipalId,
+    agent_id: agentId,
+    session_id: sessionId,
+    handoff_type: 'fulfillment',
+    handoff_snapshot: {
+      handoff_type: 'fulfillment',
+      summary: 'Sandbox handoff placeholder only. Execution requires a later Grantex source contract.',
+      safe_fields: {
+        state: 'non_executing_placeholder',
+        synthetic_only: true,
+      },
+      source_refs: [{
+        source: 'order',
+        source_id: order.id,
+        checked_at: input.cart?.source_checked_at ?? null,
+        freshness: 'fresh',
+      }],
+    },
+    source_freshness_refs: redactCommerceSandboxCheckoutPrivateFields(cloneJson(input.source_freshness_refs ?? {})),
+    audit_evidence_refs: auditEvidenceRefs,
+    idempotency_key_hash: hashRequestBody({
+      parent_idempotency_key_hash: idempotencyKeyHash,
+      handoff_type: 'fulfillment',
+      cart_id: cartId,
+    }),
+    created_from: 'order_safe_source',
+    scoped_refs: [{
+      label: 'order',
+      tenant_id: tenantId,
+      order_id: order.id,
+      merchant_id: merchantId,
+      buyer_principal_id: buyerPrincipalId,
+    }],
+    support_reference: { state: 'handoff_support_not_enabled_by_c6u9_sandbox' },
+  });
+
+  return {
+    status: 'synthetic_outcome_recorded',
+    tenant_id: tenantId,
+    merchant_id: merchantId,
+    buyer_principal_id: buyerPrincipalId,
+    agent_id: agentId,
+    session_id: sessionId,
+    environment: 'sandbox',
+    buyer_facing_checkout_surface: 'not_exposed',
+    public_discovery_state: input.public_discovery_state as 'hidden' | 'disabled',
+    idempotency_scope: 'sandbox.checkout.e2e.contract',
+    idempotency_key_hash: idempotencyKeyHash,
+    request_body_hash: requestBodyHash,
+    order,
+    handoff,
+    synthetic_payment: {
+      payment_intent_id: input.payment_intent_id ?? null,
+      outcome: normalizeSyntheticOutcome(input.synthetic_payment_outcome),
+      mode: 'local_sandbox_contract_only',
+      live_mode: false,
+      provider_call: false,
+      partner_payment_rail_call: false,
+      carrier_call: false,
+      merchant_private_api_call: false,
+      production_checkout_enabled: false,
+    },
+    buyer_safe_context: redactCommerceSandboxCheckoutPrivateFields(cloneJson(input.buyer_safe_context ?? {})),
+    audit_evidence_refs: auditEvidenceRefs,
+    non_enablement: {
+      production_checkout: false,
+      live_payment: false,
+      live_partner_payment_rail: false,
+      provider_call: false,
+      partner_payment_rail_call: false,
+      carrier_call: false,
+      merchant_private_api_call: false,
+      public_discovery: false,
+    },
+    sequence: [
+      {
+        step: 'authority',
+        status: 'authority_checked',
+        message: 'Sandbox consent and Commerce Passport authority were represented without exposing raw authority material.',
+      },
+      {
+        step: 'order_foundation',
+        status: 'order_linked',
+        message: publicCommerceOrderRefusal('order_payment_not_enabled_by_c6u7').message,
+      },
+      {
+        step: 'handoff_foundation',
+        status: 'handoff_linked',
+        message: publicCommerceOrderHandoffRefusal('order_handoff_execution_not_enabled_by_c6u8').message,
+      },
+      {
+        step: 'synthetic_payment',
+        status: 'synthetic_outcome_recorded',
+        message: 'Synthetic payment outcome was recorded locally without checkout, provider, partner rail, carrier, or merchant private API execution.',
+      },
+    ],
+  };
+}

--- a/apps/auth-service/tests/commerce-c6u9-sandbox-checkout-e2e.test.ts
+++ b/apps/auth-service/tests/commerce-c6u9-sandbox-checkout-e2e.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  allowedCommerceSandboxCheckoutStatusTransitions,
+  assertCommerceSandboxCheckoutStatusTransition,
+  buildCommerceSandboxCheckoutE2EPlan,
+  compareCommerceSandboxCheckoutReplay,
+  hashCommerceSandboxCheckoutRequest,
+  publicCommerceSandboxCheckoutRefusal,
+  redactCommerceSandboxCheckoutPrivateFields,
+  type CommerceSandboxCheckoutE2EInput,
+  type CommerceSandboxCheckoutPriorResult,
+} from '../src/lib/commerce/sandbox-checkout-e2e.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const DOC_PATH = join(TEST_DIR, '../../../docs/internal/commerce-v1/commerce-v1-c6u9-sandbox-checkout-e2e-foundation.md');
+
+const TENANT = 'cten_C6U9';
+const MERCHANT = 'mch_C6U9';
+const AGENT = 'cag_C6U9';
+const BUYER = 'buyer_C6U9';
+const SESSION = 'buyer_session_C6U9';
+const CART = 'ccart_C6U9';
+const PAYMENT_INTENT = 'cpi_C6U9';
+
+function baseInput(overrides: Partial<CommerceSandboxCheckoutE2EInput> = {}): CommerceSandboxCheckoutE2EInput {
+  return {
+    tenant_id: TENANT,
+    merchant_id: MERCHANT,
+    buyer_principal_id: BUYER,
+    agent_id: AGENT,
+    session_id: SESSION,
+    environment: 'sandbox',
+    public_discovery_state: 'hidden',
+    cart: {
+      cart_id: CART,
+      source_checked_at: '2026-06-10T00:00:00.000Z',
+      line_items: [{
+        product_id: 'cprd_C6U9',
+        variant_id: 'cvar_C6U9',
+        title: 'Sandbox Router',
+        sku: 'RTR-C6U9',
+        quantity: 1,
+        unit_price_minor_units: 199900,
+        currency: 'INR',
+        tax_amount_minor_units: null,
+        final_price_minor_units: null,
+        source_refs: [{
+          source: 'cart',
+          source_id: CART,
+          checked_at: '2026-06-10T00:00:00.000Z',
+          freshness: 'fresh',
+        }],
+      }],
+    },
+    payment_intent_id: PAYMENT_INTENT,
+    synthetic_payment_outcome: 'synthetic_authorized',
+    authority: {
+      consent_granted: true,
+      passport_status: 'valid',
+      passport_type: 'checkout',
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      agent_id: AGENT,
+      buyer_principal_id: BUYER,
+      session_id: SESSION,
+      environment: 'sandbox',
+      scopes: ['commerce:checkout.create', 'commerce:payment.initiate'],
+    },
+    source_freshness_refs: {
+      cart_checked_at: '2026-06-10T00:00:00.000Z',
+      source: 'local_sandbox_fixture',
+    },
+    buyer_safe_context: {
+      display_state: 'sandbox_sequence_ready',
+    },
+    audit_evidence_refs: [
+      { audit_event_id: 'caud_C6U9_CONSENT' },
+      { audit_event_id: 'caud_C6U9_CART' },
+    ],
+    idempotency_key_hash: 'hash_c6u9_idempotency',
+    ...overrides,
+  };
+}
+
+describe('C6U9 sandbox checkout E2E foundation', () => {
+  it('builds a tenant-scoped sandbox sequence linking cart, authority, order, handoff, synthetic payment, and audit facts', () => {
+    const result = buildCommerceSandboxCheckoutE2EPlan(baseInput());
+
+    expect(result.status).toBe('synthetic_outcome_recorded');
+    if (result.status !== 'synthetic_outcome_recorded') throw new Error('expected ready result');
+
+    expect(result).toMatchObject({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      buyer_principal_id: BUYER,
+      agent_id: AGENT,
+      session_id: SESSION,
+      environment: 'sandbox',
+      buyer_facing_checkout_surface: 'not_exposed',
+      public_discovery_state: 'hidden',
+      idempotency_scope: 'sandbox.checkout.e2e.contract',
+      idempotency_key_hash: 'hash_c6u9_idempotency',
+    });
+    expect(result.order).toMatchObject({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      buyer_principal_id: BUYER,
+      cart_id: CART,
+      payment_intent_id: PAYMENT_INTENT,
+      status: 'pending_source_facts',
+    });
+    expect(result.order.line_items_snapshot[0]?.title).toBe('Sandbox Router');
+    expect(result.order.commercial_facts_snapshot.totals.unknown_markers).toEqual([
+      'final_price_unknown',
+      'tax_unknown',
+    ]);
+    expect(result.handoff).toMatchObject({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      buyer_principal_id: BUYER,
+      session_id: SESSION,
+      handoff_type: 'fulfillment',
+      status: 'draft',
+    });
+    expect(result.handoff.order_id).toBe(result.order.id);
+    expect(result.synthetic_payment).toMatchObject({
+      payment_intent_id: PAYMENT_INTENT,
+      outcome: 'synthetic_authorized',
+      mode: 'local_sandbox_contract_only',
+      live_mode: false,
+      provider_call: false,
+      partner_payment_rail_call: false,
+      carrier_call: false,
+      merchant_private_api_call: false,
+      production_checkout_enabled: false,
+    });
+    expect(result.non_enablement).toEqual({
+      production_checkout: false,
+      live_payment: false,
+      live_partner_payment_rail: false,
+      provider_call: false,
+      partner_payment_rail_call: false,
+      carrier_call: false,
+      merchant_private_api_call: false,
+      public_discovery: false,
+    });
+    expect(result.audit_evidence_refs).toHaveLength(2);
+    expect(result.sequence.map((step) => step.status)).toEqual([
+      'authority_checked',
+      'order_linked',
+      'handoff_linked',
+      'synthetic_outcome_recorded',
+    ]);
+  });
+
+  it('refuses missing tenant, merchant, buyer, agent, session, cart, audit, and idempotency context fail closed', () => {
+    const cases: Array<[Partial<CommerceSandboxCheckoutE2EInput>, string]> = [
+      [{ tenant_id: '' }, 'sandbox_checkout_tenant_context_required'],
+      [{ merchant_id: '' }, 'sandbox_checkout_merchant_context_required'],
+      [{ buyer_principal_id: '' }, 'sandbox_checkout_buyer_context_required'],
+      [{ agent_id: '' }, 'sandbox_checkout_agent_context_required'],
+      [{ session_id: '' }, 'sandbox_checkout_session_context_required'],
+      [{ cart: { cart_id: '', line_items: [] } }, 'sandbox_checkout_cart_required'],
+      [{ cart: { cart_id: CART, line_items: [] } }, 'sandbox_checkout_cart_facts_required'],
+      [{ audit_evidence_refs: [] }, 'sandbox_checkout_audit_evidence_required'],
+      [{ idempotency_key_hash: '' }, 'sandbox_checkout_idempotency_required'],
+    ];
+
+    for (const [override, code] of cases) {
+      const result = buildCommerceSandboxCheckoutE2EPlan(baseInput(override));
+      expect(result.status).toBe('refused');
+      if (result.status !== 'refused') throw new Error('expected refused result');
+      expect(result.refusal.code).toBe(code);
+      expect(result.buyer_facing_checkout_surface).toBe('not_exposed');
+      expect(result.non_enablement.public_discovery).toBe(false);
+    }
+  });
+
+  it('refuses missing, expired, revoked, mismatched, unknown, and non-checkout authority', () => {
+    const cases: Array<[Partial<CommerceSandboxCheckoutE2EInput>, string]> = [
+      [{ authority: { ...baseInput().authority, consent_granted: false } }, 'sandbox_checkout_consent_required'],
+      [{ authority: { ...baseInput().authority, passport_status: 'missing' } }, 'sandbox_checkout_passport_required'],
+      [{ authority: { ...baseInput().authority, passport_status: 'expired' } }, 'sandbox_checkout_passport_expired'],
+      [{ authority: { ...baseInput().authority, passport_status: 'revoked' } }, 'sandbox_checkout_passport_revoked'],
+      [{ authority: { ...baseInput().authority, passport_status: 'mismatched' } }, 'sandbox_checkout_passport_mismatch'],
+      [{ authority: { ...baseInput().authority, passport_status: 'unknown' } }, 'sandbox_checkout_passport_unknown'],
+      [{ authority: { ...baseInput().authority, passport_type: 'browse' } }, 'sandbox_checkout_checkout_passport_required'],
+      [{ authority: { ...baseInput().authority, scopes: ['commerce:checkout.create'] } }, 'sandbox_checkout_scope_required'],
+      [{ authority: { ...baseInput().authority, merchant_id: 'mch_OTHER' } }, 'sandbox_checkout_passport_mismatch'],
+      [{ authority: { ...baseInput().authority, environment: 'live' } }, 'sandbox_checkout_environment_refused'],
+    ];
+
+    for (const [override, code] of cases) {
+      const result = buildCommerceSandboxCheckoutE2EPlan(baseInput(override));
+      expect(result.status).toBe('refused');
+      if (result.status !== 'refused') throw new Error('expected refused result');
+      expect(result.refusal.code).toBe(code);
+      expect(JSON.stringify(result)).not.toContain('provider_payment_id');
+      expect(JSON.stringify(result)).not.toContain('raw_payload');
+    }
+  });
+
+  it('keeps public discovery and buyer-facing checkout unavailable in this slice', () => {
+    const hidden = buildCommerceSandboxCheckoutE2EPlan(baseInput({ public_discovery_state: 'disabled' }));
+    expect(hidden.status).toBe('synthetic_outcome_recorded');
+    if (hidden.status !== 'synthetic_outcome_recorded') throw new Error('expected ready result');
+    expect(hidden.buyer_facing_checkout_surface).toBe('not_exposed');
+    expect(hidden.non_enablement.public_discovery).toBe(false);
+
+    const enabled = buildCommerceSandboxCheckoutE2EPlan(baseInput({ public_discovery_state: 'enabled' }));
+    expect(enabled.status).toBe('refused');
+    if (enabled.status !== 'refused') throw new Error('expected refused result');
+    expect(enabled.refusal.code).toBe('sandbox_checkout_public_discovery_not_available');
+  });
+
+  it('supports replay for the same idempotency scope and conflicts on changed request bodies', () => {
+    const input = baseInput();
+    const response = buildCommerceSandboxCheckoutE2EPlan(input);
+    const previous: CommerceSandboxCheckoutPriorResult = {
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      idempotency_scope: 'sandbox.checkout.e2e.contract',
+      idempotency_key_hash: 'hash_c6u9_idempotency',
+      request_body_hash: hashCommerceSandboxCheckoutRequest(input),
+      response,
+    };
+
+    expect(compareCommerceSandboxCheckoutReplay(input, null)).toMatchObject({ kind: 'new' });
+    expect(compareCommerceSandboxCheckoutReplay(input, previous)).toMatchObject({ kind: 'replay', response });
+    expect(compareCommerceSandboxCheckoutReplay(baseInput({
+      cart: {
+        cart_id: CART,
+        source_checked_at: '2026-06-10T00:00:00.000Z',
+        line_items: (input.cart?.line_items ?? []).map((item) => ({ ...item, quantity: 2 })),
+      },
+    }), previous)).toMatchObject({ kind: 'conflict' });
+  });
+
+  it('keeps sandbox status transitions narrow and fail closed', () => {
+    expect(allowedCommerceSandboxCheckoutStatusTransitions('draft')).toEqual([
+      'authority_checked',
+      'refused',
+      'blocked',
+    ]);
+    expect(() => assertCommerceSandboxCheckoutStatusTransition('draft', 'authority_checked')).not.toThrow();
+    expect(() => assertCommerceSandboxCheckoutStatusTransition('authority_checked', 'order_linked')).not.toThrow();
+    expect(() => assertCommerceSandboxCheckoutStatusTransition('handoff_linked', 'synthetic_outcome_recorded')).not.toThrow();
+    expect(() => assertCommerceSandboxCheckoutStatusTransition('synthetic_outcome_recorded', 'order_linked')).toThrow(/not allowed/);
+    expect(() => assertCommerceSandboxCheckoutStatusTransition('draft', 'paid' as never)).toThrow(/not allowed/);
+  });
+
+  it('rejects provider, Plural, carrier, private API, raw payload, production allowlist, and execution fields recursively', () => {
+    const forbiddenSamples = [
+      { provider_payment_id: 'pay_private' },
+      { checkoutUrl: 'https://checkout.example.invalid' },
+      { liveProviderEnabled: true },
+      { pluralCall: true },
+      { carrierTrackingUrl: 'https://carrier.example.invalid/track/private' },
+      { merchantPrivateApiUrl: 'https://merchant-private.example.invalid/orders' },
+      { rawProviderPayload: { private: true } },
+      { productionAllowlist: ['tenant-prod'] },
+      { settlementId: 'set_private' },
+      { payoutId: 'po_private' },
+      { refundTransactionId: 'refund_private' },
+    ];
+
+    for (const buyer_safe_context of forbiddenSamples) {
+      expect(() => buildCommerceSandboxCheckoutE2EPlan(baseInput({
+        buyer_safe_context: { nested: buyer_safe_context },
+      }))).toThrow(/Sandbox checkout cannot carry/);
+    }
+  });
+
+  it('redacts private fields and keeps public refusals buyer safe', () => {
+    const redacted = redactCommerceSandboxCheckoutPrivateFields({
+      public_state: 'sandbox_sequence_ready',
+      nested: {
+        jwt: 'private-token',
+        webhook_secret: 'private-secret',
+        private_url: 'https://private.example.invalid/path',
+      },
+    });
+    expect(redacted).toEqual({
+      public_state: 'sandbox_sequence_ready',
+      nested: {
+        jwt: '[redacted]',
+        webhook_secret: '[redacted]',
+        private_url: '[redacted]',
+      },
+    });
+
+    const result = buildCommerceSandboxCheckoutE2EPlan(baseInput({
+      buyer_safe_context: redacted,
+    }));
+    const refusal = publicCommerceSandboxCheckoutRefusal('sandbox_checkout_passport_revoked');
+    const serialized = JSON.stringify({ result, refusal });
+    expect(serialized).not.toContain('private-token');
+    expect(serialized).not.toContain('private-secret');
+    expect(serialized).not.toContain('private.example.invalid');
+    expect(serialized).not.toContain('raw_payload');
+    expect(serialized).not.toContain('provider_payment_id');
+  });
+
+  it('documents sandbox-only scope, unchanged API surface, and AgenticOrg refusal rules', () => {
+    const doc = readFileSync(DOC_PATH, 'utf8');
+
+    expect(doc).toContain('No migration, route, endpoint, or OpenAPI surface is added by C6U9');
+    expect(doc).toContain('AgenticOrg must continue refusing checkout, order, payment, support, fulfillment, delivery, return, or refund status');
+    expect(doc).toContain('This is not a production launch, public discovery approval, checkout approval, payment approval, merchant approval');
+    expect(doc).toContain('Sandbox checkout E2E must stop if a future change requires provider, Plural, carrier, merchant-private API, or public discovery behavior');
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6u9-sandbox-checkout-e2e-foundation.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6u9-sandbox-checkout-e2e-foundation.md
@@ -1,0 +1,164 @@
+# C6U9 Sandbox Checkout E2E Foundation
+
+Status: internal implementation note only. This is not a production launch, public discovery approval, checkout approval, payment approval, merchant approval, protocol publication, external submission, certification, compliance, conformance, standardization, public-launch readiness, production readiness, fulfillment enablement, delivery enablement, shipping enablement, refund enablement, settlement enablement, or payout enablement claim.
+
+This is not a production launch, public discovery approval, checkout approval, payment approval, merchant approval, fulfillment approval, refund approval, settlement approval, payout approval, or protocol publication.
+
+## Scope
+
+C6U9 adds a Grantex-owned sandbox checkout E2E contract foundation. It is model/helper, docs, and tests only. No migration, route, endpoint, or OpenAPI surface is added by C6U9 because no external or buyer-facing checkout API is exposed by this slice.
+
+The foundation proves a synthetic, local sequence across cart facts, consent and Commerce Passport authority, order foundation, handoff foundation, sandbox payment intent reference, audit evidence, idempotency, and refusal paths. It does not create checkout links, create production payment records, call payment providers, call Plural, call carriers, call merchant private APIs, expose public discovery, set production allowlists, change production config, execute fulfillment, execute refunds, perform settlement, or perform payout.
+
+## Sandbox-Only Sequence
+
+The C6U9 helper records the intended sequence as a local contract:
+
+1. Resolve tenant, merchant, buyer, CommerceAgent, and buyer session context.
+2. Confirm public discovery remains hidden or disabled for this slice.
+3. Confirm user consent and checkout-scoped Commerce Passport authority are represented by safe metadata only.
+4. Reference a Grantex cart snapshot with buyer-safe product, variant, SKU, price, tax-unknown, final-price-unknown, and freshness facts.
+5. Build an order foundation draft from C6U7 using the safe cart snapshot.
+6. Build a C6U8 handoff placeholder linked to the order with non-executing fulfillment status.
+7. Record a synthetic payment outcome label only.
+8. Attach redacted audit evidence references and hashed idempotency evidence.
+
+The result is a proof of shape and safety, not a live or production checkout path.
+
+## Actors And Authority
+
+| Actor | C6U9 Role |
+| --- | --- |
+| Tenant | Owns every sandbox checkout fact and idempotency scope |
+| Merchant | Owns the cart, order, payment-intent reference, and handoff context |
+| Buyer | Matches the consent and Commerce Passport authority metadata |
+| CommerceAgent | Must match the authority metadata and requested scopes |
+| Grantex authority | Remains source of truth for consent, passport status, revocation, policy, and audit evidence |
+
+Agent authentication is not user consent. C6U9 requires both consent and checkout-scoped Commerce Passport authority before the sandbox sequence can be represented.
+
+## Consent And Passport Role
+
+C6U9 treats authority as buyer-safe metadata:
+
+- consent granted
+- passport state: valid, missing, expired, revoked, mismatched, or unknown
+- passport type
+- tenant, merchant, buyer, agent, and session match
+- sandbox environment
+- checkout and payment-initiation scopes
+
+Missing consent, missing passport, expired passport, revoked passport, mismatched authority, unknown authority, non-checkout passport type, missing scopes, or non-sandbox environment all fail closed.
+
+## Order Foundation Role
+
+C6U9 uses the C6U7 order foundation to represent a safe order draft from cart facts. The order foundation remains fail-closed and non-payment-enabling. It does not imply checkout creation, payment creation, provider action, fulfillment, support, refund, settlement, or payout.
+
+## Handoff Foundation Role
+
+C6U9 uses the C6U8 handoff foundation to represent a non-executing fulfillment placeholder linked to the order. The handoff record is buyer-safe and cannot imply fulfillment execution, delivery execution, carrier booking, support workflow execution, return execution, refund execution, settlement, or payout.
+
+## Synthetic Payment Outcome Model
+
+Allowed C6U9 outcome labels are:
+
+- `not_attempted`
+- `synthetic_authorized`
+- `synthetic_pending`
+- `synthetic_succeeded`
+- `synthetic_declined`
+- `synthetic_expired`
+- `synthetic_cancelled`
+
+These are local contract labels only. They do not create provider payments, Plural payments, checkout links, hosted checkout URLs, webhook payloads, settlement records, payout records, or live payment status.
+
+## Idempotency And Replay Model
+
+C6U9 idempotency is scoped to `sandbox.checkout.e2e.contract` with tenant, merchant, hashed idempotency key, and request-body hash evidence. The helper can classify:
+
+- new request
+- replay when the same hashed key and same request body are used
+- conflict when the same hashed key is used with a different request body
+
+Raw idempotency keys are not required and must not be exposed.
+
+## Audit Evidence Model
+
+C6U9 requires redacted audit evidence references. The helper and docs must not expose raw passports, JWTs, raw tokens, raw consent payloads, provider credentials, carrier credentials, raw provider payloads, raw carrier payloads, raw connector payloads, provider payment IDs, checkout URLs, merchant private URLs, DB/Redis URLs, webhook secrets, production config values, concrete production allowlists, settlement references, payout references, or refund execution references.
+
+## Fail-Closed Refusals
+
+| Condition | Public-Safe Refusal |
+| --- | --- |
+| Missing tenant | Sandbox checkout requires a tenant-bound Grantex context. |
+| Missing merchant | Sandbox checkout requires a merchant-bound Grantex context. |
+| Missing buyer/session principal | Sandbox checkout requires a buyer or session principal. |
+| Missing CommerceAgent | Sandbox checkout requires a registered CommerceAgent context. |
+| Missing consent | Sandbox checkout requires user consent before protected sequencing can continue. |
+| Missing passport | Sandbox checkout requires Commerce Passport authority before protected sequencing can continue. |
+| Expired passport | Sandbox checkout authority has expired. Refresh consent before continuing. |
+| Revoked passport | Sandbox checkout authority has been revoked. |
+| Mismatched authority | Sandbox checkout authority does not match this tenant, merchant, buyer, session, or agent. |
+| Unknown authority | Sandbox checkout authority is unknown. Refresh from Grantex before continuing. |
+| Missing scopes | Sandbox checkout requires checkout and payment initiation scopes. |
+| Live or unknown environment | Sandbox checkout E2E refuses live or unknown payment environments. |
+| Public discovery not hidden | Buyer-facing checkout remains unavailable while public discovery is not enabled for this slice. |
+| Missing audit evidence | Sandbox checkout requires redacted audit evidence references. |
+
+## Buyer-Safe Wording Examples
+
+- "Sandbox checkout requires user consent before protected sequencing can continue."
+- "Sandbox checkout authority has been revoked."
+- "Sandbox checkout E2E refuses live or unknown payment environments."
+- "Synthetic payment outcome was recorded locally without checkout, provider, Plural, carrier, or merchant private API execution."
+
+## Unsafe Wording Examples
+
+- "Checkout is approved."
+- "Payment is approved."
+- "Live payment is ready."
+- "Fulfillment is enabled."
+- "Refunds are enabled."
+- "Settlement or payout is complete."
+- "Provider payment ID is available."
+- "Merchant private API returned order status."
+
+Those phrases are unsafe unless a later slice adds explicit Grantex-owned source facts, execution controls, buyer-safe evidence, and review.
+
+## AgenticOrg Future-Consumption Note
+
+AgenticOrg must continue refusing checkout, order, payment, support, fulfillment, delivery, return, or refund status unless Grantex supplies buyer-safe source facts scoped to the same tenant, merchant, buyer, session, and CommerceAgent. AgenticOrg must not infer status from cached state and must not create or expose checkout/payment status from this C6U9 helper alone.
+
+## API And OpenAPI Note
+
+No migration, route, endpoint, or OpenAPI surface is added by C6U9. The helper exists only to validate local sandbox sequencing and refusal behavior in tests. A future external or buyer-facing surface requires a separate API, OpenAPI, auth, tenant-boundary, rate-limit, audit, and non-enablement review.
+
+## Stop Conditions
+
+Sandbox checkout E2E must stop if a future change requires provider, Plural, carrier, merchant-private API, or public discovery behavior. It must also stop if it requires:
+
+- production checkout or payment creation
+- live payment or live Plural
+- raw provider, carrier, connector, or merchant private payloads
+- production config or production allowlists
+- workflow changes
+- cloud resources or deploy behavior
+- fulfillment, delivery, support, return, refund, settlement, payout, or shipping execution
+- protocol publication or external submission
+- certification, compliance, conformance, standardization, merchant approval, public-launch readiness, production readiness, checkout approval, payment approval, fulfillment enablement, delivery enablement, shipping enablement, refund enablement, settlement enablement, or payout enablement claims
+
+## Future Slices
+
+- AgenticOrg buyer-facing sandbox checkout consumption
+- payment provider sandbox adapter readiness
+- webhook and reconciliation hardening
+- support and fulfillment execution contracts
+- refund execution
+- settlement, payout, and reconciliation
+- live provider readiness
+
+Each future slice needs its own source-of-truth, tenant-boundary, authorization, audit, redaction, rollback, and non-enablement review before any external surface is exposed.
+
+## Validation
+
+C6U9 validation should include focused sandbox checkout E2E tests, nearby cart/payment/order/handoff/refusal tests, typecheck, whitespace diff check, ASCII check for new files, secret/private scan, passport/JWT/raw-token scan, production config/allowlist scan, public discovery enablement scan, production checkout/payment enablement scan, live-provider/live-Plural scan, direct provider/Plural scan, carrier/private API scan, raw connector/private payload scan, protocol publication/submission scan, and overclaim scan.


### PR DESCRIPTION
## Summary
- Add a Grantex-owned sandbox checkout E2E helper that composes existing C6U7 order and C6U8 handoff foundations without adding routes or migrations.
- Add focused tests for tenant/merchant/buyer/session authority, consent/passport refusal, idempotency replay/conflict, redaction, and forbidden execution fields.
- Add the internal C6U9 scope doc with AgenticOrg future-consumption refusal rules and stop conditions.

## Scope notes
- No migration, route, endpoint, OpenAPI, workflow, config, or AgenticOrg runtime change.
- No production checkout/payment path, live provider path, live Plural path, carrier path, merchant-private API path, public discovery path, settlement, payout, fulfillment execution, or refund execution.

## Local validation
- Focused and nearby commerce tests: 6 files, 70 tests passed.
- Auth-service typecheck passed.
- Internal preview gate script passed in PR mode.
- Diff check, trailing-whitespace scan, ASCII scan, and focused guardrail scans completed on touched files.