### PR TITLE
Fix Gemma production E2E runner

### DIFF
--- a/packages/gemma/package.json
+++ b/packages/gemma/package.json
@@ -23,7 +23,7 @@
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:e2e": "vitest run tests/e2e/",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/packages/gemma/tests/e2e/production.test.ts
+++ b/packages/gemma/tests/e2e/production.test.ts
@@ -106,17 +106,14 @@ describe('Live Production', () => {
         expect(key).toHaveProperty('kid');
       }
 
-      // Expect at least one RSA key (RS256, kid: grantex-2026-04)
+      // Key IDs rotate; assert the stable signing-key contract instead.
       const rsaKeys = body.keys.filter(
         (k) => k.kty === 'RSA',
       );
       expect(rsaKeys.length).toBeGreaterThanOrEqual(1);
-
-      const primaryKey = body.keys.find(
-        (k) => k.kid === 'grantex-2026-04',
+      expect(rsaKeys).toContainEqual(
+        expect.objectContaining({ alg: 'RS256', use: 'sig' }),
       );
-      expect(primaryKey).toBeDefined();
-      expect(primaryKey!.kty).toBe('RSA');
     },
     30_000,
   );

--- a/packages/gemma/vitest.e2e.config.ts
+++ b/packages/gemma/vitest.e2e.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['tests/e2e/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## What changed

- Add a dedicated Vitest config that includes Gemma production E2E tests.
- Point `test:e2e` at that config.
- Validate the rotating production RSA signing-key contract instead of a hardcoded April key ID.

## Root cause

The shared Vitest config excluded `tests/e2e/**`, so the E2E script never selected a test file. Once enabled, the JWKS test exposed a stale hardcoded key ID after normal production key rotation.

## Validation

- `npm --prefix packages/gemma run typecheck`
- `npm --prefix packages/gemma run test:e2e` — 11 passed
- `python -m pytest tests/e2e/ -m live` in `packages/gemma-py` — 4 passed