### PR TITLE
Update public release status documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added missing TypeScript Vault documentation, package READMEs, JSON-LD contexts, and documentation health checks.
 
 ### Changed
-- Published Python SDK 0.3.14 and Go SDK v0.1.10 on 2026-07-11. TypeScript SDK 0.3.13 remains prepared for publication after npm credentials are refreshed.
+- Published TypeScript SDK 0.3.13, Python SDK 0.3.14, and Go SDK v0.1.10 on 2026-07-11; synchronized the public release snapshot across the landing page, README, compatibility matrix, and SDK documentation.
 
 ### Fixed
 - Corrected SDK quick starts, audit payloads, verification examples, endpoint paths, usage semantics, package metadata, and OpenAPI coverage.
@@ -296,6 +296,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - MPP demo UI (`apps/mpp-demo/`) — 3-screen interactive demo (issue, flow, verify)
 - W3C JSON-LD context document at `grantex.dev/contexts/mpp/v1`
 - E2E test for full MPP passport lifecycle
+
+## [0.1.5] - 2026-03-01
+
+### Added
+- Principal sessions — `POST /v1/principal-sessions` creates short-lived session JWTs for end-users
+- End-user permissions dashboard — `GET /permissions` serves HTML self-service UI
+- Three principal endpoints: `GET /v1/principal/grants`, `GET /v1/principal/audit`, `DELETE /v1/principal/grants/:id`
+- Express middleware (`@grantex/express`) — drop-in Grantex token verification for Node.js APIs
+- FastAPI middleware (`grantex-fastapi`) — drop-in Grantex token verification for Python APIs
+- Go SDK (`github.com/mishrasanjeev/grantex-go`) v0.1.0 — 12 resource services, offline JWT verification, PKCE, webhook HMAC-SHA256
+- Service provider adapters (`@grantex/adapters`) — Google Calendar, Gmail, Stripe, Slack
+- Reverse-proxy gateway (`@grantex/gateway`) — YAML-configured, Fastify-based token verification proxy
+- `principalSessions.create()` in TypeScript and Python SDKs
+- Conformance suite: principal-sessions test suite
+
+### Changed
+- Bumped `@grantex/sdk` to 0.1.5 and `grantex` (Python) to 0.1.5
+- Bumped `@grantex/conformance` to 0.1.2
+
+## [0.1.4] - 2026-02-28
+
+### Added
+- Token refresh — `POST /v1/token/refresh` with single-use rotation per SPEC §7.4
+- `tokens.refresh()` method in TypeScript and Python SDKs
+- Conformance suite: token refresh tests
+- Troubleshooting guide in docs
+
+### Changed
+- Bumped `@grantex/sdk` to 0.1.4 and `grantex` (Python) to 0.1.4
 
 ## [0.1.3] - 2026-02-28
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,27 +1,28 @@
 # Grantex Compatibility Matrix
 
-Last updated: 2026-07-11
+Last updated: 2026-07-12
 
-This repository currently uses package-specific versions. The public README should not be read as a monorepo-wide `v2.5` release. Repository versions can be ahead of package registries while an unreleased patch is under review, so the rows below distinguish those states.
+This repository uses package-specific versions; there is no monorepo-wide SDK or package release number. The protocol specification remains v1.0 Final, while repository metadata and package registries can move independently during a release.
 
 ## Canonical Release Signals
 
 | Surface | Current value | Notes |
 | --- | --- | --- |
 | Repository changelog | v0.3.12 | Latest top-level release entry in `CHANGELOG.md`. |
-| TypeScript SDK | @grantex/sdk 0.3.13 (unreleased) | Next repository patch; latest published version is 0.3.12. |
+| TypeScript SDK | @grantex/sdk 0.3.13 | Published to npm on 2026-07-11. |
 | Python SDK | grantex 0.3.14 | Published to PyPI on 2026-07-11. |
-| Go SDK | github.com/mishrasanjeev/grantex-go v0.1.10 | Published through the Go module proxy on 2026-07-11 (requires Go 1.26.1). |
-| OpenAPI | 0.3.12 | Aligned with the repository changelog and TypeScript SDK release line. |
-| MCP Auth | @grantex/mcp-auth 2.0.2 | Independently versioned package. |
+| Go SDK | github.com/mishrasanjeev/grantex-go v0.1.10 | Published through the Go module proxy on 2026-07-11 (requires Go 1.26.1); see known limitations below. |
+| OpenAPI | 0.3.12 | API-contract version; independent of package-only SDK patches. |
+| MCP Auth | @grantex/mcp-auth 2.0.2 | Independently versioned and published to npm; single-process evaluation limitations apply. |
+| Published snapshot | [release-status.json](release-status.json) | Machine-readable source for advertised versions and live registry checks. |
 
 ## Package Versions
 
-The repository contains 29 packages under `packages/`. Each row maps a directory to its artifact name and repository version. An `unreleased` status means consumer installation examples intentionally remain on the latest registry version until publication.
+The repository contains 29 packages under `packages/`. Each row maps a directory to its artifact name and repository version. A `published` status means the exact version has been verified on its public registry; other rows describe the package's role without claiming registry publication.
 
 | # | Directory | Published name | Version | Status |
 | ---: | --- | --- | ---: | --- |
-| 1 | `packages/sdk-ts` | @grantex/sdk | 0.3.13 | Primary SDK (TypeScript); unreleased, latest published 0.3.12 |
+| 1 | `packages/sdk-ts` | @grantex/sdk | 0.3.13 | Primary SDK (TypeScript); published |
 | 2 | `packages/sdk-py` | grantex | 0.3.14 | Primary SDK (Python); published |
 | 3 | `packages/go-sdk` | github.com/mishrasanjeev/grantex-go | v0.1.10 (Go 1.26.1) | Primary SDK (Go); published |
 | 4 | `packages/cli` | @grantex/cli | 0.2.5 | Tooling |
@@ -51,12 +52,35 @@ The repository contains 29 packages under `packages/`. Each row maps a directory
 | 28 | `packages/x402` | @grantex/x402 | 0.1.2 | x402 support |
 | 29 | `packages/terraform-provider-grantex` | terraform-provider-grantex | Go module (Go 1.25.0) | Terraform provider |
 
+## Known Published-Package Limitations
+
+- **Go SDK `v0.1.10`:** the API returns `agentId`, while `Agent.ID` expects an
+  `id` JSON field, so registration leaves `Agent.ID` empty. Derive the ID from
+  `did:grantex:<agentId>` for this release. `LogAuditParams` also omits the
+  required `agentDid` and `principalId` fields; use the REST endpoint or CLI for
+  audit writes.
+- **MCP Auth `2.0.2`:** client registrations default to process memory and
+  authorization codes always use a non-configurable process-local store.
+  `consentUi` is metadata only, `onTokenIssued` is not invoked, local
+  introspection/middleware do not check revocation, and the Grantex authorization
+  code is not persisted for token exchange. Treat this release as single-process
+  evaluation software until a corrected package is published.
+
 ## Installation Guidance
 
-Use the latest published primary SDK for your language, then choose adapter versions from the same date range in this matrix. Unreleased repository versions are release-candidate metadata, not proof that a registry artifact exists.
+Install the verified public releases needed by your application:
 
-## Required Follow-Up
+```bash
+npm install @grantex/sdk@0.3.13
+pip install grantex==0.3.14
+go get github.com/mishrasanjeev/grantex-go@v0.1.10
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
+```
 
-- Pick independent versioning or lockstep versioning and document it permanently.
+Unpinned install commands resolve to the registry's current release. For reproducible builds, keep the explicit versions above and review this matrix before upgrading.
+
+## Release Maintenance
+
+- Treat package versions as independent and publish package-specific release notes for every release.
 - Add release automation that verifies changed package source never reuses an already-published version and updates this matrix at publication time.
 - Define and automate a supported Go toolchain policy for the SDK (Go 1.26.1) and Terraform provider (Go 1.25.0).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
 [![npm downloads](https://img.shields.io/npm/dm/@grantex/sdk?label=npm%20downloads)](https://www.npmjs.com/package/@grantex/sdk)
 [![GitHub Stars](https://img.shields.io/github/stars/mishrasanjeev/grantex?style=social)](https://github.com/mishrasanjeev/grantex)
 [![Docs](https://img.shields.io/badge/docs-grantex.dev-3fb950)](https://docs.grantex.dev)
-[![MCP Server](https://img.shields.io/badge/MCP-Server-blue)](https://www.npmjs.com/package/@grantex/mcp)
+[![MCP Tool Server](https://img.shields.io/npm/v/@grantex/mcp?label=MCP%20tool%20server)](https://www.npmjs.com/package/@grantex/mcp)
+[![MCP Auth](https://img.shields.io/npm/v/@grantex/mcp-auth?label=MCP%20Auth)](https://www.npmjs.com/package/@grantex/mcp-auth)
 [![DPDP Mapping](https://img.shields.io/badge/DPDP-control%20mapping-informational)](https://grantex.dev/dpdp)
 [![EU AI Act Mapping](https://img.shields.io/badge/EU_AI_Act-control%20mapping-informational)](https://grantex.dev/dpdp)
 
@@ -59,12 +60,31 @@ flowchart LR
 
 Start with the [OACP runtime launch closure PRD](docs/guides/oacp/runtime-launch-closure-prd.mdx), [OACP authority overview](docs/guides/oacp/overview.mdx), [merchant self-service config boundary](docs/guides/oacp/merchant-self-service-config.mdx), [truth inventory](docs/guides/oacp/truth-inventory.mdx), [AgenticOrg integration guide](docs/guides/oacp/agenticorg-integration.mdx), [POS bridge boundary](docs/guides/oacp/pos-bridge-boundary.mdx), and [operator runbook](docs/guides/oacp/operator-runbook.mdx). The older [Commerce V1 overview](docs/guides/commerce-v1-overview.mdx) remains historical/contextual and should not be used to imply that Grantex owns AgenticOrg merchant connector runtime.
 
-## Current Development Snapshot
+## Current Releases
 
-The latest repository changelog currently tops out at v0.3.12. Use [COMPATIBILITY.md](COMPATIBILITY.md) as the source of truth for package-specific versions.
+Grantex components are independently versioned. The protocol specification remains **v1.0 Final**; SDK, MCP package, and roadmap milestone versions are separate release lines and do not represent a monorepo-wide version.
+
+Current public releases, verified 2026-07-12:
+
+| Component | Public version | Reproducible install |
+| --- | ---: | --- |
+| TypeScript SDK | `@grantex/sdk` `0.3.13` | `npm install @grantex/sdk@0.3.13` |
+| Python SDK | `grantex` `0.3.14` | `python -m pip install grantex==0.3.14` |
+| Go SDK | `github.com/mishrasanjeev/grantex-go` `v0.1.10` (Go 1.26.1+) | `go get github.com/mishrasanjeev/grantex-go@v0.1.10` |
+| MCP Authorization Server | `@grantex/mcp-auth` `2.0.2` | `npm install @grantex/mcp-auth@2.0.2` |
+
+> **Known published-package limits:** Go SDK `v0.1.10` does not populate
+> `Agent.ID` from the API's `agentId` response and its audit type omits two
+> required fields. MCP Auth `2.0.2` keeps authorization codes in process memory,
+> does not render consent, and has an incomplete Grantex code handoff. See the
+> [release-status guide](https://docs.grantex.dev/release-status) for supported
+> workarounds and deployment boundaries.
+
+Omit a version pin to install the registry's current latest release. See the [release-status documentation](https://docs.grantex.dev/release-status), [COMPATIBILITY.md](COMPATIBILITY.md) for the full package matrix, and [CHANGELOG.md](CHANGELOG.md) for release notes.
 
 - **@grantex/gemma**: Offline consent bundles and on-device verification examples
-- **MCP Auth Server**: OAuth 2.1 + PKCE for MCP servers, managed and self-hosted modes
+- **MCP Authorization Server (`@grantex/mcp-auth`)**: Published OAuth 2.1 + PKCE endpoint package; review the documented `2.0.2` single-process, consent, and token-exchange limitations
+- **MCP Tool Server (`@grantex/mcp`)**: Agent-facing Grantex tools for MCP clients
 - **@grantex/dpdp**: DPDP Act 2023 and EU AI Act control mappings
 - **Trust Registry**: Public DID verification registry — `grantex.dev/registry`
 - **`grantex verify`**: Token inspection CLI — no account needed
@@ -72,34 +92,52 @@ The latest repository changelog currently tops out at v0.3.12. Use [COMPATIBILIT
 
 ---
 
-## Try in 30 seconds
+## SDK quickstart
 
 ```bash
-npm install @grantex/sdk
+npm install @grantex/sdk@0.3.13
 ```
 
 ```typescript
 import { Grantex, verifyGrantToken } from '@grantex/sdk';
 const gx = new Grantex({ apiKey: process.env.GRANTEX_API_KEY });
 
-// 1. Authorize an agent for a user
-const auth = await gx.authorize({ agentId: 'agent-123', userId: 'user-456', scopes: ['calendar:read', 'email:send'] });
+// 1. Register an agent, then request authorization from a user
+const agent = await gx.agents.register({
+  name: 'quickstart-agent',
+  description: 'Grantex quickstart agent',
+  scopes: ['calendar:read', 'email:send'],
+});
+const auth = await gx.authorize({
+  agentId: agent.id,
+  userId: 'user-456',
+  scopes: ['calendar:read', 'email:send'],
+});
 
-// 2. Exchange code for a scoped, signed JWT
-const { grantToken } = await gx.tokens.exchange({ code: auth.code, agentId: 'agent-123' });
+// Live mode requires consent at this URL and returns the code to your callback.
+// Sandbox or policy auto-approval can return the code immediately.
+if (!auth.code) {
+  console.log(`Approve access at: ${auth.consentUrl}`);
+} else {
+  // 2. Exchange the authorization code for a scoped, signed JWT
+  const { grantToken } = await gx.tokens.exchange({ code: auth.code, agentId: agent.id });
 
-// 3. Verify locally using the issuer's published JWKS
-const grant = await verifyGrantToken(grantToken, { jwksUri: 'https://api.grantex.dev/.well-known/jwks.json' });
-console.log(grant.scopes); // ['calendar:read', 'email:send']
+  // 3. Verify locally using the issuer's published JWKS
+  const grant = await verifyGrantToken(grantToken, {
+    jwksUri: 'https://api.grantex.dev/.well-known/jwks.json',
+  });
+  console.log(grant.scopes); // ['calendar:read', 'email:send']
+}
 ```
 
 ```bash
-pip install grantex             # Python
-go get github.com/mishrasanjeev/grantex-go  # Go
-npm install -g @grantex/cli     # CLI
+python -m pip install grantex==0.3.14               # Python SDK
+go get github.com/mishrasanjeev/grantex-go@v0.1.10 # Go SDK (Go 1.26.1+)
+npm install @grantex/mcp-auth@2.0.2                 # MCP Authorization Server
+npm install -g @grantex/cli                         # Optional CLI tooling
 ```
 
-> **29 packages** across TypeScript, Python, and Go. Integrations for **Anthropic SDK, LangChain, OpenAI Agents SDK, Google ADK, Strands Agents SDK, CrewAI, Vercel AI, AutoGen, MCP, Express.js, FastAPI**, and **Terraform**. The changelog and GitHub Actions are the source of truth for current pass/fail status. Fully self-hostable. Apache 2.0.
+> **29 packages** across TypeScript, Python, and Go. Integrations for **Anthropic SDK, LangChain, OpenAI Agents SDK, Google ADK, Strands Agents SDK, CrewAI, Vercel AI, AutoGen, MCP, Express.js, FastAPI**, and **Terraform**. Use the compatibility matrix for versions, the changelog for release notes, and GitHub Actions for current CI status. Fully self-hostable. Apache 2.0.
 
 ---
 
@@ -213,11 +251,12 @@ await grantex.audit.log({
 // In any service that receives agent requests — no Grantex account needed
 import { verifyGrantToken } from '@grantex/sdk';
 
-const grant = await verifyGrantToken(token, {
-  jwksUri: 'https://api.grantex.dev/.well-known/jwks.json',  // or cache locally
+const grant = await verifyGrantToken(token.grantToken, {
+  jwksUri: 'https://api.grantex.dev/.well-known/jwks.json',
   requiredScopes: ['payments:initiate'],
 });
-// Throws if token is expired, revoked, tampered, or missing required scopes
+// Throws if the token is expired, tampered with, has invalid claims, or lacks required scopes.
+// Use grantex.tokens.verify(token.grantToken) when you also need current revocation status.
 ```
 
 ### 7. Give users control over their permissions
@@ -1347,7 +1386,8 @@ Service providers implement scope definitions for their APIs. Agents declare whi
 | **Gemma 4 (Python)** | `grantex-gemma` | `pip install grantex-gemma` | ✅ Shipped |
 | **DPDP Compliance** | `@grantex/dpdp` | `npm install @grantex/dpdp` | ✅ Shipped |
 | **Adapters** | `@grantex/adapters` | `npm install @grantex/adapters` | ✅ Shipped |
-| **MCP Auth Server** | `@grantex/mcp-auth` | `npm install @grantex/mcp-auth` | ✅ Shipped |
+| **MCP Tool Server** | `@grantex/mcp` (`0.1.10`) | `npm install @grantex/mcp` | ✅ Shipped |
+| **MCP Authorization Server** | `@grantex/mcp-auth` (`2.0.2`) | `npm install @grantex/mcp-auth` | ⚠️ Published; evaluate documented limitations |
 | **Gateway** | `@grantex/gateway` | `npm install @grantex/gateway` | ✅ Shipped |
 | **Express.js** | `@grantex/express` | `npm install @grantex/express` | ✅ Shipped |
 | **FastAPI** | `grantex-fastapi` | `pip install grantex-fastapi` | ✅ Shipped |
@@ -1360,9 +1400,9 @@ Service providers implement scope definitions for their APIs. Agents declare whi
 | **Strands Agents SDK (Python)** | `grantex-strands` | `pip install grantex-strands` | ✅ Shipped |
 | **Anthropic SDK** | `@grantex/anthropic` | `npm install @grantex/anthropic` | ✅ Shipped |
 | **Vercel AI SDK** | `@grantex/vercel-ai` | `npm install @grantex/vercel-ai` | ✅ Shipped |
-| **TypeScript SDK** | `@grantex/sdk` | `npm install @grantex/sdk` | ✅ Shipped |
-| **Python SDK** | `grantex` | `pip install grantex` | ✅ Shipped |
-| **Go SDK** | `grantex-go` | `go get github.com/mishrasanjeev/grantex-go` | ✅ Shipped |
+| **TypeScript SDK** | `@grantex/sdk` (`0.3.13`) | `npm install @grantex/sdk` | ✅ Shipped |
+| **Python SDK** | `grantex` (`0.3.14`) | `python -m pip install grantex` | ✅ Shipped |
+| **Go SDK** | `grantex-go` (`v0.1.10`, Go 1.26.1+) | `go get github.com/mishrasanjeev/grantex-go` | ✅ Shipped |
 | **CLI** | `@grantex/cli` | `npm install -g @grantex/cli` | ✅ Shipped |
 | **Conformance Suite** | `@grantex/conformance` | `npm install -g @grantex/conformance` | ✅ Shipped |
 | **A2A Bridge (TS)** | `@grantex/a2a` | `npm install @grantex/a2a` | ✅ Shipped |
@@ -1623,15 +1663,15 @@ Walk through all 7 steps of the protocol: register an agent, authorize, exchange
 
 ## Roadmap
 
-All milestones through v1.0 are complete. See [ROADMAP.md](https://github.com/mishrasanjeev/grantex/blob/main/ROADMAP.md) for full details.
+All listed roadmap milestones through v2.4 are complete. These labels are historical product milestones, not a shared npm, PyPI, Go module, or monorepo release line; package versions vary independently, while the protocol specification remains v1.0 Final. See [ROADMAP.md](https://github.com/mishrasanjeev/grantex/blob/main/ROADMAP.md) for completed and active work.
 
 | Milestone | Highlights | Status |
 |-----------|-----------|--------|
 | **v0.1 — Foundation** | Protocol spec, TypeScript & Python SDKs, auth service, consent UI, audit trail, multi-agent delegation, sandbox mode | ✅ Complete |
 | **v0.2 — Integrations** | LangChain, AutoGen, webhooks, Stripe billing, CLI | ✅ Complete |
 | **v0.3 — Enterprise** | CrewAI, Vercel AI, compliance exports, policy engine, SCIM/SSO, anomaly detection | ✅ Complete |
-| **v1.0 — Stable Protocol** | Protocol spec finalized (v1.0), security audit, SOC 2 readiness mapping, standards submission | ✅ Complete |
-| **v2.0 — Platform** | MCP Auth Server, Credential Vault, 7 new adapters, webhook delivery log, examples | ✅ Complete |
+| **v1.0 — Stable Protocol** | Protocol spec finalized (v1.0), security audit, SOC 2 readiness mapping, individual IETF Internet-Draft submission | ✅ Complete |
+| **v2.0 — Platform** | MCP Authorization Server, Credential Vault, 7 new adapters, webhook delivery log, examples | ✅ Complete |
 | **v2.1 — Enterprise Scale** | Event streaming, budget controls, observability, Terraform provider, gateway, conformance | ✅ Complete |
 | **v2.2 — Ecosystem** | OPA/Cedar policy backends, A2A protocol bridge, usage metering, custom domains, policy-as-code | ✅ Complete |
 | **v2.3 — Trust & Identity** | FIDO2/WebAuthn passkeys, W3C Verifiable Credentials, SD-JWT selective disclosure, DID infrastructure, StatusList2021 revocation, Mastercard Verifiable Intent | ✅ Complete |
@@ -1659,7 +1699,7 @@ Read [CONTRIBUTING.md](https://github.com/mishrasanjeev/grantex/blob/main/CONTRI
 | **OWASP** | Covers ASI-01, ASI-03, ASI-05, ASI-10 from the [Agentic Security Top 10](https://docs.grantex.dev/blog/owasp-agentic-top-10-compliance) (Dec 2025) |
 | **EU AI Act** | Technical control mapping only, not legal advice. Application is phased: transparency rules from Aug 2026, certain high-risk rules from Dec 2027, and product-integrated high-risk rules from Aug 2028 under the political agreement. See the [European Commission timeline](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai). |
 | **NIST AI RMF** | Govern 1.1, Map 5.1, Measure 2.5 — repository comment draft; no public submission receipt or endorsement |
-| **IETF** | Individual Internet-Draft -01 targeting OAuth Working Group discussion; not adopted or endorsed ([draft-mishra-oauth-agent-grants-01](https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/)) |
+| **IETF** | Active individual Internet-Draft -01; not adopted or endorsed by the IETF ([draft-mishra-oauth-agent-grants-01](https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/)) |
 | **AuthZEN** | Conformance mapped |
 | **SOC 2** | Readiness control mapping published; formal third-party attestation not published |
 | **Protocol Spec** | [v1.0 Final](https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md) — frozen, open, Apache 2.0 |
@@ -1691,7 +1731,7 @@ OAuth 2.0 was designed for "user grants app permission to access their data." Ag
 MCP solves tool connectivity — how agents access data and call functions. Grantex solves trust — proving that an agent is authorized to use those tools on behalf of a specific human. They're complementary. A Grantex-authorized agent uses MCP tools.
 
 **Who owns the standard?**  
-The protocol spec is open (Apache 2.0). Grantex Inc. maintains a hosted reference implementation. Our goal is to contribute the spec to a neutral standards body (W3C, IETF, or CNCF) once it stabilizes.
+The v1.0 protocol specification is open (Apache 2.0), and Grantex Inc. maintains the reference implementation. An active -01 document is published as an individual IETF Internet-Draft; that publication is not working-group adoption or IETF endorsement.
 
 **Can I self-host?**  
 Yes. The reference implementation is fully open-source. Docker Compose deploy in one command. See [`DEPLOYMENT.md`](DEPLOYMENT.md) for the complete guide or the [self-hosting docs](https://docs.grantex.dev/guides/self-hosting).

--- a/docs/blog/mcp-server-oauth-authentication.mdx
+++ b/docs/blog/mcp-server-oauth-authentication.mdx
@@ -1,42 +1,45 @@
 ---
 title: "Adding OAuth 2.1 Authentication to Any MCP Server"
-description: "MCP servers lack built-in authentication. Learn how to add OAuth 2.1 with PKCE, dynamic client registration, token introspection, and scoped permissions to any MCP server using @grantex/mcp-auth."
+description: "Current status and evaluation setup for @grantex/mcp-auth 2.0.2."
 date: "2026-04-05"
 authors:
   - name: "Sanjeev Kumar"
 ---
 
-The Model Context Protocol (MCP) has become the standard way to connect AI agents to external tools and data sources. Claude Desktop, Cursor, Windsurf, and a growing list of clients all speak MCP. But MCP has a gap that matters in production: **authentication is mandatory in the spec, but building it is left as an exercise for the server developer.**
+<Warning>
+  **Status correction — July 12, 2026:** this article previously described the
+  intended production flow as if it were complete. The published
+  `@grantex/mcp-auth@2.0.2` package exposes useful OAuth endpoint and middleware
+  building blocks, but it has material state, consent, code-handoff, hook, and
+  revocation-check limitations. Treat it as single-process evaluation software.
+  The [MCP Auth feature guide](/features/mcp-auth-server) is authoritative.
+</Warning>
 
-The MCP specification mandates OAuth 2.1 for transport-level authorization. Implementing it correctly requires PKCE S256, Dynamic Client Registration (RFC 7591), token introspection (RFC 7662), token revocation (RFC 7009), proper JWKS key management, rate limiting, and a well-known metadata endpoint. That is weeks of work before you write a single tool handler.
+MCP servers need authenticated, scoped access when they expose sensitive tools.
+The `@grantex/mcp-auth` package is an early implementation of the endpoint
+surface needed for that workflow.
 
-This post walks through adding production-ready OAuth 2.1 authentication to any MCP server using `@grantex/mcp-auth` — a single function call that handles the entire OAuth stack.
+## What 2.0.2 implements
 
-## Why MCP Servers Need Authentication
+`createMcpAuthServer()` returns a Fastify instance with these routes:
 
-Without authentication, any MCP client that can reach your server can call any tool with full access. In a local development setup, this is fine. In production — where your MCP server reads databases, calls APIs, or modifies infrastructure — it is a serious exposure.
+| Endpoint | Implemented behavior |
+|---|---|
+| `/.well-known/oauth-authorization-server` | Metadata discovery |
+| `/register` | Dynamic client registration backed by `ClientStore` |
+| `/authorize` | PKCE S256 and client/redirect validation, then a Grantex authorization request |
+| `/token` | PKCE validation plus Grantex exchange/refresh calls |
+| `/introspect` | JWT signature and claim validation against JWKS |
+| `/revoke` | Decode the JWT `jti` and request Grantex revocation |
 
-Consider a concrete scenario: you build an MCP server that gives Claude Desktop access to your company's Jira instance. Without auth, anyone who discovers the server URL can list tickets, create issues, and close sprints. With auth, each user gets a scoped token that limits what they can do and expires automatically.
+The package also exports Express and Hono middleware that validate JWT
+signatures, claims, algorithms, and required scopes.
 
-MCP authentication solves three problems:
-
-1. **Identity.** You know *who* is calling your tools — which user, which agent, which client application.
-2. **Scoped access.** You control *what* they can do. A read-only user cannot call write tools, even if the MCP client sends the request.
-3. **Revocation.** You can cut off access immediately when a user leaves, a session expires, or an agent misbehaves.
-
-## Setting Up MCP OAuth Authentication with @grantex/mcp-auth
-
-### Step 1: Install Dependencies
+## Reproducible evaluation setup
 
 ```bash
-npm install @grantex/mcp-auth @grantex/sdk
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
 ```
-
-`@grantex/mcp-auth` works in both **managed** (Grantex Cloud) and **self-hosted** modes. The API is identical — just point the SDK at a different base URL.
-
-### Step 2: Create the Auth Server
-
-The `createMcpAuthServer()` function spins up a fully compliant OAuth 2.1 authorization server as a Fastify instance. It registers six endpoints that MCP clients auto-discover:
 
 ```typescript
 import { Grantex } from '@grantex/sdk';
@@ -50,197 +53,55 @@ const grantex = new Grantex({
 const authServer = await createMcpAuthServer({
   grantex,
   agentId: 'ag_your_mcp_server',
-  scopes: [
-    'tools:read',       // List available tools
-    'tools:execute',    // Call tools
-    'resources:read',   // Read resources
-    'resources:write',  // Create/update resources
-  ],
+  scopes: ['tools:read', 'tools:execute'],
   issuer: 'https://your-mcp-server.example.com',
 });
 
 await authServer.listen({ port: 3001 });
-console.log('MCP Auth Server running on http://localhost:3001');
 ```
 
-This single call gives you:
+This starts the endpoint surface for inspection. It does not make the full token
+issuance flow production-ready.
 
-| Endpoint | RFC | Purpose |
-|----------|-----|---------|
-| `/.well-known/oauth-authorization-server` | RFC 8414 | Metadata discovery for MCP clients |
-| `/register` | RFC 7591 | Dynamic Client Registration |
-| `/authorize` | OAuth 2.1 | Authorization endpoint (PKCE required) |
-| `/token` | OAuth 2.1 | Token exchange and refresh |
-| `/introspect` | RFC 7662 | Token introspection |
-| `/revoke` | RFC 7009 | Token revocation |
+## Current limitations
 
-### Step 3: Protect Your MCP Routes with Middleware
+- Client registrations use process memory unless you provide a `ClientStore`.
+- Authorization codes always use a non-configurable `InMemoryCodeStore`; restart
+  and multi-replica flows are unsafe.
+- `consentUi` only adds metadata. The package does not register `/consent` or
+  render a user approval page.
+- The package does not persist the Grantex SDK's returned authorization code for
+  the token handler, which can make real backend exchange fail.
+- The `onTokenIssued` type is declared but is not invoked in `2.0.2`.
+- Introspection and middleware do not query current revocation state. Use online
+  verification or synchronized revocation data when immediate revocation matters.
+- `allowedRedirectUris` is declared but is not enforced as a server-wide allowlist
+  in this release.
 
-Use the Express middleware to validate tokens on every incoming request:
+## Middleware boundary
 
 ```typescript
-import express from 'express';
 import { requireMcpAuth } from '@grantex/mcp-auth/express';
-import type { McpAuthRequest } from '@grantex/mcp-auth/express';
 
-const app = express();
-
-// All MCP routes require a valid token with tools:execute scope
 app.use('/mcp', requireMcpAuth({
   issuer: 'https://your-mcp-server.example.com',
   scopes: ['tools:execute'],
 }));
-
-app.post('/mcp/tools/call', (req: McpAuthRequest, res) => {
-  const grant = req.mcpGrant!;
-  console.log(`Agent: ${grant.agentDid}`);
-  console.log(`Scopes: ${grant.scopes.join(', ')}`);
-  console.log(`User: ${grant.sub}`);
-
-  // Your tool logic here — the caller is authenticated and authorized
-  res.json({ result: 'tool executed' });
-});
-
-app.listen(3000);
 ```
 
-The middleware:
-- Fetches the JWKS from `{issuer}/.well-known/jwks.json` (cached after first request)
-- Validates the JWT signature, expiry, and issuer
-- Checks that all required scopes are present in the token
-- Attaches the decoded grant to `req.mcpGrant` for your handler to use
-- Returns 401 for missing/invalid tokens and 403 for insufficient scopes
+This protects a route with signature, claim, algorithm, expiry, and scope checks.
+It is not a live revocation check.
 
-### Step 4: Verify Client Auto-Discovery
+## Deployment guidance
 
-MCP clients find your auth server automatically via the well-known metadata endpoint:
+Use one process for evaluation, test every authorize/token transition against the
+actual Grantex backend, and do not advertise a consent page or production OAuth
+conformance from `2.0.2`. Wait for a corrected release that supports durable code
+state and a complete consent/code handoff before multi-replica production use.
 
-```bash
-curl https://your-mcp-server.example.com/.well-known/oauth-authorization-server
-```
+## Next steps
 
-Response:
-
-```json
-{
-  "issuer": "https://your-mcp-server.example.com",
-  "authorization_endpoint": "https://your-mcp-server.example.com/authorize",
-  "token_endpoint": "https://your-mcp-server.example.com/token",
-  "registration_endpoint": "https://your-mcp-server.example.com/register",
-  "introspection_endpoint": "https://your-mcp-server.example.com/introspect",
-  "revocation_endpoint": "https://your-mcp-server.example.com/revoke",
-  "response_types_supported": ["code"],
-  "grant_types_supported": ["authorization_code", "refresh_token"],
-  "code_challenge_methods_supported": ["S256"],
-  "scopes_supported": ["tools:read", "tools:execute", "resources:read", "resources:write"]
-}
-```
-
-Claude Desktop, Cursor, and other MCP clients read this metadata to know where to send authorization requests. No manual client configuration needed.
-
-## How the PKCE Authorization Flow Works
-
-When an MCP client connects to your authenticated server, the full OAuth 2.1 + PKCE flow runs automatically:
-
-1. **Discovery.** The client fetches `/.well-known/oauth-authorization-server` to find endpoints.
-2. **Registration.** The client calls `/register` to get a `client_id` (Dynamic Client Registration per RFC 7591).
-3. **Authorization.** The client redirects the user to `/authorize` with a PKCE `code_challenge` (S256). The user sees a consent screen listing the requested scopes.
-4. **Consent.** The user approves or denies. On approval, the auth server redirects back with an authorization code.
-5. **Token exchange.** The client sends the code and `code_verifier` to `/token`. The server verifies PKCE, issues a JWT access token and a refresh token.
-6. **API calls.** The client includes the token as a Bearer token on all subsequent MCP requests.
-7. **Refresh.** When the token expires, the client uses the refresh token to get a new one without re-prompting the user.
-
-PKCE (Proof Key for Code Exchange) prevents authorization code interception attacks. The S256 method is the only one supported — plain PKCE is rejected.
-
-## Customizing the Consent UI
-
-The default consent page works out of the box, but you can brand it:
-
-```typescript
-const authServer = await createMcpAuthServer({
-  grantex,
-  agentId: 'ag_your_server',
-  scopes: ['tools:read', 'tools:execute'],
-  issuer: 'https://your-mcp-server.example.com',
-  consentUi: {
-    appName: 'Acme Analytics MCP',
-    appLogo: 'https://acme.example.com/logo.png',
-    privacyUrl: 'https://acme.example.com/privacy',
-    termsUrl: 'https://acme.example.com/terms',
-  },
-});
-```
-
-Users see your app name, logo, and the exact scopes being requested before they approve.
-
-## Lifecycle Hooks for Audit and Monitoring
-
-React to authorization events for audit logging, analytics, or downstream notifications:
-
-```typescript
-const authServer = await createMcpAuthServer({
-  grantex,
-  agentId: 'ag_your_server',
-  scopes: ['tools:read', 'tools:execute'],
-  issuer: 'https://your-mcp-server.example.com',
-  hooks: {
-    onTokenIssued: async (event) => {
-      console.log(`Token issued for client ${event.clientId}`);
-      console.log(`Scopes: ${event.scopes.join(', ')}`);
-      console.log(`Grant ID: ${event.grantId}`);
-      // Send to your monitoring system
-    },
-    onRevocation: async (jti) => {
-      console.log(`Token ${jti} was revoked`);
-      // Invalidate cached sessions
-    },
-  },
-});
-```
-
-Combined with the Grantex audit trail, you get a complete record of who authorized what, when tokens were issued, and when access was revoked.
-
-## Token Introspection and Revocation
-
-Resource servers can validate tokens by calling the introspection endpoint directly:
-
-```bash
-curl -X POST https://your-mcp-server.example.com/introspect \
-  -H "Content-Type: application/json" \
-  -d '{"token": "eyJhbGciOiJSUzI1NiIs..."}'
-```
-
-The response includes the token's active status, scopes, subject, expiry, and Grantex-specific claims like the agent DID and grant ID.
-
-Revoke tokens when a user logs out or an agent is deauthorized:
-
-```bash
-curl -X POST https://your-mcp-server.example.com/revoke \
-  -H "Content-Type: application/json" \
-  -d '{"token": "eyJhbGciOiJSUzI1NiIs..."}'
-```
-
-Per RFC 7009, the endpoint always returns 200 OK, even if the token was already revoked.
-
-## Managed vs Self-Hosted
-
-`@grantex/mcp-auth` works in two modes:
-
-| Feature | Managed (Grantex Cloud) | Self-Hosted |
-|---------|------------------------|-------------|
-| **Setup** | Point SDK at Grantex Cloud | Point SDK at your infrastructure |
-| **Client Store** | In-memory (stateless, horizontal scale) | Bring your own (Postgres, Redis) |
-| **Token Signing** | Grantex signs tokens | Grantex signs (delegated) |
-| **Rate Limiting** | Built-in per-endpoint | Built-in, configurable |
-| **Audit Trail** | Full audit via Grantex events | Full audit via Grantex events |
-| **Uptime SLA** | 99.9% | Your responsibility |
-
-The API is identical in both modes. Start with managed, move to self-hosted when you need it.
-
-## Next Steps
-
-- [MCP Auth Server docs](/features/mcp-auth-server) — full configuration reference
-- [MCP integration docs](/integrations/mcp) — Grantex MCP server with 17 tools for Claude Desktop
-- [Self-hosting guide](/guides/self-hosting) — run the entire Grantex stack on your infrastructure
-- [Quickstart](/quickstart) — get a Grantex API key in under 5 minutes
-- [GitHub](https://github.com/mishrasanjeev/grantex) — open source, Apache 2.0
+- [MCP Auth Server status and reference](/features/mcp-auth-server)
+- [Release Status](/release-status)
+- [MCP tool-server integration](/integrations/mcp)
+- [Self-hosting guide](/guides/self-hosting)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -23,6 +23,7 @@
             "pages": [
               "introduction",
               "quickstart",
+              "release-status",
               "local-development"
             ]
           },

--- a/docs/features/mcp-auth-server.mdx
+++ b/docs/features/mcp-auth-server.mdx
@@ -1,39 +1,59 @@
 ---
 title: "MCP Auth Server"
 sidebarTitle: "MCP Auth Server"
-description: "Production-ready OAuth 2.1 + PKCE authorization server for any MCP server. Managed or self-hosted."
+description: "OAuth 2.1 + PKCE endpoint package for MCP servers, including current v2.0.2 limitations."
 ---
 
 ## Overview
 
-The **MCP specification mandates OAuth 2.1** for transport-level authorization. Implementing it correctly requires PKCE S256, Dynamic Client Registration (RFC 7591), token introspection (RFC 7662), token revocation (RFC 7009), rate limiting, and proper key management.
+MCP clients use OAuth authorization-server metadata, Dynamic Client Registration,
+PKCE, token exchange, introspection, and revocation endpoints.
+`@grantex/mcp-auth` registers those six routes on a Fastify instance and provides
+Express and Hono JWT-verification middleware.
 
-`@grantex/mcp-auth` handles all of this in a single function call. It creates a fully-compliant OAuth 2.1 authorization server that MCP clients auto-discover via the well-known metadata endpoint.
+Current published release: **`@grantex/mcp-auth@2.0.2`**.
 
 ```bash
-npm install @grantex/mcp-auth @grantex/sdk
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
 ```
 
+This exact command is reproducible. See [Release Status](/release-status) before
+upgrading either independently versioned package.
+
 <Info>
-  `@grantex/mcp-auth` works in both **managed** (Grantex Cloud) and **self-hosted** modes.
-  The API is identical -- just point the Grantex SDK at a different base URL.
+  The supplied `Grantex` client can point at Grantex Cloud or a self-hosted
+  Grantex API. That backend choice does not make the MCP authorization server's
+  own client-registration or authorization-code state managed or durable.
 </Info>
 
-## Managed vs Self-Hosted
+<Warning>
+  Release `2.0.2` is a single-process evaluation release, not a turnkey
+  production deployment. Client registrations default to process memory and
+  authorization codes always use a non-configurable in-memory store, so restarts
+  lose state and multi-replica authorize/token flows can fail. `consentUi` only
+  adds discovery metadata; no `/consent` page is registered. The package also
+  does not persist the `auth.code` returned by the Grantex SDK and can fall back
+  to an authorization-request ID during token exchange, which is not a valid
+  exchange code. Do not rely on end-to-end token issuance until a corrected
+  package release is published and validated with your backend.
+</Warning>
 
-| Feature | Managed (Grantex Cloud) | Self-Hosted |
-|---------|------------------------|-------------|
-| **Setup** | `createMcpAuthServer({ grantex, ... })` | Same API, your infrastructure |
-| **Client Store** | In-memory (stateless, horizontal scale) | Bring your own (Postgres, Redis, etc.) |
-| **JWKS** | Hosted by Grantex | Your JWKS endpoint |
-| **Token Signing** | Grantex signs tokens | Grantex signs tokens (delegated) |
-| **Rate Limiting** | Built-in per-endpoint limits | Built-in, configurable |
-| **Consent UI** | Grantex-hosted consent page | Custom consent page via `consentUi` config |
-| **Audit Trail** | Full audit via Grantex events | Full audit via Grantex events |
-| **Uptime SLA** | 99.9% | Your responsibility |
-| **Compliance** | SOC 2, GDPR ready | Your responsibility |
+## Deployment behavior in 2.0.2
+
+| Concern | Current behavior |
+|---|---|
+| Grantex backend | Cloud or self-hosted, selected through the supplied SDK client |
+| Client registrations | In-memory by default; a custom `ClientStore` can persist clients |
+| Authorization codes | Always process-local `InMemoryCodeStore`; no `codeStore` option |
+| Horizontal scaling | Unsupported for authorize/token flows in `2.0.2` |
+| Consent UI | Metadata only; the package registers no consent route or page |
+| Rate limiting | Fixed Fastify limits; not configurable through `McpAuthConfig` |
+| Middleware/introspection | Signature and claim validation; no live revocation lookup |
 
 ## Quick Start
+
+The following starts the published endpoint surface for local inspection and
+evaluation. It does not remove the limitations above.
 
 ### 1. Create the auth server
 
@@ -101,8 +121,8 @@ curl https://your-mcp-server.example.com/.well-known/oauth-authorization-server
 | `/register` | `POST` | RFC 7591 | Dynamic Client Registration |
 | `/authorize` | `GET` | OAuth 2.1 | Authorization endpoint (PKCE required) |
 | `/token` | `POST` | OAuth 2.1 | Token endpoint (authorization_code, refresh_token) |
-| `/introspect` | `POST` | RFC 7662 | Token introspection |
-| `/revoke` | `POST` | RFC 7009 | Token revocation |
+| `/introspect` | `POST` | RFC 7662 | JWT signature/claim introspection; no live revocation lookup |
+| `/revoke` | `POST` | RFC 7009 | Requests backend revocation by JWT `jti` |
 
 ### Well-Known Metadata
 
@@ -128,7 +148,7 @@ The metadata endpoint returns a JSON document that MCP clients use to discover a
 
 ### Token Introspection
 
-Resource servers validate tokens by calling the introspection endpoint:
+The endpoint verifies JWT signatures and claims against the issuer JWKS. In `2.0.2` it does not query Grantex for current revocation state, so a revoked but otherwise valid token can remain `active` here until expiry:
 
 ```bash
 curl -X POST https://your-mcp-server.example.com/introspect \
@@ -154,7 +174,7 @@ Active token response:
 
 ### Token Revocation
 
-Revoke tokens when a user logs out or an agent is deauthorized:
+The revocation endpoint decodes the token `jti` and requests revocation from Grantex. It returns `200 OK` even if that backend call fails, and the package middleware/introspection paths do not consult the resulting revocation state:
 
 ```bash
 curl -X POST https://your-mcp-server.example.com/revoke \
@@ -185,14 +205,18 @@ const authServer = await createMcpAuthServer({
 });
 ```
 
-Scopes are enforced at two levels:
+Scopes are used at two implemented points in `2.0.2`:
 
-1. **Authorization**: Users see the requested scopes on the consent page and can approve or deny
-2. **Middleware**: The `requireMcpAuth()` middleware rejects requests that lack required scopes
+1. **Authorization request**: The package forwards the requested scopes to the configured Grantex client.
+2. **Middleware**: `requireMcpAuth()` rejects tokens that lack required scopes.
 
-## Consent UI Customization
+The package does not render a consent page. A complete human-consent handoff must
+be implemented outside this release.
 
-Customize the consent page shown to users during authorization:
+## Consent metadata (not a rendered page)
+
+`consentUi` copies display metadata into the discovery document under
+`grantex_extensions.consent_ui_config`:
 
 ```typescript
 const authServer = await createMcpAuthServer({
@@ -209,34 +233,45 @@ const authServer = await createMcpAuthServer({
 });
 ```
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `appName` | `string` | Application name displayed on the consent page |
-| `appLogo` | `string` | URL to your application logo |
-| `privacyUrl` | `string` | Link to your privacy policy |
-| `termsUrl` | `string` | Link to your terms of service |
+| Property | Type | Metadata meaning |
+|---|---|---|
+| `appName` | `string` | Application label advertised to discovery consumers |
+| `appLogo` | `string` | Advertised application-logo URL |
+| `privacyUrl` | `string` | Advertised privacy-policy URL |
+| `termsUrl` | `string` | Advertised terms URL |
 
-## Lifecycle Hooks
+<Warning>
+  `2.0.2` does not register the `/consent` URL advertised in
+  `grantex_extensions.consent_ui`, and `consentUi` does not render or host a
+  consent page. Supply that interaction separately and validate the complete
+  authorization flow before use.
+</Warning>
 
-React to authorization events for audit logging, analytics, or downstream notifications:
+## Lifecycle hooks
+
+Only `hooks.onRevocation` is invoked by `2.0.2`:
 
 ```typescript
 const authServer = await createMcpAuthServer({
   // ...required fields...
   hooks: {
-    onTokenIssued: async (event) => {
-      console.log(`Token issued for client ${event.clientId}`);
-      console.log(`Scopes: ${event.scopes.join(', ')}`);
-      console.log(`Grant ID: ${event.grantId}`);
-    },
     onRevocation: async (jti) => {
-      console.log(`Token ${jti} was revoked`);
+      console.log(`Token ${jti} was submitted for revocation`);
     },
   },
 });
 ```
 
+The exported configuration type also declares `onTokenIssued`, but the token
+endpoint in `2.0.2` does not call it. Do not depend on that hook until a corrected
+release is published.
+
 ## Express Middleware
+
+<Note>
+  Express and Hono middleware verify JWT signatures, claims, algorithms, and
+  configured scopes. They do not perform an online revocation check in `2.0.2`.
+</Note>
 
 ```typescript
 import { requireMcpAuth } from '@grantex/mcp-auth/express';
@@ -293,7 +328,7 @@ app.post('/mcp/tools/call', (c) => {
 
 ## Custom Client Store
 
-By default, client registrations are stored in memory. For production, implement the `ClientStore` interface:
+By default, client registrations are stored in process memory. A custom `ClientStore` can persist registrations, but authorization codes remain in a non-configurable process-local store in `2.0.2`; a custom client store alone does not make the server durable or horizontally scalable:
 
 ```typescript
 import type { ClientStore, ClientRegistration } from '@grantex/mcp-auth';
@@ -342,12 +377,12 @@ Grantex accepts Bronze, Silver, and Gold certification applications for register
 | `agentId` | `string` | Yes | -- | Agent ID for Grantex authorization |
 | `scopes` | `string[]` | Yes | -- | Scopes to request from Grantex |
 | `issuer` | `string` | Yes | -- | Base URL for this auth server |
-| `allowedRedirectUris` | `string[]` | No | `[]` | Allowed redirect URIs (empty = all) |
+| `allowedRedirectUris` | `string[]` | No | `[]` | Declared by the type but not enforced in `2.0.2`; authorization checks each client's DCR-provided URI |
 | `allowedResources` | `string[]` | No | `[]` | Allowed resource indicators (RFC 8707) |
-| `clientStore` | `ClientStore` | No | `InMemoryClientStore` | Custom client registration store |
+| `clientStore` | `ClientStore` | No | `InMemoryClientStore` | Custom client-registration store only; authorization codes remain in memory |
 | `codeExpirationSeconds` | `number` | No | `600` | Authorization code TTL |
-| `consentUi` | `object` | No | -- | Consent UI customization |
-| `hooks` | `object` | No | -- | Lifecycle hooks |
+| `consentUi` | `object` | No | -- | Discovery metadata only; does not create a consent page |
+| `hooks` | `object` | No | -- | `onRevocation` runs; declared `onTokenIssued` is not invoked in `2.0.2` |
 
 ## Rate Limits
 
@@ -357,13 +392,13 @@ Default per-endpoint rate limits:
 |----------|-------------|--------|
 | `/authorize` | 10 | 1 minute |
 | `/token` | 20 | 1 minute |
-| `/introspect` | 30 | 1 minute |
+| `/introspect` | 20 | 1 minute |
 | `/revoke` | 20 | 1 minute |
 | All others | 100 | 1 minute |
 
 ## Security Considerations
 
-`@grantex/mcp-auth` enforces OAuth 2.1 security requirements:
+`@grantex/mcp-auth` implements the following request and token-validation controls. These controls do not remove the deployment and end-to-end flow limitations documented above:
 
 - **PKCE S256 is mandatory.** The `plain` method and implicit grant are rejected.
 - **No password grant.** The `password` grant type is not supported.

--- a/docs/integrations/mcp-auth.mdx
+++ b/docs/integrations/mcp-auth.mdx
@@ -1,43 +1,69 @@
 ---
 title: "MCP Auth Server"
 sidebarTitle: "MCP Auth"
-description: "Drop-in OAuth 2.1 + PKCE authorization server for any MCP server. Powered by Grantex."
+description: "OAuth 2.1 + PKCE endpoint package for MCP servers, with v2.0.2 limitations."
 ---
 
 <Info>Full feature guide: [MCP Auth Server](/features/mcp-auth-server)</Info>
 
 ## Overview
 
-`@grantex/mcp-auth` is a production-ready OAuth 2.1 + PKCE authorization server that adds delegated auth to any MCP (Model Context Protocol) server. Works with Claude Desktop, Cursor, Windsurf, and any MCP-compatible client.
+`@grantex/mcp-auth` registers OAuth 2.1-style metadata, PKCE authorization-code, client-registration, token, introspection, and revocation routes for MCP servers, plus JWT-verification middleware.
+
+Current published release: **`@grantex/mcp-auth@2.0.2`**.
 
 ## Install
 
 ```bash
-npm install @grantex/mcp-auth
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
 ```
+
+The exact versions above provide a reproducible install. The packages are
+versioned independently; check [Release Status](/release-status) before upgrading.
+
+<Warning>
+  Treat `2.0.2` as a single-process evaluation release. Authorization codes are
+  always process-local, `consentUi` does not create a consent page, and the
+  Grantex-backed token exchange does not persist the SDK's returned
+  authorization code. End-to-end issuance can therefore fail against the real
+  backend. Middleware and introspection validate signatures/claims but do not
+  perform live revocation checks. See the [full feature guide](/features/mcp-auth-server)
+  before deployment.
+</Warning>
 
 ## Quick Start
 
 ```typescript
+import { Grantex } from '@grantex/sdk';
 import { createMcpAuthServer } from '@grantex/mcp-auth';
 
-const auth = createMcpAuthServer({
-  grantexApiKey: process.env.GRANTEX_API_KEY!,
+const grantex = new Grantex({
+  apiKey: process.env.GRANTEX_API_KEY!,
+  baseUrl: 'https://api.grantex.dev',
+});
+
+const authServer = await createMcpAuthServer({
+  grantex,
+  agentId: 'ag_your_mcp_server',
   issuer: 'https://auth.myapp.com',
   scopes: ['calendar:read', 'email:send'],
 });
 
-// Mount on Express
-app.use('/oauth', auth.routes());
+await authServer.listen({ port: 3001, host: '0.0.0.0' });
 ```
 
-### What You Get
+`createMcpAuthServer()` is asynchronous and returns a Fastify instance with the
+OAuth metadata, registration, authorization, token, introspection, and revocation
+routes already registered. Start that returned server with `listen()`; it is not
+an Express router.
+
+### Endpoint surface in 2.0.2
 
 - **OAuth 2.1 + PKCE** — authorization code flow with S256 challenge
 - **Client registration** — dynamic or pre-registered MCP clients
-- **Token introspection** — validate tokens issued by this server
-- **Token revocation** — revoke access at any time
-- **Grantex-backed** — tokens are Grantex grant tokens with full audit trail
+- **Token introspection** — validate JWT signatures and claims; no live revocation lookup
+- **Revocation endpoint** — submit a token `jti` to Grantex; local verifiers still need synchronized revocation state
+- **Grantex calls** — authorization, exchange, refresh, and revoke handlers call the supplied SDK client, subject to the limitations above
 
 ## Links
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -32,15 +32,39 @@ Grantex solves this. It's an open protocol that lets humans authorize AI agents 
   </Card>
 </CardGroup>
 
+## Current releases
+
+The primary SDKs and MCP Auth server are published independently:
+
+| Package | Current published release |
+|---|---:|
+| TypeScript | `@grantex/sdk@0.3.13` |
+| Python | `grantex==0.3.14` |
+| Go | `github.com/mishrasanjeev/grantex-go@v0.1.10` |
+| MCP Auth | `@grantex/mcp-auth@2.0.2` |
+
+See [Release Status](/release-status) for registry links, runtime requirements,
+and the distinction between SDK, API-contract, and repository versions.
+
 ## Install
 
+The exact versions below make local and CI builds reproducible.
+
 <CodeGroup>
-```bash npm
-npm install @grantex/sdk
+```bash TypeScript
+npm install @grantex/sdk@0.3.13
 ```
 
-```bash pip
-pip install grantex
+```bash Python
+python -m pip install grantex==0.3.14
+```
+
+```bash Go
+go get github.com/mishrasanjeev/grantex-go@v0.1.10
+```
+
+```bash MCP Auth
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
 ```
 
 ```bash CLI

--- a/docs/protocol/changelog.mdx
+++ b/docs/protocol/changelog.mdx
@@ -1,111 +1,66 @@
 ---
-title: "Changelog"
+title: "Changelog and Release History"
 sidebarTitle: "Changelog"
-description: "All notable changes to the Grantex project."
+description: "How to find current Grantex releases, package compatibility, and the canonical project changelog."
 ---
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+## Current release snapshot
 
-## [0.1.5] - 2026-03-01
+Last verified: **July 12, 2026**
 
-### Added
-- Principal sessions — `POST /v1/principal-sessions` creates short-lived session JWTs for end-users
-- End-user permissions dashboard — `GET /permissions` serves HTML self-service UI
-- Three principal endpoints: `GET /v1/principal/grants`, `GET /v1/principal/audit`, `DELETE /v1/principal/grants/:id`
-- Express middleware (`@grantex/express`) — drop-in Grantex token verification for Node.js APIs
-- FastAPI middleware (`grantex-fastapi`) — drop-in Grantex token verification for Python APIs
-- Go SDK (`github.com/mishrasanjeev/grantex-go`) v0.1.0 — 12 resource services, offline JWT verification, PKCE, webhook HMAC-SHA256
-- Service provider adapters (`@grantex/adapters`) — Google Calendar, Gmail, Stripe, Slack
-- Reverse-proxy gateway (`@grantex/gateway`) — YAML-configured, Fastify-based token verification proxy
-- `principalSessions.create()` in TypeScript and Python SDKs
-- Conformance suite: principal-sessions test suite
+| Surface | Current release |
+|---|---:|
+| TypeScript SDK | `@grantex/sdk@0.3.13` |
+| Python SDK | `grantex==0.3.14` |
+| Go SDK | `github.com/mishrasanjeev/grantex-go@v0.1.10` |
+| MCP Auth server | `@grantex/mcp-auth@2.0.2` |
+| OpenAPI contract | `0.3.12` |
 
-### Changed
-- Bumped `@grantex/sdk` to 0.1.5 and `grantex` (Python) to 0.1.5
-- Bumped `@grantex/conformance` to 0.1.2
+Grantex is a multi-package repository. SDKs, integrations, the API contract, and
+repository release entries can advance independently, so a single project-wide
+version number would be misleading.
 
-## [0.1.4] - 2026-02-28
+## Canonical sources
 
-### Added
-- Token refresh — `POST /v1/token/refresh` with single-use rotation per SPEC §7.4
-- `tokens.refresh()` method in TypeScript and Python SDKs
-- Conformance suite: token refresh tests
-- Troubleshooting guide in docs
+<CardGroup cols={2}>
+  <Card title="Release Status" icon="box" href="/release-status">
+    Published SDK and MCP Auth versions, runtime requirements, registry links,
+    and reproducible install commands.
+  </Card>
+  <Card title="Compatibility Matrix" icon="table" href="https://github.com/mishrasanjeev/grantex/blob/main/COMPATIBILITY.md">
+    Repository package names, versions, roles, and verified publication status.
+  </Card>
+  <Card title="Repository Changelog" icon="clock-rotate-left" href="https://github.com/mishrasanjeev/grantex/blob/main/CHANGELOG.md">
+    The complete chronological record of cross-project additions, fixes,
+    security work, and release preparation.
+  </Card>
+  <Card title="GitHub Releases" icon="tag" href="https://github.com/mishrasanjeev/grantex/releases">
+    Tagged source releases and their associated notes and artifacts.
+  </Card>
+</CardGroup>
 
-### Changed
-- Bumped `@grantex/sdk` to 0.1.4 and `grantex` (Python) to 0.1.4
+## Interpreting versions
 
-## [0.1.3] - 2026-02-28
+- A package registry is authoritative for whether an exact artifact is publicly
+  installable.
+- The compatibility matrix records the relationship between repository packages
+  and published artifacts.
+- The repository changelog describes cross-project work; its latest numbered
+  entry may trail an independently published SDK patch.
+- The OpenAPI version describes the service contract and does not automatically
+  match any SDK package version.
+- A repository manifest can change before publication. Do not treat a manifest
+  version alone as proof that a release is available.
 
-### Added
-- PKCE (S256) support in authorization and token exchange flows
-- `generatePkce()` helper in TypeScript SDK
-- `generate_pkce()` helper in Python SDK
-- Rate limiting on auth-service (100/min global, 20/min token, 10/min authorize)
-- CHANGELOG.md, CODE_OF_CONDUCT.md, issue templates, PR template
+## Reproducible upgrades
 
-### Changed
-- Bumped `@grantex/sdk` to 0.1.3 and `grantex` (Python) to 0.1.3
+Use the exact commands on [Release Status](/release-status), regenerate your
+lockfile, and run authorization, token-verification, scope-enforcement, and
+revocation tests before deployment. Self-hosted users should also confirm that
+their deployed API contract supports the SDK features they plan to use.
 
-### Fixed
-- "ML-based detection" copy corrected to "Pattern-based detection" on landing page
-
-## [0.1.2] - 2026-02-27
-
-### Added
-- `tokens.exchange()` method to TypeScript and Python SDKs for exchanging authorization codes for grant tokens
-- Python examples for the token exchange flow
-- OpenAI Agents SDK integration (`grantex-openai-agents`)
-- Google ADK integration (`grantex-adk`)
-- MCP server package (`@grantex/mcp`) with 13 tools for Claude Desktop / Cursor / Windsurf
-- Health endpoint (`GET /health`) in auth-service
-- CLI commands for policies, billing, SCIM, and SSO
-- Portal webhooks management page
-- Webhook retry with exponential backoff (persistent delivery table + background worker)
-- Anomaly detection background worker (runs every 60 minutes)
-- Plan limit enforcement for grants, audit entries, and policies
-
-### Changed
-- Bumped `@grantex/sdk` and `grantex` (Python) to 0.1.2
-- Webhook delivery is now persistent with retry instead of fire-and-forget
-
-## [0.1.1] - 2026-02-26
-
-### Added
-- CrewAI integration (`grantex-crewai`) published to PyPI
-- Vercel AI SDK integration (`@grantex/vercel-ai`)
-- AutoGen integration (`@grantex/autogen`)
-- CLI tool (`@grantex/cli`) with commands for agents, grants, tokens, audit, and anomalies
-- LangChain integration (`@grantex/langchain`)
-- Example apps: quickstart-ts, quickstart-py, langchain-agent, crewai-agent, vercel-ai-chatbot
-- Developer portal with React dashboard
-- Landing page deployed to Firebase Hosting at grantex.dev
-
-### Changed
-- Bumped integration packages to 0.1.1
-
-### Fixed
-- Compliance timestamptz cast using null instead of empty string
-- Startup migration runner for production DB schema
-
-## [0.1.0] - 2026-02-25
-
-### Added
-- Protocol specification v1.0 (SPEC.md)
-- Auth service (Fastify + PostgreSQL + Redis) with full API surface:
-  - Authorization flow, consent, approve/deny
-  - Token exchange, verification, and revocation
-  - Grant management with delegation support
-  - Tamper-evident audit log with hash chaining
-  - Anomaly detection
-  - Policy engine
-  - SCIM provisioning
-  - SSO configuration (OIDC)
-  - Billing integration (Stripe)
-  - Webhook registration and delivery
-  - JWKS endpoint for offline token verification
-- TypeScript SDK (`@grantex/sdk`) published to npm
-- Python SDK (`grantex`) published to PyPI
-- CI/CD pipelines (GitHub Actions)
-- Cloud Run deployment configuration
-- Docker Compose for local development
+<Info>
+  This page intentionally links to the root changelog instead of duplicating its
+  historical entries. Keeping one canonical history prevents the documentation
+  copy from becoming stale.
+</Info>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -6,13 +6,21 @@ description: "Get up and running with Grantex in under 5 minutes."
 
 ## 1. Install the SDK
 
+This guide targets TypeScript `0.3.13`, Python `0.3.14`, Go `v0.1.10`
+(which requires Go 1.26.1+), and MCP Auth `2.0.2`.
+See [Release Status](/release-status) for publication details and upgrade guidance.
+
 <CodeGroup>
-```bash npm
-npm install @grantex/sdk
+```bash TypeScript
+npm install @grantex/sdk@0.3.13
 ```
 
-```bash pip
-pip install grantex
+```bash Python
+python -m pip install grantex==0.3.14
+```
+
+```bash Go
+go get github.com/mishrasanjeev/grantex-go@v0.1.10
 ```
 
 ```bash CLI
@@ -54,6 +62,27 @@ print(agent.did)
 # → did:grantex:ag_01HXYZ123abc...
 ```
 
+```go Go
+ctx := context.Background()
+client := grantex.NewClient(os.Getenv("GRANTEX_API_KEY"))
+
+agent, err := client.Agents.Register(ctx, grantex.RegisterAgentParams{
+    Name:        "travel-booker",
+    Description: "Books flights and hotels on behalf of users",
+    Scopes:      []string{"calendar:read", "payments:initiate:max_500", "email:send"},
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+const didPrefix = "did:grantex:"
+if !strings.HasPrefix(agent.DID, didPrefix) {
+    log.Fatal("unexpected agent DID")
+}
+agentID := strings.TrimPrefix(agent.DID, didPrefix)
+fmt.Printf("%s (%s)\n", agentID, agent.DID)
+```
+
 ```bash CLI
 grantex agents register \
   --name travel-booker \
@@ -61,6 +90,13 @@ grantex agents register \
   --scopes calendar:read,payments:initiate:max_500,email:send
 ```
 </CodeGroup>
+
+<Note>
+  Go SDK `v0.1.10` expects an `id` response field while the current API returns
+  `agentId`, so `agent.ID` is empty after registration. The Go example derives
+  `agentID` from the stable `did:grantex:<agentId>` value until a corrected SDK
+  release is published. Add `strings` to your imports.
+</Note>
 
 ## 3. Request authorization from a user
 
@@ -90,6 +126,22 @@ auth = client.authorize(AuthorizeParams(
 
 # Redirect user to the consent page
 print(auth.consent_url)
+```
+
+```go Go
+authRequest, err := client.Authorize(ctx, grantex.AuthorizeParams{
+    AgentID:     agentID,
+    PrincipalID: "user_abc123",
+    Scopes:      []string{"calendar:read", "payments:initiate:max_500"},
+    ExpiresIn:   "24h",
+    RedirectURI: "https://yourapp.com/auth/callback",
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+// Redirect the user to the consent page.
+fmt.Println(authRequest.ConsentURL)
 ```
 
 ```bash CLI
@@ -130,6 +182,20 @@ print(token.scopes)       # ('calendar:read', 'payments:initiate:max_500')
 print(token.grant_id)     # 'grnt_01HXYZ...'
 ```
 
+```go Go
+token, err := client.Tokens.Exchange(ctx, grantex.ExchangeTokenParams{
+    Code:    code, // from the redirect callback
+    AgentID: agentID,
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Println(token.GrantToken)
+fmt.Println(token.Scopes)
+fmt.Println(token.GrantID)
+```
+
 ```bash CLI
 grantex tokens exchange --code <code> --agent-id ag_01HXYZ...
 # Returns grantToken (JWT), refreshToken, grantId, scopes
@@ -160,6 +226,19 @@ grant = verify_grant_token(token.grant_token, VerifyGrantTokenOptions(
 
 print(grant.principal_id)  # 'user_abc123'
 print(grant.scopes)        # ('calendar:read', 'payments:initiate:max_500')
+```
+
+```go Go
+grant, err := grantex.VerifyGrantToken(ctx, token.GrantToken, grantex.VerifyOptions{
+    JwksURI:        "https://api.grantex.dev/.well-known/jwks.json",
+    RequiredScopes: []string{"calendar:read"},
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Println(grant.PrincipalID) // "user_abc123"
+fmt.Println(grant.Scopes)
 ```
 
 ```bash CLI
@@ -207,6 +286,13 @@ grantex audit log \
 ```
 </CodeGroup>
 
+<Warning>
+  Go SDK `v0.1.10` cannot send the current audit-log contract: its
+  `LogAuditParams` omits the required `agentDid` and `principalId` fields. Use
+  the CLI or call `POST /v1/audit/log` directly for this optional step until a
+  corrected Go SDK release is published.
+</Warning>
+
 ## Next steps
 
 <CardGroup cols={2}>
@@ -221,6 +307,9 @@ grantex audit log \
   </Card>
   <Card title="Python SDK" icon="python" href="/sdks/python/overview">
     Full API reference for the Python SDK.
+  </Card>
+  <Card title="Go SDK" icon="code" href="/sdks/go/overview">
+    Full API reference for the Go SDK.
   </Card>
   <Card title="CLI" icon="terminal" href="/integrations/cli">
     83 commands with --json support for scripting and AI agents.

--- a/docs/release-status.mdx
+++ b/docs/release-status.mdx
@@ -1,0 +1,102 @@
+---
+title: "Release Status"
+sidebarTitle: "Release Status"
+description: "Current published Grantex SDK and MCP Auth versions, compatibility boundaries, and reproducible install commands."
+---
+
+## Current published releases
+
+Last verified: **July 12, 2026**
+
+Grantex packages are versioned independently. There is no single version number
+that represents every SDK, integration, service, and protocol artifact in this
+repository.
+
+| Surface | Current release | Status | Runtime requirement |
+|---|---:|---|---|
+| TypeScript SDK | `@grantex/sdk@0.3.13` | Published to npm | Node.js 18+; ESM |
+| Python SDK | `grantex==0.3.14` | Published to PyPI | Python 3.9+ |
+| Go SDK | `github.com/mishrasanjeev/grantex-go@v0.1.10` | Published with known limitations | Go 1.26.1+ |
+| MCP Auth server | `@grantex/mcp-auth@2.0.2` | Published with known limitations | Node.js 18+; ESM |
+| OpenAPI contract | `0.3.12` | Repository API-contract version | Independent of SDK-only patches |
+
+<Info>
+  The SDK patch versions differ because each language package is released on its
+  own schedule. A newer package version does not imply a newer protocol or API
+  contract version.
+</Info>
+
+## Known limitations in the current published artifacts
+
+<Warning>
+  **Go SDK `v0.1.10`:** registration responses use `agentId`, but the published
+  `Agent.ID` field expects JSON `id`, so it remains empty. Derive the agent ID
+  from the returned `did:grantex:<agentId>` value for this release. Its
+  `LogAuditParams` also lacks the API-required `agentDid` and `principalId`;
+  submit audit records with the REST API or CLI.
+</Warning>
+
+<Warning>
+  **MCP Auth `2.0.2`:** use a single process for evaluation only. Authorization
+  codes are always process-local, `consentUi` does not create a page,
+  `onTokenIssued` is not called, middleware/introspection do not check current
+  revocation state, and the Grantex authorization code is not persisted for the
+  token handler. See [MCP Auth Server](/features/mcp-auth-server) for the detailed
+  endpoint and deployment matrix.
+</Warning>
+
+## Reproducible installation
+
+Pin exact versions in applications, examples, CI, and deployment manifests:
+
+<CodeGroup>
+```bash TypeScript
+npm install @grantex/sdk@0.3.13
+```
+
+```bash Python
+python -m pip install grantex==0.3.14
+```
+
+```bash Go
+go get github.com/mishrasanjeev/grantex-go@v0.1.10
+```
+
+```bash MCP Auth
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
+```
+</CodeGroup>
+
+Unpinned `npm install`, `pip install`, and `go get` commands resolve according to
+their registries and module proxy. Use the pinned commands above when the build
+must be repeatable.
+
+## How to read release information
+
+- [Machine-readable release snapshot](https://github.com/mishrasanjeev/grantex/blob/main/release-status.json)
+  drives the automated cross-surface version and registry checks.
+- [Compatibility matrix](https://github.com/mishrasanjeev/grantex/blob/main/COMPATIBILITY.md)
+  maps repository packages to artifact names, versions, and publication status.
+- [Repository changelog](https://github.com/mishrasanjeev/grantex/blob/main/CHANGELOG.md)
+  records cross-project work. Its latest numbered entry can trail independently
+  published SDK patches.
+- Package registries are authoritative for public availability:
+  [npm (`@grantex/sdk`)](https://www.npmjs.com/package/@grantex/sdk),
+  [PyPI (`grantex`)](https://pypi.org/project/grantex/),
+  [Go Packages](https://pkg.go.dev/github.com/mishrasanjeev/grantex-go), and
+  [npm (`@grantex/mcp-auth`)](https://www.npmjs.com/package/@grantex/mcp-auth).
+
+## Upgrade checklist
+
+1. Read the package-specific notes in the compatibility matrix and changelog.
+2. Confirm the required Node.js, Python, or Go toolchain version.
+3. Update the exact dependency version and regenerate the relevant lockfile.
+4. Run your authorization, token-verification, scope-enforcement, and revocation
+   tests before deployment.
+5. For self-hosted environments, verify the API contract used by your service;
+   an SDK-only patch does not upgrade the service automatically.
+
+<Warning>
+  Do not infer publication from a repository manifest or marketing page alone.
+  Confirm the exact artifact on its public registry before promoting a release.
+</Warning>

--- a/docs/sdks/go/audit.mdx
+++ b/docs/sdks/go/audit.mdx
@@ -5,16 +5,26 @@ description: "Log and query tamper-evident audit entries"
 
 ## Log
 
-```go
-entry, err := client.Audit.Log(ctx, grantex.LogAuditParams{
-    AgentID: "agent-id",
-    GrantID: "grant-id",
-    Action:  "email:read",
-    Status:  "success",
-    Metadata: map[string]interface{}{
-        "messageId": "msg-123",
-    },
-})
+<Warning>
+  Go SDK `v0.1.10` cannot create an audit entry through
+  `client.Audit.Log`: its `LogAuditParams` omits the API-required `agentDid` and
+  `principalId` fields. Use the REST endpoint or CLI for writes until a corrected
+  Go SDK release is published. List and get operations below remain available.
+</Warning>
+
+```bash REST workaround
+curl -X POST https://api.grantex.dev/v1/audit/log \
+  -H "Authorization: Bearer $GRANTEX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "ag_01HXYZ...",
+    "agentDid": "did:grantex:ag_01HXYZ...",
+    "grantId": "grnt_01HXYZ...",
+    "principalId": "user_123",
+    "action": "email:read",
+    "status": "success",
+    "metadata": {"messageId": "msg-123"}
+  }'
 ```
 
 ## List

--- a/docs/sdks/go/overview.mdx
+++ b/docs/sdks/go/overview.mdx
@@ -5,13 +5,19 @@ description: "Official Go SDK for the Grantex delegated authorization protocol"
 
 ## Installation
 
+Current published release: **`v0.1.10`** (verified July 12, 2026).
+
 ```bash
-go get github.com/mishrasanjeev/grantex-go
+go get github.com/mishrasanjeev/grantex-go@v0.1.10
 ```
+
+The unpinned `go get github.com/mishrasanjeev/grantex-go` command follows Go's
+module-version resolution. Keep the exact version above in reproducible builds.
+See [Release Status](/release-status) before upgrading.
 
 ## Requirements
 
-- Go 1.26.1+
+- **Go 1.26.1+**, matching this module's `go.mod` directive
 
 ## Configuration
 
@@ -37,6 +43,13 @@ client := grantex.NewClient("your-api-key",
 
 ## Quick Start
 
+<Warning>
+  In `v0.1.10`, the API's `agentId` response does not populate `Agent.ID`
+  because that SDK field expects `id`. This example derives the ID from the
+  returned `did:grantex:<agentId>` value. Remove the workaround only after
+  upgrading to a release that corrects the response mapping.
+</Warning>
+
 ```go
 package main
 
@@ -44,6 +57,7 @@ import (
     "context"
     "fmt"
     "log"
+    "strings"
 
     grantex "github.com/mishrasanjeev/grantex-go"
 )
@@ -61,11 +75,16 @@ func main() {
     if err != nil {
         log.Fatal(err)
     }
-    fmt.Printf("Agent registered: %s (DID: %s)\n", agent.ID, agent.DID)
+    const didPrefix = "did:grantex:"
+    if !strings.HasPrefix(agent.DID, didPrefix) {
+        log.Fatal("unexpected agent DID")
+    }
+    agentID := strings.TrimPrefix(agent.DID, didPrefix)
+    fmt.Printf("Agent registered: %s (DID: %s)\n", agentID, agent.DID)
 
     // 2. Create authorization request
     authReq, err := client.Authorize(ctx, grantex.AuthorizeParams{
-        AgentID:     agent.ID,
+        AgentID:     agentID,
         PrincipalID: "user-123",
         Scopes:      []string{"read:email", "send:email"},
     })
@@ -77,7 +96,7 @@ func main() {
     // 3. Exchange authorization code for token (after user consents)
     tokenResp, err := client.Tokens.Exchange(ctx, grantex.ExchangeTokenParams{
         Code:    "authorization-code-from-callback",
-        AgentID: agent.ID,
+        AgentID: agentID,
     })
     if err != nil {
         log.Fatal(err)

--- a/docs/sdks/python/overview.mdx
+++ b/docs/sdks/python/overview.mdx
@@ -6,9 +6,15 @@ description: "Install and configure the Grantex Python SDK for delegated authori
 
 ## Installation
 
+Current published release: **`grantex==0.3.14`** (verified July 12, 2026).
+
 ```bash
-pip install grantex
+python -m pip install grantex==0.3.14
 ```
+
+The unpinned `python -m pip install grantex` command follows PyPI's current
+release. Keep the exact version above in reproducible builds. See
+[Release Status](/release-status) before upgrading.
 
 ### Requirements
 
@@ -16,7 +22,7 @@ pip install grantex
 - [httpx](https://www.python-httpx.org/) (sync HTTP client)
 - [PyJWT](https://pyjwt.readthedocs.io/) >= 2.8 with [cryptography](https://cryptography.io/) (for offline token verification)
 
-All dependencies are installed automatically with `pip install grantex`.
+All dependencies are installed automatically with the SDK.
 
 ## Quick Start
 

--- a/docs/sdks/typescript/overview.mdx
+++ b/docs/sdks/typescript/overview.mdx
@@ -6,9 +6,15 @@ description: "Install, configure, and get started with the @grantex/sdk TypeScri
 
 ## Installation
 
+Current published release: **`@grantex/sdk@0.3.13`** (verified July 12, 2026).
+
 ```bash
-npm install @grantex/sdk
+npm install @grantex/sdk@0.3.13
 ```
+
+The unpinned `npm install @grantex/sdk` command follows npm's current `latest`
+tag. Keep the exact version above in reproducible builds. See
+[Release Status](/release-status) before upgrading.
 
 ## Requirements
 

--- a/packages/mcp-auth/README.md
+++ b/packages/mcp-auth/README.md
@@ -4,27 +4,39 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/mishrasanjeev/grantex/blob/main/LICENSE)
 [![npm downloads](https://img.shields.io/npm/dm/@grantex/mcp-auth)](https://www.npmjs.com/package/@grantex/mcp-auth)
 
-**OAuth 2.1 + PKCE authorization server for MCP servers, powered by Grantex.**
+**OAuth 2.1 + PKCE endpoint package for MCP servers, powered by Grantex.**
 
-Turn any [Model Context Protocol](https://modelcontextprotocol.io/) server into a fully-compliant OAuth 2.1 authorization server in under 10 lines of code. Built on the Grantex delegated authorization protocol, `@grantex/mcp-auth` handles token issuance, introspection, revocation, Dynamic Client Registration (DCR), and PKCE -- so you can focus on building tools, not auth infrastructure.
+Current published release: **`@grantex/mcp-auth@2.0.2`**.
 
-## Why @grantex/mcp-auth?
+`createMcpAuthServer()` registers authorization-server metadata, Dynamic Client
+Registration, PKCE authorization, token, introspection, and revocation routes on
+a Fastify instance. The package also exports Express and Hono JWT-verification
+middleware.
 
-The MCP specification mandates OAuth 2.1 for transport-level auth. Implementing it correctly is hard:
+> [!WARNING]
+> Treat `2.0.2` as a single-process evaluation release. Client registrations
+> default to process memory and authorization codes always use a
+> non-configurable in-memory store. `consentUi` adds metadata but no consent
+> route. The Grantex authorization code returned by the SDK is not persisted for
+> token exchange, so end-to-end issuance can fail against the real backend.
+> Middleware and introspection verify signatures/claims but do not perform a live
+> revocation lookup. See the
+> [feature guide](https://docs.grantex.dev/features/mcp-auth-server) for the full
+> current-status matrix.
 
-- **PKCE S256** is mandatory (no `plain`, no implicit flow)
-- **Dynamic Client Registration** (RFC 7591) for zero-config MCP clients
-- **Token introspection** (RFC 7662) for resource servers to validate tokens
-- **Token revocation** (RFC 7009) for secure logout
-- **Rate limiting** on all sensitive endpoints
-- **Grantex integration** for delegated, auditable, scope-controlled authorization
+## What 2.0.2 implements
 
-`@grantex/mcp-auth` handles all of this out of the box, with a single function call.
+- PKCE S256 request validation (no `plain` or implicit flow)
+- Dynamic Client Registration (RFC 7591) with a replaceable client store
+- Authorization, token, introspection, and revocation endpoint handlers
+- Fixed Fastify rate limits on sensitive endpoints
+- Express and Hono JWT signature, claim, algorithm, and scope verification
+- Calls to a supplied Grantex SDK client for authorization and token operations
 
 ## Installation
 
 ```bash
-npm install @grantex/mcp-auth
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
 ```
 
 ## Quick Start
@@ -66,7 +78,7 @@ app.use('/mcp', requireMcpAuth({
 }));
 ```
 
-That's it. MCP clients can now discover your auth server via `/.well-known/oauth-authorization-server`, register dynamically, and obtain tokens.
+The server now exposes the published endpoint surface for inspection. Discovery and registration can be exercised locally; token issuance remains subject to the `2.0.2` limitations above.
 
 ## Endpoints
 
@@ -78,8 +90,8 @@ That's it. MCP clients can now discover your auth server via `/.well-known/oauth
 | `/register` | POST | RFC 7591 | Dynamic Client Registration |
 | `/authorize` | GET | OAuth 2.1 | Authorization endpoint (PKCE required) |
 | `/token` | POST | OAuth 2.1 | Token endpoint (authorization_code, refresh_token) |
-| `/introspect` | POST | RFC 7662 | Token introspection |
-| `/revoke` | POST | RFC 7009 | Token revocation |
+| `/introspect` | POST | RFC 7662 | JWT signature/claim introspection; no live revocation lookup |
+| `/revoke` | POST | RFC 7009 | Requests backend revocation by JWT `jti` |
 
 ## API Reference
 
@@ -101,16 +113,18 @@ const server = await createMcpAuthServer(config);
 | `agentId` | `string` | Yes | - | Agent ID for Grantex authorization |
 | `scopes` | `string[]` | Yes | - | Scopes to request from Grantex |
 | `issuer` | `string` | Yes | - | Base URL for this auth server (used in metadata) |
-| `allowedRedirectUris` | `string[]` | No | `[]` | Allowed redirect URIs (empty = all allowed) |
+| `allowedRedirectUris` | `string[]` | No | `[]` | Declared but not enforced in `2.0.2`; the client's registered URI is checked |
 | `allowedResources` | `string[]` | No | `[]` | Allowed resource indicators (RFC 8707) |
-| `clientStore` | `ClientStore` | No | `InMemoryClientStore` | Custom client registration store |
+| `clientStore` | `ClientStore` | No | `InMemoryClientStore` | Client registrations only; authorization codes stay in process memory |
 | `codeExpirationSeconds` | `number` | No | `600` | Authorization code TTL in seconds |
-| `consentUi` | `object` | No | - | Consent UI customization (appName, appLogo, privacyUrl, termsUrl) |
-| `hooks` | `object` | No | - | Lifecycle hooks (onTokenIssued, onRevocation) |
+| `consentUi` | `object` | No | - | Discovery metadata only; no consent page is created |
+| `hooks` | `object` | No | - | `onRevocation` runs; declared `onTokenIssued` is not invoked in `2.0.2` |
 
-#### Consent UI
+#### Consent metadata
 
-Customize the consent page shown to users:
+`consentUi` copies labels and links into
+`grantex_extensions.consent_ui_config` in the discovery response. It does not
+render or register the advertised `/consent` page in `2.0.2`.
 
 ```typescript
 const server = await createMcpAuthServer({
@@ -124,31 +138,27 @@ const server = await createMcpAuthServer({
 });
 ```
 
-#### Lifecycle Hooks
+#### Lifecycle hooks
 
-React to authorization events:
+Only `onRevocation` is invoked by `2.0.2`:
 
 ```typescript
 const server = await createMcpAuthServer({
   // ...required fields...
   hooks: {
-    onTokenIssued: async (event) => {
-      console.log(`Token issued for client ${event.clientId}`);
-      console.log(`Scopes: ${event.scopes.join(', ')}`);
-      console.log(`Grant ID: ${event.grantId}`);
-      // Send to your analytics, audit log, etc.
-    },
     onRevocation: async (jti) => {
-      console.log(`Token ${jti} was revoked`);
-      // Invalidate cached sessions, notify downstream, etc.
+      console.log(`Token ${jti} was submitted for revocation`);
     },
   },
 });
 ```
 
+`onTokenIssued` is present in the exported type but is not called by the token
+endpoint in this release.
+
 ### Custom Client Store
 
-By default, client registrations are stored in memory. For production, implement the `ClientStore` interface backed by your database:
+By default, client registrations are stored in memory. A custom `ClientStore` can persist clients, but the authorization-code store remains process-local and non-configurable in `2.0.2`:
 
 ```typescript
 import type { ClientStore, ClientRegistration } from '@grantex/mcp-auth';
@@ -180,7 +190,8 @@ const server = await createMcpAuthServer({
 
 ## Express.js Middleware
 
-Protect your Express routes with JWT validation:
+Protect Express routes with JWT signature, claim, algorithm, and scope validation.
+This middleware does not check current revocation state in 2.0.2:
 
 ```typescript
 import express from 'express';
@@ -261,7 +272,7 @@ export default app;
 
 ## Token Introspection (RFC 7662)
 
-Resource servers can validate tokens by calling the introspection endpoint:
+Resource servers can validate JWT signatures and claims by calling the introspection endpoint. It does not query Grantex for current revocation state, so a revoked but otherwise valid token can remain `active` until expiry:
 
 ```bash
 curl -X POST https://your-mcp-server.example.com/introspect \
@@ -307,7 +318,7 @@ curl -X POST https://your-mcp-server.example.com/introspect \
 
 ## Token Revocation (RFC 7009)
 
-Revoke tokens when a user logs out or an agent is deauthorized:
+The endpoint decodes the JWT `jti` and requests backend revocation. It returns `200 OK` even when that call fails, and local middleware/introspection do not consult the resulting state:
 
 ```bash
 curl -X POST https://your-mcp-server.example.com/revoke \
@@ -318,52 +329,13 @@ curl -X POST https://your-mcp-server.example.com/revoke \
 
 Per RFC 7009, the endpoint always returns `200 OK`, even if the token was already revoked or unknown.
 
-## Managed vs Self-Hosted
+## Backend selection and local state
 
-| Feature | Managed (Grantex Cloud) | Self-Hosted |
-|---------|------------------------|-------------|
-| **Setup** | `createMcpAuthServer({ grantex, ... })` | Same API, your infrastructure |
-| **Client Store** | In-memory (stateless, horizontal scale) | Bring your own (Postgres, Redis, etc.) |
-| **JWKS** | Hosted by Grantex | Your JWKS endpoint |
-| **Token Signing** | Grantex signs tokens | Grantex signs tokens (delegated) |
-| **Rate Limiting** | Built-in per-endpoint limits | Built-in, configurable |
-| **Consent UI** | Grantex-hosted consent page | Custom consent page via `consentUi` config |
-| **Audit Trail** | Full audit via Grantex events | Full audit via Grantex events |
-| **Uptime SLA** | 99.9% | Your responsibility |
-| **Compliance** | SOC 2, GDPR ready | Your responsibility |
-
-### Managed Mode (Recommended)
-
-Use the Grantex Cloud auth service. Zero infrastructure to manage:
-
-```typescript
-const server = await createMcpAuthServer({
-  grantex: new Grantex({
-    baseUrl: 'https://api.grantex.dev',
-    apiKey: process.env.GRANTEX_API_KEY!,
-  }),
-  agentId: 'ag_your_server',
-  scopes: ['tools:read', 'tools:execute'],
-  issuer: 'https://your-domain.example.com',
-});
-```
-
-### Self-Hosted Mode
-
-Run your own Grantex auth service and point the SDK at it:
-
-```typescript
-const server = await createMcpAuthServer({
-  grantex: new Grantex({
-    baseUrl: 'https://auth.your-company.internal',
-    apiKey: process.env.GRANTEX_API_KEY!,
-  }),
-  agentId: 'ag_internal_server',
-  scopes: ['internal:read', 'internal:write'],
-  issuer: 'https://auth.your-company.internal',
-  clientStore: new PostgresClientStore(),  // Persistent storage
-});
-```
+The `Grantex` SDK passed to `createMcpAuthServer()` can target Grantex Cloud or a
+self-hosted API. In both cases, the MCP auth Fastify process owns its client and
+code state. A custom `ClientStore` persists only registrations; `2.0.2` exposes
+no custom authorization-code store. Run a single process for evaluation and do
+not treat selecting Grantex Cloud as managed MCP-auth hosting.
 
 ## Conformance testing
 
@@ -379,14 +351,14 @@ Passing the suite is useful deployment evidence; it is not a certification or en
 
 ## Security Considerations
 
-`@grantex/mcp-auth` enforces OAuth 2.1 security requirements:
+`@grantex/mcp-auth` implements the following request and token-validation controls. They do not remove the deployment and issuance limitations above:
 
 - **PKCE S256 is mandatory.** The `plain` method and implicit grant are rejected.
 - **No password grant.** The `password` grant type is not supported.
 - **No implicit grant.** Only `response_type=code` is accepted.
 - **Authorization codes are single-use.** Replayed codes are rejected.
 - **HS256 rejected.** Only asymmetric algorithms (RS256, ES256, PS256, EdDSA) are accepted for token verification.
-- **Rate limiting** is applied to all endpoints (configurable per-endpoint).
+- **Rate limiting** is applied with fixed per-endpoint values in this release.
 - **Client secrets** are generated using `crypto.randomBytes(32)`.
 - **JWKS verification** uses the `jose` library with remote key set fetching and caching.
 
@@ -403,7 +375,7 @@ Symmetric algorithms (`HS256`, `HS384`, `HS512`) are explicitly rejected.
 
 ## Discovery
 
-MCP clients discover your auth server via the well-known metadata endpoint:
+MCP clients can read the well-known metadata endpoint. Note that `2.0.2` advertises `/consent` and `/events/stream` extension URLs without registering those routes:
 
 ```bash
 curl https://your-mcp-server.example.com/.well-known/oauth-authorization-server
@@ -431,7 +403,7 @@ curl https://your-mcp-server.example.com/.well-known/oauth-authorization-server
 }
 ```
 
-## Full Example: MCP Server with Auth
+## Endpoint wiring example (subject to 2.0.2 limitations)
 
 ```typescript
 import { Grantex } from '@grantex/sdk';
@@ -453,23 +425,8 @@ const authServer = await createMcpAuthServer({
   scopes: ['calendar:read', 'calendar:write'],
   issuer: 'https://calendar-mcp.example.com',
   hooks: {
-    onTokenIssued: async (event) => {
-      const verification = await grantex.tokens.verify(event.accessToken);
-      if (!verification.principal) {
-        throw new Error('Issued token did not contain a principal');
-      }
-      await grantex.audit.log({
-        agentId: 'ag_calendar_mcp',
-        agentDid: event.agentDid,
-        grantId: event.grantId,
-        principalId: verification.principal,
-        action: 'mcp.token.issued',
-        metadata: { scopes: event.scopes, clientId: event.clientId },
-      });
-    },
     onRevocation: async (jti) => {
-      // Token revocation is recorded by Grantex; use this hook to clear local caches.
-      console.log(`Revoked token ${jti}`);
+      console.log(`Submitted token ${jti} for revocation`);
     },
   },
 });
@@ -538,7 +495,7 @@ Default limits per endpoint:
 |----------|-------------|--------|
 | `/authorize` | 10 | 1 minute |
 | `/token` | 20 | 1 minute |
-| `/introspect` | 30 | 1 minute |
+| `/introspect` | 20 | 1 minute |
 | `/revoke` | 20 | 1 minute |
 | All others | 100 | 1 minute |
 
@@ -549,7 +506,7 @@ Default limits per endpoint:
 | [`@grantex/sdk`](https://www.npmjs.com/package/@grantex/sdk) | Core TypeScript SDK |
 | [`@grantex/express`](https://www.npmjs.com/package/@grantex/express) | Express.js middleware for Grantex |
 | [`@grantex/gateway`](https://www.npmjs.com/package/@grantex/gateway) | Reverse-proxy gateway with YAML config |
-| [`@grantex/mcp`](https://www.npmjs.com/package/@grantex/mcp) | MCP server with 13 Grantex tools |
+| [`@grantex/mcp`](https://www.npmjs.com/package/@grantex/mcp) | MCP tool server (17 tools in the current repository surface) |
 | [`@grantex/cli`](https://www.npmjs.com/package/@grantex/cli) | CLI for managing grants, tokens, and agents |
 | [`@grantex/conformance`](https://www.npmjs.com/package/@grantex/conformance) | Protocol conformance test suite |
 

--- a/release-status.json
+++ b/release-status.json
@@ -1,0 +1,52 @@
+{
+  "schemaVersion": 1,
+  "verifiedAt": "2026-07-12",
+  "artifacts": [
+    {
+      "id": "typescript-sdk",
+      "label": "TypeScript SDK",
+      "ecosystem": "npm",
+      "name": "@grantex/sdk",
+      "version": "0.3.13",
+      "status": "published",
+      "registryUrl": "https://registry.npmjs.org/%40grantex%2Fsdk/latest"
+    },
+    {
+      "id": "python-sdk",
+      "label": "Python SDK",
+      "ecosystem": "pypi",
+      "name": "grantex",
+      "version": "0.3.14",
+      "status": "published",
+      "registryUrl": "https://pypi.org/pypi/grantex/json"
+    },
+    {
+      "id": "go-sdk",
+      "label": "Go SDK",
+      "ecosystem": "go",
+      "name": "github.com/mishrasanjeev/grantex-go",
+      "version": "v0.1.10",
+      "status": "published-with-known-limitations",
+      "limitations": [
+        "Agent.ID expects JSON id while the API returns agentId; derive the ID from the returned DID.",
+        "LogAuditParams omits the API-required agentDid and principalId fields; use REST or CLI for audit writes."
+      ],
+      "registryUrl": "https://proxy.golang.org/github.com/mishrasanjeev/grantex-go/@latest"
+    },
+    {
+      "id": "mcp-auth",
+      "label": "MCP Authorization Server",
+      "ecosystem": "npm",
+      "name": "@grantex/mcp-auth",
+      "version": "2.0.2",
+      "status": "published-with-known-limitations",
+      "limitations": [
+        "Authorization codes are stored in a non-configurable process-local store; use one process for evaluation only.",
+        "consentUi is discovery metadata and does not register or render a consent page.",
+        "The Grantex authorization code is not persisted for token exchange, so end-to-end issuance can fail.",
+        "Middleware and introspection validate signatures and claims but do not query current revocation state."
+      ],
+      "registryUrl": "https://registry.npmjs.org/%40grantex%2Fmcp-auth/latest"
+    }
+  ]
+}

--- a/scripts/check-docs-integrity.mjs
+++ b/scripts/check-docs-integrity.mjs
@@ -168,6 +168,11 @@ async function validatePublicReferences(routes, docFiles) {
     [/\/v1\/anomalies\/(?:alerts|channels|metrics|rules)\b/g, 'incorrect plural anomaly endpoint'],
     [/\/v1\/me\/rotate-key\b/g, 'retired key rotation endpoint'],
     [/\b13\s+MCP\s+tools\b/gi, 'stale MCP tool count'],
+    [/\bfully[- ]compliant OAuth 2\.1 authorization server\b/gi, 'unsupported MCP Auth conformance claim'],
+    [/\bproduction-ready OAuth 2\.1(?: \+ PKCE)? authorization server\b/gi, 'unsupported MCP Auth production-readiness claim'],
+    [/In-memory\s*\(stateless,\s*horizontal scale\)/gi, 'incorrect MCP Auth horizontal-scaling claim'],
+    [/Custom consent page via\s+`?consentUi`?\s+config/gi, 'incorrect MCP Auth consent-page claim'],
+    [/default consent page works out of the box/gi, 'incorrect MCP Auth consent-page claim'],
     [/failures\s+are\s+never\s+retried/gi, 'incorrect webhook retry claim'],
     [/DNS-TXT,\s+manual,\s+or\s+SOC\s+2\s+verification/gi, 'unsupported Trust Registry verification methods'],
     [/https:\/\/grantex\.dev\/integrations\/anthropic\b/g, 'incorrect Anthropic documentation host'],
@@ -354,6 +359,305 @@ async function validateOpenApi() {
   if (/name:\s*status\b/.test(dpdpList)) failures.push('DPDP consent list documents unsupported status query filtering');
 }
 
+function hasReleasePair(text, name, version) {
+  const escape = (value) => value.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&');
+  const namePattern = '(?:^|[^0-9A-Za-z@/._-])' + escape(name) + '(?=$|[^0-9A-Za-z/._-])';
+  const versionPattern = '(?:^|[^0-9A-Za-z.])' + escape(version) + '(?=$|[^0-9A-Za-z.])';
+  const pairPattern = new RegExp(namePattern + '[\\s\\S]*?' + versionPattern);
+  const releaseCards = text.match(/<a\b[^>]*\brelease-card\b[^>]*>[\s\S]*?<\/a>/gi) || [];
+  return [...text.split(/\r?\n/), ...releaseCards].some((segment) => pairPattern.test(segment));
+}
+
+function isValidIsoDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(value + 'T00:00:00Z');
+  return !Number.isNaN(parsed.valueOf()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+function releaseDateForms(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return [value];
+  const months = [
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December',
+  ];
+  const month = months[Number(match[2]) - 1];
+  const day = Number(match[3]);
+  return [value, day + ' ' + month + ' ' + match[1], month + ' ' + day + ', ' + match[1]];
+}
+
+function hasReleaseDate(text, value) {
+  const datePattern = releaseDateForms(value).join('|');
+  const pattern = new RegExp('(?:verified|updated|release snapshot).{0,160}(?:' + datePattern + ')', 'i');
+  return text.split(/\r?\n/).some((line) => pattern.test(line));
+}
+
+async function loadReleaseSnapshot() {
+  const snapshotPath = path.join(root, 'release-status.json');
+  let snapshot;
+  try {
+    snapshot = JSON.parse(await fs.readFile(snapshotPath, 'utf8'));
+  } catch (error) {
+    failures.push('release-status.json is unreadable or invalid JSON: ' + error.message);
+    return { schemaVersion: 1, verifiedAt: '', artifacts: [] };
+  }
+
+  if (snapshot.schemaVersion !== 1) {
+    failures.push('release-status.json must use schemaVersion 1');
+  }
+  if (typeof snapshot.verifiedAt !== 'string' || !isValidIsoDate(snapshot.verifiedAt)) {
+    failures.push('release-status.json must have a verifiedAt date in YYYY-MM-DD format');
+  }
+
+  const required = new Map([
+    ['typescript-sdk', {
+      name: '@grantex/sdk',
+      ecosystem: 'npm',
+      registryUrl: 'https://registry.npmjs.org/%40grantex%2Fsdk/latest',
+    }],
+    ['python-sdk', {
+      name: 'grantex',
+      ecosystem: 'pypi',
+      registryUrl: 'https://pypi.org/pypi/grantex/json',
+    }],
+    ['go-sdk', {
+      name: 'github.com/mishrasanjeev/grantex-go',
+      ecosystem: 'go',
+      registryUrl: 'https://proxy.golang.org/github.com/mishrasanjeev/grantex-go/@latest',
+    }],
+    ['mcp-auth', {
+      name: '@grantex/mcp-auth',
+      ecosystem: 'npm',
+      registryUrl: 'https://registry.npmjs.org/%40grantex%2Fmcp-auth/latest',
+    }],
+  ]);
+  const expectedStatus = new Map([
+    ['typescript-sdk', 'published'],
+    ['python-sdk', 'published'],
+    ['go-sdk', 'published-with-known-limitations'],
+    ['mcp-auth', 'published-with-known-limitations'],
+  ]);
+  const artifacts = Array.isArray(snapshot.artifacts) ? snapshot.artifacts : [];
+  if (!Array.isArray(snapshot.artifacts)) {
+    failures.push('release-status.json artifacts must be an array');
+  }
+
+  const seenIds = new Set();
+  const seenNames = new Set();
+  for (const artifact of artifacts) {
+    for (const field of ['id', 'label', 'ecosystem', 'name', 'version', 'status', 'registryUrl']) {
+      if (typeof artifact?.[field] !== 'string' || !artifact[field]) {
+        failures.push('release-status.json artifact is missing string field ' + field);
+      }
+    }
+    if (!artifact?.id) continue;
+    if (seenIds.has(artifact.id)) failures.push('release-status.json repeats artifact id ' + artifact.id);
+    if (artifact.name && seenNames.has(artifact.name)) failures.push('release-status.json repeats artifact name ' + artifact.name);
+    seenIds.add(artifact.id);
+    if (artifact.name) seenNames.add(artifact.name);
+
+    if (!['published', 'published-with-known-limitations'].includes(artifact.status)) {
+      failures.push('release-status.json artifact ' + artifact.id + ' has invalid status ' + artifact.status);
+    }
+    if (artifact.id && expectedStatus.has(artifact.id) && artifact.status !== expectedStatus.get(artifact.id)) {
+      failures.push('release-status.json artifact ' + artifact.id + ' must use status ' + expectedStatus.get(artifact.id));
+    }
+    if (artifact.status === 'published-with-known-limitations' && (
+      !Array.isArray(artifact.limitations)
+      || artifact.limitations.length === 0
+      || artifact.limitations.some((item) => typeof item !== 'string' || !item)
+    )) {
+      failures.push('release-status.json artifact ' + artifact.id + ' must list its known limitations');
+    }
+
+    const expected = required.get(artifact.id);
+    if (expected && (
+      artifact.name !== expected.name
+      || artifact.ecosystem !== expected.ecosystem
+      || artifact.registryUrl !== expected.registryUrl
+    )) {
+      failures.push('release-status.json artifact ' + artifact.id + ' must use the canonical ' + expected.ecosystem + ' identity and registry URL for ' + expected.name);
+    }
+    try {
+      const target = new URL(artifact.registryUrl);
+      if (
+        target.protocol !== 'https:'
+        || !allowedRegistryOrigins.has(target.origin)
+        || target.username
+        || target.password
+      ) {
+        failures.push('release-status.json has an unapproved registry URL for ' + artifact.id);
+      }
+    } catch {
+      failures.push('release-status.json has an invalid registry URL for ' + artifact.id);
+    }
+  }
+  for (const id of required.keys()) {
+    if (!seenIds.has(id)) failures.push('release-status.json is missing required artifact ' + id);
+  }
+
+  const validArtifacts = artifacts.filter((artifact) => artifact
+    && ['id', 'label', 'ecosystem', 'name', 'version', 'status', 'registryUrl']
+      .every((field) => typeof artifact[field] === 'string' && artifact[field]));
+  return { ...snapshot, artifacts: validArtifacts };
+}
+
+async function validateReleaseCopy() {
+  async function readVersionSource(sourcePath, label) {
+    try {
+      return await fs.readFile(sourcePath, 'utf8');
+    } catch (error) {
+      failures.push(label + ' version source is unreadable (' + relative(sourcePath) + '): ' + error.message);
+      return '';
+    }
+  }
+
+  async function readPackageVersion(sourcePath, expectedName) {
+    const source = await readVersionSource(sourcePath, expectedName);
+    if (!source) return null;
+    try {
+      const manifest = JSON.parse(source);
+      if (manifest.name !== expectedName || typeof manifest.version !== 'string' || !manifest.version) {
+        failures.push(relative(sourcePath) + ' has no version for ' + expectedName);
+        return null;
+      }
+      return manifest.version;
+    } catch (error) {
+      failures.push(relative(sourcePath) + ' is not valid JSON: ' + error.message);
+      return null;
+    }
+  }
+
+  const releaseSnapshot = await loadReleaseSnapshot();
+  const releaseById = new Map(releaseSnapshot.artifacts.map((artifact) => [artifact.id, artifact]));
+
+  const localVersions = new Map();
+  localVersions.set('typescript-sdk', await readPackageVersion(
+    path.join(root, 'packages', 'sdk-ts', 'package.json'),
+    '@grantex/sdk',
+  ));
+  localVersions.set('mcp-auth', await readPackageVersion(
+    path.join(root, 'packages', 'mcp-auth', 'package.json'),
+    '@grantex/mcp-auth',
+  ));
+
+  const pythonSourcePath = path.join(root, 'packages', 'sdk-py', 'pyproject.toml');
+  const pythonSource = await readVersionSource(pythonSourcePath, 'grantex');
+  const pythonProject = pythonSource.match(/\[project\]([\s\S]*?)(?=\n\[|$)/);
+  const pythonVersion = pythonProject?.[1].match(/^version\s*=\s*"([^"]+)"/m)?.[1] || null;
+  if (pythonSource && !pythonVersion) {
+    failures.push(relative(pythonSourcePath) + ' has no [project] version for grantex');
+  }
+  localVersions.set('python-sdk', pythonVersion);
+
+  const goSourcePath = path.join(root, 'packages', 'go-sdk', 'http.go');
+  const goSource = await readVersionSource(goSourcePath, 'Grantex Go SDK');
+  const goSdkVersion = goSource.match(/const\s+sdkVersion\s*=\s*"([^"]+)"/)?.[1] || null;
+  if (goSource && !goSdkVersion) {
+    failures.push(relative(goSourcePath) + ' has no sdkVersion for release-copy checking');
+  }
+  localVersions.set('go-sdk', goSdkVersion
+    ? (goSdkVersion.startsWith('v') ? goSdkVersion : 'v' + goSdkVersion)
+    : null);
+
+  for (const [id, localVersion] of localVersions) {
+    const published = releaseById.get(id);
+    if (localVersion && published && compareVersions(localVersion, published.version) < 0) {
+      failures.push('Local ' + published.label + ' version is behind the published snapshot (' + localVersion + ' < ' + published.version + ')');
+    }
+  }
+
+  const overviewFilesById = new Map([
+    ['typescript-sdk', ['docs/sdks/typescript/overview.mdx']],
+    ['python-sdk', ['docs/sdks/python/overview.mdx']],
+    ['go-sdk', ['docs/sdks/go/overview.mdx']],
+    ['mcp-auth', [
+      'docs/features/mcp-auth-server.mdx',
+      'docs/integrations/mcp-auth.mdx',
+    ]],
+  ]);
+  const artifacts = [...overviewFilesById].flatMap(([id, overviewFiles]) => {
+    const published = releaseById.get(id);
+    return published
+      ? [{ label: published.label, name: published.name, version: published.version, overviewFiles }]
+      : [];
+  });
+
+  const globalFiles = [
+    'README.md',
+    'COMPATIBILITY.md',
+    'web/index.html',
+    'web/llms.txt',
+    'web/llms-full.txt',
+    'docs/release-status.mdx',
+    'docs/protocol/changelog.mdx',
+  ];
+  const contentByFile = new Map();
+  async function readReleaseTarget(file) {
+    if (contentByFile.has(file)) return contentByFile.get(file);
+    const target = path.join(root, ...file.split('/'));
+    try {
+      const text = await fs.readFile(target, 'utf8');
+      contentByFile.set(file, text);
+      return text;
+    } catch (error) {
+      failures.push('Release-copy target is unreadable (' + file + '): ' + error.message);
+      contentByFile.set(file, null);
+      return null;
+    }
+  }
+
+  for (const file of globalFiles) {
+    const text = await readReleaseTarget(file);
+    if (text === null) continue;
+    for (const artifact of artifacts) {
+      if (!hasReleasePair(text, artifact.name, artifact.version)) {
+        failures.push(file + ' must associate ' + artifact.name + ' with current ' + artifact.label + ' version ' + artifact.version);
+      }
+    }
+    if (!hasReleaseDate(text, releaseSnapshot.verifiedAt)) {
+      failures.push(file + ' must display release snapshot date ' + releaseSnapshot.verifiedAt);
+    }
+  }
+
+  for (const artifact of artifacts) {
+    for (const file of artifact.overviewFiles) {
+      const text = await readReleaseTarget(file);
+      if (text !== null && !hasReleasePair(text, artifact.name, artifact.version)) {
+        failures.push(file + ' must associate ' + artifact.name + ' with current ' + artifact.label + ' version ' + artifact.version);
+      }
+    }
+  }
+  const stalePatterns = [
+    [/\bMCP Auth Server v2\.0\.1\b/i, 'MCP Auth Server v2.0.1'],
+    [/(?:TypeScript(?: SDK)?|@grantex\/sdk)[^\n]{0,120}\b0\.3\.13\b[^\n]{0,80}\bunreleased\b/i, 'TypeScript 0.3.13 marked unreleased'],
+    [/(?:TypeScript(?: SDK)?|@grantex\/sdk)[^\n]{0,120}\b0\.3\.13\b[^\n]{0,80}\bprepared for publication\b/i, 'TypeScript 0.3.13 prepared for publication'],
+    [/\blatest published(?: version)?(?:\s+is)?\s+0\.3\.12\b/i, 'latest published 0.3.12'],
+    [/TypeScript\s+0\.3\.12[^\n]{0,80}Python\s+0\.3\.13[^\n]{0,80}Go\s+v0\.1\.9/i, 'stale three-SDK release summary'],
+    [/AgentID:\s+agent\.ID\b/, 'Go v0.1.10 empty Agent.ID used in a request'],
+    [/client\.Audit\.Log\s*\([\s\S]{0,160}?grantex\.LogAuditParams\s*\{/m, 'Go v0.1.10 audit payload documented as usable'],
+  ];
+  const staleFiles = new Set([
+    ...globalFiles,
+    ...artifacts.flatMap((artifact) => artifact.overviewFiles),
+    'CHANGELOG.md',
+    'docs/quickstart.mdx',
+    'docs/sdks/go/audit.mdx',
+  ]);
+  for (const file of staleFiles) {
+    const text = await readReleaseTarget(file);
+    if (text === null) continue;
+    for (const [pattern, label] of stalePatterns) {
+      const match = pattern.exec(text);
+      if (match) {
+        failures.push(file + ':' + lineAt(text, match.index) + ' contains stale current-release copy: ' + label);
+      }
+    }
+  }
+
+  return releaseSnapshot;
+}
+
 function compareVersions(left, right) {
   const parse = (value) => value.replace(/^v/, '').split(/[.-]/).slice(0, 3).map((part) => Number.parseInt(part, 10) || 0);
   const a = parse(left);
@@ -416,21 +720,29 @@ async function fetchJson(url) {
   return response.json();
 }
 
-async function validatePublishedVersions() {
+async function validatePublishedVersions(releaseSnapshot) {
+  const releaseByName = new Map(releaseSnapshot.artifacts.map((artifact) => [artifact.name, artifact]));
+
   const manifests = await walk(path.join(root, 'packages'), (file) => path.basename(file) === 'package.json');
   for (const manifestPath of manifests) {
     const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
     if (manifest.private || !manifest.name?.startsWith('@grantex/') || !manifest.version) continue;
-    const registryUrl = npmRegistryUrls.get(manifest.name);
+    const advertised = releaseByName.get(manifest.name);
+    const registryUrl = advertised?.registryUrl || npmRegistryUrls.get(manifest.name);
     if (!registryUrl) {
       failures.push(relative(manifestPath) + ' has no approved npm registry URL');
       continue;
     }
     try {
       const metadata = await fetchJson(registryUrl);
-      const comparison = compareVersions(manifest.version, metadata.version);
-      if (comparison < 0) {
-        failures.push(relative(manifestPath) + ' is behind npm (' + manifest.version + ' < ' + metadata.version + ')');
+      const publishedVersion = String(metadata.version || '');
+      if (!publishedVersion) throw new Error('npm response has no version');
+      if (advertised) {
+        if (advertised.version !== publishedVersion) {
+          failures.push('release-status.json is out of sync with npm for ' + manifest.name + ' (' + advertised.version + ' != ' + publishedVersion + ')');
+        }
+      } else if (compareVersions(manifest.version, publishedVersion) < 0) {
+        failures.push(relative(manifestPath) + ' is behind npm (' + manifest.version + ' < ' + publishedVersion + ')');
       }
     } catch (error) {
       warnings.push('Could not verify npm package ' + manifest.name + ': ' + error.message);
@@ -444,38 +756,43 @@ async function validatePublishedVersions() {
     const name = project?.[1].match(/^name\s*=\s*"([^"]+)"/m)?.[1];
     const version = project?.[1].match(/^version\s*=\s*"([^"]+)"/m)?.[1];
     if (!name?.startsWith('grantex') || !version) continue;
-    const registryUrl = pypiRegistryUrls.get(name);
+    const advertised = releaseByName.get(name);
+    const registryUrl = advertised?.registryUrl || pypiRegistryUrls.get(name);
     if (!registryUrl) {
       failures.push(relative(projectPath) + ' has no approved PyPI registry URL');
       continue;
     }
     try {
       const metadata = await fetchJson(registryUrl);
-      const comparison = compareVersions(version, metadata.info.version);
-      if (comparison < 0) {
-        failures.push(relative(projectPath) + ' is behind PyPI (' + version + ' < ' + metadata.info.version + ')');
+      const publishedVersion = String(metadata.info?.version || '');
+      if (!publishedVersion) throw new Error('PyPI response has no version');
+      if (advertised) {
+        if (advertised.version !== publishedVersion) {
+          failures.push('release-status.json is out of sync with PyPI for ' + name + ' (' + advertised.version + ' != ' + publishedVersion + ')');
+        }
+      } else if (compareVersions(version, publishedVersion) < 0) {
+        failures.push(relative(projectPath) + ' is behind PyPI (' + version + ' < ' + publishedVersion + ')');
       }
     } catch (error) {
       warnings.push('Could not verify PyPI package ' + name + ': ' + error.message);
     }
   }
 
-  try {
-    const goSourcePath = path.join(root, 'packages', 'go-sdk', 'http.go');
-    const goSource = await fs.readFile(goSourcePath, 'utf8');
-    const localVersion = goSource.match(/const\s+sdkVersion\s*=\s*"([^"]+)"/)?.[1];
-    if (!localVersion) {
-      failures.push('packages/go-sdk/http.go has no sdkVersion for release-integrity checking');
-    } else {
-      const metadata = await fetchJson('https://proxy.golang.org/github.com/mishrasanjeev/grantex-go/@latest');
-      const publishedVersion = String(metadata.Version || '').replace(/^v/, '');
+  const goModule = 'github.com/mishrasanjeev/grantex-go';
+  const advertisedGo = releaseByName.get(goModule);
+  if (!advertisedGo) {
+    failures.push('release-status.json is missing the Go SDK');
+  } else {
+    try {
+      const metadata = await fetchJson(advertisedGo.registryUrl);
+      const publishedVersion = String(metadata.Version || '');
       if (!publishedVersion) throw new Error('Go proxy response has no Version');
-      if (compareVersions(localVersion, publishedVersion) < 0) {
-        failures.push('packages/go-sdk/http.go is behind the Go proxy (' + localVersion + ' < ' + publishedVersion + ')');
+      if (advertisedGo.version !== publishedVersion) {
+        failures.push('release-status.json is out of sync with the Go proxy (' + advertisedGo.version + ' != ' + publishedVersion + ')');
       }
+    } catch (error) {
+      warnings.push('Could not verify Go SDK version: ' + error.message);
     }
-  } catch (error) {
-    warnings.push('Could not verify Go SDK version: ' + error.message);
   }
 }
 
@@ -521,9 +838,13 @@ await validateLocks();
 await validateContexts();
 await validateYamlArtifacts();
 await validateOpenApi();
+const releaseSnapshot = await validateReleaseCopy();
 if (live) {
-  await validatePublishedVersions();
+  await validatePublishedVersions(releaseSnapshot);
   await validateLiveUrls(publicContent);
+  if (warnings.length) {
+    failures.push('Live checks were incomplete because ' + warnings.length + ' network verification warning(s) occurred');
+  }
 }
 
 for (const warning of warnings) console.warn('WARN:', warning);

--- a/web/index.html
+++ b/web/index.html
@@ -54,7 +54,8 @@
     "sameAs": [
       "https://github.com/mishrasanjeev/grantex",
       "https://www.npmjs.com/package/@grantex/sdk",
-      "https://pypi.org/project/grantex/"
+      "https://pypi.org/project/grantex/",
+      "https://pkg.go.dev/github.com/mishrasanjeev/grantex-go"
     ]
   }
   </script>
@@ -93,7 +94,7 @@
         "name": "How do I secure my AI agent with Grantex?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Install the SDK (npm install @grantex/sdk or pip install grantex), register your agent, create an authorization request with specific scopes, have the user approve via consent URL, and exchange the code for a signed JWT. The agent uses this token for all API calls, and any service can verify its signature and claims with JWKS. The entire flow takes about 10 lines of code."
+          "text": "Install the SDK for your language (npm install @grantex/sdk, pip install grantex, or go get github.com/mishrasanjeev/grantex-go@v0.1.10), register your agent, create an authorization request with specific scopes, have the user approve via the consent URL, and exchange the code for a signed JWT. Services can verify the token's signature and claims locally after retrieving the issuer's JWKS."
         }
       },
       {
@@ -253,6 +254,7 @@
       align-items: center;
       justify-content: space-between;
       height: 60px;
+      min-width: 0;
     }
     .nav-logo {
       font-family: var(--mono);
@@ -262,11 +264,33 @@
       letter-spacing: -0.5px;
     }
     .nav-logo span { color: var(--text); }
+    .nav-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      min-height: 40px;
+      padding: 8px 12px;
+      color: var(--text);
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font-family: var(--mono);
+      font-size: 13px;
+      cursor: pointer;
+    }
+    .nav-toggle:hover { border-color: var(--muted); }
+    .nav-toggle:focus-visible,
+    .nav-links a:focus-visible {
+      outline: 2px solid var(--accent2);
+      outline-offset: 2px;
+    }
     .nav-links {
       display: flex;
       gap: 28px;
       list-style: none;
       font-size: 14px;
+      min-width: 0;
     }
     .nav-links a { color: var(--muted); transition: color 0.15s; }
     .nav-links a:hover { color: var(--text); text-decoration: none; }
@@ -340,11 +364,148 @@
       color: var(--muted);
       background: var(--surface);
     }
+    .badge:hover {
+      color: var(--text);
+      border-color: var(--muted);
+      text-decoration: none;
+    }
     .badge .dot {
       width: 6px; height: 6px;
       border-radius: 50%;
       background: var(--accent);
     }
+
+    /* ── Release snapshot ──────────────────────────────────────────────────── */
+    .snapshot-section { padding: 56px 0 64px; }
+    .release-header {
+      display: flex;
+      align-items: flex-end;
+      justify-content: space-between;
+      gap: 24px;
+      margin-bottom: 28px;
+    }
+    .release-header .section-title { margin-bottom: 8px; }
+    .release-intro {
+      max-width: 680px;
+      color: var(--muted);
+      font-size: 15px;
+    }
+    .release-links {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      gap: 8px 16px;
+      flex-shrink: 0;
+      font-size: 13px;
+    }
+    .release-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 16px;
+    }
+    .release-card {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      padding: 22px;
+      color: var(--text);
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      transition: border-color 0.2s, transform 0.2s;
+    }
+    .release-card:hover {
+      border-color: var(--accent2);
+      text-decoration: none;
+      transform: translateY(-1px);
+    }
+    .release-card:focus-visible,
+    .snapshot-card:focus-visible {
+      outline: 2px solid var(--accent2);
+      outline-offset: 3px;
+    }
+    .release-language {
+      margin-bottom: 6px;
+      color: var(--accent);
+      font-family: var(--mono);
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+    }
+    .release-name {
+      overflow-wrap: anywhere;
+      color: var(--muted);
+      font-family: var(--mono);
+      font-size: 12px;
+    }
+    .release-version {
+      margin: 6px 0 10px;
+      font-family: var(--mono);
+      font-size: 24px;
+      font-weight: 700;
+      line-height: 1.2;
+    }
+    .release-meta {
+      margin-top: auto;
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.5;
+    }
+    .release-caveat {
+      margin-top: 16px;
+      padding: 14px 16px;
+      color: var(--muted);
+      background: rgba(210, 168, 255, 0.07);
+      border: 1px solid rgba(210, 168, 255, 0.25);
+      border-radius: var(--radius);
+      font-size: 13px;
+      line-height: 1.6;
+    }
+    .release-caveat strong { color: var(--text); }
+    .capability-heading {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 24px;
+      margin: 48px 0 20px;
+    }
+    .capability-heading h3 { font-size: 20px; }
+    .capability-heading p { color: var(--muted); font-size: 13px; }
+    .snapshot-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 16px;
+    }
+    .snapshot-card {
+      display: block;
+      padding: 22px;
+      color: var(--text);
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      transition: border-color 0.2s;
+    }
+    .snapshot-card:hover { border-color: var(--accent); text-decoration: none; }
+    .snapshot-card-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 8px;
+    }
+    .status-tag {
+      padding: 2px 8px;
+      color: #0d1117;
+      background: var(--accent);
+      border-radius: 4px;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.5px;
+    }
+    .status-tag.blue { background: var(--accent2); }
+    .status-tag.purple { background: #d2a8ff; }
+    .snapshot-card-title { font-weight: 600; }
+    .snapshot-card p { color: var(--muted); font-size: 14px; line-height: 1.55; }
 
     /* ── Problem cards ─────────────────────────────────────────────────────── */
     .section-label {
@@ -444,6 +605,7 @@
     .tabs {
       display: flex;
       gap: 0;
+      overflow-x: auto;
       border-bottom: 1px solid var(--border);
       margin-bottom: 0;
     }
@@ -458,14 +620,21 @@
       border-bottom: 2px solid transparent;
       margin-bottom: -1px;
       transition: color 0.15s;
+      white-space: nowrap;
     }
     .tab-btn.active {
       color: var(--accent2);
       border-bottom-color: var(--accent2);
     }
     .tab-btn:hover { color: var(--text); }
+    .tab-btn:focus-visible {
+      outline: 2px solid var(--accent2);
+      outline-offset: -2px;
+    }
+    .quickstart-shell { max-width: 760px; }
     .tab-panel { display: none; }
     .tab-panel.active { display: block; }
+    .tab-panel[hidden] { display: none; }
     .code-block {
       position: relative;
       background: var(--surface);
@@ -507,26 +676,30 @@
 
     /* ── Install commands ──────────────────────────────────────────────────── */
     .install-commands {
-      display: flex;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 16px;
-      flex-wrap: wrap;
       margin-bottom: 40px;
-      max-width: 680px;
+      max-width: 900px;
     }
     .install-cmd {
-      flex: 1;
-      min-width: 260px;
       display: flex;
       align-items: center;
       gap: 12px;
+      width: 100%;
+      min-width: 0;
       padding: 14px 18px;
+      color: var(--text);
       background: var(--surface);
       border: 1px solid var(--border);
       border-radius: var(--radius);
+      font: inherit;
+      text-align: left;
       cursor: pointer;
       transition: border-color 0.2s;
     }
     .install-cmd:hover { border-color: var(--accent2); }
+    .install-cmd:focus-visible { outline: 2px solid var(--accent2); outline-offset: 2px; }
     .install-label {
       font-family: var(--mono);
       font-size: 11px;
@@ -542,6 +715,8 @@
       font-size: 14px;
       color: var(--text);
       flex: 1;
+      min-width: 0;
+      overflow-wrap: anywhere;
     }
     .install-copy {
       font-family: var(--mono);
@@ -930,10 +1105,43 @@
     .alt-table .partial { color: #d29922; font-size: 12px; }
 
     /* ── Responsive ────────────────────────────────────────────────────────── */
+    @media (max-width: 900px) {
+      .nav-inner {
+        height: auto;
+        min-height: 60px;
+        flex-wrap: wrap;
+      }
+      .nav-toggle { display: inline-flex; }
+      .nav-links {
+        display: none;
+        order: 3;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        width: 100%;
+        gap: 4px;
+        padding: 10px 0 14px;
+        border-top: 1px solid var(--border);
+      }
+      .nav-links.is-open { display: grid; }
+      .nav-links a {
+        display: block;
+        padding: 8px 10px;
+        border-radius: 6px;
+      }
+      .nav-links a:hover { background: var(--surface); }
+      .release-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
     @media (max-width: 640px) {
       section { padding: 56px 0; }
-      .nav-links { gap: 16px; font-size: 13px; }
+      .container { padding: 0 18px; }
+      .nav-links { grid-template-columns: 1fr; font-size: 13px; }
       .hero { padding: 64px 0 56px; }
+      .snapshot-section { padding: 48px 0 56px; }
+      .release-header,
+      .capability-heading { align-items: flex-start; flex-direction: column; gap: 12px; }
+      .release-links { justify-content: flex-start; }
+      .release-grid,
+      .install-commands { grid-template-columns: 1fr; }
+      .tab-btn { padding: 10px 14px; }
       .footer-inner { flex-direction: column; align-items: flex-start; }
     }
   </style>
@@ -947,11 +1155,18 @@
       <a href="/" class="nav-logo" style="text-decoration:none;">
         grant<span>ex</span>
       </a>
-      <ul class="nav-links">
+      <button type="button" class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        Menu
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M2 4.25a.75.75 0 01.75-.75h10.5a.75.75 0 010 1.5H2.75A.75.75 0 012 4.25zm0 3.75a.75.75 0 01.75-.75h10.5a.75.75 0 010 1.5H2.75A.75.75 0 012 8zm0 3.75a.75.75 0 01.75-.75h10.5a.75.75 0 010 1.5H2.75a.75.75 0 01-.75-.75z"/>
+        </svg>
+      </button>
+      <ul class="nav-links" id="primary-navigation">
         <li><a href="https://docs.grantex.dev"
                onclick="gtag('event','docs_click',{event_category:'nav'})">Docs</a></li>
         <li><a href="https://github.com/mishrasanjeev/grantex"
                onclick="gtag('event','github_click',{event_category:'nav'})">GitHub</a></li>
+        <li><a href="#whats-new">Releases</a></li>
         <li><a href="/playground"
                onclick="gtag('event','playground_click',{event_category:'nav'})">Playground</a></li>
         <li><a href="/gemma">Gemma 4</a></li>
@@ -1014,82 +1229,130 @@
       <span class="badge"><span class="dot"></span> IETF I-D</span>
       <span class="badge"><span class="dot"></span> SOC 2 readiness mapping</span>
       <span class="badge"><span class="dot"></span> Apache 2.0</span>
-      <span class="badge"><span class="dot"></span> v1.0</span>
+      <a class="badge" href="https://github.com/mishrasanjeev/grantex/blob/main/SPEC.md"
+         aria-label="Read the Grantex protocol version 1.0 specification">
+        <span class="dot"></span> Protocol v1.0
+      </a>
     </div>
   </div>
 </section>
 
-<!-- ── Current Development Snapshot ───────────────────────────────────────── -->
-<section id="whats-new" style="padding:48px 0;border-bottom:1px solid var(--border);">
+<!-- ── Published releases and capability highlights ───────────────────────── -->
+<section id="whats-new" class="snapshot-section">
   <div class="container">
-    <div class="section-label">Current snapshot</div>
-    <h2 class="section-title" style="font-size:clamp(24px,4vw,36px);">Recent Grantex capabilities</h2>
-    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px;margin-top:32px;">
+    <div class="release-header">
+      <div>
+        <div class="section-label">Published releases</div>
+        <h2 class="section-title">Current public releases</h2>
+        <p class="release-intro">
+          Verified against npm, PyPI, and the Go module proxy on 12 July 2026.
+          Grantex packages are independently versioned.
+        </p>
+      </div>
+      <div class="release-links" aria-label="Release resources">
+        <a href="https://docs.grantex.dev/release-status">Release status guide</a>
+        <a href="https://github.com/mishrasanjeev/grantex/blob/main/COMPATIBILITY.md">Compatibility matrix</a>
+        <a href="https://github.com/mishrasanjeev/grantex/blob/main/CHANGELOG.md">Release notes</a>
+      </div>
+    </div>
 
-      <a href="/gemma" style="text-decoration:none;display:block;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:24px;transition:border-color .2s;" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
-        <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
-          <span style="background:#3fb950;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">NEW</span>
-          <span style="color:var(--text);font-weight:600;">@grantex/gemma</span>
-        </div>
-        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">Offline consent bundles and on-device verification examples for Gemma agents.</p>
+    <div class="release-grid">
+      <a class="release-card" href="https://www.npmjs.com/package/@grantex/sdk/v/0.3.13">
+        <span class="release-language">TypeScript SDK</span>
+        <span class="release-name">@grantex/sdk</span>
+        <strong class="release-version">0.3.13</strong>
+        <span class="release-meta">npm &middot; published 11 Jul 2026</span>
       </a>
-
-      <a href="/mcp" style="text-decoration:none;display:block;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:24px;transition:border-color .2s;" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
-        <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
-          <span style="background:#3fb950;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">PKG</span>
-          <span style="color:var(--text);font-weight:600;">MCP Auth Server v2.0.1</span>
-        </div>
-        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">OAuth 2.1 + PKCE for MCP servers, with managed and self-hosted modes.</p>
+      <a class="release-card" href="https://pypi.org/project/grantex/0.3.14/">
+        <span class="release-language">Python SDK</span>
+        <span class="release-name">grantex</span>
+        <strong class="release-version">0.3.14</strong>
+        <span class="release-meta">PyPI &middot; published 11 Jul 2026</span>
       </a>
-
-      <a href="/dpdp" style="text-decoration:none;display:block;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:24px;transition:border-color .2s;" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
-        <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
-          <span style="background:#3fb950;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">NEW</span>
-          <span style="color:var(--text);font-weight:600;">@grantex/dpdp</span>
-        </div>
-        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">DPDP Act 2023 and EU AI Act control mappings, structured consent records, purpose limitation, and audit-ready exports.</p>
+      <a class="release-card" href="https://pkg.go.dev/github.com/mishrasanjeev/grantex-go@v0.1.10">
+        <span class="release-language">Go SDK</span>
+        <span class="release-name">github.com/mishrasanjeev/grantex-go</span>
+        <strong class="release-version">v0.1.10</strong>
+        <span class="release-meta">Go module proxy &middot; Go 1.26.1+ &middot; known SDK gaps</span>
       </a>
-
-      <a href="/registry" style="text-decoration:none;display:block;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:24px;transition:border-color .2s;" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
-        <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
-          <span style="background:#58a6ff;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">LAUNCH</span>
-          <span style="color:var(--text);font-weight:600;">Trust Registry</span>
-        </div>
-        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">Public DID-based directory of verified AI agent publishers, DNS verification, and embeddable widgets.</p>
+      <a class="release-card" href="https://www.npmjs.com/package/@grantex/mcp-auth/v/2.0.2">
+        <span class="release-language">MCP Auth</span>
+        <span class="release-name">@grantex/mcp-auth</span>
+        <strong class="release-version">2.0.2</strong>
+        <span class="release-meta">npm &middot; independently versioned</span>
       </a>
+    </div>
 
-      <a href="/anomaly" style="text-decoration:none;display:block;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:24px;transition:border-color .2s;" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
-        <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
-          <span style="background:#58a6ff;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">EXPANDED</span>
-          <span style="color:var(--text);font-weight:600;">Anomaly Detection</span>
+    <div class="release-caveat" role="note">
+      <strong>Known published-package limits:</strong>
+      Go SDK v0.1.10 needs an agent-ID workaround after registration and cannot
+      send the current audit payload through its typed client. MCP Auth 2.0.2 is
+      single-process evaluation software with in-memory code state, no rendered
+      consent page, and an incomplete backend code handoff.
+      <a href="https://docs.grantex.dev/release-status">Read the exact boundaries and workarounds.</a>
+    </div>
+
+    <div class="capability-heading">
+      <h3>Capability highlights</h3>
+      <p>Implemented product areas; follow the linked docs for package-level status and limitations.</p>
+    </div>
+    <div class="snapshot-grid">
+      <a class="snapshot-card" href="/gemma">
+        <div class="snapshot-card-header">
+          <span class="status-tag">SDK</span>
+          <span class="snapshot-card-title">@grantex/gemma</span>
         </div>
-        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">Four SQL-backed activity checks, finding lifecycle APIs, and stored custom-rule and channel configuration.</p>
+        <p>Offline consent bundles and on-device verification examples for Gemma agents.</p>
       </a>
-
-      <a href="https://docs.grantex.dev/cli/verify" style="text-decoration:none;display:block;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:24px;transition:border-color .2s;" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
-        <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
-          <span style="background:#58a6ff;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">NEW</span>
-          <span style="color:var(--text);font-weight:600;">grantex verify</span>
+      <a class="snapshot-card" href="/mcp">
+        <div class="snapshot-card-header">
+          <span class="status-tag blue">AUTH</span>
+          <span class="snapshot-card-title">MCP Auth Server</span>
         </div>
-        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">One command to inspect any grant token. Claims can be decoded locally; signature verification may retrieve JWKS, and live revocation checks require network access.</p>
+        <p>Published OAuth endpoint package for single-process evaluation; review the v2.0.2 consent, state, and token-exchange limitations.</p>
       </a>
-
-      <a href="https://docs.grantex.dev/guides/security-hardening" style="text-decoration:none;display:block;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:24px;transition:border-color .2s;" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
-        <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
-          <span style="background:#f97583;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">CURRENT</span>
-          <span style="color:var(--text);font-weight:600;">Enterprise Hardening</span>
+      <a class="snapshot-card" href="/dpdp">
+        <div class="snapshot-card-header">
+          <span class="status-tag purple">CONTROLS</span>
+          <span class="snapshot-card-title">@grantex/dpdp</span>
         </div>
-        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">Rate limiting on every endpoint, HTTP security headers, SDK retry with backoff, structured logging, deep health checks, DB transactions, graceful shutdown.</p>
+        <p>DPDP Act 2023 and EU AI Act control mappings, structured consent records, purpose limitation, and audit-ready exports.</p>
       </a>
-
-      <a href="#scope-enforcement" style="text-decoration:none;display:block;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:24px;transition:border-color .2s;" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
-        <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
-          <span style="background:#f97583;color:#0d1117;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">CURRENT</span>
-          <span style="color:var(--text);font-weight:600;">Scope Enforcement</span>
+      <a class="snapshot-card" href="/registry">
+        <div class="snapshot-card-header">
+          <span class="status-tag blue">TRUST</span>
+          <span class="snapshot-card-title">Trust Registry</span>
         </div>
-        <p style="color:var(--muted);font-size:14px;margin:0;line-height:1.5;">enforce() + wrapTool() + Express/FastAPI middleware. Define manifests for any connector, or use 53 pre-built ones. &lt;1ms per call.</p>
+        <p>Public DID-based directory of verified AI agent publishers, DNS verification, and embeddable widgets.</p>
       </a>
-
+      <a class="snapshot-card" href="/anomaly">
+        <div class="snapshot-card-header">
+          <span class="status-tag blue">SECURITY</span>
+          <span class="snapshot-card-title">Anomaly Detection</span>
+        </div>
+        <p>Four SQL-backed activity checks, finding lifecycle APIs, and stored custom-rule and channel configuration.</p>
+      </a>
+      <a class="snapshot-card" href="https://docs.grantex.dev/cli/verify">
+        <div class="snapshot-card-header">
+          <span class="status-tag">CLI</span>
+          <span class="snapshot-card-title">grantex verify</span>
+        </div>
+        <p>Decode claims locally, verify signatures with JWKS, and opt into a network-backed live revocation check.</p>
+      </a>
+      <a class="snapshot-card" href="https://docs.grantex.dev/guides/security-hardening">
+        <div class="snapshot-card-header">
+          <span class="status-tag purple">OPERATIONS</span>
+          <span class="snapshot-card-title">Enterprise Hardening</span>
+        </div>
+        <p>Rate limiting, HTTP security headers, SDK retry, structured logging, deep health checks, transactions, and graceful shutdown.</p>
+      </a>
+      <a class="snapshot-card" href="#scope-enforcement">
+        <div class="snapshot-card-header">
+          <span class="status-tag">ENFORCEMENT</span>
+          <span class="snapshot-card-title">Scope Enforcement</span>
+        </div>
+        <p>enforce(), wrapTool(), and Express/FastAPI middleware with custom or pre-built tool manifests.</p>
+      </a>
     </div>
   </div>
 </section>
@@ -1558,90 +1821,161 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
     <div class="section-label">Quickstart</div>
     <h2 class="section-title">Up and running in minutes</h2>
     <p class="section-sub">
-      Install the SDK and authorize your first agent in under 10 lines.
+      Choose an SDK. These pinned commands reproduce the releases verified above; each follows the same consent, token exchange, and verification lifecycle.
     </p>
 
     <div class="install-commands">
-      <div class="install-cmd" onclick="copyInstall('npm install @grantex/sdk', this)">
+      <button type="button" class="install-cmd" onclick="copyInstall('npm install @grantex/sdk@0.3.13', this)"
+              aria-label="Copy the TypeScript SDK install command">
         <span class="install-label">npm</span>
-        <code>npm install @grantex/sdk</code>
+        <code>npm install @grantex/sdk@0.3.13</code>
         <span class="install-copy">Copy</span>
-      </div>
-      <div class="install-cmd" onclick="copyInstall('pip install grantex', this)">
+      </button>
+      <button type="button" class="install-cmd" onclick="copyInstall('python -m pip install grantex==0.3.14', this)"
+              aria-label="Copy the Python SDK install command">
         <span class="install-label">PyPI</span>
-        <code>pip install grantex</code>
+        <code>python -m pip install grantex==0.3.14</code>
         <span class="install-copy">Copy</span>
-      </div>
-      <div class="install-cmd" onclick="copyInstall('npm install -g @grantex/cli', this)">
+      </button>
+      <button type="button" class="install-cmd" onclick="copyInstall('go get github.com/mishrasanjeev/grantex-go@v0.1.10', this)"
+              aria-label="Copy the Go SDK version 0.1.10 install command">
+        <span class="install-label">Go</span>
+        <code>go get github.com/mishrasanjeev/grantex-go@v0.1.10</code>
+        <span class="install-copy">Copy</span>
+      </button>
+      <button type="button" class="install-cmd" onclick="copyInstall('npm install -g @grantex/cli', this)"
+              aria-label="Copy the Grantex CLI install command">
         <span class="install-label">CLI</span>
         <code>npm install -g @grantex/cli</code>
         <span class="install-copy">Copy</span>
-      </div>
+      </button>
     </div>
 
-    <div style="max-width:680px;">
-      <div class="tabs">
-        <button class="tab-btn active" onclick="switchTab('node', this)">Node.js</button>
-        <button class="tab-btn" onclick="switchTab('python', this)">Python</button>
-        <button class="tab-btn" onclick="switchTab('cli', this)">CLI</button>
+    <div class="quickstart-shell">
+      <div class="tabs" role="tablist" aria-label="SDK quickstarts">
+        <button type="button" class="tab-btn active" id="tab-button-node" role="tab"
+                aria-selected="true" aria-controls="tab-node" tabindex="0" onclick="switchTab('node', this)">Node.js</button>
+        <button type="button" class="tab-btn" id="tab-button-python" role="tab"
+                aria-selected="false" aria-controls="tab-python" tabindex="-1" onclick="switchTab('python', this)">Python</button>
+        <button type="button" class="tab-btn" id="tab-button-go" role="tab"
+                aria-selected="false" aria-controls="tab-go" tabindex="-1" onclick="switchTab('go', this)">Go</button>
+        <button type="button" class="tab-btn" id="tab-button-cli" role="tab"
+                aria-selected="false" aria-controls="tab-cli" tabindex="-1" onclick="switchTab('cli', this)">CLI</button>
       </div>
 
       <!-- Node.js -->
-      <div class="tab-panel active" id="tab-node">
+      <div class="tab-panel active" id="tab-node" role="tabpanel" aria-labelledby="tab-button-node">
         <div class="code-block">
-          <button class="copy-btn" onclick="copyCode('code-node', this, 'npm_install_copy')">Copy</button>
-          <pre id="code-node"><span class="cm">// npm install @grantex/sdk</span>
+          <button type="button" class="copy-btn" aria-label="Copy the Node.js quickstart"
+                  onclick="copyCode('code-node', this, 'node_quickstart_copy')">Copy</button>
+          <pre id="code-node"><span class="cm">// npm install @grantex/sdk@0.3.13</span>
 <span class="kw">import</span> <span class="op">{ </span><span class="id">Grantex</span><span class="op">,</span> <span class="id">verifyGrantToken</span><span class="op"> }</span> <span class="kw">from</span> <span class="str">'@grantex/sdk'</span>;
 
 <span class="kw">const</span> <span class="id">grantex</span> <span class="op">=</span> <span class="kw">new</span> <span class="fn">Grantex</span><span class="op">({</span> <span class="id">apiKey</span><span class="op">:</span> <span class="str">'YOUR_API_KEY'</span> <span class="op">});</span>
 
-<span class="cm">// 1. Request authorization — redirect user to consentUrl</span>
-<span class="kw">const</span> <span class="op">{</span> <span class="id">consentUrl</span> <span class="op">}</span> <span class="op">=</span> <span class="kw">await</span> <span class="id">grantex</span><span class="op">.</span><span class="fn">authorize</span><span class="op">({</span>
+<span class="cm">// 1. Request authorization; live mode returns the code to your callback.</span>
+<span class="kw">const</span> <span class="id">auth</span> <span class="op">=</span> <span class="kw">await</span> <span class="id">grantex</span><span class="op">.</span><span class="fn">authorize</span><span class="op">({</span>
   <span class="id">agentId</span><span class="op">:</span>  <span class="str">'ag_01J...'</span><span class="op">,</span>
   <span class="id">userId</span><span class="op">:</span>   <span class="str">'usr_01J...'</span><span class="op">,</span>
   <span class="id">scopes</span><span class="op">:</span>  <span class="op">[</span><span class="str">'calendar:read'</span><span class="op">,</span> <span class="str">'email:send'</span><span class="op">],</span>
+  <span class="id">audience</span><span class="op">:</span> <span class="str">'https://api.example.com'</span><span class="op">,</span>
 <span class="op">});</span>
 
-<span class="cm">// 2. Exchange the authorization code for a grant token</span>
-<span class="kw">const</span> <span class="id">token</span> <span class="op">=</span> <span class="kw">await</span> <span class="id">grantex</span><span class="op">.</span><span class="id">tokens</span><span class="op">.</span><span class="fn">exchange</span><span class="op">({</span> <span class="id">code</span><span class="op">,</span> <span class="id">agentId</span><span class="op">:</span> <span class="str">'ag_01J...'</span> <span class="op">});</span>
+<span class="kw">if</span> <span class="op">(!</span><span class="id">auth</span><span class="op">.</span><span class="id">code</span><span class="op">) {</span>
+  <span class="id">console</span><span class="op">.</span><span class="fn">log</span><span class="op">(</span><span class="str">`Approve access at: ${auth.consentUrl}`</span><span class="op">);</span>
+  <span class="cm">// Exchange the callback's code in your redirect handler.</span>
+<span class="op">} else {</span>
+  <span class="cm">// 2. Sandbox or policy auto-approval can return a code immediately.</span>
+  <span class="kw">const</span> <span class="id">token</span> <span class="op">=</span> <span class="kw">await</span> <span class="id">grantex</span><span class="op">.</span><span class="id">tokens</span><span class="op">.</span><span class="fn">exchange</span><span class="op">({</span> <span class="id">code</span><span class="op">:</span> <span class="id">auth</span><span class="op">.</span><span class="id">code</span><span class="op">,</span> <span class="id">agentId</span><span class="op">:</span> <span class="str">'ag_01J...'</span> <span class="op">});</span>
 
-<span class="cm">// 3. Verify locally (valid JWKS keys are reused; fetch and refresh may use network)</span>
-<span class="kw">const</span> <span class="id">grant</span> <span class="op">=</span> <span class="kw">await</span> <span class="fn">verifyGrantToken</span><span class="op">(</span><span class="id">token</span><span class="op">.</span><span class="id">grantToken</span><span class="op">,</span> <span class="op">{</span>
-  <span class="id">jwksUri</span><span class="op">:</span> <span class="str">'https://api.grantex.dev/.well-known/jwks.json'</span><span class="op">,</span>
-<span class="op">});</span>
-<span class="id">console</span><span class="op">.</span><span class="fn">log</span><span class="op">(</span><span class="id">grant</span><span class="op">.</span><span class="id">scopes</span><span class="op">);</span> <span class="cm">// ['calendar:read', 'email:send']</span></pre>
+  <span class="cm">// 3. Verify locally; retrieving or refreshing JWKS may use the network.</span>
+  <span class="kw">const</span> <span class="id">grant</span> <span class="op">=</span> <span class="kw">await</span> <span class="fn">verifyGrantToken</span><span class="op">(</span><span class="id">token</span><span class="op">.</span><span class="id">grantToken</span><span class="op">,</span> <span class="op">{</span>
+    <span class="id">jwksUri</span><span class="op">:</span> <span class="str">'https://api.grantex.dev/.well-known/jwks.json'</span><span class="op">,</span>
+    <span class="id">audience</span><span class="op">:</span> <span class="str">'https://api.example.com'</span><span class="op">,</span>
+  <span class="op">});</span>
+  <span class="id">console</span><span class="op">.</span><span class="fn">log</span><span class="op">(</span><span class="id">grant</span><span class="op">.</span><span class="id">scopes</span><span class="op">);</span> <span class="cm">// ['calendar:read', 'email:send']</span>
+<span class="op">}</span></pre>
         </div>
       </div>
 
       <!-- Python -->
-      <div class="tab-panel" id="tab-python">
+      <div class="tab-panel" id="tab-python" role="tabpanel" aria-labelledby="tab-button-python" hidden>
         <div class="code-block">
-          <button class="copy-btn" onclick="copyCode('code-python', this, 'pip_install_copy')">Copy</button>
-          <pre id="code-python"><span class="cm"># pip install grantex</span>
-<span class="kw">from</span> <span class="id">grantex</span> <span class="kw">import</span> <span class="id">Grantex</span><span class="op">,</span> <span class="id">ExchangeTokenParams</span>
+          <button type="button" class="copy-btn" aria-label="Copy the Python quickstart"
+                  onclick="copyCode('code-python', this, 'python_quickstart_copy')">Copy</button>
+          <pre id="code-python"><span class="cm"># python -m pip install grantex==0.3.14</span>
+<span class="kw">from</span> <span class="id">grantex</span> <span class="kw">import</span> <span class="id">AuthorizeParams</span><span class="op">,</span> <span class="id">ExchangeTokenParams</span><span class="op">,</span> <span class="id">Grantex</span>
 
 <span class="id">client</span> <span class="op">=</span> <span class="fn">Grantex</span><span class="op">(</span><span class="id">api_key</span><span class="op">=</span><span class="str">"YOUR_API_KEY"</span><span class="op">)</span>
 
-<span class="cm"># 1. Request authorization — redirect user to consent_url</span>
-<span class="id">auth</span> <span class="op">=</span> <span class="id">client</span><span class="op">.</span><span class="fn">authorize</span><span class="op">(</span>
+<span class="cm"># 1. Request authorization; live mode returns the code to your callback.</span>
+<span class="id">auth</span> <span class="op">=</span> <span class="id">client</span><span class="op">.</span><span class="fn">authorize</span><span class="op">(</span><span class="fn">AuthorizeParams</span><span class="op">(</span>
     <span class="id">agent_id</span><span class="op">=</span><span class="str">"ag_01J..."</span><span class="op">,</span>
     <span class="id">user_id</span><span class="op">=</span><span class="str">"usr_01J..."</span><span class="op">,</span>
     <span class="id">scopes</span><span class="op">=[</span><span class="str">"calendar:read"</span><span class="op">,</span> <span class="str">"email:send"</span><span class="op">],</span>
-<span class="op">)</span>
+    <span class="id">audience</span><span class="op">=</span><span class="str">"https://api.example.com"</span><span class="op">,</span>
+<span class="op">))</span>
 
-<span class="cm"># 2. Exchange the authorization code for a grant token</span>
-<span class="id">token</span> <span class="op">=</span> <span class="id">client</span><span class="op">.</span><span class="id">tokens</span><span class="op">.</span><span class="fn">exchange</span><span class="op">(</span><span class="fn">ExchangeTokenParams</span><span class="op">(</span><span class="id">code</span><span class="op">=</span><span class="id">code</span><span class="op">,</span> <span class="id">agent_id</span><span class="op">=</span><span class="str">"ag_01J..."</span><span class="op">))</span>
+<span class="kw">if</span> <span class="kw">not</span> <span class="id">auth</span><span class="op">.</span><span class="id">code</span><span class="op">:</span>
+    <span class="fn">print</span><span class="op">(</span><span class="str">f"Approve access at: {auth.consent_url}"</span><span class="op">)</span>
+    <span class="cm"># Exchange the callback code in your redirect handler.</span>
+<span class="kw">else</span><span class="op">:</span>
+    <span class="cm"># 2. Sandbox or policy auto-approval can return a code immediately.</span>
+    <span class="id">token</span> <span class="op">=</span> <span class="id">client</span><span class="op">.</span><span class="id">tokens</span><span class="op">.</span><span class="fn">exchange</span><span class="op">(</span><span class="fn">ExchangeTokenParams</span><span class="op">(</span><span class="id">code</span><span class="op">=</span><span class="id">auth</span><span class="op">.</span><span class="id">code</span><span class="op">,</span> <span class="id">agent_id</span><span class="op">=</span><span class="str">"ag_01J..."</span><span class="op">))</span>
 
-<span class="cm"># 3. Use the token — scopes, grantId, and JWT are all available</span>
-<span class="fn">print</span><span class="op">(</span><span class="id">token</span><span class="op">.</span><span class="id">scopes</span><span class="op">)</span>      <span class="cm"># ('calendar:read', 'email:send')</span>
-<span class="fn">print</span><span class="op">(</span><span class="id">token</span><span class="op">.</span><span class="id">grant_token</span><span class="op">)</span> <span class="cm"># RS256-signed JWT</span></pre>
+    <span class="cm"># 3. Use the token — scopes, grant ID, and JWT are available.</span>
+    <span class="fn">print</span><span class="op">(</span><span class="id">token</span><span class="op">.</span><span class="id">scopes</span><span class="op">)</span>      <span class="cm"># ('calendar:read', 'email:send')</span>
+    <span class="fn">print</span><span class="op">(</span><span class="id">token</span><span class="op">.</span><span class="id">grant_token</span><span class="op">)</span> <span class="cm"># RS256-signed JWT</span></pre>
+        </div>
+      </div>
+
+      <!-- Go -->
+      <div class="tab-panel" id="tab-go" role="tabpanel" aria-labelledby="tab-button-go" hidden>
+        <div class="code-block">
+          <button type="button" class="copy-btn" aria-label="Copy the Go quickstart"
+                  onclick="copyCode('code-go', this, 'go_quickstart_copy')">Copy</button>
+          <pre id="code-go">// go get github.com/mishrasanjeev/grantex-go@v0.1.10
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	grantex "github.com/mishrasanjeev/grantex-go"
+)
+
+func main() {
+	ctx := context.Background()
+	client := grantex.NewClient("YOUR_API_KEY")
+	auth, err := client.Authorize(ctx, grantex.AuthorizeParams{
+		AgentID:     "ag_01J...",
+		PrincipalID: "usr_01J...",
+		Scopes:      []string{"calendar:read", "email:send"},
+		Audience:    "https://api.example.com",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(auth.ConsentURL)
+	token, err := client.Tokens.Exchange(ctx, grantex.ExchangeTokenParams{
+		Code:    "authorization-code-from-callback",
+		AgentID: "ag_01J...",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(token.GrantToken)
+}
+</pre>
         </div>
       </div>
 
       <!-- CLI -->
-      <div class="tab-panel" id="tab-cli">
+      <div class="tab-panel" id="tab-cli" role="tabpanel" aria-labelledby="tab-button-cli" hidden>
         <div class="code-block">
-          <button class="copy-btn" onclick="copyCode('code-cli', this, 'cli_copy')">Copy</button>
+          <button type="button" class="copy-btn" aria-label="Copy the CLI quickstart"
+                  onclick="copyCode('code-cli', this, 'cli_quickstart_copy')">Copy</button>
           <pre id="code-cli"><span class="cm"># npm install -g @grantex/cli</span>
 <span class="cm"># All commands support --json for AI agent / script use</span>
 
@@ -1797,11 +2131,12 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
     <!-- ── Install + CTA ──────────────────────────────────────────────── -->
     <div style="margin-top:40px;">
       <div class="install-commands">
-        <div class="install-cmd" onclick="navigator.clipboard.writeText('npm install @grantex/mpp')">
+        <button type="button" class="install-cmd" onclick="copyInstall('npm install @grantex/mpp', this)"
+                aria-label="Copy the MPP package install command">
           <span class="install-label">npm</span>
           <code>npm install @grantex/mpp</code>
           <span class="install-copy">Copy</span>
-        </div>
+        </button>
       </div>
       <div style="display:flex;gap:12px;flex-wrap:wrap;margin-top:20px;">
         <a href="https://docs.grantex.dev/features/mpp-agent-passport" class="btn btn-primary"
@@ -1948,11 +2283,12 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
     <!-- ── Install + CTA ──────────────────────────────────────────────── -->
     <div style="margin-top:40px;">
       <div class="install-commands">
-        <div class="install-cmd" onclick="navigator.clipboard.writeText('npm install @grantex/x402')">
+        <button type="button" class="install-cmd" onclick="copyInstall('npm install @grantex/x402', this)"
+                aria-label="Copy the x402 package install command">
           <span class="install-label">npm</span>
           <code>npm install @grantex/x402</code>
           <span class="install-copy">Copy</span>
-        </div>
+        </button>
       </div>
       <div style="display:flex;gap:12px;flex-wrap:wrap;margin-top:20px;">
         <a href="https://docs.grantex.dev/integrations/x402" class="btn btn-primary"
@@ -2342,17 +2678,19 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
     <div class="section-label">Trust &amp; compliance</div>
     <h2 class="section-title">Built to enterprise standards</h2>
     <p class="section-sub">
-      Security audited, standards-track, open source.
+      Published security assessment, individual IETF Internet-Draft, open source.
     </p>
     <div class="trust-cards">
       <div class="trust-card">
-        <div class="trust-label">Security Audit</div>
-        <h3>Independent Penetration Test</h3>
+        <div class="trust-label">Security assessment</div>
+        <h3>External Review Published</h3>
         <p>
-          External security review found no critical or high severity findings.
-          Full report available to enterprise customers under NDA.
+          No critical findings were identified. The single high-severity finding
+          was fixed during the engagement; the report and remediation notes are public.
         </p>
-        <div class="auditor">Vestige Security Labs</div>
+        <div class="auditor">
+          <a href="https://docs.grantex.dev/security/audit-report" style="color:var(--accent2);">Read the public report &rarr;</a>
+        </div>
       </div>
       <div class="trust-card">
         <div class="trust-label">SOC 2 readiness</div>
@@ -2369,7 +2707,8 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
         <p>
           The Grantex wire protocol is an open IETF Internet-Draft
           (<code style="font-family:var(--mono)">draft-mishra-oauth-agent-grants-01</code>),
-          built on the OAuth 2.0 framework.
+          built on the OAuth 2.0 framework. It is an individual submission for
+          discussion, not an IETF-adopted or endorsed standard.
         </p>
         <div class="auditor">
           <a href="https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/"
@@ -2493,7 +2832,7 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
             <span class="check">&#x2713;</span>
             <div>
               <h4>MCP Auth Server</h4>
-              <p>Drop-in OAuth 2.1 + PKCE authorization for any MCP server with dynamic client registration.</p>
+              <p>Fastify OAuth 2.1 + PKCE endpoint package with dynamic client registration; v2.0.2 limitations are documented.</p>
             </div>
           </div>
           <div class="enterprise-feature">
@@ -2671,13 +3010,73 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
 
 <!-- ── Scripts ────────────────────────────────────────────────────────────── -->
 <script>
-  /* Tab switcher */
+  /* Responsive navigation */
+  (function() {
+    var toggle = document.querySelector('.nav-toggle');
+    var navigation = document.getElementById('primary-navigation');
+    if (!toggle || !navigation) return;
+
+    function setNavigationOpen(open) {
+      navigation.classList.toggle('is-open', open);
+      toggle.setAttribute('aria-expanded', String(open));
+    }
+
+    toggle.addEventListener('click', function() {
+      setNavigationOpen(toggle.getAttribute('aria-expanded') !== 'true');
+    });
+    navigation.querySelectorAll('a').forEach(function(link) {
+      link.addEventListener('click', function() { setNavigationOpen(false); });
+    });
+    document.addEventListener('keydown', function(event) {
+      if (event.key === 'Escape' && toggle.getAttribute('aria-expanded') === 'true') {
+        setNavigationOpen(false);
+        toggle.focus();
+      }
+    });
+    window.addEventListener('resize', function() {
+      if (window.innerWidth > 900) setNavigationOpen(false);
+    });
+  })();
+
+  /* Accessible tab switcher */
   function switchTab(id, btn) {
-    document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
-    document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
-    document.getElementById('tab-' + id).classList.add('active');
-    btn.classList.add('active');
+    var shell = btn.closest('.quickstart-shell');
+    if (!shell) return;
+    var activePanelId = 'tab-' + id;
+
+    shell.querySelectorAll('[role="tab"]').forEach(function(tab) {
+      var active = tab === btn;
+      tab.classList.toggle('active', active);
+      tab.setAttribute('aria-selected', String(active));
+      tab.tabIndex = active ? 0 : -1;
+    });
+    shell.querySelectorAll('[role="tabpanel"]').forEach(function(panel) {
+      var active = panel.id === activePanelId;
+      panel.classList.toggle('active', active);
+      panel.hidden = !active;
+    });
   }
+
+  document.querySelectorAll('.tabs[role="tablist"]').forEach(function(tabList) {
+    tabList.addEventListener('keydown', function(event) {
+      var tabs = Array.from(tabList.querySelectorAll('[role="tab"]'));
+      var current = tabs.indexOf(document.activeElement);
+      if (current < 0) return;
+
+      var nextIndex = current;
+      if (event.key === 'ArrowRight') nextIndex = (current + 1) % tabs.length;
+      else if (event.key === 'ArrowLeft') nextIndex = (current - 1 + tabs.length) % tabs.length;
+      else if (event.key === 'Home') nextIndex = 0;
+      else if (event.key === 'End') nextIndex = tabs.length - 1;
+      else return;
+
+      event.preventDefault();
+      var nextTab = tabs[nextIndex];
+      var panelId = nextTab.getAttribute('aria-controls');
+      switchTab(panelId.replace(/^tab-/, ''), nextTab);
+      nextTab.focus();
+    });
+  });
 
   /* Copy button */
   function copyCode(id, btn, gaEvent) {

--- a/web/llms-full.txt
+++ b/web/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Delegated authorization protocol for AI agents. What OAuth 2.0 is to humans, Grantex is to agents.
 
-Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, human-approved, revocable permissions via signed JWTs. Any service can verify tokens offline using published JWKS — no runtime dependency on Grantex infrastructure.
+Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, human-approved, revocable permissions via signed JWTs. Any service can verify token signatures and claims locally after retrieving the issuer's published JWKS; current revocation status requires an online check or synchronized revocation data.
 
 ## Quick Facts
 
@@ -13,6 +13,10 @@ Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, hum
 - IETF Draft: https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/
 - License: Apache 2.0
 - Protocol Version: 1.0 (Final, frozen)
+- Release Status: https://docs.grantex.dev/release-status
+- Release snapshot verified: 2026-07-12
+- Current public releases: `@grantex/sdk@0.3.13`, `grantex==0.3.14`, `github.com/mishrasanjeev/grantex-go@v0.1.10`, `@grantex/mcp-auth@2.0.2`
+- Known limitations: Go v0.1.10 has agent-ID response mapping and audit-payload gaps; MCP Auth 2.0.2 is single-process evaluation software with process-local codes, no rendered consent page, no live revocation lookup, and an incomplete Grantex code handoff
 - Tests: the monorepo contains 29 packages; GitHub Actions is the source of truth for current pass/fail status
 - SOC 2: readiness control mapping published; formal third-party attestation is not published
 - Production API: https://api.grantex.dev

--- a/web/llms.txt
+++ b/web/llms.txt
@@ -1,10 +1,10 @@
 # Grantex
 
-> Last updated: 2026-04-06
+> Last updated: 2026-07-12
 
 > Delegated authorization protocol for AI agents. What OAuth 2.0 is to humans, Grantex is to agents.
 
-Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, human-approved, revocable permissions via signed JWTs. Any service can verify tokens offline using published JWKS — no runtime dependency on Grantex infrastructure.
+Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, human-approved, revocable permissions via signed JWTs. Any service can verify token signatures and claims locally after retrieving the issuer's published JWKS; current revocation status requires an online check or synchronized revocation data.
 
 ## Quick Facts
 
@@ -15,12 +15,15 @@ Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, hum
 - IETF Draft: https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/
 - License: Apache 2.0
 - Protocol Version: 1.0 (Final, frozen)
+- Release status: https://docs.grantex.dev/release-status
+- Release snapshot verified: 2026-07-12
 
 ## SDKs
 
-- TypeScript: `npm install @grantex/sdk`
-- Python: `pip install grantex`
-- Go: `go get github.com/mishrasanjeev/grantex-go`
+- TypeScript: `npm install @grantex/sdk@0.3.13`
+- Python: `python -m pip install grantex==0.3.14`
+- Go: `go get github.com/mishrasanjeev/grantex-go@v0.1.10` (Go 1.26.1+)
+- MCP Authorization Server: `npm install @grantex/mcp-auth@2.0.2`
 - CLI: `npm install -g @grantex/cli`
 
 ## Framework Integrations
@@ -39,7 +42,7 @@ Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, hum
 
 ## Key Packages
 - @grantex/gemma: Offline authorization for Gemma 4 on-device agents
-- @grantex/mcp-auth: OAuth 2.1 auth server for MCP servers
+- @grantex/mcp-auth 2.0.2: OAuth 2.1 + PKCE endpoint package for MCP servers; review MCP Auth limitations before production use
 - @grantex/dpdp: DPDP Act 2023 + EU AI Act control mappings
 
 ## Agentic Commerce V1 Live Pilot
@@ -129,12 +132,17 @@ Grantex is an open protocol (Apache 2.0) that lets AI agents request scoped, hum
 - Structured JSON logging via pino (zero console.log remaining)
 - Webhook retry with 20% jitter (prevents thundering herd)
 - The monorepo contains 29 packages; GitHub Actions is the source of truth for current test status
-- Zero known vulnerabilities (npm audit, pip-audit, govulncheck all clean)
+- Security status: use `SECURITY.md`, the public audit report, and current GitHub Actions scans; do not infer current vulnerability status from this static file
 
-## SDK Parity
+## SDK Coverage
 
-All 3 SDKs (TypeScript 0.3.12, Python 0.3.13, Go v0.1.9) have:
-- 21 resource services each (agents, tokens, grants, audit, anomalies, compliance, billing, policies, scim, sso, principal sessions, vault, budgets, events, usage, domains, webauthn, credentials, passports, webhooks, dpdp)
+Current primary releases are TypeScript `@grantex/sdk@0.3.13`, Python
+`grantex==0.3.14`, and Go `github.com/mishrasanjeev/grantex-go@v0.1.10`.
+Known current-release limitations:
+- Go v0.1.10: derive the registered agent ID from `did:grantex:<agentId>`; use REST/CLI for audit writes because the typed payload omits required fields
+- MCP Auth 2.0.2: single-process evaluation only; process-local codes, metadata-only consent config, no live revocation lookup, and incomplete Grantex code handoff
+
+Coverage across the primary SDKs includes core authorization resources plus:
 - Offline JWT verification via JWKS
 - Retry with exponential backoff
 - PassportsClient for MPP agent identity


### PR DESCRIPTION
## Summary

- synchronize the landing page, GitHub README, compatibility matrix, changelog, SDK guides, MCP Auth documentation, and public LLM indexes with the current published releases
- add a canonical human-readable release-status page and machine-readable `release-status.json` snapshot
- document the known Go v0.1.10 and MCP Auth v2.0.2 package limitations without overstating current behavior
- strengthen the documentation integrity checker to detect version drift, malformed release metadata, stale examples, and unsupported claims
- improve the landing page's responsive navigation, accessibility, release cards, pinned install commands, and embedded quickstarts

## Why

PR #756 established the current release metadata, but several public surfaces still showed older versions or stronger capability claims than the published packages support. This change gives users one consistent, verifiable release story across the website, repository, and documentation.

## User and developer impact

Users now see the exact published TypeScript, Python, Go, and MCP Auth versions, correct installation commands, and explicit release limitations. Maintainers gain a machine-readable release snapshot and automated drift protection for future updates.

## Validation

- `node scripts/check-docs-integrity.mjs`
- `node --check scripts/check-docs-integrity.mjs`
- `git diff --check`
- Node, Python, and Go landing examples parsed successfully; Go example is `gofmt`-clean
- four JSON-LD blocks and two inline landing-page scripts parsed successfully
- published package versions verified against their registries on 2026-07-12