### PR TITLE
Fix Mintlify parser warnings

### DIFF
--- a/docs/.mintignore
+++ b/docs/.mintignore
@@ -1,0 +1,2 @@
+# Raw kramdown-rfc2629 source artifacts are published through community/ietf-draft.mdx.
+ietf-draft/

--- a/docs/blog/mpp-agent-identity.mdx
+++ b/docs/blog/mpp-agent-identity.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent Identity for Machine Payments: Why MPP Needs a Passport Layer"
-description: "MPP solves how agents pay. But who authorized the payment? Grantex adds a verifiable identity layer — W3C credentials that let merchants know exactly who is behind every agent transaction."
+description: "Grantex adds verifiable agent and principal credential context that merchants can validate alongside independent payment and risk controls."
 date: "2026-03-20"
 authors:
   - name: "Sanjeev Kumar"
@@ -42,11 +42,11 @@ Here is the flow:
 | **1. Issue** | Human | Issues `AgentPassportCredential` — W3C VC 2.0, Ed25519 signed, with categories, spending limit, and expiry |
 | **2. Store** | Agent | Receives and stores the passport credential |
 | **3. Pay** | Agent | Makes MPP request with `Authorization: Payment` + `X-Grantex-Passport` headers |
-| **4. Verify** | Merchant | Checks signature, expiry, categories, amount in **<50ms** via cached JWKS |
-| **5. Deliver** | Merchant | Returns resource — knows the human, org, and delegation chain |
-| **6. Audit** | System | Every event logged. Revoke anytime via StatusList2021 bit-flip |
+| **4. Verify** | Merchant | Checks signature, expiry, categories, and amount using cached JWKS; latency depends on the deployment |
+| **5. Deliver** | Merchant | Returns the resource after configured passport-claim and merchant-policy checks pass |
+| **6. Record** | Application | Records configured verification and action events; current status depends on synchronized status material |
 
-The credential contains everything a merchant needs to make a trust decision:
+The credential carries inputs for a merchant trust decision. Merchants must combine them with independent payment, order, fraud, and settlement controls:
 
 | Field | What It Tells the Merchant |
 |-------|---------------------------|
@@ -60,9 +60,9 @@ The credential contains everything a merchant needs to make a trust decision:
 
 ## What Makes This Different
 
-### 1. Offline Verification in Under 50ms
+### 1. Offline Cryptographic Verification
 
-The passport is a self-contained JWT signed with the issuer's key. Merchants fetch the JWKS once, cache it, and verify every subsequent passport locally. No API call to Grantex. No latency added to the payment flow.
+The passport is a self-contained JWT signed with the issuer's key. With cached JWKS and status material, merchants can perform signature and claim checks locally without a per-request Grantex verification call. Latency and current revocation freshness depend on deployment and synchronization choices.
 
 ```typescript
 import { requireAgentPassport } from '@grantex/mpp';
@@ -210,4 +210,4 @@ npm install @grantex/mpp @grantex/sdk
 
 ---
 
-*MPP solved how agents pay. Grantex solves who authorized the payment. Together, they make agentic commerce auditable, revocable, and compliant — without locking anyone into a proprietary network.*
+*MPP addresses payment transport. Grantex can add verifiable agent and principal authority context without replacing merchant, payment, order, settlement, fraud, or compliance controls.*

--- a/docs/guides/raspberry-pi.mdx
+++ b/docs/guides/raspberry-pi.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Raspberry Pi Guide"
 sidebarTitle: "Raspberry Pi"
-description: "Run Grantex-authorized Gemma 4 agents on Raspberry Pi 5 with offline verification in under 5ms."
+description: "Run Grantex-authorized Gemma agents on Raspberry Pi 5 with offline token verification, scope enforcement, local audit records, and later synchronization."
 ---
 
 ## Overview
 
-Raspberry Pi 5 with 8GB RAM can run Gemma 4's smaller model variants locally via `llama.cpp` or `mediapipe`. This guide shows how to add Grantex offline authorization to a Gemma 4 agent running on a Pi, so every action is scope-checked and audit-logged even without internet.
+Raspberry Pi 5 with 8GB RAM can run smaller Gemma model variants locally through compatible runtimes. This guide shows how to add Grantex offline authorization so configured actions are scope-checked and recorded locally without internet connectivity; current revocation state requires later synchronization.
 
 ## Prerequisites
 
@@ -214,19 +214,19 @@ if result.revocation_status == "revoked":
     os.remove(BUNDLE_PATH)
 ```
 
-## Benchmarks
+## Performance Considerations
 
-Measured on a Raspberry Pi 5 (8GB, Bookworm, Python 3.11):
+A Raspberry Pi deployment performs these operations locally:
 
-| Operation | Time | Notes |
+| Operation | Execution characteristic | Notes |
 |---|---|---|
-| `loadBundle` (decrypt) | ~8ms | AES-256-GCM decryption of ~2KB bundle |
-| `verifier.verify()` | ~3-5ms | RS256 signature verification |
-| `enforce_scopes()` | <0.01ms | Array comparison |
-| `audit_log.append()` | ~2ms | SHA-256 hash + Ed25519 sign + JSONL append |
-| `verify_chain()` (100 entries) | ~15ms | Full chain re-verification |
+| `loadBundle` (decrypt) | Local cryptographic operation | AES-256-GCM decryption of the stored bundle |
+| `verifier.verify()` | Local signature verification | Runtime depends on key material, implementation, and device load |
+| `enforce_scopes()` | Local array comparison | Cost scales with the number of required and granted scopes |
+| `audit_log.append()` | Local hashing, signing, and storage | Runtime depends on storage and signing configuration |
+| `verify_chain()` | Full-chain verification | Cost scales with the number of entries |
 
-Total overhead per agent action: **under 5ms**. This is negligible compared to Gemma 4 inference time (~500ms-2s for the 2B model on Pi 5).
+Benchmark these operations on the target device and workload. Performance varies with bundle size, key implementation, storage, thermal state, and concurrent inference load.
 
 ## Production Tips
 


### PR DESCRIPTION
# Fix Mintlify parser warnings

## What changed

- Removed raw less-than latency expressions that Mintlify interpreted as malformed JSX.
- Replaced unsupported fixed-latency and automatic-audit claims with deployment-dependent implementation guidance.
- Added `docs/.mintignore` so raw kramdown-rfc2629 source artifacts are not parsed as MDX; the public community wrapper remains published.

## Why

The production docs deployment succeeded but reported parser errors for two navigated pages and two raw IETF source files. This follow-up makes the deployment clean and restores the Raspberry Pi guide route.

## Validation

- `node scripts/check-docs-integrity.mjs`
- `node scripts/check-seo-aeo.mjs`
- No raw `<digit` constructs remain in the affected MDX pages
- `git diff --check`
