### PR TITLE
C6Y4 retention disposition compatibility guard

### DIFF
--- a/apps/auth-service/tests/commerce-c6y4-retention-disposition-compatibility.test.ts
+++ b/apps/auth-service/tests/commerce-c6y4-retention-disposition-compatibility.test.ts
@@ -1,0 +1,155 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  OACP_C6W3_VALID_ARTIFACT_FIXTURES,
+  verifyOacpC6X2CachedArtifactEnvelope,
+} from '../src/lib/commerce/oacp-trust-artifacts.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const DOC_PATH = join(
+  TEST_DIR,
+  '../../../docs/internal/commerce-v1/commerce-v1-c6y4-retention-disposition-compatibility.md',
+);
+
+function doc() {
+  return readFileSync(DOC_PATH, 'utf8');
+}
+
+function verifiedPriceResult() {
+  return verifyOacpC6X2CachedArtifactEnvelope({
+    artifact: OACP_C6W3_VALID_ARTIFACT_FIXTURES.price,
+    now_iso: '2026-06-11T00:00:20.000Z',
+    expected_scope: {
+      tenant_id: 'cten_C6W3',
+      merchant_id: 'mch_C6W3',
+      seller_agent_id: 'seller_C6W3',
+      buyer_agent_id: 'buyer_C6W3',
+    },
+    risk_tier: 'low',
+    revocation_snapshot: {
+      status: 'fresh',
+      observed_at: '2026-06-11T00:00:10.000Z',
+      age_seconds: 10,
+      revoked_artifact_ids: [],
+      revoked_subject_ids: [],
+    },
+    verifier_result_ref: 'verifier_result_price_C6Y4',
+    signature_verified: true,
+  });
+}
+
+describe('C6Y4 AgenticOrg retention disposition compatibility guard', () => {
+  it('keeps verifier fields sufficient for AgenticOrg retention disposition dry-runs', () => {
+    const result = verifiedPriceResult();
+    expect(result.verified).toBe(true);
+    if (!result.verified) throw new Error(result.message);
+
+    const dispositionCandidate = {
+      packet_kind: 'oacp_retention_disposition_dry_run',
+      packet_id: `retention_disposition_${result.artifact_id}_C6Y4`,
+      generated_at: '2026-06-12T00:06:00.000Z',
+      summary_id: `summary_${result.artifact_id}_C6Y4`,
+      tenant_id: result.cache_scope.tenant_id,
+      merchant_id: result.cache_scope.merchant_id,
+      seller_agent_id: result.cache_scope.seller_agent_id,
+      buyer_agent_id: result.cache_scope.buyer_agent_id ?? null,
+      manifest_count: 1,
+      retention_class_counts: { standard_internal_review: 1 },
+      retention_due_count: 0,
+      legal_hold_candidate_count: 0,
+      artifact_family_counts: { [result.artifact_type]: 1 },
+      risk_tier_counts: { low: 1 },
+      freshness_ttl_summary: { freshness: { [result.freshness_status]: 1 } },
+      revocation_snapshot_summary: { [result.revocation_status]: 1 },
+      blocked_capability_summary: result.blocked_capabilities,
+      unsupported_capability_summary: result.unsupported_capabilities,
+      redacted_evidence_ref_count: result.evidence_refs.length,
+      disposition_previews: [
+        {
+          disposition: 'retain',
+          reason_code: 'retention_boundary_not_due',
+          next_step_label: 'operator_retain_review_label_only',
+        },
+      ],
+      allowed_to_execute: result.allowed_to_execute,
+      future_retention_action_allowed: false,
+      records_deleted: false,
+      retention_executed: false,
+      non_authoritative_for_transaction: result.non_authoritative_for_transaction,
+      no_checkout_payment_enablement: result.no_checkout_payment_enablement,
+      no_live_provider_enablement: result.no_live_provider_enablement,
+      no_public_discovery_enablement: result.no_public_discovery_enablement,
+      no_export_file_written: true,
+    };
+
+    for (const requiredField of [
+      'packet_kind',
+      'packet_id',
+      'summary_id',
+      'tenant_id',
+      'merchant_id',
+      'manifest_count',
+      'retention_class_counts',
+      'retention_due_count',
+      'artifact_family_counts',
+      'freshness_ttl_summary',
+      'revocation_snapshot_summary',
+      'risk_tier_counts',
+      'blocked_capability_summary',
+      'unsupported_capability_summary',
+      'redacted_evidence_ref_count',
+      'disposition_previews',
+      'allowed_to_execute',
+      'future_retention_action_allowed',
+      'records_deleted',
+      'non_authoritative_for_transaction',
+      'no_export_file_written',
+    ]) {
+      expect(dispositionCandidate[requiredField as keyof typeof dispositionCandidate]).toBeDefined();
+    }
+  });
+
+  it('keeps disposition-compatible references redacted and non-executing', () => {
+    const result = verifiedPriceResult();
+    expect(result.verified).toBe(true);
+    if (!result.verified) throw new Error(result.message);
+
+    expect(result.allowed_to_execute).toBe(false);
+    expect(result.non_authoritative_for_transaction).toBe(true);
+    expect(result.no_checkout_payment_enablement).toBe(true);
+    expect(result.no_public_discovery_enablement).toBe(true);
+    expect(result.no_live_provider_enablement).toBe(true);
+    expect(result.no_provider_calls).toBe(true);
+    expect(result.no_merchant_private_api_calls).toBe(true);
+
+    const refs = [...result.source_refs, ...result.evidence_refs, result.verifier_result_ref];
+    for (const ref of refs) {
+      expect(ref).not.toMatch(/raw|private|secret|token|jwt|passport|password|credential|allowlist/i);
+    }
+  });
+
+  it('documents the C6Y4 retention disposition compatibility boundary', () => {
+    const text = doc();
+    for (const heading of [
+      'Scope',
+      'Compatibility Guard',
+      'Retention Disposition Fields',
+      'Grantex Boundary',
+      'Guardrails',
+      'What C6Y4 Does Not Enable',
+      'Future Work',
+    ]) {
+      expect(text).toContain(`## ${heading}`);
+    }
+
+    expect(text).toContain('AgenticOrg remains the buyer and seller AI-agent runtime');
+    expect(text).toContain('Grantex remains the trust, protocol, policy, and canonical OACP artifact authority');
+    expect(text).toContain('not a transaction toll booth');
+    expect(text).toContain('does not receive every retention disposition packet');
+    expect(text).toContain('allowed_to_execute = false');
+    expect(text).toContain('future_retention_action_allowed = false');
+    expect(text).toContain('does not delete records');
+  });
+});

--- a/docs/internal/commerce-v1/commerce-v1-c6y4-retention-disposition-compatibility.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6y4-retention-disposition-compatibility.md
@@ -1,0 +1,78 @@
+# C6Y4 Retention Disposition Compatibility
+
+## Scope
+
+C6Y4 confirms that Grantex OACP verifier and authority references remain sufficient for AgenticOrg internal audit review manifest retention disposition dry-runs and operator review packets. This is a docs/tests compatibility guard only.
+
+Grantex does not add runtime code, persistence, routes, endpoints, OpenAPI contracts, workflows, cloud behavior, provider calls, private API calls, public discovery behavior, checkout/payment behavior, live rails, schedulers, CLIs, migrations, or export writers in this slice.
+
+## Compatibility Guard
+
+AgenticOrg remains the buyer and seller AI-agent runtime. AgenticOrg owns durable/local OACP artifact cache behavior, local operator decision handling, audit export bundle generation, audit review manifest handling, internal manifest query/summary behavior, and C6Y4 retention disposition dry-runs.
+
+Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. Its verifier/cache metadata can be referenced by AgenticOrg through non-sensitive authority, artifact, lineage, freshness, revocation, risk, blocked, unsupported, and evidence-count fields.
+
+## Retention Disposition Fields
+
+The compatibility guard expects AgenticOrg retention disposition packets to retain:
+
+- tenant, merchant, seller agent, and buyer agent scope
+- source C6Y3 summary id
+- manifest_count
+- retention class counts
+- retention due counts
+- legal hold candidate counts
+- artifact family/type counts
+- freshness and TTL summary
+- revocation snapshot summary
+- risk tier counts
+- blocked and unsupported capability summaries
+- redacted evidence ref count only
+- disposition previews such as retain, review_later, legal_hold_review, redaction_review_required, retention_due_review, and blocked_unsafe
+- next-step labels only
+- allowed_to_execute = false
+- future_retention_action_allowed = false
+- records_deleted = false
+- retention_executed = false
+- non_authoritative_for_transaction = true
+- no_export_file_written = true
+
+Grantex verifier results already provide the non-sensitive artifact id/type, source refs, evidence refs, freshness, revocation, risk, blocked capabilities, unsupported capabilities, and non-enablement posture needed for AgenticOrg to build these dry-run-only packets.
+
+## Grantex Boundary
+
+Grantex does not receive every retention disposition packet, every audit review manifest, every audit export bundle, every retention review, or every non-binding buyer/seller interaction. Grantex must not become a transaction toll booth for local retention review, cache review, non-binding preview, or internal operator-summary workflows; it is not a transaction toll booth.
+
+The disposition dry-run is not a Grantex approval, merchant approval, checkout approval, payment approval, mandate approval, live-provider approval, production approval, public launch approval, certification, compliance statement, conformance statement, standardization claim, or OACP public approval.
+
+## Guardrails
+
+The C6Y4 compatibility guard preserves:
+
+- internal-only review metadata
+- redacted evidence reference counts only
+- no raw artifact payloads
+- no provider payloads
+- no connector payloads
+- no raw JWTs or passports
+- no credentials, tokens, private keys, or secrets
+- no private customer data
+- no payment or bank/card data
+- no raw merchant private API values
+- no raw reviewer identity
+- allowed_to_execute = false
+- future_retention_action_allowed = false
+- records_deleted = false
+- no checkout/payment enablement
+- no live provider enablement
+- no public discovery enablement
+
+## What C6Y4 Does Not Enable
+
+C6Y4 does not execute retention, does not delete records, purge records, write export files, run maintenance, schedule retention, expose APIs, create orders, create holds, capture payments, create mandates, issue refunds, process returns, create shipments, call providers, call carriers, call shipping providers, call merchant private APIs, call Grantex live endpoints, publish OACP, submit protocols externally, or enable public discovery.
+
+C6Y4 does not claim certification, compliance, conformance, standardization, production readiness, public launch readiness, merchant approval, checkout approval, payment approval, mandate approval, live-provider readiness, or OACP approval.
+
+## Future Work
+
+A future approved slice may connect these dry-runs to durable disposition decisions or an internal operator review surface. That work must remain redacted, tenant-scoped, non-executing, and separately reviewed before any endpoint, scheduler, CLI, export writer, migration, or production retention action is introduced.


### PR DESCRIPTION
C6Y4 docs/tests compatibility guard only. Adds internal Grantex compatibility coverage for AgenticOrg retention disposition dry-runs and operator review packets over C6Y3 summaries. No runtime code, endpoints, migrations, workflows, schedulers, CLIs, export writers, provider calls, payment/checkout enablement, public discovery, or publication behavior. Local validation: C6Y1-C6Y4 focused tests, auth-service typecheck, C6Oe preview conformance gate, git diff --check.