### PR TITLE
fix(authz): match deny policies on overlap, bound delegation depth, attribute decisions correctly

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -77,6 +77,10 @@ LDAP_TLS_REJECT_UNAUTHORIZED=true
 # CORS browser origins, comma-separated.
 CORS_ALLOWED_ORIGINS=https://your-domain.example.com,https://portal.your-domain.example.com
 
+# Maximum sub-agent delegation chain length (SPEC §9). Default 3; values above
+# the hard cap of 10 are rejected at startup.
+MAX_DELEGATION_DEPTH=3
+
 # -----------------------------------------------------------------------------
 # Stripe billing (optional — comment out to disable billing endpoints)
 # -----------------------------------------------------------------------------

--- a/apps/auth-service/src/config.ts
+++ b/apps/auth-service/src/config.ts
@@ -189,6 +189,11 @@ export const config = {
     2_147_483_647,
   ),
   commerceReconciliationLimit: integerSetting('COMMERCE_RECONCILIATION_LIMIT', '50', 1, 1_000),
+  // SPEC §9: implementations MUST enforce a developer-configurable delegation
+  // depth limit; the RECOMMENDED default is 3 and the hard cap is 10. The `max`
+  // argument is what enforces the hard cap — a larger value is rejected at boot
+  // rather than silently honoured.
+  maxDelegationDepth: integerSetting('MAX_DELEGATION_DEPTH', '3', 1, 10),
 } as const;
 
 if (!config.rsaPrivateKey && !config.autoGenerateKeys) {

--- a/apps/auth-service/src/lib/backends/builtin.ts
+++ b/apps/auth-service/src/lib/backends/builtin.ts
@@ -6,7 +6,7 @@
  */
 
 import { getSql } from '../../db/client.js';
-import { evaluatePolicies, type PolicyRow } from '../policy.js';
+import { findMatchingPolicy, type PolicyRow } from '../policy.js';
 import type { PolicyBackend, PolicyEvalContext, PolicyDecision } from '../policy-backend.js';
 
 export class BuiltinBackend implements PolicyBackend {
@@ -21,20 +21,22 @@ export class BuiltinBackend implements PolicyBackend {
       ORDER BY priority DESC, created_at ASC
     `;
 
-    const effect = evaluatePolicies(policyRows, {
+    // Take the matched policy itself, not just its effect: the decision has to
+    // name the policy that actually decided it. Re-deriving the id by grabbing
+    // the first row attributed every decision to the highest-priority policy,
+    // regardless of which one matched.
+    const matchingPolicy = findMatchingPolicy(policyRows, {
       agentId: ctx.agentId,
       principalId: ctx.principalId,
       scopes: ctx.scopes,
       ...(ctx.time !== undefined ? { nowUtcHHMM: ctx.time } : {}),
     });
 
-    if (effect === null) return { effect: null };
+    if (matchingPolicy === null) return { effect: null };
 
-    // Find matching policy ID for traceability
-    const matchingPolicy = policyRows.find(() => true); // first match (simplified)
     return {
-      effect,
-      ...(matchingPolicy !== undefined ? { policyId: matchingPolicy.id } : {}),
+      effect: matchingPolicy.effect,
+      policyId: matchingPolicy.id,
     };
   }
 }

--- a/apps/auth-service/src/lib/policy.ts
+++ b/apps/auth-service/src/lib/policy.ts
@@ -26,6 +26,28 @@ export interface PolicyContext {
 }
 
 /**
+ * Return the first matching policy, or `null` if none match.
+ *
+ * Policies must be provided in priority order (highest first).
+ *
+ * Callers that report *which* policy decided a request must use this rather
+ * than re-deriving it — picking the first row in the list instead attributes
+ * every decision to the highest-priority policy whether or not it matched.
+ */
+export function findMatchingPolicy(
+  policies: PolicyRow[],
+  ctx: PolicyContext,
+): PolicyRow | null {
+  const time = ctx.nowUtcHHMM ?? utcHHMM(new Date());
+
+  for (const policy of policies) {
+    if (matchesPolicy(policy, ctx, time)) return policy;
+  }
+
+  return null;
+}
+
+/**
  * Return the effect of the first matching policy, or `null` if none match.
  *
  * Policies must be provided in priority order (highest first).
@@ -34,14 +56,7 @@ export function evaluatePolicies(
   policies: PolicyRow[],
   ctx: PolicyContext,
 ): 'allow' | 'deny' | null {
-  const time = ctx.nowUtcHHMM ?? utcHHMM(new Date());
-
-  for (const policy of policies) {
-    if (!matchesPolicy(policy, ctx, time)) continue;
-    return policy.effect;
-  }
-
-  return null;
+  return findMatchingPolicy(policies, ctx)?.effect ?? null;
 }
 
 function matchesPolicy(
@@ -56,10 +71,20 @@ function matchesPolicy(
   if (policy.principal_id !== null && policy.principal_id !== ctx.principalId)
     return false;
 
-  // Scope condition: all requested scopes must be covered by the policy's scopes
+  // Scope condition. The two effects need opposite tests:
+  //
+  //   allow — every requested scope must be covered, otherwise the policy
+  //           would grant scopes it never listed.
+  //   deny  — any overlap is enough. Requiring containment here let a caller
+  //           slip past a deny rule by tacking an unrelated scope onto the
+  //           request: a deny on ['payments:transfer'] stopped matching as
+  //           soon as 'calendar:read' was requested alongside it.
   if (policy.scopes !== null) {
-    const allowed = new Set(policy.scopes);
-    if (!ctx.scopes.every((s) => allowed.has(s))) return false;
+    const policyScopes = new Set(policy.scopes);
+    const matches = policy.effect === 'deny'
+      ? ctx.scopes.some((s) => policyScopes.has(s))
+      : ctx.scopes.every((s) => policyScopes.has(s));
+    if (!matches) return false;
   }
 
   // Time-of-day condition

--- a/apps/auth-service/src/routes/delegate.ts
+++ b/apps/auth-service/src/routes/delegate.ts
@@ -5,6 +5,7 @@ import { signGrantToken, parseExpiresIn } from '../lib/crypto.js';
 import { emitEvent } from '../lib/events.js';
 import { issueAgentGrantVC } from '../lib/vc.js';
 import { checkActiveGrantToken } from '../lib/active-grant-token.js';
+import { config } from '../config.js';
 
 interface DelegateBody {
   parentGrantToken: string;
@@ -75,6 +76,17 @@ export async function delegateRoutes(app: FastifyInstance): Promise<void> {
     const parentScp = parentClaims.scp;
     const parentExp = parentClaims.exp;
     const parentDepth = parentClaims.delegationDepth ?? 0;
+
+    // SPEC §9: the delegation chain has to terminate. Without this the depth was
+    // computed and signed but never compared against anything, so an agent could
+    // keep delegating to fresh sub-agents indefinitely.
+    if (parentDepth + 1 > config.maxDelegationDepth) {
+      return reply.status(403).send({
+        message: `Delegation depth limit reached: chains may not exceed ${config.maxDelegationDepth} hop(s)`,
+        code: 'DELEGATION_DEPTH_EXCEEDED',
+        requestId: request.id,
+      });
+    }
 
     // Validate scopes ⊆ parent scopes
     const invalidScopes = scopes.filter((s) => !parentScp.includes(s));

--- a/apps/auth-service/tests/delegate.test.ts
+++ b/apps/auth-service/tests/delegate.test.ts
@@ -437,3 +437,85 @@ describe('POST /v1/grants/delegate', () => {
     expect(body.verifiableCredential).toBeUndefined();
   });
 });
+
+// SPEC §9 requires a developer-configurable delegation depth limit (default 3,
+// hard cap 10). Depth was previously computed and signed but never compared
+// against anything, so chains could grow without bound.
+describe('POST /v1/grants/delegate — delegation depth limit', () => {
+  async function tokenAtDepth(depth: number): Promise<string> {
+    return signGrantToken({
+      sub: 'user_123',
+      agt: TEST_AGENT.did,
+      dev: TEST_DEVELOPER.id,
+      scp: ['read', 'write'],
+      jti: `tok_DEPTH${depth}`,
+      grnt: `grnt_DEPTH${depth}`,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      delegationDepth: depth,
+    });
+  }
+
+  function seedSuccessfulDelegation(): void {
+    seedAuth();
+    mockRedis.get.mockResolvedValue(null);
+    sqlMock.mockResolvedValueOnce([ACTIVE_PARENT_ROW]);       // parent token check
+    sqlMock.mockResolvedValueOnce([SUB_AGENT]);               // sub-agent lookup
+    sqlMock.mockResolvedValueOnce([]);                        // advisory lock
+    sqlMock.mockResolvedValueOnce([{ id: 'grnt_DEPTH' }]);    // parent re-check
+    sqlMock.mockResolvedValueOnce([]);                        // INSERT grants
+    sqlMock.mockResolvedValueOnce([]);                        // INSERT grant_tokens
+    sqlMock.mockResolvedValueOnce([]);                        // INSERT refresh_tokens
+  }
+
+  async function delegateFrom(token: string) {
+    return app.inject({
+      method: 'POST',
+      url: '/v1/grants/delegate',
+      headers: authHeader(),
+      payload: { parentGrantToken: token, subAgentId: SUB_AGENT.id, scopes: ['read'] },
+    });
+  }
+
+  it('allows delegation up to the configured depth', async () => {
+    // Default limit is 3, so a depth-2 parent may still produce a depth-3 child.
+    seedSuccessfulDelegation();
+    const res = await delegateFrom(await tokenAtDepth(2));
+
+    expect(res.statusCode).toBe(201);
+    const claims = decodeJwt(res.json<{ grantToken: string }>().grantToken);
+    expect(claims['delegationDepth']).toBe(3);
+  });
+
+  it('refuses to delegate past the configured depth', async () => {
+    seedAuth();
+    mockRedis.get.mockResolvedValue(null);
+    sqlMock.mockResolvedValueOnce([ACTIVE_PARENT_ROW]);
+
+    const res = await delegateFrom(await tokenAtDepth(3));
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json().code).toBe('DELEGATION_DEPTH_EXCEEDED');
+  });
+
+  it('refuses a parent already beyond the limit', async () => {
+    seedAuth();
+    mockRedis.get.mockResolvedValue(null);
+    sqlMock.mockResolvedValueOnce([ACTIVE_PARENT_ROW]);
+
+    const res = await delegateFrom(await tokenAtDepth(9));
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json().code).toBe('DELEGATION_DEPTH_EXCEEDED');
+  });
+
+  it('rejects before creating any grant rows', async () => {
+    seedAuth();
+    mockRedis.get.mockResolvedValue(null);
+    sqlMock.mockResolvedValueOnce([ACTIVE_PARENT_ROW]);
+    sqlMock.begin.mockClear();
+
+    await delegateFrom(await tokenAtDepth(5));
+
+    expect(sqlMock.begin).not.toHaveBeenCalled();
+  });
+});

--- a/apps/auth-service/tests/policy-backend.test.ts
+++ b/apps/auth-service/tests/policy-backend.test.ts
@@ -263,3 +263,66 @@ describe('PolicyDecision interface', () => {
     expect(decision.policyId).toBe('pol_1');
   });
 });
+
+// The decision must name the policy that actually matched. Re-deriving the id
+// by taking the first row attributed every decision to the highest-priority
+// policy, which made "why was this denied?" unanswerable from the audit trail.
+describe('BuiltinBackend — policy attribution', () => {
+  const AGENT_SPECIFIC = {
+    id: 'pol_specific', effect: 'deny' as const, priority: 100,
+    agent_id: 'ag_OTHER', principal_id: null, scopes: null,
+    time_of_day_start: null, time_of_day_end: null,
+  };
+  const CATCH_ALL = {
+    id: 'pol_catchall', effect: 'allow' as const, priority: 10,
+    agent_id: null, principal_id: null, scopes: null,
+    time_of_day_start: null, time_of_day_end: null,
+  };
+
+  it('reports the matched policy, not the highest-priority one', async () => {
+    const { BuiltinBackend } = await import('../src/lib/backends/builtin.js');
+    // Highest-priority policy is scoped to a different agent, so it cannot
+    // match; the lower-priority catch-all is what decides.
+    sqlMock.mockResolvedValueOnce([AGENT_SPECIFIC, CATCH_ALL]);
+
+    const decision = await new BuiltinBackend().evaluate({
+      agentId: 'ag_1',
+      principalId: 'user_1',
+      scopes: ['read'],
+      developerId: 'dev_TEST',
+    });
+
+    expect(decision.effect).toBe('allow');
+    expect(decision.policyId).toBe('pol_catchall');
+  });
+
+  it('reports the high-priority policy when it is the one that matches', async () => {
+    const { BuiltinBackend } = await import('../src/lib/backends/builtin.js');
+    sqlMock.mockResolvedValueOnce([{ ...AGENT_SPECIFIC, agent_id: 'ag_1' }, CATCH_ALL]);
+
+    const decision = await new BuiltinBackend().evaluate({
+      agentId: 'ag_1',
+      principalId: 'user_1',
+      scopes: ['read'],
+      developerId: 'dev_TEST',
+    });
+
+    expect(decision.effect).toBe('deny');
+    expect(decision.policyId).toBe('pol_specific');
+  });
+
+  it('returns no policyId when nothing matches', async () => {
+    const { BuiltinBackend } = await import('../src/lib/backends/builtin.js');
+    sqlMock.mockResolvedValueOnce([AGENT_SPECIFIC]);
+
+    const decision = await new BuiltinBackend().evaluate({
+      agentId: 'ag_1',
+      principalId: 'user_1',
+      scopes: ['read'],
+      developerId: 'dev_TEST',
+    });
+
+    expect(decision.effect).toBeNull();
+    expect(decision.policyId).toBeUndefined();
+  });
+});

--- a/apps/auth-service/tests/policy.test.ts
+++ b/apps/auth-service/tests/policy.test.ts
@@ -54,19 +54,57 @@ describe('evaluatePolicies', () => {
     expect(evaluatePolicies([policy], CTX)).toBeNull();
   });
 
-  it('skips when requested scopes are not a subset of policy scopes', () => {
+  // An allow policy may only match when it covers everything being requested;
+  // otherwise it would grant scopes it never listed.
+  it('skips an allow policy when requested scopes are not a subset of its scopes', () => {
     // Policy only covers 'read'; request includes 'write' too → no match
-    const policy: PolicyRow = { ...BASE, scopes: ['read'] };
+    const policy: PolicyRow = { ...BASE, effect: 'allow', scopes: ['read'] };
     expect(evaluatePolicies([policy], CTX)).toBeNull();
   });
 
-  it('matches when requested scopes are a subset of policy scopes', () => {
-    const policy: PolicyRow = { ...BASE, scopes: ['read', 'write', 'admin'] };
+  it('matches an allow policy when requested scopes are a subset of its scopes', () => {
+    const policy: PolicyRow = { ...BASE, effect: 'allow', scopes: ['read', 'write', 'admin'] };
+    expect(evaluatePolicies([policy], CTX)).toBe('allow');
+  });
+
+  it('matches an allow policy when requested scopes exactly equal its scopes', () => {
+    const policy: PolicyRow = { ...BASE, effect: 'allow', scopes: ['read', 'write'] };
+    expect(evaluatePolicies([policy], CTX)).toBe('allow');
+  });
+
+  // A deny policy matches on overlap. Requiring containment let a caller slip
+  // past a deny rule by requesting an unrelated scope alongside the blocked one.
+  it('matches a deny policy when only one requested scope is denied', () => {
+    const policy: PolicyRow = { ...BASE, effect: 'deny', scopes: ['read'] };
     expect(evaluatePolicies([policy], CTX)).toBe('deny');
   });
 
-  it('matches when requested scopes exactly equal policy scopes', () => {
-    const policy: PolicyRow = { ...BASE, scopes: ['read', 'write'] };
+  it('does not let an extra unrelated scope bypass a deny policy', () => {
+    const policy: PolicyRow = { ...BASE, effect: 'deny', scopes: ['payments:transfer'] };
+
+    expect(
+      evaluatePolicies([policy], { ...CTX, scopes: ['payments:transfer'] }),
+    ).toBe('deny');
+    expect(
+      evaluatePolicies([policy], { ...CTX, scopes: ['calendar:read', 'payments:transfer'] }),
+    ).toBe('deny');
+    expect(
+      evaluatePolicies([policy], {
+        ...CTX,
+        scopes: ['calendar:read', 'files:read', 'payments:transfer', 'profile:read'],
+      }),
+    ).toBe('deny');
+  });
+
+  it('skips a deny policy when no requested scope is denied', () => {
+    const policy: PolicyRow = { ...BASE, effect: 'deny', scopes: ['payments:transfer'] };
+    expect(
+      evaluatePolicies([policy], { ...CTX, scopes: ['calendar:read', 'files:read'] }),
+    ).toBeNull();
+  });
+
+  it('matches a deny policy when requested scopes exactly equal its scopes', () => {
+    const policy: PolicyRow = { ...BASE, effect: 'deny', scopes: ['read', 'write'] };
     expect(evaluatePolicies([policy], CTX)).toBe('deny');
   });
 


### PR DESCRIPTION
## 1. Deny policies were bypassable by adding an unrelated scope

`matchesPolicy` required the policy's scope list to be a **superset** of the requested scopes. That is correct for `allow` — a policy must cover everything it grants — but inverted for `deny`. Verified against the real code:

```
deny policy scopes: ['payments:transfer']

request ['payments:transfer']                    -> 'deny'   ✓
request ['calendar:read','payments:transfer']    -> null     ✗  no policy matched
```

Any agent defeated a deny rule by requesting one extra harmless scope alongside the blocked one. `deny` now matches on **intersection**; `allow` keeps containment.

The existing `policy.test.ts` scope cases asserted the old behaviour — the shared `BASE` fixture is `effect: 'deny'`, so "skips when requested scopes are not a subset" was pinning the bug. The scope cases are now split per effect.

## 2. Delegation depth was unbounded

`delegationDepth = parentDepth + 1` was computed, signed and stored, then never compared against anything — no depth constant existed anywhere in `src`. Chains grew without limit.

`SPEC.md` §9 is explicit:

> Implementations **MUST** enforce a developer-configurable delegation depth limit. The default RECOMMENDED limit is **3**. Implementations **MUST** enforce a hard cap of **10**.

Adds `MAX_DELEGATION_DEPTH` (default `3`), enforced before any grant rows are written, returning `403 DELEGATION_DEPTH_EXCEEDED`. The hard cap comes from the config parser's `max` argument, so an oversized value fails at **boot** rather than being silently honoured.

## 3. Every policy decision named the wrong policy

```js
const matchingPolicy = policyRows.find(() => true); // first match (simplified)
```

Rows arrive ordered `priority DESC`, so this attributed every decision to the highest-priority policy regardless of which one matched — if a high-priority rule was scoped to a different agent and a low-priority catch-all actually decided, the audit trail named the wrong rule. That makes "why was this denied?" unanswerable.

`policy.ts` now exposes `findMatchingPolicy`; the backend reports that policy's id. `evaluatePolicies` is a thin wrapper over it, so its public behaviour is unchanged.

## Test plan

`apps/auth-service`: **2008 passed** (was 1997 — 11 new). `tsc --noEmit` clean.

New coverage: deny-on-overlap including the multi-scope bypass vector; allow-containment preserved; delegation permitted at the limit and refused past it, with a check that rejection happens before `sql.begin` is ever called; policy attribution when the matching rule is *not* the highest-priority one.

## Behavioural change to be aware of

**Deny policies will now match more requests than they did before.** That is the fix, but if any integration has unknowingly come to depend on the current leaky behaviour, traffic that flows today will start being denied. Worth a look at existing deny policies with a non-null `scopes` list before rolling out.

`MAX_DELEGATION_DEPTH` defaults to 3. Any existing chain deeper than 3 keeps working — enforcement is on new delegations only — but further delegation from depth ≥ 3 will be refused. Raise the env var (max 10) if you have deeper chains in use.
