### PR TITLE
feat: index public playgrounds

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -134,12 +134,6 @@
         ]
       },
       {
-        "source": "/playground",
-        "headers": [
-          { "key": "X-Robots-Tag", "value": "noindex,nofollow" }
-        ]
-      },
-      {
         "source": "/commerce-playground",
         "headers": [
           { "key": "X-Robots-Tag", "value": "noindex,nofollow" }
@@ -147,18 +141,6 @@
       },
       {
         "source": "/ph-gallery",
-        "headers": [
-          { "key": "X-Robots-Tag", "value": "noindex,nofollow" }
-        ]
-      },
-      {
-        "source": "/mpp-demo/**",
-        "headers": [
-          { "key": "X-Robots-Tag", "value": "noindex,nofollow" }
-        ]
-      },
-      {
-        "source": "/x402-playground/**",
         "headers": [
           { "key": "X-Robots-Tag", "value": "noindex,nofollow" }
         ]

--- a/web/mpp-demo/index.html
+++ b/web/mpp-demo/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="robots" content="noindex,nofollow">
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
   <title>Grantex × MPP Demo — Agent Identity for Machine Payments</title>
-  <meta name="description" content="Interactive demo: issue AgentPassportCredentials, simulate MPP payment flows with identity verification, and verify passports as a merchant. Grantex adds verifiable agent identity to the Machine Payments Protocol.">
+  <meta name="description" content="Try Grantex agent identity for MPP payments: issue passports, verify identity, and simulate merchant payment flows in your browser.">
   <meta name="keywords" content="Grantex, MPP, Machine Payments Protocol, agent identity, AgentPassportCredential, agentic commerce, MPP OAuth, AI agent payments, Tempo, USDC, merchant verification, W3C Verifiable Credentials">
   <link rel="canonical" href="https://grantex.dev/mpp-demo">
   <meta property="og:title" content="Grantex × MPP Demo — Agent Identity for Machine Payments">
@@ -13,11 +13,16 @@
   <meta property="og:url" content="https://grantex.dev/mpp-demo">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="Grantex MPP agent identity playground">
 
   <!-- JSON-LD -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebApplication","name":"Grantex MPP Demo","url":"https://grantex.dev/mpp-demo","description":"Interactive demo of agent identity and delegation for agentic commerce using the Machine Payments Protocol","applicationCategory":"DeveloperApplication","operatingSystem":"Web"}</script>
 
   <meta name="twitter:card" content="summary">
+  <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+  <meta name="twitter:image:alt" content="Grantex MPP agent identity playground">
   <meta name="twitter:title" content="Grantex × MPP Demo — Agent Identity for Machine Payments">
   <style>
     :root {

--- a/web/playground.html
+++ b/web/playground.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="robots" content="noindex,nofollow">
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
   <title>Playground — Grantex | Try AI Agent Authorization Live</title>
   <meta name="description" content="Try the Grantex authorization protocol live in your browser. Create agents, issue scoped grants, and verify JWTs — no signup required.">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -14,6 +14,9 @@
   <meta property="og:description" content="Create agents, issue scoped grants, and verify JWTs in your browser. No signup required.">
   <meta property="og:url" content="https://grantex.dev/playground">
   <meta property="og:image" content="https://grantex.dev/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="Grantex interactive authorization playground">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Grantex">
 
@@ -25,6 +28,7 @@
   <meta name="twitter:title" content="Grantex Playground — Try AI Agent Authorization Live">
   <meta name="twitter:description" content="Create agents, issue scoped grants, and verify JWTs in your browser. No signup required.">
   <meta name="twitter:image" content="https://grantex.dev/og-image.png">
+  <meta name="twitter:image:alt" content="Grantex interactive authorization playground">
   <style>
     :root {
       --bg:       #0d1117;

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,6 +1,7 @@
 # Grantex public documentation and marketing content is crawlable.
 # Authentication, not robots.txt, protects non-public application state.
-# Public noindex app/demo shells remain crawlable so page-level noindex can be read.
+# Public demo pages remain crawlable and indexable; private app and operator shells
+# use page-level noindex so Google can process the directive without robots blocking.
 #
 # The explicit names below document known crawler purposes as of 2026-07-12.
 # Google-Extended, GPTBot, ClaudeBot, and Applebot-Extended are product/training

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -104,4 +104,16 @@
     <loc>https://grantex.dev/x402</loc>
     <lastmod>2026-07-12</lastmod>
   </url>
+  <url>
+    <loc>https://grantex.dev/playground</loc>
+    <lastmod>2026-07-29</lastmod>
+  </url>
+  <url>
+    <loc>https://grantex.dev/mpp-demo</loc>
+    <lastmod>2026-07-29</lastmod>
+  </url>
+  <url>
+    <loc>https://grantex.dev/x402-playground</loc>
+    <lastmod>2026-07-29</lastmod>
+  </url>
 </urlset>

--- a/web/x402-playground/index.html
+++ b/web/x402-playground/index.html
@@ -3,8 +3,26 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="robots" content="noindex,nofollow">
-<title>Grantex x402 Playground</title>
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
+<title>Grantex x402 Playground - Agent Payment Authorization Demo</title>
+<meta name="description" content="Try Grantex authorization for x402 agent payments in a live browser demo with scoped spend limits and merchant verification.">
+<link rel="canonical" href="https://grantex.dev/x402-playground">
+<link rel="alternate" type="text/plain" href="/llms.txt" title="Grantex LLM index">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta property="og:title" content="Grantex x402 Playground - Agent Payment Authorization Demo">
+<meta property="og:description" content="Try Grantex authorization for x402 agent payments in a live browser demo with scoped spend limits and merchant verification.">
+<meta property="og:url" content="https://grantex.dev/x402-playground">
+<meta property="og:image" content="https://grantex.dev/og-image.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="Grantex x402 agent payment authorization playground">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Grantex">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Grantex x402 Playground - Agent Payment Authorization Demo">
+<meta name="twitter:description" content="Try Grantex authorization for x402 agent payments in a live browser demo with scoped spend limits and merchant verification.">
+<meta name="twitter:image" content="https://grantex.dev/og-image.png">
+<meta name="twitter:image:alt" content="Grantex x402 agent payment authorization playground">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebApplication","name":"Grantex x402 Playground","url":"https://grantex.dev/x402-playground","description":"Interactive demo of agent spend authorization for x402 payment flows","applicationCategory":"DeveloperApplication","operatingSystem":"Web"}</script>
 <style>
 *{margin:0;padding:0;box-sizing:border-box}


### PR DESCRIPTION
## What changed

- make the authorization, MPP, and x402 playgrounds indexable
- remove their Firebase `X-Robots-Tag: noindex` rules
- add complete Open Graph and Twitter image metadata
- add the three canonical URLs to the production sitemap
- clarify the public-demo policy in `robots.txt`

## Why

These are public, useful product demos. Their page metadata and hosting headers previously prevented search indexing despite the pages being crawlable.

## Validation

- `node scripts/check-seo-aeo.mjs`
- `node scripts/check-docs-integrity.mjs`
- Firebase JSON parse and noindex-route assertions
- sitemap XML parse and canonical URL assertions
- `git diff --check`
