### PR TITLE
C6U11 provider sandbox webhook reconciliation foundation

### DIFF
--- a/apps/auth-service/src/lib/commerce/provider-sandbox-contract.ts
+++ b/apps/auth-service/src/lib/commerce/provider-sandbox-contract.ts
@@ -1,0 +1,865 @@
+import { CommerceHttpError } from './errors.js';
+import { hashRequestBody } from './idempotency.js';
+import type {
+  CommerceEnvironment,
+  Money,
+  NormalizedProviderError,
+  ProviderErrorCode,
+  ProviderKey,
+} from './payment-providers/types.js';
+import type { CommercePaymentStatus } from './payment-state.js';
+
+export const COMMERCE_PROVIDER_SANDBOX_NORMALIZED_STATUSES = [
+  'authorized',
+  'payment_pending',
+  'paid',
+  'failed',
+  'expired',
+  'cancelled',
+  'manual_review_required',
+] as const;
+
+export type CommerceProviderSandboxNormalizedStatus =
+  typeof COMMERCE_PROVIDER_SANDBOX_NORMALIZED_STATUSES[number];
+
+export type CommerceProviderSandboxRefusalCode =
+  | 'provider_sandbox_tenant_context_required'
+  | 'provider_sandbox_merchant_context_required'
+  | 'provider_sandbox_payment_intent_required'
+  | 'provider_sandbox_idempotency_required'
+  | 'provider_sandbox_audit_evidence_required'
+  | 'provider_sandbox_environment_refused'
+  | 'provider_sandbox_adapter_blocked'
+  | 'provider_sandbox_webhook_event_id_required'
+  | 'provider_sandbox_webhook_signature_required'
+  | 'provider_sandbox_webhook_replay_refused'
+  | 'provider_sandbox_webhook_unknown_event'
+  | 'provider_sandbox_reconciliation_manual_review';
+
+export interface CommerceProviderSandboxRefusal {
+  code: CommerceProviderSandboxRefusalCode;
+  message: string;
+  retryable: boolean;
+}
+
+export interface CommerceProviderSandboxContractInput {
+  tenant_id?: string | null;
+  merchant_id?: string | null;
+  agent_id?: string | null;
+  cart_id?: string | null;
+  payment_intent_id?: string | null;
+  provider_key?: ProviderKey | 'unknown' | null;
+  environment?: CommerceEnvironment | 'unknown' | null;
+  amount?: Money | null;
+  line_items_snapshot?: unknown[] | null;
+  idempotency_key_hash?: string | null;
+  source_freshness_refs?: Record<string, unknown> | null;
+  audit_evidence_refs?: Array<Record<string, string>> | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface CommerceProviderSandboxAcceptedResult {
+  status: 'accepted';
+  tenant_id: string;
+  merchant_id: string;
+  payment_intent_id: string;
+  environment: 'sandbox';
+  idempotency_scope: 'provider.sandbox.adapter.contract';
+  idempotency_key_hash: string;
+  request_body_hash: string;
+  normalized_status: 'authorized';
+  provider_reference: {
+    payment_ref: string;
+    order_ref: string;
+    raw_status_ref: string;
+  };
+  buyer_safe_status: {
+    code: 'sandbox_intent_authorized';
+    message: string;
+  };
+  source_freshness_refs: Record<string, unknown>;
+  audit_evidence_refs: Array<Record<string, string>>;
+  redacted_provider_evidence: Record<string, unknown>;
+  non_enablement: CommerceProviderSandboxNonEnablement;
+}
+
+export interface CommerceProviderSandboxRefusedResult {
+  status: 'refused';
+  refusal: CommerceProviderSandboxRefusal;
+  environment: 'sandbox' | 'live' | 'unknown';
+  non_enablement: CommerceProviderSandboxNonEnablement;
+}
+
+export type CommerceProviderSandboxContractResult =
+  | CommerceProviderSandboxAcceptedResult
+  | CommerceProviderSandboxRefusedResult;
+
+export interface CommerceProviderSandboxPriorResult {
+  tenant_id: string;
+  merchant_id: string;
+  idempotency_scope: 'provider.sandbox.adapter.contract';
+  idempotency_key_hash: string;
+  request_body_hash: string;
+  response: CommerceProviderSandboxContractResult;
+}
+
+export type CommerceProviderSandboxReplayResult =
+  | { kind: 'new'; request_body_hash: string }
+  | { kind: 'replay'; response: CommerceProviderSandboxContractResult }
+  | { kind: 'conflict'; expected_body_hash: string; actual_body_hash: string };
+
+export interface CommerceProviderSandboxStatusSummary {
+  normalized_status: CommerceProviderSandboxNormalizedStatus;
+  payment_status: CommercePaymentStatus | 'manual_review_required';
+  fail_closed: boolean;
+  raw_status_ref: string;
+  buyer_safe_message: string;
+}
+
+export interface CommerceProviderSandboxErrorSummary {
+  code: ProviderErrorCode;
+  retryable: boolean;
+  buyer_safe_message: string;
+  provider_error_ref?: string | undefined;
+  safe_metadata: Record<string, unknown>;
+}
+
+export interface CommerceProviderSandboxWebhookInput {
+  tenant_id?: string | null;
+  merchant_id?: string | null;
+  payment_intent_id?: string | null;
+  provider_key?: ProviderKey | 'unknown' | null;
+  environment?: CommerceEnvironment | 'unknown' | null;
+  event_id?: string | null;
+  event_type?: string | null;
+  signature_state?: 'valid' | 'missing' | 'invalid' | 'unconfirmed' | null;
+  replay_state?: 'fresh' | 'duplicate' | 'stale' | 'unknown' | null;
+  normalized_status?: unknown;
+  received_at?: string | null;
+  audit_evidence_refs?: Array<Record<string, string>> | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export type CommerceProviderSandboxWebhookResult =
+  | {
+    status: 'processed';
+    payment_status: CommercePaymentStatus;
+    idempotent: false;
+    evidence: CommerceProviderSandboxEventEvidence;
+    buyer_safe_message: string;
+    non_enablement: CommerceProviderSandboxNonEnablement;
+  }
+  | {
+    status: 'ignored';
+    reason: 'duplicate_event';
+    idempotent: true;
+    evidence: CommerceProviderSandboxEventEvidence;
+    buyer_safe_message: string;
+    non_enablement: CommerceProviderSandboxNonEnablement;
+  }
+  | {
+    status: 'manual_review_required';
+    reason: 'unknown_event' | 'ambiguous_status';
+    evidence: CommerceProviderSandboxEventEvidence;
+    buyer_safe_message: string;
+    non_enablement: CommerceProviderSandboxNonEnablement;
+  }
+  | CommerceProviderSandboxRefusedResult;
+
+export interface CommerceProviderSandboxReconciliationInput {
+  tenant_id?: string | null;
+  merchant_id?: string | null;
+  payment_intent_id?: string | null;
+  provider_key?: ProviderKey | 'unknown' | null;
+  environment?: CommerceEnvironment | 'unknown' | null;
+  current_status?: CommercePaymentStatus | 'unknown' | null;
+  provider_status?: unknown;
+  pending_age_seconds?: number | null;
+  mismatch_detected?: boolean | null;
+  audit_evidence_refs?: Array<Record<string, string>> | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export type CommerceProviderSandboxReconciliationResult =
+  | {
+    status: 'transition_recommended';
+    from_status: CommercePaymentStatus;
+    to_status: Extract<CommercePaymentStatus, 'paid' | 'failed' | 'expired' | 'cancelled'>;
+    reason: 'sandbox_provider_terminal_status';
+    evidence: CommerceProviderSandboxEventEvidence;
+    non_enablement: CommerceProviderSandboxNonEnablement;
+  }
+  | {
+    status: 'no_change';
+    payment_status: CommercePaymentStatus;
+    reason: 'pending_window_open' | 'provider_still_pending' | 'terminal_status';
+    evidence: CommerceProviderSandboxEventEvidence;
+    non_enablement: CommerceProviderSandboxNonEnablement;
+  }
+  | {
+    status: 'manual_review_required';
+    reason: 'status_mismatch' | 'ambiguous_status' | 'unsupported_transition';
+    evidence: CommerceProviderSandboxEventEvidence;
+    non_enablement: CommerceProviderSandboxNonEnablement;
+  }
+  | CommerceProviderSandboxRefusedResult;
+
+export interface CommerceProviderSandboxEventEvidence {
+  event_ref?: string | undefined;
+  payment_intent_ref: string | null;
+  normalized_status: CommerceProviderSandboxNormalizedStatus;
+  raw_status_ref: string;
+  audit_evidence_refs: Array<Record<string, string>>;
+  redacted_metadata: Record<string, unknown>;
+}
+
+export interface CommerceProviderSandboxNonEnablement {
+  production_checkout: false;
+  live_payment: false;
+  live_provider: false;
+  provider_call: false;
+  partner_payment_rail_call: false;
+  carrier_call: false;
+  merchant_private_api_call: false;
+  settlement_execution: false;
+  payout_execution: false;
+  refund_execution: false;
+  public_discovery: false;
+}
+
+const SANDBOX_RECONCILIATION_REVIEW_WINDOW_SECONDS = 120;
+
+const PUBLIC_PROVIDER_SANDBOX_REFUSALS: Record<CommerceProviderSandboxRefusalCode, CommerceProviderSandboxRefusal> = {
+  provider_sandbox_tenant_context_required: {
+    code: 'provider_sandbox_tenant_context_required',
+    message: 'Sandbox provider contract requires a tenant-bound Grantex context.',
+    retryable: false,
+  },
+  provider_sandbox_merchant_context_required: {
+    code: 'provider_sandbox_merchant_context_required',
+    message: 'Sandbox provider contract requires a merchant-bound Grantex context.',
+    retryable: false,
+  },
+  provider_sandbox_payment_intent_required: {
+    code: 'provider_sandbox_payment_intent_required',
+    message: 'Sandbox provider contract requires a Grantex payment intent reference.',
+    retryable: false,
+  },
+  provider_sandbox_idempotency_required: {
+    code: 'provider_sandbox_idempotency_required',
+    message: 'Sandbox provider contract requires a hashed idempotency key reference.',
+    retryable: false,
+  },
+  provider_sandbox_audit_evidence_required: {
+    code: 'provider_sandbox_audit_evidence_required',
+    message: 'Sandbox provider contract requires redacted audit evidence references.',
+    retryable: true,
+  },
+  provider_sandbox_environment_refused: {
+    code: 'provider_sandbox_environment_refused',
+    message: 'Sandbox provider contract refuses live or unknown payment environments.',
+    retryable: false,
+  },
+  provider_sandbox_adapter_blocked: {
+    code: 'provider_sandbox_adapter_blocked',
+    message: 'Only the local sandbox adapter contract is available in this slice.',
+    retryable: false,
+  },
+  provider_sandbox_webhook_event_id_required: {
+    code: 'provider_sandbox_webhook_event_id_required',
+    message: 'Sandbox webhook handling requires a stable provider event reference.',
+    retryable: false,
+  },
+  provider_sandbox_webhook_signature_required: {
+    code: 'provider_sandbox_webhook_signature_required',
+    message: 'Sandbox webhook handling requires a verified signature before status facts can be used.',
+    retryable: true,
+  },
+  provider_sandbox_webhook_replay_refused: {
+    code: 'provider_sandbox_webhook_replay_refused',
+    message: 'Sandbox webhook handling refused a stale replay window.',
+    retryable: false,
+  },
+  provider_sandbox_webhook_unknown_event: {
+    code: 'provider_sandbox_webhook_unknown_event',
+    message: 'Sandbox webhook event type is not recognized and requires manual review.',
+    retryable: true,
+  },
+  provider_sandbox_reconciliation_manual_review: {
+    code: 'provider_sandbox_reconciliation_manual_review',
+    message: 'Sandbox reconciliation is ambiguous and requires manual review.',
+    retryable: true,
+  },
+};
+
+const KNOWN_SANDBOX_WEBHOOK_EVENTS = new Set([
+  'payment.updated',
+  'payment.succeeded',
+  'payment.failed',
+  'payment.expired',
+  'payment.cancelled',
+]);
+
+const FORBIDDEN_PROVIDER_SANDBOX_KEYS = new Set([
+  'access_token',
+  'api_key',
+  'authorization',
+  'bearer',
+  'carrier_api_key',
+  'carrier_call',
+  'carrier_execution_enabled',
+  'carrier_label_url',
+  'carrier_provider',
+  'carrier_request_id',
+  'carrier_tracking_url',
+  'checkout_payment_enabled',
+  'checkout_url',
+  'credential',
+  'credentials',
+  'delivery_execution_enabled',
+  'encrypted_secret_blob',
+  'fulfillment_execution_enabled',
+  'live_payment_enabled',
+  'live_payment_provider_enabled',
+  'live_provider_enabled',
+  'merchant_private_api_call',
+  'merchant_private_api_key',
+  'merchant_private_api_url',
+  'payment_provider_call',
+  'private_api_key',
+  'private_api_url',
+  'production_allowlist',
+  'production_checkout_enabled',
+  'provider_call',
+  'provider_credentials',
+  'provider_metadata',
+  'provider_order_id',
+  'provider_payment_id',
+  'provider_raw_payload',
+  'raw_body',
+  'raw_connector_payload',
+  'raw_payload',
+  'raw_provider_payload',
+  'refund_execution_enabled',
+  'refund_provider_id',
+  'refund_transaction_id',
+  'settlement_enabled',
+  'settlement_id',
+  'shipping_enabled',
+  'shipping_label_url',
+  'tracking_number',
+  'payout_enabled',
+  'payout_id',
+  'webhook_secret',
+]);
+
+const PRIVATE_PROVIDER_SANDBOX_KEYS = new Set([
+  'access_token',
+  'api_key',
+  'authorization',
+  'bearer',
+  'credential',
+  'credentials',
+  'db_url',
+  'encrypted_secret_blob',
+  'evidence',
+  'jwt',
+  'merchant_private_url',
+  'passport',
+  'private_url',
+  'provider_credential',
+  'raw_body',
+  'raw_connector_payload',
+  'raw_payload',
+  'raw_provider_payload',
+  'redis_url',
+  'refresh_token',
+  'secret',
+  'token',
+  'webhook_secret',
+]);
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function normalizeGuardKey(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[-\s]+/g, '_')
+    .toLowerCase();
+}
+
+function nonEnablement(): CommerceProviderSandboxNonEnablement {
+  return {
+    production_checkout: false,
+    live_payment: false,
+    live_provider: false,
+    provider_call: false,
+    partner_payment_rail_call: false,
+    carrier_call: false,
+    merchant_private_api_call: false,
+    settlement_execution: false,
+    payout_execution: false,
+    refund_execution: false,
+    public_discovery: false,
+  };
+}
+
+function publicRefusal(code: CommerceProviderSandboxRefusalCode): CommerceProviderSandboxRefusal {
+  return { ...PUBLIC_PROVIDER_SANDBOX_REFUSALS[code] };
+}
+
+function refusalResult(
+  code: CommerceProviderSandboxRefusalCode,
+  environment: CommerceEnvironment | 'unknown' | null | undefined,
+): CommerceProviderSandboxRefusedResult {
+  return {
+    status: 'refused',
+    refusal: publicRefusal(code),
+    environment: environment === 'sandbox' || environment === 'live' ? environment : 'unknown',
+    non_enablement: nonEnablement(),
+  };
+}
+
+function validateSandboxContext(input: {
+  tenant_id?: string | null;
+  merchant_id?: string | null;
+  payment_intent_id?: string | null;
+  provider_key?: ProviderKey | 'unknown' | null;
+  environment?: CommerceEnvironment | 'unknown' | null;
+}): CommerceProviderSandboxRefusalCode | null {
+  if (!isNonEmptyString(input.tenant_id)) return 'provider_sandbox_tenant_context_required';
+  if (!isNonEmptyString(input.merchant_id)) return 'provider_sandbox_merchant_context_required';
+  if (!isNonEmptyString(input.payment_intent_id)) return 'provider_sandbox_payment_intent_required';
+  if (input.environment !== 'sandbox') return 'provider_sandbox_environment_refused';
+  if (input.provider_key !== 'mock') return 'provider_sandbox_adapter_blocked';
+  return null;
+}
+
+function safeAuditRefs(
+  refs: Array<Record<string, string>> | null | undefined,
+): Array<Record<string, string>> {
+  return refs ? redactCommerceProviderSandboxPrivateFields(cloneJson(refs)) : [];
+}
+
+function eventEvidence(input: {
+  event_id?: string | null | undefined;
+  payment_intent_id?: string | null | undefined;
+  normalized_status: CommerceProviderSandboxNormalizedStatus;
+  raw_status_ref: string;
+  audit_evidence_refs?: Array<Record<string, string>> | null | undefined;
+  metadata?: Record<string, unknown> | null | undefined;
+}): CommerceProviderSandboxEventEvidence {
+  return {
+    event_ref: isNonEmptyString(input.event_id)
+      ? `sandbox_event_${hashRequestBody({ event_id: input.event_id }).slice(0, 24)}`
+      : undefined,
+    payment_intent_ref: isNonEmptyString(input.payment_intent_id)
+      ? `sandbox_payment_intent_${hashRequestBody({ payment_intent_id: input.payment_intent_id }).slice(0, 24)}`
+      : null,
+    normalized_status: input.normalized_status,
+    raw_status_ref: input.raw_status_ref,
+    audit_evidence_refs: safeAuditRefs(input.audit_evidence_refs),
+    redacted_metadata: redactCommerceProviderSandboxPrivateFields(cloneJson(input.metadata ?? {})),
+  };
+}
+
+function paymentStatusForNormalized(
+  status: CommerceProviderSandboxNormalizedStatus,
+): CommercePaymentStatus | 'manual_review_required' {
+  if (status === 'authorized') return 'authorized';
+  if (status === 'payment_pending') return 'payment_pending';
+  if (status === 'paid') return 'paid';
+  if (status === 'failed') return 'failed';
+  if (status === 'expired') return 'expired';
+  if (status === 'cancelled') return 'cancelled';
+  return 'manual_review_required';
+}
+
+function terminalStatusForNormalized(
+  status: CommerceProviderSandboxNormalizedStatus,
+): Extract<CommercePaymentStatus, 'paid' | 'failed' | 'expired' | 'cancelled'> | null {
+  if (status === 'paid' || status === 'failed' || status === 'expired' || status === 'cancelled') {
+    return status;
+  }
+  return null;
+}
+
+export function assertNoCommerceProviderSandboxExecutionFields(value: unknown): void {
+  const stack: unknown[] = [value];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === null || current === undefined) continue;
+    if (Array.isArray(current)) {
+      stack.push(...current);
+      continue;
+    }
+    if (typeof current === 'object') {
+      for (const [key, child] of Object.entries(current as Record<string, unknown>)) {
+        if (FORBIDDEN_PROVIDER_SANDBOX_KEYS.has(normalizeGuardKey(key))) {
+          throw new CommerceHttpError(
+            422,
+            'provider_sandbox_execution_fields_not_allowed',
+            'Provider sandbox contract cannot carry live payment, provider execution, credential, raw payload, carrier, private API, refund, settlement, or payout fields',
+            { retryable: false },
+          );
+        }
+        stack.push(child);
+      }
+    }
+  }
+}
+
+export function redactCommerceProviderSandboxPrivateFields<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactCommerceProviderSandboxPrivateFields(item)) as T;
+  }
+  if (value !== null && typeof value === 'object') {
+    const output: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      output[key] = PRIVATE_PROVIDER_SANDBOX_KEYS.has(normalizeGuardKey(key))
+        ? '[redacted]'
+        : redactCommerceProviderSandboxPrivateFields(child);
+    }
+    return output as T;
+  }
+  return value;
+}
+
+export function publicCommerceProviderSandboxRefusal(
+  code: CommerceProviderSandboxRefusalCode,
+): CommerceProviderSandboxRefusal {
+  return publicRefusal(code);
+}
+
+export function normalizeCommerceProviderSandboxStatus(
+  rawStatus: unknown,
+): CommerceProviderSandboxStatusSummary {
+  const normalizedInput = typeof rawStatus === 'string'
+    ? rawStatus.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_')
+    : '';
+  let normalized_status: CommerceProviderSandboxNormalizedStatus;
+  if (normalizedInput === 'mock_authorized' || normalizedInput === 'authorized') {
+    normalized_status = 'authorized';
+  } else if (
+    normalizedInput === 'mock_payment_pending'
+    || normalizedInput === 'payment_pending'
+    || normalizedInput === 'pending'
+  ) {
+    normalized_status = 'payment_pending';
+  } else if (normalizedInput === 'mock_paid' || normalizedInput === 'paid' || normalizedInput === 'succeeded') {
+    normalized_status = 'paid';
+  } else if (normalizedInput === 'mock_failed' || normalizedInput === 'failed' || normalizedInput === 'declined') {
+    normalized_status = 'failed';
+  } else if (normalizedInput === 'mock_expired' || normalizedInput === 'expired') {
+    normalized_status = 'expired';
+  } else if (normalizedInput === 'mock_cancelled' || normalizedInput === 'cancelled' || normalizedInput === 'canceled') {
+    normalized_status = 'cancelled';
+  } else {
+    normalized_status = 'manual_review_required';
+  }
+
+  const failClosed = normalized_status === 'manual_review_required';
+  return {
+    normalized_status,
+    payment_status: paymentStatusForNormalized(normalized_status),
+    fail_closed: failClosed,
+    raw_status_ref: `sandbox_status_${hashRequestBody({ rawStatus }).slice(0, 24)}`,
+    buyer_safe_message: failClosed
+      ? 'Sandbox provider status is ambiguous and requires manual review.'
+      : `Sandbox provider status normalized to ${normalized_status}.`,
+  };
+}
+
+export function normalizeCommerceProviderSandboxError(
+  error: NormalizedProviderError | unknown,
+): CommerceProviderSandboxErrorSummary {
+  const candidate = error as Partial<NormalizedProviderError> | null;
+  const code = typeof candidate?.code === 'string'
+    ? candidate.code as ProviderErrorCode
+    : 'unknown_provider_error';
+  const retryable = Boolean(candidate?.retryable);
+  const providerErrorCode = typeof candidate?.provider_error_code === 'string'
+    ? candidate.provider_error_code
+    : null;
+
+  const messages: Record<ProviderErrorCode, string> = {
+    provider_unavailable: 'Sandbox provider status is temporarily unavailable.',
+    invalid_provider_credentials: 'Sandbox provider credentials are not accepted by this contract.',
+    provider_validation_failed: 'Sandbox provider validation failed without exposing private details.',
+    provider_rate_limited: 'Sandbox provider status is temporarily rate limited.',
+    provider_timeout: 'Sandbox provider status timed out.',
+    payment_declined: 'Sandbox payment outcome was declined by local test facts.',
+    payment_expired: 'Sandbox payment outcome has expired.',
+    webhook_signature_invalid: 'Sandbox webhook signature could not be verified.',
+    webhook_replay_detected: 'Sandbox webhook replay window was refused.',
+    unsupported_provider_event: 'Sandbox provider event is unsupported and requires review.',
+    unknown_provider_error: 'Sandbox provider error is unknown and requires review.',
+  };
+
+  return {
+    code,
+    retryable,
+    buyer_safe_message: messages[code] ?? messages.unknown_provider_error,
+    provider_error_ref: providerErrorCode
+      ? `sandbox_provider_error_${hashRequestBody({ providerErrorCode }).slice(0, 24)}`
+      : undefined,
+    safe_metadata: redactCommerceProviderSandboxPrivateFields(cloneJson(candidate?.safe_metadata ?? {})),
+  };
+}
+
+export function hashCommerceProviderSandboxRequest(input: CommerceProviderSandboxContractInput): string {
+  return hashRequestBody({
+    tenant_id: input.tenant_id ?? null,
+    merchant_id: input.merchant_id ?? null,
+    agent_id: input.agent_id ?? null,
+    cart_id: input.cart_id ?? null,
+    payment_intent_id: input.payment_intent_id ?? null,
+    provider_key: input.provider_key ?? null,
+    environment: input.environment ?? null,
+    amount: input.amount ?? null,
+    line_items_snapshot: input.line_items_snapshot ?? [],
+    idempotency_key_hash: input.idempotency_key_hash ?? null,
+  });
+}
+
+export function compareCommerceProviderSandboxReplay(
+  input: CommerceProviderSandboxContractInput,
+  previous?: CommerceProviderSandboxPriorResult | null,
+): CommerceProviderSandboxReplayResult {
+  const actual = hashCommerceProviderSandboxRequest(input);
+  if (!previous) return { kind: 'new', request_body_hash: actual };
+  if (
+    previous.tenant_id !== input.tenant_id
+    || previous.merchant_id !== input.merchant_id
+    || previous.idempotency_scope !== 'provider.sandbox.adapter.contract'
+    || previous.idempotency_key_hash !== input.idempotency_key_hash
+  ) {
+    return { kind: 'new', request_body_hash: actual };
+  }
+  if (previous.request_body_hash !== actual) {
+    return {
+      kind: 'conflict',
+      expected_body_hash: previous.request_body_hash,
+      actual_body_hash: actual,
+    };
+  }
+  return { kind: 'replay', response: previous.response };
+}
+
+export function buildCommerceProviderSandboxIntentContract(
+  input: CommerceProviderSandboxContractInput,
+): CommerceProviderSandboxContractResult {
+  assertNoCommerceProviderSandboxExecutionFields(input);
+  const contextRefusal = validateSandboxContext(input);
+  if (contextRefusal) return refusalResult(contextRefusal, input.environment);
+  const tenantId = input.tenant_id;
+  const merchantId = input.merchant_id;
+  const paymentIntentId = input.payment_intent_id;
+  const idempotencyKeyHash = input.idempotency_key_hash;
+  if (!isNonEmptyString(tenantId)) {
+    return refusalResult('provider_sandbox_tenant_context_required', input.environment);
+  }
+  if (!isNonEmptyString(merchantId)) {
+    return refusalResult('provider_sandbox_merchant_context_required', input.environment);
+  }
+  if (!isNonEmptyString(paymentIntentId)) {
+    return refusalResult('provider_sandbox_payment_intent_required', input.environment);
+  }
+  if (!isNonEmptyString(idempotencyKeyHash)) {
+    return refusalResult('provider_sandbox_idempotency_required', input.environment);
+  }
+  if (!input.audit_evidence_refs || input.audit_evidence_refs.length === 0) {
+    return refusalResult('provider_sandbox_audit_evidence_required', input.environment);
+  }
+
+  const requestBodyHash = hashCommerceProviderSandboxRequest(input);
+  const seedHash = hashRequestBody({
+    tenant_id: tenantId,
+    merchant_id: merchantId,
+    payment_intent_id: paymentIntentId,
+    idempotency_key_hash: idempotencyKeyHash,
+    request_body_hash: requestBodyHash,
+  });
+
+  return {
+    status: 'accepted',
+    tenant_id: tenantId,
+    merchant_id: merchantId,
+    payment_intent_id: paymentIntentId,
+    environment: 'sandbox',
+    idempotency_scope: 'provider.sandbox.adapter.contract',
+    idempotency_key_hash: idempotencyKeyHash,
+    request_body_hash: requestBodyHash,
+    normalized_status: 'authorized',
+    provider_reference: {
+      payment_ref: `sandbox_payment_ref_${seedHash.slice(0, 24)}`,
+      order_ref: `sandbox_order_ref_${seedHash.slice(24, 48)}`,
+      raw_status_ref: `sandbox_status_${seedHash.slice(48, 64)}`,
+    },
+    buyer_safe_status: {
+      code: 'sandbox_intent_authorized',
+      message: 'Sandbox payment intent contract is locally authorized for test sequencing only.',
+    },
+    source_freshness_refs: redactCommerceProviderSandboxPrivateFields(cloneJson(input.source_freshness_refs ?? {})),
+    audit_evidence_refs: safeAuditRefs(input.audit_evidence_refs),
+    redacted_provider_evidence: redactCommerceProviderSandboxPrivateFields(cloneJson(input.metadata ?? {})),
+    non_enablement: nonEnablement(),
+  };
+}
+
+export function evaluateCommerceProviderSandboxWebhook(
+  input: CommerceProviderSandboxWebhookInput,
+): CommerceProviderSandboxWebhookResult {
+  assertNoCommerceProviderSandboxExecutionFields(input);
+  const contextRefusal = validateSandboxContext(input);
+  if (contextRefusal) return refusalResult(contextRefusal, input.environment);
+  if (!isNonEmptyString(input.event_id)) {
+    return refusalResult('provider_sandbox_webhook_event_id_required', input.environment);
+  }
+  if (input.signature_state !== 'valid') {
+    return refusalResult('provider_sandbox_webhook_signature_required', input.environment);
+  }
+  if (input.replay_state === 'stale') {
+    return refusalResult('provider_sandbox_webhook_replay_refused', input.environment);
+  }
+
+  const status = normalizeCommerceProviderSandboxStatus(input.normalized_status);
+  const evidence = eventEvidence({
+    event_id: input.event_id,
+    payment_intent_id: input.payment_intent_id,
+    normalized_status: status.normalized_status,
+    raw_status_ref: status.raw_status_ref,
+    audit_evidence_refs: input.audit_evidence_refs,
+    metadata: input.metadata,
+  });
+
+  if (input.replay_state === 'duplicate') {
+    return {
+      status: 'ignored',
+      reason: 'duplicate_event',
+      idempotent: true,
+      evidence,
+      buyer_safe_message: 'Duplicate sandbox webhook event was idempotently ignored.',
+      non_enablement: nonEnablement(),
+    };
+  }
+
+  if (!KNOWN_SANDBOX_WEBHOOK_EVENTS.has(input.event_type ?? '')) {
+    return {
+      status: 'manual_review_required',
+      reason: 'unknown_event',
+      evidence,
+      buyer_safe_message: publicRefusal('provider_sandbox_webhook_unknown_event').message,
+      non_enablement: nonEnablement(),
+    };
+  }
+
+  if (status.normalized_status === 'manual_review_required') {
+    return {
+      status: 'manual_review_required',
+      reason: 'ambiguous_status',
+      evidence,
+      buyer_safe_message: status.buyer_safe_message,
+      non_enablement: nonEnablement(),
+    };
+  }
+
+  return {
+    status: 'processed',
+    payment_status: status.payment_status as CommercePaymentStatus,
+    idempotent: false,
+    evidence,
+    buyer_safe_message: 'Sandbox webhook event was normalized from supplied test facts.',
+    non_enablement: nonEnablement(),
+  };
+}
+
+export function evaluateCommerceProviderSandboxReconciliation(
+  input: CommerceProviderSandboxReconciliationInput,
+): CommerceProviderSandboxReconciliationResult {
+  assertNoCommerceProviderSandboxExecutionFields(input);
+  const contextRefusal = validateSandboxContext(input);
+  if (contextRefusal) return refusalResult(contextRefusal, input.environment);
+  if (!input.audit_evidence_refs || input.audit_evidence_refs.length === 0) {
+    return refusalResult('provider_sandbox_audit_evidence_required', input.environment);
+  }
+
+  const status = normalizeCommerceProviderSandboxStatus(input.provider_status);
+  const current = input.current_status ?? 'unknown';
+  const evidence = eventEvidence({
+    payment_intent_id: input.payment_intent_id,
+    normalized_status: status.normalized_status,
+    raw_status_ref: status.raw_status_ref,
+    audit_evidence_refs: input.audit_evidence_refs,
+    metadata: input.metadata,
+  });
+
+  if (
+    current === 'paid'
+    || current === 'failed'
+    || current === 'cancelled'
+    || current === 'expired'
+  ) {
+    return {
+      status: 'no_change',
+      payment_status: current,
+      reason: 'terminal_status',
+      evidence,
+      non_enablement: nonEnablement(),
+    };
+  }
+
+  if ((input.pending_age_seconds ?? 0) < SANDBOX_RECONCILIATION_REVIEW_WINDOW_SECONDS) {
+    return {
+      status: 'no_change',
+      payment_status: current === 'unknown' ? 'payment_pending' : current,
+      reason: 'pending_window_open',
+      evidence,
+      non_enablement: nonEnablement(),
+    };
+  }
+
+  if (input.mismatch_detected || status.normalized_status === 'manual_review_required') {
+    return {
+      status: 'manual_review_required',
+      reason: input.mismatch_detected ? 'status_mismatch' : 'ambiguous_status',
+      evidence,
+      non_enablement: nonEnablement(),
+    };
+  }
+
+  if (status.normalized_status === 'payment_pending') {
+    return {
+      status: 'no_change',
+      payment_status: 'payment_pending',
+      reason: 'provider_still_pending',
+      evidence,
+      non_enablement: nonEnablement(),
+    };
+  }
+
+  const toStatus = terminalStatusForNormalized(status.normalized_status);
+  if (current === 'payment_pending' && toStatus) {
+    return {
+      status: 'transition_recommended',
+      from_status: 'payment_pending',
+      to_status: toStatus,
+      reason: 'sandbox_provider_terminal_status',
+      evidence,
+      non_enablement: nonEnablement(),
+    };
+  }
+
+  return {
+    status: 'manual_review_required',
+    reason: 'unsupported_transition',
+    evidence,
+    non_enablement: nonEnablement(),
+  };
+}

--- a/apps/auth-service/tests/commerce-c6u11-provider-sandbox-webhook-reconciliation.test.ts
+++ b/apps/auth-service/tests/commerce-c6u11-provider-sandbox-webhook-reconciliation.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  assertNoCommerceProviderSandboxExecutionFields,
+  buildCommerceProviderSandboxIntentContract,
+  compareCommerceProviderSandboxReplay,
+  evaluateCommerceProviderSandboxReconciliation,
+  evaluateCommerceProviderSandboxWebhook,
+  hashCommerceProviderSandboxRequest,
+  normalizeCommerceProviderSandboxError,
+  normalizeCommerceProviderSandboxStatus,
+  publicCommerceProviderSandboxRefusal,
+  redactCommerceProviderSandboxPrivateFields,
+  type CommerceProviderSandboxContractInput,
+  type CommerceProviderSandboxPriorResult,
+} from '../src/lib/commerce/provider-sandbox-contract.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const DOC_PATH = join(
+  TEST_DIR,
+  '../../../docs/internal/commerce-v1/commerce-v1-c6u11-provider-sandbox-webhook-reconciliation-foundation.md',
+);
+const HELPER_PATH = join(TEST_DIR, '../src/lib/commerce/provider-sandbox-contract.ts');
+
+const TENANT = 'cten_C6U11';
+const MERCHANT = 'mch_C6U11';
+const AGENT = 'cag_C6U11';
+const CART = 'ccart_C6U11';
+const PAYMENT_INTENT = 'cpi_C6U11';
+
+function baseInput(overrides: Partial<CommerceProviderSandboxContractInput> = {}): CommerceProviderSandboxContractInput {
+  return {
+    tenant_id: TENANT,
+    merchant_id: MERCHANT,
+    agent_id: AGENT,
+    cart_id: CART,
+    payment_intent_id: PAYMENT_INTENT,
+    provider_key: 'mock',
+    environment: 'sandbox',
+    amount: {
+      amount_minor_units: 109900,
+      currency: 'INR',
+    },
+    line_items_snapshot: [{
+      product_id: 'cprd_C6U11',
+      title: 'Sandbox Switch',
+      quantity: 1,
+    }],
+    idempotency_key_hash: 'hash_c6u11_idempotency',
+    source_freshness_refs: {
+      source: 'local_sandbox_fixture',
+      checked_at: '2026-06-10T00:00:00.000Z',
+    },
+    audit_evidence_refs: [
+      { audit_event_id: 'caud_C6U11_CONTRACT' },
+    ],
+    metadata: {
+      display_state: 'sandbox_provider_contract_ready',
+    },
+    ...overrides,
+  };
+}
+
+describe('C6U11 provider sandbox adapter, webhook, and reconciliation foundation', () => {
+  it('builds a deterministic provider-neutral sandbox adapter contract without live/provider execution', () => {
+    const first = buildCommerceProviderSandboxIntentContract(baseInput());
+    const second = buildCommerceProviderSandboxIntentContract(baseInput());
+
+    expect(first).toEqual(second);
+    expect(first.status).toBe('accepted');
+    if (first.status !== 'accepted') throw new Error('expected accepted contract result');
+
+    expect(first).toMatchObject({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      payment_intent_id: PAYMENT_INTENT,
+      environment: 'sandbox',
+      idempotency_scope: 'provider.sandbox.adapter.contract',
+      normalized_status: 'authorized',
+      buyer_safe_status: {
+        code: 'sandbox_intent_authorized',
+      },
+      non_enablement: {
+        production_checkout: false,
+        live_payment: false,
+        live_provider: false,
+        provider_call: false,
+        partner_payment_rail_call: false,
+        carrier_call: false,
+        merchant_private_api_call: false,
+        settlement_execution: false,
+        payout_execution: false,
+        refund_execution: false,
+        public_discovery: false,
+      },
+    });
+    expect(first.provider_reference.payment_ref).toMatch(/^sandbox_payment_ref_/);
+    expect(JSON.stringify(first)).not.toContain('provider_payment_id');
+    expect(JSON.stringify(first)).not.toContain('raw_payload');
+    expect(JSON.stringify(first)).not.toContain('credential');
+  });
+
+  it('refuses missing context, live mode, non-local adapter selection, missing audit, and missing idempotency', () => {
+    const cases: Array<[Partial<CommerceProviderSandboxContractInput>, string]> = [
+      [{ tenant_id: '' }, 'provider_sandbox_tenant_context_required'],
+      [{ merchant_id: '' }, 'provider_sandbox_merchant_context_required'],
+      [{ payment_intent_id: '' }, 'provider_sandbox_payment_intent_required'],
+      [{ environment: 'live' }, 'provider_sandbox_environment_refused'],
+      [{ environment: 'unknown' }, 'provider_sandbox_environment_refused'],
+      [{ provider_key: 'plural' }, 'provider_sandbox_adapter_blocked'],
+      [{ idempotency_key_hash: '' }, 'provider_sandbox_idempotency_required'],
+      [{ audit_evidence_refs: [] }, 'provider_sandbox_audit_evidence_required'],
+    ];
+
+    for (const [override, code] of cases) {
+      const result = buildCommerceProviderSandboxIntentContract(baseInput(override));
+      expect(result.status).toBe('refused');
+      if (result.status !== 'refused') throw new Error('expected refused result');
+      expect(result.refusal.code).toBe(code);
+      expect(result.non_enablement.live_provider).toBe(false);
+      expect(result.non_enablement.production_checkout).toBe(false);
+    }
+  });
+
+  it('supports hashed idempotency replay and conflicts on changed request bodies', () => {
+    const input = baseInput();
+    const response = buildCommerceProviderSandboxIntentContract(input);
+    const previous: CommerceProviderSandboxPriorResult = {
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      idempotency_scope: 'provider.sandbox.adapter.contract',
+      idempotency_key_hash: 'hash_c6u11_idempotency',
+      request_body_hash: hashCommerceProviderSandboxRequest(input),
+      response,
+    };
+
+    expect(compareCommerceProviderSandboxReplay(input, null)).toMatchObject({ kind: 'new' });
+    expect(compareCommerceProviderSandboxReplay(input, previous)).toMatchObject({ kind: 'replay', response });
+    expect(compareCommerceProviderSandboxReplay(baseInput({
+      amount: { amount_minor_units: 209900, currency: 'INR' },
+    }), previous)).toMatchObject({ kind: 'conflict' });
+  });
+
+  it('normalizes statuses and provider errors fail closed for ambiguous values', () => {
+    expect(normalizeCommerceProviderSandboxStatus('mock_paid')).toMatchObject({
+      normalized_status: 'paid',
+      payment_status: 'paid',
+      fail_closed: false,
+    });
+    expect(normalizeCommerceProviderSandboxStatus('provider-side-weird-state')).toMatchObject({
+      normalized_status: 'manual_review_required',
+      payment_status: 'manual_review_required',
+      fail_closed: true,
+    });
+
+    const normalizedError = normalizeCommerceProviderSandboxError({
+      code: 'provider_timeout',
+      message: 'raw timeout details',
+      retryable: true,
+      provider_key: 'mock',
+      provider_error_code: 'timeout-private-code',
+      provider_request_id: 'private-request-id',
+      safe_metadata: {
+        public_state: 'timeout',
+        token: 'private-token',
+      },
+    });
+
+    expect(normalizedError).toMatchObject({
+      code: 'provider_timeout',
+      retryable: true,
+      buyer_safe_message: 'Sandbox provider status timed out.',
+      safe_metadata: {
+        public_state: 'timeout',
+        token: '[redacted]',
+      },
+    });
+    expect(JSON.stringify(normalizedError)).not.toContain('private-request-id');
+    expect(JSON.stringify(normalizedError)).not.toContain('timeout-private-code');
+    expect(JSON.stringify(normalizedError)).not.toContain('private-token');
+  });
+
+  it('handles webhook signature, replay, duplicate, malformed, unknown, and ambiguous cases safely', () => {
+    const processed = evaluateCommerceProviderSandboxWebhook({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      payment_intent_id: PAYMENT_INTENT,
+      provider_key: 'mock',
+      environment: 'sandbox',
+      event_id: 'evt_C6U11_PAID',
+      event_type: 'payment.succeeded',
+      signature_state: 'valid',
+      replay_state: 'fresh',
+      normalized_status: 'paid',
+      audit_evidence_refs: [{ audit_event_id: 'caud_C6U11_WEBHOOK' }],
+      metadata: { source: 'local_sandbox_fixture' },
+    });
+
+    expect(processed).toMatchObject({
+      status: 'processed',
+      payment_status: 'paid',
+      idempotent: false,
+      non_enablement: { provider_call: false },
+    });
+
+    const duplicate = evaluateCommerceProviderSandboxWebhook({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      payment_intent_id: PAYMENT_INTENT,
+      provider_key: 'mock',
+      environment: 'sandbox',
+      event_id: 'evt_C6U11_DUP',
+      event_type: 'payment.updated',
+      signature_state: 'valid',
+      replay_state: 'duplicate',
+      normalized_status: 'payment_pending',
+    });
+    expect(duplicate).toMatchObject({ status: 'ignored', reason: 'duplicate_event', idempotent: true });
+
+    const missingSignature = evaluateCommerceProviderSandboxWebhook({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      payment_intent_id: PAYMENT_INTENT,
+      provider_key: 'mock',
+      environment: 'sandbox',
+      event_id: 'evt_C6U11_MISSING_SIGNATURE',
+      event_type: 'payment.updated',
+      signature_state: 'missing',
+      replay_state: 'fresh',
+      normalized_status: 'paid',
+    });
+    expect(missingSignature).toMatchObject({
+      status: 'refused',
+      refusal: { code: 'provider_sandbox_webhook_signature_required' },
+    });
+
+    const replay = evaluateCommerceProviderSandboxWebhook({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      payment_intent_id: PAYMENT_INTENT,
+      provider_key: 'mock',
+      environment: 'sandbox',
+      event_id: 'evt_C6U11_STALE',
+      event_type: 'payment.updated',
+      signature_state: 'valid',
+      replay_state: 'stale',
+      normalized_status: 'paid',
+    });
+    expect(replay).toMatchObject({
+      status: 'refused',
+      refusal: { code: 'provider_sandbox_webhook_replay_refused' },
+    });
+
+    const unknownEvent = evaluateCommerceProviderSandboxWebhook({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      payment_intent_id: PAYMENT_INTENT,
+      provider_key: 'mock',
+      environment: 'sandbox',
+      event_id: 'evt_C6U11_UNKNOWN',
+      event_type: 'payment.refunded',
+      signature_state: 'valid',
+      replay_state: 'fresh',
+      normalized_status: 'paid',
+    });
+    expect(unknownEvent).toMatchObject({ status: 'manual_review_required', reason: 'unknown_event' });
+
+    const ambiguous = evaluateCommerceProviderSandboxWebhook({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      payment_intent_id: PAYMENT_INTENT,
+      provider_key: 'mock',
+      environment: 'sandbox',
+      event_id: 'evt_C6U11_AMBIGUOUS',
+      event_type: 'payment.updated',
+      signature_state: 'valid',
+      replay_state: 'fresh',
+      normalized_status: 'not-a-known-status',
+    });
+    expect(ambiguous).toMatchObject({ status: 'manual_review_required', reason: 'ambiguous_status' });
+  });
+
+  it('keeps reconciliation as supplied-fact hardening without settlement, payout, refund, or live status pulls', () => {
+    const youngPending = evaluateCommerceProviderSandboxReconciliation({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      payment_intent_id: PAYMENT_INTENT,
+      provider_key: 'mock',
+      environment: 'sandbox',
+      current_status: 'payment_pending',
+      provider_status: 'payment_pending',
+      pending_age_seconds: 30,
+      audit_evidence_refs: [{ audit_event_id: 'caud_C6U11_RECON' }],
+    });
+    expect(youngPending).toMatchObject({ status: 'no_change', reason: 'pending_window_open' });
+
+    const mismatch = evaluateCommerceProviderSandboxReconciliation({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      payment_intent_id: PAYMENT_INTENT,
+      provider_key: 'mock',
+      environment: 'sandbox',
+      current_status: 'payment_pending',
+      provider_status: 'paid',
+      pending_age_seconds: 300,
+      mismatch_detected: true,
+      audit_evidence_refs: [{ audit_event_id: 'caud_C6U11_RECON' }],
+    });
+    expect(mismatch).toMatchObject({ status: 'manual_review_required', reason: 'status_mismatch' });
+
+    const paid = evaluateCommerceProviderSandboxReconciliation({
+      tenant_id: TENANT,
+      merchant_id: MERCHANT,
+      payment_intent_id: PAYMENT_INTENT,
+      provider_key: 'mock',
+      environment: 'sandbox',
+      current_status: 'payment_pending',
+      provider_status: 'paid',
+      pending_age_seconds: 300,
+      audit_evidence_refs: [{ audit_event_id: 'caud_C6U11_RECON' }],
+    });
+    expect(paid).toMatchObject({
+      status: 'transition_recommended',
+      from_status: 'payment_pending',
+      to_status: 'paid',
+      non_enablement: {
+        settlement_execution: false,
+        payout_execution: false,
+        refund_execution: false,
+      },
+    });
+
+    const serialized = JSON.stringify([youngPending, mismatch, paid]);
+    expect(serialized).not.toContain('settlement_id');
+    expect(serialized).not.toContain('payout_id');
+    expect(serialized).not.toContain('refund_transaction_id');
+  });
+
+  it('rejects credentials, provider payloads, carrier fields, private API fields, and money movement fields recursively', () => {
+    const forbiddenSamples = [
+      { apiKey: 'private-api-key' },
+      { providerPaymentId: 'provider-private-id' },
+      { rawProviderPayload: { private: true } },
+      { checkoutUrl: 'https://checkout.example.invalid/private' },
+      { carrierTrackingUrl: 'https://carrier.example.invalid/private' },
+      { merchantPrivateApiUrl: 'https://merchant-private.example.invalid/orders' },
+      { settlementId: 'set_private' },
+      { payoutId: 'po_private' },
+      { refundTransactionId: 'refund_private' },
+      { webhookSecret: 'whsec_private' },
+    ];
+
+    for (const metadata of forbiddenSamples) {
+      expect(() => assertNoCommerceProviderSandboxExecutionFields({ nested: metadata }))
+        .toThrow(/Provider sandbox contract cannot carry/);
+    }
+  });
+
+  it('redacts public summaries and helper source contains no direct network or non-local adapter calls', () => {
+    const redacted = redactCommerceProviderSandboxPrivateFields({
+      public_state: 'sandbox_review',
+      nested: {
+        jwt: 'private-jwt',
+        webhook_secret: 'private-secret',
+        private_url: 'https://private.example.invalid/path',
+      },
+    });
+
+    expect(redacted).toEqual({
+      public_state: 'sandbox_review',
+      nested: {
+        jwt: '[redacted]',
+        webhook_secret: '[redacted]',
+        private_url: '[redacted]',
+      },
+    });
+    expect(publicCommerceProviderSandboxRefusal('provider_sandbox_adapter_blocked').message)
+      .toContain('local sandbox adapter contract');
+
+    const helper = readFileSync(HELPER_PATH, 'utf8');
+    expect(helper).not.toMatch(/\bfetch\s*\(/);
+    expect(helper).not.toMatch(/\baxios\b/);
+    expect(helper).not.toMatch(/\bundici\b/);
+    expect(helper).not.toMatch(/\bgetPaymentProvider\s*\(/);
+    expect(helper).not.toMatch(/\bnew\s+MockPaymentProvider\b/);
+    expect(helper.replace(/\/\*[\s\S]*?\*\/|\/\/[^\r\n]*/g, '').toLowerCase()).not.toContain('plural');
+  });
+
+  it('documents C6U11 scope, hardening requirements, unchanged API surface, and non-approval language', () => {
+    const doc = readFileSync(DOC_PATH, 'utf8');
+
+    for (const section of [
+      'Sandbox Provider Adapter Contract',
+      'Normalized Status Taxonomy',
+      'Normalized Error Taxonomy',
+      'Webhook Signature, Replay, And Idempotency Expectations',
+      'Reconciliation Expectations',
+      'Audit And Evidence Requirements',
+      'Redaction Rules',
+      'Manual Review And Stop Conditions',
+      'What This Does Not Enable',
+      'Evidence Required Before Later Live Review',
+      'API, OpenAPI, Migration, Workflow, And Config Note',
+      'Future Slices',
+      'Explicit Non-Approval Language',
+    ]) {
+      expect(doc).toContain(`## ${section}`);
+    }
+
+    expect(doc).toContain('C6U11 adds no migration, route, endpoint, OpenAPI surface, workflow, config, secret');
+    expect(doc).toContain('This C6U11 slice does not approve live provider use');
+    expect(doc).toContain('C6U11 does not enable:');
+    expect(doc).toContain('AgenticOrg must continue refusing provider, payment, fulfillment, refund, settlement, or payout status');
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6u11-provider-sandbox-webhook-reconciliation-foundation.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6u11-provider-sandbox-webhook-reconciliation-foundation.md
@@ -1,0 +1,232 @@
+# Commerce V1 C6U11 Provider Sandbox Webhook Reconciliation Foundation
+
+Status: internal planning and test foundation only.
+
+C6U11 defines a provider-neutral sandbox adapter contract and hardening expectations for webhook replay and reconciliation. It uses supplied local test facts only. It does not add a live provider adapter, provider credentials, production checkout, payment creation for production, live Plural, carrier calls, merchant-private API calls, settlement, payout, refund execution, public discovery, workflow changes, cloud resources, or production config.
+
+## Scope
+
+C6U11 is Grantex-owned and limited to helper, tests, and documentation:
+
+- A local sandbox contract helper that evaluates supplied facts.
+- Deterministic redacted references for sandbox payment intent sequencing.
+- Webhook signature, replay, duplicate, malformed, and unknown-event expectations.
+- Reconciliation expectations for pending age, status mismatch, and manual review.
+- Explicit non-enablement language for live provider use and money movement.
+
+This is not a provider adapter rollout. It is not a payment approval, checkout approval, merchant approval, production launch, certification, compliance claim, conformance claim, standardization claim, or live provider approval.
+
+## Sandbox Provider Adapter Contract
+
+The sandbox adapter contract is provider-neutral and deterministic. It can represent:
+
+- `create sandbox intent` from tenant, merchant, payment intent, amount, line item snapshot, idempotency hash, source freshness, and audit references.
+- `get sandbox status` from supplied local status facts only.
+- `normalize provider status` into the Commerce payment status taxonomy.
+- `normalize provider errors` into buyer-safe messages.
+- Redacted provider references only, such as hashed local references.
+
+The contract requires:
+
+- `tenant_id`
+- `merchant_id`
+- `payment_intent_id`
+- local sandbox environment
+- local sandbox adapter selection
+- hashed idempotency key reference
+- redacted audit evidence references
+
+The contract refuses:
+
+- live or unknown environment
+- non-local adapter selection
+- missing tenant, merchant, payment intent, idempotency, or audit facts
+- credentials, raw provider payloads, raw connector payloads, private URLs, provider execution fields, carrier fields, settlement fields, payout fields, refund execution fields, and merchant-private API fields
+
+The contract never instantiates provider adapters and never performs a network call.
+
+## Normalized Status Taxonomy
+
+Allowed normalized sandbox statuses are:
+
+| Normalized status | Meaning | Execution implication |
+| --- | --- | --- |
+| `authorized` | Local sandbox intent can continue test sequencing | No money movement |
+| `payment_pending` | Local sandbox fact says payment remains pending | No money movement |
+| `paid` | Supplied sandbox fact maps to a terminal paid state | No settlement or payout |
+| `failed` | Supplied sandbox fact maps to failure | No retry execution |
+| `expired` | Supplied sandbox fact maps to expiration | No provider call |
+| `cancelled` | Supplied sandbox fact maps to cancellation | No provider call |
+| `manual_review_required` | Unknown or ambiguous value | Fail closed |
+
+Unknown, ambiguous, or unsupported values must map to `manual_review_required`.
+
+## Normalized Error Taxonomy
+
+C6U11 uses the existing provider-neutral error taxonomy:
+
+- `provider_unavailable`
+- `invalid_provider_credentials`
+- `provider_validation_failed`
+- `provider_rate_limited`
+- `provider_timeout`
+- `payment_declined`
+- `payment_expired`
+- `webhook_signature_invalid`
+- `webhook_replay_detected`
+- `unsupported_provider_event`
+- `unknown_provider_error`
+
+Buyer-safe errors must not include raw provider request IDs, raw payloads, tokens, credentials, private URLs, webhook secrets, DB URLs, Redis URLs, or private evidence. Provider-specific error details may be represented only as redacted references or hashed local references.
+
+## Webhook Signature, Replay, And Idempotency Expectations
+
+Webhook handling must be designed around these expectations before any later runtime hardening:
+
+- Signature state must be verified before event facts can influence payment state.
+- Missing, invalid, or unconfirmed signature state must refuse protected status use.
+- Replay windows must reject stale events.
+- Duplicate event IDs must be idempotently ignored without a second transition.
+- Event IDs must be stable references.
+- Unknown event types must require manual review.
+- Malformed or ambiguous status facts must require manual review.
+- Webhook evidence must be redacted and must not carry raw request bodies.
+- Webhook handling must not call a provider, Plural, a carrier, or a merchant-private API.
+
+## Reconciliation Expectations
+
+Reconciliation in this foundation consumes supplied facts only:
+
+- Pending payment age is evaluated locally.
+- Young pending payments remain `no_change`.
+- Status mismatches map to `manual_review_required`.
+- Unknown provider status maps to `manual_review_required`.
+- Terminal supplied facts may recommend a Commerce status transition, but do not execute settlement, payout, refund, carrier, provider, or merchant-private actions.
+- Terminal existing payment status remains idempotently unchanged.
+- Reconciliation must not pull live status from a provider.
+- Reconciliation must not move money automatically.
+
+## Audit And Evidence Requirements
+
+Every protected sandbox contract, webhook, and reconciliation decision needs redacted evidence references:
+
+- audit event reference
+- tenant and merchant scope
+- payment intent reference
+- idempotency hash or event ID hash where applicable
+- source freshness timestamp or local fixture source
+- manual review reason for ambiguous states
+
+Evidence must be enough for internal traceability without leaking secrets or raw provider material.
+
+## Redaction Rules
+
+Public and audit-visible summaries must redact or refuse:
+
+- access tokens
+- API keys
+- bearer tokens
+- raw passports
+- JWTs
+- webhook secrets
+- provider credentials
+- encrypted secret blobs
+- raw connector payloads
+- raw provider payloads
+- raw request bodies
+- private URLs
+- DB URLs
+- Redis URLs
+- merchant-private API URLs
+- provider payment IDs
+- provider order IDs
+- settlement IDs
+- payout IDs
+- refund transaction IDs
+- carrier label or tracking URLs
+
+Redacted output should use stable local references such as hashed event or status references.
+
+## Manual Review And Stop Conditions
+
+Stop and require manual review if any of these appear:
+
+- live environment requested
+- non-local provider adapter requested
+- provider credentials are required
+- raw provider payload is needed
+- webhook signature state is missing, invalid, or unconfirmed
+- webhook replay state is stale
+- event type is unknown
+- status is ambiguous
+- reconciliation detects a mismatch
+- settlement, payout, refund execution, carrier, provider, Plural, or merchant-private API behavior is required
+- production checkout or public discovery would be needed
+
+## What This Does Not Enable
+
+C6U11 does not enable:
+
+- live provider use
+- live Plural
+- production Commerce V1
+- production checkout
+- payment creation for production
+- live payments
+- provider credentials
+- provider calls
+- Plural calls
+- carrier or shipping provider calls
+- merchant-private API calls
+- public discovery
+- production allowlists
+- settlement
+- payout
+- refund execution
+- fulfillment or delivery execution
+- route, endpoint, OpenAPI, migration, workflow, cloud, deploy, or config changes
+- external protocol publication or submission
+
+## Evidence Required Before Later Live Review
+
+A later live-mode review would need separate evidence before any approval discussion:
+
+- legal and partner approval records
+- security review for credential storage and rotation
+- operator runbooks for incident, rollback, and disablement
+- feature flag and config review without secrets in source
+- provider adapter contract review
+- webhook signature verification evidence
+- replay and idempotency evidence
+- reconciliation evidence for mismatch and manual review states
+- refund, settlement, and payout non-execution evidence
+- audit retention and privacy review
+- production endpoint health diagnostics handled under separately approved procedures
+
+C6U11 does not collect, approve, or certify that evidence.
+
+## API, OpenAPI, Migration, Workflow, And Config Note
+
+C6U11 adds no migration, route, endpoint, OpenAPI surface, workflow, config, secret, provider adapter, carrier adapter, cloud resource, deploy behavior, public discovery surface, production allowlist, or AgenticOrg runtime behavior.
+
+OpenAPI is unchanged because C6U11 exposes no external API surface.
+
+## AgenticOrg Future-Consumption Note
+
+AgenticOrg must continue refusing provider, payment, fulfillment, refund, settlement, or payout status unless Grantex later supplies buyer-safe source facts through an approved surface. AgenticOrg must not infer live provider state, payment outcome, reconciliation state, refund status, settlement state, or payout state from these sandbox fixtures.
+
+## Future Slices
+
+Future work must stay separately reviewed:
+
+- real sandbox provider adapter implementation
+- webhook signature runtime verification hardening
+- reconciliation dashboard or API
+- refund execution proposal
+- settlement and payout reporting
+- AgenticOrg buyer-safe consumption
+- live provider review with live mode still blocked until separately approved
+
+## Explicit Non-Approval Language
+
+This C6U11 slice does not approve live provider use, live Plural, payment approval, checkout approval, production checkout, production Commerce V1, public discovery, merchant approval, production launch, certification, compliance, conformance, standardization, live payment use, settlement, payout, refund execution, fulfillment execution, delivery execution, carrier integration, or external protocol publication.


### PR DESCRIPTION
## Summary
- Adds a provider-neutral sandbox contract helper for deterministic local intent/status facts.
- Adds webhook/replay and reconciliation hardening tests for fail-closed behavior, idempotency, redaction, and manual review outcomes.
- Adds the internal C6U11 foundation doc with API/OpenAPI/migration/workflow/config unchanged notes.

## Non-enablement
- No deployment, workflow, cloud, config, secret, route, endpoint, OpenAPI, migration, production checkout, live payment, live provider, live Plural, provider call, carrier call, merchant-private API call, settlement, payout, refund execution, public discovery, allowlist, or external protocol behavior is added.
- This PR does not approve live provider use, payment approval, checkout approval, merchant approval, production launch, certification, compliance, conformance, standardization, or enablement.

## Validation
- npm --prefix apps/auth-service test -- commerce-c6u11-provider-sandbox-webhook-reconciliation.test.ts
- npm --prefix apps/auth-service test -- commerce-cart-payment.test.ts commerce-provider-webhook.test.ts commerce-payment-foundations.test.ts commerce-payment-reconciliation.test.ts commerce-no-plural-leak.test.ts commerce-c6u9-sandbox-checkout-e2e.test.ts commerce-c6u10-live-provider-readiness.test.ts
- npm --prefix apps/auth-service run typecheck
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
- git diff --check origin/main...HEAD
- trailing whitespace and ASCII scans across touched files