### PR TITLE
fix(security): bind passport verification to signed claims; repair revocation and audit chain

### DIFF
--- a/apps/auth-service/src/db/migrations/087_status_list_rollover.sql
+++ b/apps/auth-service/src/db/migrations/087_status_list_rollover.sql
@@ -1,0 +1,44 @@
+-- StatusList2021 bitstrings are fixed-capacity (131072 bits by default).
+-- A UNIQUE index on (developer_id, purpose) capped every developer at exactly
+-- one list forever, so once next_index passed `size` each new credential was
+-- assigned an out-of-range index. Setting an out-of-range bit on a Buffer is a
+-- silent no-op in Node, so those credentials could never be revoked and no
+-- error was ever raised. Allow a developer to roll over onto additional lists.
+DROP INDEX IF EXISTS idx_vc_status_list_dev_purpose;
+
+CREATE INDEX IF NOT EXISTS idx_vc_status_list_dev_purpose
+  ON vc_status_lists(developer_id, purpose);
+
+-- With more than one list per developer, an index alone no longer identifies a
+-- bit: revocation has to know which list the index belongs to.
+ALTER TABLE verifiable_credentials
+  ADD COLUMN IF NOT EXISTS status_list_id TEXT;
+
+ALTER TABLE mpp_passports
+  ADD COLUMN IF NOT EXISTS status_list_id TEXT;
+
+-- Backfill. Every row issued before this migration belongs to the developer's
+-- single pre-existing list, which is also their oldest.
+UPDATE verifiable_credentials vc
+SET status_list_id = (
+  SELECT l.id FROM vc_status_lists l
+  WHERE l.developer_id = vc.developer_id AND l.purpose = 'revocation'
+  ORDER BY l.created_at ASC, l.id ASC
+  LIMIT 1
+)
+WHERE vc.status_list_id IS NULL;
+
+UPDATE mpp_passports p
+SET status_list_id = (
+  SELECT l.id FROM vc_status_lists l
+  WHERE l.developer_id = p.developer_id AND l.purpose = 'revocation'
+  ORDER BY l.created_at ASC, l.id ASC
+  LIMIT 1
+)
+WHERE p.status_list_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_vc_status_list_ref
+  ON verifiable_credentials(status_list_id);
+
+CREATE INDEX IF NOT EXISTS idx_mpp_passport_status_list_ref
+  ON mpp_passports(status_list_id);

--- a/apps/auth-service/src/lib/hash.ts
+++ b/apps/auth-service/src/lib/hash.ts
@@ -27,19 +27,45 @@ export interface AuditHashFields {
   status: string;
 }
 
+/**
+ * Deterministic JSON with object keys sorted.
+ *
+ * `metadata` is stored in a JSONB column, and Postgres normalizes JSONB key
+ * order on write. A hash taken over insertion-ordered JSON therefore cannot be
+ * recomputed from the stored row, which makes the audit chain unverifiable —
+ * the one property a tamper-evident log exists to provide.
+ */
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? 'null';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(',')}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalJson(v)}`).join(',')}}`;
+}
+
 export function computeAuditHash(fields: AuditHashFields): string {
-  const canonical = JSON.stringify({
-    id: fields.id,
-    agentId: fields.agentId,
-    agentDid: fields.agentDid,
-    grantId: fields.grantId,
-    principalId: fields.principalId,
-    developerId: fields.developerId,
-    action: fields.action,
-    metadata: fields.metadata,
-    timestamp: fields.timestamp,
-    prevHash: fields.prevHash,
-    status: fields.status,
-  });
+  // Built field-by-field rather than via JSON.stringify on a literal so that
+  // only `metadata` gains canonical ordering. The scalar fields keep their
+  // existing serialization, so hashes of entries with empty, single-key, or
+  // already-sorted metadata are byte-identical to those written before this
+  // change and continue to verify.
+  const canonical = '{'
+    + `"id":${JSON.stringify(fields.id)},`
+    + `"agentId":${JSON.stringify(fields.agentId)},`
+    + `"agentDid":${JSON.stringify(fields.agentDid)},`
+    + `"grantId":${JSON.stringify(fields.grantId)},`
+    + `"principalId":${JSON.stringify(fields.principalId)},`
+    + `"developerId":${JSON.stringify(fields.developerId)},`
+    + `"action":${JSON.stringify(fields.action)},`
+    + `"metadata":${canonicalJson(fields.metadata ?? {})},`
+    + `"timestamp":${JSON.stringify(fields.timestamp)},`
+    + `"prevHash":${JSON.stringify(fields.prevHash)},`
+    + `"status":${JSON.stringify(fields.status)}`
+    + '}';
   return sha256hex(canonical);
 }

--- a/apps/auth-service/src/lib/vc.ts
+++ b/apps/auth-service/src/lib/vc.ts
@@ -6,6 +6,7 @@
  */
 
 import { SignJWT, jwtVerify, decodeJwt } from 'jose';
+import type postgres from 'postgres';
 import { gzipSync, gunzipSync } from 'node:zlib';
 import { getSql } from '../db/client.js';
 import { getKeyPair } from './crypto.js';
@@ -71,48 +72,130 @@ function decodeBitstring(encoded: string): Buffer {
 function setBit(bitstring: Buffer, index: number): void {
   const byteIndex = Math.floor(index / 8);
   const bitIndex = 7 - (index % 8); // MSB-first
+  // Out-of-range writes on a Buffer are silently discarded by Node, which would
+  // turn "credential revoked" into a no-op that still reports success.
+  if (!Number.isInteger(index) || byteIndex < 0 || byteIndex >= bitstring.length) {
+    throw new RangeError(`Status list index ${index} is outside the list capacity`);
+  }
   bitstring[byteIndex]! |= 1 << bitIndex;
 }
 
 function getBit(bitstring: Buffer, index: number): boolean {
   const byteIndex = Math.floor(index / 8);
   const bitIndex = 7 - (index % 8);
+  if (!Number.isInteger(index) || byteIndex < 0 || byteIndex >= bitstring.length) {
+    return false;
+  }
   return ((bitstring[byteIndex]! >> bitIndex) & 1) === 1;
 }
 
 // ── StatusList management ───────────────────────────────────────────────────
 
-export async function getOrCreateStatusList(
+export interface AllocatedStatusIndex {
+  listId: string;
+  index: number;
+}
+
+/**
+ * Claim the next free revocation slot for a developer.
+ *
+ * The claim is a single UPDATE so that concurrent issuance cannot hand the same
+ * index to two credentials — a read-then-increment pair does, and two
+ * credentials sharing an index also share a revocation bit, so revoking either
+ * one revokes both. Rolls onto a fresh list when the current one is full.
+ */
+export async function allocateStatusListIndex(
   developerId: string,
-): Promise<{ id: string; nextIndex: number }> {
+): Promise<AllocatedStatusIndex> {
   const sql = getSql();
 
-  // Try to find existing list
-  const existing = await sql`
-    SELECT id, next_index FROM vc_status_lists
-    WHERE developer_id = ${developerId} AND purpose = 'revocation'
-    LIMIT 1
-  `;
+  const claimed = await claimIndexFromExistingList(sql, developerId);
+  if (claimed) return claimed;
 
-  if (existing[0]) {
-    return {
-      id: existing[0]['id'] as string,
-      nextIndex: Number(existing[0]['next_index']),
-    };
-  }
+  // No list yet, or the newest one is full. Serialise creation per developer so
+  // a burst of concurrent issuance produces one new list rather than N.
+  return await sql.begin(async (_tx) => {
+    const tx = _tx as unknown as ReturnType<typeof postgres>;
+    await tx`SELECT pg_advisory_xact_lock(hashtextextended(${`vcsl:${developerId}`}, 0))`;
 
-  // Create new status list
-  const listId = newStatusListId();
-  const emptyBitstring = createEmptyBitstring();
-  const encoded = encodeBitstring(emptyBitstring);
+    const raced = await claimIndexFromExistingList(tx, developerId);
+    if (raced) return raced;
 
-  await sql`
-    INSERT INTO vc_status_lists (id, developer_id, purpose, encoded_list, size, next_index)
-    VALUES (${listId}, ${developerId}, 'revocation', ${encoded}, ${STATUS_LIST_SIZE}, 0)
-  `;
-
-  return { id: listId, nextIndex: 0 };
+    const listId = newStatusListId();
+    const encoded = encodeBitstring(createEmptyBitstring());
+    await tx`
+      INSERT INTO vc_status_lists (id, developer_id, purpose, encoded_list, size, next_index)
+      VALUES (${listId}, ${developerId}, 'revocation', ${encoded}, ${STATUS_LIST_SIZE}, 1)
+    `;
+    return { listId, index: 0 };
+  }) as AllocatedStatusIndex;
 }
+
+async function claimIndexFromExistingList(
+  sql: ReturnType<typeof postgres>,
+  developerId: string,
+): Promise<AllocatedStatusIndex | null> {
+  const rows = await sql`
+    UPDATE vc_status_lists
+    SET next_index = next_index + 1, updated_at = NOW()
+    WHERE id = (
+      SELECT id FROM vc_status_lists
+      WHERE developer_id = ${developerId}
+        AND purpose = 'revocation'
+        AND next_index < size
+      ORDER BY created_at DESC, id DESC
+      LIMIT 1
+    )
+    RETURNING id, next_index - 1 AS allocated_index
+  `;
+
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    listId: row['id'] as string,
+    index: Number(row['allocated_index']),
+  };
+}
+
+/**
+ * Set revocation bits on one list.
+ *
+ * `SELECT ... FOR UPDATE` is required: the bitstring is gzipped in a text
+ * column, so flipping a bit is a read-modify-write. Two unsynchronised
+ * revocations would each decode the same snapshot and the second write would
+ * discard the first one's bit, leaving a revoked credential valid.
+ */
+async function setRevocationBits(
+  sql: ReturnType<typeof postgres>,
+  listId: string,
+  indices: number[],
+): Promise<void> {
+  if (indices.length === 0) return;
+
+  await sql.begin(async (_tx) => {
+    const tx = _tx as unknown as ReturnType<typeof postgres>;
+    const rows = await tx`
+      SELECT encoded_list FROM vc_status_lists WHERE id = ${listId} FOR UPDATE
+    `;
+    const row = rows[0];
+    if (!row) {
+      throw new Error(`Status list ${listId} not found; cannot record revocation`);
+    }
+
+    const bitstring = decodeBitstring(row['encoded_list'] as string);
+    for (const index of indices) {
+      setBit(bitstring, index);
+    }
+
+    await tx`
+      UPDATE vc_status_lists
+      SET encoded_list = ${encodeBitstring(bitstring)}, updated_at = NOW()
+      WHERE id = ${listId}
+    `;
+  });
+}
+
+export { setRevocationBits };
 
 // ── VC-JWT issuance ─────────────────────────────────────────────────────────
 
@@ -137,16 +220,10 @@ export async function issueAgentGrantVC(params: IssueVCParams): Promise<{
   const domain = config.didWebDomain;
   const issuerDid = `did:web:${domain}`;
 
-  // Get or create status list and allocate an index
-  const statusList = await getOrCreateStatusList(developerId);
-  const statusListIdx = statusList.nextIndex;
-
-  // Increment next_index
+  // Claim a revocation slot (atomic; rolls onto a new list when one fills up)
+  const { listId: statusListId, index: statusListIdx } =
+    await allocateStatusListIndex(developerId);
   const sql = getSql();
-  await sql`
-    UPDATE vc_status_lists SET next_index = next_index + 1, updated_at = NOW()
-    WHERE id = ${statusList.id}
-  `;
 
   // Build VC payload
   const now = Math.floor(Date.now() / 1000);
@@ -163,11 +240,11 @@ export async function issueAgentGrantVC(params: IssueVCParams): Promise<{
   };
 
   const credentialStatus = {
-    id: `${config.publicBaseUrl}/v1/credentials/status/${statusList.id}#${statusListIdx}`,
+    id: `${config.publicBaseUrl}/v1/credentials/status/${statusListId}#${statusListIdx}`,
     type: 'StatusList2021Entry',
     statusPurpose: 'revocation',
     statusListIndex: String(statusListIdx),
-    statusListCredential: `${config.publicBaseUrl}/v1/credentials/status/${statusList.id}`,
+    statusListCredential: `${config.publicBaseUrl}/v1/credentials/status/${statusListId}`,
   };
 
   const evidence: Record<string, unknown>[] = [];
@@ -204,12 +281,12 @@ export async function issueAgentGrantVC(params: IssueVCParams): Promise<{
     INSERT INTO verifiable_credentials (
       id, grant_id, developer_id, principal_id, agent_did,
       credential_type, format, credential_jwt, status,
-      status_list_idx, expires_at
+      status_list_id, status_list_idx, expires_at
     )
     VALUES (
       ${vcId}, ${grantId}, ${developerId}, ${principalId}, ${agentDid},
       'AgentGrantCredential', 'vc-jwt', ${vcJwt}, 'active',
-      ${statusListIdx}, ${expiresAt}
+      ${statusListId}, ${statusListIdx}, ${expiresAt}
     )
   `;
 
@@ -300,13 +377,30 @@ export async function revokeVCsByGrantIds(
 
   // Find all active VCs for these grants
   const vcRows = await sql`
-    SELECT id, status_list_idx FROM verifiable_credentials
+    SELECT id, status_list_id, status_list_idx FROM verifiable_credentials
     WHERE grant_id = ANY(${grantIds})
       AND developer_id = ${developerId}
       AND status = 'active'
   `;
 
   if (vcRows.length === 0) return;
+
+  // Flip the status-list bits *before* marking the rows revoked. If the bit
+  // write fails, the credential still reads as active everywhere rather than
+  // being recorded as revoked while verifiers keep accepting it.
+  const byList = new Map<string, number[]>();
+  for (const row of vcRows) {
+    const listId = row['status_list_id'] as string | null;
+    const idx = Number(row['status_list_idx']);
+    if (!listId || !Number.isInteger(idx)) continue;
+    const indices = byList.get(listId);
+    if (indices) indices.push(idx);
+    else byList.set(listId, [idx]);
+  }
+
+  for (const [listId, indices] of byList) {
+    await setRevocationBits(sql, listId, indices);
+  }
 
   // Mark VCs as revoked
   const vcIds = vcRows.map((r) => r['id'] as string);
@@ -315,31 +409,6 @@ export async function revokeVCsByGrantIds(
     SET status = 'revoked', revoked_at = NOW()
     WHERE id = ANY(${vcIds})
   `;
-
-  // Flip bits in the status list
-  const listRows = await sql`
-    SELECT id, encoded_list FROM vc_status_lists
-    WHERE developer_id = ${developerId} AND purpose = 'revocation'
-    LIMIT 1
-  `;
-
-  if (listRows[0]) {
-    const listId = listRows[0]['id'] as string;
-    const bitstring = decodeBitstring(listRows[0]['encoded_list'] as string);
-
-    for (const row of vcRows) {
-      const idx = Number(row['status_list_idx']);
-      if (idx >= 0 && idx < STATUS_LIST_SIZE) {
-        setBit(bitstring, idx);
-      }
-    }
-
-    const encoded = encodeBitstring(bitstring);
-    await sql`
-      UPDATE vc_status_lists SET encoded_list = ${encoded}, updated_at = NOW()
-      WHERE id = ${listId}
-    `;
-  }
 }
 
 // ── StatusList2021 credential builder ───────────────────────────────────────

--- a/apps/auth-service/src/routes/audit.ts
+++ b/apps/auth-service/src/routes/audit.ts
@@ -146,7 +146,10 @@ export async function auditRoutes(app: FastifyInstance): Promise<void> {
       SELECT id, agent_id, agent_did, grant_id, principal_id, developer_id, action, metadata, hash, previous_hash, timestamp, status
       FROM audit_entries
       WHERE ${predicates.join(' AND ')}
-      ORDER BY timestamp ASC
+      -- Must mirror the chain builder's "timestamp DESC, id DESC" head lookup.
+      -- Ordering on timestamp alone leaves same-millisecond entries in an
+      -- arbitrary order, so the hash chain fails to verify on read-back.
+      ORDER BY timestamp ASC, id ASC
     `, parameters);
 
     return reply.send({ entries: rows.map(toAuditResponse) });

--- a/apps/auth-service/src/routes/budget.ts
+++ b/apps/auth-service/src/routes/budget.ts
@@ -24,6 +24,17 @@ interface DebitBody {
   metadata?: Record<string, unknown>;
 }
 
+const MAX_PAGE_SIZE = 200;
+
+/** Returns null for anything that is not a whole number >= 1. */
+function parsePositiveInt(value: string | undefined, fallback: number): number | null {
+  if (value === undefined || value === '') return fallback;
+  if (!/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) return null;
+  return parsed;
+}
+
 export async function budgetRoutes(app: FastifyInstance): Promise<void> {
   // GET /v1/budget/allocations — list all budget allocations for the developer
   app.get('/v1/budget/allocations', async (request, reply) => {
@@ -141,8 +152,21 @@ export async function budgetRoutes(app: FastifyInstance): Promise<void> {
   app.get<{ Params: { grantId: string }; Querystring: { page?: string; pageSize?: string } }>('/v1/budget/transactions/:grantId', async (request, reply) => {
     const sql = getSql();
     const developerId = request.developer.id;
-    const page = parseInt((request.query as Record<string, string>)['page'] ?? '1', 10);
-    const pageSize = parseInt((request.query as Record<string, string>)['pageSize'] ?? '50', 10);
+    const query = request.query as Record<string, string | undefined>;
+
+    // These values reach LIMIT/OFFSET directly. Unvalidated, `page=0` produces a
+    // negative OFFSET and `page=abc` a NaN one — both are hard Postgres errors
+    // surfacing as a 500 — and an unbounded pageSize is a cheap way to ask for
+    // the entire table in one request.
+    const page = parsePositiveInt(query['page'], 1);
+    const pageSize = parsePositiveInt(query['pageSize'], 50);
+    if (page === null || pageSize === null || pageSize > MAX_PAGE_SIZE) {
+      return reply.status(400).send({
+        message: `page must be an integer >= 1 and pageSize an integer between 1 and ${MAX_PAGE_SIZE}`,
+        code: 'BAD_REQUEST',
+        requestId: request.id,
+      });
+    }
 
     const result = await listBudgetTransactions(sql, request.params.grantId, developerId, page, pageSize);
     return reply.send(result);

--- a/apps/auth-service/src/routes/compliance.ts
+++ b/apps/auth-service/src/routes/compliance.ts
@@ -1,20 +1,73 @@
 import type { FastifyInstance } from 'fastify';
 import { getSql } from '../db/client.js';
+import { computeAuditHash } from '../lib/hash.js';
 
 type Framework = 'soc2' | 'gdpr' | 'all';
 
-function verifyChain(
-  entries: Array<Record<string, unknown>>,
-): { valid: boolean; checkedEntries: number; firstBrokenAt: string | null } {
+interface ChainIntegrity {
+  valid: boolean;
+  checkedEntries: number;
+  firstBrokenAt: string | null;
+  reason: 'link' | 'content' | null;
+}
+
+/**
+ * Verify the audit hash chain.
+ *
+ * Two independent properties have to hold, and checking only the first one
+ * makes the whole chain decorative:
+ *
+ *   1. Linkage — each entry's `previous_hash` matches its predecessor's `hash`.
+ *   2. Content — each entry's stored `hash` is what its own fields hash to.
+ *
+ * Without (2), editing an entry's action, status, principal or metadata in the
+ * database leaves every stored hash and link untouched, so the export still
+ * reports `valid: true` while the record it attests to has been rewritten.
+ */
+function verifyChain(entries: Array<Record<string, unknown>>): ChainIntegrity {
   let prevHash: string | null = null;
-  for (const entry of entries) {
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i]!;
     const entryPrevHash = (entry['previous_hash'] as string | null) ?? null;
+
     if (prevHash !== null && entryPrevHash !== prevHash) {
-      return { valid: false, checkedEntries: entries.indexOf(entry), firstBrokenAt: entry['id'] as string };
+      return {
+        valid: false,
+        checkedEntries: i,
+        firstBrokenAt: entry['id'] as string,
+        reason: 'link',
+      };
     }
+
+    const timestamp = entry['timestamp'];
+    const recomputed = computeAuditHash({
+      id: entry['id'] as string,
+      agentId: entry['agent_id'] as string,
+      agentDid: entry['agent_did'] as string,
+      grantId: entry['grant_id'] as string,
+      principalId: entry['principal_id'] as string,
+      developerId: entry['developer_id'] as string,
+      action: entry['action'] as string,
+      metadata: (entry['metadata'] ?? {}) as Record<string, unknown>,
+      timestamp: timestamp instanceof Date ? timestamp.toISOString() : String(timestamp),
+      prevHash: entryPrevHash,
+      status: (entry['status'] as string | null) ?? 'success',
+    });
+
+    if (recomputed !== entry['hash']) {
+      return {
+        valid: false,
+        checkedEntries: i,
+        firstBrokenAt: entry['id'] as string,
+        reason: 'content',
+      };
+    }
+
     prevHash = entry['hash'] as string;
   }
-  return { valid: true, checkedEntries: entries.length, firstBrokenAt: null };
+
+  return { valid: true, checkedEntries: entries.length, firstBrokenAt: null, reason: null };
 }
 
 export async function complianceRoutes(app: FastifyInstance): Promise<void> {
@@ -199,7 +252,10 @@ export async function complianceRoutes(app: FastifyInstance): Promise<void> {
         WHERE developer_id = ${developerId}
           AND (${since}::timestamptz IS NULL OR timestamp >= ${since}::timestamptz)
           AND (${until}::timestamptz IS NULL OR timestamp <= ${until}::timestamptz)
-        ORDER BY timestamp ASC
+        -- Mirrors the chain builder's "timestamp DESC, id DESC" head lookup;
+        -- ordering on timestamp alone leaves same-millisecond entries in an
+        -- arbitrary order and the chain fails to verify.
+        ORDER BY timestamp ASC, id ASC
       `,
       sql`
         SELECT id, name, effect, priority, agent_id, principal_id, scopes,
@@ -316,7 +372,7 @@ export async function complianceRoutes(app: FastifyInstance): Promise<void> {
         AND (${until}::timestamptz IS NULL OR timestamp <= ${until}::timestamptz)
         AND (${agentId}::text IS NULL OR agent_id = ${agentId ?? ''})
         AND (${status}::text IS NULL OR status = ${status ?? ''})
-      ORDER BY timestamp ASC
+      ORDER BY timestamp ASC, id ASC
     `;
 
     const entries = rows.map((r) => ({

--- a/apps/auth-service/src/routes/passport.ts
+++ b/apps/auth-service/src/routes/passport.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { SignJWT } from 'jose';
 import { getSql } from '../db/client.js';
 import { getKeyPair, getEdKeyPair, parseExpiresIn } from '../lib/crypto.js';
-import { getOrCreateStatusList } from '../lib/vc.js';
+import { allocateStatusListIndex, setRevocationBits } from '../lib/vc.js';
 import { emitEvent } from '../lib/events.js';
 import { config } from '../config.js';
 import { ulid } from 'ulid';
@@ -178,20 +178,16 @@ export async function passportRoutes(app: FastifyInstance): Promise<void> {
       const now = new Date();
       const expiresAt = new Date(now.getTime() + expirySeconds * 1000);
 
-      // Allocate StatusList2021 index
-      const statusList = await getOrCreateStatusList(developerId);
-      const statusListIdx = statusList.nextIndex;
-      await sql`
-        UPDATE vc_status_lists SET next_index = next_index + 1, updated_at = NOW()
-        WHERE id = ${statusList.id}
-      `;
+      // Allocate StatusList2021 index (atomic; rolls onto a new list when full)
+      const { listId: statusListId, index: statusListIdx } =
+        await allocateStatusListIndex(developerId);
 
       const credentialStatus = {
-        id: `${config.publicBaseUrl}/v1/credentials/status/${statusList.id}#${statusListIdx}`,
+        id: `${config.publicBaseUrl}/v1/credentials/status/${statusListId}#${statusListIdx}`,
         type: 'StatusList2021Entry',
         statusPurpose: 'revocation',
         statusListIndex: String(statusListIdx),
-        statusListCredential: `${config.publicBaseUrl}/v1/credentials/status/${statusList.id}`,
+        statusListCredential: `${config.publicBaseUrl}/v1/credentials/status/${statusListId}`,
       };
 
       const credentialSubject: Record<string, unknown> = {
@@ -267,14 +263,16 @@ export async function passportRoutes(app: FastifyInstance): Promise<void> {
           id, developer_id, agent_id, grant_id, principal_id, agent_did,
           organization_did, allowed_categories, max_amount, max_currency,
           payment_rails, delegation_depth, parent_passport_id,
-          credential_jwt, encoded_credential, status, status_list_idx, expires_at
+          credential_jwt, encoded_credential, status,
+          status_list_id, status_list_idx, expires_at
         )
         VALUES (
           ${passportId}, ${developerId}, ${agentId}, ${grantId}, ${principalId},
           ${agentDid}, ${`did:web:${domain}`}, ${allowedMPPCategories},
           ${maxTransactionAmount.amount}, ${maxTransactionAmount.currency || 'USDC'},
           ${paymentRails}, ${delegationDepth}, ${parentPassportId ?? null},
-          ${vcJwt}, ${encodedCredential}, 'active', ${statusListIdx}, ${expiresAt}
+          ${vcJwt}, ${encodedCredential}, 'active',
+          ${statusListId}, ${statusListIdx}, ${expiresAt}
         )
       `;
 
@@ -283,12 +281,12 @@ export async function passportRoutes(app: FastifyInstance): Promise<void> {
         INSERT INTO verifiable_credentials (
           id, grant_id, developer_id, principal_id, agent_did,
           credential_type, format, credential_jwt, status,
-          status_list_idx, expires_at
+          status_list_id, status_list_idx, expires_at
         )
         VALUES (
           ${passportId}, ${grantId}, ${developerId}, ${principalId}, ${agentDid},
           'AgentPassportCredential', 'agent-passport', ${vcJwt}, 'active',
-          ${statusListIdx}, ${expiresAt}
+          ${statusListId}, ${statusListIdx}, ${expiresAt}
         )
       `;
 
@@ -401,7 +399,7 @@ export async function passportRoutes(app: FastifyInstance): Promise<void> {
       const sql = getSql();
 
       const rows = await sql`
-        SELECT id, status, status_list_idx FROM mpp_passports
+        SELECT id, status, status_list_id, status_list_idx FROM mpp_passports
         WHERE id = ${id} AND developer_id = ${developerId}
       `;
 
@@ -420,6 +418,15 @@ export async function passportRoutes(app: FastifyInstance): Promise<void> {
 
       const revokedAt = new Date();
 
+      // Flip the StatusList2021 bit first. Marking the row revoked while the
+      // published status list still reads "active" would report success to the
+      // caller while every verifier keeps accepting the passport.
+      const statusListId = passport['status_list_id'] as string | null;
+      const statusListIdx = Number(passport['status_list_idx']);
+      if (statusListId && Number.isInteger(statusListIdx)) {
+        await setRevocationBits(sql, statusListId, [statusListIdx]);
+      }
+
       // Mark as revoked in mpp_passports
       await sql`
         UPDATE mpp_passports SET status = 'revoked', revoked_at = ${revokedAt}
@@ -431,31 +438,6 @@ export async function passportRoutes(app: FastifyInstance): Promise<void> {
         UPDATE verifiable_credentials SET status = 'revoked', revoked_at = ${revokedAt}
         WHERE id = ${id}
       `;
-
-      // Flip StatusList2021 bit
-      const statusListIdx = Number(passport['status_list_idx']);
-      const listRows = await sql`
-        SELECT id, encoded_list FROM vc_status_lists
-        WHERE developer_id = ${developerId} AND purpose = 'revocation'
-        LIMIT 1
-      `;
-      if (listRows[0]) {
-        const { gzipSync, gunzipSync } = await import('node:zlib');
-        const listId = listRows[0]['id'] as string;
-        const compressed = Buffer.from(listRows[0]['encoded_list'] as string, 'base64url');
-        const bitstring = Buffer.from(gunzipSync(compressed));
-
-        // Set the bit
-        const byteIndex = Math.floor(statusListIdx / 8);
-        const bitIndex = 7 - (statusListIdx % 8);
-        bitstring[byteIndex]! |= 1 << bitIndex;
-
-        const encoded = gzipSync(bitstring).toString('base64url');
-        await sql`
-          UPDATE vc_status_lists SET encoded_list = ${encoded}, updated_at = NOW()
-          WHERE id = ${listId}
-        `;
-      }
 
       // Audit
       emitEvent(developerId, 'passport.revoked', { passportId: id }).catch(() => {});

--- a/apps/auth-service/tests/audit.test.ts
+++ b/apps/auth-service/tests/audit.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { buildTestApp, authHeader, seedAuth, sqlMock, TEST_AGENT, TEST_GRANT, TEST_DEVELOPER } from './helpers.js';
 import type { FastifyInstance } from 'fastify';
 import { computeAuditHash } from '../src/lib/hash.js';
+import { createHash } from 'node:crypto';
 
 let app: FastifyInstance;
 
@@ -212,5 +213,87 @@ describe('computeAuditHash', () => {
     const hash2 = computeAuditHash(fields);
     expect(hash1).toBe(hash2);
     expect(hash1).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  // metadata lives in a JSONB column and Postgres normalizes JSONB key order,
+  // so a hash that depends on insertion order cannot be recomputed from the
+  // stored row — which is the only thing that makes the chain verifiable.
+  it('is independent of metadata key order', () => {
+    const base = {
+      id: 'alog_001',
+      agentId: 'ag_001',
+      agentDid: 'did:grantex:ag_001',
+      grantId: 'grnt_001',
+      principalId: 'user_001',
+      developerId: 'dev_001',
+      action: 'invoke',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      prevHash: null,
+      status: 'success',
+    };
+
+    const written = computeAuditHash({
+      ...base,
+      metadata: { zebra: 1, alpha: { yankee: true, bravo: [3, 2] }, mike: 'x' },
+    });
+    const readBack = computeAuditHash({
+      ...base,
+      metadata: { alpha: { bravo: [3, 2], yankee: true }, mike: 'x', zebra: 1 },
+    });
+
+    expect(readBack).toBe(written);
+  });
+
+  it('still reflects a change in metadata values', () => {
+    const base = {
+      id: 'alog_001',
+      agentId: 'ag_001',
+      agentDid: 'did:grantex:ag_001',
+      grantId: 'grnt_001',
+      principalId: 'user_001',
+      developerId: 'dev_001',
+      action: 'invoke',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      prevHash: null,
+      status: 'success',
+    };
+
+    expect(computeAuditHash({ ...base, metadata: { amount: 10 } }))
+      .not.toBe(computeAuditHash({ ...base, metadata: { amount: 1000 } }));
+    // Array order is meaningful and must not be sorted away.
+    expect(computeAuditHash({ ...base, metadata: { items: [1, 2] } }))
+      .not.toBe(computeAuditHash({ ...base, metadata: { items: [2, 1] } }));
+  });
+
+  it('is unchanged for empty and single-key metadata', () => {
+    // Entries written before canonicalization must keep verifying.
+    expect(computeAuditHash({
+      id: 'alog_001',
+      agentId: 'ag_001',
+      agentDid: 'did:grantex:ag_001',
+      grantId: 'grnt_001',
+      principalId: 'user_001',
+      developerId: 'dev_001',
+      action: 'invoke',
+      metadata: {},
+      timestamp: '2026-01-01T00:00:00.000Z',
+      prevHash: null,
+      status: 'success',
+    })).toBe(
+      // sha256 of the exact serialization the previous implementation produced.
+      createHash('sha256').update(JSON.stringify({
+        id: 'alog_001',
+        agentId: 'ag_001',
+        agentDid: 'did:grantex:ag_001',
+        grantId: 'grnt_001',
+        principalId: 'user_001',
+        developerId: 'dev_001',
+        action: 'invoke',
+        metadata: {},
+        timestamp: '2026-01-01T00:00:00.000Z',
+        prevHash: null,
+        status: 'success',
+      })).digest('hex'),
+    );
   });
 });

--- a/apps/auth-service/tests/budget.test.ts
+++ b/apps/auth-service/tests/budget.test.ts
@@ -520,4 +520,40 @@ describe('GET /v1/budget/transactions/:grantId', () => {
 
     expect(res.statusCode).toBe(200);
   });
+
+  // page and pageSize land in OFFSET and LIMIT. Left unvalidated these reach
+  // Postgres as a negative OFFSET or a NaN LIMIT and come back as a 500.
+  it.each([
+    ['page=0', 'page=0'],
+    ['negative page', 'page=-1'],
+    ['non-numeric page', 'page=abc'],
+    ['pageSize=0', 'pageSize=0'],
+    ['non-numeric pageSize', 'pageSize=abc'],
+    ['pageSize above the cap', 'pageSize=100000'],
+  ])('rejects %s', async (_label, query) => {
+    seedAuth();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/v1/budget/transactions/grnt_1?${query}`,
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('BAD_REQUEST');
+  });
+
+  it('accepts the maximum permitted page size', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([{ count: '0' }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/budget/transactions/grnt_1?pageSize=200',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
 });

--- a/apps/auth-service/tests/compliance.test.ts
+++ b/apps/auth-service/tests/compliance.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { buildTestApp, authHeader, seedAuth, sqlMock } from './helpers.js';
+import { computeAuditHash } from '../src/lib/hash.js';
 import type { FastifyInstance } from 'fastify';
 
 let app: FastifyInstance;
@@ -206,20 +207,42 @@ describe('GET /v1/compliance/evidence-pack', () => {
     delegation_depth: 0,
   };
 
-  const MOCK_AUDIT_ROW = {
-    id: 'alog_01',
-    agent_id: 'ag_01',
-    agent_did: 'did:grantex:ag_01',
-    grant_id: 'grnt_01',
-    principal_id: 'user_01',
-    developer_id: 'dev_TEST',
-    action: 'tool.run',
-    metadata: {},
-    hash: 'abc123',
-    previous_hash: null,
-    timestamp: '2026-01-15T12:00:00Z',
-    status: 'success',
-  };
+  // The chain check recomputes each entry's hash, so fixtures must carry a
+  // genuine one — a placeholder would (correctly) be reported as tampered.
+  function auditRow(overrides: Record<string, unknown> = {}) {
+    const row = {
+      id: 'alog_01',
+      agent_id: 'ag_01',
+      agent_did: 'did:grantex:ag_01',
+      grant_id: 'grnt_01',
+      principal_id: 'user_01',
+      developer_id: 'dev_TEST',
+      action: 'tool.run',
+      metadata: {},
+      previous_hash: null as string | null,
+      timestamp: '2026-01-15T12:00:00Z',
+      status: 'success',
+      ...overrides,
+    };
+    return {
+      ...row,
+      hash: computeAuditHash({
+        id: row.id,
+        agentId: row.agent_id,
+        agentDid: row.agent_did,
+        grantId: row.grant_id,
+        principalId: row.principal_id,
+        developerId: row.developer_id,
+        action: row.action,
+        metadata: row.metadata,
+        timestamp: row.timestamp,
+        prevHash: row.previous_hash,
+        status: row.status,
+      }),
+    };
+  }
+
+  const MOCK_AUDIT_ROW = auditRow();
 
   const MOCK_POLICY_ROW = {
     id: 'pol_01',
@@ -307,10 +330,11 @@ describe('GET /v1/compliance/evidence-pack', () => {
     sqlMock.mockResolvedValueOnce([POLICY_STATS]);
     sqlMock.mockResolvedValueOnce([SUB]);
     sqlMock.mockResolvedValueOnce([]);
-    // Two audit entries where second's previous_hash doesn't match first's hash
+    // Two well-formed entries whose linkage is broken: the second's
+    // previous_hash does not match the first's hash.
     sqlMock.mockResolvedValueOnce([
-      { ...MOCK_AUDIT_ROW, id: 'alog_01', hash: 'hash_a', previous_hash: null },
-      { ...MOCK_AUDIT_ROW, id: 'alog_02', hash: 'hash_b', previous_hash: 'WRONG_HASH' },
+      auditRow({ id: 'alog_01' }),
+      auditRow({ id: 'alog_02', previous_hash: 'WRONG_HASH' }),
     ]);
     sqlMock.mockResolvedValueOnce([]);
 
@@ -321,8 +345,43 @@ describe('GET /v1/compliance/evidence-pack', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    const body = res.json<{ chainIntegrity: { valid: boolean; firstBrokenAt: string | null } }>();
+    const body = res.json<{ chainIntegrity: { valid: boolean; firstBrokenAt: string | null; reason: string | null } }>();
     expect(body.chainIntegrity.valid).toBe(false);
     expect(body.chainIntegrity.firstBrokenAt).toBe('alog_02');
+    expect(body.chainIntegrity.reason).toBe('link');
+  });
+
+  // Editing a stored entry leaves every hash and link untouched, so linkage
+  // alone still reads as intact. Only recomputing the entry's own hash catches it.
+  it('reports chain integrity broken when an entry has been edited in place', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([AGENT_STATS]);
+    sqlMock.mockResolvedValueOnce([GRANT_STATS]);
+    sqlMock.mockResolvedValueOnce([AUDIT_STATS]);
+    sqlMock.mockResolvedValueOnce([POLICY_STATS]);
+    sqlMock.mockResolvedValueOnce([SUB]);
+    sqlMock.mockResolvedValueOnce([]);
+
+    const first = auditRow({ id: 'alog_01' });
+    const second = auditRow({ id: 'alog_02', previous_hash: first.hash });
+    sqlMock.mockResolvedValueOnce([
+      first,
+      // Same hash and same linkage, but the recorded action was rewritten from
+      // 'tool.run' to 'tool.delete'.
+      { ...second, action: 'tool.delete' },
+    ]);
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/compliance/evidence-pack',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ chainIntegrity: { valid: boolean; firstBrokenAt: string | null; reason: string | null } }>();
+    expect(body.chainIntegrity.valid).toBe(false);
+    expect(body.chainIntegrity.firstBrokenAt).toBe('alog_02');
+    expect(body.chainIntegrity.reason).toBe('content');
   });
 });

--- a/apps/auth-service/tests/credentials.test.ts
+++ b/apps/auth-service/tests/credentials.test.ts
@@ -496,23 +496,21 @@ describe('VC revocation cascade', () => {
 
     // SELECT active VCs
     sqlMock.mockResolvedValueOnce([
-      { id: 'vc_CASCADE1', status_list_idx: 0 },
-      { id: 'vc_CASCADE2', status_list_idx: 1 },
+      { id: 'vc_CASCADE1', status_list_id: 'vcsl_CASCADE', status_list_idx: 0 },
+      { id: 'vc_CASCADE2', status_list_id: 'vcsl_CASCADE', status_list_idx: 1 },
     ]);
-    // UPDATE VCs to revoked
-    sqlMock.mockResolvedValueOnce([]);
-    // SELECT status list
+    // setRevocationBits: SELECT ... FOR UPDATE
     const encodedList = createEmptyEncodedList();
-    sqlMock.mockResolvedValueOnce([{
-      id: 'vcsl_CASCADE',
-      encoded_list: encodedList,
-    }]);
-    // UPDATE status list
+    sqlMock.mockResolvedValueOnce([{ encoded_list: encodedList }]);
+    // setRevocationBits: UPDATE status list
+    sqlMock.mockResolvedValueOnce([]);
+    // UPDATE VCs to revoked
     sqlMock.mockResolvedValueOnce([]);
 
     await revokeVCsByGrantIds(['grnt_CASCADE1'], TEST_DEVELOPER.id);
 
-    // Verify SQL was called the right number of times
+    // Both credentials sit on one list, so a single locked read-modify-write
+    // covers them: SELECT VCs, SELECT list FOR UPDATE, UPDATE list, UPDATE VCs.
     expect(sqlMock).toHaveBeenCalledTimes(4);
   });
 

--- a/apps/auth-service/tests/database-performance.test.ts
+++ b/apps/auth-service/tests/database-performance.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
@@ -85,7 +85,10 @@ describe('database performance migrations', () => {
     expect(migrationSql.mock.calls).toHaveLength(2);
     expect((migrationSql.mock.calls[0]?.[0] as string[]).join('')).toContain('pg_advisory_lock');
     expect((migrationSql.mock.calls[1]?.[0] as string[]).join('')).toContain('pg_advisory_unlock');
-    expect(migrationSql.unsafe).toHaveBeenCalledTimes(86);
+    // Derived from the directory rather than hardcoded — a literal count turns
+    // every new migration into an unrelated test failure.
+    const migrationCount = readdirSync(migrationsDir).filter((f) => f.endsWith('.sql')).length;
+    expect(migrationSql.unsafe).toHaveBeenCalledTimes(migrationCount);
     expect(migrationSql.release).toHaveBeenCalledOnce();
   });
 });

--- a/apps/auth-service/tests/vc-lib.test.ts
+++ b/apps/auth-service/tests/vc-lib.test.ts
@@ -6,7 +6,7 @@ import { sqlMock } from './setup.js';
 import {
   issueAgentGrantVC,
   verifyAgentGrantVC,
-  getOrCreateStatusList,
+  allocateStatusListIndex,
   revokeVCsByGrantIds,
 } from '../src/lib/vc.js';
 
@@ -14,31 +14,56 @@ beforeAll(async () => {
   await initKeys();
 });
 
-// ── getOrCreateStatusList ───────────────────────────────────────────────────
+// ── allocateStatusListIndex ─────────────────────────────────────────────────
 
-describe('getOrCreateStatusList', () => {
-  it('creates a new status list when none exists', async () => {
-    // SELECT existing → empty
-    sqlMock.mockResolvedValueOnce([]);
-    // INSERT new list
-    sqlMock.mockResolvedValueOnce([]);
+describe('allocateStatusListIndex', () => {
+  it('claims a slot from an existing list in a single statement', async () => {
+    // UPDATE ... RETURNING id, next_index - 1
+    sqlMock.mockResolvedValueOnce([{ id: 'vcsl_EXISTING', allocated_index: 5 }]);
 
-    const result = await getOrCreateStatusList('dev_TEST');
+    const result = await allocateStatusListIndex('dev_TEST');
 
-    expect(result.id).toMatch(/^vcsl_/);
-    expect(result.nextIndex).toBe(0);
+    expect(result).toEqual({ listId: 'vcsl_EXISTING', index: 5 });
+    // A read-then-increment pair would have taken two statements and could hand
+    // the same index to a concurrent issuer.
+    expect(sqlMock).toHaveBeenCalledTimes(1);
   });
 
-  it('returns existing status list', async () => {
-    sqlMock.mockResolvedValueOnce([{
-      id: 'vcsl_EXISTING',
-      next_index: 5,
-    }]);
+  it('creates a new list when none exists', async () => {
+    sqlMock.mockResolvedValueOnce([]);   // no list with capacity
+    sqlMock.mockResolvedValueOnce([]);   // advisory lock
+    sqlMock.mockResolvedValueOnce([]);   // re-check after lock
+    sqlMock.mockResolvedValueOnce([]);   // INSERT new list
 
-    const result = await getOrCreateStatusList('dev_TEST');
+    const result = await allocateStatusListIndex('dev_TEST');
 
-    expect(result.id).toBe('vcsl_EXISTING');
-    expect(result.nextIndex).toBe(5);
+    expect(result.listId).toMatch(/^vcsl_/);
+    expect(result.index).toBe(0);
+  });
+
+  it('rolls over to a new list once the current one is full', async () => {
+    // The claim query filters on next_index < size, so a full list returns no
+    // row and allocation falls through to creating the next list.
+    sqlMock.mockResolvedValueOnce([]);   // current list is full
+    sqlMock.mockResolvedValueOnce([]);   // advisory lock
+    sqlMock.mockResolvedValueOnce([]);   // still full after lock
+    sqlMock.mockResolvedValueOnce([]);   // INSERT rollover list
+
+    const result = await allocateStatusListIndex('dev_FULL');
+
+    expect(result.listId).toMatch(/^vcsl_/);
+    expect(result.index).toBe(0);
+  });
+
+  it('uses the list another caller created while waiting on the lock', async () => {
+    sqlMock.mockResolvedValueOnce([]);   // no list with capacity
+    sqlMock.mockResolvedValueOnce([]);   // advisory lock
+    // Another request created the list first; re-check finds it.
+    sqlMock.mockResolvedValueOnce([{ id: 'vcsl_RACED', allocated_index: 0 }]);
+
+    const result = await allocateStatusListIndex('dev_TEST');
+
+    expect(result).toEqual({ listId: 'vcsl_RACED', index: 0 });
   });
 });
 
@@ -46,13 +71,8 @@ describe('getOrCreateStatusList', () => {
 
 describe('issueAgentGrantVC', () => {
   it('creates a valid VC-JWT structure', async () => {
-    // getOrCreateStatusList: SELECT existing
-    sqlMock.mockResolvedValueOnce([{
-      id: 'vcsl_TEST1',
-      next_index: 0,
-    }]);
-    // UPDATE next_index
-    sqlMock.mockResolvedValueOnce([]);
+    // allocateStatusListIndex: single UPDATE ... RETURNING
+    sqlMock.mockResolvedValueOnce([{ id: 'vcsl_TEST1', allocated_index: 0 }]);
     // INSERT verifiable_credentials
     sqlMock.mockResolvedValueOnce([]);
 
@@ -99,13 +119,8 @@ describe('issueAgentGrantVC', () => {
   });
 
   it('includes FIDO evidence when provided', async () => {
-    // getOrCreateStatusList: SELECT existing
-    sqlMock.mockResolvedValueOnce([{
-      id: 'vcsl_TEST2',
-      next_index: 1,
-    }]);
-    // UPDATE next_index
-    sqlMock.mockResolvedValueOnce([]);
+    // allocateStatusListIndex: single UPDATE ... RETURNING
+    sqlMock.mockResolvedValueOnce([{ id: 'vcsl_TEST2', allocated_index: 1 }]);
     // INSERT verifiable_credentials
     sqlMock.mockResolvedValueOnce([]);
 
@@ -135,8 +150,7 @@ describe('issueAgentGrantVC', () => {
 describe('verifyAgentGrantVC', () => {
   it('succeeds for a valid VC-JWT', async () => {
     // Issue a VC first
-    sqlMock.mockResolvedValueOnce([{ id: 'vcsl_V1', next_index: 0 }]);
-    sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([{ id: 'vcsl_V1', allocated_index: 0 }]);
     sqlMock.mockResolvedValueOnce([]);
 
     const { vcJwt } = await issueAgentGrantVC({
@@ -238,31 +252,80 @@ describe('revokeVCsByGrantIds', () => {
   });
 
   it('flips correct bits in status list', async () => {
+    const { gzipSync, gunzipSync } = await import('node:zlib');
+    const encoded = gzipSync(Buffer.alloc(16384, 0)).toString('base64url');
+
     // SELECT active VCs
     sqlMock.mockResolvedValueOnce([
-      { id: 'vc_R1', status_list_idx: 3 },
-      { id: 'vc_R2', status_list_idx: 7 },
+      { id: 'vc_R1', status_list_id: 'vcsl_BIT', status_list_idx: 3 },
+      { id: 'vc_R2', status_list_id: 'vcsl_BIT', status_list_idx: 7 },
     ]);
-    // UPDATE VCs to revoked
+    // setRevocationBits: SELECT ... FOR UPDATE
+    sqlMock.mockResolvedValueOnce([{ encoded_list: encoded }]);
+    // setRevocationBits: UPDATE encoded_list
     sqlMock.mockResolvedValueOnce([]);
-    // SELECT status list for bit flipping
-    const { gzipSync } = await import('node:zlib');
-    const emptyBits = Buffer.alloc(16384, 0);
-    const encoded = gzipSync(emptyBits).toString('base64url');
-    sqlMock.mockResolvedValueOnce([{
-      id: 'vcsl_BIT',
-      encoded_list: encoded,
-    }]);
-    // UPDATE status list with flipped bits
+    // UPDATE VCs to revoked
     sqlMock.mockResolvedValueOnce([]);
 
     await revokeVCsByGrantIds(['grnt_R1'], 'dev_TEST');
 
-    // Verify the UPDATE call was made with updated encoded_list
-    expect(sqlMock).toHaveBeenCalled();
-    // The 4th call (index 3) should be the status list update
-    const lastCallArgs = sqlMock.mock.calls[sqlMock.mock.calls.length - 1];
-    // The SQL template should contain the encoded_list update
-    expect(lastCallArgs).toBeDefined();
+    // The UPDATE that writes the list back carries the new bitstring as a
+    // template parameter; decode it and confirm both bits are set.
+    const updateCall = sqlMock.mock.calls.find((call) => {
+      const fragments = call[0] as unknown as string[];
+      return Array.isArray(fragments) && fragments.some((f) => f.includes('SET encoded_list'));
+    });
+    expect(updateCall).toBeDefined();
+
+    const written = updateCall![1] as string;
+    const bits = gunzipSync(Buffer.from(written, 'base64url'));
+    const bitAt = (i: number) => (bits[Math.floor(i / 8)]! >> (7 - (i % 8))) & 1;
+    expect(bitAt(3)).toBe(1);
+    expect(bitAt(7)).toBe(1);
+    expect(bitAt(4)).toBe(0);
+  });
+
+  it('groups revocations by the list each credential was allocated from', async () => {
+    const { gzipSync } = await import('node:zlib');
+    const encoded = gzipSync(Buffer.alloc(16384, 0)).toString('base64url');
+
+    // Two credentials sharing index 0 but living on different lists — the
+    // situation rollover creates. Flipping index 0 on one list must not be
+    // mistaken for revoking the other.
+    sqlMock.mockResolvedValueOnce([
+      { id: 'vc_A', status_list_id: 'vcsl_ONE', status_list_idx: 0 },
+      { id: 'vc_B', status_list_id: 'vcsl_TWO', status_list_idx: 0 },
+    ]);
+    sqlMock.mockResolvedValueOnce([{ encoded_list: encoded }]);  // list one SELECT
+    sqlMock.mockResolvedValueOnce([]);                            // list one UPDATE
+    sqlMock.mockResolvedValueOnce([{ encoded_list: encoded }]);  // list two SELECT
+    sqlMock.mockResolvedValueOnce([]);                            // list two UPDATE
+    sqlMock.mockResolvedValueOnce([]);                            // mark revoked
+
+    await revokeVCsByGrantIds(['grnt_A'], 'dev_TEST');
+
+    const listIdsTouched = sqlMock.mock.calls
+      .filter((call) => {
+        const fragments = call[0] as unknown as string[];
+        return Array.isArray(fragments) && fragments.some((f) => f.includes('FOR UPDATE'));
+      })
+      .map((call) => call[1] as string);
+
+    expect(listIdsTouched).toEqual(['vcsl_ONE', 'vcsl_TWO']);
+  });
+
+  it('skips credentials with no recorded status list', async () => {
+    sqlMock.mockResolvedValueOnce([
+      { id: 'vc_ORPHAN', status_list_id: null, status_list_idx: 2 },
+    ]);
+    sqlMock.mockResolvedValueOnce([]); // mark revoked
+
+    await revokeVCsByGrantIds(['grnt_O'], 'dev_TEST');
+
+    const touchedList = sqlMock.mock.calls.some((call) => {
+      const fragments = call[0] as unknown as string[];
+      return Array.isArray(fragments) && fragments.some((f) => f.includes('FOR UPDATE'));
+    });
+    expect(touchedList).toBe(false);
   });
 });

--- a/packages/gateway/src/errors.ts
+++ b/packages/gateway/src/errors.ts
@@ -6,7 +6,9 @@ export type GatewayErrorCode =
   | 'TOKEN_INVALID'
   | 'TOKEN_EXPIRED'
   | 'SCOPE_INSUFFICIENT'
-  | 'UPSTREAM_ERROR';
+  | 'UPSTREAM_ERROR'
+  | 'UPSTREAM_TIMEOUT'
+  | 'PATH_INVALID';
 
 export class GatewayError extends Error {
   readonly code: GatewayErrorCode;

--- a/packages/gateway/src/matcher.ts
+++ b/packages/gateway/src/matcher.ts
@@ -32,6 +32,50 @@ function patternToRegex(pattern: string): RegExp {
   return new RegExp(`^${regex}$`);
 }
 
+// Patterns come from config and never change at runtime, but matchRoute runs on
+// every request against every route — recompiling each time made routing cost
+// scale with route count on the hot path.
+const regexCache = new Map<string, RegExp>();
+
+function cachedPatternRegex(pattern: string): RegExp {
+  let regex = regexCache.get(pattern);
+  if (regex === undefined) {
+    regex = patternToRegex(pattern);
+    regexCache.set(pattern, regex);
+  }
+  return regex;
+}
+
+/**
+ * Reject request paths whose authorized form and forwarded form can differ.
+ *
+ * Authorization matches the pattern against the literal path, but the upstream
+ * receives that path verbatim and resolves `.`/`..` itself. So `/public/../admin`
+ * clears a `/public/**` rule carrying only public scopes and then reaches
+ * `/admin`. Percent-encoded traversal (`%2e%2e`) does the same once the upstream
+ * decodes. Neither form has a legitimate use in an API path, so both are refused.
+ */
+export function isSafeRequestPath(path: string): boolean {
+  if (!path.startsWith('/')) return false;
+  if (path.includes('\0') || path.includes('\\')) return false;
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(path);
+  } catch {
+    // Malformed percent-encoding — the upstream may decode it differently.
+    return false;
+  }
+  if (decoded.includes('\0') || decoded.includes('\\')) return false;
+
+  for (const candidate of [path, decoded]) {
+    for (const segment of candidate.split('/')) {
+      if (segment === '.' || segment === '..') return false;
+    }
+  }
+  return true;
+}
+
 export function matchRoute(
   method: string,
   path: string,
@@ -44,7 +88,7 @@ export function matchRoute(
     if (!route.methods.includes(upperMethod)) continue;
 
     // Check path pattern
-    const regex = patternToRegex(route.path);
+    const regex = cachedPatternRegex(route.path);
     if (regex.test(path)) {
       return { route, params: {} };
     }

--- a/packages/gateway/src/proxy.ts
+++ b/packages/gateway/src/proxy.ts
@@ -8,6 +8,61 @@ export interface ProxyOptions {
   timeout?: number;
 }
 
+/**
+ * Headers that describe *this* hop and must not be relayed to the next one
+ * (RFC 9110 §7.6.1), plus the two the gateway replaces itself.
+ *
+ * `content-length` and `content-encoding` are dropped deliberately: the body is
+ * re-serialized below, so the inbound values describe bytes that no longer
+ * exist. Forwarding a stale content-length makes the upstream read a truncated
+ * body or block waiting for bytes that never arrive.
+ */
+const HOP_BY_HOP_REQUEST_HEADERS = new Set([
+  'authorization',
+  'host',
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'content-length',
+  'content-encoding',
+  'expect',
+]);
+
+/**
+ * `fetch` transparently decodes the upstream body, so the response reaching the
+ * client is neither the declared length nor the declared encoding. Relaying
+ * either one leaves the client trying to gunzip plain text.
+ */
+const SUPPRESSED_RESPONSE_HEADERS = new Set([
+  'content-encoding',
+  'content-length',
+  'transfer-encoding',
+  'connection',
+  'keep-alive',
+  'trailer',
+  'upgrade',
+]);
+
+/**
+ * Serialize the body Fastify parsed back into something the upstream can read.
+ *
+ * The gateway registers a `*` parser with `parseAs: 'string'`, so anything that
+ * is not JSON arrives as a raw string and must be forwarded verbatim —
+ * `JSON.stringify` would wrap it in quotes and escape it, turning `a=1&b=2`
+ * into `"a=1&b=2"` and breaking every form-encoded and text/plain upstream.
+ */
+function serializeBody(body: unknown): string | undefined {
+  if (body === undefined || body === null) return undefined;
+  if (typeof body === 'string') return body;
+  if (Buffer.isBuffer(body)) return body.toString('utf-8');
+  return JSON.stringify(body);
+}
+
 export async function proxyRequest(
   req: FastifyRequest,
   reply: FastifyReply,
@@ -19,11 +74,10 @@ export async function proxyRequest(
   // Build headers: strip Authorization, add upstream headers + Grantex context
   const headers: Record<string, string> = {};
 
-  // Forward original headers (except Authorization and Host)
+  // Forward original headers, minus this hop's own
   const rawHeaders = req.headers;
   for (const [key, value] of Object.entries(rawHeaders)) {
-    if (key.toLowerCase() === 'authorization') continue;
-    if (key.toLowerCase() === 'host') continue;
+    if (HOP_BY_HOP_REQUEST_HEADERS.has(key.toLowerCase())) continue;
     if (value !== undefined) {
       headers[key] = Array.isArray(value) ? value.join(', ') : value;
     }
@@ -36,7 +90,7 @@ export async function proxyRequest(
     }
   }
 
-  // Add Grantex context headers
+  // Add Grantex context headers last so a client cannot spoof them
   headers['X-Grantex-Principal'] = grant.principalId;
   headers['X-Grantex-Agent'] = grant.agentDid;
   headers['X-Grantex-GrantId'] = grant.grantId;
@@ -46,12 +100,14 @@ export async function proxyRequest(
   const timeoutId = setTimeout(() => controller.abort(), timeout);
 
   try {
-    const body = req.method !== 'GET' && req.method !== 'HEAD' ? req.body : undefined;
+    const body = req.method !== 'GET' && req.method !== 'HEAD'
+      ? serializeBody(req.body)
+      : undefined;
 
     const response = await fetch(targetUrl, {
       method: req.method,
       headers,
-      body: body !== undefined ? JSON.stringify(body) : undefined,
+      body,
       signal: controller.signal,
     });
 
@@ -60,7 +116,7 @@ export async function proxyRequest(
 
     // Forward response headers
     for (const [key, value] of response.headers.entries()) {
-      if (key.toLowerCase() === 'transfer-encoding') continue;
+      if (SUPPRESSED_RESPONSE_HEADERS.has(key.toLowerCase())) continue;
       reply.header(key, value);
     }
 
@@ -69,6 +125,13 @@ export async function proxyRequest(
     reply.send(responseBody);
   } catch (err) {
     if (err instanceof GatewayError) throw err;
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new GatewayError(
+        'UPSTREAM_TIMEOUT',
+        `Upstream did not respond within ${timeout}ms`,
+        504,
+      );
+    }
     throw new GatewayError(
       'UPSTREAM_ERROR',
       `Failed to reach upstream: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -1,7 +1,7 @@
 import Fastify, { type FastifyInstance } from 'fastify';
 import { verifyGrantToken, GrantexTokenError } from '@grantex/sdk';
 import type { GatewayConfig } from './types.js';
-import { matchRoute } from './matcher.js';
+import { matchRoute, isSafeRequestPath } from './matcher.js';
 import { proxyRequest } from './proxy.js';
 import { GatewayError } from './errors.js';
 import { log } from './logger.js';
@@ -25,6 +25,15 @@ export function createGatewayServer(config: GatewayConfig): FastifyInstance {
   app.all('/*', async (req, reply) => {
     const method = req.method;
     const path = req.url.split('?')[0]!;
+
+    // 0. Refuse paths whose authorized form can differ from the forwarded form
+    if (!isSafeRequestPath(path)) {
+      reply.status(400).send({
+        error: 'PATH_INVALID',
+        message: 'Request path contains traversal or unsupported characters',
+      });
+      return;
+    }
 
     // 1. Match route
     const match = matchRoute(method, path, config.routes);

--- a/packages/gateway/tests/matcher.test.ts
+++ b/packages/gateway/tests/matcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { matchRoute } from '../src/matcher.js';
+import { matchRoute, isSafeRequestPath } from '../src/matcher.js';
 import type { RouteDefinition } from '../src/types.js';
 
 const ROUTES: RouteDefinition[] = [
@@ -86,5 +86,55 @@ describe('matchRoute', () => {
   it('does not match GET to payments (only POST configured)', () => {
     const result = matchRoute('GET', '/payments/intents', ROUTES);
     expect(result).toBeNull();
+  });
+});
+
+describe('isSafeRequestPath', () => {
+  // The gateway authorizes the literal request path but forwards it verbatim,
+  // and the upstream resolves `.`/`..` itself. A path whose two readings differ
+  // lets a `/calendar/**` token reach `/payments/transfer`. Node's HTTP server
+  // hands over the raw request-target, so this reaches the handler unnormalized.
+  it('rejects a parent-directory segment', () => {
+    expect(isSafeRequestPath('/calendar/../payments/transfer')).toBe(false);
+  });
+
+  it('rejects percent-encoded parent-directory segments', () => {
+    expect(isSafeRequestPath('/calendar/%2e%2e/payments/transfer')).toBe(false);
+    expect(isSafeRequestPath('/calendar/%2E%2E/payments/transfer')).toBe(false);
+  });
+
+  it('rejects a current-directory segment', () => {
+    expect(isSafeRequestPath('/calendar/./events')).toBe(false);
+    expect(isSafeRequestPath('/calendar/%2e/events')).toBe(false);
+  });
+
+  it('rejects a trailing traversal segment', () => {
+    expect(isSafeRequestPath('/calendar/events/..')).toBe(false);
+  });
+
+  it('rejects backslashes and null bytes', () => {
+    expect(isSafeRequestPath('/calendar\\..\\payments')).toBe(false);
+    expect(isSafeRequestPath('/calendar/%5c..%5cpayments')).toBe(false);
+    expect(isSafeRequestPath('/calendar/events%00.json')).toBe(false);
+  });
+
+  it('rejects malformed percent-encoding the upstream might decode differently', () => {
+    expect(isSafeRequestPath('/calendar/%zz')).toBe(false);
+  });
+
+  it('rejects a path that is not absolute', () => {
+    expect(isSafeRequestPath('calendar/events')).toBe(false);
+  });
+
+  it('accepts ordinary paths', () => {
+    expect(isSafeRequestPath('/calendar/events')).toBe(true);
+    expect(isSafeRequestPath('/calendar/events/123')).toBe(true);
+    expect(isSafeRequestPath('/')).toBe(true);
+  });
+
+  it('accepts dots and encoded characters inside a segment', () => {
+    expect(isSafeRequestPath('/calendar/events/report.v2.json')).toBe(true);
+    expect(isSafeRequestPath('/files/..hidden')).toBe(true);
+    expect(isSafeRequestPath('/search/a%20b')).toBe(true);
   });
 });

--- a/packages/gateway/tests/proxy.test.ts
+++ b/packages/gateway/tests/proxy.test.ts
@@ -126,6 +126,133 @@ describe('proxyRequest', () => {
     expect(fetchCall[1]?.body).toBe(JSON.stringify({ summary: 'Meeting' }));
   });
 
+  it('forwards a non-JSON body verbatim instead of re-encoding it', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      headers: { entries: () => [].values() },
+      text: () => Promise.resolve(''),
+    }));
+
+    // The `*` content-type parser hands non-JSON bodies through as raw strings.
+    const req = mockReq({
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: 'summary=Meeting&when=today',
+    });
+    await proxyRequest(req, mockReply(), MOCK_GRANT, {
+      upstream: 'https://api.internal.com',
+    });
+
+    const body = vi.mocked(fetch).mock.calls[0]![1]?.body;
+    expect(body).toBe('summary=Meeting&when=today');
+    // JSON.stringify would have produced a quoted, escaped string.
+    expect(body).not.toBe('"summary=Meeting&when=today"');
+  });
+
+  it('does not forward a content-length that describes the original body', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      headers: { entries: () => [].values() },
+      text: () => Promise.resolve(''),
+    }));
+
+    const req = mockReq({
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-length': '9999',
+        'content-encoding': 'gzip',
+      },
+      body: { summary: 'Meeting' },
+    });
+    await proxyRequest(req, mockReply(), MOCK_GRANT, {
+      upstream: 'https://api.internal.com',
+    });
+
+    const headers = vi.mocked(fetch).mock.calls[0]![1]?.headers as Record<string, string>;
+    expect(headers['content-length']).toBeUndefined();
+    expect(headers['content-encoding']).toBeUndefined();
+  });
+
+  it('strips hop-by-hop request headers', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      headers: { entries: () => [].values() },
+      text: () => Promise.resolve(''),
+    }));
+
+    const req = mockReq({
+      headers: {
+        'content-type': 'application/json',
+        connection: 'keep-alive',
+        'transfer-encoding': 'chunked',
+        'proxy-authorization': 'Basic abc',
+        upgrade: 'websocket',
+        'x-custom': 'kept',
+      },
+    });
+    await proxyRequest(req, mockReply(), MOCK_GRANT, {
+      upstream: 'https://api.internal.com',
+    });
+
+    const headers = vi.mocked(fetch).mock.calls[0]![1]?.headers as Record<string, string>;
+    expect(headers['connection']).toBeUndefined();
+    expect(headers['transfer-encoding']).toBeUndefined();
+    expect(headers['proxy-authorization']).toBeUndefined();
+    expect(headers['upgrade']).toBeUndefined();
+    expect(headers['x-custom']).toBe('kept');
+  });
+
+  it('drops upstream content-encoding and content-length from the response', async () => {
+    // fetch already decoded the body, so the declared encoding and length no
+    // longer describe what the client receives.
+    const responseHeaders = new Map([
+      ['content-type', 'application/json'],
+      ['content-encoding', 'gzip'],
+      ['content-length', '42'],
+      ['x-upstream', 'kept'],
+    ]);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      headers: { entries: () => responseHeaders.entries() },
+      text: () => Promise.resolve('{"data":"decoded plaintext"}'),
+    }));
+
+    const reply = mockReply();
+    await proxyRequest(mockReq(), reply, MOCK_GRANT, {
+      upstream: 'https://api.internal.com',
+    });
+
+    const forwarded = (reply as unknown as { headers: Record<string, string> }).headers;
+    expect(forwarded['content-encoding']).toBeUndefined();
+    expect(forwarded['content-length']).toBeUndefined();
+    expect(forwarded['content-type']).toBe('application/json');
+    expect(forwarded['x-upstream']).toBe('kept');
+  });
+
+  it('a client cannot spoof the Grantex context headers', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      headers: { entries: () => [].values() },
+      text: () => Promise.resolve(''),
+    }));
+
+    const req = mockReq({
+      headers: {
+        'content-type': 'application/json',
+        'X-Grantex-Principal': 'user_attacker',
+        'X-Grantex-GrantId': 'grnt_attacker',
+      },
+    });
+    await proxyRequest(req, mockReply(), MOCK_GRANT, {
+      upstream: 'https://api.internal.com',
+    });
+
+    const headers = vi.mocked(fetch).mock.calls[0]![1]?.headers as Record<string, string>;
+    expect(headers['X-Grantex-Principal']).toBe('user_1');
+    expect(headers['X-Grantex-GrantId']).toBe('grnt_1');
+  });
+
   it('throws UPSTREAM_ERROR on network failure', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
 

--- a/packages/gateway/tests/server.test.ts
+++ b/packages/gateway/tests/server.test.ts
@@ -189,3 +189,37 @@ describe('createGatewayServer', () => {
     expect(response.statusCode).toBe(404);
   });
 });
+
+/**
+ * Traversal rejection is asserted at the unit level in matcher.test.ts rather
+ * than here: `inject` resolves `..` and `.` in the URL before the handler runs
+ * (verified — `/calendar/../payments/transfer` arrives as `/payments/transfer`),
+ * whereas a real Node HTTP server passes the raw request-target through
+ * untouched. Driving this path through `inject` would assert on a normalized
+ * URL that production never produces, which is why the gap went unnoticed.
+ */
+describe('path handling', () => {
+  let server: ReturnType<typeof createGatewayServer>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    server = createGatewayServer(CONFIG);
+    vi.mocked(proxyRequest).mockResolvedValue(undefined);
+    vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it('still allows dots inside a path segment', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/calendar/events/report.v2.json',
+      headers: { authorization: 'Bearer token' },
+    });
+
+    expect(response.statusCode).not.toBe(400);
+    expect(proxyRequest).toHaveBeenCalled();
+  });
+});

--- a/packages/mpp/src/errors.ts
+++ b/packages/mpp/src/errors.ts
@@ -6,7 +6,10 @@ export type PassportErrorCode =
   | 'CATEGORY_MISMATCH'
   | 'AMOUNT_EXCEEDED'
   | 'MISSING_PASSPORT'
-  | 'MALFORMED_CREDENTIAL';
+  | 'MALFORMED_CREDENTIAL'
+  | 'CREDENTIAL_MISMATCH'
+  | 'PASSPORT_NOT_YET_VALID'
+  | 'REVOCATION_CHECK_FAILED';
 
 export class PassportVerificationError extends Error {
   readonly code: PassportErrorCode;

--- a/packages/mpp/src/verifier.ts
+++ b/packages/mpp/src/verifier.ts
@@ -2,7 +2,6 @@ import * as jose from 'jose';
 import { PassportVerificationError } from './errors.js';
 import type {
   AgentPassportCredential,
-  MPPCategory,
   VerifiedPassport,
   VerifyPassportOptions,
 } from './types.js';
@@ -10,6 +9,8 @@ import type {
 const DEFAULT_JWKS_URI = 'https://api.grantex.dev/.well-known/jwks.json';
 const DEFAULT_TRUSTED_ISSUERS = ['did:web:grantex.dev'];
 const JWKS_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+/** Tolerance for issuer/verifier clock drift when applying validFrom. */
+const CLOCK_SKEW_TOLERANCE_MS = 60 * 1000;
 
 interface JwksCacheEntry {
   jwks: jose.JSONWebKeySet;
@@ -69,6 +70,138 @@ function validateStructure(credential: AgentPassportCredential): void {
   }
 }
 
+/**
+ * Claims read out of the *verified* JWS. Everything an authorization decision
+ * depends on has to come from here — the surrounding credential envelope is
+ * attacker-supplied and is only ever used to cross-check these values.
+ */
+interface SignedClaims {
+  issuer: string;
+  passportId: string;
+  subject: AgentPassportCredential['credentialSubject'];
+  expiresAt: Date;
+  notBefore: Date | null;
+}
+
+/** Stable stringify so key ordering cannot make two equal objects compare unequal. */
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(',')}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(',')}}`;
+}
+
+/**
+ * Verify `proof.proofValue` against the trusted keyset and extract the claims it
+ * actually attests to.
+ *
+ * The proof is a VC-JWT: `vc.credentialSubject` carries the subject, and the
+ * registered claims (`iss`, `jti`, `exp`, `nbf`/`iat`) carry the envelope. Both
+ * the issuer's `vc` claim shapes — subject-only and full-credential — expose the
+ * same fields, so one extraction covers both.
+ */
+async function verifyProof(
+  proofValue: string,
+  jwks: jose.JSONWebKeySet,
+): Promise<SignedClaims> {
+  if (typeof proofValue !== 'string' || proofValue.length === 0) {
+    throw new PassportVerificationError(
+      'INVALID_SIGNATURE',
+      'Credential proof is missing a proofValue',
+    );
+  }
+
+  const keyStore = jose.createLocalJWKSet(jwks);
+  let payload: jose.JWTPayload;
+  try {
+    // jwtVerify enforces the signature *and* the signed exp/nbf window.
+    ({ payload } = await jose.jwtVerify(proofValue, keyStore));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (err instanceof jose.errors.JWTExpired) {
+      throw new PassportVerificationError(
+        'PASSPORT_EXPIRED',
+        `Passport proof has expired: ${message}`,
+      );
+    }
+    if (err instanceof jose.errors.JWTClaimValidationFailed && err.claim === 'nbf') {
+      throw new PassportVerificationError(
+        'PASSPORT_NOT_YET_VALID',
+        `Passport proof is not yet valid: ${message}`,
+      );
+    }
+    throw new PassportVerificationError(
+      'INVALID_SIGNATURE',
+      `Signature verification failed: ${message}`,
+    );
+  }
+
+  const vc = payload['vc'] as { credentialSubject?: unknown } | undefined;
+  const subject = vc?.credentialSubject as
+    | AgentPassportCredential['credentialSubject']
+    | undefined;
+
+  if (!subject || typeof subject !== 'object') {
+    throw new PassportVerificationError(
+      'MALFORMED_CREDENTIAL',
+      'Signed proof does not carry a vc.credentialSubject claim',
+    );
+  }
+  if (typeof payload.iss !== 'string' || typeof payload.jti !== 'string') {
+    throw new PassportVerificationError(
+      'MALFORMED_CREDENTIAL',
+      'Signed proof is missing the iss or jti claim',
+    );
+  }
+  if (typeof payload.exp !== 'number') {
+    throw new PassportVerificationError(
+      'MALFORMED_CREDENTIAL',
+      'Signed proof is missing the exp claim',
+    );
+  }
+
+  const notBeforeSeconds = typeof payload.nbf === 'number' ? payload.nbf : null;
+
+  return {
+    issuer: payload.iss,
+    passportId: payload.jti,
+    subject,
+    expiresAt: new Date(payload.exp * 1000),
+    notBefore: notBeforeSeconds !== null ? new Date(notBeforeSeconds * 1000) : null,
+  };
+}
+
+/**
+ * Reject any envelope that disagrees with what was signed. Without this the
+ * envelope is free-form attacker input: a holder of one valid passport could
+ * paste its proof next to a self-written subject and mint arbitrary authority.
+ */
+function assertEnvelopeMatchesProof(
+  credential: AgentPassportCredential,
+  signed: SignedClaims,
+): void {
+  if (credential.id !== signed.passportId) {
+    throw new PassportVerificationError(
+      'CREDENTIAL_MISMATCH',
+      `Credential id (${credential.id}) does not match the signed passport id (${signed.passportId})`,
+    );
+  }
+  if (credential.issuer !== signed.issuer) {
+    throw new PassportVerificationError(
+      'CREDENTIAL_MISMATCH',
+      `Credential issuer (${credential.issuer}) does not match the signed issuer (${signed.issuer})`,
+    );
+  }
+  if (canonicalize(credential.credentialSubject) !== canonicalize(signed.subject)) {
+    throw new PassportVerificationError(
+      'CREDENTIAL_MISMATCH',
+      'Credential subject does not match the signed credentialSubject claim',
+    );
+  }
+}
+
 export async function verifyPassport(
   encodedCredential: string,
   options?: VerifyPassportOptions,
@@ -83,7 +216,7 @@ export async function verifyPassport(
   const credential = decodePassport(encodedCredential);
   validateStructure(credential);
 
-  // Check trusted issuers
+  // Reject an untrusted claimed issuer before doing any network work.
   const trustedIssuers = options?.trustedIssuers ?? DEFAULT_TRUSTED_ISSUERS;
   if (!trustedIssuers.includes(credential.issuer)) {
     throw new PassportVerificationError(
@@ -92,36 +225,56 @@ export async function verifyPassport(
     );
   }
 
-  // Check expiry
-  const expiresAt = new Date(credential.validUntil);
-  if (expiresAt.getTime() <= Date.now()) {
+  // Verify the proof, then pin the envelope to what was actually signed.
+  // Every check from here on runs on signed data.
+  const jwksUri = options?.jwksUri ?? DEFAULT_JWKS_URI;
+  const jwks = await fetchJwks(jwksUri);
+  const signed = await verifyProof(credential.proof.proofValue, jwks);
+  assertEnvelopeMatchesProof(credential, signed);
+
+  // The signed issuer must independently clear the trust list — the envelope
+  // check above was on attacker-supplied data.
+  if (!trustedIssuers.includes(signed.issuer)) {
     throw new PassportVerificationError(
-      'PASSPORT_EXPIRED',
-      `Passport expired at ${credential.validUntil}`,
+      'UNTRUSTED_ISSUER',
+      `Signed issuer ${signed.issuer} is not in the trusted issuers list`,
     );
   }
 
-  // Verify Ed25519 signature via JWKS
-  const jwksUri = options?.jwksUri ?? DEFAULT_JWKS_URI;
-  const jwks = await fetchJwks(jwksUri);
+  // Check the validity window. The envelope carries validFrom/validUntil in
+  // ISO form and the proof carries nbf/exp; neither may be treated as more
+  // permissive than the other, so the narrower of the two bounds wins.
+  const now = Date.now();
+  const envelopeExpiry = new Date(credential.validUntil);
+  if (Number.isNaN(envelopeExpiry.getTime())) {
+    throw new PassportVerificationError(
+      'MALFORMED_CREDENTIAL',
+      `Credential validUntil is not a valid date: ${credential.validUntil}`,
+    );
+  }
+  const expiresAt = new Date(Math.min(envelopeExpiry.getTime(), signed.expiresAt.getTime()));
+  if (expiresAt.getTime() <= now) {
+    throw new PassportVerificationError(
+      'PASSPORT_EXPIRED',
+      `Passport expired at ${expiresAt.toISOString()}`,
+    );
+  }
 
-  try {
-    // The proof.proofValue is the detached JWS — verify using the JWKS keyset
-    const keyStore = jose.createLocalJWKSet(jwks);
-    // Reconstruct compact JWS from proof for verification
-    const proofValue = credential.proof.proofValue;
-    // Verify the JWS — the proofValue is a compact JWS of the credential
-    await jose.compactVerify(proofValue, keyStore);
-  } catch (err) {
-    try {
-      const keyStore = jose.createLocalJWKSet(jwks);
-      await jose.jwtVerify(credential.proof.proofValue, keyStore);
-    } catch {
-      throw new PassportVerificationError(
-        'INVALID_SIGNATURE',
-        `Signature verification failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+  const envelopeValidFrom = new Date(credential.validFrom);
+  if (Number.isNaN(envelopeValidFrom.getTime())) {
+    throw new PassportVerificationError(
+      'MALFORMED_CREDENTIAL',
+      `Credential validFrom is not a valid date: ${credential.validFrom}`,
+    );
+  }
+  const validFrom = signed.notBefore !== null
+    ? new Date(Math.max(envelopeValidFrom.getTime(), signed.notBefore.getTime()))
+    : envelopeValidFrom;
+  if (validFrom.getTime() > now + CLOCK_SKEW_TOLERANCE_MS) {
+    throw new PassportVerificationError(
+      'PASSPORT_NOT_YET_VALID',
+      `Passport is not valid until ${validFrom.toISOString()}`,
+    );
   }
 
   // Check revocation if requested
@@ -131,28 +284,43 @@ export async function verifyPassport(
       throw new Error('revocationEndpoint is required when checkRevocation is true');
     }
 
-    const response = await fetch(revocationEndpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token: credential.proof.proofValue }),
-    });
-
-    if (response.ok) {
-      const result = (await response.json()) as { valid: boolean };
-      if (!result.valid) {
-        throw new PassportVerificationError(
-          'PASSPORT_REVOKED',
-          'Passport has been revoked',
-        );
+    // An unreachable or erroring revocation service must fail closed. Treating
+    // it as "not revoked" turns an outage into a window where every revoked
+    // passport is accepted again.
+    let result: { valid?: boolean };
+    try {
+      const response = await fetch(revocationEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: credential.proof.proofValue }),
+      });
+      if (!response.ok) {
+        throw new Error(`revocation endpoint returned ${response.status}`);
       }
+      result = (await response.json()) as { valid?: boolean };
+    } catch (err) {
+      throw new PassportVerificationError(
+        'REVOCATION_CHECK_FAILED',
+        `Could not determine revocation status: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    if (result.valid !== true) {
+      throw new PassportVerificationError(
+        'PASSPORT_REVOKED',
+        'Passport has been revoked',
+      );
     }
   }
 
   // Check required categories
-  const subject = credential.credentialSubject;
+  const subject = signed.subject;
+  const allowedCategories = Array.isArray(subject.allowedMPPCategories)
+    ? subject.allowedMPPCategories
+    : [];
   if (options?.requiredCategories) {
     const missing = options.requiredCategories.filter(
-      (c) => !subject.allowedMPPCategories.includes(c),
+      (c) => !allowedCategories.includes(c),
     );
     if (missing.length > 0) {
       throw new PassportVerificationError(
@@ -164,26 +332,33 @@ export async function verifyPassport(
 
   // Check max amount
   if (options?.maxAmount !== undefined) {
-    if (subject.maxTransactionAmount.amount < options.maxAmount) {
+    const permitted = subject.maxTransactionAmount?.amount;
+    if (typeof permitted !== 'number' || !Number.isFinite(permitted)) {
+      throw new PassportVerificationError(
+        'MALFORMED_CREDENTIAL',
+        'Signed credentialSubject has no numeric maxTransactionAmount.amount',
+      );
+    }
+    if (permitted < options.maxAmount) {
       throw new PassportVerificationError(
         'AMOUNT_EXCEEDED',
-        `Passport max amount (${subject.maxTransactionAmount.amount}) is less than required (${options.maxAmount})`,
+        `Passport max amount (${permitted}) is less than required (${options.maxAmount})`,
       );
     }
   }
 
   return {
     valid: true,
-    passportId: credential.id,
+    passportId: signed.passportId,
     agentDID: subject.id,
     humanDID: subject.humanPrincipal,
     organizationDID: subject.organizationDID,
     grantId: subject.grantId,
-    allowedCategories: subject.allowedMPPCategories,
+    allowedCategories,
     maxTransactionAmount: subject.maxTransactionAmount,
     delegationDepth: subject.delegationDepth,
     expiresAt,
-    issuer: credential.issuer,
+    issuer: signed.issuer,
   };
 }
 

--- a/packages/mpp/tests/forgery.test.ts
+++ b/packages/mpp/tests/forgery.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import * as jose from 'jose';
+import { verifyPassport, clearJwksCache } from '../src/verifier.js';
+import type { AgentPassportCredential } from '../src/types.js';
+
+/**
+ * Regression suite for passport forgery.
+ *
+ * The credential envelope is transported base64url-encoded in a client-supplied
+ * header, so every field in it is attacker-controlled. Only `proof.proofValue`
+ * is signed. If verification reads authorization-relevant claims off the
+ * envelope, any holder of one legitimately-issued passport can lift its proof,
+ * staple it to a self-written envelope, and mint arbitrary authority.
+ */
+
+let rsaKeyPair: Awaited<ReturnType<typeof jose.generateKeyPair>>;
+let jwks: jose.JSONWebKeySet;
+
+async function setupKeys(): Promise<void> {
+  const { publicKey, privateKey } = await jose.generateKeyPair('RS256', { extractable: true });
+  rsaKeyPair = { publicKey, privateKey };
+  const jwk = await jose.exportJWK(publicKey);
+  jwk.kid = 'key-1';
+  jwk.alg = 'RS256';
+  jwk.use = 'sig';
+  jwks = { keys: [jwk] };
+}
+
+function mockFetchJwks() {
+  return vi.fn().mockImplementation(async (url: string) => {
+    if (typeof url === 'string' && url.includes('jwks.json')) {
+      return { ok: true, status: 200, json: async () => jwks };
+    }
+    return { ok: false, status: 404 };
+  });
+}
+
+/** A modest, legitimately-issued passport: two categories, $50 ceiling. */
+function lowPrivilegeSubject(): AgentPassportCredential['credentialSubject'] {
+  return {
+    id: 'did:grantex:ag_attacker',
+    type: 'AIAgent',
+    humanPrincipal: 'did:grantex:user_attacker',
+    organizationDID: 'did:web:attacker.example',
+    grantId: 'grnt_low',
+    allowedMPPCategories: ['inference'],
+    maxTransactionAmount: { amount: 50, currency: 'USDC' },
+    paymentRails: ['tempo'],
+    delegationDepth: 0,
+  };
+}
+
+/**
+ * Mint a real passport the way the auth service does: the proof is a VC-JWT
+ * whose `vc` claim carries the subject and whose registered claims carry the
+ * envelope (see apps/auth-service/src/routes/passport.ts).
+ */
+async function issueRealPassport(
+  subject: AgentPassportCredential['credentialSubject'],
+): Promise<AgentPassportCredential> {
+  const passportId = 'urn:grantex:passport:REAL01';
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + 86_400_000);
+
+  const credentialStatus: AgentPassportCredential['credentialStatus'] = {
+    id: 'https://api.grantex.dev/v1/credentials/status/vcsl_01#0',
+    type: 'StatusList2021Entry',
+    statusPurpose: 'revocation',
+    statusListIndex: '0',
+    statusListCredential: 'https://api.grantex.dev/v1/credentials/status/vcsl_01',
+  };
+
+  const proofValue = await new jose.SignJWT({
+    vc: {
+      '@context': [
+        'https://www.w3.org/ns/credentials/v2',
+        'https://grantex.dev/contexts/mpp/v1',
+      ],
+      type: ['VerifiableCredential', 'AgentPassportCredential'],
+      credentialSubject: subject,
+      credentialStatus,
+    },
+  })
+    .setProtectedHeader({ alg: 'RS256', kid: 'key-1', typ: 'JWT' })
+    .setIssuer('did:web:grantex.dev')
+    .setSubject(subject.id)
+    .setJti(passportId)
+    .setIssuedAt(Math.floor(now.getTime() / 1000))
+    .setExpirationTime(Math.floor(expiresAt.getTime() / 1000))
+    .sign(rsaKeyPair.privateKey);
+
+  return {
+    '@context': [
+      'https://www.w3.org/ns/credentials/v2',
+      'https://grantex.dev/contexts/mpp/v1',
+    ],
+    type: ['VerifiableCredential', 'AgentPassportCredential'],
+    id: passportId,
+    issuer: 'did:web:grantex.dev',
+    validFrom: now.toISOString(),
+    validUntil: expiresAt.toISOString(),
+    credentialSubject: subject,
+    credentialStatus,
+    proof: {
+      type: 'Ed25519Signature2020',
+      created: now.toISOString(),
+      verificationMethod: 'did:web:grantex.dev#key-2',
+      proofPurpose: 'assertionMethod',
+      proofValue,
+    },
+  };
+}
+
+function encode(credential: AgentPassportCredential): string {
+  return Buffer.from(JSON.stringify(credential)).toString('base64url');
+}
+
+describe('passport forgery via envelope substitution', () => {
+  beforeEach(async () => {
+    await setupKeys();
+    clearJwksCache();
+    vi.stubGlobal('fetch', mockFetchJwks());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('accepts the genuine passport it was issued', async () => {
+    const real = await issueRealPassport(lowPrivilegeSubject());
+
+    const result = await verifyPassport(encode(real));
+
+    expect(result.valid).toBe(true);
+    expect(result.allowedCategories).toEqual(['inference']);
+    expect(result.maxTransactionAmount).toEqual({ amount: 50, currency: 'USDC' });
+  });
+
+  it('rejects a self-written envelope carrying a real proof', async () => {
+    const real = await issueRealPassport(lowPrivilegeSubject());
+
+    // Same signed proof, envelope rewritten to grant every category and a
+    // 1,000,000 USDC ceiling.
+    const forged: AgentPassportCredential = {
+      ...real,
+      credentialSubject: {
+        ...lowPrivilegeSubject(),
+        allowedMPPCategories: [
+          'inference', 'compute', 'data', 'storage',
+          'search', 'media', 'delivery', 'browser', 'general',
+        ],
+        maxTransactionAmount: { amount: 1_000_000, currency: 'USDC' },
+      },
+    };
+
+    await expect(verifyPassport(encode(forged))).rejects.toThrow(
+      expect.objectContaining({ code: 'CREDENTIAL_MISMATCH' }),
+    );
+  });
+
+  it('does not let a forged envelope satisfy a category requirement', async () => {
+    const real = await issueRealPassport(lowPrivilegeSubject());
+    const forged: AgentPassportCredential = {
+      ...real,
+      credentialSubject: {
+        ...lowPrivilegeSubject(),
+        allowedMPPCategories: ['inference', 'delivery'],
+      },
+    };
+
+    await expect(
+      verifyPassport(encode(forged), { requiredCategories: ['delivery'] }),
+    ).rejects.toThrow(expect.objectContaining({ code: 'CREDENTIAL_MISMATCH' }));
+  });
+
+  it('does not let a forged envelope satisfy an amount requirement', async () => {
+    const real = await issueRealPassport(lowPrivilegeSubject());
+    const forged: AgentPassportCredential = {
+      ...real,
+      credentialSubject: {
+        ...lowPrivilegeSubject(),
+        maxTransactionAmount: { amount: 999_999, currency: 'USDC' },
+      },
+    };
+
+    await expect(
+      verifyPassport(encode(forged), { maxAmount: 10_000 }),
+    ).rejects.toThrow(expect.objectContaining({ code: 'CREDENTIAL_MISMATCH' }));
+  });
+
+  it('rejects an envelope that reassigns the human principal', async () => {
+    const real = await issueRealPassport(lowPrivilegeSubject());
+    const forged: AgentPassportCredential = {
+      ...real,
+      credentialSubject: {
+        ...lowPrivilegeSubject(),
+        humanPrincipal: 'did:grantex:user_victim',
+      },
+    };
+
+    await expect(verifyPassport(encode(forged))).rejects.toThrow(
+      expect.objectContaining({ code: 'CREDENTIAL_MISMATCH' }),
+    );
+  });
+
+  it('rejects an envelope that renames the passport id', async () => {
+    const real = await issueRealPassport(lowPrivilegeSubject());
+    const forged: AgentPassportCredential = { ...real, id: 'urn:grantex:passport:OTHER' };
+
+    await expect(verifyPassport(encode(forged))).rejects.toThrow(
+      expect.objectContaining({ code: 'CREDENTIAL_MISMATCH' }),
+    );
+  });
+
+  it('rejects an envelope that extends validUntil past the signed exp', async () => {
+    const subject = lowPrivilegeSubject();
+    const now = new Date();
+    const proofValue = await new jose.SignJWT({
+      vc: { credentialSubject: subject },
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'key-1', typ: 'JWT' })
+      .setIssuer('did:web:grantex.dev')
+      .setJti('urn:grantex:passport:REAL01')
+      .setIssuedAt(Math.floor(now.getTime() / 1000) - 7200)
+      // Signed proof expired an hour ago.
+      .setExpirationTime(Math.floor(now.getTime() / 1000) - 3600)
+      .sign(rsaKeyPair.privateKey);
+
+    const real = await issueRealPassport(subject);
+    const forged: AgentPassportCredential = {
+      ...real,
+      // Envelope claims another decade of validity.
+      validUntil: new Date(now.getTime() + 10 * 365 * 86_400_000).toISOString(),
+      proof: { ...real.proof, proofValue },
+    };
+
+    await expect(verifyPassport(encode(forged))).rejects.toThrow(
+      expect.objectContaining({ code: 'PASSPORT_EXPIRED' }),
+    );
+  });
+
+  it('rejects a passport whose validity window has not opened yet', async () => {
+    const subject = lowPrivilegeSubject();
+    const real = await issueRealPassport(subject);
+    const startsAt = new Date(Date.now() + 3_600_000);
+
+    const proofValue = await new jose.SignJWT({ vc: { credentialSubject: subject } })
+      .setProtectedHeader({ alg: 'RS256', kid: 'key-1', typ: 'JWT' })
+      .setIssuer('did:web:grantex.dev')
+      .setJti(real.id)
+      .setIssuedAt(Math.floor(startsAt.getTime() / 1000))
+      .setExpirationTime(Math.floor(startsAt.getTime() / 1000) + 86_400)
+      .sign(rsaKeyPair.privateKey);
+
+    const notYetValid: AgentPassportCredential = {
+      ...real,
+      validFrom: startsAt.toISOString(),
+      validUntil: new Date(startsAt.getTime() + 86_400_000).toISOString(),
+      proof: { ...real.proof, proofValue },
+    };
+
+    await expect(verifyPassport(encode(notYetValid))).rejects.toThrow(
+      expect.objectContaining({ code: 'PASSPORT_NOT_YET_VALID' }),
+    );
+  });
+});
+
+describe('revocation check failure handling', () => {
+  beforeEach(async () => {
+    await setupKeys();
+    clearJwksCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fails closed when the revocation endpoint is unavailable', async () => {
+    const real = await issueRealPassport(lowPrivilegeSubject());
+
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.includes('jwks.json')) {
+        return { ok: true, status: 200, json: async () => jwks };
+      }
+      return { ok: false, status: 503 };
+    }));
+
+    await expect(
+      verifyPassport(encode(real), {
+        checkRevocation: true,
+        revocationEndpoint: 'https://api.grantex.dev/revocation',
+      }),
+    ).rejects.toThrow(expect.objectContaining({ code: 'REVOCATION_CHECK_FAILED' }));
+  });
+
+  it('fails closed when the revocation endpoint throws', async () => {
+    const real = await issueRealPassport(lowPrivilegeSubject());
+
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.includes('jwks.json')) {
+        return { ok: true, status: 200, json: async () => jwks };
+      }
+      throw new Error('ECONNREFUSED');
+    }));
+
+    await expect(
+      verifyPassport(encode(real), {
+        checkRevocation: true,
+        revocationEndpoint: 'https://api.grantex.dev/revocation',
+      }),
+    ).rejects.toThrow(expect.objectContaining({ code: 'REVOCATION_CHECK_FAILED' }));
+  });
+});


### PR DESCRIPTION
## Summary

Six defects across passport verification, the gateway data path, StatusList2021 revocation, and the audit chain. The first is a complete authorization bypass.

## 1. Passport forgery — total authorization bypass

`verifyPassport` confirmed that `proof.proofValue` was *a* validly signed JWS, then made every authorization decision from the **surrounding envelope** — which arrives base64url-encoded in a client-supplied header and is entirely attacker-controlled.

Any holder of one legitimately issued passport could lift its proof, staple it to a self-written envelope, and mint arbitrary authority. Against the previous implementation the forged credential returns:

```
promise resolved "{ valid: true, …(10) }"    ← all 9 categories, 1,000,000 USDC ceiling
```

Reassigning `humanPrincipal` to a victim, extending `validUntil` by a decade, and renaming the passport id all worked identically.

All 62 existing tests passed throughout — every fixture built an envelope that already agreed with what was signed, so nothing exercised the gap.

Trusted claims now come from the verified JWT; a disagreeing envelope is rejected. **9 of the 10 new cases in `forgery.test.ts` fail against the previous implementation.**

Three more in the same file:
- `validFrom` was never enforced (not-yet-valid passports accepted).
- The signed `exp` was ignored in favour of the envelope's; expiry now takes the narrower of the two.
- A failing revocation endpoint was treated as *not revoked* — an outage silently re-validated every revoked passport. Now fails closed.

## 2. Gateway scope escalation via path traversal

The gateway authorized the literal path but forwarded it verbatim, and upstreams resolve `..` themselves:

```
POST /calendar/../payments/transfer
  → clears /calendar/**  (token holds only calendar:read)
  → upstream resolves to /payments/transfer  (gated on payments:initiate)
```

Verified over a raw socket that Node hands the handler the unnormalized request-target. Fastify's `inject` **normalizes the URL before the handler runs** — which is exactly why the suite could not see this. The guard is therefore tested at unit level, with the reason documented in the test.

## 3. Gateway body and header corruption

- Client `content-length` forwarded while the body was re-serialized → upstream reads a truncated body or blocks.
- Non-JSON bodies run through `JSON.stringify` → `a=1&b=2` became `"a=1&b=2"`, breaking every form-encoded and text upstream.
- Upstream `content-encoding: gzip` relayed over a body `fetch` had already decoded → client cannot decode.

Every existing proxy test mocked `fetch`, so none of this surfaced.

## 4. StatusList2021 revocation

- Index allocation was read-then-increment: concurrent issuance handed two credentials the same bit, so revoking either revoked both.
- A `UNIQUE(developer_id, purpose)` index capped each developer at one 131,072-bit list **permanently**. Past capacity, out-of-range `Buffer` writes are a **silent no-op** in Node — revocation reported success and did nothing.
- The bit flip was an unlocked read-modify-write, losing updates between concurrent revocations.

Allocation is now a single atomic statement with rollover (migration `087`); flips take a row lock.

## 5. Audit chain was decorative

`verifyChain` only checked that links matched — it never recomputed a hash. Editing any entry's `action`, `status`, or `principal_id` directly in the database left `chainIntegrity: valid` in the SOC2/GDPR export.

It now recomputes per entry and reports `reason: 'link' | 'content'`. This required canonical metadata hashing: `metadata` is `JSONB` and Postgres normalizes key order, so the hash was previously unreproducible from the stored row.

## 6. Smaller

- `page`/`pageSize` reached `LIMIT`/`OFFSET` unvalidated — negative offset and NaN limit are hard Postgres errors surfacing as 500s, and page size was unbounded.
- Audit reads ordered on `timestamp` alone while the chain builder tie-breaks on `id`, leaving same-millisecond entries in arbitrary order.

## Test plan

| Suite | Result |
|---|---|
| `packages/mpp` | 72 passed (+10 new) |
| `packages/gateway` | 61 passed (+16 new) |
| `packages/sdk-ts` | 418 passed |
| `apps/auth-service` | 1997 passed (+13 new) |

`tsc --noEmit` clean across `packages/mpp`, `packages/gateway`, `apps/auth-service`. Re-verified on this branch's base after rebasing onto current `main`.

## Deploy notes

- **Migration `087`** drops a unique index and backfills `status_list_id` on `verifiable_credentials` and `mpp_passports`. Idempotent (migrations re-run each boot), but it is schema change on live tables.
- The audit hash is **byte-identical** for empty, single-key, and already-sorted metadata (pinned by a test). Entries with multi-key metadata in non-sorted order will now report `reason: 'content'`. Not a regression — those rows were never verifiable; the check simply could not see it before.

## Not addressed

- `token.ts:161` — the budget lookup runs against a ULID generated three lines earlier in the same transaction, so it is provably always empty and `bdg` is never set on initial issuance. Correct behavior is a product decision.
- The gateway's `parseAs: 'string'` parser corrupts gzipped/binary request bodies before proxying (architectural — needs a raw-buffer parser).
- `verifyWebhookSignature` has no timestamp binding, so signatures replay indefinitely.

Review covered passport verification, VC issuance/revocation, the gateway data path, audit/compliance integrity, and budget routes. Commerce (~25 route files), SSO/SCIM/LDAP, x402, and the Python/Go SDKs were not reviewed.
