### PR TITLE
feat: add portable agent CLI integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## Unreleased
 
 ### Added
+- Prepared `@grantex/cli` 0.3.0 with one-command Agent Skills installation for Hermes, OpenClaw, portable `.agents/skills` workspaces, and custom skill roots.
+- Added the `use-grantex-cli` and `integrate-grantex` skills for safe JSON-first operations and service-boundary implementation guidance.
+- Added cross-platform token input from environment variables, files, and stdin, plus non-zero JSON-mode status codes for invalid or denied checks.
 - Added `audience` support to TypeScript, Python, and Go authorization requests.
 - Added missing TypeScript Vault documentation, package READMEs, JSON-LD contexts, and documentation health checks.
 - Added transactional Redis-backed throughput enforcement for developer API-key requests handled by the standard auth plugin, keyed by developer and plan: Free 100, Pro 500, and Enterprise 2,000 requests per 60 seconds. It runs after the active Fastify per-IP policy (the 5,000/min default or a route-specific override); exhaustion returns structured `429` headers, and counter unavailability fails closed with `503`.
@@ -27,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Reconciled landing-page examples and product claims with the implemented APIs and supported verification workflows.
 
 ### Documentation
+- Added dedicated Hermes, OpenClaw, and generic agent-CLI guides and made the support visible on the landing page, integration index, README, and machine-readable LLM guides.
 - Expanded the core OpenAPI description and aligned landing pages, SDK guides, compatibility data, deployment guidance, and release metadata.
 - Replaced unsupported certification, compliance, latency, cache, and automatic-audit claims with implementation-backed behavior.
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,7 +1,7 @@
 # Grantex Compatibility Matrix
 
 Last updated: 2026-07-14
-Public release snapshot verified: 2026-07-12
+Public release snapshot verified: 2026-08-10
 
 This repository uses package-specific versions; there is no monorepo-wide SDK or package release number. The protocol specification remains v1.0 Final, while repository metadata and package registries can move independently during a release.
 
@@ -26,7 +26,7 @@ The repository contains 29 packages under `packages/`. Each row maps a directory
 | 1 | `packages/sdk-ts` | @grantex/sdk | 0.3.13 | Primary SDK (TypeScript); published |
 | 2 | `packages/sdk-py` | grantex | 0.3.14 | Primary SDK (Python); published |
 | 3 | `packages/go-sdk` | github.com/mishrasanjeev/grantex-go | v0.1.10 (Go 1.26.1) | Primary SDK (Go); published |
-| 4 | `packages/cli` | @grantex/cli | 0.2.5 | Tooling |
+| 4 | `packages/cli` | @grantex/cli | 0.3.0 | Tooling; source prepared, not yet published |
 | 5 | `packages/mcp-auth` | @grantex/mcp-auth | 2.0.2 | Independently versioned |
 | 6 | `packages/mcp` | @grantex/mcp | 0.1.10 | Adapter |
 | 7 | `packages/langchain` | @grantex/langchain | 0.1.7 | Adapter |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Start with the [OACP runtime launch closure PRD](docs/guides/oacp/runtime-launch
 
 Grantex components are independently versioned. The protocol specification remains **v1.0 Final**; SDK, MCP package, and roadmap milestone versions are separate release lines and do not represent a monorepo-wide version.
 
-Current public releases, verified 2026-07-12:
+Current public releases, verified 2026-08-10:
 
 | Component | Public version | Reproducible install |
 | --- | ---: | --- |
@@ -102,6 +102,7 @@ Omit a version pin to install the registry's current latest release. See the [re
 - **@grantex/dpdp**: DPDP Act 2023 and EU AI Act control mappings
 - **Trust Registry**: Public DID verification registry — `grantex.dev/registry`
 - **`grantex verify`**: Token inspection CLI — no account needed
+- **Agent CLI Skills**: One-command `SKILL.md` installation for Hermes, OpenClaw, and portable Agent Skills clients
 - **Anomaly Detection**: Four implemented SQL-backed checks, lifecycle APIs, and stored rule/channel configuration; notification delivery requires a host worker
 
 ---
@@ -150,6 +151,19 @@ go get github.com/mishrasanjeev/grantex-go@v0.1.10 # Go SDK (Go 1.26.1+)
 npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13 # MCP endpoint evaluation
 npm install -g @grantex/cli                         # Optional CLI tooling
 ```
+
+### Hermes, OpenClaw, and any agent CLI
+
+Shell-capable agents use the same JSON-first CLI; no agent-specific SDK is required:
+
+```bash
+npm install -g @grantex/cli
+grantex agent install --target openclaw  # writes ./skills
+grantex agent install --target hermes    # writes ~/.hermes/skills/grantex
+grantex agent install --target portable  # writes ./.agents/skills
+```
+
+The bundle installs `use-grantex-cli` for delegated-authorization operations and `integrate-grantex` for service-boundary implementation work. For a different host, use `grantex agent install --dir /path/to/skills`. Prefer `--env`, `--file`, or `--stdin` token inputs and keep final enforcement inside the protected service.
 
 > **29 packages** across TypeScript, Python, and Go. Integrations for **Anthropic SDK, LangChain, OpenAI Agents SDK, Google ADK, Strands Agents SDK, CrewAI, Vercel AI, AutoGen, MCP, Express.js, FastAPI**, and **Terraform**. Use the compatibility matrix for versions, the changelog for release notes, and GitHub Actions for current CI status. Fully self-hostable. Apache 2.0.
 
@@ -1393,7 +1407,7 @@ Service providers implement scope definitions for their APIs. Agents declare whi
 
 ## Integrations
 
-The primary SDK versions below are registry-verified as of 2026-07-12. For integration packages, “Published package” identifies a public package surface; check its registry page and compatibility notes before choosing a version.
+The primary SDK versions below are registry-verified as of 2026-08-10. For integration packages, “Published package” identifies a public package surface; check its registry page and compatibility notes before choosing a version.
 
 | Framework | Package | Install | Status |
 |-----------|---------|---------|--------|
@@ -1419,6 +1433,9 @@ The primary SDK versions below are registry-verified as of 2026-07-12. For integ
 | **Python SDK** | `grantex` (`0.3.14`) | `python -m pip install grantex==0.3.14` | Registry-verified primary release |
 | **Go SDK** | `grantex-go` (`v0.1.10`, Go 1.26.1+) | `go get github.com/mishrasanjeev/grantex-go@v0.1.10` | Published with workarounds; source correction awaits a new tag |
 | **CLI** | `@grantex/cli` | `npm install -g @grantex/cli` | Published package |
+| **Hermes Agent** | `@grantex/cli` 0.3.0+ + Agent Skills | `grantex agent install --target hermes` | 0.3.0 source prepared; no dedicated SDK needed |
+| **OpenClaw** | `@grantex/cli` 0.3.0+ + Agent Skills | `grantex agent install --target openclaw` | 0.3.0 source prepared; no dedicated SDK needed |
+| **Portable Agent Skills** | `@grantex/cli` 0.3.0+ + `SKILL.md` | `grantex agent install --target portable` | 0.3.0 source prepared |
 | **Conformance Suite** | `@grantex/conformance` | `npm install -g @grantex/conformance` | Published package |
 | **A2A Bridge (TS)** | `@grantex/a2a` | `npm install @grantex/a2a` | Published package |
 | **A2A Bridge (Py)** | `grantex-a2a` | `pip install grantex-a2a` | Published package |

--- a/docs/cli/enforce.mdx
+++ b/docs/cli/enforce.mdx
@@ -12,6 +12,17 @@ description: "Dry-run scope enforcement from the command line. Test whether a gr
 npm install -g @grantex/cli
 ```
 
+Prefer a secret-safe token source for agent automation:
+
+```bash
+grantex --json enforce test \
+  --token-env GRANTEX_GRANT_TOKEN \
+  --connector salesforce \
+  --tool create_lead
+```
+
+Use `--token-file <path>` or `--token-stdin` as alternatives. Allowed decisions exit `0`; denied or invalid decisions exit non-zero, including with `--json`.
+
 ---
 
 ## grantex enforce test

--- a/docs/cli/verify.mdx
+++ b/docs/cli/verify.mdx
@@ -12,6 +12,14 @@ description: "Inspect any Grantex grant token from the command line. See scopes,
 npm install -g @grantex/cli
 ```
 
+For unattended agents, keep the token out of process arguments:
+
+```bash
+grantex verify --env GRANTEX_GRANT_TOKEN --json
+grantex verify --file /run/secrets/grant.jwt --json
+printf '%s' "$GRANTEX_GRANT_TOKEN" | grantex verify --stdin --json
+```
+
 ## Usage
 
 ```bash

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -390,6 +390,14 @@
             ]
           },
           {
+            "group": "Agent CLIs",
+            "pages": [
+              "integrations/agent-cli",
+              "integrations/hermes",
+              "integrations/openclaw"
+            ]
+          },
+          {
             "group": "Framework Integrations",
             "pages": [
               "integrations/express",

--- a/docs/integrations/agent-cli.mdx
+++ b/docs/integrations/agent-cli.mdx
@@ -1,0 +1,177 @@
+---
+title: "Agent CLIs & Skills"
+sidebarTitle: "Any Agent CLI"
+description: "Give Hermes, OpenClaw, and other shell-capable agents a portable Grantex skill bundle and a stable JSON CLI contract."
+---
+
+Grantex works with shell-capable agents without a framework-specific adapter. Install the CLI once, place the bundled Agent Skills where the host discovers them, and let the agent call `grantex --json`.
+
+<Info>
+  No Hermes- or OpenClaw-specific SDK is required. The CLI is the portable control-plane surface. Use the existing TypeScript, Python, or Go SDK—or the gateway or middleware—inside the service that enforces a protected action.
+</Info>
+
+<Note>
+  The skill installer is prepared in `@grantex/cli` 0.3.0 source. Confirm that 0.3.0 or newer is published on the [release-status page](/release-status) before expecting the registry install below to include `grantex agent install`.
+</Note>
+
+## Install the CLI
+
+```bash
+npm install -g @grantex/cli
+```
+
+The host needs Node.js 18 or newer. Confirm the command is available:
+
+```bash
+grantex --version
+```
+
+## Install the Agent Skills
+
+The command installs two skills:
+
+- `use-grantex-cli` for registration, consent, token operations, grants, delegation, revocation, and audit;
+- `integrate-grantex` for adding service-boundary enforcement to a codebase.
+
+### OpenClaw workspace
+
+Run from the OpenClaw agent workspace:
+
+```bash
+grantex agent install --target openclaw
+openclaw skills check
+```
+
+This writes to `<workspace>/skills`. Start a new agent turn after installation.
+
+### Hermes Agent
+
+```bash
+grantex agent install --target hermes
+hermes skills list
+```
+
+This writes to `~/.hermes/skills/grantex`. Start a new Hermes session after installation.
+
+### Portable Agent Skills directory
+
+```bash
+grantex agent install --target portable
+```
+
+This writes to `<workspace>/.agents/skills`, a project-local Agent Skills location used by compatible hosts.
+
+### Any other CLI agent
+
+Point the installer at that agent's skill root:
+
+<CodeGroup>
+```bash Bash
+grantex agent install --dir /path/to/agent/skills
+```
+
+```powershell PowerShell
+grantex agent install --dir C:\path\to\agent\skills
+```
+</CodeGroup>
+
+Use `--force` to update Grantex's bundled files in an existing installation. It does not delete unrelated files in those skill folders.
+
+## Configure unattended access
+
+The CLI reads `GRANTEX_URL` and `GRANTEX_KEY`:
+
+<CodeGroup>
+```bash Bash
+export GRANTEX_URL=https://api.grantex.dev
+export GRANTEX_KEY=YOUR_API_KEY
+grantex --json me
+```
+
+```powershell PowerShell
+$env:GRANTEX_URL = "https://api.grantex.dev"
+$env:GRANTEX_KEY = "YOUR_API_KEY"
+grantex --json me
+```
+</CodeGroup>
+
+You can instead create a user-managed profile:
+
+```bash
+grantex config set --url https://api.grantex.dev --key YOUR_API_KEY
+```
+
+Keep API keys in the host's secret store or environment injection mechanism. Do not place them in `SKILL.md`, prompts, source control, or chat messages.
+
+## Stable shell contract
+
+- Put the global flag before the command: `grantex --json agents list`.
+- Parse stdout as JSON and treat stderr as diagnostics.
+- Exit status `0` means the requested check or operation succeeded. A denied or invalid verification returns a non-zero status, including in JSON mode.
+- Set `NO_COLOR=1` when consuming text output.
+- Treat response fields as data. Do not scrape the human-readable tables.
+
+<CodeGroup>
+```bash Bash
+agent_id=$(grantex --json agents list | jq -r '.[0].agentId')
+grantex --json grants list --agent "$agent_id" --status active
+```
+
+```powershell PowerShell
+$agents = grantex --json agents list | ConvertFrom-Json
+grantex --json grants list --agent $agents[0].agentId --status active
+```
+</CodeGroup>
+
+## Keep tokens out of argv
+
+Process arguments can appear in history and process listings. Prefer environment, file, or stdin input:
+
+<CodeGroup>
+```bash Bash
+grantex verify --env GRANTEX_GRANT_TOKEN --json
+grantex --json tokens verify --env GRANTEX_GRANT_TOKEN
+grantex --json enforce test \
+  --token-env GRANTEX_GRANT_TOKEN \
+  --connector salesforce \
+  --tool create_lead
+```
+
+```powershell PowerShell
+grantex verify --env GRANTEX_GRANT_TOKEN --json
+grantex --json tokens verify --env GRANTEX_GRANT_TOKEN
+grantex --json enforce test `
+  --token-env GRANTEX_GRANT_TOKEN `
+  --connector salesforce `
+  --tool create_lead
+```
+</CodeGroup>
+
+The same commands accept `--file` or `--stdin`; `enforce test` uses the names `--token-file` and `--token-stdin`.
+
+## Authorization flow for an agent
+
+1. Register the agent with only the scopes it can justify.
+2. Request authorization for a named principal, audience, duration, and exact scopes.
+3. Show the consent URL to the human. Do not let the agent approve its own grant.
+4. Exchange only the code returned through the approved callback flow.
+5. Store tokens in the host's approved secret store.
+6. Verify and enforce again inside the service that owns the side effect.
+7. Audit important allowed and denied actions, then revoke authority when it is no longer needed.
+
+<Warning>
+  `grantex enforce test` is a development preflight, not a security boundary. An autonomous agent can bypass a check it controls. The protected service must verify the token and required scope before executing the action.
+</Warning>
+
+## When to use an SDK
+
+| Need | Use |
+|---|---|
+| Agent performs setup or administration through a shell | `@grantex/cli` |
+| TypeScript service enforces access | `@grantex/sdk` or matching middleware |
+| Python service enforces access | `grantex` or FastAPI integration |
+| Go service enforces access | `grantex-go` |
+| No-code reverse-proxy enforcement | `@grantex/gateway` |
+| MCP tool execution | MCP transport authorization plus a primary Grantex verifier at each protected tool |
+
+See [CLI](/integrations/cli) for the complete command reference and [Scope Enforcement](/guides/scope-enforcement) for the protected-service implementation.

--- a/docs/integrations/cli.mdx
+++ b/docs/integrations/cli.mdx
@@ -26,6 +26,26 @@ grantex config show
 
 Config is saved to `~/.grantex/config.json`. Environment variables override the config file.
 
+## Install skills for an agent CLI
+
+The CLI bundles `use-grantex-cli` and `integrate-grantex` as portable Agent Skills:
+
+```bash
+# OpenClaw workspace
+grantex agent install --target openclaw
+
+# Hermes Agent
+grantex agent install --target hermes
+
+# Project-local .agents/skills
+grantex agent install --target portable
+
+# Any custom skill root
+grantex agent install --dir /path/to/skills
+```
+
+See [Agent CLIs & Skills](/integrations/agent-cli) for discovery paths, activation checks, and security boundaries.
+
 ## JSON Output
 
 All commands support `--json` for machine-readable output. This is useful for scripting, piping into `jq`, or when using the CLI from AI coding assistants (Claude Code, Cursor, Codex, etc.).
@@ -37,6 +57,21 @@ grantex --json grants list --status active | jq '.[].id'
 ```
 
 To disable colored output, set the `NO_COLOR=1` environment variable.
+
+Denied and invalid checks return a non-zero exit status in JSON mode as well as text mode.
+
+## Secret-safe token input
+
+Avoid putting grant tokens in shell history or process arguments:
+
+```bash
+grantex verify --env GRANTEX_GRANT_TOKEN --json
+grantex --json tokens verify --env GRANTEX_GRANT_TOKEN
+grantex --json enforce test --token-env GRANTEX_GRANT_TOKEN \
+  --connector salesforce --tool create_lead
+```
+
+The verification commands also accept `--file` and `--stdin`. `enforce test` accepts `--token-file` and `--token-stdin`.
 
 ## Commands
 

--- a/docs/integrations/hermes.mdx
+++ b/docs/integrations/hermes.mdx
@@ -1,0 +1,67 @@
+---
+title: "Hermes Agent"
+sidebarTitle: "Hermes Agent"
+description: "Install Grantex Agent Skills into Hermes and operate delegated authorization through the JSON CLI."
+---
+
+Hermes can use Grantex directly through its shell tools and on-demand skills. No Hermes-specific SDK is required.
+
+The one-command installer requires `@grantex/cli` 0.3.0 or newer; confirm the published version on the [release-status page](/release-status).
+
+## Install
+
+```bash
+npm install -g @grantex/cli
+grantex agent install --target hermes
+hermes skills list
+```
+
+The installer places both Grantex skills under `~/.hermes/skills/grantex/`. Start a new Hermes session so its skill inventory refreshes.
+
+<Info>
+  Hermes documents skills as `SKILL.md` folders loaded on demand, and exposes installed skills as slash commands. See the [Hermes skills guide](https://hermes-agent.nousresearch.com/docs/guides/work-with-skills).
+</Info>
+
+## Configure
+
+Inject the CLI credentials through the Hermes host environment or another approved secret mechanism:
+
+<CodeGroup>
+```bash Bash
+export GRANTEX_URL=https://api.grantex.dev
+export GRANTEX_KEY=YOUR_API_KEY
+grantex --json me
+```
+
+```powershell PowerShell
+$env:GRANTEX_URL = "https://api.grantex.dev"
+$env:GRANTEX_KEY = "YOUR_API_KEY"
+grantex --json me
+```
+</CodeGroup>
+
+Do not put the API key or grant tokens inside a skill, prompt, memory entry, or conversation.
+
+## Use
+
+Invoke the operational skill explicitly:
+
+```text
+/use-grantex-cli Register a calendar assistant with calendar:read only, then request consent for alice@example.com.
+```
+
+Or ask Hermes naturally to use `use-grantex-cli`. For implementation work, invoke `integrate-grantex` and ask it to add enforcement at the service boundary.
+
+Hermes should use JSON output and secret-safe token input:
+
+```bash
+grantex --json agents list
+grantex verify --env GRANTEX_GRANT_TOKEN --json
+grantex --json tokens verify --env GRANTEX_GRANT_TOKEN
+```
+
+## Trust boundary
+
+Keep the human consent step outside autonomous control. A Hermes-run CLI preflight helps plan and diagnose an action, but the API, connector, or gateway that performs the side effect must verify the grant again.
+
+See [Agent CLIs & Skills](/integrations/agent-cli) for the full shell contract and [Scope Enforcement](/guides/scope-enforcement) for production enforcement.

--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -1,0 +1,83 @@
+---
+title: "OpenClaw"
+sidebarTitle: "OpenClaw"
+description: "Install Grantex Agent Skills in an OpenClaw workspace and use the JSON CLI for delegated authorization."
+---
+
+OpenClaw can load the same portable Grantex skills used by other Agent Skills-compatible hosts. No OpenClaw-specific Grantex SDK is required.
+
+The one-command installer requires `@grantex/cli` 0.3.0 or newer; confirm the published version on the [release-status page](/release-status).
+
+## Install in a workspace
+
+Run from the configured OpenClaw agent workspace:
+
+```bash
+npm install -g @grantex/cli
+grantex agent install --target openclaw
+openclaw skills check
+```
+
+The installer writes both skills to `<workspace>/skills`. Start a new OpenClaw turn after installation.
+
+<Info>
+  OpenClaw loads Agent Skills-compatible folders from its workspace and managed skill roots. See the [OpenClaw skills reference](https://docs.openclaw.ai/skills).
+</Info>
+
+To install for all local OpenClaw agents instead, select the managed skill root explicitly:
+
+<CodeGroup>
+```bash Bash
+grantex agent install --dir "$HOME/.openclaw/skills"
+openclaw skills check
+```
+
+```powershell PowerShell
+grantex agent install --dir "$HOME\.openclaw\skills"
+openclaw skills check
+```
+</CodeGroup>
+
+## Configure
+
+Expose credentials to the OpenClaw host with its secret or environment configuration:
+
+<CodeGroup>
+```bash Bash
+export GRANTEX_URL=https://api.grantex.dev
+export GRANTEX_KEY=YOUR_API_KEY
+grantex --json me
+```
+
+```powershell PowerShell
+$env:GRANTEX_URL = "https://api.grantex.dev"
+$env:GRANTEX_KEY = "YOUR_API_KEY"
+grantex --json me
+```
+</CodeGroup>
+
+Never embed API keys or grant tokens in `SKILL.md`, workspace instructions, prompts, or logs.
+
+## Use
+
+Ask OpenClaw to use `use-grantex-cli` for operational tasks or `integrate-grantex` for code changes. The skills instruct it to:
+
+- request least-privilege scopes;
+- preserve the human consent step;
+- consume JSON instead of human tables;
+- keep tokens out of process arguments; and
+- distinguish a CLI preflight from protected-service enforcement.
+
+Example shell calls:
+
+```text
+grantex --json grants list --status active
+grantex verify --env GRANTEX_GRANT_TOKEN --json
+grantex --json enforce test --token-env GRANTEX_GRANT_TOKEN --connector salesforce --tool create_lead
+```
+
+## Trust boundary
+
+An autonomous OpenClaw process must not be its own final authorization boundary. Verify the grant token, exact scope, and required current state inside the service, connector, or gateway before the side effect occurs.
+
+See [Agent CLIs & Skills](/integrations/agent-cli) for the full shell contract and [Scope Enforcement](/guides/scope-enforcement) for production enforcement.

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -1,13 +1,22 @@
 ---
 title: "AI Agent Framework Integrations"
 sidebarTitle: "Overview"
-description: "Choose Grantex integrations for OpenAI Agents, Anthropic, LangChain, CrewAI, Google ADK, AutoGen, Vercel AI, MCP, Express, FastAPI, Strands, and A2A."
-keywords: ["AI agent framework integrations", "OpenAI Agents authorization", "LangChain permissions", "MCP authorization", "CrewAI security"]
+description: "Choose Grantex integrations for Hermes, OpenClaw, Agent Skills, OpenAI Agents, Anthropic, LangChain, CrewAI, Google ADK, AutoGen, MCP, and service frameworks."
+keywords: ["AI agent framework integrations", "Hermes Agent authorization", "OpenClaw authorization", "Agent Skills CLI", "MCP authorization"]
 ---
 
 ## Choose an AI agent integration
 
 <CardGroup cols={2}>
+  <Card title="Any Agent CLI" icon="terminal" href="/integrations/agent-cli">
+    Install portable Agent Skills and use the JSON CLI from any shell-capable agent.
+  </Card>
+  <Card title="Hermes Agent" icon="wand-magic-sparkles" href="/integrations/hermes">
+    Install the Grantex skill bundle into Hermes with one CLI command.
+  </Card>
+  <Card title="OpenClaw" icon="robot" href="/integrations/openclaw">
+    Add Grantex skills to an OpenClaw workspace and verify the installation.
+  </Card>
   <Card title="Service Provider Adapters" icon="puzzle-piece" href="/integrations/adapters">
     Pre-built integrations for 11 services: Google Calendar, Gmail, Drive, Stripe, Slack, GitHub, Notion, HubSpot, Salesforce, Linear, Jira.
   </Card>
@@ -92,6 +101,9 @@ keywords: ["AI agent framework integrations", "OpenAI Agents authorization", "La
 
 | Framework | Package | Install | Language |
 |-----------|---------|---------|----------|
+| Hermes Agent | `@grantex/cli` 0.3.0+ + Agent Skills | `grantex agent install --target hermes` | Any shell; 0.3.0 source prepared |
+| OpenClaw | `@grantex/cli` 0.3.0+ + Agent Skills | `grantex agent install --target openclaw` | Any shell; 0.3.0 source prepared |
+| Other Agent Skills clients | `@grantex/cli` 0.3.0+ + Agent Skills | `grantex agent install --target portable` | Any shell; 0.3.0 source prepared |
 | Adapters | `@grantex/adapters` | `npm install @grantex/adapters` | TypeScript |
 | MCP Auth Server | `@grantex/mcp-auth@2.0.2` | `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13` | TypeScript; evaluation only |
 | Gateway | `@grantex/gateway` | `npm install @grantex/gateway` | TypeScript |

--- a/docs/protocol/changelog.mdx
+++ b/docs/protocol/changelog.mdx
@@ -6,7 +6,7 @@ description: "How to find current Grantex releases, package compatibility, and t
 
 ## Current release snapshot
 
-Last verified: **July 12, 2026**
+Last verified: **August 10, 2026**
 
 | Surface | Current release |
 |---|---:|

--- a/docs/release-status.mdx
+++ b/docs/release-status.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Release Status"
 sidebarTitle: "Release Status"
-description: "Choose the current Grantex TypeScript, Python, Go, or MCP package with exact versions, runtime requirements, limitations, and reproducible install commands."
-keywords: ["Grantex SDK versions", "AI agent authorization SDK", "MCP authorization package", "release status"]
+description: "Choose the current Grantex CLI, TypeScript, Python, Go, or MCP package with exact versions, runtime requirements, limitations, and reproducible install commands."
+keywords: ["Grantex CLI version", "Grantex SDK versions", "AI agent authorization SDK", "MCP authorization package", "release status"]
 ---
 
 ## Current published releases
 
-Last verified: **July 12, 2026**
+Last verified: **August 10, 2026**
 
 Grantex packages are versioned independently. There is no single version number
 that represents every SDK, integration, service, and protocol artifact in this
@@ -15,6 +15,7 @@ repository.
 
 | Surface | Current release | Status | Runtime requirement |
 |---|---:|---|---|
+| CLI | `@grantex/cli@0.2.5` | Published to npm | Node.js 18+; ESM |
 | TypeScript SDK | `@grantex/sdk@0.3.13` | Published to npm | Node.js 18+; ESM |
 | Python SDK | `grantex==0.3.14` | Published to PyPI | Python 3.9+ |
 | Go SDK | `github.com/mishrasanjeev/grantex-go@v0.1.10` | Published with known limitations | Go 1.26.1+ |
@@ -30,7 +31,9 @@ repository.
 ## Repository changes awaiting publication
 
 <Info>
-  As of July 14, 2026, repository source on `main` corrects the documented Go
+  As of August 10, 2026, `@grantex/cli` 0.3.0 source adds the Hermes,
+  OpenClaw, and portable Agent Skills installer, but that version is not yet
+  published. Repository source on `main` also corrects the documented Go
   Agent/Audit read/write contracts, removes unsupported audit filters and list
   metadata, and URL-encodes query values. No corrected Go module tag is published.
   Standard developer API-key plan throughput is also source-only; custom-auth quotas and managed rollout remain separate.
@@ -38,6 +41,7 @@ repository.
 
 ## Which Grantex package should I use?
 
+- **Hermes, OpenClaw, or another shell-capable agent:** use the published CLI for existing commands; the one-command Agent Skills installer requires the source-prepared, unpublished `@grantex/cli@0.3.0`.
 - **TypeScript application:** use `@grantex/sdk@0.3.13`.
 - **Python application:** use `grantex==0.3.14`.
 - **Go application:** use `github.com/mishrasanjeev/grantex-go@v0.1.10` with the [published-version workarounds](/sdks/go/overview#known-v0110-limitations), including the [REST/CLI audit-write workaround](/sdks/go/audit#log).
@@ -78,6 +82,10 @@ repository.
 Pin exact versions in applications, examples, CI, and deployment manifests:
 
 <CodeGroup>
+```bash CLI
+npm install -g @grantex/cli@0.2.5
+```
+
 ```bash TypeScript
 npm install @grantex/sdk@0.3.13
 ```
@@ -110,6 +118,7 @@ must be repeatable.
   records cross-project work. Its latest numbered entry can trail independently
   published SDK patches.
 - Package registries are authoritative for public availability:
+  [npm (`@grantex/cli`)](https://www.npmjs.com/package/@grantex/cli),
   [npm (`@grantex/sdk`)](https://www.npmjs.com/package/@grantex/sdk),
   [PyPI (`grantex`)](https://pypi.org/project/grantex/),
   [Go Packages](https://pkg.go.dev/github.com/mishrasanjeev/grantex-go), and

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,7 @@
 
 Command-line tool for the [Grantex](https://grantex.dev) delegated authorization protocol.
 
-83 commands covering the full Grantex API — agents, grants, tokens, policies, budgets, audit, compliance, credentials, and more. All commands support `--json` for machine-readable output.
+80+ commands covering the full Grantex API — agents, grants, tokens, policies, budgets, audit, compliance, credentials, and more. All commands support `--json` for machine-readable output. Portable Agent Skills let Hermes, OpenClaw, and other shell-capable agents use the same interface.
 
 > **[Homepage](https://grantex.dev)** | **[Docs](https://docs.grantex.dev)** | **[CLI Docs](https://docs.grantex.dev/integrations/cli)** | **[GitHub](https://github.com/mishrasanjeev/grantex)**
 
@@ -37,6 +37,39 @@ grantex --json tokens verify <jwt> | jq '.valid'
 ```
 
 Set `NO_COLOR=1` to disable colored output.
+
+## Agent CLI Integration
+
+Install the bundled `use-grantex-cli` and `integrate-grantex` skills with one command:
+
+```bash
+# OpenClaw workspace: ./skills
+grantex agent install --target openclaw
+
+# Hermes: ~/.hermes/skills/grantex
+grantex agent install --target hermes
+
+# Portable project location: ./.agents/skills
+grantex agent install --target portable
+
+# Any other agent skill root
+grantex agent install --dir /path/to/skills
+```
+
+Use `--force` to refresh existing bundled files. A Hermes- or OpenClaw-specific SDK is not required; application code should continue to use the TypeScript, Python, or Go SDK at the protected service boundary.
+
+### Secret-safe token input
+
+Avoid placing grant tokens in shell history or process arguments:
+
+```bash
+grantex verify --env GRANTEX_GRANT_TOKEN --json
+grantex --json tokens verify --env GRANTEX_GRANT_TOKEN
+grantex --json enforce test --token-env GRANTEX_GRANT_TOKEN \
+  --connector salesforce --tool create_lead
+```
+
+The verification commands also accept `--file` and `--stdin`; `enforce test` accepts `--token-file` and `--token-stdin`. Invalid or denied checks return a non-zero process status in JSON mode.
 
 ## Commands
 
@@ -299,6 +332,12 @@ grantex enforce test --token <jwt> --connector salesforce --tool delete_contact
 
 ```bash
 grantex init gemma [--dir ./grantex-gemma-starter]
+```
+
+### Agent Skills
+
+```bash
+grantex agent install [--target openclaw|hermes|portable] [--dir <skill-root>] [--force]
 ```
 
 ## Local Development

--- a/packages/cli/agent-skills/integrate-grantex/SKILL.md
+++ b/packages/cli/agent-skills/integrate-grantex/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: integrate-grantex
+description: Add Grantex delegated authorization to an agent, CLI tool, API, MCP server, or framework integration. Use when implementing or reviewing agent identity, scoped grants, consent, JWT verification, tool manifests, service-boundary enforcement, audit logging, delegation, or revocation, and when choosing among the Grantex CLI, TypeScript SDK, Python SDK, Go SDK, middleware, gateway, or framework adapters.
+---
+
+# Integrate Grantex
+
+Implement authorization at the component that owns the side effect. Use the CLI for setup and diagnostics; use an SDK, middleware, direct verifier, or gateway at the protected runtime.
+
+## Select the integration surface
+
+Inspect the project before adding dependencies. Reuse an installed Grantex package when it already fits.
+
+| Boundary | Preferred surface |
+|---|---|
+| Shell automation or agent control plane | `@grantex/cli` with `--json` |
+| TypeScript service | `@grantex/sdk` or framework middleware |
+| Python service | `grantex` or FastAPI integration |
+| Go service | `github.com/mishrasanjeev/grantex-go` |
+| Reverse proxy without application changes | `@grantex/gateway` |
+| Framework tool wrapper | The matching Grantex adapter plus its primary SDK |
+| MCP tool execution | MCP transport authorization plus primary-SDK or direct JWKS-backed Grantex enforcement inside each protected tool |
+
+Do not add a Hermes- or OpenClaw-specific SDK. Shell-capable agents use the shared CLI and portable `SKILL.md`; application code uses the existing language SDKs.
+
+## Implement the boundary
+
+1. Inventory every protected action and map it to an explicit scope. Keep read, write, delete, admin, and capped-value operations distinct.
+2. Register a stable agent identity and request only the required scopes, audience, and duration.
+3. Preserve human control. Send the principal to the consent URL and exchange only a code returned through the approved flow.
+4. At the service boundary, validate:
+   - signature against the trusted issuer JWKS;
+   - issuer and expected audience;
+   - expiry and not-before claims;
+   - agent and principal identity;
+   - every required scope and constraint;
+   - delegation invariants; and
+   - current revocation state when the risk model requires it.
+5. Reject before executing the side effect. Unknown tools and missing manifests must fail closed.
+6. Audit both allowed and denied decisions with the agent, grant, principal, action, outcome, and non-secret metadata.
+7. Add revocation and, where needed, narrowly scoped sub-agent delegation.
+
+## Verify the implementation
+
+- Test a valid grant with exactly the required scope.
+- Test a valid token missing the required scope.
+- Test malformed, expired, wrong-issuer, wrong-audience, and invalid-signature tokens.
+- Test an unknown tool or connector.
+- Test revocation through the chosen online or synchronized-state path.
+- Test that denial occurs before the protected function is invoked.
+- Confirm logs never contain API keys, authorization codes, grant tokens, refresh tokens, or upstream credentials.
+
+## CLI handoff
+
+For an agent-operated setup, install the companion skill bundle first:
+
+```bash
+grantex agent install --target portable
+```
+
+Then use `grantex --json ...` for registration, authorization, grants, verification, audit, and revocation. Prefer token input from an environment variable, file, or stdin.
+
+## Security boundaries
+
+- Treat client-side CLI checks as diagnostics, not a security boundary.
+- Treat local JWT verification as signature-and-claims validation, not proof of current revocation.
+- Keep upstream credentials behind the protected service; do not give them directly to the agent.
+- Never silently request broader authority after a denial.
+- Treat `@grantex/mcp-auth@2.0.2` as evaluation-only unless its documented release limitations have been resolved in the selected version. For production MCP enforcement, prefer a primary SDK or direct verification at the tool boundary.

--- a/packages/cli/agent-skills/integrate-grantex/agents/openai.yaml
+++ b/packages/cli/agent-skills/integrate-grantex/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Integrate Grantex"
+  short_description: "Add scoped agent authorization to tools"
+  default_prompt: "Use $integrate-grantex to add Grantex authorization to this project."

--- a/packages/cli/agent-skills/use-grantex-cli/SKILL.md
+++ b/packages/cli/agent-skills/use-grantex-cli/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: use-grantex-cli
+description: Operate Grantex delegated authorization through its machine-readable CLI. Use when Hermes, OpenClaw, an Agent Skills-compatible assistant, or another shell-capable agent needs to configure Grantex, register an agent, request scoped human consent, exchange or verify grant tokens, inspect grants and audit records, delegate narrower authority, or revoke access without writing framework-specific code.
+---
+
+# Use Grantex CLI
+
+Use `grantex` as a control-plane tool. Prefer JSON output, keep credentials out of command arguments, and leave authorization enforcement at the protected service boundary.
+
+## Bootstrap
+
+1. Check whether `grantex` is available on `PATH`.
+2. If it is missing and the user approves installation, run `npm install -g @grantex/cli`.
+3. Configure with environment variables when running unattended. Use the syntax for the current shell:
+
+   ```bash
+   # Bash, zsh, or sh
+   export GRANTEX_URL=https://api.grantex.dev
+   export GRANTEX_KEY=YOUR_API_KEY
+   ```
+
+   ```powershell
+   # PowerShell
+   $env:GRANTEX_URL = "https://api.grantex.dev"
+   $env:GRANTEX_KEY = "YOUR_API_KEY"
+   ```
+
+   Alternatively, use `grantex config set --url <url> --key <key>` for a user-managed local profile.
+
+4. Confirm the identity with `grantex --json me`. Stop if configuration or authentication fails.
+
+## Machine contract
+
+- Put the global flag before the command: `grantex --json agents list`.
+- Parse stdout as JSON and treat stderr as diagnostics.
+- Check the process exit status before trusting output.
+- Use `NO_COLOR=1` if text output must be captured.
+- Prefer `--env`, `--file`, or `--stdin` for grant tokens. Do not expose grant tokens, refresh tokens, or API keys in logs, prompts, shell history, or process arguments.
+
+## Authorization workflow
+
+1. Register only the scopes the agent can justify:
+
+   ```text
+   grantex --json agents register --name "calendar-assistant" --description "Reads approved calendar events" --scopes calendar:read
+   ```
+
+2. Request the smallest useful grant:
+
+   ```text
+   grantex --json authorize --agent ag_... --principal user@example.com --scopes calendar:read
+   ```
+
+3. Present the returned consent URL to the human. Never approve consent on the principal's behalf. In live mode, wait for the registered callback to receive the authorization code.
+4. Exchange an approved code:
+
+   ```bash
+   grantex --json tokens exchange --code <code> --agent-id ag_...
+   ```
+
+5. Store returned tokens only in the caller's approved secret store. Do not print them back to the user unless explicitly requested.
+6. Verify without placing the token in argv:
+
+   ```bash
+   grantex verify --env GRANTEX_GRANT_TOKEN --json
+   grantex --json tokens verify --env GRANTEX_GRANT_TOKEN
+   ```
+
+   The first command performs signature and claim verification. The second performs the configured online check. Local verification alone does not prove current revocation.
+
+## Tool preflight
+
+Use the CLI to inspect a manifest decision while developing or diagnosing:
+
+```text
+grantex --json enforce test --token-env GRANTEX_GRANT_TOKEN --connector salesforce --tool create_lead
+```
+
+Treat this as a preflight only. An agent can bypass its own client-side command. Enforce the token again inside the service that owns the side effect.
+
+## Delegation and revocation
+
+- Delegate only a strict subset of the parent scopes and never extend the parent expiry.
+- Prefer a file or environment input whenever the installed command offers one. Avoid placing secrets in argv.
+- Revoke a grant when the task ends or authority is withdrawn: `grantex --json grants revoke grnt_...`.
+- Confirm important changes with a read command such as `grantex --json grants get grnt_...` and inspect the audit trail.
+
+## Safety rules
+
+- Fail closed when required identity, scope, audience, expiry, signature, or current-state checks are unavailable.
+- Never broaden scopes to make a denied action pass. Ask for a new human-approved grant.
+- Never treat `decode` as verification.
+- Never describe a CLI preflight or local JWT decode as service-side enforcement.
+- Record security-relevant success and denial events without logging secrets.

--- a/packages/cli/agent-skills/use-grantex-cli/agents/openai.yaml
+++ b/packages/cli/agent-skills/use-grantex-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Use Grantex CLI"
+  short_description: "Operate Grantex safely from any agent shell"
+  default_prompt: "Use $use-grantex-cli to configure delegated authorization for this agent."

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grantex/cli",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grantex/cli",
-      "version": "0.2.5",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grantex/sdk": ">=0.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grantex/cli",
-  "version": "0.2.5",
-  "description": "CLI tool for local Grantex development",
+  "version": "0.3.0",
+  "description": "Agent-friendly CLI for Grantex delegated authorization",
   "homepage": "https://grantex.dev",
   "bugs": {
     "url": "https://github.com/mishrasanjeev/grantex/issues"
@@ -12,6 +12,7 @@
   },
   "files": [
     "dist",
+    "agent-skills",
     "README.md"
   ],
   "scripts": {

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -1,0 +1,147 @@
+import { Command, Option } from 'commander';
+import chalk from 'chalk';
+import { cpSync, existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isJsonMode } from '../format.js';
+
+export const AGENT_SKILLS = ['use-grantex-cli', 'integrate-grantex'] as const;
+export type AgentSkillTarget = 'openclaw' | 'hermes' | 'portable';
+
+export interface AgentSkillInstallResult {
+  target: AgentSkillTarget;
+  root: string;
+  installed: Array<{ name: string; path: string }>;
+  nextStep: string;
+}
+
+function bundledSkillsRoot(): string {
+  return fileURLToPath(new URL('../../agent-skills/', import.meta.url));
+}
+
+export function resolveAgentSkillRoot(
+  target: AgentSkillTarget,
+  cwd = process.cwd(),
+  home = homedir(),
+): string {
+  switch (target) {
+    case 'openclaw':
+      return join(cwd, 'skills');
+    case 'hermes':
+      return join(home, '.hermes', 'skills', 'grantex');
+    case 'portable':
+      return join(cwd, '.agents', 'skills');
+  }
+}
+
+function nextStepFor(target: AgentSkillTarget): string {
+  switch (target) {
+    case 'openclaw':
+      return 'Run `openclaw skills check`, then start a new agent turn.';
+    case 'hermes':
+      return 'Run `hermes skills list`, then start a new Hermes session.';
+    case 'portable':
+      return 'Start a new agent session from this workspace.';
+  }
+}
+
+export function installAgentSkills(options: {
+  target: AgentSkillTarget;
+  directory?: string;
+  force?: boolean;
+  cwd?: string;
+  home?: string;
+  sourceRoot?: string;
+}): AgentSkillInstallResult {
+  const cwd = options.cwd ?? process.cwd();
+  const root = options.directory
+    ? resolve(cwd, options.directory)
+    : resolveAgentSkillRoot(options.target, cwd, options.home ?? homedir());
+  const sourceRoot = options.sourceRoot ?? bundledSkillsRoot();
+  const planned = AGENT_SKILLS.map((name) => ({
+    name,
+    source: join(sourceRoot, name),
+    destination: join(root, name),
+  }));
+
+  for (const item of planned) {
+    if (!existsSync(join(item.source, 'SKILL.md'))) {
+      throw new Error(`Bundled skill is missing: ${item.name}`);
+    }
+  }
+
+  const conflicts = planned.filter((item) => existsSync(item.destination));
+  if (conflicts.length > 0 && !options.force) {
+    throw new Error(
+      `Skill already exists: ${conflicts.map((item) => item.destination).join(', ')}. ` +
+      'Re-run with --force to update the bundled files.',
+    );
+  }
+
+  mkdirSync(root, { recursive: true });
+  for (const item of planned) {
+    cpSync(item.source, item.destination, {
+      recursive: true,
+      force: options.force ?? false,
+      errorOnExist: !(options.force ?? false),
+    });
+  }
+
+  return {
+    target: options.target,
+    root,
+    installed: planned.map((item) => ({ name: item.name, path: item.destination })),
+    nextStep: nextStepFor(options.target),
+  };
+}
+
+export function agentCommand(): Command {
+  const cmd = new Command('agent')
+    .description('Install Grantex skills for shell-capable AI agents');
+
+  cmd
+    .command('install')
+    .description('Install portable Grantex Agent Skills')
+    .addOption(
+      new Option('--target <target>', 'Agent skill location')
+        .choices(['openclaw', 'hermes', 'portable'])
+        .default('portable'),
+    )
+    .option('--dir <directory>', 'Override the skill root directory')
+    .option('--force', 'Update existing bundled skill files')
+    .action((opts: { target: AgentSkillTarget; dir?: string; force?: boolean }) => {
+      try {
+        const result = installAgentSkills({
+          target: opts.target,
+          ...(opts.dir !== undefined ? { directory: opts.dir } : {}),
+          ...(opts.force !== undefined ? { force: opts.force } : {}),
+        });
+
+        if (isJsonMode()) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+
+        console.log(
+          chalk.green('\u2713') +
+          ` Installed ${result.installed.length} Grantex skills in ${result.root}`,
+        );
+        for (const skill of result.installed) {
+          console.log(`  ${chalk.dim('\u2502')} ${skill.name}`);
+        }
+        console.log('');
+        console.log(`  Next: ${result.nextStep}`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (isJsonMode()) {
+          console.log(JSON.stringify({ installed: false, error: message }));
+        } else {
+          console.error(chalk.red('\u2717') + ` ${message}`);
+        }
+        process.exitCode = 1;
+      }
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/enforce.ts
+++ b/packages/cli/src/commands/enforce.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { requireClient } from '../client.js';
 import { isJsonMode } from '../format.js';
+import { readTokenInput } from '../token-input.js';
 
 export function enforceCommand(): Command {
   const cmd = new Command('enforce').description('Test scope enforcement against a grant token');
@@ -9,11 +10,40 @@ export function enforceCommand(): Command {
   cmd
     .command('test')
     .description('Dry-run scope enforcement for a tool call')
-    .requiredOption('--token <token>', 'Grantex grant token (JWT)')
+    .option('--token <token>', 'Grantex grant token (JWT)')
+    .option('--token-file <path>', 'Read grant token from a file')
+    .option('--token-stdin', 'Read grant token from stdin')
+    .option('--token-env <name>', 'Read grant token from an environment variable')
     .requiredOption('--connector <connector>', 'Connector name (e.g., salesforce)')
     .requiredOption('--tool <tool>', 'Tool name (e.g., delete_contact)')
     .option('--amount <amount>', 'Amount for capped scope check', parseFloat)
-    .action(async (opts: { token: string; connector: string; tool: string; amount?: number }) => {
+    .action(async (opts: {
+      token?: string;
+      tokenFile?: string;
+      tokenStdin?: boolean;
+      tokenEnv?: string;
+      connector: string;
+      tool: string;
+      amount?: number;
+    }) => {
+      let token: string;
+      try {
+        token = readTokenInput(opts.token, {
+          file: opts.tokenFile,
+          stdin: opts.tokenStdin,
+          env: opts.tokenEnv,
+        });
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        if (isJsonMode()) {
+          console.log(JSON.stringify({ allowed: false, reason }));
+          process.exitCode = 1;
+          return;
+        }
+        console.error(chalk.red('\u2717') + ` ${reason}`);
+        process.exit(1);
+        return;
+      }
       const client = await requireClient();
 
       // Load the manifest for the connector
@@ -27,6 +57,7 @@ export function enforceCommand(): Command {
             allowed: false,
             reason: `No manifest found for connector '${opts.connector}'`,
           }));
+          process.exitCode = 1;
           return;
         }
         console.log(chalk.red(`\n  ❌ No manifest found for connector '${opts.connector}'`));
@@ -35,7 +66,7 @@ export function enforceCommand(): Command {
       }
 
       const result = await client.enforce({
-        grantToken: opts.token,
+        grantToken: token,
         connector: opts.connector,
         tool: opts.tool,
         ...(opts.amount !== undefined ? { amount: opts.amount } : {}),
@@ -43,6 +74,7 @@ export function enforceCommand(): Command {
 
       if (isJsonMode()) {
         console.log(JSON.stringify(result, null, 2));
+        if (!result.allowed) process.exitCode = 1;
         return;
       }
 
@@ -57,6 +89,7 @@ export function enforceCommand(): Command {
       console.log(`  ${chalk.dim('Tool permission:')} ${result.permission || '?'} (from manifest)`);
       if (!result.allowed) {
         console.log(`  ${chalk.dim('Reason:')}         ${result.reason}`);
+        process.exitCode = 1;
       }
       if (result.grantId) {
         console.log(`  ${chalk.dim('Grant ID:')}       ${result.grantId}`);

--- a/packages/cli/src/commands/enforce.ts
+++ b/packages/cli/src/commands/enforce.ts
@@ -62,6 +62,7 @@ export function enforceCommand(): Command {
         }
         console.log(chalk.red(`\n  ❌ No manifest found for connector '${opts.connector}'`));
         console.log(chalk.dim('  Run `grantex manifest list` to see available connectors.'));
+        process.exitCode = 1;
         return;
       }
 

--- a/packages/cli/src/commands/tokens.ts
+++ b/packages/cli/src/commands/tokens.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { requireClient } from '../client.js';
 import { printRecord, shortDate, isJsonMode } from '../format.js';
+import { readTokenInput } from '../token-input.js';
 
 export function tokensCommand(): Command {
   const cmd = new Command('tokens').description('Exchange, verify, refresh, and revoke grant tokens');
@@ -36,14 +37,36 @@ export function tokensCommand(): Command {
     });
 
   cmd
-    .command('verify <token>')
+    .command('verify [token]')
     .description('Verify a grant token (online check)')
-    .action(async (token: string) => {
+    .option('--file <path>', 'Read token from a file')
+    .option('--stdin', 'Read token from stdin')
+    .option('--env <name>', 'Read token from an environment variable')
+    .action(async (tokenArg: string | undefined, opts: {
+      file?: string;
+      stdin?: boolean;
+      env?: string;
+    }) => {
+      let token: string;
+      try {
+        token = readTokenInput(tokenArg, opts);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (isJsonMode()) {
+          console.log(JSON.stringify({ valid: false, error: message }));
+          process.exitCode = 1;
+          return;
+        }
+        console.error(chalk.red('\u2717') + ` ${message}`);
+        process.exit(1);
+        return;
+      }
       const client = await requireClient();
       const res = await client.tokens.verify(token);
 
       if (isJsonMode()) {
         console.log(JSON.stringify(res, null, 2));
+        if (!res.valid) process.exitCode = 1;
         return;
       }
 

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import * as jose from 'jose';
 import { readFileSync } from 'node:fs';
 import { isJsonMode } from '../format.js';
+import { readTokenInput } from '../token-input.js';
 
 interface GrantTokenClaims {
   iss?: string;
@@ -44,27 +45,6 @@ interface VerifyResult {
   elapsedMs?: number;
   mode?: 'offline' | 'online';
   error?: string;
-}
-
-function readTokenInput(
-  tokenArg: string | undefined,
-  opts: { file?: string; stdin?: boolean },
-): string {
-  if (opts.stdin) {
-    // Read from stdin (piped input)
-    const fd = require('node:fs').openSync('/dev/stdin', 'r');
-    const buf = Buffer.alloc(1024 * 64);
-    const n = require('node:fs').readSync(fd, buf);
-    require('node:fs').closeSync(fd);
-    return buf.subarray(0, n).toString('utf8').trim();
-  }
-  if (opts.file) {
-    return readFileSync(opts.file, 'utf8').trim();
-  }
-  if (tokenArg) {
-    return tokenArg;
-  }
-  throw new Error('No token provided. Pass a token argument, --file <path>, or --stdin.');
 }
 
 function relativeTime(date: Date, now: Date): string {
@@ -240,6 +220,7 @@ export function verifyCommand(): Command {
     .option('--jwks-file <path>', 'Path to local JWKS JSON file')
     .option('--file <path>', 'Read token from a file')
     .option('--stdin', 'Read token from stdin')
+    .option('--env <name>', 'Read token from an environment variable')
     .action(async (tokenArg: string | undefined, opts: {
       verbose?: boolean;
       json?: boolean;
@@ -248,6 +229,7 @@ export function verifyCommand(): Command {
       jwksFile?: string;
       file?: string;
       stdin?: boolean;
+      env?: string;
     }) => {
       const startTime = performance.now();
       const useJson = opts.json || isJsonMode();
@@ -255,7 +237,11 @@ export function verifyCommand(): Command {
       // Read token
       let token: string;
       try {
-        token = readTokenInput(tokenArg, { file: opts.file, stdin: opts.stdin });
+        token = readTokenInput(tokenArg, {
+          file: opts.file,
+          stdin: opts.stdin,
+          env: opts.env,
+        });
       } catch (err) {
         if (useJson) {
           console.log(JSON.stringify({ status: 'error', error: (err as Error).message }));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -32,6 +32,7 @@ import { registryCommand } from './commands/registry-cmd.js';
 import { initCommand } from './commands/init.js';
 import { manifestCommand } from './commands/manifest.js';
 import { enforceCommand } from './commands/enforce.js';
+import { agentCommand } from './commands/agent.js';
 
 export function createProgram(): Command {
   const program = new Command();
@@ -39,7 +40,7 @@ export function createProgram(): Command {
   program
     .name('grantex')
     .description('CLI for the Grantex delegated authorization protocol')
-    .version('0.2.3')
+    .version('0.3.0')
     .option('--json', 'Output results as JSON (machine-readable)')
     .hook('preAction', () => {
       if (program.opts().json) {
@@ -78,6 +79,7 @@ export function createProgram(): Command {
   program.addCommand(initCommand());
   program.addCommand(manifestCommand());
   program.addCommand(enforceCommand());
+  program.addCommand(agentCommand());
 
   return program;
 }

--- a/packages/cli/src/token-input.ts
+++ b/packages/cli/src/token-input.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+
+export interface TokenInputOptions {
+  file?: string;
+  stdin?: boolean;
+  env?: string;
+}
+
+/** Read a grant token from exactly one argument, file, stdin, or environment variable. */
+export function readTokenInput(
+  tokenArg: string | undefined,
+  opts: TokenInputOptions,
+): string {
+  const selected = [
+    tokenArg !== undefined ? 'argument' : undefined,
+    opts.file !== undefined ? 'file' : undefined,
+    opts.stdin ? 'stdin' : undefined,
+    opts.env !== undefined ? 'environment variable' : undefined,
+  ].filter((source): source is string => source !== undefined);
+
+  if (selected.length > 1) {
+    throw new Error(`Provide exactly one token source; received ${selected.join(', ')}.`);
+  }
+
+  let token: string | undefined;
+  if (opts.stdin) {
+    // Numeric descriptor 0 works on Windows, macOS, and Linux.
+    token = readFileSync(0, 'utf8');
+  } else if (opts.file) {
+    token = readFileSync(opts.file, 'utf8');
+  } else if (opts.env) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(opts.env)) {
+      throw new Error(`Invalid environment variable name: ${opts.env}`);
+    }
+    token = process.env[opts.env];
+    if (token === undefined) {
+      throw new Error(`Environment variable ${opts.env} is not set.`);
+    }
+  } else {
+    token = tokenArg;
+  }
+
+  const trimmed = token?.trim();
+  if (!trimmed) {
+    throw new Error(
+      'No token provided. Pass a token argument, file, stdin, or environment variable.',
+    );
+  }
+  return trimmed;
+}

--- a/packages/cli/tests/agent.test.ts
+++ b/packages/cli/tests/agent.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  AGENT_SKILLS,
+  agentCommand,
+  installAgentSkills,
+  resolveAgentSkillRoot,
+} from '../src/commands/agent.js';
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'grantex-agent-skills-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('agentCommand()', () => {
+  it('registers the install subcommand', () => {
+    const cmd = agentCommand();
+    expect(cmd.name()).toBe('agent');
+    expect(cmd.commands.map((subcommand) => subcommand.name())).toContain('install');
+  });
+});
+
+describe('resolveAgentSkillRoot()', () => {
+  it('uses the OpenClaw workspace skills directory', () => {
+    expect(resolveAgentSkillRoot('openclaw', 'C:\\workspace', 'C:\\home'))
+      .toBe(join('C:\\workspace', 'skills'));
+  });
+
+  it('uses the Hermes personal skill category', () => {
+    expect(resolveAgentSkillRoot('hermes', 'C:\\workspace', 'C:\\home'))
+      .toBe(join('C:\\home', '.hermes', 'skills', 'grantex'));
+  });
+
+  it('uses the portable project Agent Skills directory', () => {
+    expect(resolveAgentSkillRoot('portable', 'C:\\workspace', 'C:\\home'))
+      .toBe(join('C:\\workspace', '.agents', 'skills'));
+  });
+});
+
+describe('installAgentSkills()', () => {
+  it('bundles the canonical repository skill content', () => {
+    const testDir = dirname(fileURLToPath(import.meta.url));
+    for (const name of AGENT_SKILLS) {
+      for (const relativePath of ['SKILL.md', join('agents', 'openai.yaml')]) {
+        const bundled = readFileSync(
+          join(testDir, '..', 'agent-skills', name, relativePath),
+          'utf8',
+        );
+        const canonical = readFileSync(
+          join(testDir, '..', '..', '..', 'skills', name, relativePath),
+          'utf8',
+        );
+        expect(bundled.replace(/\r\n/g, '\n')).toBe(canonical.replace(/\r\n/g, '\n'));
+      }
+    }
+  });
+
+  it('installs both bundled skills into a portable project root', () => {
+    const cwd = makeTempDir();
+    const result = installAgentSkills({ target: 'portable', cwd, home: cwd });
+
+    expect(result.installed.map((skill) => skill.name)).toEqual([...AGENT_SKILLS]);
+    for (const skill of result.installed) {
+      expect(existsSync(join(skill.path, 'SKILL.md'))).toBe(true);
+      expect(existsSync(join(skill.path, 'agents', 'openai.yaml'))).toBe(true);
+    }
+  });
+
+  it('honors a custom relative directory', () => {
+    const cwd = makeTempDir();
+    const result = installAgentSkills({
+      target: 'portable',
+      directory: 'custom-skills',
+      cwd,
+      home: cwd,
+    });
+
+    expect(result.root).toBe(join(cwd, 'custom-skills'));
+  });
+
+  it('refuses to overwrite an existing skill without force', () => {
+    const cwd = makeTempDir();
+    installAgentSkills({ target: 'portable', cwd, home: cwd });
+
+    expect(() => installAgentSkills({ target: 'portable', cwd, home: cwd }))
+      .toThrow('Skill already exists');
+  });
+
+  it('updates bundled files with force without deleting unrelated files', () => {
+    const cwd = makeTempDir();
+    const first = installAgentSkills({ target: 'portable', cwd, home: cwd });
+    const skillDir = first.installed[0]!.path;
+    writeFileSync(join(skillDir, 'SKILL.md'), 'stale');
+    writeFileSync(join(skillDir, 'notes.txt'), 'keep');
+
+    installAgentSkills({ target: 'portable', cwd, home: cwd, force: true });
+
+    expect(readFileSync(join(skillDir, 'SKILL.md'), 'utf8')).toContain('name: use-grantex-cli');
+    expect(readFileSync(join(skillDir, 'notes.txt'), 'utf8')).toBe('keep');
+  });
+});

--- a/packages/cli/tests/enforce.test.ts
+++ b/packages/cli/tests/enforce.test.ts
@@ -42,6 +42,7 @@ describe('enforceCommand()', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
     setJsonMode(false);
+    process.exitCode = undefined;
   });
 
   it('registers the "enforce" command name', () => {
@@ -79,6 +80,33 @@ describe('enforceCommand()', () => {
       tool: 'query',
     });
     expect(console.log).toHaveBeenCalled();
+  });
+
+  it('test reads the token from an environment variable', async () => {
+    process.env['GRANTEX_TEST_TOKEN'] = 'env_jwt_token';
+    mockClient.enforce.mockResolvedValue(enforceAllowedResult);
+    try {
+      const cmd = enforceCommand();
+      cmd.exitOverride();
+      await cmd.parseAsync([
+        'node',
+        'test',
+        'test',
+        '--token-env',
+        'GRANTEX_TEST_TOKEN',
+        '--connector',
+        'salesforce',
+        '--tool',
+        'query',
+      ]);
+      expect(mockClient.enforce).toHaveBeenCalledWith({
+        grantToken: 'env_jwt_token',
+        connector: 'salesforce',
+        tool: 'query',
+      });
+    } finally {
+      delete process.env['GRANTEX_TEST_TOKEN'];
+    }
   });
 
   it('test outputs ALLOWED for permitted tool call', async () => {
@@ -264,6 +292,8 @@ describe('enforceCommand()', () => {
     const parsed = JSON.parse(output);
     expect(parsed.allowed).toBe(false);
     expect(parsed.reason).toContain('salesforce:delete');
+    expect(process.exitCode).toBe(1);
+    process.exitCode = undefined;
   });
 
   // ── test with unknown connector ───────────────────────────────────────

--- a/packages/cli/tests/enforce.test.ts
+++ b/packages/cli/tests/enforce.test.ts
@@ -319,6 +319,7 @@ describe('enforceCommand()', () => {
     expect(allArgs).toContain('grantex manifest list');
     // enforce should not have been called
     expect(mockClient.enforce).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
   });
 
   it('test --json with unknown connector outputs JSON error', async () => {

--- a/packages/cli/tests/index.test.ts
+++ b/packages/cli/tests/index.test.ts
@@ -40,7 +40,7 @@ describe('createProgram()', () => {
 
   it('has the correct version', () => {
     const program = createProgram();
-    expect(program.version()).toBe('0.2.3');
+    expect(program.version()).toBe('0.3.0');
   });
 
   it('has a --json global option', () => {
@@ -49,7 +49,7 @@ describe('createProgram()', () => {
     expect(jsonOpt).toBeDefined();
   });
 
-  it('registers all 31 expected commands', () => {
+  it('registers all 32 expected commands', () => {
     const program = createProgram();
     const names = program.commands.map((c) => c.name());
 
@@ -59,7 +59,7 @@ describe('createProgram()', () => {
       'events', 'principal-sessions', 'credentials', 'dpdp', 'passports',
       'vault', 'webauthn', 'compliance', 'anomalies', 'billing',
       'scim', 'sso', 'verify', 'decode', 'audit-log', 'registry',
-      'init', 'manifest', 'enforce',
+      'init', 'manifest', 'enforce', 'agent',
     ];
 
     for (const name of expected) {

--- a/packages/cli/tests/token-input.test.ts
+++ b/packages/cli/tests/token-input.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readTokenInput } from '../src/token-input.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  delete process.env['GRANTEX_TEST_TOKEN'];
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('readTokenInput()', () => {
+  it('trims a positional token', () => {
+    expect(readTokenInput('  token-value\n', {})).toBe('token-value');
+  });
+
+  it('reads a token from a file', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'grantex-token-'));
+    tempDirs.push(dir);
+    const file = join(dir, 'grant.jwt');
+    writeFileSync(file, ' file-token\n');
+
+    expect(readTokenInput(undefined, { file })).toBe('file-token');
+  });
+
+  it('reads a token from an environment variable', () => {
+    process.env['GRANTEX_TEST_TOKEN'] = 'env-token';
+    expect(readTokenInput(undefined, { env: 'GRANTEX_TEST_TOKEN' })).toBe('env-token');
+  });
+
+  it('rejects multiple token sources', () => {
+    expect(() => readTokenInput('argument-token', { env: 'GRANTEX_TEST_TOKEN' }))
+      .toThrow('Provide exactly one token source');
+  });
+
+  it('rejects a missing environment variable', () => {
+    expect(() => readTokenInput(undefined, { env: 'GRANTEX_TEST_TOKEN' }))
+      .toThrow('is not set');
+  });
+});

--- a/packages/cli/tests/tokens.test.ts
+++ b/packages/cli/tests/tokens.test.ts
@@ -50,6 +50,7 @@ describe('tokensCommand()', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
     setJsonMode(false);
+    process.exitCode = undefined;
   });
 
   it('registers the "tokens" command name', () => {
@@ -141,6 +142,19 @@ describe('tokensCommand()', () => {
     expect(console.log).toHaveBeenCalled();
   });
 
+  it('verify reads a token from an environment variable', async () => {
+    process.env['GRANTEX_TEST_TOKEN'] = 'env_jwt_token';
+    mockClient.tokens.verify.mockResolvedValue(verifyValidResponse);
+    try {
+      const cmd = tokensCommand();
+      cmd.exitOverride();
+      await cmd.parseAsync(['node', 'test', 'verify', '--env', 'GRANTEX_TEST_TOKEN']);
+      expect(mockClient.tokens.verify).toHaveBeenCalledWith('env_jwt_token');
+    } finally {
+      delete process.env['GRANTEX_TEST_TOKEN'];
+    }
+  });
+
   it('verify prints success for valid token', async () => {
     mockClient.tokens.verify.mockResolvedValue(verifyValidResponse);
     const cmd = tokensCommand();
@@ -180,7 +194,7 @@ describe('tokensCommand()', () => {
     expect(parsed.principal).toBe('user@test.com');
   });
 
-  it('verify --json outputs JSON even for invalid token (no exit)', async () => {
+  it('verify --json outputs JSON and sets a failing status for an invalid token', async () => {
     mockClient.tokens.verify.mockResolvedValue(verifyInvalidResponse);
     setJsonMode(true);
     const cmd = tokensCommand();
@@ -189,6 +203,8 @@ describe('tokensCommand()', () => {
     const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
     const parsed = JSON.parse(output);
     expect(parsed.valid).toBe(false);
+    expect(process.exitCode).toBe(1);
+    process.exitCode = undefined;
   });
 
   // ── refresh ───────────────────────────────────────────────────────────

--- a/packages/cli/tests/verify.test.ts
+++ b/packages/cli/tests/verify.test.ts
@@ -241,4 +241,22 @@ describe('verifyCommand()', () => {
       fs.unlinkSync(tmpFile);
     }
   });
+
+  it('reads token from --env', async () => {
+    const { token } = await createTestJwt();
+    process.env['GRANTEX_TEST_TOKEN'] = token;
+
+    try {
+      setJsonMode(true);
+      const cmd = verifyCommand();
+      cmd.exitOverride();
+      await cmd.parseAsync(['node', 'test', '--env', 'GRANTEX_TEST_TOKEN', '--json']);
+
+      const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      const parsed = JSON.parse(output);
+      expect(parsed.grantId).toBe('grnt_01HXYZ');
+    } finally {
+      delete process.env['GRANTEX_TEST_TOKEN'];
+    }
+  });
 });

--- a/release-status.json
+++ b/release-status.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "canonicalUrl": "https://grantex.dev/release-status.json",
   "humanDocumentationUrl": "https://docs.grantex.dev/release-status",
-  "verifiedAt": "2026-07-12",
+  "verifiedAt": "2026-08-10",
   "product": {
     "name": "Grantex",
     "category": "AI agent authorization",
@@ -17,6 +17,7 @@
     "ietfDraftTitle": "Delegated Agent Authorization Protocol (DAAP)"
   },
   "selectionGuidance": {
+    "shellCapableAgent": "Use published @grantex/cli@0.2.5 for existing commands. The Agent Skills installer is source-prepared for 0.3.0 and is not yet published.",
     "typescriptApplication": "Use @grantex/sdk@0.3.13.",
     "pythonApplication": "Use grantex==0.3.14.",
     "goApplication": "Use github.com/mishrasanjeev/grantex-go@v0.1.10 with the documented published-version workarounds.",
@@ -26,6 +27,20 @@
     "mcpAgentSpecificEnforcement": "After MCP transport authorization, use a primary Grantex SDK or direct JWKS validation at each tool boundary when agent-specific delegated authority is required."
   },
   "artifacts": [
+    {
+      "id": "cli",
+      "label": "CLI",
+      "ecosystem": "npm",
+      "name": "@grantex/cli",
+      "version": "0.2.5",
+      "status": "published",
+      "installCommand": "npm install -g @grantex/cli@0.2.5",
+      "runtime": "Node.js 18+; ESM",
+      "registryUrl": "https://registry.npmjs.org/%40grantex%2Fcli/latest",
+      "packageUrl": "https://www.npmjs.com/package/@grantex/cli/v/0.2.5",
+      "documentationUrl": "https://docs.grantex.dev/integrations/cli",
+      "limitations": []
+    },
     {
       "id": "typescript-sdk",
       "label": "TypeScript SDK",

--- a/skills/integrate-grantex/SKILL.md
+++ b/skills/integrate-grantex/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: integrate-grantex
+description: Add Grantex delegated authorization to an agent, CLI tool, API, MCP server, or framework integration. Use when implementing or reviewing agent identity, scoped grants, consent, JWT verification, tool manifests, service-boundary enforcement, audit logging, delegation, or revocation, and when choosing among the Grantex CLI, TypeScript SDK, Python SDK, Go SDK, middleware, gateway, or framework adapters.
+---
+
+# Integrate Grantex
+
+Implement authorization at the component that owns the side effect. Use the CLI for setup and diagnostics; use an SDK, middleware, direct verifier, or gateway at the protected runtime.
+
+## Select the integration surface
+
+Inspect the project before adding dependencies. Reuse an installed Grantex package when it already fits.
+
+| Boundary | Preferred surface |
+|---|---|
+| Shell automation or agent control plane | `@grantex/cli` with `--json` |
+| TypeScript service | `@grantex/sdk` or framework middleware |
+| Python service | `grantex` or FastAPI integration |
+| Go service | `github.com/mishrasanjeev/grantex-go` |
+| Reverse proxy without application changes | `@grantex/gateway` |
+| Framework tool wrapper | The matching Grantex adapter plus its primary SDK |
+| MCP tool execution | MCP transport authorization plus primary-SDK or direct JWKS-backed Grantex enforcement inside each protected tool |
+
+Do not add a Hermes- or OpenClaw-specific SDK. Shell-capable agents use the shared CLI and portable `SKILL.md`; application code uses the existing language SDKs.
+
+## Implement the boundary
+
+1. Inventory every protected action and map it to an explicit scope. Keep read, write, delete, admin, and capped-value operations distinct.
+2. Register a stable agent identity and request only the required scopes, audience, and duration.
+3. Preserve human control. Send the principal to the consent URL and exchange only a code returned through the approved flow.
+4. At the service boundary, validate:
+   - signature against the trusted issuer JWKS;
+   - issuer and expected audience;
+   - expiry and not-before claims;
+   - agent and principal identity;
+   - every required scope and constraint;
+   - delegation invariants; and
+   - current revocation state when the risk model requires it.
+5. Reject before executing the side effect. Unknown tools and missing manifests must fail closed.
+6. Audit both allowed and denied decisions with the agent, grant, principal, action, outcome, and non-secret metadata.
+7. Add revocation and, where needed, narrowly scoped sub-agent delegation.
+
+## Verify the implementation
+
+- Test a valid grant with exactly the required scope.
+- Test a valid token missing the required scope.
+- Test malformed, expired, wrong-issuer, wrong-audience, and invalid-signature tokens.
+- Test an unknown tool or connector.
+- Test revocation through the chosen online or synchronized-state path.
+- Test that denial occurs before the protected function is invoked.
+- Confirm logs never contain API keys, authorization codes, grant tokens, refresh tokens, or upstream credentials.
+
+## CLI handoff
+
+For an agent-operated setup, install the companion skill bundle first:
+
+```bash
+grantex agent install --target portable
+```
+
+Then use `grantex --json ...` for registration, authorization, grants, verification, audit, and revocation. Prefer token input from an environment variable, file, or stdin.
+
+## Security boundaries
+
+- Treat client-side CLI checks as diagnostics, not a security boundary.
+- Treat local JWT verification as signature-and-claims validation, not proof of current revocation.
+- Keep upstream credentials behind the protected service; do not give them directly to the agent.
+- Never silently request broader authority after a denial.
+- Treat `@grantex/mcp-auth@2.0.2` as evaluation-only unless its documented release limitations have been resolved in the selected version. For production MCP enforcement, prefer a primary SDK or direct verification at the tool boundary.

--- a/skills/integrate-grantex/agents/openai.yaml
+++ b/skills/integrate-grantex/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Integrate Grantex"
+  short_description: "Add scoped agent authorization to tools"
+  default_prompt: "Use $integrate-grantex to add Grantex authorization to this project."

--- a/skills/use-grantex-cli/SKILL.md
+++ b/skills/use-grantex-cli/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: use-grantex-cli
+description: Operate Grantex delegated authorization through its machine-readable CLI. Use when Hermes, OpenClaw, an Agent Skills-compatible assistant, or another shell-capable agent needs to configure Grantex, register an agent, request scoped human consent, exchange or verify grant tokens, inspect grants and audit records, delegate narrower authority, or revoke access without writing framework-specific code.
+---
+
+# Use Grantex CLI
+
+Use `grantex` as a control-plane tool. Prefer JSON output, keep credentials out of command arguments, and leave authorization enforcement at the protected service boundary.
+
+## Bootstrap
+
+1. Check whether `grantex` is available on `PATH`.
+2. If it is missing and the user approves installation, run `npm install -g @grantex/cli`.
+3. Configure with environment variables when running unattended. Use the syntax for the current shell:
+
+   ```bash
+   # Bash, zsh, or sh
+   export GRANTEX_URL=https://api.grantex.dev
+   export GRANTEX_KEY=YOUR_API_KEY
+   ```
+
+   ```powershell
+   # PowerShell
+   $env:GRANTEX_URL = "https://api.grantex.dev"
+   $env:GRANTEX_KEY = "YOUR_API_KEY"
+   ```
+
+   Alternatively, use `grantex config set --url <url> --key <key>` for a user-managed local profile.
+
+4. Confirm the identity with `grantex --json me`. Stop if configuration or authentication fails.
+
+## Machine contract
+
+- Put the global flag before the command: `grantex --json agents list`.
+- Parse stdout as JSON and treat stderr as diagnostics.
+- Check the process exit status before trusting output.
+- Use `NO_COLOR=1` if text output must be captured.
+- Prefer `--env`, `--file`, or `--stdin` for grant tokens. Do not expose grant tokens, refresh tokens, or API keys in logs, prompts, shell history, or process arguments.
+
+## Authorization workflow
+
+1. Register only the scopes the agent can justify:
+
+   ```text
+   grantex --json agents register --name "calendar-assistant" --description "Reads approved calendar events" --scopes calendar:read
+   ```
+
+2. Request the smallest useful grant:
+
+   ```text
+   grantex --json authorize --agent ag_... --principal user@example.com --scopes calendar:read
+   ```
+
+3. Present the returned consent URL to the human. Never approve consent on the principal's behalf. In live mode, wait for the registered callback to receive the authorization code.
+4. Exchange an approved code:
+
+   ```bash
+   grantex --json tokens exchange --code <code> --agent-id ag_...
+   ```
+
+5. Store returned tokens only in the caller's approved secret store. Do not print them back to the user unless explicitly requested.
+6. Verify without placing the token in argv:
+
+   ```bash
+   grantex verify --env GRANTEX_GRANT_TOKEN --json
+   grantex --json tokens verify --env GRANTEX_GRANT_TOKEN
+   ```
+
+   The first command performs signature and claim verification. The second performs the configured online check. Local verification alone does not prove current revocation.
+
+## Tool preflight
+
+Use the CLI to inspect a manifest decision while developing or diagnosing:
+
+```text
+grantex --json enforce test --token-env GRANTEX_GRANT_TOKEN --connector salesforce --tool create_lead
+```
+
+Treat this as a preflight only. An agent can bypass its own client-side command. Enforce the token again inside the service that owns the side effect.
+
+## Delegation and revocation
+
+- Delegate only a strict subset of the parent scopes and never extend the parent expiry.
+- Prefer a file or environment input whenever the installed command offers one. Avoid placing secrets in argv.
+- Revoke a grant when the task ends or authority is withdrawn: `grantex --json grants revoke grnt_...`.
+- Confirm important changes with a read command such as `grantex --json grants get grnt_...` and inspect the audit trail.
+
+## Safety rules
+
+- Fail closed when required identity, scope, audience, expiry, signature, or current-state checks are unavailable.
+- Never broaden scopes to make a denied action pass. Ask for a new human-approved grant.
+- Never treat `decode` as verification.
+- Never describe a CLI preflight or local JWT decode as service-side enforcement.
+- Record security-relevant success and denial events without logging secrets.

--- a/skills/use-grantex-cli/agents/openai.yaml
+++ b/skills/use-grantex-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Use Grantex CLI"
+  short_description: "Operate Grantex safely from any agent shell"
+  default_prompt: "Use $use-grantex-cli to configure delegated authorization for this agent."

--- a/web/index.html
+++ b/web/index.html
@@ -93,7 +93,7 @@
           "height": 630,
           "caption": "Grantex AI agent authorization"
         },
-        "dateModified": "2026-07-14",
+        "dateModified": "2026-08-10",
         "inLanguage": "en"
       },
       {
@@ -210,7 +210,7 @@
             "name": "How do I authorize tools used by AI agent frameworks?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Use a primary Grantex SDK to register the agent, request a grant, and exchange the authorization code, then enforce scopes at the service boundary with an SDK verifier or direct JWKS validation. Framework adapters are available for OpenAI Agents SDK, Anthropic, LangChain, CrewAI, Google ADK, Vercel AI, AutoGen, Express, FastAPI, and MCP."
+              "text": "Use a primary Grantex SDK to register the agent, request a grant, and exchange the authorization code, then enforce scopes at the service boundary with an SDK verifier or direct JWKS validation. Hermes, OpenClaw, and other shell-capable agents can install the portable Grantex Agent Skills and use the JSON CLI; no agent-specific SDK is required. Framework adapters are available for OpenAI Agents SDK, Anthropic, LangChain, CrewAI, Google ADK, Vercel AI, AutoGen, Express, FastAPI, and MCP."
             }
           },
           {
@@ -416,6 +416,29 @@
       border-radius: 50%;
       background: var(--accent);
     }
+    .hero-agent-support {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 8px 12px;
+      max-width: 720px;
+      margin: -14px auto 32px;
+      padding: 9px 16px;
+      color: var(--muted);
+      background: rgba(88, 166, 255, 0.06);
+      border: 1px solid rgba(88, 166, 255, 0.28);
+      border-radius: 999px;
+      font-family: var(--mono);
+      font-size: 12px;
+    }
+    .hero-agent-support span:first-child {
+      color: var(--accent);
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.6px;
+    }
+    .hero-agent-support a { color: var(--text); }
 
     /* ── Direct answer hub ────────────────────────────────────────────────── */
     .answers-section {
@@ -833,6 +856,83 @@
     }
     .install-cmd:hover .install-copy { color: var(--text); }
 
+    /* Agent CLI support */
+    .agent-cli-layout {
+      display: grid;
+      grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+      gap: 48px;
+      align-items: center;
+    }
+    .agent-cli-platforms {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin: 24px 0;
+    }
+    .agent-cli-platform {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      color: var(--text);
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      font-family: var(--mono);
+      font-size: 12px;
+    }
+    .agent-cli-platform::before {
+      width: 7px;
+      height: 7px;
+      background: var(--accent);
+      border-radius: 50%;
+      content: '';
+    }
+    .agent-cli-terminal {
+      position: relative;
+      min-width: 0;
+      overflow: hidden;
+      background: #010409;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      box-shadow: 0 20px 50px rgba(0, 0, 0, 0.28);
+    }
+    .agent-cli-terminal-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      min-height: 42px;
+      padding: 0 16px;
+      color: var(--muted);
+      border-bottom: 1px solid var(--border);
+      font-family: var(--mono);
+      font-size: 11px;
+    }
+    .terminal-dot { width: 8px; height: 8px; border-radius: 50%; background: #30363d; }
+    .terminal-dot:first-child { background: #f85149; }
+    .terminal-dot:nth-child(2) { background: #d29922; }
+    .terminal-dot:nth-child(3) { background: var(--accent); margin-right: 6px; }
+    .agent-cli-terminal pre {
+      overflow-x: auto;
+      padding: 24px;
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 13px;
+      line-height: 1.8;
+    }
+    .agent-cli-terminal .copy-btn { top: 8px; right: 10px; }
+    .agent-cli-boundary {
+      margin-top: 18px;
+      padding: 12px 14px;
+      color: var(--muted);
+      background: rgba(210, 153, 34, 0.06);
+      border: 1px solid rgba(210, 153, 34, 0.24);
+      border-radius: var(--radius);
+      font-size: 12px;
+      line-height: 1.6;
+    }
+    .agent-cli-boundary strong { color: #d29922; }
+
     /* ── Integrations ──────────────────────────────────────────────────────── */
     .integrations-grid {
       display: flex;
@@ -1236,6 +1336,7 @@
       }
       .nav-links a:hover { background: var(--surface); }
       .release-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .agent-cli-layout { grid-template-columns: minmax(0, 1fr); gap: 32px; }
     }
     @media (max-width: 640px) {
       section { padding: 56px 0; }
@@ -1283,6 +1384,7 @@
         <li><a href="/dpdp">DPDP</a></li>
         <li><a href="/registry">Registry</a></li>
         <li><a href="#answers">Answers</a></li>
+        <li><a href="#agent-clis">Agent CLIs</a></li>
         <li><a href="#examples">Examples</a></li>
         <li><a href="/dashboard" style="color:var(--accent);font-weight:600;">Dashboard</a></li>
       </ul>
@@ -1299,6 +1401,14 @@
     <p>
       Grantex is an open-source delegated authorization protocol and reference implementation for AI agents. It gives each agent a verifiable identity and scoped, time-limited, revocable authority from a human or organization, with multi-agent delegation, service-side verification, and audit records. Grantex complements OAuth 2.0 and MCP: OAuth handles application and user authorization, MCP connects models to tools, and Grantex proves which agent may perform which action for which principal.
     </p>
+    <div class="hero-agent-support" aria-label="Supported agent command-line environments">
+      <span>Agent CLI ready</span>
+      <a href="https://docs.grantex.dev/integrations/hermes">Hermes</a>
+      <span aria-hidden="true">&middot;</span>
+      <a href="https://docs.grantex.dev/integrations/openclaw">OpenClaw</a>
+      <span aria-hidden="true">&middot;</span>
+      <a href="https://docs.grantex.dev/integrations/agent-cli">Any shell-capable agent</a>
+    </div>
     <div class="hero-ctas">
       <a href="#quickstart" class="btn btn-primary"
          onclick="gtag('event','get_started_click',{event_category:'hero'})">
@@ -1356,7 +1466,7 @@
         <div class="section-label">Published releases</div>
         <h2 class="section-title">Current public releases</h2>
         <p class="release-intro">
-          Verified against npm, PyPI, and the Go module proxy on 12 July 2026.
+          Verified against npm, PyPI, and the Go module proxy on 10 August 2026.
           Grantex packages are independently versioned.
         </p>
       </div>
@@ -1510,7 +1620,7 @@
       </details>
       <details class="answer-card" data-faq-item>
         <summary>How do I authorize tools used by AI agent frameworks?</summary>
-        <p>Use a primary Grantex SDK to register the agent, request a grant, and exchange the authorization code, then enforce scopes at the service boundary with an SDK verifier or direct JWKS validation. Framework adapters are available for OpenAI Agents SDK, Anthropic, LangChain, CrewAI, Google ADK, Vercel AI, AutoGen, Express, FastAPI, and MCP.</p>
+        <p>Use a primary Grantex SDK to register the agent, request a grant, and exchange the authorization code, then enforce scopes at the service boundary with an SDK verifier or direct JWKS validation. Hermes, OpenClaw, and other shell-capable agents can install the portable Grantex Agent Skills and use the JSON CLI; no agent-specific SDK is required. Framework adapters are available for OpenAI Agents SDK, Anthropic, LangChain, CrewAI, Google ADK, Vercel AI, AutoGen, Express, FastAPI, and MCP.</p>
       </details>
       <details class="answer-card" data-faq-item>
         <summary>Is @grantex/mcp-auth 2.0.2 ready for general production deployment?</summary>
@@ -2453,6 +2563,66 @@ func main() {
   </div>
 </section>
 
+<!-- Agent CLIs -->
+<section id="agent-clis">
+  <div class="container">
+    <div class="agent-cli-layout">
+      <div>
+        <div class="section-label">Agent-native CLI</div>
+        <h2 class="section-title">One CLI. Any agent.</h2>
+        <p class="section-sub" style="margin-bottom:0;">
+          Hermes, OpenClaw, and other shell-capable agents can install the same
+          portable skills and operate Grantex through predictable JSON. No
+          framework-specific SDK is required for the agent itself.
+        </p>
+        <div class="agent-cli-platforms" aria-label="Agent CLI compatibility">
+          <a class="agent-cli-platform" href="https://docs.grantex.dev/integrations/hermes">Hermes Agent</a>
+          <a class="agent-cli-platform" href="https://docs.grantex.dev/integrations/openclaw">OpenClaw</a>
+          <a class="agent-cli-platform" href="https://docs.grantex.dev/integrations/agent-cli">Agent Skills</a>
+          <span class="agent-cli-platform">Any CLI shell</span>
+        </div>
+        <p style="color:var(--muted);font-size:14px;line-height:1.7;">
+          The bundle teaches agents least-privilege consent, secret-safe token
+          handling, JSON parsing, revocation, and the difference between a CLI
+          preflight and real service-side enforcement.
+        </p>
+        <div style="display:flex;gap:12px;flex-wrap:wrap;margin-top:24px;">
+          <a href="https://docs.grantex.dev/integrations/agent-cli" class="btn btn-primary"
+             onclick="gtag('event','agent_cli_docs_click',{event_category:'agent_cli'})">Agent CLI docs &rarr;</a>
+          <a href="https://github.com/mishrasanjeev/grantex/tree/main/skills" class="btn btn-secondary"
+             onclick="gtag('event','agent_skills_click',{event_category:'agent_cli'})">View the skills</a>
+        </div>
+      </div>
+      <div>
+        <div class="agent-cli-terminal">
+          <div class="agent-cli-terminal-header">
+            <span class="terminal-dot"></span><span class="terminal-dot"></span><span class="terminal-dot"></span>
+            Install Grantex skills
+          </div>
+          <button type="button" class="copy-btn" aria-label="Copy agent skill install commands"
+                  onclick="copyCode('code-agent-cli', this, 'agent_cli_install_copy')">Copy</button>
+          <pre id="code-agent-cli"><span class="cm"># Install the JSON-first CLI</span>
+npm install -g @grantex/cli
+
+<span class="cm"># Choose the agent host</span>
+grantex agent install --target openclaw
+grantex agent install --target hermes
+grantex agent install --target portable
+
+<span class="cm"># Any other skill directory</span>
+grantex agent install --dir /path/to/skills</pre>
+        </div>
+        <div class="agent-cli-boundary">
+          <strong>Security boundary:</strong> the protected API, connector, or gateway
+          still verifies the grant and exact scope before executing the side effect.<br>
+          <strong>Release:</strong> the installer is prepared in CLI 0.3.0 source; confirm
+          the published version before installing from npm.
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
 <!-- ── Integrations ───────────────────────────────────────────────────────── -->
 <section id="integrations">
   <div class="container">
@@ -2462,6 +2632,18 @@ func main() {
       Drop Grantex into any AI framework or language runtime.
     </p>
     <div class="integrations-grid">
+      <a href="https://docs.grantex.dev/integrations/hermes" class="integration-pill" style="text-decoration:none;">
+        <span class="integration-icon" style="font-family:var(--mono);font-size:14px;font-weight:700;">H</span>
+        Hermes Agent
+      </a>
+      <a href="https://docs.grantex.dev/integrations/openclaw" class="integration-pill" style="text-decoration:none;">
+        <span class="integration-icon" style="font-family:var(--mono);font-size:14px;font-weight:700;">OC</span>
+        OpenClaw
+      </a>
+      <a href="https://docs.grantex.dev/integrations/agent-cli" class="integration-pill" style="text-decoration:none;">
+        <span class="integration-icon" style="font-family:var(--mono);font-size:14px;font-weight:700;">&gt;_</span>
+        Any Agent CLI
+      </a>
       <a href="https://www.npmjs.com/package/@grantex/adapters" class="integration-pill" style="text-decoration:none;">
         <span class="integration-icon">&#x1F9E9;</span>
         Adapters (11)

--- a/web/ld.json
+++ b/web/ld.json
@@ -52,7 +52,7 @@
         "height": 630,
         "caption": "Grantex AI agent authorization"
       },
-      "dateModified": "2026-07-14",
+      "dateModified": "2026-08-10",
       "inLanguage": "en"
     },
     {
@@ -169,7 +169,7 @@
           "name": "How do I authorize tools used by AI agent frameworks?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Use a primary Grantex SDK to register the agent, request a grant, and exchange the authorization code, then enforce scopes at the service boundary with an SDK verifier or direct JWKS validation. Framework adapters are available for OpenAI Agents SDK, Anthropic, LangChain, CrewAI, Google ADK, Vercel AI, AutoGen, Express, FastAPI, and MCP."
+            "text": "Use a primary Grantex SDK to register the agent, request a grant, and exchange the authorization code, then enforce scopes at the service boundary with an SDK verifier or direct JWKS validation. Hermes, OpenClaw, and other shell-capable agents can install the portable Grantex Agent Skills and use the JSON CLI; no agent-specific SDK is required. Framework adapters are available for OpenAI Agents SDK, Anthropic, LangChain, CrewAI, Google ADK, Vercel AI, AutoGen, Express, FastAPI, and MCP."
           }
         },
         {

--- a/web/llms-full.txt
+++ b/web/llms-full.txt
@@ -1,7 +1,7 @@
 # Grantex — Full Implementation Brief for AI Assistants
 
-> Last updated: 2026-07-14
-> Public release snapshot verified: 2026-07-12
+> Last updated: 2026-08-10
+> Public release snapshot verified: 2026-08-10
 
 Grantex is an open-source delegated authorization protocol and reference implementation for AI agents. It gives each agent a verifiable identity and scoped, time-limited, revocable authority from a human or organization, with multi-agent delegation, service-side verification, and audit records.
 
@@ -61,6 +61,7 @@ The Grantex protocol specification is open and frozen at version 1.0. The relate
 | Agent-specific enforcement in MCP tools | Primary Grantex SDK or direct JWKS-backed validation | Add after transport authorization when the tool must verify delegated agent authority |
 | MCP endpoint evaluation | `@grantex/mcp-auth@2.0.2` plus `@grantex/sdk@0.3.13` | Single-process evaluation only |
 | Terminal automation | `@grantex/cli` | Optional operational tooling |
+| Hermes, OpenClaw, or another shell-capable agent | `@grantex/cli` 0.3.0+ plus the bundled Agent Skills | 0.3.0 source prepared; no agent-specific SDK required; enforce again at the protected service |
 | Framework-specific tools | Named Grantex adapter plus its primary SDK where required | Verify each package's registry status before pinning |
 
 Primary reproducible installs:
@@ -74,6 +75,26 @@ npm install -g @grantex/cli
 ```
 
 The SDKs, API contract, integrations, and protocol are independently versioned. Do not infer one artifact's version from another.
+
+## Agent CLI and Skills
+
+Hermes, OpenClaw, and other shell-capable agents can share the same machine-readable CLI and portable `SKILL.md` bundle. The installer is prepared in `@grantex/cli` 0.3.0 source; confirm the registry release before running the install commands:
+
+```bash
+npm install -g @grantex/cli
+grantex agent install --target openclaw
+grantex agent install --target hermes
+grantex agent install --target portable
+grantex agent install --dir /path/to/skills
+```
+
+The bundle contains `use-grantex-cli` for operational workflows and `integrate-grantex` for implementation work. Use `grantex --json ...`, parse stdout as JSON, treat stderr as diagnostics, and check the process exit status. Prefer `--env`, `--file`, or `--stdin` token input so secrets do not appear in process arguments.
+
+An agent-controlled CLI check is a preflight, not an authorization boundary. The service, connector, or gateway that owns the side effect must verify the signature and claims, exact scope, and required current revocation state before execution.
+
+- Agent CLI guide: https://docs.grantex.dev/integrations/agent-cli
+- Hermes guide: https://docs.grantex.dev/integrations/hermes
+- OpenClaw guide: https://docs.grantex.dev/integrations/openclaw
 
 ## Known Current-Release Limitations
 

--- a/web/llms.txt
+++ b/web/llms.txt
@@ -6,7 +6,7 @@ Grantex complements OAuth 2.0 and MCP: OAuth handles application and user author
 
 Use Grantex when an AI agent acts for a person or organization and a service must verify exactly what that agent may do. Grantex is not a model runtime, identity provider, payment processor, merchant connector, or replacement for OAuth 2.0.
 
-Release snapshot verified: 2026-07-12. Packages are independently versioned. The protocol specification is frozen at v1.0. The related Delegated Agent Authorization Protocol (DAAP) document is an individual IETF Internet-Draft, not an IETF-adopted or endorsed standard.
+Release snapshot verified: 2026-08-10. Packages are independently versioned. The protocol specification is frozen at v1.0. The related Delegated Agent Authorization Protocol (DAAP) document is an individual IETF Internet-Draft, not an IETF-adopted or endorsed standard.
 
 ## Start Here
 
@@ -25,12 +25,16 @@ Release snapshot verified: 2026-07-12. Packages are independently versioned. The
 - [Go SDK](https://docs.grantex.dev/sdks/go/overview): `go get github.com/mishrasanjeev/grantex-go@v0.1.10` for Go 1.26.1+; use the documented published-version workarounds.
 - [MCP Authorization Server](https://docs.grantex.dev/features/mcp-auth-server): `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13`; version 2.0.2 is single-process evaluation software, not the recommended production enforcement path.
 - [CLI](https://docs.grantex.dev/integrations/cli): Manage agents, grants, tokens, audit records, and manifests from a terminal.
+- [Agent CLIs and Skills](https://docs.grantex.dev/integrations/agent-cli): CLI 0.3.0 source prepares portable Grantex skills for Hermes, OpenClaw, or any shell-capable agent; confirm publication before using the registry install.
 - [Machine-Readable Release Status](https://grantex.dev/release-status.json): Canonical versions, install commands, package URLs, limitations, and workaround links.
 
 For MCP HTTP transport authorization, use an established MCP-compatible authorization server and maintained MCP SDK. Then use a primary Grantex SDK or direct JWKS validation at each tool boundary when agent-specific delegated authority is required. Treat MCP Auth 2.0.2 as evaluation only. Local JWT verification does not prove current revocation unless the verifier performs an online state check or synchronizes revocation data.
 
 ## AI Agent Frameworks
 
+- [Hermes Agent](https://docs.grantex.dev/integrations/hermes): Install `use-grantex-cli` and `integrate-grantex` under the Hermes skill root.
+- [OpenClaw](https://docs.grantex.dev/integrations/openclaw): Install the same portable skills in an OpenClaw workspace.
+- [Any Agent CLI](https://docs.grantex.dev/integrations/agent-cli): Use the JSON CLI contract or choose a custom Agent Skills directory.
 - [Framework Integration Hub](https://grantex.dev/for): Grantex packages and guides for agent frameworks, APIs, and multi-agent systems.
 - [OpenAI Agents SDK Authorization](https://grantex.dev/for/openai-agents): Scoped FunctionTool execution and grant verification.
 - [Anthropic and Claude Tool Authorization](https://grantex.dev/for/anthropic): Scope-enforced tool use for Anthropic SDK applications.

--- a/web/release-status.json
+++ b/web/release-status.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "canonicalUrl": "https://grantex.dev/release-status.json",
   "humanDocumentationUrl": "https://docs.grantex.dev/release-status",
-  "verifiedAt": "2026-07-12",
+  "verifiedAt": "2026-08-10",
   "product": {
     "name": "Grantex",
     "category": "AI agent authorization",
@@ -17,6 +17,7 @@
     "ietfDraftTitle": "Delegated Agent Authorization Protocol (DAAP)"
   },
   "selectionGuidance": {
+    "shellCapableAgent": "Use published @grantex/cli@0.2.5 for existing commands. The Agent Skills installer is source-prepared for 0.3.0 and is not yet published.",
     "typescriptApplication": "Use @grantex/sdk@0.3.13.",
     "pythonApplication": "Use grantex==0.3.14.",
     "goApplication": "Use github.com/mishrasanjeev/grantex-go@v0.1.10 with the documented published-version workarounds.",
@@ -26,6 +27,20 @@
     "mcpAgentSpecificEnforcement": "After MCP transport authorization, use a primary Grantex SDK or direct JWKS validation at each tool boundary when agent-specific delegated authority is required."
   },
   "artifacts": [
+    {
+      "id": "cli",
+      "label": "CLI",
+      "ecosystem": "npm",
+      "name": "@grantex/cli",
+      "version": "0.2.5",
+      "status": "published",
+      "installCommand": "npm install -g @grantex/cli@0.2.5",
+      "runtime": "Node.js 18+; ESM",
+      "registryUrl": "https://registry.npmjs.org/%40grantex%2Fcli/latest",
+      "packageUrl": "https://www.npmjs.com/package/@grantex/cli/v/0.2.5",
+      "documentationUrl": "https://docs.grantex.dev/integrations/cli",
+      "limitations": []
+    },
     {
       "id": "typescript-sdk",
       "label": "TypeScript SDK",


### PR DESCRIPTION
## What changed

- add `grantex agent install` targets for Hermes, OpenClaw, portable `.agents/skills`, and custom skill roots
- bundle `use-grantex-cli` and `integrate-grantex` Agent Skills with UI metadata
- add secret-safe token input through environment variables, files, or stdin, with reliable non-zero denial/error statuses in JSON mode
- add prominent agent support to the landing page and dedicated Hermes, OpenClaw, and generic Agent CLI documentation
- document that no agent-specific SDK is needed: agents use the CLI control plane while existing SDKs, middleware, or the gateway enforce at the protected service boundary
- distinguish published CLI 0.2.5 from source-prepared 0.3.0 in release status

## Why

Shell-capable agents should be able to discover and operate Grantex without a framework-specific adapter or leaking grant tokens through process arguments. The same portable skills and JSON contract now work across supported agent hosts.

## Impact

Hermes and OpenClaw receive one-command skill installation after CLI 0.3.0 is published. Other Agent Skills-compatible tools can use the portable or custom-directory target. Existing CLI positional-token behavior remains compatible.

## Validation

- CLI CI-equivalent SDK build/install sequence
- CLI typecheck
- CLI test suite: 35 files, 520 tests
- CLI production build
- npm package dry-run includes both skills and `agents/openai.yaml`
- both skills pass `quick_validate.py`
- documentation integrity check
- SEO/AEO integrity check
- `git diff --check`
