### PR TITLE
docs: reconcile OACP launch evidence and blockers

### DIFF
--- a/docs/blog/shopify-oacp-commerce-live-flow.mdx
+++ b/docs/blog/shopify-oacp-commerce-live-flow.mdx
@@ -1,171 +1,64 @@
 ---
-title: "Shopify To OACP: The Grantex Commerce Live Flow"
-description: "The end-to-end live-pilot path from a Shopify merchant profile to AgenticOrg discovery, Grantex consent, Commerce Passport, payment intent, Plural webhook intake, reconciliation, and audit."
-date: "2026-06-14"
+title: "Shopify, Grantex Commerce, And OACP: Current Boundary"
+description: "Separates the Grantex Commerce payment-control pilot from the blocked AgenticOrg C6Z OACP runtime artifact vertical."
+date: "2026-06-18"
 authors:
   - name: "Sanjeev Mishra"
 ---
 
-Grantex Commerce V1 is now live for the approved Shopify pilot merchant
-`mch_shopify_mgx0n6_22`, imported from `mgx0n6-22.myshopify.com`.
+This draft is retained as a boundary note, not as a launch announcement.
 
-The important design choice is still the same: the agent does not get direct
-payment-provider credentials or private merchant-system access. AgenticOrg uses
-Grantex commerce tools. Grantex owns the consent, Commerce Passport, merchant
-policy, payment-control, webhook, reconciliation, and audit boundary.
+Grantex Commerce payment-control pilot work and the AgenticOrg C6Z OACP runtime
+artifact vertical are separate. The payment-control pilot can discuss Grantex
+Commerce V1, consent, Commerce Passport, payment intent, webhook intake,
+reconciliation, and audit inside its own approved scope. It must not be used as
+proof that the AgenticOrg production OACP artifact vertical is complete.
 
-## What Is Deployed
+## Current C6Z OACP Runtime Status
 
-The live pilot currently has:
+As of June 18, 2026, the real production C6Z OACP runtime vertical is blocked:
 
-- Shopify merchant profile imported as `mch_shopify_mgx0n6_22`.
-- Tenant `cten_shopify_mgx0n6_22`.
-- AgenticOrg commerce agent `cag_agenticorg_mgx0n6_22`.
-- Five Shopify products and five variants available through Grantex catalog
-  search.
-- Commerce discovery metadata at
-  `https://api.grantex.dev/.well-known/grantex-commerce`.
-- Plural webhook intake at
-  `https://api.grantex.dev/v1/webhooks/providers/plural`.
-- Live Commerce V1 runtime flags and live-readiness acknowledgements enabled.
-- Reconciliation worker enabled.
-- Operator health reporting green for database, mock adapter, Plural adapter,
-  and reconciliation.
+- AgenticOrg production is healthy at commit
+  `2fdccc7ca1337b3b2caa20a2e9ac1d03c7bfbc9c`.
+- Grantex production is healthy at commit
+  `7fd4dd3c865fbd8187d92aec792cff249c9c01c3`.
+- AgenticOrg Shopify Admin GraphQL read-only sync for
+  `mgx0n6-22.myshopify.com` fails with `401 Unauthorized`.
+- A direct status-only Shopify GraphQL probe using the mounted AgenticOrg C6Z
+  Shopify token also returns `401`.
+- Grantex C6Z authority called with the AgenticOrg-configured internal token
+  returns `422 tenant_not_provisioned`.
+- Grantex C6Z authority called by a platform-admin operator can issue 8
+  internal artifacts, all verifier-valid and all non-executing.
 
-Plural credentials currently authenticate against Plural UAT-compatible rails.
-That makes the adapter and webhook path operational for the pilot, but this post
-does not claim production Plural settlement certification.
+## Correct Architecture
 
-## End-To-End Flow
+- AgenticOrg is the buyer and seller AI-agent runtime.
+- Grantex is the trust, protocol, policy, and canonical OACP artifact authority.
+- Shopify remains the operational system of record for merchant catalog facts.
+- Plural/Pine and other provider or fintech rails own mandate and payment
+  execution.
+- Valid cached OACP artifacts may support non-binding buyer answers without
+  routing every buyer turn through Grantex.
 
-```mermaid
-sequenceDiagram
-  participant S as Shopify merchant
-  participant G as Grantex Commerce
-  participant A as AgenticOrg commerce agent
-  participant U as Buyer
-  participant P as Plural/Pine
+## What Is Not Claimed
 
-  S->>G: Import profile, products, variants
-  A->>G: Discover merchant profile
-  A->>G: Search catalog and inspect item
-  A->>G: Check inventory and create cart
-  A->>G: Request checkout consent
-  U->>G: Approve or deny consent
-  G-->>A: Commerce Passport when approved
-  A->>G: Create payment intent
-  A->>G: Request checkout handoff
-  G->>P: Provider adapter call when policy allows
-  P-->>G: Signed webhook or status response
-  G->>G: Reconcile status and append audit events
-  A->>G: Poll payment status
-```
+This draft does not claim:
 
-## Step 1: Import The Merchant
+- OACP certification, conformance, compliance, or external standardization.
+- Public OACP discovery.
+- Merchant approval, production payment approval, mandate approval, or
+  live-provider readiness from OACP work.
+- Checkout, payment, order, mandate, refund, return, shipment, inventory hold,
+  provider execution, or merchant-private API mutation.
 
-The pilot starts from the real Shopify shop profile. The importer reads the
-shop profile and active products, normalizes the catalog into Grantex commerce
-tables, archives stale Shopify-imported rows, and appends an audit event.
+## Required Before A Launch Post
 
-The production result is intentionally small and reviewable:
-
-| Field | Value |
-| --- | --- |
-| Shopify shop | `mgx0n6-22.myshopify.com` |
-| Merchant ID | `mch_shopify_mgx0n6_22` |
-| Tenant ID | `cten_shopify_mgx0n6_22` |
-| Currency | `INR` |
-| Country | `IN` |
-| Product count | 5 |
-| Variant count | 5 |
-
-No Shopify token, Grantex API key, provider credential, webhook secret, passport,
-or database URL is included in docs or evidence.
-
-## Step 2: Publish The Merchant Profile
-
-Agents can retrieve the approved merchant profile through:
-
-```bash
-curl "https://api.grantex.dev/.well-known/grantex-commerce?merchant_id=mch_shopify_mgx0n6_22"
-```
-
-The profile tells agents which Grantex-native REST and MCP surfaces are
-available. It also reports the live-pilot posture: live payments and live Plural
-runtime flags are enabled for the approved pilot, while provider credentials
-remain hidden.
-
-## Step 3: Ground Catalog Search
-
-AgenticOrg searches catalog through Grantex, not Shopify directly:
-
-```http
-POST /v1/commerce/catalog/search
-Authorization: Bearer <agent-api-key>
-Content-Type: application/json
-
-{
-  "merchant_id": "mch_shopify_mgx0n6_22",
-  "limit": 5
-}
-```
-
-The live smoke returns the five imported products. Agents must use returned
-product and variant IDs; they must not invent price, stock, warranty, return, or
-delivery facts.
-
-## Step 4: Create Cart, Consent, And Passport
-
-Checkout-affecting work is consent-first:
-
-1. The agent creates a cart from grounded variant IDs.
-2. The agent asks Grantex for a consent request.
-3. The buyer approves or denies the request in Grantex.
-4. Grantex issues a scoped Commerce Passport only after consent and policy pass.
-
-The Commerce Passport is runtime-sensitive material. It should never appear in
-logs, docs, screenshots, tickets, or chat.
-
-## Step 5: Create Payment Intent And Checkout Handoff
-
-The agent creates a provider-neutral payment intent through Grantex. Grantex
-checks tenant ownership, merchant status, active policy, amount caps, passport
-scope, idempotency, and live-readiness controls before any provider-affecting
-work proceeds.
-
-AgenticOrg never receives Plural credentials and never calls Pine or Plural
-directly for this flow.
-
-## Step 6: Receive Plural Webhook And Reconcile
-
-Plural/Pine webhook callbacks are pointed at:
-
-```text
-https://api.grantex.dev/v1/webhooks/providers/plural
-```
-
-The route verifies provider headers and signature material before processing.
-Unsigned or missing-header requests fail with `webhook_signature_invalid`.
-That is the expected fail-closed result for unauthenticated probes.
-
-Reconciliation runs as a background safety net and updates payment status from
-safe provider state when needed.
-
-## Step 7: Audit The Flow
-
-Every protected transition writes safe audit evidence. Audit records may include
-IDs, policy versions, decision references, hashes, provider reference IDs, and
-normalized error codes. They must not include bearer tokens, raw passports, raw
-credentials, webhook secrets, raw signatures, payment card data, database URLs,
-Redis URLs, or plaintext idempotency keys.
-
-## What This Launch Means
-
-This is a live Grantex control-plane pilot for a named Shopify merchant. It
-proves the end-to-end OACP path from merchant profile and catalog grounding to
-AgenticOrg tool use, consent, Commerce Passport, payment intent, Plural webhook
-intake, reconciliation, and audit.
-
-It does not claim broad merchant self-service, provider certification, or
-production Plural settlement while the available Plural credentials authenticate
-against UAT-compatible rails.
+1. Rotate or replace the AgenticOrg C6Z Shopify Admin token and confirm
+   read-only GraphQL access.
+2. Provision or replace the AgenticOrg-to-Grantex internal token so the
+   configured path can issue artifacts without platform-admin substitution.
+3. Re-run the full production vertical and capture redacted evidence for:
+   Shopify product/variant counts, Grantex artifact issuance, AgenticOrg cache
+   records, buyer answer source/freshness labels, MCP seller facts, Plural/Pine
+   capability metadata, public discovery disabled, and no execution.

--- a/docs/guides/commerce-v1-agentic-commerce-implementation-prd.md
+++ b/docs/guides/commerce-v1-agentic-commerce-implementation-prd.md
@@ -139,23 +139,30 @@ The repo already has important foundations:
 | MCP/native agent surface | `merchant.get_profile`, `catalog.search`, `catalog.get_item`, `inventory.check`, `cart.create`, `checkout.create`, `payment.create_intent`, `payment.get_status`. | Correct agent surface; public discovery remains fail-closed. |
 | Docs navigation | Commerce V1 docs group exists in `docs/docs.json`. | Updated by this PRD pass to include this implementation PRD. |
 | Deploy workflow guard | Auth-service and portal deploy workflows have path filters for runtime paths. | Docs-only changes should not trigger Grantex deploy workflows, but CI still runs broad validation. |
-| OACP artifact foundation | C6W3-C6W9 internal helpers, tests, and docs define artifact families, adapter previews, commitment boundaries, prepared envelopes, evidence reconciliation, eligibility packets, and dry-run verifier results. | Internal only; no runtime execution, public protocol publication, certification, or production readiness. |
+| OACP artifact foundation | C6W3-C6Z internal helpers, tests, docs, authority route, verifier, and AgenticOrg runtime handoff foundations define artifact families, adapter previews, commitment boundaries, prepared envelopes, evidence reconciliation, eligibility packets, dry-run verifier results, authority requests, cache use, buyer answers, MCP bridge, and capability checks. | Internal only; the 2026-06-18 production vertical is blocked by Shopify token and Grantex tenant-token provisioning issues; no execution, public protocol publication, certification, or production readiness. |
 
-### 2.1 Current OACP Status Through C6W9
+### 2.1 Current OACP Status Through C6Z
 
-The current OACP implementation is a strong internal contract foundation, not a
-live commerce product:
+The current OACP implementation is a strong internal runtime foundation, not a
+live commerce product. The 2026-06-18 production closure run is blocked because
+the mounted AgenticOrg Shopify token returns `401 Unauthorized` and the
+AgenticOrg-configured Grantex token returns `422 tenant_not_provisioned`.
 
 - implemented: internal artifact schemas, public-safe fixtures, adapter
   previews, commitment boundary resolver, prepared envelopes, response
-  reconciliation, eligibility packets, and execution-controller dry-run
-  verifier;
+  reconciliation, eligibility packets, execution-controller dry-run verifier,
+  internal C6Z authority request route, artifact verifier, and non-enablement
+  flags;
 - implemented in both repos: Grantex authority helpers/tests/docs and
-  AgenticOrg local consumer helpers/tests/docs;
-- not implemented: public OACP spec site, public endpoint, production artifact
-  issuer, persistent artifact cache, live connector sync, provider-owned mandate
-  verification runtime, execution controller, order/fulfillment/refund runtime,
-  public discovery, or live checkout/payment;
+  AgenticOrg local consumer/runtime helpers/tests/docs, including seller-agent
+  packet creation, Shopify sync initiation, artifact cache, buyer answer, MCP
+  bridge, and Plural/Pine capability verifier paths;
+- blocked in production: successful Shopify read-only sync with the mounted
+  token and successful AgenticOrg-to-Grantex tenant provisioning for the
+  configured internal token;
+- not implemented or not enabled: public OACP spec site, public endpoint,
+  public discovery, execution controller, order/fulfillment/refund runtime, or
+  live checkout/payment;
 - still blocked: publication, certification, conformance, standards submission,
   production readiness claims, and any real merchant approval.
 
@@ -215,7 +222,7 @@ must not turn protocol adapters into transaction authority.
 
 | Surface | Relevant external idea | Grantex implementation requirement |
 | --- | --- | --- |
-| OACP artifacts | Internal trust profile for seller agents, buyer agents, merchant systems, and provider rails. | C6W3-C6W9 are internal only; artifacts preserve TTL, source/freshness, refusals, and non-enablement flags. |
+| OACP artifacts | Internal trust profile for seller agents, buyer agents, merchant systems, and provider rails. | C6W3-C6Z are internal only; artifacts preserve TTL, source/freshness, refusals, and non-enablement flags. |
 | Native Grantex API | First-party authority APIs for artifacts and policy. | Continue as authority surface, not as a mandatory toll booth for all non-binding cached interactions. |
 | MCP | Agent tool transport. UCP also lists MCP among supported transports. | Expose tools that consume artifacts and preserve refusal semantics. |
 | UCP-style capability profile | UCP discovery uses business/platform profiles, services, capabilities, negotiation, and transports such as REST, MCP, A2A, and embedded. See [UCP overview](https://ucp.dev/specification/overview/). | Publish profiles only from approved merchant capability state. Do not claim UCP certification until conformance tests exist. |
@@ -333,7 +340,8 @@ Grantex landing page planning blocks:
   refusal semantics, source/freshness, revocation, audit evidence.
 - Section 2: "What Grantex does not own" - seller agents, buyer chat runtime,
   merchant operational systems, provider mandate/payment execution.
-- Section 3: "OACP status" - internal C6W9 foundation, no public standard claim.
+- Section 3: "OACP status" - internal C6Z foundation, blocked production
+  vertical, no public standard claim.
 - Section 4: "Protocol adapters" - schema.org, UCP-style, ACP-style,
   AP2-style, A2A-style, MCP-style previews generated from artifacts.
 - Section 5: "Pending before live" - persistent cache, real connectors,
@@ -349,7 +357,7 @@ Blog series plan:
 | How AgenticOrg Seller Agents Connect Shopify, WooCommerce, And ERP | Merchants and integrators | Connector credential-custody choices and source/freshness flow. |
 | Provider-Owned Mandates In Agentic Commerce | Fintech and risk teams | Buyer mandate setup at provider rail, AgenticOrg verification, Grantex evidence refs. |
 | From schema.org To ACP To AP2: Adapter Previews Without Overclaiming | Standards and developers | OACP artifact -> adapter preview fan-out. |
-| What Still Blocks Autonomous Commerce | Leadership and operators | Gap map from C6W9 to live pilot. |
+| What Still Blocks Autonomous Commerce | Leadership and operators | Gap map from C6Z blocked production vertical to live pilot. |
 
 Avoid claims that imply:
 

--- a/docs/guides/commerce-v1-agentic-commerce-prd.md
+++ b/docs/guides/commerce-v1-agentic-commerce-prd.md
@@ -103,11 +103,11 @@ AgenticOrg must not:
 
 ## 4. Current Implementation Snapshot
 
-Status as of 2026-06-13:
+Status as of 2026-06-18:
 
-- Grantex and AgenticOrg have merged the internal OACP foundation through C6W9.
+- Grantex and AgenticOrg have merged the internal OACP foundation through C6Z.
   The implementation is internal, non-publication, non-certifying,
-  non-production, non-executing, and fail-closed.
+  non-executing, and fail-closed.
 - C6W3 defines the OACP artifact family and public-safe fixture corpus.
 - C6W4 defines internal adapter previews for schema.org, UCP-style,
   ACP-style, AP2-style, A2A-style, and MCP-style targets without publication.
@@ -121,6 +121,12 @@ Status as of 2026-06-13:
   read the packet contract. It still does not execute, approve, publish, create
   orders, create checkout/payment, call providers, call merchant private APIs,
   or enable public discovery.
+- C6Z adds the AgenticOrg Seller Commerce Agent runtime path, Shopify read-only
+  sync initiation, Grantex internal authority request route, AgenticOrg artifact
+  cache, buyer answer path, MCP seller facts bridge, and Plural/Pine capability
+  verifier. The 2026-06-18 production closure run is blocked because the
+  mounted AgenticOrg Shopify token returns `401 Unauthorized` and the
+  AgenticOrg-configured Grantex token returns `422 tenant_not_provisioned`.
 - Public discovery, production Commerce V1, checkout/payment enablement, live
   payments, live Plural, production allowlists, certification claims, provider
   execution, and merchant private API execution remain blocked.
@@ -156,20 +162,22 @@ Status as of 2026-06-13:
 
 ### 4.3 OACP Pending Work Register
 
-The current C6W9 state proves internal contract shape only. It is not a public
-protocol, not a transaction engine, and not a live commerce launch. Pending work
-before any public or production OACP claim:
+The current C6Z state proves the internal runtime shape locally and proves the
+Grantex authority issuer route in isolation, but it does not complete the
+AgenticOrg-to-Grantex production vertical. It is not a public protocol, not a
+transaction engine, and not a live commerce launch. Pending work before any
+public or production OACP claim:
 
 | Pending area | Why it matters | Correct owner | First acceptable output |
 | --- | --- | --- | --- |
 | Seller Commerce Agent onboarding | Merchants expect to start in AgenticOrg, not in a protocol console. | AgenticOrg runtime + Grantex authority | Seller agent creates onboarding packet, connector plan, artifact authority request, and blocked-path explanation. |
 | Persistent artifact cache | Buyer and seller agents need continuity without Grantex in every non-binding turn. | AgenticOrg | Cache scoped by buyer agent, seller agent, tenant, and merchant with TTL, revocation snapshot, risk tier, and audit-safe telemetry. |
-| Artifact issuance runtime | C6W3-C6W9 are helper/test foundations, not production issuance services. | Grantex | Internal artifact issuer/verifier service with key lifecycle, detached signature profile, revocation lookup, and no public endpoint until approved. |
+| Artifact issuance runtime | C6Z adds an internal Grantex authority route and verifier, but the AgenticOrg-configured production token is not yet mapped to a commerce tenant. | Grantex | Provisioned internal issuer/verifier path for AgenticOrg with key lifecycle, detached signature profile, revocation lookup, and no public endpoint until approved. |
 | Connector credential custody | Merchants will choose where credentials live. | AgenticOrg + merchant/external connector provider + Grantex policy | Credential-custody matrix, OAuth/app install flow, source evidence refs, no raw secrets in Grantex by default. |
-| Shopify/WooCommerce/ERP sync | Manual/CSV is not enough for real merchants. | AgenticOrg seller connectors + Grantex validation | First real connector sync dry-run with public-safe normalized evidence and rollback. |
+| Shopify/WooCommerce/ERP sync | Manual/CSV is not enough for real merchants. | AgenticOrg seller connectors + Grantex validation | First real connector sync dry-run with public-safe normalized evidence and rollback; the 2026-06-18 Shopify production probe is blocked by `401 Unauthorized`. |
 | Price/inventory freshness | Agents must not promise stale stock or price. | Merchant systems + AgenticOrg cache + Grantex policy | TTL defaults, source timestamps, stale refusal, and refresh request UX per risk tier. |
 | Provider-owned mandate verification | Mandates belong to fintech rails, not Grantex. | Provider/fintech + AgenticOrg verifier | First provider capability verifier with non-sensitive evidence refs only. |
-| Execution controller ownership | C6W9 only dry-runs a future contract. | Product decision across AgenticOrg, merchant systems, and providers | Explicit owner, handoff contract, human approval gates, and stop conditions before any execution slice. |
+| Execution controller ownership | C6Z still creates no checkout, order, mandate, refund, shipment, inventory hold, or provider execution. | Product decision across AgenticOrg, merchant systems, and providers | Explicit owner, handoff contract, human approval gates, and stop conditions before any execution slice. |
 | Third-party agent cards | Other agents should consume seller cards safely. | AgenticOrg + Grantex artifacts | Full or reduced seller cards with risk filters, artifact refs, and no transaction authority. |
 | Public landing and blogs | Market needs clarity; overclaiming would damage trust. | Product/web/docs | Approved public-safe pages and visual explainers after this PRD is approved. |
 | Public OACP governance | A protocol needs neutral stewardship. | Founder/legal/product decision | Separate repo/site, license, IPR posture, versioning, contribution model, and no standards claims until actually submitted/accepted. |
@@ -405,7 +413,7 @@ runtime consumer and channel bridge.
 
 | Surface | Purpose | Requirement |
 | --- | --- | --- |
-| OACP artifacts | Internal trust and interoperability profile across buyer/seller agents, Grantex policy, merchant systems, and provider rails. | Implemented internally through C6W9; not public, not standardized, not certified. |
+| OACP artifacts | Internal trust and interoperability profile across buyer/seller agents, Grantex policy, merchant systems, and provider rails. | Implemented internally through C6Z with a blocked production vertical; not public, not standardized, not certified. |
 | Native Grantex API | First-party authority APIs for canonical artifacts and policy. | Must not be required for every non-binding cached interaction. |
 | MCP | Agent tool transport. | Use as one bridge for ChatGPT/Claude-style surfaces; tools consume artifacts and must preserve refusal semantics. |
 | UCP-style profile | Capability discovery and shopping capabilities. | Publish only approved merchant/channel capability state. |
@@ -468,7 +476,7 @@ in V1 form; others are future gaps.
 | CommerceSettlement/Payout | Grantex | Seller payment reporting. | Gap. |
 | CommerceAuditEvent | Grantex | Append-only evidence. | Foundation exists. |
 | CommerceAgentSession | AgenticOrg/Grantex boundary | Buyer-agent session attribution and channel state. | C6I channel-neutral session orchestration merged; live channels pending. |
-| OacpArtifact | Grantex authority, AgenticOrg cache | Signed or signature-ready public-safe artifact scoped to tenant, merchant, seller agent, and buyer agent. | Internal C6W3-C6W9 foundation merged; persistent runtime issuance/cache pending. |
+| OacpArtifact | Grantex authority, AgenticOrg cache | Signed or signature-ready public-safe artifact scoped to tenant, merchant, seller agent, and buyer agent. | Internal C6W3-C6Z foundation merged; Grantex issuer route and AgenticOrg cache exist, but production handoff is blocked by Shopify token and Grantex tenant provisioning issues. |
 | OacpProtocolAdapterPreview | Grantex authority, AgenticOrg consumer | schema.org/UCP-style/ACP-style/AP2-style/A2A/MCP preview derived from artifacts. | Internal C6W4 foundation merged; public adapter publication pending. |
 | OacpPreparedEnvelope | Grantex authority, AgenticOrg consumer | Prepared-only request envelope for buyer/source/merchant/provider confirmation. | Internal C6W6 foundation merged; runtime handoff pending. |
 | OacpReconciliation | AgenticOrg local runtime, Grantex rules | Local/cached response-evidence reconciliation result. | Internal C6W7 foundation merged; production persistence pending. |
@@ -514,7 +522,7 @@ in V1 form; others are future gaps.
 | Live provider readiness | Payments need approval. | Provider/fintech owner + AgenticOrg verification + Grantex evidence policy | Provider-owned capability verification, non-sensitive evidence refs, rollback rules. | Live provider risk. |
 | Commerce Passport production delivery | Real consent needs delivery. | Grantex | Email/SMS/passkey challenge, revocation, signed evidence. | Weak authorization. |
 | Policy simulator | Merchants need confidence. | Grantex | Preview policy by product/category/channel/amount. | Accidental capability exposure. |
-| OACP and standards adapters | Major platforms need standard surfaces. | Grantex defines artifacts; AgenticOrg consumes and bridges | C6W3-C6W9 internal artifact, adapter, boundary, envelope, reconciliation, eligibility, and dry-run verifier foundations are merged; external publication remains blocked. | Fragmented protocol state or premature external claims. |
+| OACP and standards adapters | Major platforms need standard surfaces. | Grantex defines artifacts; AgenticOrg consumes and bridges | C6W3-C6Z internal artifact, adapter, boundary, envelope, reconciliation, eligibility, dry-run verifier, authority route, cache, and bridge foundations are merged; external publication remains blocked. | Fragmented protocol state or premature external claims. |
 | Buyer channel launch | Buyers need easy entry. | AgenticOrg + Grantex approval | C6I channel-neutral response merged; live channel adapters next. | Agentic commerce hard to use. |
 | Buyer UX | Buyers need understandable flow. | AgenticOrg | C6I read-only buyer session merged; cart/consent/checkout UX remains future. | Confusing or unsafe agent behavior. |
 | Merchant demo UX | Sellers need education. | AgenticOrg | Demo walkthroughs and blocked-path examples. | Misunderstanding production readiness. |
@@ -530,7 +538,7 @@ in V1 form; others are future gaps.
 | --- | --- | --- | --- |
 | 1. Consolidated PRD and docs alignment | One source of truth. | This PRD, docs nav, overview links, AgenticOrg pointers. Status: merged. | Docs-only. |
 | 2. Seller sandbox onboarding | Merchant can prepare without engineers. | AgenticOrg Seller Commerce Agent workflow plus Grantex authority review. Status: planning/docs/runtime foundations exist; full self-serve runtime remains pending. | No live enablement. |
-| 3. Catalog connector MVP | Merchant data enters the OACP artifact path. | CSV/manual readiness and C6N connector registry foundation merged; AgenticOrg seller-agent sync initiation and real adapters pending. | No automatic live publish. |
+| 3. Catalog connector MVP | Merchant data enters the OACP artifact path. | CSV/manual readiness and C6N connector registry foundation merged; AgenticOrg C6Z seller-agent sync path exists, but the 2026-06-18 Shopify production probe is blocked by `401 Unauthorized`. | No automatic live publish. |
 | 4. Public-safe preview | Merchant sees what agents can see. | Catalog/profile preview, schema.org draft, readiness score, and protocol previews merged through C6J-C6M. | Fail-closed until approved. |
 | 5. Buyer web/mobile channel | First controllable buyer launch. | C6H and C6I merged for channel-neutral read-only session; hosted widget/app pending. | Read-only first. |
 | 6. ChatGPT/Claude MCP | Major AI chat surfaces. | Channel-neutral response model merged; remote MCP/app connector pending. | Respect platform write limits. |
@@ -541,7 +549,7 @@ in V1 form; others are future gaps.
 | 11. Order/fulfillment backbone | Operational paid flow. | Order, shipment, pickup/delivery, cancellation. | Required before broad checkout. |
 | 12. Return/refund request | Safe post-purchase support. | Request, eligibility, manual approval, audit. | No automatic refund execution. |
 | 13. Settlement/payout reporting | Seller finance visibility. | Reconciliation and payout read model. | No raw provider payloads. |
-| 14. OACP hardening | Platform interoperability. | C6W3-C6W9 internal artifact, adapter, commitment-boundary, envelope, reconciliation, eligibility, and dry-run verifier foundations are merged. | No submission, publication, certification, or execution claims without explicit approval and evidence. |
+| 14. OACP hardening | Platform interoperability. | C6W3-C6Z internal artifact, adapter, commitment-boundary, envelope, reconciliation, eligibility, dry-run verifier, authority route, cache, and bridge foundations are merged; production closure is blocked on Shopify and Grantex tenant-token provisioning. | No submission, publication, certification, or execution claims without explicit approval and evidence. |
 | 15. Controlled pilot | Minimal real launch. | One merchant, category, channel, provider, geography, rollback owner. | Separate explicit approval. |
 
 Current sequencing decision:

--- a/docs/internal/commerce-v1/commerce-v1-oacp-documentation-inventory.md
+++ b/docs/internal/commerce-v1/commerce-v1-oacp-documentation-inventory.md
@@ -1,0 +1,30 @@
+# Commerce V1 OACP Documentation Inventory
+
+Status: current inventory for OACP closure docs.
+
+Last updated: 2026-06-18.
+
+## Canonical Current Docs
+
+| Document | Purpose | Current status |
+| --- | --- | --- |
+| `commerce-v1-oacp-launch-gap-prd.md` | Blocking gaps and launch status. | Current. |
+| `commerce-v1-oacp-runtime-launch-runbook.md` | Safe production runbook for the C6Z vertical. | Current. |
+| `commerce-v1-oacp-public-narrative-boundary.md` | Allowed and disallowed public claims. | Current. |
+| `commerce-v1-oacp-final-launch-evidence.md` | Final production evidence packet. | Current. |
+| `commerce-v1-oacp-landing-blog-plan.md` | Landing/blog narrative plan. | Updated for C6Z blocker and payment-control separation. |
+| `docs/blog/shopify-oacp-commerce-live-flow.mdx` | Blog draft. | Updated to avoid treating payment-control pilot as C6Z OACP launch proof. |
+
+## Historical Or Adjacent Docs
+
+Older C6W/C6X/C6Y/C6Z implementation notes remain useful for traceability, but they must not override this inventory or the final evidence packet. If copied into public material, they must preserve the non-execution, non-publication, non-certification, and non-standardization boundaries.
+
+## Required Scan Terms
+
+When adding OACP docs, scan for stale claims around:
+
+- "certified", "certification", "conformant", "conformance", "standardized", "standardization"
+- "public discovery enabled"
+- "production ready", "public launch ready", "live-provider ready"
+- "checkout", "payment", "order", "mandate", "refund", "return", "shipment", "inventory hold"
+- "all through Grantex", "Grantex owns every interaction", "thin client"

--- a/docs/internal/commerce-v1/commerce-v1-oacp-final-launch-evidence.md
+++ b/docs/internal/commerce-v1/commerce-v1-oacp-final-launch-evidence.md
@@ -1,0 +1,98 @@
+# Commerce V1 OACP Final Launch Evidence
+
+Status: blocked for production C6Z launch.
+
+Evidence date: 2026-06-18.
+
+## Repository And Deployment State
+
+| Item | Evidence |
+| --- | --- |
+| Grantex `origin/main` | `7fd4dd3c865fbd8187d92aec792cff249c9c01c3` |
+| Grantex production service | `grantex-auth` |
+| Grantex production revision | `grantex-auth-00204-zhz`, 100 percent traffic |
+| Grantex production image | `auth-service:7fd4dd3c865fbd8187d92aec792cff249c9c01c3` |
+| AgenticOrg production commit | `2fdccc7ca1337b3b2caa20a2e9ac1d03c7bfbc9c` |
+| AgenticOrg API revision | `agenticorg-api-00103-jbk`, 100 percent traffic |
+| AgenticOrg UI revision | `agenticorg-ui-00064-kcp`, 100 percent traffic |
+
+## Production Health
+
+- `https://api.grantex.dev/health`: healthy; database ok; Redis ok.
+- `https://app.agenticorg.ai/api/v1/health`: healthy; commit `2fdccc7ca1337b3b2caa20a2e9ac1d03c7bfbc9c`; DB healthy; Redis healthy.
+- `https://app.agenticorg.ai/`: HTTP 200.
+
+## Grantex C6Z Authority Evidence
+
+Unauthenticated and invalid calls to `/v1/commerce/oacp/c6z/authority-requests` returned `401`.
+
+AgenticOrg-configured internal token result:
+
+- HTTP `422`
+- code `tenant_not_provisioned`
+- meaning: the token authenticated, but no commerce tenant is mapped to the developer in this environment.
+
+Platform-admin isolation result:
+
+- status `artifact_issuance_ready`
+- route kind `grantex_internal_c6z_authority_request`
+- artifact count `8`
+- artifact families: `merchant_profile`, `seller_agent_card`, `connector_evidence`, `catalog_snapshot`, `offer_price_snapshot`, `inventory_snapshot`, `policy_scope`, `authority_request_status`
+- verifier summary: 8 valid, 0 invalid
+- `allowed_to_execute=false`
+- `no_payment_execution=true`
+- `no_public_discovery_enablement=true`
+- `non_authoritative_for_transaction=true`
+
+This proves the Grantex issuer route can issue internal C6Z artifacts, but it does not prove the configured AgenticOrg-to-Grantex production path.
+
+## AgenticOrg Vertical Evidence
+
+The real production vertical did not complete.
+
+- Seller onboarding packet creation authenticated successfully.
+- Identity fields used:
+  - tenant id: redacted; production smoke tenant is managed through Secret Manager and is not printed in this packet.
+  - merchant id: `mch_shopify_mgx0n6_22`
+  - seller agent id: `seller_oacp_launch_evidence_20260618`
+  - buyer agent id requested for the vertical: `buyer_oacp_launch_evidence_20260618`
+  - packet id: created by the API, but not captured because the smoke aborted before emitting the final summary; a later safe recapture attempt was blocked by current Secret Manager access.
+  - evidence id: not created because Shopify sync failed before connector evidence was produced.
+- Shopify Admin GraphQL read-only sync reached Shopify and failed with `401 Unauthorized`.
+- Direct status-only Shopify GraphQL probe using the mounted AgenticOrg C6Z Shopify token also returned `401`.
+- Because Shopify sync did not produce connector evidence, AgenticOrg did not complete Grantex authority request, artifact cache, buyer answer, MCP seller-facts production smoke, or Plural/Pine capability metadata verification in the same vertical run.
+
+## Safety
+
+- AgenticOrg public discovery flag: `false`.
+- Grantex public discovery flag: `false`.
+- Grantex Commerce payment/live flags exist for the separate payment-control pilot and must not be treated as OACP C6Z runtime artifact launch proof.
+- No checkout, payment, order, mandate, refund, return, shipment, inventory hold, provider execution, public discovery publication, or OACP external publication was performed.
+- No secrets, tokens, raw Shopify payloads, raw Grantex artifacts, raw provider payloads, raw JWTs, passports, DB URLs, or Redis URLs are included in this evidence packet.
+
+## Local Validation
+
+- `npm --prefix apps/auth-service test -- commerce-c6z-runtime-artifact-authority.test.ts`: passed, 5 tests.
+- `npm --prefix apps/auth-service run typecheck`: passed.
+- `node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr`: passed.
+
+## Skipped Or Blocked Checks
+
+- Real Shopify product and variant counts: blocked by Shopify `401`.
+- AgenticOrg artifact cache proof: blocked by missing real connector evidence/artifacts.
+- Buyer answer proof: blocked by missing real connector evidence/artifacts.
+- MCP production seller facts proof: blocked by missing real connector evidence/artifacts.
+- Plural/Pine production capability proof in the same vertical: blocked because the vertical stopped at Shopify sync.
+- Cost-risky and signed-event smoke checks: intentionally skipped by guard flags.
+
+## Exact Launch Status
+
+- Internal runtime demo: blocked in production.
+- Closed merchant pilot: blocked.
+- Public OACP preview: blocked.
+
+## Required Next Actions
+
+1. AgenticOrg owner: rotate or replace `agenticorg-c6z-shopify-admin-access-token`, then verify a status-only Shopify GraphQL query returns 200.
+2. Grantex owner: provision the commerce tenant/developer mapping for the AgenticOrg internal token or replace it with an approved mapped token.
+3. After both fixes, re-run the C6Z vertical from AgenticOrg onboarding through Shopify sync, Grantex authority issuance, artifact cache, buyer answer, MCP seller tools, and Plural/Pine capability metadata verification.

--- a/docs/internal/commerce-v1/commerce-v1-oacp-landing-blog-plan.md
+++ b/docs/internal/commerce-v1/commerce-v1-oacp-landing-blog-plan.md
@@ -26,7 +26,12 @@ rails own mandate and payment execution.
 
 ## Current Implementation Summary
 
-Internal OACP work is implemented through C6W9:
+Internal OACP work is implemented through C6Z, but the production C6Z vertical
+is not complete. The June 18, 2026 closure run found two production blockers:
+AgenticOrg Shopify Admin GraphQL sync returns `401 Unauthorized`, and the
+AgenticOrg-configured Grantex internal token returns `422 tenant_not_provisioned`.
+
+Implementation status:
 
 | Slice | Current result | Public posture |
 | --- | --- | --- |
@@ -37,6 +42,7 @@ Internal OACP work is implemented through C6W9:
 | C6W7 | Local response evidence reconciliation. | Reconciled only; no execution. |
 | C6W8 | Eligibility and audit-readiness packets. | Eligibility only; no approval. |
 | C6W9 | Dry-run verifier for future execution-controller contract shape. | Dry-run only; no readiness claim. |
+| C6Z | Runtime artifact authority route and AgenticOrg vertical wiring. | Route verified in isolation; full production vertical blocked. |
 
 ## Landing Page: Grantex
 
@@ -72,7 +78,9 @@ Required sections:
    - merchant systems;
    - provider/fintech rails.
 4. OACP implementation status
-   - C6W3 through C6W9 complete internally;
+   - C6W3 through C6Z complete internally;
+   - the 2026-06-18 production vertical is blocked on Shopify token validity
+     and AgenticOrg-to-Grantex tenant-token provisioning;
    - execution, live payments, public discovery, and standardization remain
      blocked.
 5. Protocol adapter previews
@@ -232,3 +240,5 @@ sequenceDiagram
   provider rails, merchant approval, or production readiness.
 - Landing pages include "internal preview" or "planning" posture until launch
   approval exists.
+- Grantex Commerce payment-control pilot wording is kept separate from OACP
+  runtime artifact protocol wording.

--- a/docs/internal/commerce-v1/commerce-v1-oacp-launch-gap-prd.md
+++ b/docs/internal/commerce-v1/commerce-v1-oacp-launch-gap-prd.md
@@ -1,0 +1,37 @@
+# Commerce V1 OACP Launch Gap PRD
+
+Status: current closure record, internal only.
+
+Last updated: 2026-06-18.
+
+## Canonical Architecture
+
+- AgenticOrg is the buyer and seller AI-agent runtime.
+- Grantex is the trust, protocol, policy, and canonical OACP artifact authority.
+- Merchant systems such as Shopify remain operational systems of record.
+- Provider and fintech rails such as Plural/Pine own mandate and payment execution.
+- Grantex is not a toll booth for every non-binding buyer/seller interaction.
+
+## Current Launch Result
+
+The production OACP C6Z runtime vertical is blocked, not launched.
+
+Blocking evidence captured on 2026-06-18:
+
+- AgenticOrg production health is healthy at commit `2fdccc7ca1337b3b2caa20a2e9ac1d03c7bfbc9c`.
+- Grantex production health is healthy at commit `7fd4dd3c865fbd8187d92aec792cff249c9c01c3`.
+- AgenticOrg authenticated Shopify Admin GraphQL read-only sync reached Shopify but Shopify returned `401 Unauthorized`.
+- A direct status-only Shopify GraphQL probe using the mounted AgenticOrg C6Z Shopify token also returned `401`.
+- Grantex C6Z authority called with the AgenticOrg-configured internal token returned `422 tenant_not_provisioned`.
+- Grantex C6Z authority called with a platform-admin operator token issued 8 internal artifacts, all verifier-valid, with `allowed_to_execute=false`.
+
+## Gaps To Close
+
+1. Rotate or replace the AgenticOrg C6Z Shopify Admin token and verify read-only GraphQL access to `mgx0n6-22.myshopify.com`.
+2. Provision the Grantex commerce tenant/developer mapping for the AgenticOrg internal token, or replace the token with an approved operator/developer credential that is already mapped.
+3. Re-run the AgenticOrg production C6Z vertical from onboarding packet to Shopify sync, Grantex authority request, artifact cache, buyer answer, MCP seller facts, and Plural/Pine capability metadata verification.
+4. Keep `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED=false` and `COMMERCE_PUBLIC_DISCOVERY_ENABLED=false` until a separate public discovery rollout is approved.
+
+## Non-Goals
+
+This PRD does not approve checkout, payment, order, mandate, refund, return, shipment, inventory hold, live-provider execution, public discovery publication, production allowlist changes, OACP publication, certification, standardization, or conformance claims.

--- a/docs/internal/commerce-v1/commerce-v1-oacp-public-narrative-boundary.md
+++ b/docs/internal/commerce-v1/commerce-v1-oacp-public-narrative-boundary.md
@@ -1,0 +1,33 @@
+# Commerce V1 OACP Public Narrative Boundary
+
+Status: canonical wording boundary, internal only.
+
+Last updated: 2026-06-18.
+
+## Allowed Positioning
+
+Use this wording:
+
+- "Grantex is the trust, protocol, policy, and canonical OACP artifact authority."
+- "AgenticOrg is the buyer and seller AI-agent runtime."
+- "Merchant systems remain operational systems of record."
+- "Provider and fintech rails own mandate and payment execution."
+- "OACP artifacts support non-binding agent answers when cache, freshness, revocation, and scope checks pass."
+- "The C6Z production vertical is currently blocked by Shopify credential and Grantex tenant-mapping issues."
+
+## Disallowed Positioning
+
+Do not say or imply:
+
+- OACP is externally standardized, certified, conformant, or compliance-approved.
+- Public OACP discovery is enabled.
+- OACP launch proof enables checkout, payment, order, mandate, refund, return, shipment, inventory hold, live-provider execution, or merchant-private API mutation.
+- Grantex must sit in every non-binding buyer/seller conversation.
+- AgenticOrg is only a thin client.
+- The Grantex Commerce payment-control pilot proves the AgenticOrg C6Z OACP runtime artifact vertical.
+
+## Payment-Control Pilot Separation
+
+Grantex Commerce payment-control work and the OACP runtime artifact protocol are separate.
+
+The Grantex payment-control pilot may discuss Commerce V1 runtime, consent, Commerce Passport, payment intent, webhook intake, reconciliation, and audit only inside that pilot scope. It must not be reused as proof that the C6Z AgenticOrg-to-Grantex OACP artifact vertical has completed.

--- a/docs/internal/commerce-v1/commerce-v1-oacp-runtime-launch-runbook.md
+++ b/docs/internal/commerce-v1/commerce-v1-oacp-runtime-launch-runbook.md
@@ -1,0 +1,37 @@
+# Commerce V1 OACP Runtime Launch Runbook
+
+Status: internal runbook for the C6Z OACP runtime artifact vertical.
+
+Last updated: 2026-06-18.
+
+## Safe Preconditions
+
+- Use production AgenticOrg and production Grantex only with approved smoke credentials.
+- Do not print tokens, raw Shopify payloads, raw Grantex artifacts, raw provider payloads, JWTs, passports, DB URLs, Redis URLs, or Secret Manager values.
+- Keep public discovery disabled.
+- Do not create checkout, payment, order, mandate, refund, return, shipment, inventory hold, live-provider execution, production allowlist entries, or public OACP publication.
+
+## Required Production Checks
+
+1. Confirm AgenticOrg health reports the deployed commit and healthy DB/Redis.
+2. Confirm Grantex health reports healthy DB/Redis and the deployed commit/revision.
+3. Confirm Grantex C6Z route refuses unauthenticated or invalid calls with `401` or `403`.
+4. Create or reuse an AgenticOrg Seller Commerce Agent onboarding packet for the approved Shopify pilot merchant.
+5. Run AgenticOrg Shopify Admin GraphQL read-only sync.
+6. Send AgenticOrg authority request to Grantex.
+7. Cache returned Grantex artifacts in AgenticOrg.
+8. Ask a buyer product question from cache and record source/freshness labels.
+9. Smoke the MCP seller facts bridge against the cached data.
+10. Run Plural/Pine capability metadata verification only; do not execute mandates or payments.
+
+## Current Blockers
+
+As of 2026-06-18, step 5 is blocked because Shopify returns `401 Unauthorized` for the AgenticOrg C6Z Shopify Admin token. Step 6 is independently blocked because Grantex returns `422 tenant_not_provisioned` for the AgenticOrg-configured internal token.
+
+Do not proceed to closed merchant pilot or public preview until both blockers are resolved and the full vertical is re-run.
+
+## Launch Status Labels
+
+- Internal runtime demo: blocked in production until the real vertical completes.
+- Closed merchant pilot: blocked until Shopify sync and AgenticOrg-to-Grantex authority issuance pass with the configured production credentials.
+- Public OACP preview: blocked. Public discovery remains disabled and OACP is not externally published.


### PR DESCRIPTION
Docs-only OACP C6Z closure packet. Records production health, Shopify 401 blocker, Grantex tenant_not_provisioned blocker, safety boundaries, validation results, and stale-doc reconciliation. No code/runtime enablement.