### PR TITLE
docs: mark CLI 0.3.0 published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## Unreleased
 
 ### Added
-- Prepared `@grantex/cli` 0.3.0 with one-command Agent Skills installation for Hermes, OpenClaw, portable `.agents/skills` workspaces, and custom skill roots.
+- Published `@grantex/cli` 0.3.0 on 2026-08-10 with one-command Agent Skills installation for Hermes, OpenClaw, portable `.agents/skills` workspaces, and custom skill roots.
 - Added the `use-grantex-cli` and `integrate-grantex` skills for safe JSON-first operations and service-boundary implementation guidance.
 - Added cross-platform token input from environment variables, files, and stdin, plus non-zero JSON-mode status codes for invalid or denied checks.
 - Added `audience` support to TypeScript, Python, and Go authorization requests.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -26,7 +26,7 @@ The repository contains 29 packages under `packages/`. Each row maps a directory
 | 1 | `packages/sdk-ts` | @grantex/sdk | 0.3.13 | Primary SDK (TypeScript); published |
 | 2 | `packages/sdk-py` | grantex | 0.3.14 | Primary SDK (Python); published |
 | 3 | `packages/go-sdk` | github.com/mishrasanjeev/grantex-go | v0.1.10 (Go 1.26.1) | Primary SDK (Go); published |
-| 4 | `packages/cli` | @grantex/cli | 0.3.0 | Tooling; source prepared, not yet published |
+| 4 | `packages/cli` | @grantex/cli | 0.3.0 | Tooling; published with bundled Agent Skills |
 | 5 | `packages/mcp-auth` | @grantex/mcp-auth | 2.0.2 | Independently versioned |
 | 6 | `packages/mcp` | @grantex/mcp | 0.1.10 | Adapter |
 | 7 | `packages/langchain` | @grantex/langchain | 0.1.7 | Adapter |

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ if (!auth.code) {
 python -m pip install grantex==0.3.14               # Python SDK
 go get github.com/mishrasanjeev/grantex-go@v0.1.10 # Go SDK (Go 1.26.1+)
 npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13 # MCP endpoint evaluation
-npm install -g @grantex/cli                         # Optional CLI tooling
+npm install -g @grantex/cli@0.3.0                   # Optional CLI tooling
 ```
 
 ### Hermes, OpenClaw, and any agent CLI
@@ -157,7 +157,7 @@ npm install -g @grantex/cli                         # Optional CLI tooling
 Shell-capable agents use the same JSON-first CLI; no agent-specific SDK is required:
 
 ```bash
-npm install -g @grantex/cli
+npm install -g @grantex/cli@0.3.0
 grantex agent install --target openclaw  # writes ./skills
 grantex agent install --target hermes    # writes ~/.hermes/skills/grantex
 grantex agent install --target portable  # writes ./.agents/skills
@@ -1432,10 +1432,10 @@ The primary SDK versions below are registry-verified as of 2026-08-10. For integ
 | **TypeScript SDK** | `@grantex/sdk` (`0.3.13`) | `npm install @grantex/sdk@0.3.13` | Registry-verified primary release |
 | **Python SDK** | `grantex` (`0.3.14`) | `python -m pip install grantex==0.3.14` | Registry-verified primary release |
 | **Go SDK** | `grantex-go` (`v0.1.10`, Go 1.26.1+) | `go get github.com/mishrasanjeev/grantex-go@v0.1.10` | Published with workarounds; source correction awaits a new tag |
-| **CLI** | `@grantex/cli` | `npm install -g @grantex/cli` | Published package |
-| **Hermes Agent** | `@grantex/cli` 0.3.0+ + Agent Skills | `grantex agent install --target hermes` | 0.3.0 source prepared; no dedicated SDK needed |
-| **OpenClaw** | `@grantex/cli` 0.3.0+ + Agent Skills | `grantex agent install --target openclaw` | 0.3.0 source prepared; no dedicated SDK needed |
-| **Portable Agent Skills** | `@grantex/cli` 0.3.0+ + `SKILL.md` | `grantex agent install --target portable` | 0.3.0 source prepared |
+| **CLI** | `@grantex/cli` (`0.3.0`) | `npm install -g @grantex/cli@0.3.0` | Registry-verified published package |
+| **Hermes Agent** | `@grantex/cli` 0.3.0+ + Agent Skills | `grantex agent install --target hermes` | Published in 0.3.0; no dedicated SDK needed |
+| **OpenClaw** | `@grantex/cli` 0.3.0+ + Agent Skills | `grantex agent install --target openclaw` | Published in 0.3.0; no dedicated SDK needed |
+| **Portable Agent Skills** | `@grantex/cli` 0.3.0+ + `SKILL.md` | `grantex agent install --target portable` | Published in 0.3.0 |
 | **Conformance Suite** | `@grantex/conformance` | `npm install -g @grantex/conformance` | Published package |
 | **A2A Bridge (TS)** | `@grantex/a2a` | `npm install @grantex/a2a` | Published package |
 | **A2A Bridge (Py)** | `grantex-a2a` | `pip install grantex-a2a` | Published package |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ Only the following versions of Grantex components receive security patches:
 | Protocol spec | v1.0 | ✅ Yes |
 | `@grantex/sdk` | 0.3.x | ✅ Yes |
 | `grantex` (Python) | 0.3.x | ✅ Yes |
-| `@grantex/cli` | 0.2.x | ✅ Yes |
+| `@grantex/cli` | 0.3.x | ✅ Yes |
 | `github.com/mishrasanjeev/grantex-go` | 0.1.x | ✅ Yes |
 | `@grantex/mcp` | 0.1.x | ✅ Yes |
 | `@grantex/mcp-auth` | 2.0.x | ✅ Yes |

--- a/docs/integrations/agent-cli.mdx
+++ b/docs/integrations/agent-cli.mdx
@@ -11,13 +11,13 @@ Grantex works with shell-capable agents without a framework-specific adapter. In
 </Info>
 
 <Note>
-  The skill installer is prepared in `@grantex/cli` 0.3.0 source. Confirm that 0.3.0 or newer is published on the [release-status page](/release-status) before expecting the registry install below to include `grantex agent install`.
+  Published `@grantex/cli@0.3.0` includes the Hermes, OpenClaw, portable, and custom-directory Agent Skills installer.
 </Note>
 
 ## Install the CLI
 
 ```bash
-npm install -g @grantex/cli
+npm install -g @grantex/cli@0.3.0
 ```
 
 The host needs Node.js 18 or newer. Confirm the command is available:

--- a/docs/integrations/hermes.mdx
+++ b/docs/integrations/hermes.mdx
@@ -6,12 +6,12 @@ description: "Install Grantex Agent Skills into Hermes and operate delegated aut
 
 Hermes can use Grantex directly through its shell tools and on-demand skills. No Hermes-specific SDK is required.
 
-The one-command installer requires `@grantex/cli` 0.3.0 or newer; confirm the published version on the [release-status page](/release-status).
+Published `@grantex/cli@0.3.0` includes the one-command Hermes skill installer.
 
 ## Install
 
 ```bash
-npm install -g @grantex/cli
+npm install -g @grantex/cli@0.3.0
 grantex agent install --target hermes
 hermes skills list
 ```

--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -6,14 +6,14 @@ description: "Install Grantex Agent Skills in an OpenClaw workspace and use the 
 
 OpenClaw can load the same portable Grantex skills used by other Agent Skills-compatible hosts. No OpenClaw-specific Grantex SDK is required.
 
-The one-command installer requires `@grantex/cli` 0.3.0 or newer; confirm the published version on the [release-status page](/release-status).
+Published `@grantex/cli@0.3.0` includes the one-command OpenClaw skill installer.
 
 ## Install in a workspace
 
 Run from the configured OpenClaw agent workspace:
 
 ```bash
-npm install -g @grantex/cli
+npm install -g @grantex/cli@0.3.0
 grantex agent install --target openclaw
 openclaw skills check
 ```

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -101,9 +101,9 @@ keywords: ["AI agent framework integrations", "Hermes Agent authorization", "Ope
 
 | Framework | Package | Install | Language |
 |-----------|---------|---------|----------|
-| Hermes Agent | `@grantex/cli` 0.3.0+ + Agent Skills | `grantex agent install --target hermes` | Any shell; 0.3.0 source prepared |
-| OpenClaw | `@grantex/cli` 0.3.0+ + Agent Skills | `grantex agent install --target openclaw` | Any shell; 0.3.0 source prepared |
-| Other Agent Skills clients | `@grantex/cli` 0.3.0+ + Agent Skills | `grantex agent install --target portable` | Any shell; 0.3.0 source prepared |
+| Hermes Agent | `@grantex/cli@0.3.0` + Agent Skills | `grantex agent install --target hermes` | Any shell; published package |
+| OpenClaw | `@grantex/cli@0.3.0` + Agent Skills | `grantex agent install --target openclaw` | Any shell; published package |
+| Other Agent Skills clients | `@grantex/cli@0.3.0` + Agent Skills | `grantex agent install --target portable` | Any shell; published package |
 | Adapters | `@grantex/adapters` | `npm install @grantex/adapters` | TypeScript |
 | MCP Auth Server | `@grantex/mcp-auth@2.0.2` | `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13` | TypeScript; evaluation only |
 | Gateway | `@grantex/gateway` | `npm install @grantex/gateway` | TypeScript |
@@ -122,7 +122,7 @@ keywords: ["AI agent framework integrations", "Hermes Agent authorization", "Ope
 | Go SDK | `grantex-go@v0.1.10` | `go get github.com/mishrasanjeev/grantex-go@v0.1.10` | Go 1.26.1+; workarounds documented |
 | A2A Bridge (TS) | `@grantex/a2a` | `npm install @grantex/a2a` | TypeScript |
 | A2A Bridge (Py) | `grantex-a2a` | `pip install grantex-a2a` | Python |
-| CLI | `@grantex/cli` | `npm install -g @grantex/cli` | TypeScript |
+| CLI | `@grantex/cli@0.3.0` | `npm install -g @grantex/cli@0.3.0` | TypeScript |
 | Conformance Suite | `@grantex/conformance` | `npm install -g @grantex/conformance` | TypeScript |
 | Event Destinations | `@grantex/destinations` | `npm install @grantex/destinations` | TypeScript |
 | MPP Agent Identity | `@grantex/mpp` | `npm install @grantex/mpp` | TypeScript |

--- a/docs/release-status.mdx
+++ b/docs/release-status.mdx
@@ -15,7 +15,7 @@ repository.
 
 | Surface | Current release | Status | Runtime requirement |
 |---|---:|---|---|
-| CLI | `@grantex/cli@0.2.5` | Published to npm | Node.js 18+; ESM |
+| CLI | `@grantex/cli@0.3.0` | Published to npm with bundled Agent Skills | Node.js 18+; ESM |
 | TypeScript SDK | `@grantex/sdk@0.3.13` | Published to npm | Node.js 18+; ESM |
 | Python SDK | `grantex==0.3.14` | Published to PyPI | Python 3.9+ |
 | Go SDK | `github.com/mishrasanjeev/grantex-go@v0.1.10` | Published with known limitations | Go 1.26.1+ |
@@ -28,12 +28,12 @@ repository.
   contract version.
 </Info>
 
-## Repository changes awaiting publication
+## Published and source-only changes
 
 <Info>
-  As of August 10, 2026, `@grantex/cli` 0.3.0 source adds the Hermes,
-  OpenClaw, and portable Agent Skills installer, but that version is not yet
-  published. Repository source on `main` also corrects the documented Go
+  As of August 10, 2026, published `@grantex/cli@0.3.0` includes the Hermes,
+  OpenClaw, and portable Agent Skills installer. Repository source on `main`
+  also corrects the documented Go
   Agent/Audit read/write contracts, removes unsupported audit filters and list
   metadata, and URL-encodes query values. No corrected Go module tag is published.
   Standard developer API-key plan throughput is also source-only; custom-auth quotas and managed rollout remain separate.
@@ -41,7 +41,7 @@ repository.
 
 ## Which Grantex package should I use?
 
-- **Hermes, OpenClaw, or another shell-capable agent:** use the published CLI for existing commands; the one-command Agent Skills installer requires the source-prepared, unpublished `@grantex/cli@0.3.0`.
+- **Hermes, OpenClaw, or another shell-capable agent:** use published `@grantex/cli@0.3.0`; install its bundled skills with `grantex agent install`. No agent-specific SDK is required.
 - **TypeScript application:** use `@grantex/sdk@0.3.13`.
 - **Python application:** use `grantex==0.3.14`.
 - **Go application:** use `github.com/mishrasanjeev/grantex-go@v0.1.10` with the [published-version workarounds](/sdks/go/overview#known-v0110-limitations), including the [REST/CLI audit-write workaround](/sdks/go/audit#log).
@@ -83,7 +83,7 @@ Pin exact versions in applications, examples, CI, and deployment manifests:
 
 <CodeGroup>
 ```bash CLI
-npm install -g @grantex/cli@0.2.5
+npm install -g @grantex/cli@0.3.0
 ```
 
 ```bash TypeScript

--- a/release-status.json
+++ b/release-status.json
@@ -17,7 +17,7 @@
     "ietfDraftTitle": "Delegated Agent Authorization Protocol (DAAP)"
   },
   "selectionGuidance": {
-    "shellCapableAgent": "Use published @grantex/cli@0.2.5 for existing commands. The Agent Skills installer is source-prepared for 0.3.0 and is not yet published.",
+    "shellCapableAgent": "Use published @grantex/cli@0.3.0 for Hermes, OpenClaw, and other shell-capable agents. Install the bundled skills with grantex agent install; no agent-specific SDK is required.",
     "typescriptApplication": "Use @grantex/sdk@0.3.13.",
     "pythonApplication": "Use grantex==0.3.14.",
     "goApplication": "Use github.com/mishrasanjeev/grantex-go@v0.1.10 with the documented published-version workarounds.",
@@ -32,12 +32,12 @@
       "label": "CLI",
       "ecosystem": "npm",
       "name": "@grantex/cli",
-      "version": "0.2.5",
+      "version": "0.3.0",
       "status": "published",
-      "installCommand": "npm install -g @grantex/cli@0.2.5",
+      "installCommand": "npm install -g @grantex/cli@0.3.0",
       "runtime": "Node.js 18+; ESM",
       "registryUrl": "https://registry.npmjs.org/%40grantex%2Fcli/latest",
-      "packageUrl": "https://www.npmjs.com/package/@grantex/cli/v/0.2.5",
+      "packageUrl": "https://www.npmjs.com/package/@grantex/cli/v/0.3.0",
       "documentationUrl": "https://docs.grantex.dev/integrations/cli",
       "limitations": []
     },

--- a/web/index.html
+++ b/web/index.html
@@ -521,7 +521,7 @@
     }
     .release-grid {
       display: grid;
-      grid-template-columns: repeat(4, minmax(0, 1fr));
+      grid-template-columns: repeat(5, minmax(0, 1fr));
       gap: 16px;
     }
     .release-card {
@@ -1479,6 +1479,12 @@
     </div>
 
     <div class="release-grid">
+      <a class="release-card" href="https://www.npmjs.com/package/@grantex/cli/v/0.3.0">
+        <span class="release-language">Agent CLI</span>
+        <span class="release-name">@grantex/cli</span>
+        <strong class="release-version">0.3.0</strong>
+        <span class="release-meta">npm &middot; published 10 Aug 2026 &middot; Agent Skills</span>
+      </a>
       <a class="release-card" href="https://www.npmjs.com/package/@grantex/sdk/v/0.3.13">
         <span class="release-language">TypeScript SDK</span>
         <span class="release-name">@grantex/sdk</span>
@@ -2097,10 +2103,10 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
         <code>go get github.com/mishrasanjeev/grantex-go@v0.1.10</code>
         <span class="install-copy">Copy</span>
       </button>
-      <button type="button" class="install-cmd" onclick="copyInstall('npm install -g @grantex/cli', this)"
+      <button type="button" class="install-cmd" onclick="copyInstall('npm install -g @grantex/cli@0.3.0', this)"
               aria-label="Copy the Grantex CLI install command">
         <span class="install-label">CLI</span>
-        <code>npm install -g @grantex/cli</code>
+        <code>npm install -g @grantex/cli@0.3.0</code>
         <span class="install-copy">Copy</span>
       </button>
     </div>
@@ -2230,7 +2236,7 @@ func main() {
         <div class="code-block">
           <button type="button" class="copy-btn" aria-label="Copy the CLI quickstart"
                   onclick="copyCode('code-cli', this, 'cli_quickstart_copy')">Copy</button>
-          <pre id="code-cli"><span class="cm"># npm install -g @grantex/cli</span>
+          <pre id="code-cli"><span class="cm"># npm install -g @grantex/cli@0.3.0</span>
 <span class="cm"># All commands support --json for AI agent / script use</span>
 
 <span class="cm"># 1. Request authorization (sandbox auto-approves)</span>
@@ -2602,7 +2608,7 @@ func main() {
           <button type="button" class="copy-btn" aria-label="Copy agent skill install commands"
                   onclick="copyCode('code-agent-cli', this, 'agent_cli_install_copy')">Copy</button>
           <pre id="code-agent-cli"><span class="cm"># Install the JSON-first CLI</span>
-npm install -g @grantex/cli
+npm install -g @grantex/cli@0.3.0
 
 <span class="cm"># Choose the agent host</span>
 grantex agent install --target openclaw
@@ -2615,8 +2621,8 @@ grantex agent install --dir /path/to/skills</pre>
         <div class="agent-cli-boundary">
           <strong>Security boundary:</strong> the protected API, connector, or gateway
           still verifies the grant and exact scope before executing the side effect.<br>
-          <strong>Release:</strong> the installer is prepared in CLI 0.3.0 source; confirm
-          the published version before installing from npm.
+          <strong>Release:</strong> published as <code>@grantex/cli@0.3.0</code> with
+          bundled Hermes, OpenClaw, and portable Agent Skills.
         </div>
       </div>
     </div>

--- a/web/llms-full.txt
+++ b/web/llms-full.txt
@@ -61,7 +61,7 @@ The Grantex protocol specification is open and frozen at version 1.0. The relate
 | Agent-specific enforcement in MCP tools | Primary Grantex SDK or direct JWKS-backed validation | Add after transport authorization when the tool must verify delegated agent authority |
 | MCP endpoint evaluation | `@grantex/mcp-auth@2.0.2` plus `@grantex/sdk@0.3.13` | Single-process evaluation only |
 | Terminal automation | `@grantex/cli` | Optional operational tooling |
-| Hermes, OpenClaw, or another shell-capable agent | `@grantex/cli` 0.3.0+ plus the bundled Agent Skills | 0.3.0 source prepared; no agent-specific SDK required; enforce again at the protected service |
+| Hermes, OpenClaw, or another shell-capable agent | Published `@grantex/cli@0.3.0` plus the bundled Agent Skills | No agent-specific SDK required; enforce again at the protected service |
 | Framework-specific tools | Named Grantex adapter plus its primary SDK where required | Verify each package's registry status before pinning |
 
 Primary reproducible installs:
@@ -71,17 +71,17 @@ npm install @grantex/sdk@0.3.13
 python -m pip install grantex==0.3.14
 go get github.com/mishrasanjeev/grantex-go@v0.1.10
 npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
-npm install -g @grantex/cli
+npm install -g @grantex/cli@0.3.0
 ```
 
 The SDKs, API contract, integrations, and protocol are independently versioned. Do not infer one artifact's version from another.
 
 ## Agent CLI and Skills
 
-Hermes, OpenClaw, and other shell-capable agents can share the same machine-readable CLI and portable `SKILL.md` bundle. The installer is prepared in `@grantex/cli` 0.3.0 source; confirm the registry release before running the install commands:
+Hermes, OpenClaw, and other shell-capable agents can share the same machine-readable CLI and portable `SKILL.md` bundle. The installer is published in `@grantex/cli@0.3.0`:
 
 ```bash
-npm install -g @grantex/cli
+npm install -g @grantex/cli@0.3.0
 grantex agent install --target openclaw
 grantex agent install --target hermes
 grantex agent install --target portable

--- a/web/llms.txt
+++ b/web/llms.txt
@@ -24,8 +24,8 @@ Release snapshot verified: 2026-08-10. Packages are independently versioned. The
 - [Python SDK](https://docs.grantex.dev/sdks/python/overview): `python -m pip install grantex==0.3.14` for Python 3.9+ applications.
 - [Go SDK](https://docs.grantex.dev/sdks/go/overview): `go get github.com/mishrasanjeev/grantex-go@v0.1.10` for Go 1.26.1+; use the documented published-version workarounds.
 - [MCP Authorization Server](https://docs.grantex.dev/features/mcp-auth-server): `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13`; version 2.0.2 is single-process evaluation software, not the recommended production enforcement path.
-- [CLI](https://docs.grantex.dev/integrations/cli): Manage agents, grants, tokens, audit records, and manifests from a terminal.
-- [Agent CLIs and Skills](https://docs.grantex.dev/integrations/agent-cli): CLI 0.3.0 source prepares portable Grantex skills for Hermes, OpenClaw, or any shell-capable agent; confirm publication before using the registry install.
+- [CLI](https://docs.grantex.dev/integrations/cli): Install `@grantex/cli@0.3.0` to manage agents, grants, tokens, audit records, manifests, and portable Agent Skills from a terminal.
+- [Agent CLIs and Skills](https://docs.grantex.dev/integrations/agent-cli): Published `@grantex/cli@0.3.0` bundles portable Grantex skills for Hermes, OpenClaw, or any shell-capable agent; no agent-specific SDK is required.
 - [Machine-Readable Release Status](https://grantex.dev/release-status.json): Canonical versions, install commands, package URLs, limitations, and workaround links.
 
 For MCP HTTP transport authorization, use an established MCP-compatible authorization server and maintained MCP SDK. Then use a primary Grantex SDK or direct JWKS validation at each tool boundary when agent-specific delegated authority is required. Treat MCP Auth 2.0.2 as evaluation only. Local JWT verification does not prove current revocation unless the verifier performs an online state check or synchronizes revocation data.

--- a/web/release-status.json
+++ b/web/release-status.json
@@ -17,7 +17,7 @@
     "ietfDraftTitle": "Delegated Agent Authorization Protocol (DAAP)"
   },
   "selectionGuidance": {
-    "shellCapableAgent": "Use published @grantex/cli@0.2.5 for existing commands. The Agent Skills installer is source-prepared for 0.3.0 and is not yet published.",
+    "shellCapableAgent": "Use published @grantex/cli@0.3.0 for Hermes, OpenClaw, and other shell-capable agents. Install the bundled skills with grantex agent install; no agent-specific SDK is required.",
     "typescriptApplication": "Use @grantex/sdk@0.3.13.",
     "pythonApplication": "Use grantex==0.3.14.",
     "goApplication": "Use github.com/mishrasanjeev/grantex-go@v0.1.10 with the documented published-version workarounds.",
@@ -32,12 +32,12 @@
       "label": "CLI",
       "ecosystem": "npm",
       "name": "@grantex/cli",
-      "version": "0.2.5",
+      "version": "0.3.0",
       "status": "published",
-      "installCommand": "npm install -g @grantex/cli@0.2.5",
+      "installCommand": "npm install -g @grantex/cli@0.3.0",
       "runtime": "Node.js 18+; ESM",
       "registryUrl": "https://registry.npmjs.org/%40grantex%2Fcli/latest",
-      "packageUrl": "https://www.npmjs.com/package/@grantex/cli/v/0.2.5",
+      "packageUrl": "https://www.npmjs.com/package/@grantex/cli/v/0.3.0",
       "documentationUrl": "https://docs.grantex.dev/integrations/cli",
       "limitations": []
     },


### PR DESCRIPTION
## What changed

- mark `@grantex/cli@0.3.0` as published across release metadata, docs, compatibility tables, and LLM discovery files
- pin agent CLI installation examples to the registry-verified release
- add the CLI and bundled Agent Skills to the landing page's current public releases grid

## Why

`@grantex/cli@0.3.0` is now published to npm and tagged `latest`, so the repository and production surfaces must no longer describe its Hermes, OpenClaw, and portable Agent Skills installer as source-only.

## Impact

Shell-capable agents now see an accurate, reproducible install command. No SDK or runtime implementation changes are included.

## Validation

- `node scripts/check-docs-integrity.mjs`
- `node scripts/check-seo-aeo.mjs`
- root and web release-status JSON match exactly
- advertised CLI version matches the npm registry
- local landing smoke confirms five release cards, the CLI card, pinned install command, and no stale unpublished wording