### PR TITLE
Fix mobile layout and page semantics

### DIFF
--- a/apps/portal/src/pages/Login.tsx
+++ b/apps/portal/src/pages/Login.tsx
@@ -29,7 +29,7 @@ export function Login() {
   }
 
   return (
-    <div className="min-h-screen bg-gx-bg flex items-center justify-center px-4">
+    <main className="min-h-screen bg-gx-bg flex items-center justify-center px-4">
       <Card className="w-full max-w-md">
         <div className="text-center mb-8">
           <h1 className="font-mono text-xl font-bold text-gx-accent mb-1">
@@ -45,7 +45,10 @@ export function Login() {
             </label>
             <input
               id="apiKey"
+              name="apiKey"
               type="password"
+              autoComplete="current-password"
+              required
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
               placeholder="gx_live_..."
@@ -66,6 +69,6 @@ export function Login() {
           </Link>
         </p>
       </Card>
-    </div>
+    </main>
   );
 }

--- a/apps/portal/src/pages/Signup.tsx
+++ b/apps/portal/src/pages/Signup.tsx
@@ -62,7 +62,7 @@ export function Signup() {
 
   if (newKey) {
     return (
-      <div className="min-h-screen bg-gx-bg flex items-center justify-center px-4">
+      <main className="min-h-screen bg-gx-bg flex items-center justify-center px-4">
         <Card className="w-full max-w-md">
           <div className="text-center mb-6">
             <div className="w-12 h-12 rounded-full bg-gx-accent/15 flex items-center justify-center mx-auto mb-3">
@@ -70,7 +70,7 @@ export function Signup() {
                 <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
               </svg>
             </div>
-            <h2 className="text-lg font-semibold text-gx-text">Account created</h2>
+            <h1 className="text-lg font-semibold text-gx-text">Account created</h1>
             <p className="text-sm text-gx-muted mt-1">
               Save your API key — you won&apos;t see it again.
             </p>
@@ -91,12 +91,12 @@ export function Signup() {
             Continue to Dashboard
           </Button>
         </Card>
-      </div>
+      </main>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gx-bg flex items-center justify-center px-4">
+    <main className="min-h-screen bg-gx-bg flex items-center justify-center px-4">
       <Card className="w-full max-w-md">
         <div className="text-center mb-8">
           <h1 className="font-mono text-xl font-bold text-gx-accent mb-1">
@@ -112,7 +112,10 @@ export function Signup() {
             </label>
             <input
               id="name"
+              name="name"
               type="text"
+              autoComplete="organization"
+              required
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="Acme Corp"
@@ -127,7 +130,9 @@ export function Signup() {
             </label>
             <input
               id="email"
+              name="email"
               type="email"
+              autoComplete="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="dev@acme.com"
@@ -147,6 +152,6 @@ export function Signup() {
           </Link>
         </p>
       </Card>
-    </div>
+    </main>
   );
 }

--- a/apps/portal/src/pages/__tests__/Login.test.tsx
+++ b/apps/portal/src/pages/__tests__/Login.test.tsx
@@ -30,7 +30,12 @@ describe('Login', () => {
 
   it('renders the login form with API key input', () => {
     renderLogin();
-    expect(screen.getByLabelText('API Key')).toBeInTheDocument();
+    const apiKeyInput = screen.getByLabelText('API Key');
+    expect(screen.getByRole('main')).toBeInTheDocument();
+    expect(apiKeyInput).toBeInTheDocument();
+    expect(apiKeyInput).toHaveAttribute('name', 'apiKey');
+    expect(apiKeyInput).toHaveAttribute('autocomplete', 'current-password');
+    expect(apiKeyInput).toBeRequired();
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
     expect(screen.getByText(/Sign in to your developer dashboard/)).toBeInTheDocument();
   });

--- a/apps/portal/src/pages/__tests__/Signup.test.tsx
+++ b/apps/portal/src/pages/__tests__/Signup.test.tsx
@@ -32,8 +32,15 @@ describe('Signup', () => {
 
   it('renders the signup form', () => {
     renderSignup();
-    expect(screen.getByLabelText('Name')).toBeInTheDocument();
-    expect(screen.getByLabelText(/Email/)).toBeInTheDocument();
+    const name = screen.getByLabelText('Name');
+    const email = screen.getByLabelText(/Email/);
+    expect(screen.getByRole('main')).toBeInTheDocument();
+    expect(name).toHaveAttribute('name', 'name');
+    expect(name).toHaveAttribute('autocomplete', 'organization');
+    expect(name).toBeRequired();
+    expect(email).toHaveAttribute('name', 'email');
+    expect(email).toHaveAttribute('autocomplete', 'email');
+    expect(email).not.toBeRequired();
     expect(screen.getByRole('button', { name: 'Create Account' })).toBeInTheDocument();
   });
 
@@ -81,6 +88,7 @@ describe('Signup', () => {
     await user.type(screen.getByLabelText('Name'), 'Acme');
     await user.click(screen.getByRole('button', { name: 'Create Account' }));
     await waitFor(() => expect(screen.getByText('gx_live_key123')).toBeInTheDocument());
+    expect(screen.getByRole('main')).toBeInTheDocument();
     expect(screen.getByText('Account created')).toBeInTheDocument();
     expect(screen.getByText(/Save your API key/)).toBeInTheDocument();
   });

--- a/web/index.html
+++ b/web/index.html
@@ -748,6 +748,13 @@
       overflow-x: auto;
       color: var(--text);
     }
+    .feature-code-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 32px;
+      align-items: start;
+    }
+    .feature-code-grid > * { min-width: 0; }
     .copy-btn {
       position: absolute;
       top: 12px;
@@ -930,7 +937,7 @@
     }
     @media (max-width: 680px) {
       .enterprise-grid { grid-template-columns: 1fr; }
-      #mpp .cards + div + div { grid-template-columns: 1fr !important; }
+      .feature-code-grid { grid-template-columns: minmax(0, 1fr); }
     }
     .enterprise-features {
       display: flex;
@@ -1026,6 +1033,7 @@
     }
     .footer-links {
       display: flex;
+      flex-wrap: wrap;
       gap: 20px;
       list-style: none;
       font-size: 13px;
@@ -1242,6 +1250,7 @@
       .install-commands { grid-template-columns: 1fr; }
       .tab-btn { padding: 10px 14px; }
       .footer-inner { flex-direction: column; align-items: flex-start; }
+      .footer-links { width: 100%; gap: 10px 16px; }
     }
   </style>
 </head>
@@ -1279,6 +1288,8 @@
     </div>
   </div>
 </nav>
+
+<main>
 
 <!-- ── Hero ──────────────────────────────────────────────────────────────── -->
 <section class="hero">
@@ -1555,7 +1566,7 @@
 
     <!-- Bring Your Own Manifest — hero callout -->
     <div style="background:linear-gradient(135deg, rgba(88,166,255,0.08), rgba(249,117,131,0.08));border:2px solid var(--accent);border-radius:16px;padding:32px 40px;max-width:800px;margin:0 auto 48px;">
-      <div style="display:grid;grid-template-columns:repeat(auto-fit, minmax(300px, 1fr));gap:40px;align-items:center;">
+      <div style="display:grid;grid-template-columns:repeat(auto-fit, minmax(min(300px, 100%), 1fr));gap:40px;align-items:center;">
         <div>
           <div style="font-size:13px;font-weight:600;color:var(--accent);text-transform:uppercase;letter-spacing:1px;margin-bottom:8px;">Bring Your Own Manifest</div>
           <h3 style="font-size:22px;color:var(--text);margin:0 0 12px;line-height:1.3;">Your connectors.<br>Your permissions.<br>Your manifests.</h3>
@@ -2203,7 +2214,7 @@ func main() {
     </div>
 
     <!-- ── Two-column: features + code ────────────────────────────────── -->
-    <div style="display:grid;grid-template-columns:1fr 1fr;gap:32px;align-items:start;">
+    <div class="feature-code-grid">
       <!-- Left: feature cards -->
       <div style="display:flex;flex-direction:column;gap:16px;">
         <div class="card" style="border-left:3px solid var(--accent);margin:0;">
@@ -2351,7 +2362,7 @@ func main() {
     </div>
 
     <!-- ── Two-column: features + code ────────────────────────────────── -->
-    <div style="display:grid;grid-template-columns:1fr 1fr;gap:32px;align-items:start;">
+    <div class="feature-code-grid">
       <!-- Left: problem/solution -->
       <div style="display:flex;flex-direction:column;gap:16px;">
         <div class="card" style="border-left:3px solid #ef4444;margin:0;">
@@ -3109,6 +3120,8 @@ func main() {
     </div>
   </div>
 </section>
+
+</main>
 
 <!-- ── Footer ─────────────────────────────────────────────────────────────── -->
 <footer>

--- a/web/playground.html
+++ b/web/playground.html
@@ -235,7 +235,7 @@
   </div>
 </nav>
 
-<div class="container">
+<main class="container">
 
   <!-- Header -->
   <div class="pg-header">
@@ -420,7 +420,7 @@
     </div>
 
   </div>
-</div>
+</main>
 
 <footer class="pg-footer">
   <div class="container">


### PR DESCRIPTION
## What changed

- prevent landing-page overflow at 320px and 390px by making feature/code grids shrink safely and stack on mobile
- allow footer links and the manifest callout grid to wrap within narrow viewports
- add one `main` landmark to the landing page, playground, login, signup, and signup success state
- add semantic credential/form metadata to login and signup inputs
- promote the signup success heading to the page-level heading
- add portal regression assertions for landmarks and input semantics

## Root cause

Two inline CSS grids used auto minimum track sizing, so long code samples expanded the document beyond the viewport. The footer link list and manifest callout also retained fixed minimum content widths on narrow screens. Several standalone routes used generic wrappers rather than page landmarks, and their inputs omitted browser/accessibility metadata.

## Impact

The landing page now fits 320px, 390px, and desktop viewports without horizontal scrolling. Screen readers receive a single main landmark on every affected route, and password managers/form tooling receive the expected field metadata.

## Validation

- `npm --prefix apps/portal run typecheck`
- `npm --prefix apps/portal test` — 96 files, 938 tests
- `npm --prefix apps/portal run build`
- `node scripts/check-docs-integrity.mjs`
- static landmark/layout assertions
- in-app browser at 320x800, 390x844, and 1440x900
- login, signup, playground, mobile menu, and console-error checks