### PR TITLE
C6X4 durable OACP cache compatibility guard

### DIFF
--- a/apps/auth-service/tests/commerce-c6x4-durable-cache-compatibility.test.ts
+++ b/apps/auth-service/tests/commerce-c6x4-durable-cache-compatibility.test.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  OACP_C6W3_VALID_ARTIFACT_FIXTURES,
+  verifyOacpC6X2CachedArtifactEnvelope,
+} from '../src/lib/commerce/oacp-trust-artifacts.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const DOC_PATH = join(
+  TEST_DIR,
+  '../../../docs/internal/commerce-v1/commerce-v1-c6x4-durable-cache-compatibility.md',
+);
+
+function doc() {
+  return readFileSync(DOC_PATH, 'utf8');
+}
+
+function verifiedPriceResult() {
+  return verifyOacpC6X2CachedArtifactEnvelope({
+    artifact: OACP_C6W3_VALID_ARTIFACT_FIXTURES.price,
+    now_iso: '2026-06-11T00:01:00.000Z',
+    expected_scope: {
+      tenant_id: 'cten_C6W3',
+      merchant_id: 'mch_C6W3',
+      seller_agent_id: 'seller_C6W3',
+    },
+    risk_tier: 'low',
+    revocation_snapshot: {
+      status: 'fresh',
+      observed_at: '2026-06-11T00:00:30.000Z',
+      age_seconds: 30,
+      revoked_artifact_ids: [],
+      revoked_subject_ids: [],
+    },
+    verifier_result_ref: 'verifier_result_price_C6X4',
+    signature_verified: true,
+  });
+}
+
+describe('C6X4 durable AgenticOrg cache compatibility guard', () => {
+  it('keeps verifier results sufficient for durable AgenticOrg cache storage', () => {
+    const result = verifiedPriceResult();
+    expect(result.verified).toBe(true);
+    if (!result.verified) throw new Error(result.message);
+
+    const durableCacheRecord = {
+      cache_record_id: `durable_${result.artifact_id}_C6X4`,
+      artifact_id: result.artifact_id,
+      artifact_type: result.artifact_type,
+      artifact_family: result.artifact_family,
+      authority: result.source_authority,
+      issuer: result.issuer,
+      tenant_id: result.cache_scope.tenant_id,
+      merchant_id: result.cache_scope.merchant_id,
+      seller_agent_id: result.cache_scope.seller_agent_id,
+      buyer_agent_id: result.cache_scope.buyer_agent_id ?? null,
+      source_refs: result.source_refs,
+      evidence_refs: result.evidence_refs,
+      generated_at: result.generated_at,
+      issued_at: result.issued_at,
+      cached_at: result.issued_at,
+      expires_at: result.expires_at,
+      freshness_status: result.freshness_status,
+      revocation_snapshot_status: result.revocation_status,
+      revocation_snapshot_age_seconds: 30,
+      revocation_snapshot_observed_at: result.revocation_snapshot_observed_at,
+      ttl_policy: {
+        ttl_policy_seconds: result.max_ttl_seconds,
+        artifact_family: result.artifact_family,
+      },
+      risk_tier: 'low',
+      blocked_capabilities: result.blocked_capabilities,
+      unsupported_capabilities: result.unsupported_capabilities,
+      verifier_result_ref: result.verifier_result_ref,
+      allowed_to_execute: result.allowed_to_execute,
+      non_authoritative_for_transaction: result.non_authoritative_for_transaction,
+      no_checkout_payment_enablement: result.no_checkout_payment_enablement,
+      no_live_provider_enablement: result.no_live_provider_enablement,
+      no_public_discovery_enablement: result.no_public_discovery_enablement,
+    };
+
+    for (const requiredField of [
+      'cache_record_id',
+      'artifact_id',
+      'artifact_type',
+      'artifact_family',
+      'authority',
+      'issuer',
+      'tenant_id',
+      'merchant_id',
+      'seller_agent_id',
+      'source_refs',
+      'evidence_refs',
+      'generated_at',
+      'issued_at',
+      'cached_at',
+      'expires_at',
+      'freshness_status',
+      'revocation_snapshot_status',
+      'revocation_snapshot_age_seconds',
+      'revocation_snapshot_observed_at',
+      'ttl_policy',
+      'risk_tier',
+      'blocked_capabilities',
+      'unsupported_capabilities',
+      'verifier_result_ref',
+    ]) {
+      expect(durableCacheRecord[requiredField as keyof typeof durableCacheRecord]).toBeDefined();
+    }
+
+    expect(durableCacheRecord.allowed_to_execute).toBe(false);
+    expect(durableCacheRecord.non_authoritative_for_transaction).toBe(true);
+    expect(durableCacheRecord.no_checkout_payment_enablement).toBe(true);
+    expect(durableCacheRecord.no_live_provider_enablement).toBe(true);
+    expect(durableCacheRecord.no_public_discovery_enablement).toBe(true);
+  });
+
+  it('keeps Grantex verifier output non-executing and non-private', () => {
+    const result = verifiedPriceResult();
+    expect(result.verified).toBe(true);
+    if (!result.verified) throw new Error(result.message);
+
+    expect(result.allowed_to_execute).toBe(false);
+    expect(result.non_authoritative_for_transaction).toBe(true);
+    expect(result.no_checkout_payment_enablement).toBe(true);
+    expect(result.no_public_discovery_enablement).toBe(true);
+    expect(result.no_live_provider_enablement).toBe(true);
+    expect(result.no_provider_calls).toBe(true);
+    expect(result.no_merchant_private_api_calls).toBe(true);
+    expect(result.verifier_result_only).toBe(true);
+
+    const refs = [...result.source_refs, ...result.evidence_refs, result.verifier_result_ref];
+    for (const ref of refs) {
+      expect(ref).not.toMatch(/raw|private|secret|token|jwt|password|credential|allowlist/i);
+    }
+  });
+
+  it('documents the durable cache compatibility boundary', () => {
+    const text = doc();
+    for (const heading of [
+      'Scope',
+      'Compatibility Guard',
+      'Durable Cache Fields',
+      'Non-Execution Posture',
+      'Grantex Boundary',
+      'Guardrails',
+      'Future Work',
+    ]) {
+      expect(text).toContain(`## ${heading}`);
+    }
+
+    expect(text).toContain('AgenticOrg remains the buyer and seller AI-agent runtime');
+    expect(text).toContain('Grantex remains the trust, protocol, policy, and canonical OACP artifact authority');
+    expect(text).toContain('not a transaction toll booth');
+    expect(text).toContain('allowed_to_execute = false');
+    expect(text).toContain('no checkout/payment enablement');
+    expect(text).toContain('no live provider rail enablement');
+    expect(text).toContain('no raw provider payloads');
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6x4-durable-cache-compatibility.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6x4-durable-cache-compatibility.md
@@ -1,0 +1,29 @@
+# Commerce V1 C6X4 Durable Cache Compatibility
+
+## Scope
+
+C6X4 adds Grantex-side compatibility guard tests and internal documentation for the AgenticOrg durable OACP artifact cache repository contract. It adds no Grantex runtime code, migration, endpoint, route, OpenAPI runtime contract, workflow, provider adapter, or external call.
+
+## Compatibility Guard
+
+The guard proves the existing Grantex C6X2 cached-artifact verifier result and C6X3 repository intake shape still provide every field AgenticOrg needs for durable cache storage. AgenticOrg remains the buyer and seller AI-agent runtime and owns local/durable OACP artifact cache behavior. Grantex remains the trust, protocol, policy, and canonical OACP artifact authority.
+
+## Durable Cache Fields
+
+The compatible result includes artifact id, artifact type and family, issuer, authority, tenant, merchant, seller-agent, and buyer-agent scope ids, source refs, redacted evidence refs, generated, issued, cached, and expiry timestamps, freshness, revocation snapshot status and age, TTL policy, risk tier, blocked capabilities, unsupported capabilities, verifier result ref, and non-enablement flags.
+
+## Non-Execution Posture
+
+Every compatible result keeps `allowed_to_execute = false`, `non_authoritative_for_transaction = true`, `no_checkout_payment_enablement = true`, `no_live_provider_enablement = true`, and `no_public_discovery_enablement = true`.
+
+## Grantex Boundary
+
+Grantex remains the canonical artifact authority, not a transaction toll booth. Cache-compatible verifier output is verifier-result-only and does not call providers, merchant private APIs, checkout/payment systems, public discovery systems, carriers, shipping systems, or live rails.
+
+## Guardrails
+
+C6X4 Grantex changes store no durable records and expose no new runtime surface. Compatibility refs must remain public-safe and non-sensitive: no raw provider payloads, raw connector payloads, raw JWTs, credentials, tokens, private keys, bank or card data, private customer data, private merchant API values, secrets, production allowlists, no checkout/payment enablement, no live provider rail enablement, public discovery enablement, external OACP publication, or certification/approval/readiness claims.
+
+## Future Work
+
+Future Grantex slices may add additional verifier compatibility checks as AgenticOrg cache storage evolves. Those checks must remain separate from provider execution, merchant private APIs, checkout, payment, public discovery publication, and any public OACP submission unless separately approved.


### PR DESCRIPTION
## Summary
- Adds C6X4 Grantex compatibility guard tests for AgenticOrg durable OACP cache intake.
- Documents that Grantex remains the canonical artifact authority and does not become a transaction toll booth.
- Keeps the slice docs/tests-only on the Grantex side: no runtime code, endpoint, migration, workflow, provider adapter, or external call.

## Validation
- `npm --prefix apps/auth-service test -- commerce-c6x2-oacp-cache-verifier.test.ts commerce-c6x3-cache-repository-compatibility.test.ts commerce-c6x4-durable-cache-compatibility.test.ts`
- `npm --prefix apps/auth-service run typecheck`
- `node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr`
- `git diff --cached --check`

## Guardrails
- Internal-only, non-publication, non-certifying, non-production, non-executing.
- `allowed_to_execute = false` and non-authoritative for transactions.
- No checkout/payment/public discovery/live provider enablement.
- No provider calls, merchant private API calls, raw/private payloads, secrets, allowlists, or publication/approval claims.
