### PR TITLE
[codex] Add C6W4 OACP adapter previews

### DIFF
--- a/apps/auth-service/src/lib/commerce/oacp-trust-artifacts.ts
+++ b/apps/auth-service/src/lib/commerce/oacp-trust-artifacts.ts
@@ -367,6 +367,68 @@ export interface OacpBlockedArtifactFixture {
   fixture: OacpArtifactFixture;
 }
 
+export const OACP_C6W4_PROTOCOL_ADAPTER_SURFACES = [
+  'schema_org_jsonld',
+  'ucp_capability_profile',
+  'acp_commerce_capability',
+  'ap2_evidence_intent_summary',
+  'a2a_agent_card_task_capability',
+  'mcp_tool_resource_capability',
+] as const;
+
+export type OacpProtocolAdapterSurface = typeof OACP_C6W4_PROTOCOL_ADAPTER_SURFACES[number];
+
+export type OacpAdapterPreviewRefusalCode =
+  | 'unknown_adapter_surface'
+  | 'source_artifact_missing'
+  | 'source_artifact_invalid'
+  | 'source_artifact_expired_or_stale'
+  | 'private_or_forbidden_payload_field';
+
+export interface OacpProtocolAdapterDescriptor {
+  surface: OacpProtocolAdapterSurface;
+  summary: string;
+  required_artifact_types: readonly OacpArtifactType[];
+  max_ttl_seconds: number;
+  blocked_capabilities: readonly string[];
+}
+
+export interface OacpProtocolAdapterPreviewInput {
+  surface: OacpProtocolAdapterSurface;
+  artifacts: readonly OacpArtifactFixture[];
+  generated_at: string;
+  now_iso?: string | undefined;
+}
+
+export type OacpProtocolAdapterPreviewResult =
+  | {
+    generated: true;
+    status: 'preview_only';
+    surface: OacpProtocolAdapterSurface;
+    adapter_descriptor: OacpProtocolAdapterDescriptor;
+    source_artifact_ids: string[];
+    source_artifact_families: OacpArtifactType[];
+    source_authority: 'grantex_canonical_oacp_artifact_authority';
+    generated_at: string;
+    expires_at: string;
+    max_ttl_seconds: number;
+    freshness_tier: OacpArtifactEnvelope['freshness_class'] | 'mixed';
+    unsupported_capabilities: string[];
+    blocked_capabilities: string[];
+    non_authoritative_for_transaction: true;
+    no_checkout_payment_enablement: true;
+    no_live_provider_enablement: true;
+    no_public_discovery_enablement: true;
+    surface_payload: Record<string, unknown>;
+  }
+  | {
+    generated: false;
+    status: 'refused';
+    surface: string;
+    refusal_code: OacpAdapterPreviewRefusalCode;
+    message: string;
+  };
+
 export type OacpOfflineCommitmentDecision =
   | {
     allowed: true;
@@ -476,6 +538,66 @@ const OACP_REQUIRED_SAFETY_FIELDS = [
   'stale_behavior',
   'refusal_code_if_invalid',
 ] as const;
+
+const C6W4_COMMON_BLOCKED_ADAPTER_CAPABILITIES = [
+  'checkout_create',
+  'payment_authorize',
+  'payment_capture',
+  'refund_execute',
+  'settlement_execute',
+  'payout_execute',
+  'fulfillment_start',
+  'merchant_approval',
+  'public_discovery_publish',
+  'public_discovery_unpublish',
+  'live_provider_call',
+  'merchant_private_api_call',
+] as const;
+
+export const OACP_C6W4_PROTOCOL_ADAPTER_DESCRIPTORS: Record<OacpProtocolAdapterSurface, OacpProtocolAdapterDescriptor> = {
+  schema_org_jsonld: {
+    surface: 'schema_org_jsonld',
+    summary: 'schema.org JSON-LD style internal discovery preview derived from signed OACP artifacts.',
+    required_artifact_types: ['merchant_capability', 'seller_agent_capability', 'catalog_snapshot', 'policy', 'protocol_adapter'],
+    max_ttl_seconds: OACP_ARTIFACT_TTLS_SECONDS.protocol_adapter,
+    blocked_capabilities: C6W4_COMMON_BLOCKED_ADAPTER_CAPABILITIES,
+  },
+  ucp_capability_profile: {
+    surface: 'ucp_capability_profile',
+    summary: 'UCP-style internal capability profile preview derived from signed OACP artifacts.',
+    required_artifact_types: ['merchant_capability', 'seller_agent_capability', 'policy', 'protocol_adapter'],
+    max_ttl_seconds: OACP_ARTIFACT_TTLS_SECONDS.protocol_adapter,
+    blocked_capabilities: C6W4_COMMON_BLOCKED_ADAPTER_CAPABILITIES,
+  },
+  acp_commerce_capability: {
+    surface: 'acp_commerce_capability',
+    summary: 'ACP-style commerce capability shape preview without checkout or payment authority.',
+    required_artifact_types: ['merchant_capability', 'seller_agent_capability', 'policy', 'protocol_adapter'],
+    max_ttl_seconds: OACP_ARTIFACT_TTLS_SECONDS.protocol_adapter,
+    blocked_capabilities: C6W4_COMMON_BLOCKED_ADAPTER_CAPABILITIES,
+  },
+  ap2_evidence_intent_summary: {
+    surface: 'ap2_evidence_intent_summary',
+    summary: 'AP2-style evidence and intent summary preview without mandate or payment execution authority.',
+    required_artifact_types: ['merchant_capability', 'seller_agent_capability', 'policy', 'commitment_evidence', 'protocol_adapter'],
+    max_ttl_seconds: OACP_ARTIFACT_TTLS_SECONDS.protocol_adapter,
+    blocked_capabilities: C6W4_COMMON_BLOCKED_ADAPTER_CAPABILITIES,
+  },
+  a2a_agent_card_task_capability: {
+    surface: 'a2a_agent_card_task_capability',
+    summary: 'A2A-style agent card and task capability preview for read-only agent routing.',
+    required_artifact_types: ['merchant_capability', 'seller_agent_capability', 'policy', 'protocol_adapter'],
+    max_ttl_seconds: OACP_ARTIFACT_TTLS_SECONDS.protocol_adapter,
+    blocked_capabilities: C6W4_COMMON_BLOCKED_ADAPTER_CAPABILITIES,
+  },
+  mcp_tool_resource_capability: {
+    surface: 'mcp_tool_resource_capability',
+    summary: 'MCP-style tool and resource capability preview limited to read-only commerce facts.',
+    required_artifact_types: ['merchant_capability', 'seller_agent_capability', 'policy', 'protocol_adapter'],
+    max_ttl_seconds: OACP_ARTIFACT_TTLS_SECONDS.protocol_adapter,
+    blocked_capabilities: C6W4_COMMON_BLOCKED_ADAPTER_CAPABILITIES,
+  },
+};
 
 export const OACP_ARTIFACT_SCHEMA_DESCRIPTORS: Record<OacpArtifactType, OacpArtifactSchemaDescriptor> = {
   merchant_capability: {
@@ -1253,6 +1375,298 @@ export function validateOacpArtifactSchema(input: {
     artifact_type: artifactTypeValue,
     schema_version: String(envelope.schema_version),
     required_payload_fields: descriptor.required_payload_fields,
+  };
+}
+
+function adapterPreviewRefusal(
+  surface: string,
+  refusal_code: OacpAdapterPreviewRefusalCode,
+  message: string,
+): OacpProtocolAdapterPreviewResult {
+  return {
+    generated: false,
+    status: 'refused',
+    surface,
+    refusal_code,
+    message,
+  };
+}
+
+function isOacpProtocolAdapterSurface(value: string): value is OacpProtocolAdapterSurface {
+  return (OACP_C6W4_PROTOCOL_ADAPTER_SURFACES as readonly string[]).includes(value);
+}
+
+function stringArrayValue(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function artifactTypeFromFixture(fixture: OacpArtifactFixture): OacpArtifactType | null {
+  const artifactType = fixture.envelope.artifact_type;
+  return typeof artifactType === 'string' && isOacpArtifactType(artifactType) ? artifactType : null;
+}
+
+function stringValue(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === 'string' ? value : null;
+}
+
+function numberValue(record: Record<string, unknown>, key: string): number | null {
+  const value = record[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function buildSourceArtifactIndex(artifacts: readonly OacpArtifactFixture[]): Map<OacpArtifactType, OacpArtifactFixture> {
+  const index = new Map<OacpArtifactType, OacpArtifactFixture>();
+  for (const artifact of artifacts) {
+    const artifactType = artifactTypeFromFixture(artifact);
+    if (artifactType !== null && !index.has(artifactType)) {
+      index.set(artifactType, artifact);
+    }
+  }
+  return index;
+}
+
+function sourceArtifactId(fixture: OacpArtifactFixture | undefined): string | null {
+  return fixture && typeof fixture.envelope.artifact_id === 'string' ? fixture.envelope.artifact_id : null;
+}
+
+function freshnessTierForArtifacts(artifacts: readonly OacpArtifactFixture[]): OacpArtifactEnvelope['freshness_class'] | 'mixed' {
+  const freshness = new Set(
+    artifacts
+      .map((artifact) => artifact.envelope.freshness_class)
+      .filter((value): value is OacpArtifactEnvelope['freshness_class'] => (
+        value === 'fresh' || value === 'acceptable' || value === 'stale' || value === 'unknown'
+      )),
+  );
+  const onlyFreshness = [...freshness][0];
+  return freshness.size === 1 && onlyFreshness !== undefined ? onlyFreshness : 'mixed';
+}
+
+function unsupportedCapabilitiesForArtifacts(
+  descriptor: OacpProtocolAdapterDescriptor,
+  artifacts: readonly OacpArtifactFixture[],
+): string[] {
+  const capabilities = new Set<string>(descriptor.blocked_capabilities);
+  for (const artifact of artifacts) {
+    const safety = asRecord(artifact.envelope.safety);
+    for (const item of stringArrayValue(safety?.forbidden_agent_uses)) {
+      capabilities.add(item);
+    }
+  }
+  return [...capabilities].sort();
+}
+
+function buildPreviewSourceRefs(artifacts: readonly OacpArtifactFixture[]): Array<Record<string, unknown>> {
+  return artifacts.map((artifact) => ({
+    artifact_id: artifact.envelope.artifact_id,
+    artifact_type: artifact.envelope.artifact_type,
+    issuer: artifact.envelope.issuer,
+    policy_version: artifact.envelope.policy_version,
+    freshness_class: artifact.envelope.freshness_class,
+    expires_at: artifact.envelope.expires_at,
+    evidence_refs: stringArrayValue(artifact.envelope.evidence_refs),
+  }));
+}
+
+function buildC6W4SurfacePayload(
+  surface: OacpProtocolAdapterSurface,
+  byType: Map<OacpArtifactType, OacpArtifactFixture>,
+  sourceArtifacts: readonly OacpArtifactFixture[],
+  unsupportedCapabilities: readonly string[],
+): Record<string, unknown> {
+  const merchant = byType.get('merchant_capability')?.payload ?? {};
+  const seller = byType.get('seller_agent_capability')?.payload ?? {};
+  const catalog = byType.get('catalog_snapshot')?.payload ?? {};
+  const policy = byType.get('policy')?.payload ?? {};
+  const price = byType.get('price');
+  const inventory = byType.get('inventory');
+  const commitment = byType.get('commitment_evidence');
+  const source_refs = buildPreviewSourceRefs(sourceArtifacts);
+  const merchantName = stringValue(merchant, 'merchant_display_name') ?? 'Synthetic OACP merchant';
+  const sellerAgentId = stringValue(seller, 'seller_agent_id') ?? 'seller_agent_unknown';
+  const supportedTasks = stringArrayValue(seller.supported_tasks);
+  const publicClaimLimits = stringArrayValue(seller.public_claim_limits);
+  const basePayload = {
+    preview_only: true,
+    internal_only: true,
+    non_publication: true,
+    non_certifying: true,
+    source_refs,
+    unsupported_capabilities: unsupportedCapabilities,
+  };
+
+  if (surface === 'schema_org_jsonld') {
+    return {
+      ...basePayload,
+      '@context': 'https://schema.org',
+      '@type': 'OfferCatalog',
+      name: merchantName,
+      itemListElement: stringArrayValue(catalog.product_refs).map((productId) => ({
+        '@type': 'Product',
+        productID: productId,
+        name: productId,
+        offers: {
+          '@type': 'Offer',
+          availability: 'PreviewOnly',
+          priceSpecification: 'NonFinalPreview',
+        },
+      })),
+      final_price_inventory_or_delivery_promise: false,
+    };
+  }
+
+  if (surface === 'ucp_capability_profile') {
+    return {
+      ...basePayload,
+      profile_kind: 'ucp_style_internal_capability_preview',
+      merchant_display_name: merchantName,
+      read_capabilities: ['merchant_profile.read', 'catalog.preview', 'policy.summary'],
+      unsupported_write_capabilities: unsupportedCapabilities,
+      public_claim_limits: publicClaimLimits,
+    };
+  }
+
+  if (surface === 'acp_commerce_capability') {
+    return {
+      ...basePayload,
+      shape_kind: 'acp_style_commerce_capability_preview',
+      seller_agent_id: sellerAgentId,
+      supported_non_binding_tasks: supportedTasks,
+      checkout_or_payment_authority: false,
+      policy_summary_refs: {
+        return_policy_summary: stringValue(policy, 'return_policy_summary'),
+        fulfillment_policy_summary: stringValue(policy, 'fulfillment_policy_summary'),
+      },
+    };
+  }
+
+  if (surface === 'ap2_evidence_intent_summary') {
+    return {
+      ...basePayload,
+      summary_kind: 'ap2_style_evidence_intent_preview',
+      intent_status: 'non_binding_preview_only',
+      commitment_ref: sourceArtifactId(commitment) ?? null,
+      payment_or_mandate_authorization: false,
+      evidence_refs: source_refs.flatMap((ref) => stringArrayValue(ref.evidence_refs)),
+    };
+  }
+
+  if (surface === 'a2a_agent_card_task_capability') {
+    return {
+      ...basePayload,
+      card_kind: 'a2a_style_agent_card_preview',
+      agent_id: sellerAgentId,
+      display_name: merchantName,
+      tasks: supportedTasks.map((task) => ({
+        task,
+        mode: 'non_binding_preview',
+        transaction_authority: false,
+      })),
+    };
+  }
+
+  return {
+    ...basePayload,
+    capability_kind: 'mcp_style_tool_resource_preview',
+    tools: [
+      { name: 'oacp.preview.merchant.read', write: false, source_required: true },
+      { name: 'oacp.preview.policy.read', write: false, source_required: true },
+    ],
+    resources: [
+      { uri_template: 'oacp-preview://merchant/{merchant_id}', source_required: true },
+      { uri_template: 'oacp-preview://policy/{merchant_id}', source_required: true },
+    ],
+    write_tools: [],
+    non_final_price_preview: price ? {
+      source_artifact_id: sourceArtifactId(price),
+      product_id: stringValue(price.payload, 'product_id'),
+      variant_id: stringValue(price.payload, 'variant_id'),
+      currency: stringValue(price.payload, 'currency'),
+      amount_minor_units: numberValue(price.payload, 'amount_minor_units'),
+      final_price_promise: false,
+    } : null,
+    non_final_inventory_preview: inventory ? {
+      source_artifact_id: sourceArtifactId(inventory),
+      product_id: stringValue(inventory.payload, 'product_id'),
+      availability_state: stringValue(inventory.payload, 'availability_state'),
+      hold_or_delivery_promise: false,
+    } : null,
+  };
+}
+
+export function buildOacpC6W4ProtocolAdapterPreview(
+  input: OacpProtocolAdapterPreviewInput,
+): OacpProtocolAdapterPreviewResult {
+  if (!isOacpProtocolAdapterSurface(input.surface)) {
+    return adapterPreviewRefusal(input.surface, 'unknown_adapter_surface', 'Unknown adapter preview surface.');
+  }
+  const descriptor = OACP_C6W4_PROTOCOL_ADAPTER_DESCRIPTORS[input.surface];
+  const byType = buildSourceArtifactIndex(input.artifacts);
+  for (const artifactType of descriptor.required_artifact_types) {
+    if (!byType.has(artifactType)) {
+      return adapterPreviewRefusal(input.surface, 'source_artifact_missing', `Missing required source artifact: ${artifactType}.`);
+    }
+  }
+
+  const generatedMillis = parseIsoMillis(input.generated_at);
+  if (generatedMillis === null) {
+    return adapterPreviewRefusal(input.surface, 'source_artifact_invalid', 'generated_at must be a valid ISO timestamp.');
+  }
+
+  const sourceArtifacts = input.artifacts.filter((artifact) => artifactTypeFromFixture(artifact) !== null);
+  const validationNow = input.now_iso ?? input.generated_at;
+  for (const artifact of sourceArtifacts) {
+    const artifactType = artifactTypeFromFixture(artifact);
+    const validation = validateOacpArtifactSchema({
+      envelope: artifact.envelope,
+      payload: artifact.payload,
+      now_iso: validationNow,
+    });
+    if (!validation.valid) {
+      const refusal = validation.refusal_code === 'private_or_forbidden_payload_field'
+        ? 'private_or_forbidden_payload_field'
+        : validation.refusal_code === 'artifact_expired_or_stale'
+          ? 'source_artifact_expired_or_stale'
+          : 'source_artifact_invalid';
+      return adapterPreviewRefusal(input.surface, refusal, validation.message);
+    }
+  }
+
+  const expiresMillis = sourceArtifacts
+    .map((artifact) => parseIsoMillis(typeof artifact.envelope.expires_at === 'string' ? artifact.envelope.expires_at : undefined))
+    .filter((value): value is number => value !== null);
+  if (expiresMillis.length !== sourceArtifacts.length) {
+    return adapterPreviewRefusal(input.surface, 'source_artifact_invalid', 'Every source artifact must have a valid expiry.');
+  }
+  const earliestExpiryMillis = Math.min(...expiresMillis);
+  const ttlSeconds = Math.floor((earliestExpiryMillis - generatedMillis) / 1000);
+  if (ttlSeconds <= 0) {
+    return adapterPreviewRefusal(input.surface, 'source_artifact_expired_or_stale', 'Adapter preview cannot outlive source artifacts.');
+  }
+
+  const boundedTtlSeconds = Math.min(ttlSeconds, descriptor.max_ttl_seconds);
+  const boundedExpiresAt = new Date(generatedMillis + boundedTtlSeconds * 1000).toISOString();
+  const unsupportedCapabilities = unsupportedCapabilitiesForArtifacts(descriptor, sourceArtifacts);
+
+  return {
+    generated: true,
+    status: 'preview_only',
+    surface: input.surface,
+    adapter_descriptor: descriptor,
+    source_artifact_ids: sourceArtifacts.map((artifact) => String(artifact.envelope.artifact_id)),
+    source_artifact_families: sourceArtifacts.map((artifact) => artifactTypeFromFixture(artifact)).filter((value): value is OacpArtifactType => value !== null),
+    source_authority: 'grantex_canonical_oacp_artifact_authority',
+    generated_at: input.generated_at,
+    expires_at: boundedExpiresAt,
+    max_ttl_seconds: boundedTtlSeconds,
+    freshness_tier: freshnessTierForArtifacts(sourceArtifacts),
+    unsupported_capabilities: unsupportedCapabilities,
+    blocked_capabilities: unsupportedCapabilities,
+    non_authoritative_for_transaction: true,
+    no_checkout_payment_enablement: true,
+    no_live_provider_enablement: true,
+    no_public_discovery_enablement: true,
+    surface_payload: buildC6W4SurfacePayload(input.surface, byType, sourceArtifacts, unsupportedCapabilities),
   };
 }
 

--- a/apps/auth-service/src/lib/commerce/oacp-trust-artifacts.ts
+++ b/apps/auth-service/src/lib/commerce/oacp-trust-artifacts.ts
@@ -1616,7 +1616,6 @@ export function buildOacpC6W4ProtocolAdapterPreview(
   const sourceArtifacts = input.artifacts.filter((artifact) => artifactTypeFromFixture(artifact) !== null);
   const validationNow = input.now_iso ?? input.generated_at;
   for (const artifact of sourceArtifacts) {
-    const artifactType = artifactTypeFromFixture(artifact);
     const validation = validateOacpArtifactSchema({
       envelope: artifact.envelope,
       payload: artifact.payload,

--- a/apps/auth-service/tests/commerce-c6w4-oacp-adapter-previews.test.ts
+++ b/apps/auth-service/tests/commerce-c6w4-oacp-adapter-previews.test.ts
@@ -1,0 +1,179 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  OACP_C6W3_VALID_ARTIFACT_FIXTURES,
+  OACP_C6W4_PROTOCOL_ADAPTER_SURFACES,
+  buildOacpC6W4ProtocolAdapterPreview,
+  hashOacpPayload,
+} from '../src/lib/commerce/oacp-trust-artifacts.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const DOC_PATH = join(
+  TEST_DIR,
+  '../../../docs/internal/commerce-v1/commerce-v1-c6w4-oacp-protocol-adapter-previews.md',
+);
+
+function c6w4SourceArtifacts() {
+  return [
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.merchant_capability,
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.seller_agent_capability,
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.catalog_snapshot,
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.policy,
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.protocol_adapter,
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.commitment_evidence,
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.price,
+  ];
+}
+
+function c6w4SourceArtifactsWithInventory() {
+  return [
+    ...c6w4SourceArtifacts(),
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.inventory,
+  ];
+}
+
+describe('C6W4 OACP protocol adapter preview foundation', () => {
+  it('builds bounded preview payloads for every internal adapter surface', () => {
+    for (const surface of OACP_C6W4_PROTOCOL_ADAPTER_SURFACES) {
+      const preview = buildOacpC6W4ProtocolAdapterPreview({
+        surface,
+        artifacts: c6w4SourceArtifacts(),
+        generated_at: '2026-06-11T00:01:00.000Z',
+      });
+
+      expect(preview).toMatchObject({
+        generated: true,
+        status: 'preview_only',
+        surface,
+        source_authority: 'grantex_canonical_oacp_artifact_authority',
+        generated_at: '2026-06-11T00:01:00.000Z',
+        expires_at: '2026-06-11T00:05:00.000Z',
+        max_ttl_seconds: 240,
+        freshness_tier: 'fresh',
+        non_authoritative_for_transaction: true,
+        no_checkout_payment_enablement: true,
+        no_live_provider_enablement: true,
+        no_public_discovery_enablement: true,
+      });
+      if (preview.generated) {
+        expect(preview.source_artifact_families).toContain('protocol_adapter');
+        expect(preview.source_artifact_ids).toContain('protocol_adapter_C6W3');
+        expect(preview.unsupported_capabilities).toContain('checkout_create');
+        expect(preview.unsupported_capabilities).toContain('live_provider_call');
+        expect(preview.surface_payload).toMatchObject({
+          preview_only: true,
+          internal_only: true,
+          non_publication: true,
+          non_certifying: true,
+        });
+      }
+    }
+  });
+
+  it('projects surface-specific shapes without creating transaction authority', () => {
+    const artifacts = c6w4SourceArtifacts();
+    const schemaOrg = buildOacpC6W4ProtocolAdapterPreview({
+      surface: 'schema_org_jsonld',
+      artifacts,
+      generated_at: '2026-06-11T00:01:00.000Z',
+    });
+    const ap2 = buildOacpC6W4ProtocolAdapterPreview({
+      surface: 'ap2_evidence_intent_summary',
+      artifacts,
+      generated_at: '2026-06-11T00:01:00.000Z',
+    });
+    const mcp = buildOacpC6W4ProtocolAdapterPreview({
+      surface: 'mcp_tool_resource_capability',
+      artifacts: c6w4SourceArtifactsWithInventory(),
+      generated_at: '2026-06-11T00:00:30.000Z',
+    });
+
+    expect(schemaOrg.generated && schemaOrg.surface_payload).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'OfferCatalog',
+      final_price_inventory_or_delivery_promise: false,
+    });
+    expect(ap2.generated && ap2.surface_payload).toMatchObject({
+      summary_kind: 'ap2_style_evidence_intent_preview',
+      intent_status: 'non_binding_preview_only',
+      payment_or_mandate_authorization: false,
+    });
+    expect(mcp.generated && mcp.surface_payload).toMatchObject({
+      capability_kind: 'mcp_style_tool_resource_preview',
+      write_tools: [],
+      non_final_price_preview: {
+        source_artifact_id: 'price_C6W3',
+        final_price_promise: false,
+      },
+      non_final_inventory_preview: {
+        source_artifact_id: 'inventory_C6W3',
+        hold_or_delivery_promise: false,
+      },
+    });
+  });
+
+  it('fails closed for missing, invalid, private, or expired source artifacts', () => {
+    const missingProtocolAdapter = c6w4SourceArtifacts().filter(
+      (artifact) => artifact.envelope.artifact_type !== 'protocol_adapter',
+    );
+    expect(buildOacpC6W4ProtocolAdapterPreview({
+      surface: 'mcp_tool_resource_capability',
+      artifacts: missingProtocolAdapter,
+      generated_at: '2026-06-11T00:01:00.000Z',
+    })).toMatchObject({
+      generated: false,
+      refusal_code: 'source_artifact_missing',
+    });
+
+    const price = OACP_C6W3_VALID_ARTIFACT_FIXTURES.price;
+    const privatePayload = { ...price.payload, rawProviderPayload: { private: true } };
+    const privateArtifact = {
+      envelope: {
+        ...price.envelope,
+        payload_hash: hashOacpPayload(privatePayload),
+      },
+      payload: privatePayload,
+    };
+    expect(buildOacpC6W4ProtocolAdapterPreview({
+      surface: 'mcp_tool_resource_capability',
+      artifacts: [
+        ...c6w4SourceArtifacts().filter((artifact) => artifact.envelope.artifact_type !== 'price'),
+        privateArtifact,
+      ],
+      generated_at: '2026-06-11T00:01:00.000Z',
+    })).toMatchObject({
+      generated: false,
+      refusal_code: 'private_or_forbidden_payload_field',
+    });
+
+    expect(buildOacpC6W4ProtocolAdapterPreview({
+      surface: 'ucp_capability_profile',
+      artifacts: c6w4SourceArtifacts(),
+      generated_at: '2026-06-11T00:06:00.000Z',
+    })).toMatchObject({
+      generated: false,
+      refusal_code: 'source_artifact_expired_or_stale',
+    });
+  });
+
+  it('documents non-enabling C6W4 adapter behavior', () => {
+    const doc = readFileSync(DOC_PATH, 'utf8');
+
+    for (const heading of [
+      'Scope',
+      'Adapter Surfaces',
+      'Preview Safety Contract',
+      'Source Fact Rules',
+      'What This Does Not Enable',
+      'Stop Conditions',
+      'Next Slices',
+    ]) {
+      expect(doc).toContain(`## ${heading}`);
+    }
+
+    expect(doc).toContain('Adapter previews are not transaction authority');
+    expect(doc).toContain('Grantex does not become a synchronous toll booth');
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6w4-oacp-protocol-adapter-previews.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6w4-oacp-protocol-adapter-previews.md
@@ -1,0 +1,101 @@
+# Commerce V1 C6W4 - OACP Protocol Adapter Preview Foundation
+
+Status: implementation foundation, internal-only, non-enabling.
+
+## Scope
+
+C6W4 adds internal protocol adapter preview helpers over the C6W3 OACP artifact family.
+
+This slice adds:
+
+- Internal adapter descriptors for schema.org JSON-LD style discovery, UCP-style capability profiles, ACP-style commerce capability shapes, AP2-style evidence and intent summaries, A2A-style agent card/task capabilities, and MCP-style tool/resource capabilities.
+- Pure helper mapping from signed OACP artifact fixtures to bounded preview payloads.
+- Focused tests for source artifact binding, TTL bounding, source authority, unsupported capabilities, and fail-closed private/missing/stale artifact handling.
+
+No endpoint, migration, workflow, provider adapter, public discovery, checkout/payment, live provider, merchant private API, allowlist, cloud, deploy, or external protocol publication behavior is added.
+
+## Adapter Surfaces
+
+| Surface | Preview purpose | Required source artifact families |
+| --- | --- | --- |
+| schema.org JSON-LD style discovery | Internal read-only discovery shape for public-safe catalog hints. | merchant_capability, seller_agent_capability, catalog_snapshot, policy, protocol_adapter |
+| UCP-style capability profile | Internal capability profile preview for non-binding agent routing. | merchant_capability, seller_agent_capability, policy, protocol_adapter |
+| ACP-style commerce capability | Internal commerce capability shape with checkout/payment blocked. | merchant_capability, seller_agent_capability, policy, protocol_adapter |
+| AP2-style evidence/intent summary | Internal evidence and intent summary without mandate or payment execution. | merchant_capability, seller_agent_capability, policy, commitment_evidence, protocol_adapter |
+| A2A-style agent card/task capability | Internal buyer/seller agent card and task capability preview. | merchant_capability, seller_agent_capability, policy, protocol_adapter |
+| MCP-style tool/resource capability | Internal read-only tool/resource capability shape. | merchant_capability, seller_agent_capability, policy, protocol_adapter |
+
+## Preview Safety Contract
+
+Every preview includes:
+
+- Source artifact IDs and families.
+- Source authority set to Grantex canonical OACP artifact authority.
+- generated_at.
+- expires_at and max_ttl_seconds bounded by the shortest source artifact TTL.
+- Freshness tier.
+- Unsupported and blocked capabilities.
+- non_authoritative_for_transaction: true.
+- no_checkout_payment_enablement: true.
+- no_live_provider_enablement: true.
+- no_public_discovery_enablement: true.
+
+Adapter previews are not transaction authority. They can display, route, or summarize public-safe facts already present in signed OACP artifacts, but they cannot approve checkout, payment, mandate execution, fulfillment, refund, public discovery, merchant approval, or provider use.
+
+## Source Fact Rules
+
+Adapter previews must remain derived from signed canonical artifacts:
+
+- Merchant facts come from merchant_capability.
+- Seller-agent task facts come from seller_agent_capability.
+- Catalog hints come from catalog_snapshot.
+- Policy summaries come from policy.
+- Price and inventory snippets are non-final only and require valid price/inventory artifacts.
+- AP2-style evidence summaries can reference commitment_evidence but cannot imply payment capture, refund execution, settlement, payout, fulfillment start, or merchant approval.
+- Protocol adapter previews cannot outlive referenced source artifacts.
+
+The helper refuses missing, expired, stale, invalid, private, raw, credential-bearing, or enabling source artifacts.
+
+## Toll Booth Boundary
+
+Grantex does not become a synchronous toll booth for browse, comparison, recommendation, or other non-binding messages. Grantex issues canonical artifacts and adapter descriptors; AgenticOrg can cache and consume valid previews locally, subject to TTL, revocation, freshness, and scope rules.
+
+## What This Does Not Enable
+
+C6W4 does not enable:
+
+- Public discovery.
+- Production Commerce V1.
+- Checkout/payment creation.
+- Payment capture or debit.
+- Live payments.
+- Live provider use.
+- Live Plural use.
+- Provider calls.
+- Carrier or shipping provider calls.
+- Merchant private API calls.
+- Connector credential storage in Grantex.
+- Production allowlists.
+- Public OACP publication.
+- External protocol submission.
+- Certification, compliance, conformance, standardization, production readiness, public-launch readiness, merchant approval, checkout approval, payment approval, live provider readiness, or OACP public readiness claims.
+
+## Stop Conditions
+
+Stop later implementation if:
+
+- Adapter previews expose raw credentials, tokens, private provider payloads, raw JWTs, raw connector payloads, or merchant private API values.
+- Adapter previews become final transaction authority.
+- Adapter previews create checkout/payment, public discovery, live provider, live Plural, or production allowlist enablement.
+- Adapter previews publish or submit external protocol artifacts.
+- Adapter previews outlive source artifact TTL or ignore revocation/freshness posture.
+- Grantex becomes a required hop for every non-binding agent interaction.
+
+## Next Slices
+
+Recommended next slices:
+
+- C6W5: AgenticOrg commitment-boundary resolver over cached signed artifacts and adapter previews.
+- C6W6: Offline Commitment Mode evidence and reconciliation contract, docs/tests first.
+- C6W7: Provider-owned mandate verification boundary with non-production evidence only.
+- C6W8: Merchant connector evidence path from dry-run source snapshots to Grantex canonical facts.


### PR DESCRIPTION
## Summary
- Adds internal-only C6W4 OACP protocol adapter preview descriptors and mapping helpers.
- Covers schema.org JSON-LD style, UCP-style, ACP-style, AP2-style, A2A-style, and MCP-style bounded preview payloads.
- Adds focused tests and internal docs for non-enabling adapter preview behavior.

## Validation
- npm --prefix apps/auth-service test -- commerce-c6w3-oacp-artifact-schemas.test.ts commerce-c6w4-oacp-adapter-previews.test.ts
- npm --prefix apps/auth-service run typecheck
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
- git diff --cached --check
- ASCII and focused guardrail scans