### PR TITLE
Document OACP merchant self-service boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,17 @@
 
 ## OACP Authority For Agentic Commerce
 
-Grantex is the OACP protocol, trust, policy, artifact, verification, and adapter authority for agentic commerce. AgenticOrg owns buyer and seller AI-agent runtime, merchant onboarding, Shopify connector runtime, buyer sessions, channel bridges, OACP cache, and provider-owned Pine Labs Plural/P3P capability verification.
+Grantex is the OACP protocol, trust, policy, artifact, verification, and adapter authority for agentic commerce. AgenticOrg owns buyer and seller AI-agent runtime, merchant self-service onboarding, Shopify connector runtime, future merchant connector setup intent, buyer sessions, channel bridges, OACP cache, and provider-owned capability verification.
 
-Merchant systems such as Shopify and POS systems remain the source of record. Provider, POS, and payment rails own mandate, payment, and in-store execution. Grantex signs and verifies artifacts; it is not a merchant connector runtime or a toll booth for every buyer and seller message.
+Merchant systems such as Shopify, future WooCommerce/ERP sources, POS systems, and provider systems remain the source of record. Provider, bank, POS, and payment rails own mandate, payment, and in-store execution. Grantex signs and verifies artifacts; it is not a merchant connector runtime or a toll booth for every buyer and seller message.
 
 ```mermaid
 flowchart LR
-  merchant[Shopify and merchant systems] --> agentic[AgenticOrg buyer and seller runtime]
+  merchant[Shopify, future ERP/WooCommerce, POS, provider systems] --> agentic[AgenticOrg buyer and seller runtime]
   agentic -->|redacted authority request| grantex[Grantex OACP authority]
   grantex -->|OACP artifacts or blockers| agentic
   agentic --> buyer[Buyer surfaces]
-  agentic -->|capability check| provider[Pine Labs Plural/P3P]
+  agentic -->|capability check or handoff| provider[Pine Labs Plural/P3P, bank/POS/provider rails]
 ```
 
 | Area | Current posture |
@@ -53,11 +53,11 @@ flowchart LR
 | Grantex C6Z authority route | Implemented at `POST /v1/commerce/oacp/c6z/authority-requests` for allowlisted AgenticOrg tenants. |
 | Artifact families | 11 internal OACP families are issued or refused: merchant profile, seller agent card, connector evidence, catalog, price, inventory, policy, public discovery state, mandate capability, protocol adapter, and request status. |
 | Protocol adapters | Schema.org, UCP-style, ACP-style, AP2-style, A2A, MCP, and OpenAPI mappings are compatibility mappings derived from OACP artifacts. |
-| AgenticOrg runtime | Seller onboarding, Shopify sync, cache, buyer Q&A, bridges, and provider capability verification live in AgenticOrg. |
+| AgenticOrg runtime | Merchant self-service config, Seller onboarding, Shopify sync, future connector/provider intent capture, cache, buyer Q&A, bridges, and provider capability verification live in AgenticOrg. |
 | Payment/order/POS execution | Outside OACP artifact authority. Provider, POS, and merchant systems must execute and confirm; agents must not invent success. |
 | Historical Commerce V1 docs | Retained for context, but superseded for the AgenticOrg OACP runtime split. |
 
-Start with the [OACP authority overview](docs/guides/oacp/overview.mdx), [truth inventory](docs/guides/oacp/truth-inventory.mdx), [AgenticOrg integration guide](docs/guides/oacp/agenticorg-integration.mdx), [POS bridge boundary](docs/guides/oacp/pos-bridge-boundary.mdx), and [operator runbook](docs/guides/oacp/operator-runbook.mdx). The older [Commerce V1 overview](docs/guides/commerce-v1-overview.mdx) remains historical/contextual and should not be used to imply that Grantex owns AgenticOrg merchant connector runtime.
+Start with the [OACP authority overview](docs/guides/oacp/overview.mdx), [merchant self-service config boundary](docs/guides/oacp/merchant-self-service-config.mdx), [truth inventory](docs/guides/oacp/truth-inventory.mdx), [AgenticOrg integration guide](docs/guides/oacp/agenticorg-integration.mdx), [POS bridge boundary](docs/guides/oacp/pos-bridge-boundary.mdx), and [operator runbook](docs/guides/oacp/operator-runbook.mdx). The older [Commerce V1 overview](docs/guides/commerce-v1-overview.mdx) remains historical/contextual and should not be used to imply that Grantex owns AgenticOrg merchant connector runtime.
 
 ## Current Development Snapshot
 

--- a/docs/blog/commerce-live-readiness-gate.mdx
+++ b/docs/blog/commerce-live-readiness-gate.mdx
@@ -1,47 +1,49 @@
 ---
-title: "Why Grantex Commerce Live Mode Needs a Readiness Gate"
-description: "How Grantex separates sandbox checkout evidence from live payment authorization for agentic commerce."
+title: "Why OACP Commerce Needs A Readiness Gate"
+description: "How Grantex separates OACP authority evidence from live payment, provider, POS, and merchant execution."
 date: "2026-06-14"
 authors:
   - name: "Sanjeev Mishra"
 ---
 
 Agentic commerce needs more than a working demo. A commerce agent can search a
-catalog, prepare a cart, ask for consent, and create a mock payment intent, but
-that does not prove the system is ready to touch live payment rails.
+catalog, prepare a handoff, ask for consent, and verify provider capability
+metadata, but that does not prove the system is ready to touch live payment,
+bank, POS, order, refund, or fulfillment rails.
 
-Grantex Commerce V1 now treats that distinction as a runtime boundary. Sandbox
-evidence can prove the control plane works. Live mode needs a separate
-readiness gate, and the approved Shopify live pilot now runs behind that gate.
+This article is retained as a readiness-boundary note. The current OACP split is
+that AgenticOrg owns merchant self-service runtime and buyer/seller agent
+channels, while Grantex owns OACP authority and artifact verification. Merchant
+configuration, including Shopify today and future WooCommerce/ERP/bank/provider
+refs, is not by itself live execution approval.
 
-## What Works Today
+## What Works Today In The Current OACP Split
 
-The current Commerce V1 evidence covers the path from closed-beta validation to
-the approved Shopify live pilot:
+The current OACP runtime path covers:
 
-- Grantex-controlled catalog, cart, consent, Commerce Passport, policy, audit,
-  webhook, and mock-provider flows.
-- AgenticOrg handoff through Grantex-only commerce tools.
-- Shopify and other merchant-system connectors as metadata foundations, not
-  credentialed production sync or direct private API execution.
-- Plural behind the provider abstraction, including token, hosted-checkout,
-  status, and signed webhook handling. The current stored credentials validate
-  against Plural UAT-compatible rails, so production Plural settlement is not
-  claimed.
-- OACP trust-artifact foundations for describing commerce capability and policy
-  without turning those artifacts into payment authority.
+- AgenticOrg merchant self-service config scoped by tenant, merchant, and seller
+  agent.
+- Shopify read-only Admin GraphQL runtime sync when the merchant provides valid
+  credentials.
+- WooCommerce, ERP, PIM, OMS, WMS, custom API, bank-owned rail, fintech rail,
+  and custom provider setup as pending-adapter config, not fake-live support.
+- Grantex OACP authority requests, signed/internal artifact issuance or refusal,
+  artifact verification, and protocol adapter governance.
+- AgenticOrg OACP cache and buyer-channel answers with source/freshness labels.
+- Plural/Pine provider-owned capability verification where configured, without
+  claiming payment execution.
+- Offline POS handoff packets and verified confirmation evidence refs without
+  Grantex executing POS transactions.
 
-That was enough for controlled sandbox validation. The live-pilot promotion
-added a named Shopify merchant, machine-readable live acknowledgements,
-production ops health, stored secrets, the Plural webhook route, and hosted OACP
-E2E evidence before live mode was enabled.
+That is enough to prepare buyer-safe answers and handoffs. It is not a claim
+that every merchant, channel, provider, bank, POS, or order path is live.
 
 ## Why Flags Are Not Enough
 
-Live payment execution depends on legal language, provider contracts, webhook
-signature behavior, India data-residency review, final user confirmation,
-merchant support ownership, append-only audit verification, incident runbooks,
-and rollback ownership.
+Live payment or order execution depends on legal language, provider or bank
+contracts, webhook signature behavior, data-residency review, final buyer
+confirmation, merchant support ownership, audit verification, incident runbooks,
+monitoring, and rollback ownership.
 
 Those are not just deployment details. They are part of the safety model.
 
@@ -50,37 +52,37 @@ snapshot reports only safe values: booleans, requirement keys, env names, and
 blocker strings. It does not carry passports, bearer tokens, provider secrets,
 raw payloads, DB URLs, Redis URLs, or webhook secrets.
 
-If any readiness acknowledgement is missing, live provider paths fail closed
-with `live_readiness_blocked`.
+If any readiness acknowledgement is missing, provider, bank, POS, or merchant
+execution paths must fail closed with a precise blocker.
 
 ## The Required Evidence
 
-The live-readiness gate requires acknowledgements for legal approval, provider
-contract confirmation, Plural sandbox E2E completion, webhook signature
-confirmation, India data residency, final user confirmation text, named pilot
-merchant approval, hosted OACP E2E evidence, production secret review,
-append-only audit verification, operator runbook approval, and rollback owner
-assignment.
+The readiness gate requires acknowledgements for legal approval, provider or
+bank contract confirmation, sandbox E2E completion, webhook signature
+confirmation, data residency, final user confirmation text, merchant approval,
+OACP E2E evidence, production secret review, audit verification, operator
+runbook approval, support ownership, and rollback owner assignment.
 
 This keeps the release posture clear:
 
-- Sandbox and mock-provider evidence can continue.
-- Public docs and demos must distinguish the approved Shopify live pilot from
-  broader provider settlement or certification claims.
-- AgenticOrg must keep using Grantex-only commerce tools.
-- Shopify and Plural remain controlled integrations, not shortcuts around the
-  Grantex consent, policy, and audit layer.
-- Live mode starts only after the evidence packet and runtime snapshot both
-  clear.
+- Shopify runtime sync can continue when credentials are valid.
+- Future WooCommerce/ERP/bank/provider configs can be saved as pending-adapter
+  setup without implying live support.
+- Public docs and demos must distinguish OACP authority evidence from provider
+  settlement, bank authorization, POS confirmation, channel approval, or
+  certification claims.
+- AgenticOrg must preserve OACP artifacts, source/freshness labels, and
+  fail-closed blockers across buyer channels.
+- Execution starts only after the evidence packet, provider/bank/POS approval,
+  and runtime readiness snapshot all clear.
 
 ## Current Status
 
-As of June 14, 2026, Commerce V1 is live for the approved Shopify pilot merchant
-`mch_shopify_mgx0n6_22` from `mgx0n6-22.myshopify.com`. The live-readiness
-snapshot is complete, ops health reports no blockers, catalog search returns
-the imported Shopify products, and Plural webhook intake reaches signature
-validation at `https://api.grantex.dev/v1/webhooks/providers/plural`.
+As of June 25, 2026, the current public OACP posture is not a broad live-payment
+or live-order claim. AgenticOrg owns merchant self-service config and Shopify
+runtime sync; Grantex owns authority artifacts; provider, bank, POS, and
+merchant systems own execution. Public wording must keep those owners separate.
 
-That is deliberately scoped. The boundary between "the Grantex live control
-plane is running" and "a payment provider has certified production settlement"
-must stay visible in code, tests, docs, and operations.
+That boundary must stay visible in code, tests, docs, and operations: "OACP
+authority artifacts are available" is different from "a merchant/provider/bank
+has approved live execution."

--- a/docs/blog/grantex-not-transaction-toll-booth.mdx
+++ b/docs/blog/grantex-not-transaction-toll-booth.mdx
@@ -7,7 +7,7 @@ description: Why OACP authority signs artifacts without relaying every buyer and
 
 ## Summary
 
-Grantex is the OACP authority, not a relay for every buyer message. Valid cached artifacts let AgenticOrg answer non-binding questions while commitment requests remain gated.
+Grantex is the OACP authority, not a relay for every buyer message. Valid cached artifacts let AgenticOrg answer non-binding questions while commitment requests remain gated by merchant, provider, bank, POS, and channel evidence.
 
 ## Target Audience
 
@@ -26,15 +26,15 @@ flowchart LR
 
 ## End-To-End Flow
 
-Grantex signs the trust artifact. AgenticOrg stores a scoped cache. Buyer questions use the cache until freshness or revocation fails. Purchase requests must use approved merchant/provider/channel paths and cannot be converted into success by cache alone.
+Grantex signs the trust artifact. AgenticOrg stores a scoped cache. Buyer questions use the cache until freshness or revocation fails. Purchase requests must use approved merchant/provider/bank/POS/channel paths and cannot be converted into success by cache alone.
 
 ## What Is Implemented Now
 
-The authority endpoint issues/refuses artifacts. AgenticOrg cache and bridge routes consume them for Q&A and prepared handoff.
+The authority endpoint issues/refuses artifacts. AgenticOrg cache and bridge routes consume them for Q&A and prepared handoff. AgenticOrg merchant config records Shopify runtime setup plus WooCommerce/ERP/bank/custom provider pending-adapter intent without making Grantex the config owner.
 
 ## What Requires External Approval Or Config
 
-Public tenant launch, provider rail execution, and channel rollout.
+Public tenant launch, provider or bank rail execution, POS callback approval, and channel rollout.
 
 ## Failure Modes
 

--- a/docs/blog/oacp-merchant-self-service-config.mdx
+++ b/docs/blog/oacp-merchant-self-service-config.mdx
@@ -1,0 +1,45 @@
+---
+title: Merchant Self-Service Config Without Moving Commerce Truth Into Grantex
+description: How AgenticOrg lets merchants configure sources, channels, provider rails, public publishing, and Offline POS while Grantex remains OACP authority.
+date: "2026-06-25"
+authors:
+  - name: "Sanjeev Mishra"
+---
+
+Agentic commerce needs merchant-controlled setup. A Shopify store, a future WooCommerce storefront, an ERP-backed catalog, a bank-owned mandate rail, and an offline POS terminal all have different operational owners. OACP should describe the trust boundary between those systems; it should not move every setting or every buyer turn into Grantex.
+
+## The Split
+
+AgenticOrg owns the merchant self-service runtime. A merchant operator can configure source connectors, buyer channels, provider-owned payment rails, public catalog publishing, and Offline POS metadata during Seller Commerce Agent onboarding or later from the same settings surface.
+
+Grantex owns OACP authority. It receives redacted authority requests, signs or refuses artifacts, verifies TTL/source/freshness/scope, and governs protocol adapter mappings. It does not store Shopify tokens, WooCommerce keys, ERP credentials, bank secrets, payment URLs, raw provider callbacks, or POS transaction payloads.
+
+```mermaid
+flowchart LR
+  merchant[Merchant operator] --> agentic[AgenticOrg config]
+  agentic --> source[Shopify runtime sync or pending adapter refs]
+  source --> evidence[Public-safe evidence]
+  evidence --> grantex[Grantex OACP authority]
+  grantex --> artifacts[Artifacts or blockers]
+  artifacts --> cache[AgenticOrg buyer channels]
+```
+
+## What Is Runtime-Supported Now
+
+Shopify is the current runtime source connector. AgenticOrg can use read-only Shopify Admin GraphQL sync, reconcile webhook-triggered refresh state, request OACP artifacts, and answer buyers from cache with source/freshness labels.
+
+Pine Labs Plural/P3P is the current provider-owned mandate capability verifier where credentials are configured. Capability evidence is not payment execution.
+
+## What Is Configurable But Not Live
+
+WooCommerce, ERP, PIM, OMS, WMS, custom APIs, bank-owned rails, fintech rails, and custom providers can be saved as merchant intent. Those configs are valuable because they show what the merchant wants to connect, but they remain pending adapter until approved connector code, sandbox tests, webhook verification, source precedence policy, and rollout approval exist.
+
+## Public Catalog And Search
+
+AgenticOrg can publish seller profile pages, product pages, buyer-safe catalog JSON, Schema.org JSON-LD, sitemap, and llms.txt only when the merchant enables public publishing and cached artifacts are fresh enough. Grantex may sign public discovery-state artifacts; it does not host the catalog pages.
+
+## Safe Claim
+
+The safe claim is simple: merchants can configure their own commerce runtime in AgenticOrg; Grantex remains the OACP trust authority; Shopify is runtime-supported; future sources and bank/provider rails are adapter-ready but non-executing until approved.
+
+No OACP certification, UCP/ACP/AP2 approval, IETF/NIST acceptance, universal channel launch, live payment execution, live order creation, or live POS settlement is implied by merchant configuration.

--- a/docs/blog/oacp-shopify-merchant-agentic-commerce-seller.mdx
+++ b/docs/blog/oacp-shopify-merchant-agentic-commerce-seller.mdx
@@ -7,7 +7,7 @@ description: The Grantex authority view of Shopify onboarding through AgenticOrg
 
 ## Summary
 
-A Shopify merchant becomes an agentic commerce seller through AgenticOrg seller onboarding, read-only Shopify sync, Grantex OACP authority artifacts, and buyer-safe cache consumption.
+A Shopify merchant becomes an agentic commerce seller through AgenticOrg merchant self-service configuration, Seller Commerce Agent onboarding, read-only Shopify sync, Grantex OACP authority artifacts, and buyer-safe cache consumption.
 
 ## Target Audience
 
@@ -28,21 +28,24 @@ flowchart LR
 
 ## End-To-End Flow
 
-1. Merchant creates a Seller Commerce Agent in AgenticOrg.
-2. AgenticOrg stores Shopify credential custody outside Grantex.
-3. AgenticOrg syncs public-safe catalog, price, image, and inventory evidence.
-4. AgenticOrg requests Grantex C6Z authority artifacts.
-5. Grantex issues or refuses OACP artifacts.
-6. AgenticOrg caches artifacts and answers buyer questions with labels.
-7. Purchase intent becomes a prepared provider/merchant handoff or blocker.
+1. Merchant saves tenant/merchant/store-scoped source, channel, provider, public publishing, and POS settings in AgenticOrg.
+2. Merchant creates or updates a Seller Commerce Agent in AgenticOrg.
+3. AgenticOrg stores Shopify credential custody outside Grantex.
+4. AgenticOrg syncs public-safe catalog, price, image, and inventory evidence.
+5. AgenticOrg requests Grantex C6Z authority artifacts.
+6. Grantex issues or refuses OACP artifacts.
+7. AgenticOrg caches artifacts and answers buyer questions with labels.
+8. Purchase intent becomes a prepared provider/POS/merchant handoff or blocker.
 
 ## What Is Implemented Now
 
-Grantex has the C6Z authority route, internal artifact issuance, adapter mapping, artifact verification helpers, and focused tests. AgenticOrg owns seller onboarding, Shopify sync, cache intake, buyer Q&A, bridge endpoints, and Plural/Pine capability verification.
+Grantex has the C6Z authority route, internal artifact issuance, adapter mapping, artifact verification helpers, and focused tests. AgenticOrg owns merchant self-service config, seller onboarding, Shopify sync, cache intake, buyer Q&A, bridge endpoints, public catalog publishing, Offline POS handoff, and Plural/Pine capability verification.
+
+WooCommerce, ERP, PIM, OMS, WMS, custom API, bank-owned rail, fintech rail, and custom provider setup can be recorded in AgenticOrg as pending-adapter config. Grantex should not treat those refs as live source or payment execution until an approved adapter and evidence path exists.
 
 ## What Requires External Approval Or Config
 
-Merchant Shopify credentials, AgenticOrg tenant allowlist, provider rail approval, channel webhook approvals, and partner review for any public program claim.
+Merchant Shopify credentials, AgenticOrg tenant allowlist, provider or bank rail approval, channel webhook approvals, POS callback approval, and partner review for any public program claim.
 
 ## Failure Modes
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -77,6 +77,7 @@
               "guides/oacp/truth-inventory",
               "guides/oacp/architecture",
               "guides/oacp/artifact-authority",
+              "guides/oacp/merchant-self-service-config",
               "guides/oacp/protocol-adapter",
               "guides/oacp/policy-governance",
               "guides/oacp/merchant-source-of-record",
@@ -744,6 +745,7 @@
             "group": "Posts",
             "pages": [
               "blog/oacp-shopify-merchant-agentic-commerce-seller",
+              "blog/oacp-merchant-self-service-config",
               "blog/oacp-keeps-buyer-agents-honest",
               "blog/oacp-buyer-surfaces-chatgpt-claude-gemini-perplexity-whatsapp-telegram",
               "blog/oacp-maps-to-protocols",

--- a/docs/guides/oacp/agenticorg-integration.mdx
+++ b/docs/guides/oacp/agenticorg-integration.mdx
@@ -16,7 +16,8 @@ sequenceDiagram
   participant M as Merchant
   participant A as AgenticOrg
   participant G as Grantex
-  M->>A: Create Seller Commerce Agent and connect Shopify
+  M->>A: Save merchant config and create Seller Commerce Agent
+  A->>A: Store source/channel/provider/POS refs
   A->>A: Read-only Shopify sync and redacted evidence
   A->>G: POST /v1/commerce/oacp/c6z/authority-requests
   G-->>A: Signed/internal OACP artifacts or blockers
@@ -30,6 +31,7 @@ sequenceDiagram
 AgenticOrg sends:
 
 - tenant, merchant, seller agent, and source identifiers;
+- merchant self-service config refs for source connector, buyer channels, provider-owned payment rails, public publishing, and POS metadata;
 - requested OACP artifact families;
 - source observed timestamp;
 - public-safe connector evidence;
@@ -67,7 +69,8 @@ Those outputs must include source and freshness labels, must not expose Shopify 
 | `COMMERCE_C6Z_AUTHORITY_SERVICE_TOKEN` | Grantex + AgenticOrg | Service-token auth for authority requests. |
 | `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS` | Grantex | Tenant allowlist. |
 | Shopify credential custody | AgenticOrg + merchant | Read-only source evidence generation. |
-| Provider capability config | AgenticOrg + provider | Capability evidence checks outside Grantex. |
+| Future connector config | AgenticOrg + merchant | WooCommerce, ERP, PIM, OMS, WMS, and custom API setup intent; not live until adapters exist. |
+| Provider capability config | AgenticOrg + provider or bank | Capability evidence checks outside Grantex. |
 | POS provider approval | AgenticOrg + merchant + POS/payment provider | Verified callback/evidence refs for Offline POS Bridge reconciliation. |
 
 ## Failure Handling

--- a/docs/guides/oacp/architecture.mdx
+++ b/docs/guides/oacp/architecture.mdx
@@ -11,7 +11,9 @@ OACP separates facts, authority, runtime behavior, and payment rails so no agent
 
 ```mermaid
 flowchart TD
-  shopify[Shopify and merchant systems] -->|catalog, price, inventory, policy facts| agenticSeller[AgenticOrg Seller Commerce Agent]
+  config[AgenticOrg merchant config] --> agenticSeller[AgenticOrg Seller Commerce Agent]
+  shopify[Shopify and merchant systems] -->|catalog, price, inventory, policy facts| agenticSeller
+  future[WooCommerce/ERP/bank/provider refs] -->|pending-adapter config only| config
   agenticSeller -->|redacted connector evidence| grantex[Grantex OACP authority]
   grantex -->|signed/internal artifacts or refusals| cache[AgenticOrg OACP cache]
   cache --> buyerAgent[AgenticOrg buyer agent]
@@ -19,10 +21,11 @@ flowchart TD
   buyerAgent --> mcp[MCP clients]
   buyerAgent --> openapi[OpenAPI clients]
   buyerAgent --> a2a[A2A card]
+  buyerAgent --> search[Public catalog/search when enabled]
   buyerAgent --> wa[WhatsApp]
   buyerAgent --> tg[Telegram]
-  buyerAgent -->|capability check only| pine[Pine Labs Plural/P3P]
-  pine -->|redacted evidence ref| cache
+  buyerAgent -->|capability check only| provider[Pine Labs Plural/P3P, bank/POS/provider rails]
+  provider -->|redacted evidence ref| cache
 ```
 
 ## Responsibilities
@@ -30,9 +33,9 @@ flowchart TD
 | Party | Owns | Does not own |
 | --- | --- | --- |
 | Merchant systems | Catalog, price, inventory, order, policy, support, and source timestamps. | OACP artifact policy. |
-| AgenticOrg | Seller and buyer agents, Shopify connector runtime, cache, buyer channels, and capability verification. | Canonical OACP authority or payment rail execution. |
+| AgenticOrg | Merchant self-service config, Seller and buyer agents, Shopify connector runtime, pending-adapter setup refs, cache, buyer channels, public publishing, POS handoff orchestration, and capability verification. | Canonical OACP authority or payment/bank/POS rail execution. |
 | Grantex | Policy, trust, artifacts, verification, and adapter authority. | Merchant connector runtime, buyer sessions, orders, or payments. |
-| Provider rails | Mandate and payment execution, provider status, settlement, and provider webhooks. | OACP trust authority or buyer-agent answers. |
+| Provider/bank/POS rails | Mandate and payment execution, provider status, settlement, receipt evidence, and provider webhooks. | OACP trust authority or buyer-agent answers. |
 
 ## Why Grantex Is Not In Every Loop
 

--- a/docs/guides/oacp/explainers/shopify-to-agentic-commerce.mdx
+++ b/docs/guides/oacp/explainers/shopify-to-agentic-commerce.mdx
@@ -11,17 +11,19 @@ This page is for merchants evaluating a Seller Commerce Agent in AgenticOrg.
 
 ## Steps
 
-1. Create a Seller Commerce Agent in AgenticOrg.
-2. Connect Shopify with read-only Admin API access or an approved OAuth flow.
-3. Run a read-only sync for catalog, variants, price, inventory, and source timestamps.
-4. Let AgenticOrg submit redacted evidence to Grantex.
-5. Grantex issues OACP artifacts or exact blockers.
-6. AgenticOrg caches artifacts and exposes buyer-safe channels.
-7. Purchase requests are prepared for approved provider/merchant handoff or refused.
+1. Save tenant/merchant/seller commerce config in AgenticOrg.
+2. Create or update a Seller Commerce Agent in AgenticOrg.
+3. Connect Shopify with read-only Admin API access or an approved OAuth flow.
+4. Run a read-only sync for catalog, variants, price, inventory, and source timestamps.
+5. Let AgenticOrg submit redacted evidence to Grantex.
+6. Grantex issues OACP artifacts or exact blockers.
+7. AgenticOrg caches artifacts and exposes buyer-safe channels.
+8. Purchase requests are prepared for approved provider/POS/merchant handoff or refused.
 
 ```mermaid
 flowchart LR
-  merchant[Merchant] --> agent[Seller Commerce Agent]
+  merchant[Merchant] --> config[AgenticOrg commerce config]
+  config --> agent[Seller Commerce Agent]
   agent --> shopify[Read-only Shopify sync]
   shopify --> grantex[Grantex authority]
   grantex --> cache[AgenticOrg cache]
@@ -33,14 +35,17 @@ flowchart LR
 | Requirement | Owner |
 | --- | --- |
 | Shopify read-only credential or OAuth install | Merchant + AgenticOrg |
+| Merchant commerce config for sources, channels, providers, public publishing, and POS | Merchant + AgenticOrg |
 | AgenticOrg tenant and seller agent id | AgenticOrg |
 | Grantex tenant allowlist and service token | Grantex |
-| Provider capability configuration | AgenticOrg + Pine Labs Plural/P3P |
+| Provider or bank capability configuration | AgenticOrg + Pine Labs Plural/P3P, bank, or provider |
 | Channel approvals | AgenticOrg + channel owners |
 
 ## Expected Timeline
 
 Local demo can be run after credentials and allowlisting. Public channel launch requires source evidence review, provider capability evidence, channel webhook approval, rollback owner, and operator signoff.
+
+WooCommerce, ERP, PIM, OMS, WMS, custom API, bank-owned rail, fintech rail, and custom provider setup can be recorded as pending-adapter config in AgenticOrg. Grantex should not treat those refs as live execution or source evidence until an approved adapter path exists.
 
 ## What Agents Can Say
 

--- a/docs/guides/oacp/merchant-self-service-config.mdx
+++ b/docs/guides/oacp/merchant-self-service-config.mdx
@@ -1,0 +1,67 @@
+---
+title: OACP Merchant Self-Service Config Boundary
+description: What AgenticOrg merchant configuration owns, what Grantex signs, and how future connectors and bank providers stay non-executing until approved.
+---
+
+# OACP Merchant Self-Service Config Boundary
+
+Canonical end-to-end flow: [OACP authority overview](./overview).
+
+AgenticOrg owns merchant self-service configuration. Grantex does not store merchant connector secrets, payment-provider credentials, bank secrets, raw POS payloads, or merchant onboarding UI state. Grantex receives public-safe authority requests and issues or refuses OACP artifacts from redacted evidence.
+
+## Configuration Scope
+
+AgenticOrg scopes merchant commerce configuration by tenant, merchant, and seller agent. A merchant can create the config during Seller Commerce Agent onboarding and update it later.
+
+The config may include:
+
+| Config group | AgenticOrg-owned meaning | Grantex-owned authority view |
+| --- | --- | --- |
+| Merchant profile | Display name, categories, public-safe profile refs. | May be represented in merchant profile artifacts. |
+| Source connector | Shopify runtime config today; WooCommerce, ERP, PIM, OMS, WMS, and custom API setup intent for future adapters. | Receives only redacted connector evidence refs, hashes, timestamps, source ids, and freshness. |
+| Buyer channels | Web, MCP, OpenAPI, A2A, search/public catalog, WhatsApp, Telegram readiness and approval refs. | May sign protocol adapter or public discovery-state artifacts; does not run channel bridges. |
+| Payment providers | Plural/Pine capability verifier today; bank, fintech, and custom provider refs as provider-owned non-executing setup. | May sign non-sensitive mandate capability evidence refs; does not execute rails. |
+| Offline POS | Store/POS refs and webhook-secret refs held by AgenticOrg. | May verify redacted POS evidence refs when authority refresh is needed. |
+| Public publishing | Merchant-level enablement for public-safe seller/product surfaces. | May sign public discovery-state artifacts; does not host AgenticOrg catalog pages. |
+
+## Runtime-Supported Vs Pending Adapter
+
+| Source or provider | Current status |
+| --- | --- |
+| Shopify | Runtime-supported through AgenticOrg read-only Admin GraphQL sync and webhook-triggered refresh/reconciliation. |
+| WooCommerce | Configurable as pending adapter; not live until approved connector code, tests, credentials, and webhooks exist. |
+| ERP/PIM/OMS/WMS/custom API | Configurable as pending adapter; not live until source precedence and adapter contracts exist. |
+| Pine Labs Plural/P3P | Runtime-supported as provider-owned mandate capability verification where credentials are configured. |
+| Bank-owned rail | Configurable as provider-owned pending adapter; not executable until a bank adapter, contract, callback verification, and rollout approval exist. |
+| Fintech/custom provider | Configurable as provider-owned pending adapter; not executable until approved. |
+
+## Authority Request Boundary
+
+```mermaid
+flowchart LR
+  merchant[Merchant operator] --> agentic[AgenticOrg config UI]
+  agentic --> shopify[Shopify runtime sync]
+  agentic --> pending[WooCommerce/ERP/bank pending-adapter refs]
+  shopify --> evidence[Redacted public-safe evidence]
+  evidence --> grantex[Grantex authority request]
+  grantex --> artifacts[OACP artifacts or blockers]
+  artifacts --> cache[AgenticOrg cache and channels]
+```
+
+Grantex rejects authority requests that include raw secrets, raw provider payloads, private merchant payloads, executable checkout/payment/order/refund targets, unsupported live claims, or certification/standardization claims.
+
+## Public Wording
+
+Safe wording:
+
+- "Merchant configuration is owned by AgenticOrg and scoped per tenant, merchant, and seller agent."
+- "Shopify is the current runtime source connector."
+- "WooCommerce, ERP, bank-owned rails, and custom providers are pending adapter until approved."
+- "Grantex signs or refuses OACP artifacts; it does not execute payments or host merchant connector runtime."
+
+Unsafe wording:
+
+- "Grantex runs every buyer/seller message."
+- Any wording that presents UCP, ACP, AP2, IETF, NIST, provider, or external-program certification as already granted.
+- "Configuring a bank provider means live payment execution is enabled."
+- "WooCommerce or ERP sync is live before the adapter and tests exist."

--- a/docs/guides/oacp/merchant-source-of-record.mdx
+++ b/docs/guides/oacp/merchant-source-of-record.mdx
@@ -7,11 +7,12 @@ description: Why Shopify and merchant systems remain authoritative in OACP.
 
 Canonical end-to-end flow: [OACP authority overview](./overview).
 
-OACP does not move commerce truth into Grantex. Shopify, merchant OMS, inventory systems, policy stores, support systems, and payment providers remain operational systems of record.
+OACP does not move commerce truth into Grantex. Shopify, future WooCommerce/ERP/PIM/OMS/WMS sources, merchant inventory systems, policy stores, support systems, POS systems, banks, and payment providers remain operational systems of record.
 
 ```mermaid
 flowchart LR
   shopify[Shopify catalog, price, inventory] --> evidence[AgenticOrg public-safe evidence]
+  future[WooCommerce/ERP/PIM/OMS/WMS/custom API pending adapter] --> intent[AgenticOrg config intent]
   evidence --> grantex[Grantex authority]
   grantex --> artifact[OACP artifact with source and freshness]
   artifact --> cache[AgenticOrg cache]
@@ -21,10 +22,12 @@ flowchart LR
 ## Source Rules
 
 - Product names, descriptions, variants, images, prices, and inventory come from Shopify or the merchant-approved source.
+- Shopify is the current runtime-supported source connector.
+- WooCommerce, ERP, PIM, OMS, WMS, and custom API source configs are merchant-owned setup intent until approved adapters exist.
 - Grantex validates evidence shape and policy, not the raw private connector payload.
 - AgenticOrg stores public-safe artifact refs and freshness labels, not raw Shopify secrets.
 - If source evidence is stale or conflicting, buyer answers must refresh or refuse.
 
 ## Pending Runtime Gap
 
-Multi-system conflict resolution across Shopify, ERP, OMS, WMS, support, and provider records needs explicit source precedence policy before broad launch.
+Multi-system conflict resolution across Shopify, WooCommerce, ERP, OMS, WMS, support, bank/provider, and POS records needs explicit source precedence policy before broad launch.

--- a/docs/guides/oacp/operator-runbook.mdx
+++ b/docs/guides/oacp/operator-runbook.mdx
@@ -12,7 +12,8 @@ Canonical end-to-end flow: [OACP authority overview](./overview).
 ```mermaid
 flowchart TD
   start[Start] --> token[Verify service token and tenant allowlist]
-  token --> request[Submit fixture authority request]
+  token --> config[Confirm AgenticOrg merchant config is tenant/merchant/seller scoped]
+  config --> request[Submit fixture authority request]
   request --> artifact[Confirm 11 artifact families or expected blocker]
   artifact --> verify[Run artifact verifier checks]
   verify --> adapters[Inspect adapter mapping payload]
@@ -29,6 +30,7 @@ flowchart TD
 | Adapter tests pass | `npm --prefix apps/auth-service test -- commerce-c6w4-oacp-adapter-previews.test.ts` |
 | Conformance gate | `node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr` |
 | Guardrail scan | Search changed docs for stale or overclaim wording. |
+| Merchant config boundary | Confirm Shopify is runtime-supported and WooCommerce/ERP/bank/custom provider configs are pending-adapter unless approved. |
 
 ## Rollback
 

--- a/docs/guides/oacp/overview.mdx
+++ b/docs/guides/oacp/overview.mdx
@@ -7,19 +7,19 @@ description: The canonical Grantex overview for Open Agentic Commerce Protocol a
 
 This is the canonical Grantex OACP page. The canonical end-to-end flow starts here and links to the AgenticOrg runtime guide from the integration page.
 
-OACP is the trust and interoperability layer for agentic commerce. Grantex owns the protocol, trust, policy, artifact, verification, and protocol-adapter authority. AgenticOrg owns the buyer and seller AI-agent runtime, Shopify connector runtime, buyer sessions, channel bridges, OACP cache, and provider-owned mandate capability verification.
+OACP is the trust and interoperability layer for agentic commerce. Grantex owns the protocol, trust, policy, artifact, verification, and protocol-adapter authority. AgenticOrg owns the buyer and seller AI-agent runtime, merchant self-service configuration, Shopify connector runtime, future connector setup intent, buyer sessions, channel bridges, OACP cache, and provider-owned mandate capability verification.
 
-Merchant systems such as Shopify and POS systems remain the source of record. Pine Labs Plural/P3P, POS systems, and other provider rails own mandate, payment, and in-store execution. Grantex must not become a toll booth for every buyer and seller interaction.
+Merchant systems such as Shopify, future WooCommerce/ERP sources, and POS systems remain the source of record. Pine Labs Plural/P3P, bank-owned rails, POS systems, and other provider rails own mandate, payment, and in-store execution. Grantex must not become a toll booth for every buyer and seller interaction.
 
 ## Four-Party Architecture
 
 ```mermaid
 flowchart LR
-  merchant[Merchant systems: Shopify, OMS, inventory, policy] --> agentic[AgenticOrg seller and buyer runtime]
+  merchant[Merchant systems: Shopify, future WooCommerce/ERP, OMS, inventory, policy] --> agentic[AgenticOrg seller and buyer runtime]
   agentic -->|authority request with redacted evidence| grantex[Grantex OACP authority]
   grantex -->|signed internal artifacts and blockers| agentic
   agentic -->|buyer answer from valid cache| buyer[Buyer surfaces]
-  agentic -->|capability or POS handoff only| provider[Pine Labs Plural/P3P, POS, or payment rail]
+  agentic -->|capability or POS handoff only| provider[Pine Labs Plural/P3P, bank, POS, or payment rail]
   provider -->|redacted capability or POS evidence ref| agentic
 ```
 
@@ -35,7 +35,7 @@ flowchart LR
 
 ## What Grantex Does Not Own
 
-Grantex does not own Shopify runtime credentials, merchant onboarding UX, buyer sessions, WhatsApp or Telegram webhooks, MCP/OpenAPI client sessions, AgenticOrg artifact cache storage, Offline POS Bridge orchestration, final checkout execution, POS transaction execution, order creation, stock holds, mandate setup, payment capture, refund execution, or provider settlement.
+Grantex does not own Shopify runtime credentials, WooCommerce/ERP connector credentials, merchant onboarding UX, buyer sessions, WhatsApp or Telegram webhooks, MCP/OpenAPI client sessions, AgenticOrg artifact cache storage, Offline POS Bridge orchestration, final checkout execution, POS transaction execution, order creation, stock holds, mandate setup, payment capture, refund execution, or provider/bank settlement.
 
 ## Runtime Reality
 
@@ -44,7 +44,7 @@ Grantex does not own Shopify runtime credentials, merchant onboarding UX, buyer 
 | Implemented runtime | `POST /v1/commerce/oacp/c6z/authority-requests`, internal artifact issuance, verifier helpers, adapter preview helpers, and OACP guard tests. |
 | Implemented docs only | Historical Commerce V1 planning and C6 audit/review reports remain useful as internal history but are superseded for the public OACP split. |
 | Requires external credentials or approval | AgenticOrg service token and tenant allowlist, merchant Shopify access, channel approvals, and provider rail approval. |
-| Missing | Public standards program approval, universal channel launch, live POS provider approval, and broad payment/order execution. |
+| Missing | Public standards program approval, universal channel launch, live POS provider approval, non-Shopify source adapters, bank/custom payment adapters, and broad payment/order execution. |
 | Stale/confusing documentation | Older Commerce V1 pages that frame Grantex as the merchant control plane are historical; use this OACP group for the current authority narrative. |
 
 ## Artifact Families
@@ -58,6 +58,7 @@ AgenticOrg may continue non-binding product questions and comparison from valid 
 ## Related Pages
 
 - [Architecture](./architecture)
+- [Merchant self-service config](./merchant-self-service-config)
 - [Artifact authority](./artifact-authority)
 - [Offline POS Bridge boundary](./pos-bridge-boundary)
 - [AgenticOrg integration guide](./agenticorg-integration)

--- a/docs/guides/oacp/provider-payment-boundary.mdx
+++ b/docs/guides/oacp/provider-payment-boundary.mdx
@@ -7,13 +7,14 @@ description: How OACP treats Pine Labs Plural/P3P and other payment rails.
 
 Canonical end-to-end flow: [OACP authority overview](./overview).
 
-Pine Labs Plural/P3P, POS systems, and other provider rails own mandate setup, payment execution, provider status, settlement, receipt evidence, and provider webhooks. Grantex does not execute provider or POS rails in the AgenticOrg OACP runtime split.
+Pine Labs Plural/P3P, bank-owned rails, POS systems, and other provider rails own mandate setup, payment execution, provider status, settlement, receipt evidence, and provider webhooks. Grantex does not execute provider, bank, or POS rails in the AgenticOrg OACP runtime split.
 
 ```mermaid
 flowchart LR
   buyer[Buyer intent] --> agentic[AgenticOrg purchase preparation]
   agentic --> cache[OACP cache checks]
   agentic --> verifier[Plural/Pine capability verifier]
+  agentic --> bank[Bank/fintech/custom provider config refs]
   agentic --> pos[Offline POS handoff packet]
   verifier --> ref[Redacted capability evidence ref]
   pos --> posref[Redacted POS/provider evidence ref]
@@ -29,6 +30,7 @@ flowchart LR
 | Area | Rule |
 | --- | --- |
 | Mandate setup | Provider-owned. OACP may carry non-sensitive capability evidence refs. |
+| Bank-owned rails | Provider-owned config refs only until an approved bank adapter exists. |
 | Payment capture | Provider-owned and outside artifact issuance. |
 | POS handoff | AgenticOrg-owned orchestration; POS/provider-owned confirmation. |
 | Checkout/order success | Must come from merchant/provider systems, never from an agent guess. |
@@ -37,4 +39,4 @@ flowchart LR
 
 ## Pending Runtime Gap
 
-Provider-owned or POS-owned execution can only be added after merchant, provider/POS, legal, security, operations, channel, rollback, and observability approval. Until then, docs must say prepared handoff, POS accepted pending staff/payment confirmation, or blocker.
+Provider-owned, bank-owned, or POS-owned execution can only be added after merchant, provider/POS/bank, legal, security, operations, channel, rollback, and observability approval. Until then, docs must say prepared handoff, POS accepted pending staff/payment confirmation, pending adapter, or blocker.

--- a/docs/guides/oacp/truth-inventory.mdx
+++ b/docs/guides/oacp/truth-inventory.mdx
@@ -13,11 +13,11 @@ This inventory is based on the Grantex C6Z authority route, OACP artifact librar
 
 | Category | Grantex reality | Owner/action |
 | --- | --- | --- |
-| Implemented runtime | C6Z authority endpoint under commerce auth; allowlisted AgenticOrg service-token access; internal artifact issuance; artifact safety checks; TTL and signature metadata; adapter mapping payloads; cache/offline verifier helpers; POS handoff evidence-ref boundary in policy/mandate/protocol artifacts. | Grantex keeps tests and guard scans current. |
+| Implemented runtime | C6Z authority endpoint under commerce auth; allowlisted AgenticOrg service-token access; internal artifact issuance; artifact safety checks; TTL and signature metadata; adapter mapping payloads; cache/offline verifier helpers; POS handoff evidence-ref boundary in policy/mandate/protocol artifacts. AgenticOrg owns implemented tenant/merchant/seller scoped commerce config and Shopify runtime sync. | Grantex keeps tests and guard scans current. |
 | Implemented docs only | Historical Commerce V1 PRDs, launch plans, C6 review reports, and publication drafts. | Mark as historical where they conflict with this architecture. |
 | Implemented but not broad launch | Commerce V1 payment-control pilot code and Plural sandbox/UAT-compatible adapter paths exist separately from the AgenticOrg OACP runtime split. | Keep separate from OACP authority docs. |
-| Requires credentials or approval | `COMMERCE_C6Z_AUTHORITY_SERVICE_TOKEN`, `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS`, merchant/AgenticOrg tenant approval, production key custody, provider rail approval, and external channel approvals. | Ops owner must collect evidence before public claims. |
-| Missing | Public standards approval, broad external protocol partner program, universal buyer-surface rollout, live POS provider approval, and order/payment/mandate/POS execution through OACP artifacts. | Treat as pending runtime/product gaps. |
+| Requires credentials or approval | `COMMERCE_C6Z_AUTHORITY_SERVICE_TOKEN`, `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS`, merchant/AgenticOrg tenant approval, production key custody, provider or bank rail approval, POS callback approval, and external channel approvals. | Ops owner must collect evidence before public claims. |
+| Missing | Public standards approval, broad external protocol partner program, universal buyer-surface rollout, live non-Shopify source adapters, live bank/custom provider adapters, live POS provider approval, and order/payment/mandate/POS execution through OACP artifacts. | Treat as pending runtime/product gaps. |
 | Stale/confusing docs | Older copy that says Grantex is the merchant connector runtime or payment-control loop for every buyer interaction. | Supersede with OACP authority docs and link here. |
 
 ## Evidence Pointers
@@ -34,5 +34,6 @@ This inventory is based on the Grantex C6Z authority route, OACP artifact librar
 | --- | --- | --- |
 | External protocol approval | Grantex + partners | Create a public partner review process and evidence checklist before making official status claims. |
 | AgenticOrg production tenant rollout | AgenticOrg + Grantex | Allowlist tenant, rotate service token, verify source evidence intake, and run authority request smoke. |
-| Provider rail execution | Pine Labs Plural/P3P + merchant + AgenticOrg | Complete provider-owned approval, webhook, rollback, and human review path. Grantex stores only non-sensitive evidence refs where needed. |
+| Non-Shopify source adapters | AgenticOrg + merchants | Keep WooCommerce, ERP, PIM, OMS, WMS, and custom API configs as pending adapter until connector code, source precedence, tests, and approvals exist. |
+| Provider or bank rail execution | Pine Labs Plural/P3P, banks, fintech/custom providers + merchant + AgenticOrg | Complete provider-owned approval, webhook, rollback, and human review path. Grantex stores only non-sensitive evidence refs where needed. |
 | Buyer-surface approvals | AgenticOrg + channel owners | Verify WhatsApp, Telegram, MCP, OpenAPI, A2A, and web policies before public launch. |


### PR DESCRIPTION
Updates Grantex OACP docs, README, guide navigation, and blogs to reflect the AgenticOrg-owned merchant self-service commerce configuration journey, Shopify-current/future WooCommerce-ERP source model, provider/bank-owned payment boundaries, public publishing/search surfaces, and non-certification language. Validation run locally: docs JSON parse, stale/overclaim scan, git diff --check.