### PR TITLE
[codex] Fix live principal verification E2E

### DIFF
--- a/.github/workflows/e2e-mpp.yml
+++ b/.github/workflows/e2e-mpp.yml
@@ -89,15 +89,20 @@ jobs:
           echo "Agent: $AGENT_ID"
 
           echo "=== Authorize ==="
-          AUTH_REQ=$(curl -sf -X POST "$API/v1/authorize" \
+          AUTH_JSON=$(curl -sf -X POST "$API/v1/authorize" \
             -H "$AUTH_H" -H "Content-Type: application/json" \
-            -d "{\"agentId\":\"$AGENT_ID\",\"principalId\":\"user_ci_e2e\",\"scopes\":[\"payments:mpp:inference\",\"payments:mpp:compute\"],\"expiresIn\":\"1h\"}" | jq -r '.authRequestId')
+            -d "{\"agentId\":\"$AGENT_ID\",\"principalId\":\"user_ci_e2e\",\"scopes\":[\"payments:mpp:inference\",\"payments:mpp:compute\"],\"expiresIn\":\"1h\"}")
+          AUTH_REQ=$(echo "$AUTH_JSON" | jq -r '.authRequestId')
+          CODE=$(echo "$AUTH_JSON" | jq -r '.code // empty')
           echo "Auth: $AUTH_REQ"
 
-          echo "=== Approve ==="
-          CODE=$(curl -sf -X POST "$API/v1/consent/$AUTH_REQ/approve" \
-            -H "Content-Type: application/json" -d '{}' | jq -r '.code')
-          echo "Code: $CODE"
+          if [ -z "$CODE" ]; then
+            echo "=== Approve ==="
+            CODE=$(curl -sf -X POST "$API/v1/consent/$AUTH_REQ/approve" \
+              -H "Content-Type: application/json" -d '{}' | jq -r '.code // empty')
+          fi
+          [ -n "$CODE" ] || { echo "FAIL: missing authorization code"; exit 1; }
+          echo "Code: ${CODE:0:8}..."
 
           echo "=== Exchange token ==="
           GRANT_ID=$(curl -sf -X POST "$API/v1/token" \
@@ -173,14 +178,21 @@ jobs:
             body: JSON.stringify({ agentId: agent.agentId, principalId: 'user_sig_e2e', scopes: ['payments:mpp:inference'], expiresIn: '1h' }),
           })).json();
 
-          const consent = await (await fetch(`${API}/v1/consent/${auth.authRequestId}/approve`, {
-            method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}',
-          })).json();
+          let code = auth.code;
+          if (!code) {
+            const consent = await (await fetch(`${API}/v1/consent/${auth.authRequestId}/approve`, {
+              method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}',
+            })).json();
+            code = consent.code;
+          }
+          if (!code) {
+            throw new Error('missing authorization code');
+          }
 
           const token = await (await fetch(`${API}/v1/token`, {
             method: 'POST',
             headers: { 'Authorization': `Bearer ${KEY}`, 'Content-Type': 'application/json' },
-            body: JSON.stringify({ code: consent.code, agentId: agent.agentId }),
+            body: JSON.stringify({ code, agentId: agent.agentId }),
           })).json();
 
           const passport = await (await fetch(`${API}/v1/passport/issue`, {

--- a/apps/auth-service/src/routes/webauthn.ts
+++ b/apps/auth-service/src/routes/webauthn.ts
@@ -173,9 +173,9 @@ export async function webauthnRoutes(app: FastifyInstance): Promise<void> {
 
       const sql = getSql();
 
-      // Look up auth request to get principal and developer
+      // Look up auth request to get principal and developer.
       const arRows = await sql`
-        SELECT ar.principal_id, ar.developer_id, d.fido_required
+        SELECT ar.principal_id, ar.developer_id, d.fido_required, d.mode
         FROM auth_requests ar
         JOIN developers d ON d.id = ar.developer_id
         WHERE ar.id = ${authRequestId} AND ar.status = 'pending' AND ar.expires_at > NOW()
@@ -185,7 +185,8 @@ export async function webauthnRoutes(app: FastifyInstance): Promise<void> {
         return reply.status(404).send({ message: 'Auth request not found or expired', code: 'NOT_FOUND', requestId: request.id });
       }
 
-      if (!ar['fido_required']) {
+      const requiresPrincipalVerification = ar['fido_required'] || ar['mode'] !== 'sandbox';
+      if (!requiresPrincipalVerification) {
         return reply.status(400).send({ message: 'FIDO not required for this developer', code: 'BAD_REQUEST', requestId: request.id });
       }
 

--- a/apps/auth-service/tests/webauthn.test.ts
+++ b/apps/auth-service/tests/webauthn.test.ts
@@ -282,12 +282,13 @@ describe('POST /v1/webauthn/assert/options', () => {
     expect(res.statusCode).toBe(404);
   });
 
-  it('returns 400 when FIDO not required for developer', async () => {
-    // Auth request lookup — fido_required is false
+  it('returns 400 when FIDO is not required for a sandbox developer', async () => {
+    // Auth request lookup - sandbox requests do not need FIDO.
     sqlMock.mockResolvedValueOnce([{
       principal_id: 'user_123',
       developer_id: 'dev_TEST',
       fido_required: false,
+      mode: 'sandbox',
     }]);
 
     const res = await app.inject({
@@ -301,11 +302,12 @@ describe('POST /v1/webauthn/assert/options', () => {
   });
 
   it('returns 400 when principal has no FIDO credentials', async () => {
-    // Auth request lookup — fido_required is true
+    // Auth request lookup - fido_required is true
     sqlMock.mockResolvedValueOnce([{
       principal_id: 'user_123',
       developer_id: 'dev_TEST',
       fido_required: true,
+      mode: 'live',
     }]);
     // Credentials lookup — empty
     sqlMock.mockResolvedValueOnce([]);
@@ -326,6 +328,38 @@ describe('POST /v1/webauthn/assert/options', () => {
       principal_id: 'user_123',
       developer_id: 'dev_TEST',
       fido_required: true,
+      mode: 'live',
+    }]);
+    // Credentials lookup
+    sqlMock.mockResolvedValueOnce([{
+      credential_id: 'bW9jay1jcmVk',
+      public_key: 'AQIDBA',
+      counter: 5,
+      transports: ['internal'],
+    }]);
+    // Insert challenge
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/webauthn/assert/options',
+      payload: { authRequestId: 'areq_test' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.challengeId).toBeDefined();
+    expect(body.publicKey).toBeDefined();
+    expect(body.publicKey.challenge).toBeDefined();
+  });
+
+  it('returns assertion options for live principal verification even when FIDO is not explicitly required', async () => {
+    // Auth request lookup
+    sqlMock.mockResolvedValueOnce([{
+      principal_id: 'user_123',
+      developer_id: 'dev_TEST',
+      fido_required: false,
+      mode: 'live',
     }]);
     // Credentials lookup
     sqlMock.mockResolvedValueOnce([{


### PR DESCRIPTION
## Summary

Fixes the post-deploy MPP E2E failure exposed after PR #687 and aligns WebAuthn assertion options with the new live principal verification gate.

## Changes

- Allow WebAuthn assertion options for live developers that require principal verification, even when `fido_required` is not explicitly enabled.
- Keep sandbox developers on the existing `FIDO not required` path.
- Update production MPP E2E to use an authorization code returned by policy/sandbox auto-approval before falling back to the consent approval endpoint.

## Validation

- `npm --prefix apps/auth-service test -- --run tests/webauthn.test.ts tests/authorize.test.ts tests/consent.test.ts`
- `npm --prefix apps/auth-service run typecheck`
- `git diff --check`