### PR TITLE
[codex] Tighten C6Z authority intake

### DIFF
--- a/apps/auth-service/src/routes/commerce-oacp-runtime.ts
+++ b/apps/auth-service/src/routes/commerce-oacp-runtime.ts
@@ -31,8 +31,13 @@ export async function commerceOacpRuntimeRoutes(app: FastifyInstance) {
     const authorityRequest = body.request;
     const requestStatus = validateC6ZSellerAuthorityRequest(authorityRequest, now);
     if (!body.connector_evidence || requestStatus.status !== 'artifact_issuance_ready') {
+      const intakeOnly = !body.connector_evidence && requestStatus.status === 'artifact_issuance_ready';
       return reply.status(requestStatus.status === 'rejected' ? 422 : 202).send({
         ...requestStatus,
+        status: intakeOnly ? 'received' : requestStatus.status,
+        message: intakeOnly
+          ? 'Authority request received. Connector evidence is required before internal C6Z artifact issuance.'
+          : requestStatus.message,
         route_kind: 'grantex_internal_c6z_authority_request',
         artifact_issuance_attempted: false,
       });

--- a/apps/auth-service/tests/commerce-c6z-runtime-artifact-authority.test.ts
+++ b/apps/auth-service/tests/commerce-c6z-runtime-artifact-authority.test.ts
@@ -157,6 +157,19 @@ describe('C6Z Grantex runtime artifact authority', () => {
       allowed_to_execute: false,
     });
 
+    expect(issueC6ZInternalOacpArtifacts({
+      request: authorityRequest(),
+      evidence: {
+        ...connectorEvidence(),
+        inventory_snapshot_refs: ['raw_provider_payload:provider'],
+      },
+      now_iso: NOW,
+    })).toMatchObject({
+      status: 'rejected',
+      refusal_code: 'private_or_executable_connector_evidence',
+      allowed_to_execute: false,
+    });
+
     expect(validateC6ZSellerAuthorityRequest(
       authorityRequest({ requested_authority_scope: ['checkout.create'] }),
       NOW,
@@ -191,5 +204,30 @@ describe('C6Z Grantex runtime artifact authority', () => {
       no_public_discovery_enablement: true,
     });
     expect(body.artifacts[0].envelope.tenant_id).toBe('cten_C6Z');
+  });
+
+  it('receives valid intake requests without issuing artifacts until connector evidence is present', async () => {
+    seedCommerceContext('cten_C6Z');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/oacp/c6z/authority-requests',
+      headers: authHeader(),
+      payload: {
+        now_iso: NOW,
+        request: authorityRequest(),
+      },
+    });
+
+    expect(response.statusCode).toBe(202);
+    expect(response.json()).toMatchObject({
+      route_kind: 'grantex_internal_c6z_authority_request',
+      status: 'received',
+      artifact_issuance_attempted: false,
+      artifacts: [],
+      allowed_to_execute: false,
+      no_payment_execution: true,
+      no_public_discovery_enablement: true,
+    });
   });
 });

--- a/docs/internal/commerce-v1/commerce-v1-c6z-runtime-artifact-authority.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6z-runtime-artifact-authority.md
@@ -40,12 +40,12 @@ It accepts:
 
 It returns one of:
 
-- `received`
+- `received` when a valid intake request arrives before connector evidence
 - `pending_sandbox_review`
 - `rejected`
 - `artifact_issuance_ready`
 
-No live approval or public discovery state is created by this endpoint.
+No live approval or public discovery state is created by this endpoint. Internal artifacts are issued only when the request is valid and redacted connector evidence is present.
 
 ## Issued Artifact Families
 


### PR DESCRIPTION
## Summary

Completes the Grantex side of the C6Z runtime vertical demo gaps on top of the existing C6Z authority/issuance implementation:

- returns `received` for valid authority intake requests that do not yet include redacted connector evidence
- keeps internal artifact issuance gated until valid request scope and connector evidence are both present
- adds regression coverage for intake-without-evidence and raw provider payload rejection
- updates the internal C6Z authority documentation to reflect intake-only behavior

Grantex remains the trust/protocol/policy/canonical OACP artifact authority and does not become the runtime transaction path. This PR does not enable live approval, public discovery, checkout/payment execution, mandates, orders, or provider rail execution.

## Validation

- `cd apps/auth-service && npm test -- commerce-c6z-runtime-artifact-authority.test.ts`
- `cd apps/auth-service && npm test -- commerce-c6z-runtime-artifact-authority.test.ts commerce-c6w3-oacp-artifact-schemas.test.ts commerce-c6w4-oacp-adapter-previews.test.ts commerce-c6x2-oacp-cache-verifier.test.ts commerce-c6x3-cache-repository-compatibility.test.ts commerce-c6x4-durable-cache-compatibility.test.ts commerce-no-plural-leak.test.ts`
- `cd apps/auth-service && npm run typecheck`
- `node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr`
- `node docs/commerce-v1-pilot-readiness.validate.mjs`
- `git diff --check`

## Guardrail Scans

- Secret/private payload scan: only intentional raw-payload rejection fixtures and generic credential wording found.
- Provider-specific leak scan: no `Plural`/`Pine`/`plural_pine`/`plural-pine` hits in the changed Grantex route, C6Z authority test, or C6Z authority doc.
- Existing `commerce-no-plural-leak.test.ts` passed.

## External Blockers

This PR adds internal authority intake/issuance behavior only. It does not publish OACP externally and does not validate live merchant/provider operations.
