### PR TITLE
C6X5 OACP cache maintenance compatibility guard

### DIFF
--- a/apps/auth-service/tests/commerce-c6x5-cache-maintenance-compatibility.test.ts
+++ b/apps/auth-service/tests/commerce-c6x5-cache-maintenance-compatibility.test.ts
@@ -1,0 +1,149 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  OACP_C6W3_VALID_ARTIFACT_FIXTURES,
+  verifyOacpC6X2CachedArtifactEnvelope,
+} from '../src/lib/commerce/oacp-trust-artifacts.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const DOC_PATH = join(
+  TEST_DIR,
+  '../../../docs/internal/commerce-v1/commerce-v1-c6x5-cache-maintenance-compatibility.md',
+);
+
+function doc() {
+  return readFileSync(DOC_PATH, 'utf8');
+}
+
+function verifiedPriceResult() {
+  return verifyOacpC6X2CachedArtifactEnvelope({
+    artifact: OACP_C6W3_VALID_ARTIFACT_FIXTURES.price,
+    now_iso: '2026-06-11T00:01:00.000Z',
+    expected_scope: {
+      tenant_id: 'cten_C6W3',
+      merchant_id: 'mch_C6W3',
+      seller_agent_id: 'seller_C6W3',
+    },
+    risk_tier: 'low',
+    revocation_snapshot: {
+      status: 'fresh',
+      observed_at: '2026-06-11T00:00:30.000Z',
+      age_seconds: 30,
+      revoked_artifact_ids: [],
+      revoked_subject_ids: [],
+    },
+    verifier_result_ref: 'verifier_result_price_C6X5',
+    signature_verified: true,
+  });
+}
+
+describe('C6X5 AgenticOrg cache maintenance compatibility guard', () => {
+  it('keeps Grantex verifier output sufficient for AgenticOrg maintenance planning', () => {
+    const result = verifiedPriceResult();
+    expect(result.verified).toBe(true);
+    if (!result.verified) throw new Error(result.message);
+
+    const maintenanceCandidate = {
+      cache_record_id: `maintenance_${result.artifact_id}_C6X5`,
+      artifact_id: result.artifact_id,
+      artifact_type: result.artifact_type,
+      artifact_family: result.artifact_family,
+      authority: result.source_authority,
+      issuer: result.issuer,
+      tenant_id: result.cache_scope.tenant_id,
+      merchant_id: result.cache_scope.merchant_id,
+      seller_agent_id: result.cache_scope.seller_agent_id,
+      buyer_agent_id: result.cache_scope.buyer_agent_id ?? null,
+      source_refs: result.source_refs,
+      evidence_refs: result.evidence_refs,
+      generated_at: result.generated_at,
+      cached_at: result.issued_at,
+      expires_at: result.expires_at,
+      freshness_status: result.freshness_status,
+      revocation_snapshot_status: result.revocation_status,
+      revocation_snapshot_age_seconds: 30,
+      revocation_snapshot_observed_at: result.revocation_snapshot_observed_at,
+      ttl_policy_seconds: result.max_ttl_seconds,
+      risk_tier: 'low',
+      blocked_capabilities: result.blocked_capabilities,
+      unsupported_capabilities: result.unsupported_capabilities,
+      verifier_result_ref: result.verifier_result_ref,
+      allowed_to_execute: result.allowed_to_execute,
+      non_authoritative_for_transaction: result.non_authoritative_for_transaction,
+      no_checkout_payment_enablement: result.no_checkout_payment_enablement,
+      no_live_provider_enablement: result.no_live_provider_enablement,
+      no_public_discovery_enablement: result.no_public_discovery_enablement,
+    };
+
+    for (const requiredField of [
+      'artifact_id',
+      'artifact_type',
+      'authority',
+      'issuer',
+      'tenant_id',
+      'merchant_id',
+      'seller_agent_id',
+      'source_refs',
+      'evidence_refs',
+      'generated_at',
+      'cached_at',
+      'expires_at',
+      'freshness_status',
+      'revocation_snapshot_status',
+      'revocation_snapshot_age_seconds',
+      'revocation_snapshot_observed_at',
+      'ttl_policy_seconds',
+      'risk_tier',
+      'blocked_capabilities',
+      'unsupported_capabilities',
+      'verifier_result_ref',
+    ]) {
+      expect(maintenanceCandidate[requiredField as keyof typeof maintenanceCandidate]).toBeDefined();
+    }
+  });
+
+  it('keeps maintenance-compatible verifier output non-executing and public-safe', () => {
+    const result = verifiedPriceResult();
+    expect(result.verified).toBe(true);
+    if (!result.verified) throw new Error(result.message);
+
+    expect(result.allowed_to_execute).toBe(false);
+    expect(result.non_authoritative_for_transaction).toBe(true);
+    expect(result.no_checkout_payment_enablement).toBe(true);
+    expect(result.no_public_discovery_enablement).toBe(true);
+    expect(result.no_live_provider_enablement).toBe(true);
+    expect(result.no_provider_calls).toBe(true);
+    expect(result.no_merchant_private_api_calls).toBe(true);
+    expect(result.verifier_result_only).toBe(true);
+
+    const refs = [...result.source_refs, ...result.evidence_refs, result.verifier_result_ref];
+    for (const ref of refs) {
+      expect(ref).not.toMatch(/raw|private|secret|token|jwt|password|credential|allowlist/i);
+    }
+  });
+
+  it('documents the C6X5 maintenance compatibility boundary', () => {
+    const text = doc();
+    for (const heading of [
+      'Scope',
+      'Compatibility Guard',
+      'Maintenance Fields',
+      'Maintenance Outcomes',
+      'Grantex Boundary',
+      'Guardrails',
+      'What C6X5 Does Not Enable',
+      'Future Work',
+    ]) {
+      expect(text).toContain(`## ${heading}`);
+    }
+
+    expect(text).toContain('AgenticOrg remains the buyer and seller AI-agent runtime');
+    expect(text).toContain('Grantex remains the trust, protocol, policy, and canonical OACP artifact authority');
+    expect(text).toContain('not a transaction toll booth');
+    expect(text).toContain('allowed_to_execute = false');
+    expect(text).toContain('no scheduler');
+    expect(text).toContain('no raw provider payloads');
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6x5-cache-maintenance-compatibility.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6x5-cache-maintenance-compatibility.md
@@ -1,0 +1,35 @@
+# Commerce V1 C6X5 Cache Maintenance Compatibility
+
+## Scope
+
+C6X5 adds Grantex-side compatibility guard tests and internal documentation for AgenticOrg OACP durable cache maintenance planning. It adds no Grantex runtime code, migration, endpoint, route, OpenAPI runtime contract, workflow, scheduler, queue, background worker, provider adapter, or external call.
+
+## Compatibility Guard
+
+The guard proves the existing Grantex cached-artifact verifier result still provides every field AgenticOrg needs to plan cache refresh, eviction, revocation maintenance, quarantine, and human review outcomes. AgenticOrg remains the buyer and seller AI-agent runtime and owns durable/local OACP cache behavior. Grantex remains the trust, protocol, policy, and canonical OACP artifact authority.
+
+## Maintenance Fields
+
+The compatible result includes artifact id, artifact type and family, issuer, authority, tenant, merchant, seller-agent, and buyer-agent scope ids, source refs, redacted evidence refs, generated, cached, and expiry timestamps, freshness, revocation snapshot status and age, TTL policy, risk tier, blocked capabilities, unsupported capabilities, verifier result ref, and non-enablement flags.
+
+Every compatible maintenance candidate keeps `allowed_to_execute = false`, `non_authoritative_for_transaction = true`, `no_checkout_payment_enablement = true`, `no_live_provider_enablement = true`, and `no_public_discovery_enablement = true`.
+
+## Maintenance Outcomes
+
+AgenticOrg may classify cache records as `keep_usable`, `refresh_recommended`, `refresh_required_before_commitment`, `evict_expired`, `purge_revoked`, `quarantine_ambiguous_revocation`, `quarantine_scope_mismatch`, `quarantine_private_or_raw_ref`, `source_refresh_needed`, `human_review_required`, or `blocked_unsafe`. Grantex does not execute those actions in C6X5.
+
+## Grantex Boundary
+
+Grantex remains the canonical artifact authority, not a transaction toll booth. Cache-maintenance-compatible verifier output is verifier-result-only and does not call providers, merchant private APIs, checkout/payment systems, public discovery systems, carriers, shipping systems, Grantex live endpoints, or live rails.
+
+## Guardrails
+
+C6X5 Grantex changes store no durable records and expose no new runtime surface. Compatibility refs must remain public-safe and non-sensitive: no raw provider payloads, raw connector payloads, raw JWTs, credentials, tokens, private keys, bank or card data, private customer data, private merchant API values, secrets, production allowlists, checkout/payment enablement, live provider rail enablement, public discovery enablement, external OACP publication, or approval claims.
+
+## What C6X5 Does Not Enable
+
+C6X5 adds no public endpoint, public OpenAPI runtime contract, workflow, no scheduler, cron, queue, background worker, cloud resource, production config, secret, public discovery enablement, checkout, payment, order, hold, refund, return, shipping execution, live provider rail enablement, merchant private API execution, external OACP publication, or approval claim.
+
+## Future Work
+
+Future Grantex slices may add additional compatibility checks as AgenticOrg maintenance planning evolves. Those checks must stay separate from provider execution, merchant private APIs, checkout, payment, public discovery publication, and any public OACP submission unless separately approved.


### PR DESCRIPTION
## Summary
- Adds C6X5 Grantex compatibility guard tests for AgenticOrg OACP cache maintenance planning.
- Documents that Grantex verifier/cache fields remain sufficient for AgenticOrg refresh, eviction, revocation, quarantine, and review planning.
- Keeps Grantex docs/tests-only: no runtime code, endpoint, route, OpenAPI runtime contract, migration, workflow, scheduler, queue, background worker, provider adapter, or external call.

## Validation
- `npm --prefix apps/auth-service test -- commerce-c6x2-oacp-cache-verifier.test.ts commerce-c6x3-cache-repository-compatibility.test.ts commerce-c6x4-durable-cache-compatibility.test.ts commerce-c6x5-cache-maintenance-compatibility.test.ts`
- `npm --prefix apps/auth-service run typecheck`
- `node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr`
- `git diff --cached --check`

## Guardrails
- Internal-only, non-publication, non-certifying, non-production, non-executing.
- Grantex remains the canonical artifact authority, not a transaction toll booth.
- No scheduler, cron, queue, background worker, migration, endpoint, provider call, merchant private API call, checkout/payment/public discovery/live rail enablement, or OACP publication.
- Compatible maintenance candidates keep `allowed_to_execute = false` and remain non-authoritative for transactions.
