### PR TITLE
C6X8 operator decision audit compatibility

### DIFF
--- a/apps/auth-service/tests/commerce-c6x8-operator-decision-audit-compatibility.test.ts
+++ b/apps/auth-service/tests/commerce-c6x8-operator-decision-audit-compatibility.test.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  OACP_C6W3_VALID_ARTIFACT_FIXTURES,
+  verifyOacpC6X2CachedArtifactEnvelope,
+} from '../src/lib/commerce/oacp-trust-artifacts.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const DOC_PATH = join(
+  TEST_DIR,
+  '../../../docs/internal/commerce-v1/commerce-v1-c6x8-operator-decision-audit-compatibility.md',
+);
+
+function doc() {
+  return readFileSync(DOC_PATH, 'utf8');
+}
+
+function verifiedPriceResult() {
+  return verifyOacpC6X2CachedArtifactEnvelope({
+    artifact: OACP_C6W3_VALID_ARTIFACT_FIXTURES.price,
+    now_iso: '2026-06-11T00:00:20.000Z',
+    expected_scope: {
+      tenant_id: 'cten_C6W3',
+      merchant_id: 'mch_C6W3',
+      seller_agent_id: 'seller_C6W3',
+      buyer_agent_id: 'buyer_C6W3',
+    },
+    risk_tier: 'low',
+    revocation_snapshot: {
+      status: 'fresh',
+      observed_at: '2026-06-11T00:00:10.000Z',
+      age_seconds: 10,
+      revoked_artifact_ids: [],
+      revoked_subject_ids: [],
+    },
+    verifier_result_ref: 'verifier_result_price_C6X8',
+    signature_verified: true,
+  });
+}
+
+describe('C6X8 AgenticOrg operator decision audit-chain compatibility guard', () => {
+  it('keeps Grantex verifier output sufficient for durable AgenticOrg decision audit references', () => {
+    const result = verifiedPriceResult();
+    expect(result.verified).toBe(true);
+    if (!result.verified) throw new Error(result.message);
+
+    const operatorDecisionCandidate = {
+      decision_id: `decision_${result.artifact_id}_C6X8`,
+      review_packet_id: 'oacp_c6x6_operator_review_price_C6X8',
+      maintenance_plan_id: 'oacp_c6x5_maintenance_plan_price_C6X8',
+      decision_kind: 'approve_future_refresh_request',
+      tenant_id: result.cache_scope.tenant_id,
+      merchant_id: result.cache_scope.merchant_id,
+      seller_agent_id: result.cache_scope.seller_agent_id,
+      buyer_agent_id: result.cache_scope.buyer_agent_id,
+      artifact_families_affected: [result.artifact_type],
+      source_refs: result.source_refs,
+      evidence_refs: result.evidence_refs,
+      verifier_result_ref: result.verifier_result_ref,
+      reviewer_ref: 'operator_ref_c6x8_opaque',
+      next_step_labels: ['future_refresh_request_label_only_no_api_call'],
+      allowed_to_execute: result.allowed_to_execute,
+      future_action_allowed: false,
+      prepared_only: true,
+      non_authoritative_for_transaction: result.non_authoritative_for_transaction,
+      no_checkout_payment_enablement: result.no_checkout_payment_enablement,
+      no_live_provider_enablement: result.no_live_provider_enablement,
+      no_public_discovery_enablement: result.no_public_discovery_enablement,
+    };
+
+    for (const requiredField of [
+      'decision_id',
+      'review_packet_id',
+      'maintenance_plan_id',
+      'decision_kind',
+      'tenant_id',
+      'merchant_id',
+      'seller_agent_id',
+      'buyer_agent_id',
+      'artifact_families_affected',
+      'source_refs',
+      'evidence_refs',
+      'reviewer_ref',
+      'next_step_labels',
+      'allowed_to_execute',
+      'future_action_allowed',
+      'non_authoritative_for_transaction',
+    ]) {
+      expect(operatorDecisionCandidate[requiredField as keyof typeof operatorDecisionCandidate]).toBeDefined();
+    }
+  });
+
+  it('keeps audit-chain fields redacted and non-executing', () => {
+    const result = verifiedPriceResult();
+    expect(result.verified).toBe(true);
+    if (!result.verified) throw new Error(result.message);
+
+    expect(result.allowed_to_execute).toBe(false);
+    expect(result.non_authoritative_for_transaction).toBe(true);
+    expect(result.no_checkout_payment_enablement).toBe(true);
+    expect(result.no_live_provider_enablement).toBe(true);
+    expect(result.no_public_discovery_enablement).toBe(true);
+    expect(result.no_provider_calls).toBe(true);
+    expect(result.no_merchant_private_api_calls).toBe(true);
+
+    const refs = [...result.source_refs, ...result.evidence_refs, result.verifier_result_ref];
+    for (const ref of refs) {
+      expect(ref).not.toMatch(/raw|private|secret|token|jwt|password|credential|allowlist/i);
+    }
+  });
+
+  it('documents the C6X8 audit compatibility boundary', () => {
+    const text = doc();
+    for (const heading of [
+      'Scope',
+      'Compatibility Guard',
+      'Audit-Chain Fields',
+      'Grantex Boundary',
+      'Guardrails',
+      'What C6X8 Does Not Enable',
+      'Future Work',
+    ]) {
+      expect(text).toContain(`## ${heading}`);
+    }
+
+    expect(text).toContain('AgenticOrg remains the buyer and seller AI-agent runtime');
+    expect(text).toContain('Grantex remains the trust, protocol, policy, and canonical OACP artifact authority');
+    expect(text).toContain('not a transaction toll booth');
+    expect(text).toContain('not Grantex approvals');
+    expect(text).toContain('allowed_to_execute = false');
+    expect(text).toContain('future_action_allowed = false');
+    expect(text).toContain('no scheduler');
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6x8-operator-decision-audit-compatibility.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6x8-operator-decision-audit-compatibility.md
@@ -1,0 +1,44 @@
+# Commerce V1 C6X8 Operator Decision Audit Compatibility
+
+## Scope
+
+C6X8 adds a Grantex compatibility guard for AgenticOrg durable OACP operator decision records. Grantex changes are docs and tests only. The guard proves that Grantex cached-artifact verifier output remains sufficient for AgenticOrg to store redacted local operator decision audit-chain references.
+
+## Compatibility Guard
+
+The guard checks that Grantex verifier output carries the fields AgenticOrg needs for durable decision records:
+
+- artifact id and family
+- tenant, merchant, seller-agent, and buyer-agent scope where applicable
+- source refs
+- evidence refs
+- verifier result ref
+- freshness and revocation posture
+- blocked and unsupported capabilities
+- non-enablement flags
+
+Those fields are enough for AgenticOrg to connect C6X5 maintenance plans, C6X6 operator review packets, and C6X7 operator decision records without sending every non-binding cache turn back through Grantex.
+
+## Audit-Chain Fields
+
+AgenticOrg can derive durable decision fields such as decision id, review packet id, maintenance plan id, decision kind, scope ids, artifact families, redacted reason codes, redacted evidence refs, opaque reviewer reference, and label-only next steps from the local review packet and Grantex-compatible verifier metadata.
+
+The durable decision remains audit-safe: `allowed_to_execute = false`, `future_action_allowed = false`, `non_authoritative_for_transaction = true`, `no_checkout_payment_enablement = true`, `no_live_provider_enablement = true`, and `no_public_discovery_enablement = true`.
+
+## Grantex Boundary
+
+Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. AgenticOrg remains the buyer and seller AI-agent runtime and owns local operator decision handling. Grantex is not a transaction toll booth and does not need to receive every local cache maintenance report, every local operator decision, or every non-binding buyer/seller agent interaction.
+
+Operator decisions are not Grantex approvals, merchant approvals, checkout approvals, payment approvals, mandate approvals, live-provider approvals, or production approvals.
+
+## Guardrails
+
+C6X8 keeps OACP internal, non-publication, non-certifying, non-production, non-executing, fail-closed, and non-authoritative for transactions. Grantex stores only non-sensitive evidence references where policy or artifact lineage requires them. This guard does not add Grantex persistence for AgenticOrg operator decisions.
+
+## What C6X8 Does Not Enable
+
+C6X8 adds no Grantex route, endpoint, public OpenAPI runtime contract, migration, workflow, or cloud resource. It adds no scheduler, queue, background worker, production config, secret, provider adapter, provider call, merchant private API call, public discovery enablement, checkout, payment, order, hold, refund, return, shipping execution, live rail enablement, allowlist, external OACP publication, or approval/readiness claim.
+
+## Future Work
+
+Future slices may define a separately approved audit-chain export or controller handoff. That work must remain separate from checkout, payment, provider rail, merchant private API, public OACP publication, production config, and public endpoint behavior unless explicitly approved.


### PR DESCRIPTION
## Summary
- Adds Grantex docs/tests compatibility guard for AgenticOrg durable operator decision audit-chain records.
- Confirms verifier output remains sufficient for redacted local decision references without making Grantex a transaction toll booth.
- Adds no Grantex runtime code, persistence, endpoints, workflows, config, provider calls, or publication behavior.

## Validation
- npm --prefix apps/auth-service test -- commerce-c6x5-cache-maintenance-compatibility.test.ts commerce-c6x6-cache-maintenance-report-compatibility.test.ts commerce-c6x7-operator-decision-compatibility.test.ts commerce-c6x8-operator-decision-audit-compatibility.test.ts
- npm --prefix apps/auth-service run typecheck
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
- git diff --check origin/main...HEAD
- ASCII/hidden Unicode and guardrail scans on touched files

## Guardrails
Internal-only, non-publication, non-certifying, non-production, non-executing, and non-authoritative for transactions. No checkout/payment, live rail, public discovery, provider/private API, allowlist, cloud, workflow, or readiness behavior is added.