### PR TITLE
[codex] Add C6W7 response reconciliation

### DIFF
--- a/apps/auth-service/src/lib/commerce/oacp-trust-artifacts.ts
+++ b/apps/auth-service/src/lib/commerce/oacp-trust-artifacts.ts
@@ -616,6 +616,115 @@ export type OacpC6W6PreparedEnvelopeResult =
     blocked_envelope?: OacpC6W6PreparedCommitmentEnvelope;
   };
 
+export const OACP_C6W7_RESPONSE_EVIDENCE_KINDS = [
+  'buyer_confirmation_response',
+  'seller_source_refresh_response',
+  'merchant_confirmation_response',
+  'mandate_capability_evidence_response',
+  'support_escalation_response',
+] as const;
+
+export const OACP_C6W7_RECONCILIATION_STATUSES = [
+  'accepted_for_preparation',
+  'rejected',
+  'needs_source_refresh',
+  'needs_human_review',
+  'expired',
+  'stale',
+  'mismatched',
+  'blocked',
+] as const;
+
+export type OacpC6W7ResponseEvidenceKind = typeof OACP_C6W7_RESPONSE_EVIDENCE_KINDS[number];
+export type OacpC6W7ReconciliationStatus = typeof OACP_C6W7_RECONCILIATION_STATUSES[number];
+
+export type OacpC6W7ReconciliationRefusalCode =
+  | 'prepared_envelope_missing'
+  | 'prepared_envelope_allows_execution'
+  | 'prepared_envelope_not_prepared_only'
+  | 'source_freshness_missing_or_stale'
+  | 'response_kind_envelope_mismatch'
+  | 'response_status_attempts_execution'
+  | 'response_evidence_refs_missing'
+  | 'private_or_forbidden_response_field'
+  | 'response_indicates_forbidden_execution'
+  | 'risk_context_missing_or_ambiguous'
+  | 'mandate_evidence_stale'
+  | 'response_conflicts_with_envelope';
+
+export interface OacpC6W7PreparedResponseInput {
+  envelope: OacpC6W6PreparedCommitmentEnvelope | null;
+  response_kind: OacpC6W7ResponseEvidenceKind;
+  response_status: OacpC6W7ReconciliationStatus;
+  created_at: string;
+  response_evidence_refs?: readonly string[] | undefined;
+  response_flags?: readonly string[] | undefined;
+  response_claimed_envelope_id?: string | null | undefined;
+  response_claimed_action?: OacpC6W5CommitmentBoundaryAction | string | null | undefined;
+  response_evidence_issued_at?: string | null | undefined;
+  amount_minor_units?: number | null | undefined;
+  currency?: string | null | undefined;
+  total_quantity?: number | null | undefined;
+}
+
+export interface OacpC6W7DecisionSummary {
+  source_resolver_decision_id: string;
+  action_class: OacpC6W5ActionClass;
+  offline_mode_status: OacpC6W5OfflineModeStatus;
+  allowed_to_prepare_from_envelope: boolean;
+  non_authoritative_for_transaction: true;
+}
+
+export interface OacpC6W7PreparedResponseReconciliation {
+  reconciliation_id: string;
+  envelope_id: string;
+  envelope_kind: OacpC6W6PreparedEnvelopeKind;
+  response_kind: OacpC6W7ResponseEvidenceKind;
+  response_status: OacpC6W7ReconciliationStatus;
+  created_at: string;
+  expires_at: string;
+  max_ttl_seconds: number;
+  action_class: OacpC6W5ActionClass;
+  requested_action: OacpC6W5CommitmentBoundaryAction;
+  risk_tier: OacpRiskTier;
+  source_artifact_ids: string[];
+  source_artifact_families: OacpArtifactType[];
+  source_authority: 'grantex_canonical_oacp_artifact_authority';
+  response_evidence_refs: string[];
+  freshness_summary: OacpC6W5FreshnessSummary;
+  decision_summary: OacpC6W7DecisionSummary;
+  unsupported_capabilities: string[];
+  blocked_capabilities: string[];
+  required_next_artifact_families: OacpArtifactType[];
+  buyer_safe_message: string;
+  seller_safe_message: string;
+  next_human_step: string;
+  next_system_step_label: string;
+  allowed_to_preview: boolean;
+  allowed_to_prepare: boolean;
+  allowed_to_execute: false;
+  prepared_only: true;
+  reconciled_only: true;
+  non_authoritative_for_transaction: true;
+  no_checkout_payment_enablement: true;
+  no_live_provider_enablement: true;
+  no_public_discovery_enablement: true;
+}
+
+export type OacpC6W7PreparedResponseReconciliationResult =
+  | {
+    reconciled: true;
+    status: OacpC6W7ReconciliationStatus;
+    reconciliation: OacpC6W7PreparedResponseReconciliation;
+  }
+  | {
+    reconciled: false;
+    status: 'blocked';
+    refusal_code: OacpC6W7ReconciliationRefusalCode;
+    message: string;
+    blocked_reconciliation?: OacpC6W7PreparedResponseReconciliation;
+  };
+
 export type OacpOfflineCommitmentDecision =
   | {
     allowed: true;
@@ -2510,6 +2619,286 @@ export function prepareOacpC6W6CommitmentRequestEnvelope(
   }
 
   return { generated: true, status: 'prepared_only', envelope };
+}
+
+const C6W7_RESPONSE_TTL_SECONDS: Record<OacpC6W7ResponseEvidenceKind, number> = {
+  buyer_confirmation_response: 15 * 60,
+  seller_source_refresh_response: 30 * 60,
+  merchant_confirmation_response: 10 * 60,
+  mandate_capability_evidence_response: 2 * 60,
+  support_escalation_response: 10 * 60,
+};
+
+const C6W7_RESPONSE_KIND_BY_ENVELOPE_KIND: Record<OacpC6W6PreparedEnvelopeKind, OacpC6W7ResponseEvidenceKind> = {
+  buyer_confirmation_request: 'buyer_confirmation_response',
+  seller_source_refresh_request: 'seller_source_refresh_response',
+  merchant_confirmation_request: 'merchant_confirmation_response',
+  mandate_capability_evidence_request: 'mandate_capability_evidence_response',
+  support_escalation_preparation: 'support_escalation_response',
+};
+
+const C6W7_FORBIDDEN_RESPONSE_PATTERN = /(https?:\/\/|postgres:\/\/|redis:\/\/|mongodb:\/\/|private[_-]?key|raw[_-]?jwt|passport|access[_-]?token|api[_-]?key|password|secret|credential|allowlist|customer[_-]?(data|identifier|email|phone|address)|raw[_-]?(provider|connector)[_-]?payload)/i;
+
+const C6W7_FORBIDDEN_EXECUTION_PATTERN = /(execute|executed|execution|checkout|payment|order[_-]?(create|created|placed)|hold[_-]?created|refund[_-]?created|return[_-]?created|shipment|shipping|carrier|provider[_-]?call|merchant[_-]?private[_-]?api|public[_-]?discovery[_-]?(enable|publish)|protocol[_-]?(publication|submission)|certification|conformance|standardization|production[_-]?ready|live[_-]?(provider|rail|payment)|mandate[_-]?created)/i;
+
+function c6w7SafeEvidenceRefs(evidenceRefs: readonly string[] | undefined): string[] | null {
+  const refs: string[] = [];
+  for (const value of evidenceRefs ?? []) {
+    if (typeof value !== 'string' || value.length === 0) continue;
+    if (C6W7_FORBIDDEN_RESPONSE_PATTERN.test(value)) return null;
+    if (!refs.includes(value)) refs.push(value);
+  }
+  return refs.slice(0, 20);
+}
+
+function c6w7ExpiresAt(input: {
+  response_kind: OacpC6W7ResponseEvidenceKind;
+  created_at: string;
+  envelope: OacpC6W6PreparedCommitmentEnvelope;
+}): { expires_at: string; max_ttl_seconds: number } | null {
+  const createdMillis = parseIsoMillis(input.created_at);
+  const envelopeExpiryMillis = parseIsoMillis(input.envelope.expires_at);
+  if (createdMillis === null || envelopeExpiryMillis === null) return null;
+  const defaultExpiryMillis = createdMillis + C6W7_RESPONSE_TTL_SECONDS[input.response_kind] * 1000;
+  const expiresMillis = Math.min(defaultExpiryMillis, envelopeExpiryMillis);
+  if (expiresMillis <= createdMillis) return null;
+  return {
+    expires_at: new Date(expiresMillis).toISOString(),
+    max_ttl_seconds: Math.floor((expiresMillis - createdMillis) / 1000),
+  };
+}
+
+function c6w7NeedsRiskContext(envelope: OacpC6W6PreparedCommitmentEnvelope): boolean {
+  return envelope.envelope_kind !== 'seller_source_refresh_request' && envelope.action_class === 'commitment_bound';
+}
+
+function c6w7RiskContextMissing(input: OacpC6W7PreparedResponseInput, envelope: OacpC6W6PreparedCommitmentEnvelope): boolean {
+  if (!c6w7NeedsRiskContext(envelope)) return false;
+  return !isKnownCurrency(input.currency)
+    || input.amount_minor_units === null
+    || input.amount_minor_units === undefined
+    || input.amount_minor_units < 0
+    || input.total_quantity === null
+    || input.total_quantity === undefined
+    || input.total_quantity <= 0;
+}
+
+function c6w7MandateEvidenceStale(input: OacpC6W7PreparedResponseInput): boolean {
+  if (input.response_kind !== 'mandate_capability_evidence_response' || input.response_status !== 'accepted_for_preparation') return false;
+  const createdMillis = parseIsoMillis(input.created_at);
+  const evidenceMillis = parseIsoMillis(input.response_evidence_issued_at ?? undefined);
+  if (createdMillis === null || evidenceMillis === null || evidenceMillis > createdMillis) return true;
+  return createdMillis - evidenceMillis > OACP_ARTIFACT_TTLS_SECONDS.mandate_capability * 1000;
+}
+
+function c6w7ResponseConflictsWithEnvelope(input: OacpC6W7PreparedResponseInput, envelope: OacpC6W6PreparedCommitmentEnvelope): boolean {
+  if (input.response_claimed_envelope_id !== null
+    && input.response_claimed_envelope_id !== undefined
+    && input.response_claimed_envelope_id !== envelope.envelope_id) return true;
+  if (input.response_claimed_action !== null
+    && input.response_claimed_action !== undefined
+    && input.response_claimed_action !== envelope.requested_action) return true;
+  return false;
+}
+
+function c6w7ResponseIndicatesForbiddenExecution(input: OacpC6W7PreparedResponseInput): boolean {
+  for (const value of input.response_flags ?? []) {
+    if (typeof value === 'string' && C6W7_FORBIDDEN_EXECUTION_PATTERN.test(value)) return true;
+  }
+  return false;
+}
+
+function c6w7NextHumanStep(status: OacpC6W7ReconciliationStatus, envelope: OacpC6W6PreparedCommitmentEnvelope): string {
+  if (status === 'accepted_for_preparation') return `Review reconciled ${envelope.requested_action} evidence before any separate execution handoff exists.`;
+  if (status === 'rejected') return `Stop ${envelope.requested_action} preparation and keep source evidence attached for audit.`;
+  if (status === 'needs_source_refresh' || status === 'stale' || status === 'expired') return 'Refresh source artifacts before preparing another envelope.';
+  if (status === 'needs_human_review' || status === 'mismatched') return 'Route the response to a human reviewer with source and freshness labels.';
+  return 'Do not proceed; the response is blocked by C6W7 fail-closed policy.';
+}
+
+function c6w7NextSystemStepLabel(status: OacpC6W7ReconciliationStatus): string {
+  if (status === 'accepted_for_preparation') return 'local_reconciled_preparation_handoff_label';
+  if (status === 'needs_source_refresh' || status === 'stale' || status === 'expired') return 'source_refresh_reconciliation_label';
+  if (status === 'needs_human_review' || status === 'mismatched') return 'human_review_reconciliation_label';
+  if (status === 'rejected') return 'local_rejection_record_label';
+  return 'blocked_reconciliation_label';
+}
+
+function c6w7BuyerSafeMessage(status: OacpC6W7ReconciliationStatus, envelope: OacpC6W6PreparedCommitmentEnvelope): string {
+  if (status === 'accepted_for_preparation') return `Response accepted for preparation only for ${envelope.requested_action}; no order, hold, checkout, payment, mandate, refund, return, shipment, or provider action occurred.`;
+  if (status === 'rejected') return `Response rejected ${envelope.requested_action} preparation; no execution occurred.`;
+  if (status === 'needs_source_refresh' || status === 'stale' || status === 'expired') return 'Source evidence is missing, stale, or expired. A refreshed source artifact is required before preparation continues.';
+  if (status === 'needs_human_review' || status === 'mismatched') return 'The response needs human review because source or envelope evidence is ambiguous.';
+  return 'The response is blocked. C6W7 does not execute or approve live transaction actions.';
+}
+
+function c6w7SellerSafeMessage(status: OacpC6W7ReconciliationStatus, envelope: OacpC6W6PreparedCommitmentEnvelope): string {
+  if (status === 'accepted_for_preparation') return `Evidence for ${envelope.envelope_kind} was reconciled locally as prepared-only; keep merchant systems and provider rails as operational authorities.`;
+  if (status === 'rejected') return 'Seller response is recorded as rejected and does not create operational obligations.';
+  if (status === 'needs_source_refresh' || status === 'stale' || status === 'expired') return 'Seller or source owner must provide refreshed cached evidence without private payloads or credentials.';
+  if (status === 'needs_human_review' || status === 'mismatched') return 'Seller response conflicts with local envelope metadata and must be reviewed before another prepared handoff.';
+  return 'Seller response is blocked and must not be treated as transaction authority.';
+}
+
+function c6w7ReconciliationId(input: {
+  envelope_id: string;
+  response_kind: OacpC6W7ResponseEvidenceKind;
+  response_status: OacpC6W7ReconciliationStatus;
+  created_at: string;
+  response_evidence_refs: string[];
+}): string {
+  return `oacp_c6w7_reconciliation_${sha256hex(stableJson(input)).slice(0, 20)}`;
+}
+
+function c6w7Reconciliation(input: {
+  envelope: OacpC6W6PreparedCommitmentEnvelope;
+  response_kind: OacpC6W7ResponseEvidenceKind;
+  response_status: OacpC6W7ReconciliationStatus;
+  created_at: string;
+  expires_at: string;
+  max_ttl_seconds: number;
+  response_evidence_refs: string[];
+}): OacpC6W7PreparedResponseReconciliation {
+  const allowed = input.response_status === 'accepted_for_preparation';
+  return {
+    reconciliation_id: c6w7ReconciliationId({
+      envelope_id: input.envelope.envelope_id,
+      response_kind: input.response_kind,
+      response_status: input.response_status,
+      created_at: input.created_at,
+      response_evidence_refs: input.response_evidence_refs,
+    }),
+    envelope_id: input.envelope.envelope_id,
+    envelope_kind: input.envelope.envelope_kind,
+    response_kind: input.response_kind,
+    response_status: input.response_status,
+    created_at: input.created_at,
+    expires_at: input.expires_at,
+    max_ttl_seconds: input.max_ttl_seconds,
+    action_class: input.envelope.action_class,
+    requested_action: input.envelope.requested_action,
+    risk_tier: input.envelope.risk_tier,
+    source_artifact_ids: [...input.envelope.source_artifact_ids],
+    source_artifact_families: [...input.envelope.source_artifact_families],
+    source_authority: input.envelope.source_authority,
+    response_evidence_refs: input.response_evidence_refs,
+    freshness_summary: input.envelope.freshness_summary,
+    decision_summary: {
+      source_resolver_decision_id: input.envelope.source_resolver_decision_id,
+      action_class: input.envelope.action_class,
+      offline_mode_status: input.envelope.offline_mode_status,
+      allowed_to_prepare_from_envelope: input.envelope.allowed_to_prepare,
+      non_authoritative_for_transaction: true,
+    },
+    unsupported_capabilities: [...input.envelope.unsupported_capabilities],
+    blocked_capabilities: [...input.envelope.blocked_capabilities],
+    required_next_artifact_families: [...input.envelope.required_fresh_artifact_families],
+    buyer_safe_message: c6w7BuyerSafeMessage(input.response_status, input.envelope),
+    seller_safe_message: c6w7SellerSafeMessage(input.response_status, input.envelope),
+    next_human_step: c6w7NextHumanStep(input.response_status, input.envelope),
+    next_system_step_label: c6w7NextSystemStepLabel(input.response_status),
+    allowed_to_preview: input.envelope.allowed_to_preview,
+    allowed_to_prepare: allowed && input.envelope.allowed_to_prepare,
+    allowed_to_execute: false,
+    prepared_only: true,
+    reconciled_only: true,
+    non_authoritative_for_transaction: true,
+    no_checkout_payment_enablement: true,
+    no_live_provider_enablement: true,
+    no_public_discovery_enablement: true,
+  };
+}
+
+function c6w7Refusal(
+  refusal_code: OacpC6W7ReconciliationRefusalCode,
+  message: string,
+  blocked_reconciliation?: OacpC6W7PreparedResponseReconciliation,
+): OacpC6W7PreparedResponseReconciliationResult {
+  return blocked_reconciliation === undefined
+    ? { reconciled: false, status: 'blocked', refusal_code, message }
+    : { reconciled: false, status: 'blocked', refusal_code, message, blocked_reconciliation };
+}
+
+export function reconcileOacpC6W7PreparedCommitmentResponse(
+  input: OacpC6W7PreparedResponseInput,
+): OacpC6W7PreparedResponseReconciliationResult {
+  if (input.envelope === null) {
+    return c6w7Refusal('prepared_envelope_missing', 'C6W7 requires a C6W6 prepared envelope before response reconciliation.');
+  }
+
+  const envelope = input.envelope;
+  const evidenceRefs = c6w7SafeEvidenceRefs(input.response_evidence_refs);
+  const ttl = c6w7ExpiresAt({ response_kind: input.response_kind, created_at: input.created_at, envelope });
+  const blockedReconciliation = ttl === null || evidenceRefs === null || evidenceRefs.length === 0
+    ? undefined
+    : c6w7Reconciliation({
+      envelope,
+      response_kind: input.response_kind,
+      response_status: 'blocked',
+      created_at: input.created_at,
+      expires_at: ttl.expires_at,
+      max_ttl_seconds: ttl.max_ttl_seconds,
+      response_evidence_refs: evidenceRefs,
+    });
+
+  if (envelope.allowed_to_execute !== false) {
+    return c6w7Refusal('prepared_envelope_allows_execution', 'C6W7 refuses executable envelope input.', blockedReconciliation);
+  }
+  if (envelope.prepared_only !== true || envelope.envelope_status !== 'prepared_only') {
+    return c6w7Refusal('prepared_envelope_not_prepared_only', 'C6W7 reconciles prepared-only envelopes only.', blockedReconciliation);
+  }
+  if (
+    envelope.source_artifact_ids.length === 0
+    || envelope.source_artifact_families.length === 0
+    || envelope.freshness_summary.earliest_expires_at === null
+    || envelope.freshness_summary.freshness_tier === 'stale'
+    || envelope.freshness_summary.freshness_tier === 'unknown'
+    || ttl === null
+  ) {
+    return c6w7Refusal('source_freshness_missing_or_stale', 'C6W7 requires fresh envelope source metadata and a live TTL.', blockedReconciliation);
+  }
+  if (C6W7_RESPONSE_KIND_BY_ENVELOPE_KIND[envelope.envelope_kind] !== input.response_kind) {
+    return c6w7Refusal('response_kind_envelope_mismatch', 'Response kind does not match the prepared envelope kind.', blockedReconciliation);
+  }
+  if (!(OACP_C6W7_RECONCILIATION_STATUSES as readonly string[]).includes(input.response_status)) {
+    return c6w7Refusal('response_status_attempts_execution', 'Response status is not an allowed C6W7 fail-closed status.', blockedReconciliation);
+  }
+  if (evidenceRefs === null) {
+    return c6w7Refusal('private_or_forbidden_response_field', 'Response evidence refs contain private or enabling fields.', blockedReconciliation);
+  }
+  if (evidenceRefs.length === 0) {
+    return c6w7Refusal('response_evidence_refs_missing', 'C6W7 requires local cached response evidence refs.', blockedReconciliation);
+  }
+  if (c6w7ResponseIndicatesForbiddenExecution(input)) {
+    return c6w7Refusal('response_indicates_forbidden_execution', 'Response evidence implies forbidden live execution or publication behavior.', blockedReconciliation);
+  }
+  if (c6w7RiskContextMissing(input, envelope)) {
+    return c6w7Refusal('risk_context_missing_or_ambiguous', 'Commitment-bound reconciliation requires amount, currency, and quantity context.', blockedReconciliation);
+  }
+  if (c6w7MandateEvidenceStale(input)) {
+    return c6w7Refusal('mandate_evidence_stale', 'Mandate capability evidence is older than the commitment-boundary TTL.', blockedReconciliation);
+  }
+  if (c6w7ResponseConflictsWithEnvelope(input, envelope)) {
+    return c6w7Refusal('response_conflicts_with_envelope', 'Response evidence conflicts with C6W6 envelope metadata.', blockedReconciliation);
+  }
+
+  const reconciliation = c6w7Reconciliation({
+    envelope,
+    response_kind: input.response_kind,
+    response_status: input.response_status,
+    created_at: input.created_at,
+    expires_at: ttl.expires_at,
+    max_ttl_seconds: ttl.max_ttl_seconds,
+    response_evidence_refs: evidenceRefs,
+  });
+
+  try {
+    assertNoForbiddenOacpArtifactFields(reconciliation);
+  } catch {
+    return c6w7Refusal('private_or_forbidden_response_field', 'Prepared response reconciliation contains private or enabling fields.', blockedReconciliation);
+  }
+
+  return { reconciled: true, status: input.response_status, reconciliation };
 }
 
 export function assertNoForbiddenOacpArtifactFields(value: unknown): void {

--- a/apps/auth-service/tests/commerce-c6w7-response-reconciliation.test.ts
+++ b/apps/auth-service/tests/commerce-c6w7-response-reconciliation.test.ts
@@ -1,0 +1,383 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  OACP_C6W3_VALID_ARTIFACT_FIXTURES,
+  buildOacpC6W4ProtocolAdapterPreview,
+  evaluateOacpC6W5CommitmentBoundaryMetadata,
+  prepareOacpC6W6CommitmentRequestEnvelope,
+  reconcileOacpC6W7PreparedCommitmentResponse,
+} from '../src/lib/commerce/oacp-trust-artifacts.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const DOC_PATH = join(
+  TEST_DIR,
+  '../../../docs/internal/commerce-v1/commerce-v1-c6w7-response-reconciliation.md',
+);
+
+function c6w7Artifacts() {
+  return [
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.merchant_capability,
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.seller_agent_capability,
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.catalog_snapshot,
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.offer,
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.price,
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.inventory,
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.policy,
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.mandate_capability,
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.commitment_evidence,
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES.protocol_adapter,
+  ];
+}
+
+function adapterPreview() {
+  const preview = buildOacpC6W4ProtocolAdapterPreview({
+    surface: 'mcp_tool_resource_capability',
+    artifacts: c6w7Artifacts(),
+    generated_at: '2026-06-11T00:00:30.000Z',
+  });
+  if (!preview.generated) throw new Error(preview.message);
+  return preview;
+}
+
+function decision(action = 'price_lock' as const) {
+  return evaluateOacpC6W5CommitmentBoundaryMetadata({
+    action,
+    artifacts: c6w7Artifacts(),
+    adapter_preview: adapterPreview(),
+    now_iso: '2026-06-11T00:01:00.000Z',
+    grantex_available: false,
+    revocation_snapshot_age_seconds: 30,
+    currency: 'INR',
+    amount_minor_units: 200000,
+    total_quantity: 1,
+    max_quantity_per_sku: 1,
+  });
+}
+
+function envelope(kind = 'buyer_confirmation_request' as const) {
+  const prepared = prepareOacpC6W6CommitmentRequestEnvelope({
+    envelope_kind: kind,
+    resolver_decision: decision(),
+    created_at: '2026-06-11T00:01:15.000Z',
+    evidence_refs: ['prepared-price-ref'],
+    unsupported_capabilities: ['checkout_create', 'payment_authorize'],
+    currency: 'INR',
+    amount_minor_units: 200000,
+    total_quantity: 1,
+  });
+  if (!prepared.generated) throw new Error(prepared.message);
+  return prepared.envelope;
+}
+
+describe('C6W7 OACP response reconciliation', () => {
+  it('reconciles buyer and merchant responses as prepared-only evidence', () => {
+    const buyer = reconcileOacpC6W7PreparedCommitmentResponse({
+      envelope: envelope(),
+      response_kind: 'buyer_confirmation_response',
+      response_status: 'accepted_for_preparation',
+      created_at: '2026-06-11T00:01:30.000Z',
+      response_evidence_refs: ['buyer-confirmation-cache-ref'],
+      response_claimed_action: 'price_lock',
+      currency: 'INR',
+      amount_minor_units: 200000,
+      total_quantity: 1,
+    });
+    expect(buyer.reconciled).toBe(true);
+    if (!buyer.reconciled) throw new Error(buyer.message);
+    expect(buyer.reconciliation).toMatchObject({
+      envelope_kind: 'buyer_confirmation_request',
+      response_kind: 'buyer_confirmation_response',
+      response_status: 'accepted_for_preparation',
+      requested_action: 'price_lock',
+      allowed_to_execute: false,
+      prepared_only: true,
+      reconciled_only: true,
+      non_authoritative_for_transaction: true,
+      no_checkout_payment_enablement: true,
+      no_live_provider_enablement: true,
+      no_public_discovery_enablement: true,
+    });
+    expect(buyer.reconciliation.source_artifact_ids).toContain('price_C6W3');
+    expect(buyer.reconciliation.response_evidence_refs).toContain('buyer-confirmation-cache-ref');
+    expect(buyer.reconciliation.next_system_step_label).not.toMatch(/https?:\/\//);
+    expect(buyer.reconciliation.buyer_safe_message).toContain('no order, hold, checkout, payment');
+
+    const merchantEnvelope = prepareOacpC6W6CommitmentRequestEnvelope({
+      envelope_kind: 'merchant_confirmation_request',
+      resolver_decision: decision(),
+      created_at: '2026-06-11T00:01:15.000Z',
+      evidence_refs: ['prepared-price-ref'],
+      currency: 'INR',
+      amount_minor_units: 200000,
+      total_quantity: 1,
+    });
+    if (!merchantEnvelope.generated) throw new Error(merchantEnvelope.message);
+    const merchant = reconcileOacpC6W7PreparedCommitmentResponse({
+      envelope: merchantEnvelope.envelope,
+      response_kind: 'merchant_confirmation_response',
+      response_status: 'needs_human_review',
+      created_at: '2026-06-11T00:01:30.000Z',
+      response_evidence_refs: ['merchant-confirmation-cache-ref'],
+      response_claimed_envelope_id: merchantEnvelope.envelope.envelope_id,
+      currency: 'INR',
+      amount_minor_units: 200000,
+      total_quantity: 1,
+    });
+    expect(merchant.reconciled).toBe(true);
+    if (!merchant.reconciled) throw new Error(merchant.message);
+    expect(merchant.reconciliation.allowed_to_prepare).toBe(false);
+    expect(merchant.reconciliation.next_system_step_label).toBe('human_review_reconciliation_label');
+  });
+
+  it('reconciles source refresh, mandate, and support response kinds', () => {
+    const refreshDecision = evaluateOacpC6W5CommitmentBoundaryMetadata({
+      action: 'ask_refresh_source_facts',
+      artifacts: c6w7Artifacts(),
+      adapter_preview: adapterPreview(),
+      now_iso: '2026-06-11T00:01:00.000Z',
+      grantex_available: true,
+      revocation_snapshot_age_seconds: 30,
+    });
+    const refreshEnvelope = prepareOacpC6W6CommitmentRequestEnvelope({
+      envelope_kind: 'seller_source_refresh_request',
+      resolver_decision: refreshDecision,
+      created_at: '2026-06-11T00:01:15.000Z',
+      evidence_refs: ['refresh-request-ref'],
+    });
+    if (!refreshEnvelope.generated) throw new Error(refreshEnvelope.message);
+    const refresh = reconcileOacpC6W7PreparedCommitmentResponse({
+      envelope: refreshEnvelope.envelope,
+      response_kind: 'seller_source_refresh_response',
+      response_status: 'needs_source_refresh',
+      created_at: '2026-06-11T00:01:30.000Z',
+      response_evidence_refs: ['refreshed-artifact-id-only-ref'],
+    });
+    expect(refresh.reconciled).toBe(true);
+    if (!refresh.reconciled) throw new Error(refresh.message);
+    expect(refresh.reconciliation.response_status).toBe('needs_source_refresh');
+
+    const mandateDecision = evaluateOacpC6W5CommitmentBoundaryMetadata({
+      action: 'prepare_mandate_capability_check_request',
+      artifacts: c6w7Artifacts(),
+      adapter_preview: adapterPreview(),
+      now_iso: '2026-06-11T00:01:00.000Z',
+      grantex_available: true,
+      revocation_snapshot_age_seconds: 30,
+    });
+    const mandateEnvelope = prepareOacpC6W6CommitmentRequestEnvelope({
+      envelope_kind: 'mandate_capability_evidence_request',
+      resolver_decision: mandateDecision,
+      created_at: '2026-06-11T00:01:15.000Z',
+      evidence_refs: ['mandate-request-ref'],
+    });
+    if (!mandateEnvelope.generated) throw new Error(mandateEnvelope.message);
+    const mandate = reconcileOacpC6W7PreparedCommitmentResponse({
+      envelope: mandateEnvelope.envelope,
+      response_kind: 'mandate_capability_evidence_response',
+      response_status: 'accepted_for_preparation',
+      created_at: '2026-06-11T00:01:30.000Z',
+      response_evidence_refs: ['mandate-capability-cache-ref'],
+      response_evidence_issued_at: '2026-06-11T00:00:45.000Z',
+    });
+    expect(mandate.reconciled).toBe(true);
+    if (!mandate.reconciled) throw new Error(mandate.message);
+    expect(mandate.reconciliation.max_ttl_seconds).toBeLessThanOrEqual(120);
+
+    const supportDecision = evaluateOacpC6W5CommitmentBoundaryMetadata({
+      action: 'support_escalation_sla_promise',
+      artifacts: c6w7Artifacts(),
+      adapter_preview: adapterPreview(),
+      now_iso: '2026-06-11T00:01:00.000Z',
+      grantex_available: true,
+      revocation_snapshot_age_seconds: 30,
+      currency: 'USD',
+      amount_minor_units: 5000,
+      total_quantity: 1,
+    });
+    const supportEnvelope = prepareOacpC6W6CommitmentRequestEnvelope({
+      envelope_kind: 'support_escalation_preparation',
+      resolver_decision: supportDecision,
+      created_at: '2026-06-11T00:01:15.000Z',
+      evidence_refs: ['support-request-ref'],
+      currency: 'USD',
+      amount_minor_units: 5000,
+      total_quantity: 1,
+    });
+    if (!supportEnvelope.generated) throw new Error(supportEnvelope.message);
+    const support = reconcileOacpC6W7PreparedCommitmentResponse({
+      envelope: supportEnvelope.envelope,
+      response_kind: 'support_escalation_response',
+      response_status: 'rejected',
+      created_at: '2026-06-11T00:01:30.000Z',
+      response_evidence_refs: ['support-response-ref'],
+      currency: 'USD',
+      amount_minor_units: 5000,
+      total_quantity: 1,
+    });
+    expect(support.reconciled).toBe(true);
+    if (!support.reconciled) throw new Error(support.message);
+    expect(support.reconciliation.seller_safe_message).toContain('does not create operational obligations');
+  });
+
+  it('fails closed for unsafe or mismatched response evidence', () => {
+    const prepared = envelope();
+    const missing = reconcileOacpC6W7PreparedCommitmentResponse({
+      envelope: null,
+      response_kind: 'buyer_confirmation_response',
+      response_status: 'accepted_for_preparation',
+      created_at: '2026-06-11T00:01:30.000Z',
+      response_evidence_refs: ['buyer-ref'],
+    });
+    expect(missing.reconciled).toBe(false);
+    if (missing.reconciled) throw new Error('expected refusal');
+    expect(missing.refusal_code).toBe('prepared_envelope_missing');
+
+    const executable = reconcileOacpC6W7PreparedCommitmentResponse({
+      envelope: { ...prepared, allowed_to_execute: true as false },
+      response_kind: 'buyer_confirmation_response',
+      response_status: 'accepted_for_preparation',
+      created_at: '2026-06-11T00:01:30.000Z',
+      response_evidence_refs: ['buyer-ref'],
+      currency: 'INR',
+      amount_minor_units: 200000,
+      total_quantity: 1,
+    });
+    expect(executable.reconciled).toBe(false);
+    if (executable.reconciled) throw new Error('expected refusal');
+    expect(executable.refusal_code).toBe('prepared_envelope_allows_execution');
+
+    const mismatch = reconcileOacpC6W7PreparedCommitmentResponse({
+      envelope: prepared,
+      response_kind: 'merchant_confirmation_response',
+      response_status: 'accepted_for_preparation',
+      created_at: '2026-06-11T00:01:30.000Z',
+      response_evidence_refs: ['merchant-ref'],
+      currency: 'INR',
+      amount_minor_units: 200000,
+      total_quantity: 1,
+    });
+    expect(mismatch.reconciled).toBe(false);
+    if (mismatch.reconciled) throw new Error('expected refusal');
+    expect(mismatch.refusal_code).toBe('response_kind_envelope_mismatch');
+
+    const privateRef = reconcileOacpC6W7PreparedCommitmentResponse({
+      envelope: prepared,
+      response_kind: 'buyer_confirmation_response',
+      response_status: 'accepted_for_preparation',
+      created_at: '2026-06-11T00:01:30.000Z',
+      response_evidence_refs: ['https://private.example/customer/address'],
+      currency: 'INR',
+      amount_minor_units: 200000,
+      total_quantity: 1,
+    });
+    expect(privateRef.reconciled).toBe(false);
+    if (privateRef.reconciled) throw new Error('expected refusal');
+    expect(privateRef.refusal_code).toBe('private_or_forbidden_response_field');
+
+    const execution = reconcileOacpC6W7PreparedCommitmentResponse({
+      envelope: prepared,
+      response_kind: 'buyer_confirmation_response',
+      response_status: 'accepted_for_preparation',
+      created_at: '2026-06-11T00:01:30.000Z',
+      response_evidence_refs: ['buyer-ref'],
+      response_flags: ['payment_executed'],
+      currency: 'INR',
+      amount_minor_units: 200000,
+      total_quantity: 1,
+    });
+    expect(execution.reconciled).toBe(false);
+    if (execution.reconciled) throw new Error('expected refusal');
+    expect(execution.refusal_code).toBe('response_indicates_forbidden_execution');
+  });
+
+  it('fails closed for stale, ambiguous, old mandate, and conflicting evidence', () => {
+    const prepared = envelope();
+    const stale = reconcileOacpC6W7PreparedCommitmentResponse({
+      envelope: prepared,
+      response_kind: 'buyer_confirmation_response',
+      response_status: 'accepted_for_preparation',
+      created_at: '2026-06-11T00:10:30.000Z',
+      response_evidence_refs: ['buyer-ref'],
+      currency: 'INR',
+      amount_minor_units: 200000,
+      total_quantity: 1,
+    });
+    expect(stale.reconciled).toBe(false);
+    if (stale.reconciled) throw new Error('expected refusal');
+    expect(stale.refusal_code).toBe('source_freshness_missing_or_stale');
+
+    const ambiguous = reconcileOacpC6W7PreparedCommitmentResponse({
+      envelope: prepared,
+      response_kind: 'buyer_confirmation_response',
+      response_status: 'accepted_for_preparation',
+      created_at: '2026-06-11T00:01:30.000Z',
+      response_evidence_refs: ['buyer-ref'],
+    });
+    expect(ambiguous.reconciled).toBe(false);
+    if (ambiguous.reconciled) throw new Error('expected refusal');
+    expect(ambiguous.refusal_code).toBe('risk_context_missing_or_ambiguous');
+
+    const conflict = reconcileOacpC6W7PreparedCommitmentResponse({
+      envelope: prepared,
+      response_kind: 'buyer_confirmation_response',
+      response_status: 'accepted_for_preparation',
+      created_at: '2026-06-11T00:01:30.000Z',
+      response_evidence_refs: ['buyer-ref'],
+      response_claimed_action: 'inventory_hold',
+      currency: 'INR',
+      amount_minor_units: 200000,
+      total_quantity: 1,
+    });
+    expect(conflict.reconciled).toBe(false);
+    if (conflict.reconciled) throw new Error('expected refusal');
+    expect(conflict.refusal_code).toBe('response_conflicts_with_envelope');
+
+    const mandateDecision = evaluateOacpC6W5CommitmentBoundaryMetadata({
+      action: 'prepare_mandate_capability_check_request',
+      artifacts: c6w7Artifacts(),
+      adapter_preview: adapterPreview(),
+      now_iso: '2026-06-11T00:01:00.000Z',
+      grantex_available: true,
+      revocation_snapshot_age_seconds: 30,
+    });
+    const mandateEnvelope = prepareOacpC6W6CommitmentRequestEnvelope({
+      envelope_kind: 'mandate_capability_evidence_request',
+      resolver_decision: mandateDecision,
+      created_at: '2026-06-11T00:01:15.000Z',
+      evidence_refs: ['mandate-request-ref'],
+    });
+    if (!mandateEnvelope.generated) throw new Error(mandateEnvelope.message);
+    const oldMandate = reconcileOacpC6W7PreparedCommitmentResponse({
+      envelope: mandateEnvelope.envelope,
+      response_kind: 'mandate_capability_evidence_response',
+      response_status: 'accepted_for_preparation',
+      created_at: '2026-06-11T00:01:30.000Z',
+      response_evidence_refs: ['mandate-cache-ref'],
+      response_evidence_issued_at: '2026-06-10T23:58:00.000Z',
+    });
+    expect(oldMandate.reconciled).toBe(false);
+    if (oldMandate.reconciled) throw new Error('expected refusal');
+    expect(oldMandate.refusal_code).toBe('mandate_evidence_stale');
+  });
+
+  it('documents C6W7 response reconciliation boundaries', () => {
+    const doc = readFileSync(DOC_PATH, 'utf8');
+    for (const heading of [
+      'Scope',
+      'Response Evidence Kinds',
+      'Reconciliation Output',
+      'Status Enum',
+      'Fail-Closed Rules',
+      'Human And Source Responses',
+      'Toll Booth Boundary',
+      'What This Does Not Enable',
+      'Future Slices',
+    ]) {
+      expect(doc).toContain(`## ${heading}`);
+    }
+    expect(doc).toContain('allowed_to_execute remains false');
+    expect(doc).toContain('reconciled_only remains true');
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6w7-response-reconciliation.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6w7-response-reconciliation.md
@@ -1,0 +1,98 @@
+# Commerce V1 C6W7 - Response Reconciliation
+
+Status: implementation foundation, internal-only, non-enabling.
+
+## Scope
+
+C6W7 defines internal prepared commitment response intake and evidence reconciliation over C6W6 prepared envelopes. Reconciliation is a local evidence result, not an execution instruction and not transaction authority.
+
+This slice adds helper logic, tests, and internal documentation only. It does not add endpoints, routes, OpenAPI, migrations, workflows, config, secrets, provider adapters, external calls, public discovery, checkout/payment, live provider rail behavior, merchant private API behavior, shipping behavior, or cloud behavior.
+
+Grantex remains the trust, protocol, policy, and canonical-artifact authority. AgenticOrg remains the buyer/seller agent runtime. Merchant systems remain operational sources of record. Provider and fintech rails own payment and mandate execution.
+
+## Response Evidence Kinds
+
+C6W7 supports five internal response evidence kinds:
+
+- buyer_confirmation_response: buyer accepts for preparation, rejects, asks for clarification, or requests refresh.
+- seller_source_refresh_response: seller agent reports refreshed, unchanged, missing, stale, or ambiguous source facts.
+- merchant_confirmation_response: merchant or source owner confirms, rejects, expires, or asks for manual review.
+- mandate_capability_evidence_response: cached provider-owned mandate capability evidence is present, missing, expired, rejected, or needs human review.
+- support_escalation_response: support preparation is acknowledged, rejected, or routed for review without promising outcomes.
+
+## Reconciliation Output
+
+Every reconciliation includes reconciliation_id, envelope_id, envelope_kind, response_kind, response_status, created_at, expires_at, max_ttl_seconds, action_class, requested_action, risk_tier, source artifact IDs and families, source authority, response evidence refs, freshness summary, decision summary, unsupported capabilities, blocked capabilities, required next artifact families, buyer-safe message, seller-safe message, next_human_step, next_system_step_label, and non-authoritative/non-enablement flags.
+
+allowed_to_execute remains false. prepared_only remains true. reconciled_only remains true. next_system_step_label is a label only, never an endpoint URL.
+
+## Status Enum
+
+C6W7 uses a small fail-closed status enum:
+
+- accepted_for_preparation
+- rejected
+- needs_source_refresh
+- needs_human_review
+- expired
+- stale
+- mismatched
+- blocked
+
+accepted_for_preparation means local evidence can continue as preparation only. It does not mean checkout, payment, order, hold, refund, return, shipment, provider rail use, or merchant private API execution.
+
+## Fail-Closed Rules
+
+C6W7 refuses or emits a blocked result when:
+
+- the C6W6 envelope is missing.
+- the envelope allows execution.
+- the envelope is not prepared_only.
+- source artifact IDs, families, freshness, or TTL metadata is missing, stale, expired, or ambiguous.
+- response kind does not match envelope kind.
+- response status or flags try to execute or approve live action.
+- response evidence refs are missing.
+- response evidence contains private credentials, raw JWTs, private URLs, provider payloads, private customer data, DB/Redis URLs, private keys, or allowlist values.
+- response evidence indicates checkout, payment, order, hold, refund, return, shipping, provider call, carrier call, merchant private API use, public discovery enablement, protocol publication/submission, certification, or production readiness.
+- commitment-bound amount, currency, or quantity context is ambiguous.
+- mandate capability evidence is older than the mandate TTL at the commitment boundary.
+- merchant or source responses conflict with the C6W5 decision or C6W6 envelope metadata.
+
+## Human And Source Responses
+
+Buyer responses are recorded as local confirmation evidence only. Seller refresh responses can reference new artifact IDs only as evidence references. Merchant responses confirm or reject source facts without creating orders, holds, payments, refunds, returns, or shipments. Mandate evidence responses use cached evidence only and do not call provider rails. Support responses do not promise SLA, refund, return, replacement, settlement, or payout without source authority.
+
+## Toll Booth Boundary
+
+Grantex does not become a synchronous toll booth for non-binding agent interactions. Grantex defines and validates the canonical artifact and reconciliation policy. AgenticOrg can reconcile cached response evidence locally while preserving source authority and remaining fail-closed.
+
+## What This Does Not Enable
+
+C6W7 does not enable:
+
+- Public discovery.
+- Production Commerce V1.
+- Checkout/payment creation.
+- Order creation.
+- Inventory holds.
+- Payment capture or debit.
+- Mandate creation.
+- Refund or return execution.
+- Shipping or carrier calls.
+- Live provider rail use.
+- Provider calls.
+- Merchant private API calls.
+- Connector credential export.
+- Production allowlists.
+- Public OACP publication.
+- External protocol submission.
+- Certification, compliance, conformance, standardization, production readiness, public-launch readiness, merchant approval, checkout approval, payment approval, live provider readiness, or OACP public readiness claims.
+
+## Future Slices
+
+Future implementation must still add separate controls before any execution handoff:
+
+- Human confirmation audit storage.
+- Merchant-system evidence ingestion from source-owned channels.
+- Provider-owned mandate verification outside C6W7.
+- Explicit controlled execution handoff outside Grantex policy helpers and AgenticOrg preview surfaces.


### PR DESCRIPTION
## Summary

- Adds internal C6W7 prepared commitment response evidence kinds and reconciliation statuses.
- Adds authority-side response reconciliation helper over C6W6 prepared envelopes.
- Adds focused C6W7 tests and internal documentation.

## Guardrails

- Internal-only, non-publication, non-certifying, non-production, and non-executing.
- Keeps allowed_to_execute false, prepared_only true, reconciled_only true, and non_authoritative_for_transaction true.
- Adds no endpoints, routes, OpenAPI, migrations, workflows, config, secrets, provider adapters, external calls, checkout/payment path, public discovery path, or live provider rail behavior.
- Grantex remains trust/protocol/policy/canonical-artifact authority, not a transaction toll booth.

## Validation

- npm --prefix apps/auth-service test -- commerce-no-plural-leak.test.ts commerce-c6w3-oacp-artifact-schemas.test.ts commerce-c6w4-oacp-adapter-previews.test.ts commerce-c6w5-commitment-boundary.test.ts commerce-c6w6-prepared-envelopes.test.ts commerce-c6w7-response-reconciliation.test.ts
- npm --prefix apps/auth-service run typecheck
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
- git diff --check origin/main...HEAD
- ASCII and focused guardrail scans on touched files
