### PR TITLE
Fix production Trust Registry E2E after seed removal

### DIFF
--- a/tests/e2e/portal-features.test.ts
+++ b/tests/e2e/portal-features.test.ts
@@ -418,10 +418,12 @@ describe('Credentials', () => {
 // ─── Trust Registry ─────────────────────────────────────────────────────────
 
 describe('Trust Registry', () => {
-  it('gets grantex.dev org', async () => {
-    const { status, data } = await api('GET', '/v1/trust-registry/did:web:grantex.dev');
+  it('serves the public registry search', async () => {
+    const { status, data } = await api('GET', '/v1/registry/orgs?limit=1');
     expect(status).toBe(200);
-    expect((data as { trustLevel: string }).trustLevel).toBeTruthy();
+    const registry = data as { data: unknown[]; meta: { total: number } };
+    expect(Array.isArray(registry.data)).toBe(true);
+    expect(typeof registry.meta.total).toBe('number');
   });
 });
 


### PR DESCRIPTION
## What changed

Replace the full production E2E assertion that required the removed `did:web:grantex.dev` demo Trust Registry row with a public registry response-shape check.

## Root cause

Migration 062 intentionally deletes or neutralizes unsupported demo verification claims. The production service correctly returned 404, but the older E2E fixture still treated that seeded row as a permanent contract.

## Impact

The E2E suite now validates the supported public registry API without reintroducing unsafe seed assumptions.

## Verification

- Focused production test passed: `tests/e2e/portal-features.test.ts -t "Trust Registry"`
- Original production failure: https://github.com/mishrasanjeev/grantex/actions/runs/29135211724