### PR TITLE
Close OACP C6Z authority handoff gap

### DIFF
--- a/apps/auth-service/src/lib/commerce/caller.ts
+++ b/apps/auth-service/src/lib/commerce/caller.ts
@@ -1,6 +1,7 @@
 import type postgres from 'postgres';
 import type { FastifyRequest } from 'fastify';
 import type { Redis } from 'ioredis';
+import { createHash } from 'node:crypto';
 import { hashApiKey } from '../hash.js';
 import { resolveMerchantApiKey, looksLikeMerchantApiKey } from './merchant-auth.js';
 import {
@@ -12,13 +13,16 @@ import {
 
 type Sql = ReturnType<typeof postgres>;
 
+export const C6Z_AUTHORITY_SERVICE_SCOPE = 'commerce.oacp.c6z.authority_requests.write';
+const C6Z_AUTHORITY_ROUTE_SUFFIX = '/oacp/c6z/authority-requests';
+
 export type CommerceCaller =
   | {
       kind: 'operator';
       developerId: string;
       developerName: string;
       tenantId: string;
-      /** null when no developer→tenant mapping exists (then tenantId === ''). */
+      /** null when no developer-to-tenant mapping exists (then tenantId === ''). */
       tenantStatus: 'active' | 'disabled' | null;
       isOwnerOfTenant: boolean;
       isPlatformAdmin: boolean;
@@ -83,7 +87,7 @@ async function loadDeveloperByApiKey(sql: Sql, token: string): Promise<Developer
 
 /**
  * Single JOIN that resolves the operator's default tenant + tenant
- * status + role. Returns null when no developer→tenant mapping exists
+ * status + role. Returns null when no developer-to-tenant mapping exists
  * (caller decides auto-provision vs 422). Returns status='disabled' so
  * the route preHandler can 403 without an extra round-trip.
  */
@@ -120,6 +124,34 @@ function isPlatformAdminToken(token: string): boolean {
   return diff === 0;
 }
 
+function timingSafeStringEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+function tokenSha256(token: string): string {
+  return createHash('sha256').update(token, 'utf8').digest('hex');
+}
+
+function isC6ZAuthorityRoute(request: FastifyRequest): boolean {
+  if (request.method !== 'POST') return false;
+  const path = request.url.split('?')[0] ?? '';
+  return path.endsWith(C6Z_AUTHORITY_ROUTE_SUFFIX);
+}
+
+function isC6ZAuthorityServiceToken(request: FastifyRequest, token: string): boolean {
+  if (!isC6ZAuthorityRoute(request)) return false;
+  const rawToken = process.env['COMMERCE_C6Z_AUTHORITY_SERVICE_TOKEN'];
+  if (rawToken && rawToken.length >= 16 && timingSafeStringEqual(token, rawToken)) return true;
+  const expectedHash = process.env['COMMERCE_C6Z_AUTHORITY_SERVICE_TOKEN_SHA256'];
+  if (expectedHash && /^[a-f0-9]{64}$/i.test(expectedHash)) {
+    return timingSafeStringEqual(tokenSha256(token).toLowerCase(), expectedHash.toLowerCase());
+  }
+  return false;
+}
+
 /**
  * Single entry point for commerce route auth. Detects token shape and
  * dispatches to the appropriate resolver. Sets request.commerceCaller
@@ -143,6 +175,18 @@ export async function resolveCommerceCaller(
 
   // Order matters: check the most specific shapes first so an opaque
   // token doesn't accidentally match the operator fallback.
+  if (isC6ZAuthorityServiceToken(request, token)) {
+    return {
+      ok: true,
+      caller: {
+        kind: 'service',
+        serviceId: 'agenticorg_c6z_authority',
+        tenantId: process.env['COMMERCE_C6Z_AUTHORITY_SERVICE_DEFAULT_TENANT'] ?? '',
+        scopes: [C6Z_AUTHORITY_SERVICE_SCOPE],
+      },
+    };
+  }
+
   if (looksLikeMerchantApiKey(token)) {
     const r = await resolveMerchantApiKey(sql, token);
     if (!r.ok) {
@@ -199,7 +243,7 @@ export async function resolveCommerceCaller(
     return { ok: false, failure: { status: 401, code: 'invalid_developer_key', message: 'Developer API key not recognized' } };
   }
   // Admin without a backing developer record: synthesize an operator caller
-  // marked as platform admin. The admin caller has no implicit tenant —
+  // marked as platform admin. The admin caller has no implicit tenant -
   // operator endpoints that require a tenant context must accept a
   // tenant_id parameter and validate the admin gate.
   if (isAdmin && !developer) {

--- a/apps/auth-service/src/lib/commerce/oacp-runtime-vertical.ts
+++ b/apps/auth-service/src/lib/commerce/oacp-runtime-vertical.ts
@@ -328,6 +328,7 @@ function payloadForFamily(
     public_discovery_publication_allowed: family === 'public_discovery_state' ? false : undefined,
     mandate_capability_status: family === 'mandate_capability' ? 'provider_owned_verification_required' : undefined,
     provider_execution_authority: family === 'mandate_capability' ? 'provider_owned_not_grantex_or_agenticorg' : undefined,
+    mandate_capability_ref: family === 'mandate_capability' ? 'provider:mandate_rail:capability:pending:redacted' : undefined,
     adapter_surfaces: family === 'protocol_adapter'
       ? [
         'schema_org_product_offer_jsonld',
@@ -341,6 +342,9 @@ function payloadForFamily(
       : undefined,
     adapter_claim_boundary: family === 'protocol_adapter'
       ? 'compatibility_mapping_only_no_certification_or_standardization_claim'
+      : undefined,
+    allowed_protocol_adapters: family === 'protocol_adapter'
+      ? ['schema.org', 'ucp_style', 'acp_style', 'ap2_style', 'a2a', 'mcp']
       : undefined,
     authority_request_status: family === 'authority_request_status' ? 'artifact_issuance_ready' : undefined,
     unsupported_capabilities: [

--- a/apps/auth-service/src/routes/commerce-oacp-runtime.ts
+++ b/apps/auth-service/src/routes/commerce-oacp-runtime.ts
@@ -1,5 +1,9 @@
 import type { FastifyInstance } from 'fastify';
 import {
+  C6Z_AUTHORITY_SERVICE_SCOPE,
+  type CommerceCaller,
+} from '../lib/commerce/caller.js';
+import {
   issueC6ZInternalOacpArtifacts,
   validateC6ZSellerAuthorityRequest,
   type C6ZConnectorEvidence,
@@ -23,10 +27,39 @@ function requireOperator(request: { commerceCaller?: { kind?: string } }): void 
   }
 }
 
+function allowedServiceTenants(): Set<string> {
+  return new Set(
+    (process.env['COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS'] ?? '')
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean),
+  );
+}
+
+function requireAuthorityCaller(
+  request: { commerceCaller?: CommerceCaller },
+  body: C6ZAuthorityBody,
+): void {
+  const caller = request.commerceCaller;
+  if (caller?.kind === 'operator') return;
+  if (caller?.kind === 'service' && caller.scopes.includes(C6Z_AUTHORITY_SERVICE_SCOPE)) {
+    const tenantId = body.request?.tenant_id;
+    const allowed = allowedServiceTenants();
+    if (typeof tenantId === 'string' && tenantId && allowed.has(tenantId)) return;
+    throw new CommerceHttpError(
+      403,
+      'service_tenant_not_allowed',
+      'AgenticOrg C6Z authority service token is not allowed for this tenant',
+      { retryable: false },
+    );
+  }
+  requireOperator(request);
+}
+
 export async function commerceOacpRuntimeRoutes(app: FastifyInstance) {
   app.post<{ Body: C6ZAuthorityBody }>('/oacp/c6z/authority-requests', async (request, reply) => {
-    requireOperator(request);
     const body = request.body ?? {};
+    requireAuthorityCaller(request, body);
     const now = typeof body.now_iso === 'string' && body.now_iso ? body.now_iso : nowIso();
     const authorityRequest = body.request;
     const requestStatus = validateC6ZSellerAuthorityRequest(authorityRequest, now);

--- a/apps/auth-service/tests/commerce-c6z-runtime-artifact-authority.test.ts
+++ b/apps/auth-service/tests/commerce-c6z-runtime-artifact-authority.test.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from 'fastify';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   issueC6ZInternalOacpArtifacts,
   validateC6ZSellerAuthorityRequest,
@@ -67,6 +67,7 @@ describe('C6Z Grantex runtime artifact authority', () => {
   });
 
   afterEach(async () => {
+    vi.unstubAllEnvs();
     await app.close();
   });
 
@@ -246,5 +247,56 @@ describe('C6Z Grantex runtime artifact authority', () => {
       no_payment_execution: true,
       no_public_discovery_enablement: true,
     });
+  });
+
+  it('accepts a tenant-allowlisted AgenticOrg authority service token for this endpoint only', async () => {
+    vi.stubEnv('COMMERCE_C6Z_AUTHORITY_SERVICE_TOKEN', 'agenticorg-c6z-fixture-service-key');
+    vi.stubEnv('COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS', 'cten_C6Z');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/oacp/c6z/authority-requests',
+      headers: { authorization: 'Bearer agenticorg-c6z-fixture-service-key' },
+      payload: {
+        now_iso: NOW,
+        request: authorityRequest(),
+        connector_evidence: connectorEvidence(),
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toMatchObject({
+      route_kind: 'grantex_internal_c6z_authority_request',
+      status: 'artifact_issuance_ready',
+      artifact_count: 11,
+      allowed_to_execute: false,
+    });
+
+    const blocked = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/merchants/mch_C6Z',
+      headers: { authorization: 'Bearer agenticorg-c6z-fixture-service-key' },
+    });
+    expect(blocked.statusCode).toBe(401);
+    expect(blocked.json<{ error: { code: string } }>().error.code).toBe('invalid_developer_key');
+  });
+
+  it('rejects the authority service token when the tenant is not explicitly allowlisted', async () => {
+    vi.stubEnv('COMMERCE_C6Z_AUTHORITY_SERVICE_TOKEN', 'agenticorg-c6z-fixture-service-key');
+    vi.stubEnv('COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS', 'cten_OTHER');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/commerce/oacp/c6z/authority-requests',
+      headers: { authorization: 'Bearer agenticorg-c6z-fixture-service-key' },
+      payload: {
+        now_iso: NOW,
+        request: authorityRequest(),
+        connector_evidence: connectorEvidence(),
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json<{ error: { code: string } }>().error.code).toBe('service_tenant_not_allowed');
   });
 });

--- a/docs/guides/commerce-v1-end-to-end-agentic-commerce-flow.mdx
+++ b/docs/guides/commerce-v1-end-to-end-agentic-commerce-flow.mdx
@@ -8,7 +8,7 @@ description: Plain-language buyer and seller flow for OACP agentic commerce with
 This guide explains how agentic commerce should work from the perspective of
 both sellers and buyers. It is documentation only. It does not enable production
 Commerce V1, public discovery, checkout/payment creation, live payments, live
-Plural, merchant approval, or a production allowlist.
+provider rails, merchant approval, or a production allowlist.
 
 ## Current OACP Runtime Closure Boundary
 
@@ -36,6 +36,15 @@ systems through approved connector custody. Grantex validates public-safe facts
 into signed OACP artifacts and policy decisions. Buyers start from their
 preferred agent or chat surface. Provider and fintech rails own mandate and
 payment execution.
+
+For the C6Z live-runtime path, AgenticOrg calls Grantex through
+`POST /v1/commerce/oacp/c6z/authority-requests`. Production should use the
+dedicated AgenticOrg C6Z authority service token, limited to that route and to
+tenant ids configured in `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS`. Grantex
+issues the full C6Z artifact set: merchant profile, seller agent card,
+connector evidence, catalog snapshot, offer/price snapshot, inventory snapshot,
+policy scope, public-discovery state, mandate capability, protocol adapter, and
+authority-request status.
 
 ```mermaid
 flowchart TB

--- a/docs/internal/commerce-v1/commerce-v1-c6z-runtime-artifact-authority.md
+++ b/docs/internal/commerce-v1/commerce-v1-c6z-runtime-artifact-authority.md
@@ -24,6 +24,25 @@ The internal endpoint is:
 
 `POST /v1/commerce/oacp/c6z/authority-requests`
 
+It can be called by either:
+
+- an existing Grantex commerce operator token with a mapped active commerce tenant; or
+- the dedicated AgenticOrg C6Z authority service token, limited to this route and to
+  explicit tenant ids configured in `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS`.
+
+For production AgenticOrg handoff, configure one of:
+
+- `COMMERCE_C6Z_AUTHORITY_SERVICE_TOKEN`
+- `COMMERCE_C6Z_AUTHORITY_SERVICE_TOKEN_SHA256`
+
+and always configure:
+
+- `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS`
+
+The service token is intentionally not accepted on other commerce endpoints. It is not a
+merchant credential, provider credential, checkout credential, public-discovery credential,
+or general operator credential.
+
 It accepts:
 
 - tenant, merchant, and seller agent scope
@@ -58,6 +77,9 @@ C6Z issues internal artifacts for:
 - `offer_price_snapshot`
 - `inventory_snapshot`
 - `policy_scope`
+- `public_discovery_state`
+- `mandate_capability`
+- `protocol_adapter`
 - `authority_request_status`
 
 Each artifact includes tenant, merchant, seller agent, Shopify source evidence reference,
@@ -92,6 +114,9 @@ Focused tests cover:
 - accepted authority request validation
 - internal artifact issuance for all C6Z families
 - internal signature verification
+- eleven-family parity with AgenticOrg cache intake
+- dedicated AgenticOrg authority service-token acceptance for allowlisted tenants
+- proof that the service token is not a general commerce route credential
 - stale source evidence rejection
 - missing or mismatched scope rejection
 - raw connector payload and secret rejection


### PR DESCRIPTION
## Summary
- Adds a route-scoped AgenticOrg C6Z authority service token path for /v1/commerce/oacp/c6z/authority-requests.
- Requires tenant allowlisting through COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS so the service token is not a general commerce credential.
- Aligns Grantex C6Z issuance with AgenticOrg's 11 artifact families: merchant profile, seller agent card, connector evidence, catalog, price, inventory, policy, public-discovery state, mandate capability, protocol adapter, and authority status.
- Updates C6Z authority and end-to-end flow docs.

## Validation
- npm --prefix apps/auth-service test -- commerce-c6z-runtime-artifact-authority.test.ts commerce-no-plural-leak.test.ts
- npm --prefix apps/auth-service run typecheck
- node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
- git diff --check

## Boundaries
No deploy, workflow, migration, public discovery, checkout/payment execution, live provider rail, provider call, merchant private API call, allowlist change, or OACP publication is included.