### PR TITLE
fix(commerce): validate pagination cursors; pin ID token algorithms

### DIFF
--- a/apps/auth-service/src/lib/sso.ts
+++ b/apps/auth-service/src/lib/sso.ts
@@ -135,6 +135,18 @@ const jwksCache = new Map<string, { keySet: jose.JSONWebKeySet; fetchedAt: numbe
 const JWKS_TTL_MS = 3600_000;
 
 /**
+ * Signature algorithms accepted on an IdP ID token. Every asymmetric family an
+ * OIDC provider realistically uses is here; HMAC variants and `none` are not,
+ * because a JWKS only ever carries public keys.
+ */
+const ID_TOKEN_ALGORITHMS = [
+  'RS256', 'RS384', 'RS512',
+  'PS256', 'PS384', 'PS512',
+  'ES256', 'ES384', 'ES512',
+  'EdDSA',
+];
+
+/**
  * Verify an OIDC ID token's signature using the IdP's JWKS, and return the
  * payload claims. Rejects if the token is expired, malformed, or the
  * signature doesn't match.
@@ -168,6 +180,13 @@ export async function verifyIdToken(
   const { payload } = await jose.jwtVerify(idToken, JWKS, {
     issuer: discovery.issuer,
     audience: clientId,
+    // Restrict to asymmetric signatures. Without an allowlist the accepted
+    // algorithm is whatever the token header asks for, which is the input an
+    // algorithm-confusion attack controls. jose will not hand an RSA public key
+    // to HMAC today, so this is defence in depth rather than a live hole — but
+    // it makes the guarantee explicit and matches the RS256 pin the SDK's
+    // verifyGrantToken already applies.
+    algorithms: ID_TOKEN_ALGORITHMS,
   });
 
   return payload as unknown as IdTokenClaims;

--- a/apps/auth-service/src/routes/commerce.ts
+++ b/apps/auth-service/src/routes/commerce.ts
@@ -358,6 +358,42 @@ function asInt(v: unknown): number | null {
   return null;
 }
 
+export interface ListCursor {
+  timestamp: string;
+  id: string;
+}
+
+/**
+ * Decode an opaque keyset cursor of the form base64url("<iso-timestamp>|<id>").
+ * Returns null when the value is anything other than that.
+ *
+ * The timestamp half is interpolated into a `::timestamptz` cast, so it has to
+ * be validated here. `Buffer.from(value, 'base64url')` never throws — it drops
+ * characters it cannot decode and returns whatever is left — so a try/catch
+ * around the decode catches nothing, and a cursor decoding to "notadate|xyz"
+ * reached Postgres as `'notadate'::timestamptz` and came back as a 500.
+ */
+function parseListCursor(raw: string): ListCursor | null {
+  if (raw.length === 0 || raw.length > 512) return null;
+
+  const decoded = Buffer.from(raw, 'base64url').toString('utf8');
+  const separator = decoded.indexOf('|');
+  if (separator <= 0) return null;
+
+  const timestamp = decoded.slice(0, separator);
+  const id = decoded.slice(separator + 1);
+  if (id.length === 0 || id.length > 128) return null;
+
+  // Must round-trip as a real instant; Date.parse accepts far too much on its
+  // own (e.g. "2026" or "Mar 5"), so require the ISO form we emit.
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?(Z|[+-]\d{2}:\d{2})$/.test(timestamp)) {
+    return null;
+  }
+  if (Number.isNaN(Date.parse(timestamp))) return null;
+
+  return { timestamp, id };
+}
+
 function validatePatchKeys(
   body: Record<string, unknown>,
   allowed: Set<string>,
@@ -3125,8 +3161,14 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
     if (status !== null && !AGENT_STATUSES.has(status)) {
       fieldErrors['status'] = 'must be one of: active, disabled';
     }
+    let cursor: ListCursor | null = null;
     if (request.query.cursor !== undefined && typeof request.query.cursor !== 'string') {
       fieldErrors['cursor'] = 'must be a string';
+    } else if (request.query.cursor) {
+      cursor = parseListCursor(request.query.cursor);
+      if (cursor === null) {
+        fieldErrors['cursor'] = 'must be an opaque cursor returned by a previous page';
+      }
     }
 
     let merchantId = request.query.merchant_id ?? null;
@@ -3146,15 +3188,8 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
         { details: { fields: fieldErrors }, retryable: false });
     }
 
-    let cursorCreated: string | null = null;
-    let cursorId: string | null = null;
-    if (request.query.cursor) {
-      try {
-        const decoded = Buffer.from(request.query.cursor, 'base64url').toString('utf8');
-        const [created, id] = decoded.split('|');
-        if (created && id) { cursorCreated = created; cursorId = id; }
-      } catch { /* ignore malformed cursor */ }
-    }
+    const cursorCreated: string | null = cursor?.timestamp ?? null;
+    const cursorId: string | null = cursor?.id ?? null;
 
     const sql = getSql();
     const tenantId = request.commerceTenantId;
@@ -4138,15 +4173,18 @@ export async function commerceRoutes(app: FastifyInstance): Promise<void> {
     const sql = getSql();
     const tenantId = request.commerceTenantId;
     const limit = Math.min(Math.max(asInt(request.query.limit) ?? 25, 1), 100);
-    let cursorOccurred: string | null = null;
-    let cursorId: string | null = null;
+    let cursor: ListCursor | null = null;
     if (request.query.cursor) {
-      try {
-        const decoded = Buffer.from(request.query.cursor, 'base64url').toString('utf8');
-        const [occ, id] = decoded.split('|');
-        if (occ && id) { cursorOccurred = occ; cursorId = id; }
-      } catch { /* ignore malformed cursor */ }
+      cursor = parseListCursor(request.query.cursor);
+      if (cursor === null) {
+        throw new CommerceHttpError(422, 'validation_failed', 'Request validation failed', {
+          details: { fields: { cursor: 'must be an opaque cursor returned by a previous page' } },
+          retryable: false,
+        });
+      }
     }
+    const cursorOccurred: string | null = cursor?.timestamp ?? null;
+    const cursorId: string | null = cursor?.id ?? null;
     const merchantId = isString(request.query.merchant_id) ? request.query.merchant_id : null;
     const agentId = isString(request.query.agent_id) ? request.query.agent_id : null;
     const eventType = isString(request.query.event_type) ? request.query.event_type : null;

--- a/apps/auth-service/tests/commerce-audit.test.ts
+++ b/apps/auth-service/tests/commerce-audit.test.ts
@@ -71,3 +71,63 @@ describe('Commerce audit append-only DDL (verified by reading the migration file
     expect(sql).toMatch(/GRANT INSERT, SELECT ON commerce_audit_events/);
   });
 });
+
+// The cursor's timestamp half is interpolated into a `::timestamptz` cast.
+// Buffer.from(x, 'base64url') never throws — it drops undecodable characters
+// and returns the remainder — so the try/catch that used to wrap the decode
+// caught nothing, and a cursor decoding to "notadate|xyz" reached Postgres as
+// `'notadate'::timestamptz` and surfaced as an unhandled 500.
+describe('GET /v1/commerce/audit/events — cursor validation', () => {
+  function cursorFor(value: string): string {
+    return Buffer.from(value, 'utf8').toString('base64url');
+  }
+
+  async function get(cursor: string) {
+    return app.inject({
+      method: 'GET',
+      url: `/v1/commerce/audit/events?cursor=${encodeURIComponent(cursor)}`,
+      headers: authHeader(),
+    });
+  }
+
+  it.each([
+    ['non-date timestamp half', cursorFor('notadate|caud_1')],
+    ['empty timestamp half', cursorFor('|caud_1')],
+    ['missing separator', cursorFor('2026-01-01T00:00:00.000Z')],
+    ['empty id half', cursorFor('2026-01-01T00:00:00.000Z|')],
+    ['loose date accepted by Date.parse', cursorFor('2026|caud_1')],
+    ['sql fragment in the timestamp half', cursorFor("now()')--|caud_1")],
+    ['undecodable base64url', '!!!not-base64!!!'],
+  ])('rejects %s with 422 rather than a 500', async (_label, cursor) => {
+    seedCommerceContext();
+
+    const res = await get(cursor);
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json().error.code).toBe('validation_failed');
+  });
+
+  it('accepts a cursor it previously emitted', async () => {
+    seedCommerceContext();
+    const occurredAt = new Date('2026-01-01T00:00:00.000Z');
+    sqlMock.mockResolvedValueOnce([
+      { id: 'caud_a', occurred_at: occurredAt, metadata: {} },
+      { id: 'caud_b', occurred_at: occurredAt, metadata: {} },
+      { id: 'caud_c', occurred_at: occurredAt, metadata: {} },
+    ]);
+
+    const first = await app.inject({
+      method: 'GET',
+      url: '/v1/commerce/audit/events?limit=2',
+      headers: authHeader(),
+    });
+    const emitted = first.json<{ next_cursor: string }>().next_cursor;
+    expect(emitted).toBeTruthy();
+
+    seedCommerceContext();
+    sqlMock.mockResolvedValueOnce([]);
+    const second = await get(emitted);
+
+    expect(second.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## 1. Malformed pagination cursor returned a 500

A list cursor is `base64url("<iso-timestamp>|<id>")` supplied by the client, and its timestamp half was interpolated into a `::timestamptz` cast without ever being validated:

```js
try {
  const decoded = Buffer.from(request.query.cursor, 'base64url').toString('utf8');
  const [created, id] = decoded.split('|');
  if (created && id) { cursorCreated = created; cursorId = id; }
} catch { /* ignore malformed cursor */ }
```

`Buffer.from(value, 'base64url')` **does not throw** on undecodable input — it drops the characters it cannot decode and returns the remainder — so that `catch` was unreachable. Verified:

```
$ node -e "console.log(JSON.stringify(Buffer.from('!!!not-base64!!!','base64url').toString('utf8')))"
"\ufffd\ufffd~m\ufffd\u001e\ufffd"
```

Two reachable failure modes:

| cursor decodes to | before | after |
|---|---|---|
| `notadate\|xyz` | `'notadate'::timestamptz` → Postgres `22007` → **500** | 422 `validation_failed` |
| no `\|` separator | silently ignored, page 1 returned again | 422 `validation_failed` |

The values were already parameterised, so this is error handling, not injection. Both endpoints (`/agents`, `/audit/events`) now share `parseListCursor`, which requires the ISO-8601 shape the encoders actually emit (`Date.toISOString()`) and rejects everything else. `Date.parse` alone is far too permissive — it accepts `"2026"` and `"Mar 5"` — so the check is a shape regex plus `Date.parse`.

## 2. ID token algorithms are now pinned

`jose.jwtVerify` for IdP ID tokens passed `issuer` and `audience` but no `algorithms` allowlist, so the accepted algorithm was whatever the token header asked for — the exact input an algorithm-confusion attack controls.

Not currently exploitable: the keys come from `createLocalJWKSet`, jose refuses `alg: none`, and it will not hand an RSA public key to HMAC. This makes the guarantee explicit and matches the RS256 pin `verifyGrantToken` already applies in the SDK. The allowlist covers every asymmetric family a real OIDC provider uses (RS/PS/ES + EdDSA) and excludes HMAC — a JWKS only ever carries public keys.

## Test plan

`apps/auth-service`: **2016 passed** (was 2008 — 8 new). `tsc --noEmit` clean.

The 7 rejection cases were run against pre-fix `commerce.ts` and **all 7 fail** there; they pass after. Includes a round-trip case asserting a cursor the API itself emitted is still accepted, so the validation cannot be tightened past what the encoders produce.

## Note on scope

This came out of a review of the SSO surface and the commerce pagination paths. The SSO review found **no exploitable defect** — details in the thread. The algorithm pin above is the one hardening item worth carrying, and it is deliberately non-breaking.
