### PR TITLE
[codex] Add OACP POS bridge authority boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 Grantex is the OACP protocol, trust, policy, artifact, verification, and adapter authority for agentic commerce. AgenticOrg owns buyer and seller AI-agent runtime, merchant onboarding, Shopify connector runtime, buyer sessions, channel bridges, OACP cache, and provider-owned Pine Labs Plural/P3P capability verification.
 
-Merchant systems such as Shopify remain the source of record. Provider rails own mandate and payment execution. Grantex signs and verifies artifacts; it is not a merchant connector runtime or a toll booth for every buyer and seller message.
+Merchant systems such as Shopify and POS systems remain the source of record. Provider, POS, and payment rails own mandate, payment, and in-store execution. Grantex signs and verifies artifacts; it is not a merchant connector runtime or a toll booth for every buyer and seller message.
 
 ```mermaid
 flowchart LR
@@ -54,10 +54,10 @@ flowchart LR
 | Artifact families | 11 internal OACP families are issued or refused: merchant profile, seller agent card, connector evidence, catalog, price, inventory, policy, public discovery state, mandate capability, protocol adapter, and request status. |
 | Protocol adapters | Schema.org, UCP-style, ACP-style, AP2-style, A2A, MCP, and OpenAPI mappings are compatibility mappings derived from OACP artifacts. |
 | AgenticOrg runtime | Seller onboarding, Shopify sync, cache, buyer Q&A, bridges, and provider capability verification live in AgenticOrg. |
-| Payment/order execution | Outside OACP artifact authority. Provider and merchant systems must execute and confirm; agents must not invent success. |
+| Payment/order/POS execution | Outside OACP artifact authority. Provider, POS, and merchant systems must execute and confirm; agents must not invent success. |
 | Historical Commerce V1 docs | Retained for context, but superseded for the AgenticOrg OACP runtime split. |
 
-Start with the [OACP authority overview](docs/guides/oacp/overview.mdx), [truth inventory](docs/guides/oacp/truth-inventory.mdx), [AgenticOrg integration guide](docs/guides/oacp/agenticorg-integration.mdx), and [operator runbook](docs/guides/oacp/operator-runbook.mdx). The older [Commerce V1 overview](docs/guides/commerce-v1-overview.mdx) remains historical/contextual and should not be used to imply that Grantex owns AgenticOrg merchant connector runtime.
+Start with the [OACP authority overview](docs/guides/oacp/overview.mdx), [truth inventory](docs/guides/oacp/truth-inventory.mdx), [AgenticOrg integration guide](docs/guides/oacp/agenticorg-integration.mdx), [POS bridge boundary](docs/guides/oacp/pos-bridge-boundary.mdx), and [operator runbook](docs/guides/oacp/operator-runbook.mdx). The older [Commerce V1 overview](docs/guides/commerce-v1-overview.mdx) remains historical/contextual and should not be used to imply that Grantex owns AgenticOrg merchant connector runtime.
 
 ## Current Development Snapshot
 

--- a/apps/auth-service/src/lib/commerce/oacp-runtime-vertical.ts
+++ b/apps/auth-service/src/lib/commerce/oacp-runtime-vertical.ts
@@ -324,11 +324,23 @@ function payloadForFamily(
     price_snapshot_refs: family === 'offer_price_snapshot' ? evidence.price_snapshot_refs : undefined,
     inventory_snapshot_refs: family === 'inventory_snapshot' ? evidence.inventory_snapshot_refs : undefined,
     requested_authority_scope: family === 'policy_scope' ? request.requested_authority_scope : undefined,
+    offline_pos_bridge_boundary: family === 'policy_scope'
+      ? 'agenticorg_orchestrates_handoff_pos_or_provider_owns_execution'
+      : undefined,
+    offline_pos_evidence_refs_allowed: family === 'policy_scope'
+      ? true
+      : undefined,
     public_discovery_state: family === 'public_discovery_state' ? 'disabled' : undefined,
     public_discovery_publication_allowed: family === 'public_discovery_state' ? false : undefined,
     mandate_capability_status: family === 'mandate_capability' ? 'provider_owned_verification_required' : undefined,
     provider_execution_authority: family === 'mandate_capability' ? 'provider_owned_not_grantex_or_agenticorg' : undefined,
     mandate_capability_ref: family === 'mandate_capability' ? 'provider:mandate_rail:capability:pending:redacted' : undefined,
+    offline_pos_confirmation_authority: family === 'mandate_capability'
+      ? 'pos_or_payment_provider_callback_required_not_grantex'
+      : undefined,
+    offline_pos_evidence_ref: family === 'mandate_capability'
+      ? 'pos:provider_or_simulator:handoff_or_receipt:pending:redacted'
+      : undefined,
     adapter_surfaces: family === 'protocol_adapter'
       ? [
         'schema_org_product_offer_jsonld',
@@ -383,7 +395,7 @@ function payloadForFamily(
           {
             surface: 'ap2_style_mandate_payment_evidence_profile',
             source_artifact_families: ['mandate_capability', 'policy_scope', 'authority_request_status'],
-            prohibited_outputs: ['provider execution claim', 'payment success claim'],
+            prohibited_outputs: ['provider execution claim', 'settled-payment claim', 'POS paid-state claim'],
           },
           {
             surface: 'a2a_agent_card_task_metadata',
@@ -398,9 +410,14 @@ function payloadForFamily(
           {
             surface: 'openapi_buyer_safe_bridge_schema',
             source_artifact_families: ['seller_agent_card', 'policy_scope', 'protocol_adapter'],
-            prohibited_outputs: ['payment or order operation exposure'],
+            prohibited_outputs: ['payment, order, or POS operation exposure'],
           },
         ],
+        offline_pos_bridge_mapping: {
+          source_artifact_families: ['policy_scope', 'catalog_snapshot', 'offer_price_snapshot', 'inventory_snapshot', 'mandate_capability'],
+          allowed_refs: ['offline_pos_handoff_packet_ref', 'provider_pos_evidence_ref', 'receipt_evidence_ref'],
+          prohibited_outputs: ['POS transaction execution', 'POS payment capture', 'POS order success claim'],
+        },
       }
       : undefined,
     authority_request_status: family === 'authority_request_status' ? 'artifact_issuance_ready' : undefined,
@@ -409,6 +426,9 @@ function payloadForFamily(
       'order_creation',
       'inventory_hold',
       'live_provider_execution',
+      'offline_pos_transaction_execution',
+      'pos_order_creation',
+      'pos_payment_capture',
       'public_discovery_publication',
     ],
     allowed_to_execute: false,
@@ -430,6 +450,9 @@ function artifactSafety(family: C6ZArtifactFamily) {
       'refund_execution',
       'return_execution',
       'shipping_execution',
+      'offline_pos_transaction_execution',
+      'pos_order_creation',
+      'pos_payment_capture',
       'public_discovery_publication',
     ],
     commitment_allowed: false,

--- a/apps/auth-service/tests/commerce-c6z-runtime-artifact-authority.test.ts
+++ b/apps/auth-service/tests/commerce-c6z-runtime-artifact-authority.test.ts
@@ -131,6 +131,12 @@ describe('C6Z Grantex runtime artifact authority', () => {
       .toMatchObject({
         mandate_capability_status: 'provider_owned_verification_required',
         provider_execution_authority: 'provider_owned_not_grantex_or_agenticorg',
+        offline_pos_confirmation_authority: 'pos_or_payment_provider_callback_required_not_grantex',
+      });
+    expect(result.artifacts.find((artifact) => artifact.artifact_family === 'policy_scope')?.payload)
+      .toMatchObject({
+        offline_pos_bridge_boundary: 'agenticorg_orchestrates_handoff_pos_or_provider_owns_execution',
+        offline_pos_evidence_refs_allowed: true,
       });
     expect(result.artifacts.find((artifact) => artifact.artifact_family === 'protocol_adapter')?.payload)
       .toMatchObject({
@@ -139,7 +145,15 @@ describe('C6Z Grantex runtime artifact authority', () => {
           canonical_source: 'grantex_signed_oacp_artifacts',
           generated_by: 'agenticorg_runtime_from_cached_artifacts',
           external_certification_status: 'compatibility_mapping_only_not_publicly_certified',
+          offline_pos_bridge_mapping: {
+            prohibited_outputs: expect.arrayContaining(['POS transaction execution', 'POS payment capture', 'POS order success claim']),
+          },
         },
+        unsupported_capabilities: expect.arrayContaining([
+          'offline_pos_transaction_execution',
+          'pos_order_creation',
+          'pos_payment_capture',
+        ]),
       });
     expect(
       result.artifacts.find((artifact) => artifact.artifact_family === 'protocol_adapter')
@@ -148,6 +162,10 @@ describe('C6Z Grantex runtime artifact authority', () => {
       surface_contracts: expect.arrayContaining([
         expect.objectContaining({ surface: 'schema_org_product_offer_jsonld' }),
         expect.objectContaining({ surface: 'openapi_buyer_safe_bridge_schema' }),
+        expect.objectContaining({
+          surface: 'ap2_style_mandate_payment_evidence_profile',
+          prohibited_outputs: expect.arrayContaining(['POS paid-state claim']),
+        }),
       ]),
     });
   });

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -82,6 +82,7 @@
               "guides/oacp/merchant-source-of-record",
               "guides/oacp/buyer-safety-freshness",
               "guides/oacp/provider-payment-boundary",
+              "guides/oacp/pos-bridge-boundary",
               "guides/oacp/agenticorg-integration",
               "guides/oacp/operator-runbook",
               "guides/oacp/launch-readiness",

--- a/docs/guides/oacp/agenticorg-integration.mdx
+++ b/docs/guides/oacp/agenticorg-integration.mdx
@@ -21,6 +21,7 @@ sequenceDiagram
   A->>G: POST /v1/commerce/oacp/c6z/authority-requests
   G-->>A: Signed/internal OACP artifacts or blockers
   A->>A: Cache artifacts by tenant, merchant, seller, buyer scope
+  A->>A: Prepare purchase or Offline POS handoff without execution
   A-->>M: Runtime ready, refresh needed, or blocker
 ```
 
@@ -33,6 +34,7 @@ AgenticOrg sends:
 - source observed timestamp;
 - public-safe connector evidence;
 - no raw Shopify credential, raw provider payload, checkout URL, or payment URL.
+- no raw POS payload, raw payment payload, order-created claim, or POS paid-state claim.
 
 Grantex returns:
 
@@ -48,7 +50,8 @@ Grantex returns:
 | `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS` | Grantex | Tenant allowlist. |
 | Shopify credential custody | AgenticOrg + merchant | Read-only source evidence generation. |
 | Provider capability config | AgenticOrg + provider | Capability evidence checks outside Grantex. |
+| POS provider approval | AgenticOrg + merchant + POS/payment provider | Verified callback/evidence refs for Offline POS Bridge reconciliation. |
 
 ## Failure Handling
 
-If Grantex is unavailable, AgenticOrg may answer non-binding buyer questions from valid cached artifacts. Commitment-bound requests must refresh, prepare no execution, or refuse.
+If Grantex is unavailable, AgenticOrg may answer non-binding buyer questions from valid cached artifacts. Commitment-bound or POS-bound requests must refresh, prepare no execution, use only valid cached policy when risk permits, or refuse.

--- a/docs/guides/oacp/overview.mdx
+++ b/docs/guides/oacp/overview.mdx
@@ -9,7 +9,7 @@ This is the canonical Grantex OACP page. The canonical end-to-end flow starts he
 
 OACP is the trust and interoperability layer for agentic commerce. Grantex owns the protocol, trust, policy, artifact, verification, and protocol-adapter authority. AgenticOrg owns the buyer and seller AI-agent runtime, Shopify connector runtime, buyer sessions, channel bridges, OACP cache, and provider-owned mandate capability verification.
 
-Merchant systems such as Shopify remain the source of record. Pine Labs Plural/P3P and other provider rails own mandate and payment execution. Grantex must not become a toll booth for every buyer and seller interaction.
+Merchant systems such as Shopify and POS systems remain the source of record. Pine Labs Plural/P3P, POS systems, and other provider rails own mandate, payment, and in-store execution. Grantex must not become a toll booth for every buyer and seller interaction.
 
 ## Four-Party Architecture
 
@@ -19,8 +19,8 @@ flowchart LR
   agentic -->|authority request with redacted evidence| grantex[Grantex OACP authority]
   grantex -->|signed internal artifacts and blockers| agentic
   agentic -->|buyer answer from valid cache| buyer[Buyer surfaces]
-  agentic -->|capability check only| provider[Pine Labs Plural/P3P or payment rail]
-  provider -->|redacted capability evidence ref| agentic
+  agentic -->|capability or POS handoff only| provider[Pine Labs Plural/P3P, POS, or payment rail]
+  provider -->|redacted capability or POS evidence ref| agentic
 ```
 
 ## What Grantex Owns
@@ -35,7 +35,7 @@ flowchart LR
 
 ## What Grantex Does Not Own
 
-Grantex does not own Shopify runtime credentials, merchant onboarding UX, buyer sessions, WhatsApp or Telegram webhooks, MCP/OpenAPI client sessions, AgenticOrg artifact cache storage, final checkout execution, order creation, stock holds, mandate setup, payment capture, refund execution, or provider settlement.
+Grantex does not own Shopify runtime credentials, merchant onboarding UX, buyer sessions, WhatsApp or Telegram webhooks, MCP/OpenAPI client sessions, AgenticOrg artifact cache storage, Offline POS Bridge orchestration, final checkout execution, POS transaction execution, order creation, stock holds, mandate setup, payment capture, refund execution, or provider settlement.
 
 ## Runtime Reality
 
@@ -44,7 +44,7 @@ Grantex does not own Shopify runtime credentials, merchant onboarding UX, buyer 
 | Implemented runtime | `POST /v1/commerce/oacp/c6z/authority-requests`, internal artifact issuance, verifier helpers, adapter preview helpers, and OACP guard tests. |
 | Implemented docs only | Historical Commerce V1 planning and C6 audit/review reports remain useful as internal history but are superseded for the public OACP split. |
 | Requires external credentials or approval | AgenticOrg service token and tenant allowlist, merchant Shopify access, channel approvals, and provider rail approval. |
-| Missing | Public standards program approval, universal channel launch, and broad payment/order execution. |
+| Missing | Public standards program approval, universal channel launch, live POS provider approval, and broad payment/order execution. |
 | Stale/confusing documentation | Older Commerce V1 pages that frame Grantex as the merchant control plane are historical; use this OACP group for the current authority narrative. |
 
 ## Artifact Families
@@ -53,11 +53,12 @@ Grantex currently issues or refuses these internal OACP families for the C6Z Age
 
 ## Buyer-Safe Rule
 
-AgenticOrg may continue non-binding product questions and comparison from valid cached artifacts. A request that would commit the buyer, create a checkout, create a mandate, capture payment, reserve inventory, create an order, refund, return, or ship must use the approved provider, merchant, and channel path. OACP artifacts do not invent success.
+AgenticOrg may continue non-binding product questions and comparison from valid cached artifacts. A request that would commit the buyer, create a checkout, create a mandate, capture payment, execute a POS transaction, reserve inventory, create an order, refund, return, or ship must use the approved provider, merchant, POS, and channel path. OACP artifacts do not invent success.
 
 ## Related Pages
 
 - [Architecture](./architecture)
 - [Artifact authority](./artifact-authority)
+- [Offline POS Bridge boundary](./pos-bridge-boundary)
 - [AgenticOrg integration guide](./agenticorg-integration)
 - [Launch readiness](./launch-readiness)

--- a/docs/guides/oacp/pos-bridge-boundary.mdx
+++ b/docs/guides/oacp/pos-bridge-boundary.mdx
@@ -1,0 +1,74 @@
+---
+title: OACP Offline POS Bridge Boundary
+description: How Grantex treats Offline POS handoff evidence without owning POS transactions.
+---
+
+# OACP Offline POS Bridge Boundary
+
+Canonical end-to-end flow: [OACP authority overview](./overview).
+
+AgenticOrg owns Offline POS Bridge orchestration. POS systems and payment providers own final price, inventory, staff review, payment, receipt, and order evidence. Grantex only recognizes non-sensitive evidence references when they are needed for OACP policy or authority refresh.
+
+```mermaid
+sequenceDiagram
+  participant B as Buyer surface
+  participant A as AgenticOrg runtime
+  participant C as OACP cache
+  participant P as POS/provider
+  participant G as Grantex authority
+  B->>A: Ask product question
+  A->>C: Read valid OACP artifacts
+  A-->>B: Source/freshness answer
+  B->>A: Request in-store handoff
+  A->>A: Build non-executing POS handoff packet
+  A->>P: Send packet to POS/provider or simulator
+  P-->>A: Confirmation status and redacted evidence ref
+  A-->>B: Final confirmation or blocker
+  A-->>G: Optional authority refresh with non-sensitive refs only
+```
+
+## Ownership
+
+| Area | Owner | Grantex role |
+| --- | --- | --- |
+| POS handoff packet | AgenticOrg | Verify that referenced OACP artifacts and policy boundaries are valid when asked. |
+| Final POS price/inventory | POS or merchant system | Treat as source-of-record evidence, not as Grantex state. |
+| Payment confirmation | POS/payment provider | Accept only redacted evidence refs; never store raw payment payloads. |
+| Receipt evidence | POS/payment provider | Reference only when callback evidence is verified. |
+| Policy refresh | Grantex | Issue or refuse refreshed OACP artifacts from public-safe evidence. |
+
+## Allowed Evidence
+
+OACP artifacts may carry references such as:
+
+- `offline_pos_handoff_packet_ref`
+- `provider_pos_evidence_ref`
+- `receipt_evidence_ref`
+- catalog, price, inventory, policy, and mandate capability artifact refs
+
+The references must be non-sensitive, scoped to tenant/merchant/seller agent, and tied to freshness metadata. They are not proof that a payment succeeded unless the POS or provider callback says so.
+
+## Blocked Claims
+
+Grantex does not:
+
+- execute a POS transaction;
+- capture a POS payment;
+- create a POS order;
+- reserve in-store inventory;
+- verify raw card, wallet, mandate, or provider payloads;
+- turn a simulator confirmation into a live paid state.
+
+## Safe Wording
+
+Use:
+
+> POS accepted the handoff. Staff must confirm final price and payment at the store.
+
+Do not use:
+
+> OACP completed the POS purchase.
+
+## Runtime Status
+
+AgenticOrg has an internal Offline POS Bridge foundation with non-sensitive handoff packets, confirmation intake, local simulator confirmation, and reconciliation status. Live POS integrations require merchant/POS provider approval, verified callbacks, monitoring, rollback, and operator readiness.

--- a/docs/guides/oacp/provider-payment-boundary.mdx
+++ b/docs/guides/oacp/provider-payment-boundary.mdx
@@ -7,16 +7,19 @@ description: How OACP treats Pine Labs Plural/P3P and other payment rails.
 
 Canonical end-to-end flow: [OACP authority overview](./overview).
 
-Pine Labs Plural/P3P and other provider rails own mandate setup, payment execution, provider status, settlement, and provider webhooks. Grantex does not execute provider rails in the AgenticOrg OACP runtime split.
+Pine Labs Plural/P3P, POS systems, and other provider rails own mandate setup, payment execution, provider status, settlement, receipt evidence, and provider webhooks. Grantex does not execute provider or POS rails in the AgenticOrg OACP runtime split.
 
 ```mermaid
 flowchart LR
   buyer[Buyer intent] --> agentic[AgenticOrg purchase preparation]
   agentic --> cache[OACP cache checks]
   agentic --> verifier[Plural/Pine capability verifier]
+  agentic --> pos[Offline POS handoff packet]
   verifier --> ref[Redacted capability evidence ref]
+  pos --> posref[Redacted POS/provider evidence ref]
   cache --> result{All checks pass?}
   ref --> result
+  posref --> result
   result -->|Yes| prepared[Prepared provider-owned handoff]
   result -->|No| blocker[Exact blocker]
 ```
@@ -27,10 +30,11 @@ flowchart LR
 | --- | --- |
 | Mandate setup | Provider-owned. OACP may carry non-sensitive capability evidence refs. |
 | Payment capture | Provider-owned and outside artifact issuance. |
+| POS handoff | AgenticOrg-owned orchestration; POS/provider-owned confirmation. |
 | Checkout/order success | Must come from merchant/provider systems, never from an agent guess. |
 | Raw secrets | Not stored in OACP artifacts. |
 | Evidence | Redacted refs and freshness only. |
 
 ## Pending Runtime Gap
 
-Provider-owned execution can only be added after merchant, provider, legal, security, operations, channel, rollback, and observability approval. Until then, docs must say prepared handoff or blocker.
+Provider-owned or POS-owned execution can only be added after merchant, provider/POS, legal, security, operations, channel, rollback, and observability approval. Until then, docs must say prepared handoff, POS accepted pending staff/payment confirmation, or blocker.

--- a/docs/guides/oacp/truth-inventory.mdx
+++ b/docs/guides/oacp/truth-inventory.mdx
@@ -13,11 +13,11 @@ This inventory is based on the Grantex C6Z authority route, OACP artifact librar
 
 | Category | Grantex reality | Owner/action |
 | --- | --- | --- |
-| Implemented runtime | C6Z authority endpoint under commerce auth; allowlisted AgenticOrg service-token access; internal artifact issuance; artifact safety checks; TTL and signature metadata; adapter mapping payloads; cache/offline verifier helpers. | Grantex keeps tests and guard scans current. |
+| Implemented runtime | C6Z authority endpoint under commerce auth; allowlisted AgenticOrg service-token access; internal artifact issuance; artifact safety checks; TTL and signature metadata; adapter mapping payloads; cache/offline verifier helpers; POS handoff evidence-ref boundary in policy/mandate/protocol artifacts. | Grantex keeps tests and guard scans current. |
 | Implemented docs only | Historical Commerce V1 PRDs, launch plans, C6 review reports, and publication drafts. | Mark as historical where they conflict with this architecture. |
 | Implemented but not broad launch | Commerce V1 payment-control pilot code and Plural sandbox/UAT-compatible adapter paths exist separately from the AgenticOrg OACP runtime split. | Keep separate from OACP authority docs. |
 | Requires credentials or approval | `COMMERCE_C6Z_AUTHORITY_SERVICE_TOKEN`, `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS`, merchant/AgenticOrg tenant approval, production key custody, provider rail approval, and external channel approvals. | Ops owner must collect evidence before public claims. |
-| Missing | Public standards approval, broad external protocol partner program, universal buyer-surface rollout, order/payment/mandate execution through OACP artifacts. | Treat as pending runtime/product gaps. |
+| Missing | Public standards approval, broad external protocol partner program, universal buyer-surface rollout, live POS provider approval, and order/payment/mandate/POS execution through OACP artifacts. | Treat as pending runtime/product gaps. |
 | Stale/confusing docs | Older copy that says Grantex is the merchant connector runtime or payment-control loop for every buyer interaction. | Supersede with OACP authority docs and link here. |
 
 ## Evidence Pointers

--- a/web/commerce.html
+++ b/web/commerce.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Grantex OACP Authority</title>
-  <meta name="description" content="Grantex is the protocol, trust, policy, and artifact authority for OACP agentic commerce. AgenticOrg runs buyer and seller agents; merchant and provider systems remain authoritative." />
+  <meta name="description" content="Grantex is the protocol, trust, policy, and artifact authority for OACP agentic commerce. AgenticOrg runs buyer and seller agents; merchant, POS, and provider systems remain authoritative." />
   <style>
     :root {
       color-scheme: light;
@@ -162,9 +162,9 @@
         <h1>Protocol, trust, policy, artifact authority for agentic commerce.</h1>
         <p>
           Grantex is the OACP authority layer. AgenticOrg runs buyer and seller
-          AI agents. Shopify and merchant systems remain source of record.
-          Pine Labs Plural/P3P and other provider rails own mandate and payment
-          execution.
+          AI agents. Shopify, POS, and merchant systems remain source of record.
+          Pine Labs Plural/P3P, POS, and other provider rails own mandate,
+          payment, and in-store execution.
         </p>
         <div class="actions">
           <a class="button primary" href="https://docs.grantex.dev/guides/oacp/overview">Read OACP docs</a>
@@ -187,10 +187,10 @@
     <div class="wrap">
       <h2>Four-party architecture</h2>
       <div class="diagram" aria-label="OACP architecture diagram">
-        <div class="node"><h3>Merchant systems</h3><p>Shopify, OMS, inventory, policy, support, and order systems keep operational truth.</p></div>
-        <div class="node"><h3>AgenticOrg runtime</h3><p>Seller Commerce Agent onboarding, Shopify sync, buyer sessions, channel bridges, and OACP cache.</p></div>
+        <div class="node"><h3>Merchant and POS systems</h3><p>Shopify, POS, OMS, inventory, policy, support, and order systems keep operational truth.</p></div>
+        <div class="node"><h3>AgenticOrg runtime</h3><p>Seller Commerce Agent onboarding, Shopify sync, buyer sessions, channel bridges, OACP cache, and Offline POS handoff orchestration.</p></div>
         <div class="node"><h3>Grantex authority</h3><p>Trust, policy, canonical OACP artifacts, artifact verification, and protocol adapters.</p></div>
-        <div class="node"><h3>Provider rails</h3><p>Pine Labs Plural/P3P owns mandate and payment rail execution and provider status.</p></div>
+        <div class="node"><h3>Provider and POS rails</h3><p>Pine Labs Plural/P3P, POS, and payment providers own mandate, payment, receipt, and final transaction status.</p></div>
       </div>
     </div>
   </section>
@@ -244,11 +244,11 @@
         </p>
       </div>
       <div class="card">
-        <h3>Payment and order boundary</h3>
+        <h3>Payment, POS, and order boundary</h3>
         <p>
-          Final payment, mandate, checkout, order, stock hold, refund, return,
-          and shipment execution requires the approved provider, merchant, and
-          channel path. OACP artifacts do not invent success.
+          Final payment, mandate, checkout, POS confirmation, order, stock hold,
+          refund, return, and shipment execution requires the approved provider,
+          merchant, POS, and channel path. OACP artifacts do not invent success.
         </p>
       </div>
     </div>
@@ -262,13 +262,13 @@
         tenants, caches returned OACP artifacts, and exposes buyer surfaces with
         source and freshness labels.
       </p>
-      <p><a href="https://docs.grantex.dev/guides/oacp/agenticorg-integration">Open the AgenticOrg integration guide</a></p>
+      <p><a href="https://docs.grantex.dev/guides/oacp/agenticorg-integration">Open the AgenticOrg integration guide</a> - <a href="https://docs.grantex.dev/guides/oacp/pos-bridge-boundary">Read the Offline POS Bridge boundary</a></p>
     </div>
   </section>
 
   <footer>
     <div class="wrap">
-      <p style="margin:0;">No raw Shopify credentials, provider secrets, card data, bank data, checkout URLs, payment URLs, or private merchant payloads are represented on this page.</p>
+      <p style="margin:0;">No raw Shopify credentials, POS payloads, provider secrets, card data, bank data, checkout URLs, payment URLs, or private merchant payloads are represented on this page.</p>
     </div>
   </footer>
 </body>

--- a/web/index.html
+++ b/web/index.html
@@ -1664,20 +1664,21 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
 <section id="mpp" style="background: linear-gradient(180deg, rgba(63,185,80,0.04) 0%, transparent 60%);">
   <div class="container">
     <div class="section-label">New — Agentic Commerce</div>
-    <h2 class="section-title">Agent Identity for Machine Payments</h2>
+    <h2 class="section-title">OACP Authority And Agent Identity</h2>
     <p class="section-sub">
       MPP defines how agents pay for services. Grantex adds the missing identity layer —
       so merchants know exactly who authorized every payment.
     </p>
     <p class="section-sub" style="font-size:15px;margin-top:-22px;">
-      Agentic Commerce V1 is live for the approved Shopify pilot merchant.
-      The Grantex control plane now exposes the merchant profile, catalog
-      search, consent, Commerce Passport, payment-intent, Plural webhook,
-      reconciliation, and audit path with machine-readable live-readiness evidence.
+      For OACP, Grantex is the protocol, trust, policy, artifact, verification,
+      and adapter authority. AgenticOrg runs seller and buyer agents, Shopify
+      connector runtime, buyer surfaces, purchase preparation, and Offline POS
+      handoff orchestration. Merchant, POS, and payment providers remain source
+      of record for final execution.
     </p>
     <div class="hero-ctas" style="justify-content:center;margin:0 0 40px;">
-      <a href="/commerce.html" class="btn btn-primary">View Commerce live pilot</a>
-      <a href="https://docs.grantex.dev/guides/commerce-v1-overview" class="btn btn-secondary">Commerce docs</a>
+      <a href="/commerce.html" class="btn btn-primary">View OACP authority</a>
+      <a href="https://docs.grantex.dev/guides/oacp/overview" class="btn btn-secondary">OACP docs</a>
     </div>
 
     <!-- ── Visual flow pipeline ───────────────────────────────────────── -->


### PR DESCRIPTION
## What changed

This PR keeps Grantex in the OACP authority role and adds the Offline POS Bridge boundary to authority artifacts, docs, and landing copy.

- Adds POS-boundary fields to OACP `policy_scope`, `mandate_capability`, and `protocol_adapter` artifacts.
- Marks POS transaction execution, POS order creation, and POS payment capture as unsupported Grantex capabilities.
- Extends artifact-authority tests to prove Grantex recognizes POS evidence refs without owning POS execution.
- Adds a dedicated OACP Offline POS Bridge Boundary guide and links it from docs navigation.
- Updates the OACP overview, AgenticOrg integration guide, payment/provider boundary, truth inventory, README, and commerce landing copy.

## Stale docs cleaned or superseded

- Tightened homepage and commerce-page wording so Grantex is described as protocol, policy, trust, and artifact authority, not a transaction runtime.
- Replaced older live-pilot style commerce copy with OACP authority positioning and explicit payment/POS boundaries.

## Pages and diagrams added

- `docs/guides/oacp/pos-bridge-boundary.mdx`
  - Four-party POS flow Mermaid diagram.
  - Ownership table.
  - Allowed evidence refs.
  - Blocked claims and safe wording.

## Runtime gaps remaining

- Live POS integrations are external to Grantex and require AgenticOrg plus merchant/POS provider approval.
- Provider/POS callbacks must supply verified non-sensitive evidence refs before any paid/receipt state can be represented.
- Grantex does not execute POS, payment, mandate, checkout, inventory reservation, or order creation flows.

## Validation

- `npm --prefix apps/auth-service test -- commerce-c6z-runtime-artifact-authority.test.ts` - passed, 7 tests.
- `npm --prefix apps/auth-service run typecheck` - passed.
- `node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr` - passed.
- `git diff --cached --check` - passed.
- Staged hidden Unicode scan - clean.
- Staged secret/raw payload scan - clean.
- Staged overclaim scan - clean for unsupported certification/standardization/live-payment claims.

## Guardrails

- Compatibility wording only; no certification or public-standardization claims added.
- No raw payment/provider/POS payload storage claims.
- No Grantex-as-toll-booth architecture.
- No fake order/payment/mandate/POS success claims.
