### PR TITLE
chore: ignore local video render artifacts and scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ twitter-thread-full-session.md
 packages/mcp/.mcpregistry_*
 packages/mcp/mcp-publisher.exe
 awesome-mcp-servers-pr.md
+
+# Grantex impact video (local only)
+/assets/video/
+/scripts/video/


### PR DESCRIPTION
## Summary

Adds `/assets/video/` and `/scripts/video/` to `.gitignore`.

- `assets/video` — 36 MB of generated output (`.mp4`, `.png`, `.srt`)
- `scripts/video` — local render tooling plus its `__pycache__`

Neither path has ever been tracked, so this changes nothing about the repo contents or CI inputs. It just stops both directories showing up as untracked in every `git status`, where a stray `git add -A` would have pulled 36 MB of binaries into history.

## Note

`scripts/video` contains source, not only artifacts — `render_grantex_explainer.py`, `render_grantex_impact.py`, `README.md`, and `grantex-impact-voiceover.txt`. Ignoring the directory leaves that tooling untracked. That matches the existing intent (the surrounding `.gitignore` already carries a "Marketing content - local only" block), but if the render scripts should be version-controlled, narrow the rule to the artifacts instead:

```gitignore
/assets/video/
/scripts/video/__pycache__/
```

## Verification

```
$ git check-ignore -v assets/video/grantex-impact-60s.mp4 scripts/video/render_grantex_impact.py
.gitignore:76:/assets/video/     assets/video/grantex-impact-60s.mp4
.gitignore:77:/scripts/video/    scripts/video/render_grantex_impact.py
```

`git status` is clean afterwards; `git ls-tree -r origin/main` confirms no file under either path was ever committed, so nothing needs `git rm --cached`.
