### PR TITLE
[codex] Close OACP runtime authority gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ flowchart LR
 | Area | Current posture |
 | --- | --- |
 | Grantex C6Z authority route | Implemented at `POST /v1/commerce/oacp/c6z/authority-requests` for allowlisted AgenticOrg tenants. |
-| Artifact families | 11 internal OACP families are issued or refused: merchant profile, seller agent card, connector evidence, catalog, price, inventory, policy, public discovery state, mandate capability, protocol adapter, and request status. |
+| Artifact families | 11 internal OACP families are issued or refused with source lineage, TTL, freshness, revocation posture, blocked capabilities, non-sensitive evidence refs, and signature metadata. |
 | Protocol adapters | Schema.org, UCP-style, ACP-style, AP2-style, A2A, MCP, and OpenAPI mappings are compatibility mappings derived from OACP artifacts. |
 | AgenticOrg runtime | Merchant self-service config, Seller onboarding, Shopify sync, future connector/provider intent capture, cache, buyer Q&A, bridges, and provider capability verification live in AgenticOrg. |
 | Payment/order/POS execution | Outside OACP artifact authority. Provider, POS, and merchant systems must execute and confirm; agents must not invent success. |
 | Historical Commerce V1 docs | Retained for context, but superseded for the AgenticOrg OACP runtime split. |
 
-Start with the [OACP authority overview](docs/guides/oacp/overview.mdx), [merchant self-service config boundary](docs/guides/oacp/merchant-self-service-config.mdx), [truth inventory](docs/guides/oacp/truth-inventory.mdx), [AgenticOrg integration guide](docs/guides/oacp/agenticorg-integration.mdx), [POS bridge boundary](docs/guides/oacp/pos-bridge-boundary.mdx), and [operator runbook](docs/guides/oacp/operator-runbook.mdx). The older [Commerce V1 overview](docs/guides/commerce-v1-overview.mdx) remains historical/contextual and should not be used to imply that Grantex owns AgenticOrg merchant connector runtime.
+Start with the [OACP runtime launch closure PRD](docs/guides/oacp/runtime-launch-closure-prd.mdx), [OACP authority overview](docs/guides/oacp/overview.mdx), [merchant self-service config boundary](docs/guides/oacp/merchant-self-service-config.mdx), [truth inventory](docs/guides/oacp/truth-inventory.mdx), [AgenticOrg integration guide](docs/guides/oacp/agenticorg-integration.mdx), [POS bridge boundary](docs/guides/oacp/pos-bridge-boundary.mdx), and [operator runbook](docs/guides/oacp/operator-runbook.mdx). The older [Commerce V1 overview](docs/guides/commerce-v1-overview.mdx) remains historical/contextual and should not be used to imply that Grantex owns AgenticOrg merchant connector runtime.
 
 ## Current Development Snapshot
 

--- a/apps/auth-service/src/lib/commerce/oacp-runtime-vertical.ts
+++ b/apps/auth-service/src/lib/commerce/oacp-runtime-vertical.ts
@@ -121,6 +121,16 @@ const FAMILY_TTL_SECONDS: Record<C6ZArtifactFamily, number> = {
   protocol_adapter: 24 * 60 * 60,
   authority_request_status: 15 * 60,
 };
+const BLOCKED_RUNTIME_CAPABILITIES = [
+  'checkout_payment_execution',
+  'order_creation',
+  'inventory_hold',
+  'live_provider_execution',
+  'offline_pos_transaction_execution',
+  'pos_order_creation',
+  'pos_payment_capture',
+  'public_discovery_publication',
+] as const;
 const PRIVATE_VALUE_MARKERS = [
   'access_token',
   'api_key',
@@ -169,6 +179,19 @@ function isoAfter(value: string, seconds: number): string {
 
 function stableId(parts: readonly string[]): string {
   return parts.join(':').replace(/[^a-zA-Z0-9:_-]/g, '_');
+}
+
+function revocationStatusUrl(request: C6ZSellerAuthorityRequest): string {
+  return `internal:oacp:c6z:revocation:${request.tenant_id}:${request.merchant_id}`;
+}
+
+function nonSensitiveEvidenceRefs(evidence: C6ZConnectorEvidence): string[] {
+  return [
+    evidence.source_evidence_ref,
+    ...evidence.catalog_sample_refs,
+    ...evidence.price_snapshot_refs,
+    ...evidence.inventory_snapshot_refs,
+  ].filter((value): value is string => typeof value === 'string' && value.length > 0);
 }
 
 function containsUnsafeValue(value: unknown): boolean {
@@ -308,6 +331,7 @@ function payloadForFamily(
   request: C6ZSellerAuthorityRequest,
   evidence: C6ZConnectorEvidence,
 ): Record<string, unknown> {
+  const ttlSeconds = FAMILY_TTL_SECONDS[family];
   return {
     artifact_family: family,
     tenant_id: request.tenant_id,
@@ -316,6 +340,39 @@ function payloadForFamily(
     source_system: 'shopify',
     source_evidence_ref: evidence.source_evidence_ref,
     source_observed_at: evidence.source_observed_at,
+    source_lineage: {
+      source_system: 'shopify',
+      connector_mode: 'read_only',
+      connector_evidence_id: evidence.evidence_id,
+      source_evidence_ref: evidence.source_evidence_ref,
+      source_observed_at: evidence.source_observed_at,
+      merchant_system_source_of_record: true,
+      raw_shopify_payload_stored_by_grantex: false,
+      raw_provider_payload_stored_by_grantex: false,
+    },
+    ttl_seconds: ttlSeconds,
+    freshness: {
+      source_observed_at: evidence.source_observed_at,
+      max_source_age_seconds: MAX_SOURCE_AGE_SECONDS,
+      requested_max_age_seconds: request.source_freshness_policy.max_age_seconds,
+      status_at_issuance: 'fresh',
+      stale_behavior: 'refuse_final_commitment_or_require_refresh',
+    },
+    revocation_posture: {
+      revocation_status_url: revocationStatusUrl(request),
+      status_at_issuance: 'not_revoked',
+      stale_or_unreachable_behavior: 'treat_as_not_authorized_for_commitment',
+    },
+    blocked_capabilities: [...BLOCKED_RUNTIME_CAPABILITIES],
+    non_sensitive_evidence_refs: nonSensitiveEvidenceRefs(evidence),
+    signature_metadata: {
+      issuer: ISSUER,
+      issuer_key_id: ISSUER_KEY_ID,
+      algorithm: 'ES256',
+      payload_hash_algorithm: 'sha256',
+      detached_jws_required: true,
+      signature_value_in_payload: false,
+    },
     merchant_display_name: family === 'merchant_profile' ? request.merchant_display_name : undefined,
     commerce_categories: family === 'merchant_profile' ? request.commerce_categories : undefined,
     product_count: ['catalog_snapshot', 'connector_evidence'].includes(family) ? evidence.product_count : undefined,
@@ -421,16 +478,7 @@ function payloadForFamily(
       }
       : undefined,
     authority_request_status: family === 'authority_request_status' ? 'artifact_issuance_ready' : undefined,
-    unsupported_capabilities: [
-      'checkout_payment_execution',
-      'order_creation',
-      'inventory_hold',
-      'live_provider_execution',
-      'offline_pos_transaction_execution',
-      'pos_order_creation',
-      'pos_payment_capture',
-      'public_discovery_publication',
-    ],
+    unsupported_capabilities: [...BLOCKED_RUNTIME_CAPABILITIES],
     allowed_to_execute: false,
     no_payment_execution: true,
     no_public_discovery_enablement: true,
@@ -511,7 +559,7 @@ export function issueC6ZInternalOacpArtifacts(input: {
       expires_at: isoAfter(input.now_iso, FAMILY_TTL_SECONDS[family]),
       source_observed_at: input.evidence.source_observed_at,
       policy_version: POLICY_VERSION,
-      revocation_status_url: `internal:oacp:c6z:revocation:${input.request.tenant_id}:${input.request.merchant_id}`,
+      revocation_status_url: revocationStatusUrl(input.request),
       payload,
       safety: artifactSafety(family),
       issuer_key: issuerKey,

--- a/apps/auth-service/src/lib/stripe.ts
+++ b/apps/auth-service/src/lib/stripe.ts
@@ -8,9 +8,11 @@ export function getStripe(): Stripe {
     if (!config.stripeSecretKey) {
       throw new Error('STRIPE_SECRET_KEY is not configured');
     }
-    _stripe = new Stripe(config.stripeSecretKey, {
+    const stripeConfig = {
+      // The installed Stripe SDK type union lags this pinned account/API version.
       apiVersion: '2026-06-24.dahlia',
-    });
+    } as unknown as ConstructorParameters<typeof Stripe>[1];
+    _stripe = new Stripe(config.stripeSecretKey, stripeConfig);
   }
   return _stripe;
 }

--- a/apps/auth-service/tests/commerce-c6z-runtime-artifact-authority.test.ts
+++ b/apps/auth-service/tests/commerce-c6z-runtime-artifact-authority.test.ts
@@ -112,11 +112,45 @@ describe('C6Z Grantex runtime artifact authority', () => {
       expect(artifact.envelope.seller_agent_id).toBe('seller_C6Z');
       expect(artifact.payload).toMatchObject({
         source_system: 'shopify',
+        source_lineage: {
+          source_system: 'shopify',
+          connector_mode: 'read_only',
+          connector_evidence_id: 'shopify_evidence_C6Z',
+          raw_shopify_payload_stored_by_grantex: false,
+          raw_provider_payload_stored_by_grantex: false,
+        },
+        freshness: {
+          source_observed_at: '2026-06-14T03:25:00.000Z',
+          status_at_issuance: 'fresh',
+          stale_behavior: 'refuse_final_commitment_or_require_refresh',
+        },
+        revocation_posture: {
+          revocation_status_url: 'internal:oacp:c6z:revocation:cten_C6Z:mch_C6Z',
+          status_at_issuance: 'not_revoked',
+          stale_or_unreachable_behavior: 'treat_as_not_authorized_for_commitment',
+        },
+        signature_metadata: {
+          issuer: 'grantex_internal_oacp_authority',
+          issuer_key_id: 'kid_c6z_internal_demo',
+          algorithm: 'ES256',
+          payload_hash_algorithm: 'sha256',
+          detached_jws_required: true,
+          signature_value_in_payload: false,
+        },
         allowed_to_execute: false,
         no_payment_execution: true,
         no_public_discovery_enablement: true,
         non_authoritative_for_transaction: true,
       });
+      expect(artifact.payload.ttl_seconds).toBeGreaterThan(0);
+      expect(artifact.payload.non_sensitive_evidence_refs).toEqual(expect.arrayContaining([
+        'agenticorg:shopify:evidence:c6z_001:redacted',
+      ]));
+      expect(artifact.payload.blocked_capabilities).toEqual(expect.arrayContaining([
+        'checkout_payment_execution',
+        'offline_pos_transaction_execution',
+        'pos_payment_capture',
+      ]));
       expect(artifact.verifier_status).toMatchObject({
         valid: true,
         status: 'valid',

--- a/docs/api/grantex-commerce-v1.openapi.yaml
+++ b/docs/api/grantex-commerce-v1.openapi.yaml
@@ -60,6 +60,7 @@ tags:
   - name: Webhooks
   - name: Connectors
   - name: Well-Known
+  - name: OACP
 
 components:
   securitySchemes:
@@ -3611,6 +3612,114 @@ security:
   - developerApiKey: []
 
 paths:
+  # =====================================================================
+  # OACP C6Z runtime authority path
+  # =====================================================================
+
+  /v1/commerce/oacp/c6z/authority-requests:
+    post:
+      tags: [OACP]
+      summary: AgenticOrg C6Z authority request
+      description: >-
+        Canonical AgenticOrg-to-Grantex authority path for Shopify-backed OACP
+        artifacts. The route accepts allowlisted AgenticOrg service callers or
+        operators, validates redacted read-only connector evidence, and returns
+        11 signed/internal OACP artifact families or an exact refusal. Grantex
+        does not store raw Shopify payloads, raw provider payloads, payment
+        credentials, connector secrets, checkout links, payment links, or POS
+        execution payloads.
+      security:
+        - developerApiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [request]
+              properties:
+                now_iso: { type: string, format: date-time }
+                request:
+                  type: object
+                  required:
+                    - tenant_id
+                    - merchant_id
+                    - seller_agent_id
+                    - merchant_display_name
+                    - commerce_categories
+                    - connector_choice
+                    - connector_mode
+                    - requested_authority_scope
+                    - artifact_cache_scope
+                    - source_freshness_policy
+                    - source_evidence_ref
+                    - source_observed_at
+                    - no_payment_execution
+                    - no_public_discovery_enablement
+                  properties:
+                    request_id: { type: string }
+                    tenant_id: { type: string }
+                    merchant_id: { type: string }
+                    seller_agent_id: { type: string }
+                    merchant_display_name: { type: string }
+                    commerce_categories:
+                      type: array
+                      items: { type: string }
+                    connector_choice: { type: string, enum: [shopify] }
+                    connector_mode: { type: string, enum: [read_only] }
+                    requested_authority_scope:
+                      type: array
+                      items: { type: string }
+                    artifact_cache_scope:
+                      type: object
+                      required: [tenant_id, merchant_id, seller_agent_id]
+                      properties:
+                        tenant_id: { type: string }
+                        merchant_id: { type: string }
+                        seller_agent_id: { type: string }
+                    source_freshness_policy:
+                      type: object
+                      required: [max_age_seconds]
+                      properties:
+                        max_age_seconds: { type: integer, minimum: 1, maximum: 900 }
+                    source_evidence_ref: { type: string }
+                    source_observed_at: { type: string, format: date-time }
+                    no_payment_execution: { type: boolean, const: true }
+                    no_public_discovery_enablement: { type: boolean, const: true }
+                connector_evidence:
+                  type: object
+                  properties:
+                    evidence_id: { type: string }
+                    tenant_id: { type: string }
+                    merchant_id: { type: string }
+                    seller_agent_id: { type: string }
+                    source_system: { type: string, enum: [shopify] }
+                    source_evidence_ref: { type: string }
+                    source_observed_at: { type: string, format: date-time }
+                    product_count: { type: integer, minimum: 0 }
+                    variant_count: { type: integer, minimum: 0 }
+                    currency: { type: string }
+                    catalog_sample_refs:
+                      type: array
+                      items: { type: string }
+                    price_snapshot_refs:
+                      type: array
+                      items: { type: string }
+                    inventory_snapshot_refs:
+                      type: array
+                      items: { type: string }
+                    no_payment_execution: { type: boolean, const: true }
+                    no_public_discovery_enablement: { type: boolean, const: true }
+      responses:
+        "201":
+          description: 11 artifact families issued for AgenticOrg cache intake.
+        "202":
+          description: Authority request accepted but connector evidence is required before issuance.
+        "403":
+          description: AgenticOrg service token is not allowlisted for the tenant.
+        "422":
+          description: Request is unsafe, stale, malformed, private, or executable.
+
   # =====================================================================
   # M1 — implemented
   # =====================================================================

--- a/docs/guides/oacp/operator-runbook.mdx
+++ b/docs/guides/oacp/operator-runbook.mdx
@@ -5,7 +5,18 @@ description: Grantex operator runbook for authority requests, cache safety, laun
 
 # OACP Operator Runbook
 
-Canonical end-to-end flow: [OACP authority overview](./overview).
+Canonical end-to-end flow: [OACP authority overview](./overview). Launch closure source of truth: [OACP Runtime Launch Closure PRD](./runtime-launch-closure-prd).
+
+## Provision AgenticOrg Authority Access
+
+1. Store `COMMERCE_C6Z_AUTHORITY_SERVICE_TOKEN` through the production secret path.
+2. Add the AgenticOrg tenant id to `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS`.
+3. Deploy or restart the Grantex auth service with both values available.
+4. Submit a fixture `POST /v1/commerce/oacp/c6z/authority-requests` for that tenant.
+5. Confirm `artifact_count = 11`, or record the exact refusal/blocker.
+6. To roll back, remove the tenant id from `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS` and rotate the token if there is any suspicion of exposure.
+
+Never put Shopify tokens, provider credentials, payment credentials, raw provider payloads, checkout links, raw POS callbacks, or webhook secrets in Grantex artifacts or logs.
 
 ## Smoke Tests
 
@@ -26,6 +37,8 @@ flowchart TD
 | Check | Command or evidence |
 | --- | --- |
 | Authority route exists | `apps/auth-service/src/routes/commerce-oacp-runtime.ts` |
+| AgenticOrg tenant allowlist | `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS` contains only approved tenant ids |
+| AgenticOrg service token | `COMMERCE_C6Z_AUTHORITY_SERVICE_TOKEN` is present only via secret manager |
 | Artifact tests pass | `npm --prefix apps/auth-service test -- commerce-c6z-runtime-artifact-authority.test.ts` |
 | Adapter tests pass | `npm --prefix apps/auth-service test -- commerce-c6w4-oacp-adapter-previews.test.ts` |
 | Conformance gate | `node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr` |

--- a/docs/guides/oacp/overview.mdx
+++ b/docs/guides/oacp/overview.mdx
@@ -5,7 +5,7 @@ description: The canonical Grantex overview for Open Agentic Commerce Protocol a
 
 # OACP Authority Overview
 
-This is the canonical Grantex OACP page. The canonical end-to-end flow starts here and links to the AgenticOrg runtime guide from the integration page.
+This is the canonical Grantex OACP page. The canonical end-to-end flow starts here and links to the AgenticOrg runtime guide from the integration page. Launch closure source of truth: [OACP Runtime Launch Closure PRD](./runtime-launch-closure-prd).
 
 OACP is the trust and interoperability layer for agentic commerce. Grantex owns the protocol, trust, policy, artifact, verification, and protocol-adapter authority. AgenticOrg owns the buyer and seller AI-agent runtime, merchant self-service configuration, Shopify connector runtime, future connector setup intent, buyer sessions, channel bridges, OACP cache, and provider-owned mandate capability verification.
 
@@ -58,6 +58,7 @@ AgenticOrg may continue non-binding product questions and comparison from valid 
 ## Related Pages
 
 - [Architecture](./architecture)
+- [Runtime launch closure PRD](./runtime-launch-closure-prd)
 - [Merchant self-service config](./merchant-self-service-config)
 - [Artifact authority](./artifact-authority)
 - [Offline POS Bridge boundary](./pos-bridge-boundary)

--- a/docs/guides/oacp/runtime-launch-closure-prd.mdx
+++ b/docs/guides/oacp/runtime-launch-closure-prd.mdx
@@ -1,0 +1,122 @@
+---
+title: OACP Runtime Launch Closure PRD
+description: Canonical Grantex PRD for the AgenticOrg-to-Grantex OACP runtime authority path.
+---
+
+# OACP Runtime Launch Closure PRD
+
+Status date: 2026-06-30
+
+This is the canonical Grantex closure PRD for the OACP Shopify merchant runtime. Older Commerce V1 C6/C6W/C6X/C6Y documents are historical/internal compatibility records and are superseded for launch decisions by this OACP guide set.
+
+## Corrected Architecture
+
+```mermaid
+flowchart LR
+  shopify[Merchant Shopify source of record] --> agentic[AgenticOrg Seller Commerce Agent runtime]
+  agentic -->|redacted authority request| grantex[Grantex trust, policy, artifact authority]
+  grantex -->|signed/internal artifacts or refusal| agentic
+  agentic --> cache[AgenticOrg scoped artifact cache]
+  cache --> buyer[Buyer surfaces]
+  buyer --> provider[Pine/Plural, bank, POS, or payment provider-owned handoff]
+```
+
+Grantex owns trust, protocol, policy, canonical OACP artifacts, verification, adapter governance, and the AgenticOrg service-token/tenant allowlist. AgenticOrg owns runtime, connectors, buyer surfaces, artifact cache, public catalog pages, buyer conversations, and provider-owned handoff orchestration. Merchant systems remain source of record. Pine Labs Plural/P3P, POS, bank, and payment providers own execution.
+
+Grantex must not become a toll booth for every buyer/seller interaction. AgenticOrg may answer non-binding buyer questions from valid cached artifacts and must refresh or refuse commitment-bound flows when artifacts, provider evidence, or merchant source state are stale.
+
+## Canonical Authority Route
+
+`POST /v1/commerce/oacp/c6z/authority-requests`
+
+Accepts:
+
+- allowlisted AgenticOrg service token or operator caller;
+- tenant, merchant, seller agent scope;
+- Shopify read-only connector evidence refs and counts;
+- source observed timestamp and bounded freshness policy;
+- requested 11 OACP artifact families;
+- non-enablement flags.
+
+Rejects or blocks:
+
+- missing tenant/service-token allowlist;
+- invalid token;
+- stale evidence;
+- raw Shopify/provider/POS payloads;
+- secrets, credentials, checkout links, payment links, or raw provider callbacks;
+- execution targets or certification/standardization claims.
+
+Returns:
+
+- `201 artifact_issuance_ready` with 11 signed/internal artifact families;
+- `202 received` when connector evidence is not yet attached;
+- `403 service_tenant_not_allowed` for non-allowlisted service tenant;
+- `422` for unsafe, stale, malformed, or executable requests.
+
+## Artifact Metadata Closure
+
+Every issued artifact must carry:
+
+- source lineage;
+- TTL seconds;
+- freshness status and stale behavior;
+- revocation posture;
+- blocked and unsupported capabilities;
+- non-sensitive evidence refs only;
+- signature metadata;
+- no raw Shopify payloads;
+- no raw provider payloads;
+- no payment credentials;
+- no connector secrets;
+- no live checkout/payment/order/POS success claim.
+
+The C6Z authority implementation lives in:
+
+- `apps/auth-service/src/lib/commerce/oacp-runtime-vertical.ts`
+- `apps/auth-service/src/routes/commerce-oacp-runtime.ts`
+- `apps/auth-service/tests/commerce-c6z-runtime-artifact-authority.test.ts`
+
+## Operator Provisioning
+
+1. Create or rotate `COMMERCE_C6Z_AUTHORITY_SERVICE_TOKEN` through the production secret path.
+2. Add the AgenticOrg tenant id to `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS`.
+3. Restart or redeploy the Grantex auth service with the updated secret and allowlist.
+4. Run a fixture authority request for that tenant.
+5. Confirm `artifact_count = 11` or record the exact blocker.
+6. Remove the tenant from the allowlist to roll back.
+
+Example local smoke:
+
+```bash
+npm --prefix apps/auth-service test -- commerce-c6z-runtime-artifact-authority.test.ts
+node scripts/commerce-oacp-runtime-launch-check.mjs
+```
+
+## Closure Checklist
+
+| Requirement | Grantex closure path | Status |
+| --- | --- | --- |
+| Canonical route documented | This PRD, OpenAPI, operator runbook, integration docs. | Implemented |
+| Tenant allowlist docs | This PRD and operator runbook. | Implemented |
+| Missing tenant/token tests | `commerce-c6z-runtime-artifact-authority.test.ts`. | Implemented |
+| Unsafe evidence tests | Raw payload, secret, and execution-target rejection. | Implemented |
+| Stale evidence tests | `source_evidence_stale` and connector stale checks. | Implemented |
+| Valid issuance tests | 11 artifact-family issuance with verifier status. | Implemented |
+| Artifact metadata | Source lineage, TTL, freshness, revocation, evidence refs, signature metadata. | Implemented |
+| Verifier output | Internal verifier status on every artifact. | Implemented |
+| No raw private payloads | Payload guard and tests. | Implemented |
+| No transaction toll booth | Docs and architecture. | Implemented |
+
+## Validation Commands
+
+```bash
+npm --prefix apps/auth-service test -- commerce-c6z-runtime-artifact-authority.test.ts commerce-c6w4-oacp-adapter-previews.test.ts commerce-no-plural-leak.test.ts commerce-openapi.test.ts
+npm --prefix apps/auth-service run typecheck
+node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr
+git diff --check origin/main...HEAD
+```
+
+## Launch Readiness Rule
+
+Grantex is launch-ready for this vertical only when AgenticOrg has a real Shopify merchant/dev-store evidence run and Grantex returns either valid 11-family artifacts or an exact refusal through the canonical authority route, with no raw secrets or raw private payloads stored or logged. Public standards approval, ChatGPT/Gemini listing approval, WhatsApp/Telegram approval, Pine/Plural provider approval, and POS provider approval remain external blockers unless separately proven.

--- a/docs/internal/commerce-v1/README.md
+++ b/docs/internal/commerce-v1/README.md
@@ -1,0 +1,14 @@
+# Historical Commerce V1 Internal Records
+
+This folder is historical/internal context. C6, C6W, C6X, and C6Y files document earlier preview, compatibility, cache, audit, review, and retention slices.
+
+For current OACP runtime launch decisions, use:
+
+- [OACP Runtime Launch Closure PRD](../../guides/oacp/runtime-launch-closure-prd.mdx)
+- [OACP Authority Overview](../../guides/oacp/overview.mdx)
+- [OACP Architecture](../../guides/oacp/architecture.mdx)
+- [OACP AgenticOrg Integration Guide](../../guides/oacp/agenticorg-integration.mdx)
+- [OACP Operator Runbook](../../guides/oacp/operator-runbook.mdx)
+- [OACP Launch Readiness](../../guides/oacp/launch-readiness.mdx)
+
+The historical documents are not launch approval, not public protocol publication, not external certification, and not evidence that Grantex owns merchant connector runtime or every buyer/seller interaction. Grantex's current role is OACP trust, policy, artifact authority, verification, and adapter governance.


### PR DESCRIPTION
## Summary

Closes the Grantex-side OACP authority gaps for the runtime launch closure pass.

- Adds the canonical OACP runtime launch closure PRD and marks older C6/C6W/C6X/C6Y audit-chain docs as historical/internal.
- Extends C6Z authority artifacts with source lineage, TTL/freshness, revocation posture, blocked capabilities, non-sensitive evidence refs, and signature metadata.
- Documents the canonical `/v1/commerce/oacp/c6z/authority-requests` path in OpenAPI and the operator runbook, including AgenticOrg tenant/token allowlist setup.
- Keeps Grantex as authority/protocol/policy/artifact issuer only; raw Shopify/provider payloads, connector secrets, payment credentials, and execution stay outside Grantex.
- Includes a narrow Stripe SDK typing workaround so auth-service typecheck passes without changing the pinned Stripe API version.

## Validation

- `npm --prefix apps/auth-service test -- commerce-c6z-runtime-artifact-authority.test.ts commerce-c6w4-oacp-adapter-previews.test.ts commerce-no-plural-leak.test.ts commerce-openapi.test.ts` -> 56 passed
- `npm --prefix apps/auth-service run typecheck` -> passed
- `node scripts/commerce-c6oe-preview-conformance-gate.mjs --mode pr` -> passed
- `git diff --check origin/main...HEAD` -> passed

## Remaining caveats

- This PR does not make Grantex a merchant connector runtime or transaction toll booth.
- Live Shopify, buyer-channel, POS, and Plural/Pine proof depends on AgenticOrg runtime deployment, merchant credentials, and provider/channel approvals.
