### PR TITLE
C6Y3 review manifest summary compatibility

### DIFF
--- a/apps/auth-service/tests/commerce-c6y3-review-manifest-summary-compatibility.test.ts
+++ b/apps/auth-service/tests/commerce-c6y3-review-manifest-summary-compatibility.test.ts
@@ -1,0 +1,143 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  OACP_C6W3_VALID_ARTIFACT_FIXTURES,
+  verifyOacpC6X2CachedArtifactEnvelope,
+} from '../src/lib/commerce/oacp-trust-artifacts.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const DOC_PATH = join(
+  TEST_DIR,
+  '../../../docs/internal/commerce-v1/commerce-v1-c6y3-review-manifest-summary-compatibility.md',
+);
+
+function doc() {
+  return readFileSync(DOC_PATH, 'utf8');
+}
+
+function verifiedPriceResult() {
+  return verifyOacpC6X2CachedArtifactEnvelope({
+    artifact: OACP_C6W3_VALID_ARTIFACT_FIXTURES.price,
+    now_iso: '2026-06-11T00:00:20.000Z',
+    expected_scope: {
+      tenant_id: 'cten_C6W3',
+      merchant_id: 'mch_C6W3',
+      seller_agent_id: 'seller_C6W3',
+      buyer_agent_id: 'buyer_C6W3',
+    },
+    risk_tier: 'low',
+    revocation_snapshot: {
+      status: 'fresh',
+      observed_at: '2026-06-11T00:00:10.000Z',
+      age_seconds: 10,
+      revoked_artifact_ids: [],
+      revoked_subject_ids: [],
+    },
+    verifier_result_ref: 'verifier_result_price_C6Y3',
+    signature_verified: true,
+  });
+}
+
+describe('C6Y3 AgenticOrg review manifest summary compatibility guard', () => {
+  it('keeps Grantex verifier fields sufficient for redacted AgenticOrg manifest summaries', () => {
+    const result = verifiedPriceResult();
+    expect(result.verified).toBe(true);
+    if (!result.verified) throw new Error(result.message);
+
+    const summaryCandidate = {
+      summary_kind: 'oacp_audit_review_manifest_redacted_summary',
+      summary_id: `summary_${result.artifact_id}_C6Y3`,
+      generated_at: '2026-06-12T00:05:00.000Z',
+      tenant_id: result.cache_scope.tenant_id,
+      merchant_id: result.cache_scope.merchant_id,
+      seller_agent_id: result.cache_scope.seller_agent_id,
+      buyer_agent_id: result.cache_scope.buyer_agent_id ?? null,
+      manifest_count: 1,
+      retention_class_counts: { standard_internal_review: 1 },
+      retention_due_count: 0,
+      legal_hold_candidate_count: 0,
+      artifact_family_counts: { [result.artifact_type]: 1 },
+      risk_tier_counts: { low: 1 },
+      freshness_ttl_summary: {
+        freshness: { [result.freshness_status]: 1 },
+        expires_at_refs: [result.expires_at],
+      },
+      revocation_snapshot_summary: { [result.revocation_status]: 1 },
+      blocked_capability_summary: result.blocked_capabilities,
+      unsupported_capability_summary: result.unsupported_capabilities,
+      redacted_evidence_ref_count: result.evidence_refs.length,
+      next_step_labels: ['internal_review_summary_label_only'],
+      allowed_to_execute: result.allowed_to_execute,
+      non_authoritative_for_transaction: result.non_authoritative_for_transaction,
+      no_checkout_payment_enablement: result.no_checkout_payment_enablement,
+      no_live_provider_enablement: result.no_live_provider_enablement,
+      no_public_discovery_enablement: result.no_public_discovery_enablement,
+      no_export_file_written: true,
+    };
+
+    for (const requiredField of [
+      'summary_kind',
+      'summary_id',
+      'generated_at',
+      'tenant_id',
+      'merchant_id',
+      'manifest_count',
+      'retention_class_counts',
+      'artifact_family_counts',
+      'freshness_ttl_summary',
+      'revocation_snapshot_summary',
+      'risk_tier_counts',
+      'blocked_capability_summary',
+      'unsupported_capability_summary',
+      'redacted_evidence_ref_count',
+      'allowed_to_execute',
+      'non_authoritative_for_transaction',
+      'no_export_file_written',
+    ]) {
+      expect(summaryCandidate[requiredField as keyof typeof summaryCandidate]).toBeDefined();
+    }
+  });
+
+  it('keeps summary-compatible references redacted and non-executing', () => {
+    const result = verifiedPriceResult();
+    expect(result.verified).toBe(true);
+    if (!result.verified) throw new Error(result.message);
+
+    expect(result.allowed_to_execute).toBe(false);
+    expect(result.non_authoritative_for_transaction).toBe(true);
+    expect(result.no_checkout_payment_enablement).toBe(true);
+    expect(result.no_public_discovery_enablement).toBe(true);
+    expect(result.no_live_provider_enablement).toBe(true);
+    expect(result.no_provider_calls).toBe(true);
+    expect(result.no_merchant_private_api_calls).toBe(true);
+
+    const refs = [...result.source_refs, ...result.evidence_refs, result.verifier_result_ref];
+    for (const ref of refs) {
+      expect(ref).not.toMatch(/raw|private|secret|token|jwt|passport|password|credential|allowlist/i);
+    }
+  });
+
+  it('documents the C6Y3 review manifest summary compatibility boundary', () => {
+    const text = doc();
+    for (const heading of [
+      'Scope',
+      'Compatibility Guard',
+      'Manifest Query And Summary Fields',
+      'Grantex Boundary',
+      'Guardrails',
+      'What C6Y3 Does Not Enable',
+      'Future Work',
+    ]) {
+      expect(text).toContain(`## ${heading}`);
+    }
+
+    expect(text).toContain('AgenticOrg remains the buyer and seller AI-agent runtime');
+    expect(text).toContain('Grantex remains the trust, protocol, policy, and canonical OACP artifact authority');
+    expect(text).toContain('not a transaction toll booth');
+    expect(text).toContain('does not receive every manifest summary');
+    expect(text).toContain('allowed_to_execute = false');
+    expect(text).toContain('does not write export files');
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6y3-review-manifest-summary-compatibility.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6y3-review-manifest-summary-compatibility.md
@@ -1,0 +1,70 @@
+# C6Y3 Review Manifest Summary Compatibility
+
+## Scope
+
+C6Y3 confirms that Grantex OACP verifier and authority references remain sufficient for AgenticOrg internal audit review manifest queries and redacted summaries. This is a docs/tests compatibility guard only.
+
+Grantex does not add runtime code, persistence, routes, endpoints, OpenAPI contracts, workflows, cloud behavior, provider calls, private API calls, public discovery behavior, checkout/payment behavior, live rails, or export writers in this slice.
+
+## Compatibility Guard
+
+AgenticOrg remains the buyer and seller AI-agent runtime. AgenticOrg owns durable/local OACP artifact cache behavior, local operator decision handling, audit export bundle generation, audit review manifest handling, and C6Y3 internal manifest summary generation.
+
+Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. Its verifier/cache metadata can be referenced by AgenticOrg through non-sensitive authority, artifact, lineage, freshness, revocation, risk, blocked, unsupported, and evidence-reference fields.
+
+## Manifest Query And Summary Fields
+
+The compatibility guard expects AgenticOrg summaries to retain:
+
+- tenant, merchant, seller agent, and buyer agent scope
+- artifact family/type counts
+- retention class counts
+- retention due counts
+- legal hold candidate counts
+- freshness and TTL summary
+- revocation snapshot summary
+- risk tier counts
+- blocked and unsupported capability summaries
+- redacted evidence ref counts only
+- next-step labels only
+- allowed_to_execute = false
+- non_authoritative_for_transaction = true
+- no_export_file_written = true
+
+Grantex verifier results already provide the non-sensitive artifact id/type, source refs, evidence refs, freshness, revocation, risk, blocked capabilities, unsupported capabilities, and non-enablement posture needed for these summaries.
+
+## Grantex Boundary
+
+Grantex does not receive every manifest summary, every audit review manifest, every audit export bundle, or every non-binding buyer/seller interaction. Grantex must not become a transaction toll booth for local cache review, non-binding preview, or internal operator-summary workflows; it is not a transaction toll booth.
+
+The summary is not a Grantex approval, merchant approval, checkout approval, payment approval, mandate approval, live-provider approval, production approval, public launch approval, certification, compliance statement, conformance statement, standardization claim, or OACP public approval.
+
+## Guardrails
+
+The C6Y3 compatibility guard preserves:
+
+- internal-only review metadata
+- redacted evidence references only
+- no raw artifact payloads
+- no provider payloads
+- no connector payloads
+- no raw JWTs or passports
+- no credentials, tokens, private keys, or secrets
+- no private customer data
+- no payment or bank/card data
+- no raw merchant private API values
+- no raw reviewer identity
+- allowed_to_execute = false
+- no checkout/payment enablement
+- no live provider enablement
+- no public discovery enablement
+
+## What C6Y3 Does Not Enable
+
+C6Y3 does not write export files, run maintenance, schedule retention, expose APIs, create orders, create holds, capture payments, create mandates, issue refunds, process returns, create shipments, call providers, call carriers, call shipping providers, call merchant private APIs, publish OACP, submit protocols externally, or enable public discovery.
+
+C6Y3 does not claim certification, compliance, conformance, standardization, production readiness, public launch readiness, merchant approval, checkout approval, payment approval, mandate approval, live-provider readiness, or OACP approval.
+
+## Future Work
+
+A future approved slice may connect these summaries to an internal operator review surface. That work must remain redacted, tenant-scoped, non-executing, and separately reviewed before any endpoint, scheduler, export writer, or production retention action is introduced.


### PR DESCRIPTION
C6Y3 docs/tests compatibility guard only. Adds internal Grantex compatibility coverage for AgenticOrg redacted audit review manifest summaries. No runtime code, endpoints, migrations, workflows, schedulers, export writers, provider calls, payment/checkout enablement, public discovery, or publication behavior. Local validation: C6Y1-C6Y3 focused tests, auth-service typecheck, C6Oe preview conformance gate, git diff --check.