### PR TITLE
[codex] Add C6X9 audit export compatibility guard

### DIFF
--- a/apps/auth-service/tests/commerce-c6x9-audit-export-compatibility.test.ts
+++ b/apps/auth-service/tests/commerce-c6x9-audit-export-compatibility.test.ts
@@ -1,0 +1,142 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  OACP_C6W3_VALID_ARTIFACT_FIXTURES,
+  verifyOacpC6X2CachedArtifactEnvelope,
+} from '../src/lib/commerce/oacp-trust-artifacts.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const DOC_PATH = join(
+  TEST_DIR,
+  '../../../docs/internal/commerce-v1/commerce-v1-c6x9-audit-export-compatibility.md',
+);
+
+function doc() {
+  return readFileSync(DOC_PATH, 'utf8');
+}
+
+function verifiedPriceResult() {
+  return verifyOacpC6X2CachedArtifactEnvelope({
+    artifact: OACP_C6W3_VALID_ARTIFACT_FIXTURES.price,
+    now_iso: '2026-06-11T00:00:20.000Z',
+    expected_scope: {
+      tenant_id: 'cten_C6W3',
+      merchant_id: 'mch_C6W3',
+      seller_agent_id: 'seller_C6W3',
+      buyer_agent_id: 'buyer_C6W3',
+    },
+    risk_tier: 'low',
+    revocation_snapshot: {
+      status: 'fresh',
+      observed_at: '2026-06-11T00:00:10.000Z',
+      age_seconds: 10,
+      revoked_artifact_ids: [],
+      revoked_subject_ids: [],
+    },
+    verifier_result_ref: 'verifier_result_price_C6X9',
+    signature_verified: true,
+  });
+}
+
+describe('C6X9 AgenticOrg audit export bundle compatibility guard', () => {
+  it('keeps verifier output sufficient for redacted AgenticOrg audit export bundle refs', () => {
+    const result = verifiedPriceResult();
+    expect(result.verified).toBe(true);
+    if (!result.verified) throw new Error(result.message);
+
+    const auditBundleCandidate = {
+      bundle_kind: 'oacp_cache_operator_decision_audit_export_bundle',
+      tenant_id: result.cache_scope.tenant_id,
+      merchant_id: result.cache_scope.merchant_id,
+      seller_agent_id: result.cache_scope.seller_agent_id,
+      buyer_agent_id: result.cache_scope.buyer_agent_id ?? null,
+      artifact_family_counts: { [result.artifact_type]: 1 },
+      cache_record_references: [`cache_${result.artifact_id}_C6X9`],
+      maintenance_plan_references: ['oacp_c6x5_maintenance_plan_price_C6X9'],
+      review_packet_references: ['oacp_c6x6_operator_review_price_C6X9'],
+      decision_record_references: ['oacp_c6x7_operator_decision_price_C6X9'],
+      redacted_source_refs: result.source_refs,
+      redacted_evidence_refs: result.evidence_refs,
+      verifier_result_ref: result.verifier_result_ref,
+      freshness_ttl_summary: {
+        freshness: { [result.freshness_status]: 1 },
+        earliest_expires_at: result.expires_at,
+      },
+      revocation_snapshot_summary: { [result.revocation_status]: 1 },
+      risk_tier_summary: { low: 1 },
+      blocked_capability_summary: result.blocked_capabilities,
+      unsupported_capability_summary: result.unsupported_capabilities,
+      allowed_to_execute: result.allowed_to_execute,
+      audit_export_bundle_only: true,
+      generated_artifact_written: false,
+      non_authoritative_for_transaction: result.non_authoritative_for_transaction,
+      no_checkout_payment_enablement: result.no_checkout_payment_enablement,
+      no_live_provider_enablement: result.no_live_provider_enablement,
+      no_public_discovery_enablement: result.no_public_discovery_enablement,
+    };
+
+    for (const requiredField of [
+      'bundle_kind',
+      'tenant_id',
+      'merchant_id',
+      'artifact_family_counts',
+      'cache_record_references',
+      'maintenance_plan_references',
+      'review_packet_references',
+      'decision_record_references',
+      'redacted_source_refs',
+      'redacted_evidence_refs',
+      'freshness_ttl_summary',
+      'revocation_snapshot_summary',
+      'risk_tier_summary',
+      'allowed_to_execute',
+      'audit_export_bundle_only',
+      'non_authoritative_for_transaction',
+    ]) {
+      expect(auditBundleCandidate[requiredField as keyof typeof auditBundleCandidate]).toBeDefined();
+    }
+  });
+
+  it('keeps bundle-compatible fields evidence-only and non-executing', () => {
+    const result = verifiedPriceResult();
+    expect(result.verified).toBe(true);
+    if (!result.verified) throw new Error(result.message);
+
+    expect(result.allowed_to_execute).toBe(false);
+    expect(result.non_authoritative_for_transaction).toBe(true);
+    expect(result.no_checkout_payment_enablement).toBe(true);
+    expect(result.no_public_discovery_enablement).toBe(true);
+    expect(result.no_live_provider_enablement).toBe(true);
+    expect(result.no_provider_calls).toBe(true);
+    expect(result.no_merchant_private_api_calls).toBe(true);
+
+    const refs = [...result.source_refs, ...result.evidence_refs, result.verifier_result_ref];
+    for (const ref of refs) {
+      expect(ref).not.toMatch(/raw|private|secret|token|jwt|passport|password|credential|allowlist/i);
+    }
+  });
+
+  it('documents the C6X9 audit export compatibility boundary', () => {
+    const text = doc();
+    for (const heading of [
+      'Scope',
+      'Compatibility Guard',
+      'Audit Bundle Fields',
+      'Grantex Boundary',
+      'Guardrails',
+      'What C6X9 Does Not Enable',
+      'Future Work',
+    ]) {
+      expect(text).toContain(`## ${heading}`);
+    }
+
+    expect(text).toContain('AgenticOrg remains the buyer and seller AI-agent runtime');
+    expect(text).toContain('Grantex remains the trust, protocol, policy, and canonical OACP artifact authority');
+    expect(text).toContain('not a transaction toll booth');
+    expect(text).toContain('does not receive every audit bundle');
+    expect(text).toContain('allowed_to_execute = false');
+    expect(text).toContain('does not write generated export files');
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6x9-audit-export-compatibility.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6x9-audit-export-compatibility.md
@@ -1,0 +1,50 @@
+# Commerce V1 C6X9 Audit Export Compatibility
+
+## Scope
+
+C6X9 adds a Grantex compatibility guard for AgenticOrg internal OACP cache and operator-decision audit export bundles. Grantex changes are docs and tests only. The guard proves that Grantex cached-artifact verifier output and canonical OACP authority fields can be referenced by AgenticOrg through non-sensitive refs in an export-ready bundle.
+
+## Compatibility Guard
+
+The guard checks that Grantex verifier output carries enough redacted metadata for AgenticOrg audit bundles:
+
+- artifact id and family
+- tenant, merchant, seller-agent, and buyer-agent scope where applicable
+- source refs
+- evidence refs
+- verifier result ref
+- freshness and expiry posture
+- revocation posture
+- risk tier
+- blocked and unsupported capabilities
+- non-enablement flags
+
+These fields are enough for AgenticOrg to connect C6X4 cache records, C6X5 maintenance plans, C6X6 operator review packets, C6X7 operator decisions, and C6X8 durable decision records without sending every non-binding cache turn or every audit bundle back through Grantex.
+
+## Audit Bundle Fields
+
+AgenticOrg can derive bundle fields such as bundle id, scope ids, artifact family counts, cache record refs, maintenance plan refs, review packet refs, decision record refs, redacted reason codes, redacted evidence refs, freshness and TTL summary, revocation summary, risk-tier summary, and blocked or unsupported capability summaries from local cache and decision data plus Grantex-compatible verifier refs.
+
+The bundle remains evidence-only: `allowed_to_execute = false`, `non_authoritative_for_transaction = true`, `no_checkout_payment_enablement = true`, `no_live_provider_enablement = true`, and `no_public_discovery_enablement = true`.
+
+## Grantex Boundary
+
+Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. AgenticOrg remains the buyer and seller AI-agent runtime and owns local cache behavior, local operator decision handling, and internal audit bundle preparation. Grantex is not a transaction toll booth and does not receive every audit bundle, every local cache report, every local operator decision, or every non-binding buyer/seller agent interaction.
+
+Audit export bundles are not Grantex approvals, merchant approvals, checkout approvals, payment approvals, mandate approvals, live-provider approvals, production approvals, certification, compliance, conformance, standardization, or public launch readiness.
+
+## Guardrails
+
+C6X9 keeps OACP internal, non-publication, non-certifying, non-production, non-executing, fail-closed, and non-authoritative for transactions. Grantex stores only non-sensitive evidence references where policy or artifact lineage requires them. This guard does not add Grantex persistence for AgenticOrg audit bundles.
+
+The compatibility shape excludes raw artifact payloads, provider payloads, connector payloads, raw JWTs or passports, credentials, tokens, private keys, private customer data, payment data, bank or card data, raw merchant private API values, raw reviewer identity, secrets, production allowlists, executable URLs, and action targets.
+
+## What C6X9 Does Not Enable
+
+C6X9 adds no Grantex route, endpoint, public OpenAPI runtime contract, migration, workflow, cloud resource, scheduler, queue, background worker, production config, secret, provider adapter, provider call, merchant private API call, public discovery enablement, checkout, payment, order, hold, refund, return, shipping execution, live rail enablement, live Plural behavior, allowlist, external OACP publication, or approval/readiness claim.
+
+C6X9 does not write generated export files and does not publish or submit an audit bundle externally.
+
+## Future Work
+
+Future slices may define a separately approved internal export review surface, export writer, retention model, or audit-chain handoff. That work must remain separate from checkout, payment, provider rails, merchant private APIs, public OACP publication, production config, workflow scheduling, and public endpoint behavior unless explicitly approved.


### PR DESCRIPTION
## Summary
- add C6X9 docs/tests compatibility guard for AgenticOrg audit export bundles
- keep Grantex as canonical OACP artifact authority, not a transaction toll booth
- add no runtime source, endpoint, workflow, migration, config, provider call, or publication behavior

## Validation
- npm --prefix apps/auth-service test -- commerce-c6x6-cache-maintenance-report-compatibility.test.ts commerce-c6x7-operator-decision-compatibility.test.ts commerce-c6x8-operator-decision-audit-compatibility.test.ts commerce-c6x9-audit-export-compatibility.test.ts
- npm --prefix apps/auth-service run typecheck
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
- git diff --check origin/main...HEAD
- ASCII/hidden Unicode and guardrail scans on touched files