### PR TITLE
[codex] Document OACP authority launch story

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,54 +33,31 @@
 
 </div>
 
-## Agentic Commerce V1 (live pilot)
+## OACP Authority For Agentic Commerce
 
-Grantex Commerce V1 is the live-pilot consent, Commerce Passport, policy, audit, and payment-control layer for agentic checkout. It lets commerce agents use an approved Shopify merchant profile, create carts, request user consent, receive a scoped Commerce Passport, and create provider-neutral payment intents without giving the agent direct access to payment providers.
+Grantex is the OACP protocol, trust, policy, artifact, verification, and adapter authority for agentic commerce. AgenticOrg owns buyer and seller AI-agent runtime, merchant onboarding, Shopify connector runtime, buyer sessions, channel bridges, OACP cache, and provider-owned Pine Labs Plural/P3P capability verification.
 
-> Production Commerce V1 is live for the approved Shopify pilot merchant `mch_shopify_mgx0n6_22` from `mgx0n6-22.myshopify.com`. The runtime live-readiness gate is complete, ops health is green, and Plural webhook intake is deployed at `https://api.grantex.dev/v1/webhooks/providers/plural`. Plural credentials currently authenticate against Plural UAT-compatible rails, so public docs do not claim production Plural settlement.
+Merchant systems such as Shopify remain the source of record. Provider rails own mandate and payment execution. Grantex signs and verifies artifacts; it is not a merchant connector runtime or a toll booth for every buyer and seller message.
 
 ```mermaid
 flowchart LR
-  user[User] --> agent[AgenticOrg Commerce Sales Agent]
-  agent --> gx[Grantex Commerce REST/MCP]
-  gx --> consent[Consent and Passport]
-  gx --> policy[Policy, amount caps, audit]
-  gx --> catalog[Catalog, cart, inventory]
-  gx --> provider[Provider-neutral payment intent]
-  provider --> mock[Mock provider verified in smoke]
-  provider --> plural[Plural hosted-checkout adapter]
-  plural --> webhook[Signed Plural webhook intake]
+  merchant[Shopify and merchant systems] --> agentic[AgenticOrg buyer and seller runtime]
+  agentic -->|redacted authority request| grantex[Grantex OACP authority]
+  grantex -->|OACP artifacts or blockers| agentic
+  agentic --> buyer[Buyer surfaces]
+  agentic -->|capability check| provider[Pine Labs Plural/P3P]
 ```
 
 | Area | Current posture |
 | --- | --- |
-| Internal sandbox | Implemented for synthetic catalog, consent, passport, cart, payment, webhook, and audit flows. |
-| Temporary Option A smoke | Verified with mock provider and cleaned-up smoke resources. |
-| Shopify pilot merchant | Live profile imported from `mgx0n6-22.myshopify.com` as `mch_shopify_mgx0n6_22`, with 5 products and 5 variants available through Grantex catalog search. |
-| Plural hosted-checkout adapter | Implemented behind the provider abstraction for token, checkout order, status polling, and HMAC webhook verification; configured with stored credentials that authenticate against the Plural UAT-compatible endpoint. |
-| AgenticOrg real-staging handoff | Verified through Grantex-only tools with redacted fixture handling. |
-| Hosted AgenticOrg discovery | Verified in temporary API-only hosted smoke. |
-| Production discovery | Available for the approved Commerce V1 runtime merchant profile through `/.well-known/grantex-commerce`. |
-| Live-readiness gate | Complete for the approved pilot; feature flags alone remain insufficient and missing evidence returns `live_readiness_blocked`. |
-| Live checkout/payments | Enabled for the approved Commerce V1 live-pilot control-plane path, with consent, policy, passport, idempotency, webhook, reconciliation, and audit controls. |
-| Plural production settlement claim | Not claimed; the current credentials validate against Plural UAT-compatible rails. |
+| Grantex C6Z authority route | Implemented at `POST /v1/commerce/oacp/c6z/authority-requests` for allowlisted AgenticOrg tenants. |
+| Artifact families | 11 internal OACP families are issued or refused: merchant profile, seller agent card, connector evidence, catalog, price, inventory, policy, public discovery state, mandate capability, protocol adapter, and request status. |
+| Protocol adapters | Schema.org, UCP-style, ACP-style, AP2-style, A2A, MCP, and OpenAPI mappings are compatibility mappings derived from OACP artifacts. |
+| AgenticOrg runtime | Seller onboarding, Shopify sync, cache, buyer Q&A, bridges, and provider capability verification live in AgenticOrg. |
+| Payment/order execution | Outside OACP artifact authority. Provider and merchant systems must execute and confirm; agents must not invent success. |
+| Historical Commerce V1 docs | Retained for context, but superseded for the AgenticOrg OACP runtime split. |
 
-Start with the [Commerce V1 overview](docs/guides/commerce-v1-overview.mdx), then use the [developer guide](docs/guides/commerce-v1-developer-guide.mdx), [merchant/operator guide](docs/guides/commerce-v1-merchant-operator-guide.mdx), and [operations guide](docs/guides/commerce-v1-operations.mdx). The public education page is `web/commerce.html`, the end-to-end launch story is in [the Shopify OACP live-flow blog](docs/blog/shopify-oacp-commerce-live-flow.mdx), and the guard model is in [the Commerce live-readiness gate blog](docs/blog/commerce-live-readiness-gate.mdx).
-
-The TypeScript SDK now exposes the live-pilot control plane as `grantex.commerce.*`, including public merchant profile lookup, catalog search, cart creation, Commerce Passport consent/exchange, payment intent creation, checkout handoff, provider credential metadata, webhook source management, and operator health checks. Commerce write calls that mutate carts or payments accept `idempotencyKey` and send it as the required `Idempotency-Key` header.
-
-## OACP Authority For AgenticOrg Runtime
-
-For the Shopify-to-AgenticOrg OACP runtime, Grantex owns trust authority,
-protocol/policy governance, canonical artifact issuance, signing,
-verification, and protocol-adapter mapping rules. AgenticOrg owns seller
-onboarding, Shopify read-only connector runtime, buyer/seller agents, artifact
-cache, buyer channels, and Pine Labs Plural/P3P capability verification.
-
-The C6Z authority endpoint issues or refuses the 11 required OACP artifact
-families for allowlisted AgenticOrg tenants. It is not a merchant connector,
-buyer-session relay, checkout service, or payment toll booth. See
-[`docs/guides/oacp-runtime-authority-and-adapter-mappings.md`](docs/guides/oacp-runtime-authority-and-adapter-mappings.md).
+Start with the [OACP authority overview](docs/guides/oacp/overview.mdx), [truth inventory](docs/guides/oacp/truth-inventory.mdx), [AgenticOrg integration guide](docs/guides/oacp/agenticorg-integration.mdx), and [operator runbook](docs/guides/oacp/operator-runbook.mdx). The older [Commerce V1 overview](docs/guides/commerce-v1-overview.mdx) remains historical/contextual and should not be used to imply that Grantex owns AgenticOrg merchant connector runtime.
 
 ## Current Development Snapshot
 

--- a/apps/auth-service/tests/commerce-connector-dry-run-c6r.test.ts
+++ b/apps/auth-service/tests/commerce-connector-dry-run-c6r.test.ts
@@ -179,6 +179,13 @@ function c6qDryRunPayload(overrides: Record<string, unknown> = {}): Record<strin
   };
 }
 
+function freshC6qDryRunPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return c6qDryRunPayload({
+    source_snapshot_at: new Date().toISOString(),
+    ...overrides,
+  });
+}
+
 describe('C6R sandbox connector dry-run service', () => {
   it('normalizes the C6Q fake fixture into a capped public-safe preview', () => {
     const prepared = prepareConnectorDryRun(c6qDryRunPayload({ preview_limit: 2 }), NOW);
@@ -307,7 +314,7 @@ describe('C6R connector dry-run routes', () => {
       method: 'POST',
       url: `/v1/commerce/merchants/${MERCHANT}/connectors/dry-run`,
       headers: authHeader(),
-      payload: c6qDryRunPayload(),
+      payload: freshC6qDryRunPayload(),
     });
 
     expect(res.statusCode).toBe(201);
@@ -407,7 +414,7 @@ describe('C6R connector dry-run routes', () => {
       method: 'POST',
       url: `/v1/commerce/merchants/${MERCHANT}/connectors/dry-run`,
       headers: authHeader(),
-      payload: c6qDryRunPayload(),
+      payload: freshC6qDryRunPayload(),
     });
 
     expect(res.statusCode).toBe(409);

--- a/docs/blog/buyer-journey-prepared-purchase-handoff.mdx
+++ b/docs/blog/buyer-journey-prepared-purchase-handoff.mdx
@@ -1,0 +1,51 @@
+---
+title: The Buyer Journey From Question To Prepared Purchase Handoff
+description: How OACP moves from discovery to prepared handoff without faking execution.
+---
+
+# The Buyer Journey From Question To Prepared Purchase Handoff
+
+## Summary
+
+OACP supports a safe buyer journey: ask, compare, select, check freshness, verify provider capability, then prepare a handoff or refuse.
+
+## Target Audience
+
+Buyer-experience designers, channel teams, and operators.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+  ask[Ask] --> compare[Compare]
+  compare --> select[Select product]
+  select --> freshness[Check OACP freshness]
+  freshness --> provider[Check provider capability]
+  provider --> prepare[Prepared handoff]
+  provider --> refuse[Blocker]
+```
+
+## End-To-End Flow
+
+The buyer asks a product question. AgenticOrg answers from cache with source labels. The buyer asks to buy. AgenticOrg checks catalog, price, inventory, policy, mandate capability, protocol adapter, and freshness records. It returns a prepared handoff if allowed or a clear blocker.
+
+## What Is Implemented Now
+
+AgenticOrg has buyer Q&A, product listing, protocol adapters, bridge endpoints, provider capability verification, and purchase-preparation routes. Grantex authority artifacts support the source and policy inputs.
+
+## What Requires External Approval Or Config
+
+Provider rail execution, merchant order system integration, channel approvals, and public launch acceptance.
+
+## Failure Modes
+
+- Product no longer in valid cache.
+- Price/inventory artifact missing.
+- Provider evidence missing or stale.
+- Buyer requests payment success from the agent.
+
+## Safe User Wording Examples
+
+- "I can prepare a handoff for review."
+- "The provider capability evidence is stale; no payment was attempted."
+- "The merchant system remains the source of order status."

--- a/docs/blog/grantex-not-transaction-toll-booth.mdx
+++ b/docs/blog/grantex-not-transaction-toll-booth.mdx
@@ -1,0 +1,49 @@
+---
+title: Why Grantex Is Not A Transaction Toll Booth
+description: Why OACP authority signs artifacts without relaying every buyer and seller interaction.
+---
+
+# Why Grantex Is Not A Transaction Toll Booth
+
+## Summary
+
+Grantex is the OACP authority, not a relay for every buyer message. Valid cached artifacts let AgenticOrg answer non-binding questions while commitment requests remain gated.
+
+## Target Audience
+
+Architects, operators, and platform buyers.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+  agentic[AgenticOrg runtime] -->|authority refresh| grantex[Grantex]
+  grantex -->|artifacts| cache[AgenticOrg cache]
+  cache -->|valid non-binding answer| buyer[Buyer]
+  buyer -->|commitment request| prep[Purchase preparation]
+  prep -->|provider/merchant approval needed| provider[Provider and merchant systems]
+```
+
+## End-To-End Flow
+
+Grantex signs the trust artifact. AgenticOrg stores a scoped cache. Buyer questions use the cache until freshness or revocation fails. Purchase requests must use approved merchant/provider/channel paths and cannot be converted into success by cache alone.
+
+## What Is Implemented Now
+
+The authority endpoint issues/refuses artifacts. AgenticOrg cache and bridge routes consume them for Q&A and prepared handoff.
+
+## What Requires External Approval Or Config
+
+Public tenant launch, provider rail execution, and channel rollout.
+
+## Failure Modes
+
+- Cache used past TTL.
+- Commitment request treated like a discovery request.
+- Grantex outage misunderstood as permission to execute.
+
+## Safe User Wording Examples
+
+- "Grantex signed the source artifact; AgenticOrg answered from valid cache."
+- "A valid cache supports discovery, not payment authority."
+- "This request needs provider or merchant approval before execution."

--- a/docs/blog/oacp-buyer-surfaces-chatgpt-claude-gemini-perplexity-whatsapp-telegram.mdx
+++ b/docs/blog/oacp-buyer-surfaces-chatgpt-claude-gemini-perplexity-whatsapp-telegram.mdx
@@ -1,0 +1,58 @@
+---
+title: How ChatGPT, Claude, Gemini, Perplexity, WhatsApp, And Telegram Can Shop Through Seller Agents
+description: The buyer-surface bridge model for OACP-backed AgenticOrg seller agents.
+---
+
+# How ChatGPT, Claude, Gemini, Perplexity, WhatsApp, And Telegram Can Shop Through Seller Agents
+
+## Summary
+
+Buyer surfaces differ in transport, not truth. AgenticOrg should route web, MCP, OpenAPI, A2A, WhatsApp, and Telegram through the same OACP cache-backed answer path.
+
+## Target Audience
+
+Developer platform teams, channel partners, and customer-success teams.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+  web[Web] --> runtime[AgenticOrg buyer runtime]
+  mcp[ChatGPT/Claude-style MCP] --> runtime
+  openapi[Gemini/Perplexity-style OpenAPI] --> runtime
+  a2a[A2A agent card] --> runtime
+  wa[WhatsApp] --> runtime
+  tg[Telegram] --> runtime
+  runtime --> cache[OACP cache]
+  cache --> answer[Answer with source/freshness]
+  cache --> refuse[Refuse unsafe request]
+```
+
+## End-To-End Flow
+
+1. Channel receives buyer question.
+2. AgenticOrg normalizes to the buyer-session ask path.
+3. Runtime checks OACP cache and source labels.
+4. Low-risk answers are returned consistently.
+5. Commitment-bound requests use purchase preparation and provider capability checks.
+
+## What Is Implemented Now
+
+AgenticOrg exposes web ask, OpenAPI ask/schema, A2A card, surface matrix, WhatsApp webhook, Telegram webhook, product listing, protocol adapters, and purchase preparation routes.
+
+## What Requires External Approval Or Config
+
+Channel webhook secrets, channel policies, public client review, and provider rail approval.
+
+## Failure Modes
+
+- Webhook secret missing.
+- Channel payload cannot be normalized.
+- Cache is stale.
+- Buyer requests commitment without valid provider evidence.
+
+## Safe User Wording Examples
+
+- "I found this from the merchant source snapshot."
+- "This channel can prepare a handoff, but it cannot complete payment."
+- "The Telegram/WhatsApp bridge needs verified webhook setup before it can accept messages."

--- a/docs/blog/oacp-keeps-buyer-agents-honest.mdx
+++ b/docs/blog/oacp-keeps-buyer-agents-honest.mdx
@@ -1,0 +1,52 @@
+---
+title: Why OACP Keeps Buyer Agents Honest
+description: Why source, freshness, revocation, and non-enablement fields keep buyer agents from inventing commerce facts.
+---
+
+# Why OACP Keeps Buyer Agents Honest
+
+## Summary
+
+OACP gives buyer agents a hard evidence model: source refs, freshness, TTL, revocation posture, risk tier, and blocked capabilities. If those fields do not support the answer, the agent must refresh or refuse.
+
+## Target Audience
+
+Buyer-agent builders, safety reviewers, and commerce operators.
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+  source[Merchant source] --> evidence[Public-safe evidence]
+  evidence --> artifact[OACP artifact]
+  artifact --> cache[AgenticOrg cache verifier]
+  cache --> decision{Answer, refresh, prepare, or refuse}
+  decision --> answer[Grounded answer]
+  decision --> blocker[Safe blocker]
+```
+
+## End-To-End Flow
+
+The buyer asks a question. AgenticOrg checks cached OACP artifacts for scope, source, freshness, revocation, and risk. Low-risk questions can be answered with labels. Commitment-bound questions require stricter checks and can only prepare handoff or refuse.
+
+## What Is Implemented Now
+
+Grantex emits artifact families and non-enablement flags. AgenticOrg checks cache records before answering and uses safe blockers for stale or unsupported requests.
+
+## What Requires External Approval Or Config
+
+Channel launch, provider capability checks, merchant policy scope, and any future execution controller path.
+
+## Failure Modes
+
+- Artifact missing from cache.
+- Artifact expired.
+- Revocation snapshot too old for the action.
+- Buyer asks for payment/order/mandate without provider evidence.
+- Source and adapter fields disagree.
+
+## Safe User Wording Examples
+
+- "I can answer from the current merchant source snapshot."
+- "I cannot invent stock or price beyond the artifact."
+- "No checkout, payment, or order has occurred."

--- a/docs/blog/oacp-maps-to-protocols.mdx
+++ b/docs/blog/oacp-maps-to-protocols.mdx
@@ -1,0 +1,50 @@
+---
+title: How OACP Maps To Schema.org, UCP, ACP, AP2, A2A, And MCP
+description: A compatibility-mapping guide for protocol partners.
+---
+
+# How OACP Maps To Schema.org, UCP, ACP, AP2, A2A, And MCP
+
+## Summary
+
+OACP is the canonical trust artifact. Protocol adapters project OACP facts into known client and partner shapes while preserving source, freshness, and non-execution boundaries.
+
+## Target Audience
+
+Protocol partners, developers, and technical reviewers.
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+  oacp[Canonical OACP artifacts] --> schema[Schema.org Product/Offer]
+  oacp --> ucp[UCP-style capability]
+  oacp --> acp[ACP-style commerce profile]
+  oacp --> ap2[AP2-style evidence]
+  oacp --> a2a[A2A metadata]
+  oacp --> mcp[MCP metadata]
+```
+
+## End-To-End Flow
+
+Grantex issues OACP artifacts. AgenticOrg caches them. Adapter payloads are generated from those artifacts for a channel. Unsupported fields stay unsupported instead of being filled with guessed execution state.
+
+## What Is Implemented Now
+
+Grantex contains Schema.org, UCP-style, ACP-style, and AP2-style preview helpers. AgenticOrg generates protocol adapter payloads including Schema.org, UCP-style, ACP-style, AP2-style, A2A, MCP, and OpenAPI views.
+
+## What Requires External Approval Or Config
+
+Any external program claim requires partner review and published evidence. Current docs describe compatibility mapping only.
+
+## Failure Modes
+
+- Adapter field has no canonical artifact lineage.
+- Adapter implies checkout or payment execution.
+- Source or freshness labels are dropped.
+
+## Safe User Wording Examples
+
+- "This is an OACP compatibility mapping."
+- "The payload is buyer-safe metadata, not payment authority."
+- "Unsupported execution fields are omitted or blocked."

--- a/docs/blog/oacp-shopify-merchant-agentic-commerce-seller.mdx
+++ b/docs/blog/oacp-shopify-merchant-agentic-commerce-seller.mdx
@@ -1,0 +1,59 @@
+---
+title: How A Shopify Merchant Becomes An Agentic Commerce Seller
+description: The Grantex authority view of Shopify onboarding through AgenticOrg and OACP artifacts.
+---
+
+# How A Shopify Merchant Becomes An Agentic Commerce Seller
+
+## Summary
+
+A Shopify merchant becomes an agentic commerce seller through AgenticOrg seller onboarding, read-only Shopify sync, Grantex OACP authority artifacts, and buyer-safe cache consumption.
+
+## Target Audience
+
+Merchants, AgenticOrg operators, and Grantex reviewers.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+  merchant[Merchant] --> agentic[AgenticOrg Seller Commerce Agent]
+  agentic --> shopify[Read-only Shopify sync]
+  shopify --> evidence[Redacted source evidence]
+  evidence --> grantex[Grantex OACP authority]
+  grantex --> artifacts[OACP artifacts or blockers]
+  artifacts --> cache[AgenticOrg cache]
+  cache --> buyers[Buyer surfaces]
+```
+
+## End-To-End Flow
+
+1. Merchant creates a Seller Commerce Agent in AgenticOrg.
+2. AgenticOrg stores Shopify credential custody outside Grantex.
+3. AgenticOrg syncs public-safe catalog, price, image, and inventory evidence.
+4. AgenticOrg requests Grantex C6Z authority artifacts.
+5. Grantex issues or refuses OACP artifacts.
+6. AgenticOrg caches artifacts and answers buyer questions with labels.
+7. Purchase intent becomes a prepared provider/merchant handoff or blocker.
+
+## What Is Implemented Now
+
+Grantex has the C6Z authority route, internal artifact issuance, adapter mapping, artifact verification helpers, and focused tests. AgenticOrg owns seller onboarding, Shopify sync, cache intake, buyer Q&A, bridge endpoints, and Plural/Pine capability verification.
+
+## What Requires External Approval Or Config
+
+Merchant Shopify credentials, AgenticOrg tenant allowlist, provider rail approval, channel webhook approvals, and partner review for any public program claim.
+
+## Failure Modes
+
+- Shopify credentials missing or invalid.
+- Source evidence stale.
+- Tenant not allowlisted.
+- Artifact scope requests private or executable authority.
+- Provider capability evidence missing or stale.
+
+## Safe User Wording Examples
+
+- "This answer is based on a Shopify snapshot authorized by Grantex."
+- "I can prepare a review handoff, but no payment or order was created."
+- "The source evidence is stale. I need a refresh before continuing."

--- a/docs/blog/pine-labs-plural-p3p-oacp.mdx
+++ b/docs/blog/pine-labs-plural-p3p-oacp.mdx
@@ -1,0 +1,50 @@
+---
+title: How Pine Labs Plural/P3P Mandate Capability Fits Into Agentic Commerce
+description: The provider-owned mandate capability boundary in the OACP model.
+---
+
+# How Pine Labs Plural/P3P Mandate Capability Fits Into Agentic Commerce
+
+## Summary
+
+Plural/Pine owns the mandate and payment rail. AgenticOrg verifies provider-owned capability metadata and Grantex can carry redacted evidence refs in OACP artifacts.
+
+## Target Audience
+
+Fintech partners, payment operators, and commerce risk teams.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+  buyer[Buyer intent] --> agentic[AgenticOrg verifier]
+  agentic --> pine[Pine Labs Plural/P3P]
+  pine --> ref[Redacted capability evidence ref]
+  ref --> cache[OACP cache]
+  cache --> handoff[Prepared handoff or blocker]
+```
+
+## End-To-End Flow
+
+AgenticOrg checks whether provider capability metadata is available for the merchant and requested action. The result becomes a redacted evidence ref. Grantex OACP policy can require that evidence before a handoff is prepared.
+
+## What Is Implemented Now
+
+AgenticOrg has a Plural/Pine capability verifier and purchase-preparation blocker. Grantex models mandate capability as an OACP artifact family and marks provider execution authority as provider-owned.
+
+## What Requires External Approval Or Config
+
+Provider credentials, environment approval, webhook/reconciliation path, merchant approval, and rollback owner.
+
+## Failure Modes
+
+- Provider config missing.
+- Sandbox/non-production environment mismatch.
+- Capability evidence older than allowed TTL.
+- Buyer asks to create a mandate from cache only.
+
+## Safe User Wording Examples
+
+- "Provider capability evidence is present for preparation only."
+- "No mandate, payment, or order was created."
+- "Provider setup is missing; the request is blocked."

--- a/docs/blog/source-freshness-trust-ai-commerce.mdx
+++ b/docs/blog/source-freshness-trust-ai-commerce.mdx
@@ -1,0 +1,49 @@
+---
+title: Source, Freshness, And Trust In AI Commerce
+description: How OACP makes source and freshness visible to buyer agents.
+---
+
+# Source, Freshness, And Trust In AI Commerce
+
+## Summary
+
+AI commerce fails when agents invent old prices, stale inventory, or unsupported payment outcomes. OACP makes source and freshness first-class fields.
+
+## Target Audience
+
+Product managers, buyer-agent designers, and operators.
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+  source[Shopify observed_at] --> artifact[OACP issued_at/expires_at]
+  artifact --> cache[Cache freshness label]
+  cache --> answer[Buyer-safe answer]
+  cache --> stale[Stale refusal]
+```
+
+## End-To-End Flow
+
+Source systems timestamp facts. Grantex artifacts carry issue and expiry windows. AgenticOrg cache computes freshness labels. Buyer responses show source and freshness. Stale data blocks commitment-bound action.
+
+## What Is Implemented Now
+
+Artifact TTLs, source refs, freshness labels, revocation posture, cache verification, and stale blockers exist in Grantex and AgenticOrg runtime code.
+
+## What Requires External Approval Or Config
+
+Merchant-specific source precedence, public channel wording review, and source conflict policy.
+
+## Failure Modes
+
+- A source has not been refreshed.
+- Different source systems disagree.
+- The response hides source/freshness labels.
+- A stale artifact is used for commitment.
+
+## Safe User Wording Examples
+
+- "Source: Shopify via Grantex artifact."
+- "Freshness: current within the configured artifact window."
+- "This snapshot is stale, so I cannot prepare purchase handoff."

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -71,7 +71,30 @@
             ]
           },
           {
-            "group": "Agentic Commerce V1",
+            "group": "OACP Authority",
+            "pages": [
+              "guides/oacp/overview",
+              "guides/oacp/truth-inventory",
+              "guides/oacp/architecture",
+              "guides/oacp/artifact-authority",
+              "guides/oacp/protocol-adapter",
+              "guides/oacp/policy-governance",
+              "guides/oacp/merchant-source-of-record",
+              "guides/oacp/buyer-safety-freshness",
+              "guides/oacp/provider-payment-boundary",
+              "guides/oacp/agenticorg-integration",
+              "guides/oacp/operator-runbook",
+              "guides/oacp/launch-readiness",
+              "guides/oacp/explainers/shopify-to-agentic-commerce",
+              "guides/oacp/explainers/buyer-agent-safety",
+              "guides/oacp/explainers/developer-artifacts-bridges",
+              "guides/oacp/explainers/protocol-partner-mappings",
+              "guides/oacp/explainers/provider-owned-payment-evidence",
+              "guides/oacp/explainers/launch-rollback-runbook"
+            ]
+          },
+          {
+            "group": "Agentic Commerce V1 (Historical)",
             "pages": [
               "guides/commerce-v1-overview",
               "guides/commerce-v1-agentic-commerce-prd",
@@ -719,6 +742,14 @@
           {
             "group": "Posts",
             "pages": [
+              "blog/oacp-shopify-merchant-agentic-commerce-seller",
+              "blog/oacp-keeps-buyer-agents-honest",
+              "blog/oacp-buyer-surfaces-chatgpt-claude-gemini-perplexity-whatsapp-telegram",
+              "blog/oacp-maps-to-protocols",
+              "blog/grantex-not-transaction-toll-booth",
+              "blog/pine-labs-plural-p3p-oacp",
+              "blog/source-freshness-trust-ai-commerce",
+              "blog/buyer-journey-prepared-purchase-handoff",
               "blog/shopify-oacp-commerce-live-flow",
               "blog/commerce-live-readiness-gate",
               "blog/dpdp-act-ai-agents",

--- a/docs/guides/commerce-v1-overview.mdx
+++ b/docs/guides/commerce-v1-overview.mdx
@@ -5,6 +5,11 @@ description: Start here for Grantex Agentic Commerce architecture, readiness, sa
 
 # Commerce V1 Overview
 
+Current OACP authority docs start at [OACP Authority Overview](./oacp/overview).
+This Commerce V1 page is retained for historical/contextual payment-control
+pilot material and must not be used to imply that Grantex owns the AgenticOrg
+seller/buyer runtime, Shopify connector runtime, or provider rail execution.
+
 Grantex Commerce V1 is the trust, protocol, policy, and canonical-artifact
 authority for agentic commerce. AgenticOrg runs buyer and seller agents.
 Merchant systems remain operational sources of record. Provider and fintech

--- a/docs/guides/oacp-runtime-authority-and-adapter-mappings.md
+++ b/docs/guides/oacp-runtime-authority-and-adapter-mappings.md
@@ -1,5 +1,9 @@
 # OACP Runtime Authority And Adapter Mappings
 
+Canonical docs now start at `docs/guides/oacp/overview.mdx`. This page is
+retained as an implementation note for the C6Z authority route and adapter
+mapping payloads.
+
 Grantex is the OACP trust, protocol, policy, artifact signing, verification,
 and adapter-governance authority. AgenticOrg is the buyer/seller agent runtime
 that operates Shopify connector sync, artifact cache, buyer channels, and

--- a/docs/guides/oacp/agenticorg-integration.mdx
+++ b/docs/guides/oacp/agenticorg-integration.mdx
@@ -1,0 +1,54 @@
+---
+title: OACP Integration Guide For AgenticOrg
+description: How AgenticOrg requests and consumes Grantex OACP authority artifacts.
+---
+
+# OACP Integration Guide For AgenticOrg
+
+Canonical end-to-end flow: [OACP authority overview](./overview).
+
+AgenticOrg calls Grantex only when it needs authority artifacts or verification. It does not route every buyer message through Grantex.
+
+## Runtime Flow
+
+```mermaid
+sequenceDiagram
+  participant M as Merchant
+  participant A as AgenticOrg
+  participant G as Grantex
+  M->>A: Create Seller Commerce Agent and connect Shopify
+  A->>A: Read-only Shopify sync and redacted evidence
+  A->>G: POST /v1/commerce/oacp/c6z/authority-requests
+  G-->>A: Signed/internal OACP artifacts or blockers
+  A->>A: Cache artifacts by tenant, merchant, seller, buyer scope
+  A-->>M: Runtime ready, refresh needed, or blocker
+```
+
+## Request Contract
+
+AgenticOrg sends:
+
+- tenant, merchant, seller agent, and source identifiers;
+- requested OACP artifact families;
+- source observed timestamp;
+- public-safe connector evidence;
+- no raw Shopify credential, raw provider payload, checkout URL, or payment URL.
+
+Grantex returns:
+
+- `201 artifact_issuance_ready` with artifact families when ready;
+- `202 received` when connector evidence is still required;
+- `422` when the request is private, stale, executable, or otherwise unsafe.
+
+## Required Configuration
+
+| Config | Owner | Purpose |
+| --- | --- | --- |
+| `COMMERCE_C6Z_AUTHORITY_SERVICE_TOKEN` | Grantex + AgenticOrg | Service-token auth for authority requests. |
+| `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS` | Grantex | Tenant allowlist. |
+| Shopify credential custody | AgenticOrg + merchant | Read-only source evidence generation. |
+| Provider capability config | AgenticOrg + provider | Capability evidence checks outside Grantex. |
+
+## Failure Handling
+
+If Grantex is unavailable, AgenticOrg may answer non-binding buyer questions from valid cached artifacts. Commitment-bound requests must refresh, prepare no execution, or refuse.

--- a/docs/guides/oacp/architecture.mdx
+++ b/docs/guides/oacp/architecture.mdx
@@ -1,0 +1,52 @@
+---
+title: OACP Architecture
+description: The Grantex view of the OACP four-party architecture.
+---
+
+# OACP Architecture
+
+Canonical end-to-end flow: [OACP authority overview](./overview).
+
+OACP separates facts, authority, runtime behavior, and payment rails so no agent has to invent commerce state.
+
+```mermaid
+flowchart TD
+  shopify[Shopify and merchant systems] -->|catalog, price, inventory, policy facts| agenticSeller[AgenticOrg Seller Commerce Agent]
+  agenticSeller -->|redacted connector evidence| grantex[Grantex OACP authority]
+  grantex -->|signed/internal artifacts or refusals| cache[AgenticOrg OACP cache]
+  cache --> buyerAgent[AgenticOrg buyer agent]
+  buyerAgent --> web[Web]
+  buyerAgent --> mcp[MCP clients]
+  buyerAgent --> openapi[OpenAPI clients]
+  buyerAgent --> a2a[A2A card]
+  buyerAgent --> wa[WhatsApp]
+  buyerAgent --> tg[Telegram]
+  buyerAgent -->|capability check only| pine[Pine Labs Plural/P3P]
+  pine -->|redacted evidence ref| cache
+```
+
+## Responsibilities
+
+| Party | Owns | Does not own |
+| --- | --- | --- |
+| Merchant systems | Catalog, price, inventory, order, policy, support, and source timestamps. | OACP artifact policy. |
+| AgenticOrg | Seller and buyer agents, Shopify connector runtime, cache, buyer channels, and capability verification. | Canonical OACP authority or payment rail execution. |
+| Grantex | Policy, trust, artifacts, verification, and adapter authority. | Merchant connector runtime, buyer sessions, orders, or payments. |
+| Provider rails | Mandate and payment execution, provider status, settlement, and provider webhooks. | OACP trust authority or buyer-agent answers. |
+
+## Why Grantex Is Not In Every Loop
+
+Grantex signs and verifies authority artifacts. AgenticOrg can answer non-binding questions from valid cached artifacts until TTL, revocation, or policy state requires refresh. This reduces latency and avoids making Grantex a relay for every buyer question while preserving a hard boundary for commitment requests.
+
+## Failure Shape
+
+```mermaid
+flowchart LR
+  request[Buyer request] --> classify{Commitment?}
+  classify -->|No| cache{Valid cached artifacts?}
+  cache -->|Yes| answer[Answer with source and freshness]
+  cache -->|No| refresh[Refresh or refuse]
+  classify -->|Yes| handoff{Provider and merchant approval present?}
+  handoff -->|Yes| prepare[Prepare handoff only]
+  handoff -->|No| refuse[Refuse with blocker]
+```

--- a/docs/guides/oacp/artifact-authority.mdx
+++ b/docs/guides/oacp/artifact-authority.mdx
@@ -1,0 +1,49 @@
+---
+title: OACP Artifact Authority
+description: How Grantex issues, refuses, and verifies OACP artifacts for AgenticOrg.
+---
+
+# OACP Artifact Authority
+
+Canonical end-to-end flow: [OACP authority overview](./overview).
+
+Grantex authority is exposed through `POST /v1/commerce/oacp/c6z/authority-requests`. The route accepts an AgenticOrg seller authority request and public-safe connector evidence, validates scope, and returns issued artifacts or a refusal.
+
+```mermaid
+sequenceDiagram
+  participant A as AgenticOrg
+  participant G as Grantex
+  participant C as OACP cache
+  A->>G: Authority request plus redacted Shopify evidence
+  G->>G: Validate tenant, scope, source age, and unsafe fields
+  alt ready
+    G-->>A: 201 artifact_issuance_ready
+    A->>C: Cache signed/internal OACP artifacts
+  else blocked
+    G-->>A: 202/422 with safe blocker
+  end
+```
+
+## Artifact Families
+
+| Family | Purpose |
+| --- | --- |
+| `merchant_profile` | Merchant identity and public profile evidence. |
+| `seller_agent_card` | Seller Commerce Agent identity and runtime boundary. |
+| `connector_evidence` | Public-safe source evidence from AgenticOrg connector custody. |
+| `catalog_snapshot` | Product catalog facts from Shopify or merchant source. |
+| `offer_price_snapshot` | Price and offer facts with freshness metadata. |
+| `inventory_snapshot` | Inventory/availability facts with source time. |
+| `policy_scope` | Merchant and Grantex policy boundaries. |
+| `public_discovery_state` | Whether buyer-safe discovery may be shown. |
+| `mandate_capability` | Provider-owned capability evidence requirement and state. |
+| `protocol_adapter` | Compatibility mapping metadata. |
+| `authority_request_status` | Request result and blocker state. |
+
+## Verification Rules
+
+Artifacts must carry issuer, issuer key, artifact type, issued/expires timestamps, payload hash, signature algorithm, source refs, freshness metadata, revocation posture, risk tier, and `no_checkout_payment_enablement` behavior. Payloads must not contain raw connector payloads, tokens, provider secrets, card or bank data, checkout URLs, payment URLs, executable targets, or private merchant data.
+
+## Pending Runtime Gap
+
+Detached signature verification and key governance are implemented internally, but external public key distribution, rotation policy publication, and partner acceptance remain approval work before external program launch.

--- a/docs/guides/oacp/buyer-safety-freshness.mdx
+++ b/docs/guides/oacp/buyer-safety-freshness.mdx
@@ -1,0 +1,38 @@
+---
+title: OACP Buyer Safety And Freshness
+description: How source, freshness, cache, and refusal behavior keep buyer agents grounded.
+---
+
+# OACP Buyer Safety And Freshness
+
+Canonical end-to-end flow: [OACP authority overview](./overview).
+
+Buyer agents can ask, compare, reason, prepare, and hand off. They cannot invent product facts, stock promises, discounts, payment outcomes, orders, or mandates.
+
+```mermaid
+flowchart TD
+  ask[Buyer asks] --> cache{Cached OACP artifacts valid?}
+  cache -->|Yes| risk{Low-risk answer?}
+  risk -->|Yes| answer[Answer with source and freshness]
+  risk -->|No| prepare{Commitment checks pass?}
+  prepare -->|Yes| handoff[Prepared handoff only]
+  prepare -->|No| refuse[Safe refusal]
+  cache -->|No| unavailable{Grantex available?}
+  unavailable -->|Yes| refresh[Refresh authority request]
+  unavailable -->|No| refuse2[Refuse commitment or stale answer]
+```
+
+## Valid Cache, Grantex Unavailable
+
+If Grantex is temporarily unavailable and the cached artifacts are valid for the action class, AgenticOrg may continue non-binding Q&A with visible source and freshness labels.
+
+## Grantex Unavailable And Commitment Requested
+
+If the buyer asks for checkout, order, payment, mandate, refund, return, shipment, or inventory hold while Grantex is unavailable, AgenticOrg must refuse or prepare no further than a non-executing review handoff that clearly says execution did not occur.
+
+## Safe User Wording
+
+- "I can answer from the merchant source snapshot last refreshed at `<time>`."
+- "I cannot confirm purchase or payment from this cache."
+- "The source evidence is stale. I need a refresh before preparing this request."
+- "The provider capability evidence is missing, so no mandate or payment was created."

--- a/docs/guides/oacp/explainers/buyer-agent-safety.mdx
+++ b/docs/guides/oacp/explainers/buyer-agent-safety.mdx
@@ -1,0 +1,40 @@
+---
+title: How Buyer Agents Shop Safely With OACP
+description: Buyer explainer for OACP source, freshness, and refusal behavior.
+---
+
+# How Buyer Agents Shop Safely With OACP
+
+Canonical end-to-end flow: [OACP authority overview](../overview).
+
+OACP lets a buyer agent answer from verified commerce facts instead of guessing.
+
+```mermaid
+flowchart TD
+  question[Buyer question] --> artifacts[OACP artifacts]
+  artifacts --> fresh{Fresh and in scope?}
+  fresh -->|Yes| answer[Answer with labels]
+  fresh -->|No| refuse[Refuse or request refresh]
+  question --> commit{Commitment request?}
+  commit -->|Yes| handoff[Prepared handoff or blocker]
+```
+
+## What The Agent Can Do
+
+- Explain products, variants, availability, source, freshness, and merchant policy.
+- Compare options from valid cached artifacts.
+- Prepare a non-executing handoff when freshness and policy allow.
+- Refuse stale, private, unsupported, or high-risk requests.
+
+## What The Agent Cannot Do From OACP Artifacts
+
+- Create an order.
+- Capture payment.
+- Create a checkout session.
+- Set up a mandate.
+- Reserve stock.
+- Claim a provider rail succeeded.
+
+## Safe Wording
+
+"I can answer from a Shopify snapshot authorized by Grantex and refreshed at `<time>`. I cannot complete payment or order creation from this artifact cache."

--- a/docs/guides/oacp/explainers/developer-artifacts-bridges.mdx
+++ b/docs/guides/oacp/explainers/developer-artifacts-bridges.mdx
@@ -1,0 +1,36 @@
+---
+title: Build Against OACP Artifacts And Bridges
+description: Developer explainer for OACP artifacts, AgenticOrg bridges, and adapter payloads.
+---
+
+# Build Against OACP Artifacts And Bridges
+
+Canonical end-to-end flow: [OACP authority overview](../overview).
+
+Developers should treat OACP artifacts as signed/internal trust inputs, not as checkout execution tokens.
+
+```mermaid
+flowchart LR
+  oacp[OACP artifact] --> cache[AgenticOrg verifier/cache]
+  cache --> web[Web ask]
+  cache --> mcp[MCP tools]
+  cache --> openapi[OpenAPI ask]
+  cache --> a2a[A2A card]
+```
+
+## Integration Points
+
+| Surface | Owner | Purpose |
+| --- | --- | --- |
+| Grantex authority request | Grantex | Issues or refuses artifact families. |
+| AgenticOrg artifact cache | AgenticOrg | Stores verified public-safe refs. |
+| MCP | AgenticOrg | ChatGPT/Claude-style client tool surface. |
+| OpenAPI | AgenticOrg | Gemini/Perplexity-style client surface. |
+| A2A | AgenticOrg | Agent card and task metadata. |
+
+## Developer Rules
+
+- Never treat adapter payloads as payment approval.
+- Preserve source and freshness labels in user-facing output.
+- Block or refresh when artifact TTL, revocation, or scope fails.
+- Keep provider credentials out of OACP artifacts.

--- a/docs/guides/oacp/explainers/launch-rollback-runbook.mdx
+++ b/docs/guides/oacp/explainers/launch-rollback-runbook.mdx
@@ -1,0 +1,36 @@
+---
+title: Launch And Rollback Runbook
+description: Operator explainer for OACP launch, smoke tests, monitoring, and rollback.
+---
+
+# Launch And Rollback Runbook
+
+Canonical end-to-end flow: [OACP authority overview](../overview).
+
+## Launch Smoke
+
+```mermaid
+flowchart TD
+  creds[Verify credentials] --> shopify[Run Shopify read-only sync]
+  shopify --> authority[Request Grantex artifacts]
+  authority --> cache[Cache and verify artifacts]
+  cache --> ask[Ask buyer question]
+  ask --> purchase[Ask purchase request]
+  purchase --> result[Prepared handoff or blocker]
+```
+
+## Monitor
+
+- Authority request rate, refusal code mix, and tenant allowlist changes.
+- Artifact TTL and stale-cache refusals.
+- Adapter mapping errors.
+- Provider capability verifier status.
+- Channel webhook failures.
+
+## Rollback
+
+1. Remove tenant allowlist in Grantex.
+2. Rotate the service token if needed.
+3. Ask AgenticOrg to stop refresh and mark artifacts stale.
+4. Disable public buyer channels.
+5. Keep audit/export material for review.

--- a/docs/guides/oacp/explainers/protocol-partner-mappings.mdx
+++ b/docs/guides/oacp/explainers/protocol-partner-mappings.mdx
@@ -1,0 +1,34 @@
+---
+title: How OACP Maps To Schema.org, UCP, ACP, AP2, A2A, And MCP
+description: Protocol partner explainer for OACP compatibility mappings.
+---
+
+# How OACP Maps To Schema.org, UCP, ACP, AP2, A2A, And MCP
+
+Canonical end-to-end flow: [OACP authority overview](../overview).
+
+OACP is the canonical internal trust artifact. Protocol adapters are compatibility mappings derived from OACP, not official external approval.
+
+```mermaid
+flowchart TD
+  canonical[Canonical OACP artifacts] --> schema[Schema.org JSON-LD]
+  canonical --> ucp[UCP-style profile]
+  canonical --> acp[ACP-style commerce profile]
+  canonical --> ap2[AP2-style evidence profile]
+  canonical --> a2a[A2A metadata]
+  canonical --> mcp[MCP metadata]
+```
+
+## Compatibility Vs Official Approval
+
+| Term | Meaning |
+| --- | --- |
+| Compatibility mapping | Deterministic field lineage from OACP artifacts to a known shape. |
+| Official approval | External program review and acceptance. Not claimed here. |
+
+## Partner Review Questions
+
+- Which OACP artifact family is the canonical source?
+- Which source refs and freshness labels must be visible?
+- Which fields are unsupported because they imply execution?
+- Which external program evidence is required before public claims change?

--- a/docs/guides/oacp/explainers/provider-owned-payment-evidence.mdx
+++ b/docs/guides/oacp/explainers/provider-owned-payment-evidence.mdx
@@ -1,0 +1,30 @@
+---
+title: Provider-Owned Mandate And Payment Evidence In OACP
+description: Payment and fintech partner explainer for OACP evidence boundaries.
+---
+
+# Provider-Owned Mandate And Payment Evidence In OACP
+
+Canonical end-to-end flow: [OACP authority overview](../overview).
+
+OACP can carry evidence references that a provider-owned capability check occurred. It does not store raw payment secrets or execute the rail.
+
+```mermaid
+flowchart LR
+  agentic[AgenticOrg verifier] --> provider[Pine Labs Plural/P3P]
+  provider --> evidence[Redacted evidence ref]
+  evidence --> artifact[OACP mandate_capability artifact]
+  artifact --> handoff[Prepared handoff or blocker]
+```
+
+## Evidence Boundaries
+
+| Item | Allowed in OACP | Not allowed in OACP |
+| --- | --- | --- |
+| Capability | Redacted provider evidence ref. | Raw credential or token. |
+| Status | Freshness and capability label. | Provider secret response body. |
+| Payment | Boundary state only. | Capture, checkout URL, order success, mandate creation. |
+
+## Partner Action
+
+Provide a capability-verification endpoint or partner process that returns non-sensitive evidence refs, expiry, and environment state. Execution remains with the provider rail.

--- a/docs/guides/oacp/explainers/shopify-to-agentic-commerce.mdx
+++ b/docs/guides/oacp/explainers/shopify-to-agentic-commerce.mdx
@@ -1,0 +1,47 @@
+---
+title: Move Your Shopify Store To Agentic Commerce
+description: Merchant explainer for bringing Shopify into AgenticOrg with Grantex OACP authority.
+---
+
+# Move Your Shopify Store To Agentic Commerce
+
+Canonical end-to-end flow: [OACP authority overview](../overview).
+
+This page is for merchants evaluating a Seller Commerce Agent in AgenticOrg.
+
+## Steps
+
+1. Create a Seller Commerce Agent in AgenticOrg.
+2. Connect Shopify with read-only Admin API access or an approved OAuth flow.
+3. Run a read-only sync for catalog, variants, price, inventory, and source timestamps.
+4. Let AgenticOrg submit redacted evidence to Grantex.
+5. Grantex issues OACP artifacts or exact blockers.
+6. AgenticOrg caches artifacts and exposes buyer-safe channels.
+7. Purchase requests are prepared for approved provider/merchant handoff or refused.
+
+```mermaid
+flowchart LR
+  merchant[Merchant] --> agent[Seller Commerce Agent]
+  agent --> shopify[Read-only Shopify sync]
+  shopify --> grantex[Grantex authority]
+  grantex --> cache[AgenticOrg cache]
+  cache --> buyer[Buyer channels]
+```
+
+## Requirements
+
+| Requirement | Owner |
+| --- | --- |
+| Shopify read-only credential or OAuth install | Merchant + AgenticOrg |
+| AgenticOrg tenant and seller agent id | AgenticOrg |
+| Grantex tenant allowlist and service token | Grantex |
+| Provider capability configuration | AgenticOrg + Pine Labs Plural/P3P |
+| Channel approvals | AgenticOrg + channel owners |
+
+## Expected Timeline
+
+Local demo can be run after credentials and allowlisting. Public channel launch requires source evidence review, provider capability evidence, channel webhook approval, rollback owner, and operator signoff.
+
+## What Agents Can Say
+
+Buyer agents can answer product questions with source and freshness labels. They cannot promise payment, order, shipping, refund, mandate, or stock-hold success unless the merchant/provider system actually executed it.

--- a/docs/guides/oacp/launch-readiness.mdx
+++ b/docs/guides/oacp/launch-readiness.mdx
@@ -1,0 +1,38 @@
+---
+title: OACP Launch Readiness
+description: Launch readiness gates, rollback criteria, and remaining gaps for Grantex OACP authority.
+---
+
+# OACP Launch Readiness
+
+Canonical end-to-end flow: [OACP authority overview](./overview).
+
+OACP authority is launch-ready only for the scoped path where Grantex issues internal artifacts to an allowlisted AgenticOrg tenant and AgenticOrg uses them for non-binding buyer answers or prepared handoff decisions.
+
+## Readiness Matrix
+
+| Gate | Required evidence |
+| --- | --- |
+| Runtime route | Authority endpoint merged and protected by operator/service auth. |
+| Tenant allowlist | AgenticOrg tenant explicitly allowlisted. |
+| Source evidence | Shopify read-only sync evidence is redacted and timestamped. |
+| Artifact issue/refuse | All 11 families issue for valid evidence; unsafe requests refuse. |
+| Adapter mapping | Schema.org, UCP-style, ACP-style, AP2-style, A2A, MCP, and OpenAPI mappings derive from OACP artifacts. |
+| Cache behavior | Valid cache can answer non-binding questions; stale cache blocks commitment. |
+| Provider boundary | Plural/Pine capability evidence is provider-owned and redacted. |
+| Rollback | Tenant removal and service-token rotation tested. |
+
+## Launch And Rollback Diagram
+
+```mermaid
+flowchart LR
+  launch[Launch scoped tenant] --> monitor[Monitor authority requests and refusals]
+  monitor --> stale{Stale or unsafe?}
+  stale -->|No| continue[Continue cache-backed Q&A]
+  stale -->|Yes| rollback[Remove allowlist or rotate token]
+  rollback --> notify[Notify AgenticOrg to stop refresh and mark cache stale]
+```
+
+## Do Not Claim
+
+Do not claim official protocol approval, broad payment support, all-buyer purchase support, or payment/order success. Current OACP authority supports trust artifacts, compatibility mapping, cache-backed discovery, and prepared handoff boundaries.

--- a/docs/guides/oacp/merchant-source-of-record.mdx
+++ b/docs/guides/oacp/merchant-source-of-record.mdx
@@ -1,0 +1,30 @@
+---
+title: OACP Merchant Source Of Record
+description: Why Shopify and merchant systems remain authoritative in OACP.
+---
+
+# OACP Merchant-System Source Of Record
+
+Canonical end-to-end flow: [OACP authority overview](./overview).
+
+OACP does not move commerce truth into Grantex. Shopify, merchant OMS, inventory systems, policy stores, support systems, and payment providers remain operational systems of record.
+
+```mermaid
+flowchart LR
+  shopify[Shopify catalog, price, inventory] --> evidence[AgenticOrg public-safe evidence]
+  evidence --> grantex[Grantex authority]
+  grantex --> artifact[OACP artifact with source and freshness]
+  artifact --> cache[AgenticOrg cache]
+  cache --> buyer[Buyer answer with labels]
+```
+
+## Source Rules
+
+- Product names, descriptions, variants, images, prices, and inventory come from Shopify or the merchant-approved source.
+- Grantex validates evidence shape and policy, not the raw private connector payload.
+- AgenticOrg stores public-safe artifact refs and freshness labels, not raw Shopify secrets.
+- If source evidence is stale or conflicting, buyer answers must refresh or refuse.
+
+## Pending Runtime Gap
+
+Multi-system conflict resolution across Shopify, ERP, OMS, WMS, support, and provider records needs explicit source precedence policy before broad launch.

--- a/docs/guides/oacp/operator-runbook.mdx
+++ b/docs/guides/oacp/operator-runbook.mdx
@@ -1,0 +1,43 @@
+---
+title: OACP Operator Runbook
+description: Grantex operator runbook for authority requests, cache safety, launch checks, and rollback.
+---
+
+# OACP Operator Runbook
+
+Canonical end-to-end flow: [OACP authority overview](./overview).
+
+## Smoke Tests
+
+```mermaid
+flowchart TD
+  start[Start] --> token[Verify service token and tenant allowlist]
+  token --> request[Submit fixture authority request]
+  request --> artifact[Confirm 11 artifact families or expected blocker]
+  artifact --> verify[Run artifact verifier checks]
+  verify --> adapters[Inspect adapter mapping payload]
+  adapters --> cache[Ask AgenticOrg to cache and answer from source labels]
+  cache --> purchase[Confirm purchase request returns handoff or blocker]
+```
+
+## Checklist
+
+| Check | Command or evidence |
+| --- | --- |
+| Authority route exists | `apps/auth-service/src/routes/commerce-oacp-runtime.ts` |
+| Artifact tests pass | `npm --prefix apps/auth-service test -- commerce-c6z-runtime-artifact-authority.test.ts` |
+| Adapter tests pass | `npm --prefix apps/auth-service test -- commerce-c6w4-oacp-adapter-previews.test.ts` |
+| Conformance gate | `node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr` |
+| Guardrail scan | Search changed docs for stale or overclaim wording. |
+
+## Rollback
+
+1. Remove the AgenticOrg tenant from `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS`.
+2. Rotate the service token if compromise is suspected.
+3. Ask AgenticOrg to stop refreshing artifacts and mark affected cache records stale.
+4. Leave existing historical artifacts reviewable for audit/export.
+5. Publish an operator note with affected tenants, merchant ids, artifact families, and timestamps.
+
+## Refusal Copy
+
+Use exact blockers: missing source evidence, stale artifact, unsafe executable request, provider capability missing, tenant not allowlisted, or authority temporarily unavailable.

--- a/docs/guides/oacp/overview.mdx
+++ b/docs/guides/oacp/overview.mdx
@@ -1,0 +1,63 @@
+---
+title: OACP Authority Overview
+description: The canonical Grantex overview for Open Agentic Commerce Protocol authority, artifacts, policy, and adapter governance.
+---
+
+# OACP Authority Overview
+
+This is the canonical Grantex OACP page. The canonical end-to-end flow starts here and links to the AgenticOrg runtime guide from the integration page.
+
+OACP is the trust and interoperability layer for agentic commerce. Grantex owns the protocol, trust, policy, artifact, verification, and protocol-adapter authority. AgenticOrg owns the buyer and seller AI-agent runtime, Shopify connector runtime, buyer sessions, channel bridges, OACP cache, and provider-owned mandate capability verification.
+
+Merchant systems such as Shopify remain the source of record. Pine Labs Plural/P3P and other provider rails own mandate and payment execution. Grantex must not become a toll booth for every buyer and seller interaction.
+
+## Four-Party Architecture
+
+```mermaid
+flowchart LR
+  merchant[Merchant systems: Shopify, OMS, inventory, policy] --> agentic[AgenticOrg seller and buyer runtime]
+  agentic -->|authority request with redacted evidence| grantex[Grantex OACP authority]
+  grantex -->|signed internal artifacts and blockers| agentic
+  agentic -->|buyer answer from valid cache| buyer[Buyer surfaces]
+  agentic -->|capability check only| provider[Pine Labs Plural/P3P or payment rail]
+  provider -->|redacted capability evidence ref| agentic
+```
+
+## What Grantex Owns
+
+| Area | Grantex role |
+| --- | --- |
+| Trust authority | Issues or refuses canonical internal OACP artifacts. |
+| Policy governance | Defines artifact TTL, freshness, source, revocation, risk, and blocked-capability rules. |
+| Artifact verification | Verifies issuer, scope, payload hash, signature, TTL, and public-safe payload constraints. |
+| Protocol adapters | Governs compatibility mappings from canonical OACP artifacts to Schema.org, UCP-style, ACP-style, AP2-style, A2A, MCP, and OpenAPI payloads. |
+| Integration boundary | Accepts allowlisted AgenticOrg authority requests with public-safe connector evidence. |
+
+## What Grantex Does Not Own
+
+Grantex does not own Shopify runtime credentials, merchant onboarding UX, buyer sessions, WhatsApp or Telegram webhooks, MCP/OpenAPI client sessions, AgenticOrg artifact cache storage, final checkout execution, order creation, stock holds, mandate setup, payment capture, refund execution, or provider settlement.
+
+## Runtime Reality
+
+| Status | Reality |
+| --- | --- |
+| Implemented runtime | `POST /v1/commerce/oacp/c6z/authority-requests`, internal artifact issuance, verifier helpers, adapter preview helpers, and OACP guard tests. |
+| Implemented docs only | Historical Commerce V1 planning and C6 audit/review reports remain useful as internal history but are superseded for the public OACP split. |
+| Requires external credentials or approval | AgenticOrg service token and tenant allowlist, merchant Shopify access, channel approvals, and provider rail approval. |
+| Missing | Public standards program approval, universal channel launch, and broad payment/order execution. |
+| Stale/confusing documentation | Older Commerce V1 pages that frame Grantex as the merchant control plane are historical; use this OACP group for the current authority narrative. |
+
+## Artifact Families
+
+Grantex currently issues or refuses these internal OACP families for the C6Z AgenticOrg runtime path: `merchant_profile`, `seller_agent_card`, `connector_evidence`, `catalog_snapshot`, `offer_price_snapshot`, `inventory_snapshot`, `policy_scope`, `public_discovery_state`, `mandate_capability`, `protocol_adapter`, and `authority_request_status`.
+
+## Buyer-Safe Rule
+
+AgenticOrg may continue non-binding product questions and comparison from valid cached artifacts. A request that would commit the buyer, create a checkout, create a mandate, capture payment, reserve inventory, create an order, refund, return, or ship must use the approved provider, merchant, and channel path. OACP artifacts do not invent success.
+
+## Related Pages
+
+- [Architecture](./architecture)
+- [Artifact authority](./artifact-authority)
+- [AgenticOrg integration guide](./agenticorg-integration)
+- [Launch readiness](./launch-readiness)

--- a/docs/guides/oacp/policy-governance.mdx
+++ b/docs/guides/oacp/policy-governance.mdx
@@ -1,0 +1,38 @@
+---
+title: OACP Policy And Governance
+description: Policy, freshness, source, revocation, and adapter governance for Grantex OACP authority.
+---
+
+# OACP Policy And Governance
+
+Canonical end-to-end flow: [OACP authority overview](./overview).
+
+Grantex governs the policy envelope around OACP artifacts: source lineage, TTL, freshness, revocation snapshot age, risk tier, blocked capabilities, and adapter lineage.
+
+## Governance Controls
+
+| Control | Grantex requirement |
+| --- | --- |
+| Source lineage | Every artifact needs source refs and observed timestamps. |
+| Freshness | TTL is capped by artifact family and risk tier. |
+| Revocation | Cache consumers need current enough revocation posture for the action class. |
+| Risk tier | Low-risk discovery can use valid cache; commitment-bound actions require stronger evidence. |
+| Adapter lineage | Adapter payloads must cite canonical OACP artifact families. |
+| Non-enablement | Artifacts must not imply checkout, payment, order, mandate, refund, return, shipment, or stock-hold execution. |
+
+## Policy Diagram
+
+```mermaid
+flowchart TD
+  input[Authority request] --> source{Source refs present?}
+  source -->|No| refuse1[Refuse: missing source]
+  source -->|Yes| ttl{Fresh within TTL?}
+  ttl -->|No| refuse2[Refuse: stale]
+  ttl -->|Yes| scope{Scope allowed?}
+  scope -->|No| refuse3[Refuse: private or executable scope]
+  scope -->|Yes| issue[Issue internal OACP artifacts]
+```
+
+## Publication And Approval
+
+External public claims require documented evidence, product approval, security review, partner review, and release notes. Until then, docs must use "compatibility mapping" and "internal OACP artifact authority."

--- a/docs/guides/oacp/protocol-adapter.mdx
+++ b/docs/guides/oacp/protocol-adapter.mdx
@@ -1,0 +1,41 @@
+---
+title: OACP Protocol Adapter Authority
+description: How Grantex maps canonical OACP artifacts to compatibility payloads.
+---
+
+# OACP Protocol Adapter Authority
+
+Canonical end-to-end flow: [OACP authority overview](./overview).
+
+The canonical artifact is OACP. Adapter payloads are derived compatibility views for clients and partner systems. They are not official approval by Schema.org, UCP, ACP, AP2, A2A, MCP, or OpenAPI programs.
+
+```mermaid
+flowchart LR
+  artifact[Canonical OACP artifacts] --> schema[Schema.org Product/Offer JSON-LD]
+  artifact --> ucp[UCP-style capability profile]
+  artifact --> acp[ACP-style interaction profile]
+  artifact --> ap2[AP2-style evidence profile]
+  artifact --> a2a[A2A task metadata]
+  artifact --> mcp[MCP tool metadata]
+  artifact --> openapi[OpenAPI buyer-safe schema]
+```
+
+## Adapter Boundaries
+
+| Adapter | Current use | Boundary |
+| --- | --- | --- |
+| Schema.org | Product and offer discovery shape. | Source/freshness stays from OACP and Shopify. |
+| UCP-style | Capability summary for agentic commerce. | Compatibility mapping only. |
+| ACP-style | Checkout-like shape preview for clients. | Does not create checkout or payment. |
+| AP2-style | Mandate/evidence profile shape. | Does not create a mandate. |
+| A2A | Agent card/task metadata. | Does not authorize execution. |
+| MCP | Tool metadata for ChatGPT/Claude-style clients. | Tool calls still hit AgenticOrg runtime checks. |
+| OpenAPI | Gemini/Perplexity-style hosted/action clients. | Buyer-safe schema only. |
+
+## Internal Mapping Vs External Approval
+
+Internal mapping means Grantex defines deterministic field lineage from OACP artifacts to adapter payloads. External approval means a third-party program has reviewed and accepted claims. The current implementation is internal mapping only unless a future page links evidence for external approval.
+
+## Operator Rule
+
+If a new adapter field cannot be derived from a canonical OACP artifact and public-safe source refs, leave it out or return an unsupported field blocker.

--- a/docs/guides/oacp/provider-payment-boundary.mdx
+++ b/docs/guides/oacp/provider-payment-boundary.mdx
@@ -1,0 +1,36 @@
+---
+title: OACP Provider And Payment Boundary
+description: How OACP treats Pine Labs Plural/P3P and other payment rails.
+---
+
+# OACP Provider And Payment Boundary
+
+Canonical end-to-end flow: [OACP authority overview](./overview).
+
+Pine Labs Plural/P3P and other provider rails own mandate setup, payment execution, provider status, settlement, and provider webhooks. Grantex does not execute provider rails in the AgenticOrg OACP runtime split.
+
+```mermaid
+flowchart LR
+  buyer[Buyer intent] --> agentic[AgenticOrg purchase preparation]
+  agentic --> cache[OACP cache checks]
+  agentic --> verifier[Plural/Pine capability verifier]
+  verifier --> ref[Redacted capability evidence ref]
+  cache --> result{All checks pass?}
+  ref --> result
+  result -->|Yes| prepared[Prepared provider-owned handoff]
+  result -->|No| blocker[Exact blocker]
+```
+
+## Boundary Rules
+
+| Area | Rule |
+| --- | --- |
+| Mandate setup | Provider-owned. OACP may carry non-sensitive capability evidence refs. |
+| Payment capture | Provider-owned and outside artifact issuance. |
+| Checkout/order success | Must come from merchant/provider systems, never from an agent guess. |
+| Raw secrets | Not stored in OACP artifacts. |
+| Evidence | Redacted refs and freshness only. |
+
+## Pending Runtime Gap
+
+Provider-owned execution can only be added after merchant, provider, legal, security, operations, channel, rollback, and observability approval. Until then, docs must say prepared handoff or blocker.

--- a/docs/guides/oacp/truth-inventory.mdx
+++ b/docs/guides/oacp/truth-inventory.mdx
@@ -1,0 +1,38 @@
+---
+title: OACP Truth Inventory
+description: Evidence-backed inventory of what is implemented, gated, missing, or stale across the current OACP split.
+---
+
+# OACP Truth Inventory
+
+Canonical end-to-end flow: [OACP authority overview](./overview).
+
+This inventory is based on the Grantex C6Z authority route, OACP artifact libraries, adapter preview helpers, and tests in `apps/auth-service`.
+
+## Truth Table
+
+| Category | Grantex reality | Owner/action |
+| --- | --- | --- |
+| Implemented runtime | C6Z authority endpoint under commerce auth; allowlisted AgenticOrg service-token access; internal artifact issuance; artifact safety checks; TTL and signature metadata; adapter mapping payloads; cache/offline verifier helpers. | Grantex keeps tests and guard scans current. |
+| Implemented docs only | Historical Commerce V1 PRDs, launch plans, C6 review reports, and publication drafts. | Mark as historical where they conflict with this architecture. |
+| Implemented but not broad launch | Commerce V1 payment-control pilot code and Plural sandbox/UAT-compatible adapter paths exist separately from the AgenticOrg OACP runtime split. | Keep separate from OACP authority docs. |
+| Requires credentials or approval | `COMMERCE_C6Z_AUTHORITY_SERVICE_TOKEN`, `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS`, merchant/AgenticOrg tenant approval, production key custody, provider rail approval, and external channel approvals. | Ops owner must collect evidence before public claims. |
+| Missing | Public standards approval, broad external protocol partner program, universal buyer-surface rollout, order/payment/mandate execution through OACP artifacts. | Treat as pending runtime/product gaps. |
+| Stale/confusing docs | Older copy that says Grantex is the merchant connector runtime or payment-control loop for every buyer interaction. | Supersede with OACP authority docs and link here. |
+
+## Evidence Pointers
+
+- Route: `apps/auth-service/src/routes/commerce-oacp-runtime.ts`
+- Artifact logic: `apps/auth-service/src/lib/commerce/oacp-runtime-vertical.ts`
+- Trust helpers: `apps/auth-service/src/lib/commerce/oacp-trust-artifacts.ts`
+- Adapter previews: `schemaorg-preview.ts`, `ucp-capability-preview.ts`, `acp-checkout-preview.ts`, `ap2-evidence-preview.ts`
+- Tests: `apps/auth-service/tests/commerce-c6z-runtime-artifact-authority.test.ts` and `commerce-c6w4-oacp-adapter-previews.test.ts`
+
+## Pending Runtime Gaps
+
+| Gap | Owner | Action |
+| --- | --- | --- |
+| External protocol approval | Grantex + partners | Create a public partner review process and evidence checklist before making official status claims. |
+| AgenticOrg production tenant rollout | AgenticOrg + Grantex | Allowlist tenant, rotate service token, verify source evidence intake, and run authority request smoke. |
+| Provider rail execution | Pine Labs Plural/P3P + merchant + AgenticOrg | Complete provider-owned approval, webhook, rollback, and human review path. Grantex stores only non-sensitive evidence refs where needed. |
+| Buyer-surface approvals | AgenticOrg + channel owners | Verify WhatsApp, Telegram, MCP, OpenAPI, A2A, and web policies before public launch. |

--- a/web/commerce.html
+++ b/web/commerce.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Grantex Agentic Commerce V1 Live Pilot</title>
-  <meta name="description" content="Plain-language education for the Grantex Agentic Commerce V1 live pilot with Shopify catalog grounding, consent, Commerce Passport, policy, audit, Plural webhook intake, and payment-control flows." />
+  <title>Grantex OACP Authority</title>
+  <meta name="description" content="Grantex is the protocol, trust, policy, and artifact authority for OACP agentic commerce. AgenticOrg runs buyer and seller agents; merchant and provider systems remain authoritative." />
   <style>
     :root {
       color-scheme: light;
-      --ink: #132018;
-      --muted: #50645a;
-      --line: #d8e4dc;
-      --paper: #f7faf7;
+      --ink: #14201a;
+      --muted: #54645b;
+      --line: #d7e3db;
+      --paper: #f7faf8;
       --white: #ffffff;
-      --green: #267a4a;
-      --blue: #255f8e;
-      --amber: #9a651f;
-      --red: #a43f31;
-      --shadow: 0 18px 55px rgba(19, 32, 24, 0.11);
+      --green: #24764a;
+      --blue: #275f8d;
+      --amber: #8e641f;
+      --red: #9a3d32;
+      --shadow: 0 20px 55px rgba(20, 32, 26, 0.10);
     }
 
     * { box-sizing: border-box; }
@@ -30,24 +30,27 @@
     }
     a { color: var(--blue); }
     header, section { padding: 64px 24px; }
-    .wrap { max-width: 1120px; margin: 0 auto; }
+    .wrap { max-width: 1160px; margin: 0 auto; }
     .topbar {
       display: flex;
-      justify-content: space-between;
       align-items: center;
+      justify-content: space-between;
       padding: 18px 24px;
       border-bottom: 1px solid var(--line);
-      background: rgba(255, 255, 255, 0.9);
+      background: rgba(255, 255, 255, 0.92);
       position: sticky;
       top: 0;
-      z-index: 2;
-      backdrop-filter: blur(14px);
+      z-index: 5;
+      backdrop-filter: blur(12px);
     }
-    .brand { font-weight: 800; color: var(--ink); text-decoration: none; letter-spacing: 0; }
+    .brand { font-weight: 850; text-decoration: none; color: var(--ink); }
     .nav { display: flex; gap: 18px; font-size: 14px; }
     .nav a { color: var(--muted); text-decoration: none; }
     .hero {
-      background: linear-gradient(135deg, #ffffff 0%, #eef6f1 55%, #f7efe4 100%);
+      background:
+        linear-gradient(135deg, rgba(255,255,255,0.92), rgba(239,248,242,0.96)),
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540'%3E%3Crect width='960' height='540' fill='%23eef6f1'/%3E%3Cg fill='none' stroke='%23a8cbb8' stroke-width='2' opacity='.55'%3E%3Cpath d='M80 280h800M200 160h560M240 380h480M210 160v220M750 160v220'/%3E%3C/g%3E%3Cg font-family='Arial' font-size='28' font-weight='700' fill='%2324764a'%3E%3Ctext x='90' y='140'%3EOACP%3C/text%3E%3Ctext x='410' y='110'%3ETrust%3C/text%3E%3Ctext x='770' y='440'%3EPolicy%3C/text%3E%3C/g%3E%3C/svg%3E");
+      background-size: cover;
       border-bottom: 1px solid var(--line);
     }
     .hero-grid {
@@ -55,82 +58,88 @@
       grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
       gap: 42px;
       align-items: center;
+      min-height: 560px;
     }
-    .eyebrow { color: var(--green); font-weight: 800; text-transform: uppercase; font-size: 13px; }
-    h1 { font-size: clamp(36px, 5vw, 64px); line-height: 1.02; margin: 12px 0 18px; letter-spacing: 0; }
-    h2 { font-size: clamp(26px, 3vw, 40px); line-height: 1.14; margin: 0 0 18px; letter-spacing: 0; }
+    .eyebrow {
+      color: var(--green);
+      font-size: 13px;
+      font-weight: 850;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    h1 { font-size: clamp(38px, 5vw, 68px); line-height: 1.02; margin: 12px 0 18px; letter-spacing: 0; }
+    h2 { font-size: clamp(28px, 3vw, 42px); line-height: 1.12; margin: 0 0 18px; letter-spacing: 0; }
     h3 { margin: 0 0 8px; font-size: 19px; letter-spacing: 0; }
-    p { margin: 0 0 16px; color: var(--muted); }
-    .badges { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 26px; }
-    .badge { border: 1px solid var(--line); background: var(--white); border-radius: 999px; padding: 8px 12px; font-size: 13px; font-weight: 700; }
-    .badge.blocked { color: var(--red); border-color: #efc8c1; }
-    .badge.review { color: var(--amber); border-color: #edd9b7; }
-    .badge.ready { color: var(--green); border-color: #b8dbc6; }
-    .panel {
-      background: var(--white);
-      border: 1px solid var(--line);
+    p { color: var(--muted); margin: 0 0 16px; }
+    .actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 28px; }
+    .button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 12px 18px;
       border-radius: 8px;
-      box-shadow: var(--shadow);
-      padding: 26px;
-    }
-    .flow { display: grid; gap: 12px; }
-    .step {
-      display: grid;
-      grid-template-columns: 34px 1fr;
-      gap: 12px;
-      align-items: start;
-      padding: 14px;
-      border: 1px solid var(--line);
-      border-radius: 8px;
-      background: #fbfdfb;
-    }
-    .num {
-      width: 34px;
-      height: 34px;
-      border-radius: 50%;
-      background: var(--green);
-      color: white;
-      display: grid;
-      place-items: center;
       font-weight: 800;
+      text-decoration: none;
     }
-    .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
-    .grid-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+    .primary { color: white; background: var(--green); }
+    .secondary { color: var(--ink); background: white; border: 1px solid var(--line); }
+    .panel {
+      background: rgba(255,255,255,0.92);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 24px;
+      box-shadow: var(--shadow);
+    }
+    .mini-grid, .grid-3, .grid-2 { display: grid; gap: 18px; }
+    .mini-grid { grid-template-columns: repeat(2, 1fr); }
+    .grid-3 { grid-template-columns: repeat(3, 1fr); }
+    .grid-2 { grid-template-columns: repeat(2, 1fr); }
     .card {
-      background: var(--white);
+      background: white;
       border: 1px solid var(--line);
       border-radius: 8px;
       padding: 22px;
     }
-    .status-table { width: 100%; border-collapse: collapse; background: var(--white); border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
-    .status-table th, .status-table td { text-align: left; padding: 14px; border-bottom: 1px solid var(--line); vertical-align: top; }
-    .status-table th { background: #eef6f1; font-size: 13px; text-transform: uppercase; color: var(--muted); }
-    .ladder {
-      display: grid;
-      grid-template-columns: repeat(7, 1fr);
-      gap: 10px;
-      margin-top: 22px;
-    }
-    .rung {
-      min-height: 110px;
-      padding: 14px;
-      border-radius: 8px;
+    .card strong { color: var(--ink); }
+    .badge {
+      display: inline-flex;
       border: 1px solid var(--line);
-      background: var(--white);
+      border-radius: 999px;
+      background: white;
+      padding: 7px 11px;
+      margin: 0 8px 8px 0;
+      font-size: 13px;
       font-weight: 800;
-      font-size: 14px;
     }
-    .rung span { display: block; margin-top: 8px; color: var(--muted); font-weight: 500; font-size: 13px; }
-    .allowed { border-top: 4px solid var(--green); }
-    .blocked-line { border-top: 4px solid var(--red); }
-    .review-line { border-top: 4px solid var(--amber); }
-    .cta { background: #132018; color: white; }
-    .cta p, .cta a { color: #d8e4dc; }
-    footer { padding: 28px 24px; border-top: 1px solid var(--line); color: var(--muted); background: var(--white); }
-    @media (max-width: 880px) {
-      .hero-grid, .grid-3, .grid-2, .ladder { grid-template-columns: 1fr; }
+    .diagram {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 14px;
+      align-items: stretch;
+    }
+    .node {
+      min-height: 154px;
+      background: white;
+      border: 1px solid var(--line);
+      border-top: 5px solid var(--green);
+      border-radius: 8px;
+      padding: 18px;
+      position: relative;
+    }
+    .node:nth-child(2) { border-top-color: var(--blue); }
+    .node:nth-child(3) { border-top-color: var(--amber); }
+    .node:nth-child(4) { border-top-color: var(--red); }
+    table { width: 100%; border-collapse: collapse; background: white; border: 1px solid var(--line); }
+    th, td { text-align: left; padding: 14px; border-bottom: 1px solid var(--line); vertical-align: top; }
+    th { background: #edf6f1; color: var(--muted); font-size: 13px; text-transform: uppercase; }
+    .dark { background: #14201a; color: white; }
+    .dark p, .dark a { color: #dbe7df; }
+    footer { padding: 28px 24px; border-top: 1px solid var(--line); background: white; }
+    @media (max-width: 900px) {
+      .hero-grid, .grid-3, .grid-2, .diagram, .mini-grid { grid-template-columns: 1fr; }
       .nav { display: none; }
-      header, section { padding: 44px 18px; }
+      header, section { padding: 46px 18px; }
+      .hero-grid { min-height: auto; }
     }
   </style>
 </head>
@@ -138,127 +147,128 @@
   <nav class="topbar">
     <a class="brand" href="/">Grantex</a>
     <div class="nav">
-      <a href="#workflow">Workflow</a>
-      <a href="#readiness">Readiness</a>
-      <a href="#audiences">Audience paths</a>
-      <a href="https://docs.grantex.dev/guides/commerce-v1-overview">Docs</a>
+      <a href="#architecture">Architecture</a>
+      <a href="#artifacts">Artifacts</a>
+      <a href="#adapters">Adapters</a>
+      <a href="#boundaries">Boundaries</a>
+      <a href="https://docs.grantex.dev/guides/oacp/overview">Docs</a>
     </div>
   </nav>
 
   <header class="hero">
     <div class="wrap hero-grid">
       <div>
-        <div class="eyebrow">Agentic Commerce V1</div>
-        <h1>Consent-first live commerce control for agents.</h1>
+        <div class="eyebrow">Open Agentic Commerce Protocol</div>
+        <h1>Protocol, trust, policy, artifact authority for agentic commerce.</h1>
         <p>
-          Grantex is live for the approved Shopify pilot merchant. It keeps
-          consent, Commerce Passports, merchant policy, amount caps, audit, and
-          provider boundaries in one control layer while agents use approved
-          catalog, cart, consent, and payment-intent tools.
+          Grantex is the OACP authority layer. AgenticOrg runs buyer and seller
+          AI agents. Shopify and merchant systems remain source of record.
+          Pine Labs Plural/P3P and other provider rails own mandate and payment
+          execution.
         </p>
-        <div class="badges">
-          <span class="badge ready">Production live pilot</span>
-          <span class="badge ready">Shopify merchant imported</span>
-          <span class="badge ready">OACP E2E verified</span>
-          <span class="badge ready">Ops health green</span>
-          <span class="badge review">Plural UAT-compatible rails</span>
+        <div class="actions">
+          <a class="button primary" href="https://docs.grantex.dev/guides/oacp/overview">Read OACP docs</a>
+          <a class="button secondary" href="#architecture">View architecture</a>
         </div>
       </div>
-      <div class="panel" aria-label="Agentic checkout flow">
-        <div class="flow">
-          <div class="step"><div class="num">1</div><div><h3>Ground the cart</h3><p>Agents search catalog, retrieve items, and check inventory through Grantex.</p></div></div>
-          <div class="step"><div class="num">2</div><div><h3>Ask for consent</h3><p>Grantex creates a consent request and only approved scope proceeds.</p></div></div>
-          <div class="step"><div class="num">3</div><div><h3>Issue a passport</h3><p>The Commerce Passport carries policy and amount limits as sensitive runtime material.</p></div></div>
-          <div class="step"><div class="num">4</div><div><h3>Control payment</h3><p>Payment intents and checkout handoff stay provider-neutral and audit-visible.</p></div></div>
+      <div class="panel">
+        <h3>What Grantex does</h3>
+        <div class="mini-grid">
+          <div><strong>Authority</strong><p>Issues or refuses canonical internal OACP artifacts.</p></div>
+          <div><strong>Policy</strong><p>Defines source, freshness, TTL, revocation, and risk rules.</p></div>
+          <div><strong>Verification</strong><p>Checks issuer, signature metadata, payload hash, scope, and safety.</p></div>
+          <div><strong>Adapters</strong><p>Governs compatibility mappings for client and partner payloads.</p></div>
         </div>
       </div>
     </div>
   </header>
 
-  <section id="workflow">
+  <section id="architecture">
     <div class="wrap">
-      <h2>Why Grantex sits between agents and payment providers</h2>
-      <div class="grid-3">
-        <div class="card">
-          <h3>Consent boundary</h3>
-          <p>Agents can prepare a purchase, but Grantex controls whether the requested action matches user consent and merchant policy.</p>
-        </div>
-        <div class="card">
-          <h3>Policy boundary</h3>
-          <p>Amount caps, merchant status, trusted agent checks, and passport state are enforced before payment-affecting work proceeds.</p>
-        </div>
-        <div class="card">
-          <h3>Provider boundary</h3>
-          <p>AgenticOrg commerce does not call Stripe, Plural, Pine, or provider credentials directly. Grantex owns the provider abstraction.</p>
-        </div>
+      <h2>Four-party architecture</h2>
+      <div class="diagram" aria-label="OACP architecture diagram">
+        <div class="node"><h3>Merchant systems</h3><p>Shopify, OMS, inventory, policy, support, and order systems keep operational truth.</p></div>
+        <div class="node"><h3>AgenticOrg runtime</h3><p>Seller Commerce Agent onboarding, Shopify sync, buyer sessions, channel bridges, and OACP cache.</p></div>
+        <div class="node"><h3>Grantex authority</h3><p>Trust, policy, canonical OACP artifacts, artifact verification, and protocol adapters.</p></div>
+        <div class="node"><h3>Provider rails</h3><p>Pine Labs Plural/P3P owns mandate and payment rail execution and provider status.</p></div>
       </div>
     </div>
   </section>
 
-  <section id="readiness">
+  <section id="artifacts">
     <div class="wrap">
-      <h2>Readiness is live-pilot scoped</h2>
-      <table class="status-table">
-        <thead><tr><th>Layer</th><th>Status</th><th>Meaning</th></tr></thead>
+      <h2>Artifact families</h2>
+      <p>OACP artifacts carry source, freshness, policy, adapter, and capability evidence.</p>
+      <div>
+        <span class="badge">merchant_profile</span>
+        <span class="badge">seller_agent_card</span>
+        <span class="badge">connector_evidence</span>
+        <span class="badge">catalog_snapshot</span>
+        <span class="badge">offer_price_snapshot</span>
+        <span class="badge">inventory_snapshot</span>
+        <span class="badge">policy_scope</span>
+        <span class="badge">public_discovery_state</span>
+        <span class="badge">mandate_capability</span>
+        <span class="badge">protocol_adapter</span>
+        <span class="badge">authority_request_status</span>
+      </div>
+    </div>
+  </section>
+
+  <section id="adapters">
+    <div class="wrap">
+      <h2>Protocol adapter support</h2>
+      <table>
+        <thead><tr><th>Adapter</th><th>OACP meaning</th><th>Boundary</th></tr></thead>
         <tbody>
-          <tr><td>Internal sandbox</td><td>Ready</td><td>Synthetic data, mock-provider paths, and gated Plural sandbox adapter tests exist for controlled validation.</td></tr>
-          <tr><td>Temporary smoke</td><td>Verified</td><td>Option A and hosted AgenticOrg smoke evidence used temporary resources and scrubbed reports.</td></tr>
-          <tr><td>Shopify merchant</td><td>Live</td><td><code>mgx0n6-22.myshopify.com</code> is imported as <code>mch_shopify_mgx0n6_22</code> with 5 products and 5 variants.</td></tr>
-          <tr><td>Production discovery</td><td>Live pilot</td><td>The approved merchant profile is available through <code>/.well-known/grantex-commerce</code>.</td></tr>
-          <tr><td>Live-readiness gate</td><td>Complete</td><td>Runtime acknowledgements are complete for the approved pilot; missing evidence still returns <code>live_readiness_blocked</code>.</td></tr>
-          <tr><td>Live checkout control plane</td><td>Enabled</td><td>Consent, Passport, policy, amount-cap, idempotency, webhook, reconciliation, and audit controls are deployed.</td></tr>
-          <tr><td>Plural adapter</td><td>Configured</td><td>Webhook intake is deployed. Current credentials authenticate against Plural UAT-compatible rails, so production Plural settlement is not claimed.</td></tr>
+          <tr><td>Schema.org</td><td>Product and Offer JSON-LD derived from merchant source artifacts.</td><td>No source-of-record change.</td></tr>
+          <tr><td>UCP-style</td><td>Capability profile derived from policy and artifact families.</td><td>Compatibility mapping only.</td></tr>
+          <tr><td>ACP-style</td><td>Commerce interaction profile for clients.</td><td>No checkout creation.</td></tr>
+          <tr><td>AP2-style</td><td>Mandate/payment evidence profile shape.</td><td>No mandate or payment execution.</td></tr>
+          <tr><td>A2A</td><td>Agent card and task metadata.</td><td>No execution approval.</td></tr>
+          <tr><td>MCP</td><td>Tool metadata for ChatGPT/Claude-style clients.</td><td>AgenticOrg runtime still enforces cache and policy.</td></tr>
+          <tr><td>OpenAPI</td><td>Buyer-safe schema for Gemini/Perplexity-style clients.</td><td>No private merchant payloads.</td></tr>
         </tbody>
       </table>
-      <div class="ladder" aria-label="Readiness gate ladder">
-        <div class="rung allowed">Local tests<span>Internal sandbox</span></div>
-        <div class="rung allowed">Option A smoke<span>Temporary Grantex service</span></div>
-        <div class="rung allowed">AgenticOrg eval<span>Grantex-only path</span></div>
-        <div class="rung allowed">Hosted API smoke<span>MCP/A2A discovery</span></div>
-        <div class="rung allowed">Shopify import<span>Real merchant profile</span></div>
-        <div class="rung allowed">Live gate<span>Evidence complete</span></div>
-        <div class="rung review-line">Plural settlement<span>Not claimed</span></div>
+    </div>
+  </section>
+
+  <section id="boundaries">
+    <div class="wrap grid-2">
+      <div>
+        <h2>Why Grantex is not a toll booth</h2>
+        <p>
+          Grantex signs and verifies authority artifacts. AgenticOrg may answer
+          non-binding buyer questions from valid cached artifacts until TTL,
+          freshness, revocation, or policy state requires refresh.
+        </p>
+      </div>
+      <div class="card">
+        <h3>Payment and order boundary</h3>
+        <p>
+          Final payment, mandate, checkout, order, stock hold, refund, return,
+          and shipment execution requires the approved provider, merchant, and
+          channel path. OACP artifacts do not invent success.
+        </p>
       </div>
     </div>
   </section>
 
-  <section id="audiences">
+  <section class="dark">
     <div class="wrap">
-      <h2>Start paths</h2>
-      <div class="grid-2">
-        <div class="card"><h3>Developers</h3><p>Use the Commerce V1 developer guide and OpenAPI contract. Treat all auth, passport, idempotency, and provider material as runtime-sensitive.</p></div>
-        <div class="card"><h3>Merchants and operators</h3><p>Use the operator guide for catalog, policy, audit, webhook, emergency disable, and no-go checks.</p></div>
-        <div class="card"><h3>Agent builders</h3><p>Use Grantex Commerce REST/MCP only. AgenticOrg uses `grantex_commerce:*` tools and no direct provider credential path.</p></div>
-        <div class="card"><h3>End users</h3><p>The agent may help prepare a cart, but consent and policy checks determine whether checkout can proceed.</p></div>
-      </div>
-    </div>
-  </section>
-
-  <section class="cta">
-    <div class="wrap">
-      <h2>Use this page as the live-pilot map.</h2>
+      <h2>Integrate AgenticOrg with Grantex authority</h2>
       <p>
-        Production Commerce V1 is deployed for the approved Shopify merchant
-        flow. Agents still use Grantex-only commerce surfaces, and Plural
-        production settlement is not claimed until production Plural credentials
-        authenticate against production rails.
+        AgenticOrg sends Grantex public-safe authority requests for allowlisted
+        tenants, caches returned OACP artifacts, and exposes buyer surfaces with
+        source and freshness labels.
       </p>
-      <p><a href="https://docs.grantex.dev/guides/commerce-v1-overview">Read the Commerce V1 docs</a></p>
+      <p><a href="https://docs.grantex.dev/guides/oacp/agenticorg-integration">Open the AgenticOrg integration guide</a></p>
     </div>
   </section>
 
   <footer>
     <div class="wrap">
-      <p style="margin:0 0 0.75em 0;">No secrets, passports, tokens, raw payloads, provider credentials, or live payment material are included on this page.</p>
-      <p style="margin:0;font-size:0.9em;">
-        <a href="https://docs.grantex.dev/compliance/privacy-policy">Privacy</a> &middot;
-        <a href="https://docs.grantex.dev/compliance/terms-of-service">Terms</a> &middot;
-        <a href="https://docs.grantex.dev/compliance/dpa">DPA</a> &middot;
-        <a href="https://docs.grantex.dev/compliance/cookie-policy">Cookies</a> &middot;
-        <a href="https://docs.grantex.dev/compliance/sub-processors">Sub-processors</a> &middot;
-        <a href="https://docs.grantex.dev/compliance/data-residency">Data Residency</a> &middot;
-        <a href="https://github.com/mishrasanjeev/grantex/blob/main/SECURITY.md">Security</a>
-      </p>
+      <p style="margin:0;">No raw Shopify credentials, provider secrets, card data, bank data, checkout URLs, payment URLs, or private merchant payloads are represented on this page.</p>
     </div>
   </footer>
 </body>


### PR DESCRIPTION
## What changed
- Added a canonical Grantex OACP Authority docs set covering overview, architecture, artifact authority, protocol adapters, policy/governance, merchant source-of-record, buyer safety/freshness, provider/payment boundary, AgenticOrg integration, operator runbook, launch readiness, and truth inventory.
- Added six audience explainers for merchants, buyers, developers, protocol partners, fintech/payment partners, and operators.
- Added eight OACP article drafts with Mermaid workflows and implemented/gated/failure-mode sections.
- Replaced `web/commerce.html` with OACP authority positioning: protocol, trust, policy, artifact authority for agentic commerce.
- Updated README and Mintlify navigation so OACP Authority is primary and Agentic Commerce V1 is historical/contextual.
- Stabilized the commerce connector dry-run route regression so the live route test no longer depends on an aging fixture timestamp.

## Stale docs cleaned or superseded
- No historical docs were deleted.
- Commerce V1 navigation is marked historical.
- The prior OACP runtime mapping note and Commerce V1 overview now point to the canonical OACP authority docs.
- Stale live-pilot/control-plane language was removed from the active public commerce page and README lead section.

## Pages and articles added
- 12 canonical OACP authority pages under `docs/guides/oacp/`.
- 6 explainer pages under `docs/guides/oacp/explainers/`.
- 8 OACP blog/article drafts under `docs/blog/`.

## Remaining runtime/product gaps
- External protocol/program approval is not claimed.
- AgenticOrg production tenant rollout still needs tenant allowlist, service token, and evidence smoke.
- Pine Labs Plural/P3P execution still requires provider, merchant, legal, security, ops, rollback, and channel approval.
- Broad buyer-surface launch still needs channel approvals and smoke evidence.

## Validation run
- `git diff --check`: passed.
- `docs/docs.json` JSON parse: passed.
- `node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr`: passed.
- `npm --prefix apps/auth-service test -- commerce-c6z-runtime-artifact-authority.test.ts commerce-c6w4-oacp-adapter-previews.test.ts commerce-connector-dry-run-c6r.test.ts`: 3 files, 22 tests passed.
- ASCII/hidden Unicode scan on new files and added lines: clean.
- Overclaim scan: clean.
- Stale wording scan: only expected historical/report references remain.
- GitHub PR checks: green on head `9caa9c6`.

## Guardrail summary
- No payment/order/mandate success is claimed.
- No official protocol approval is claimed.
- Grantex is positioned as authority infrastructure, not a transaction toll booth or merchant connector runtime.
