### PR TITLE
feat(sso): bind OIDC logins with a nonce and PKCE

### DIFF
--- a/apps/auth-service/src/lib/sso.ts
+++ b/apps/auth-service/src/lib/sso.ts
@@ -26,6 +26,8 @@ export interface OidcDiscoveryDocument {
   token_endpoint: string;
   jwks_uri: string;
   userinfo_endpoint?: string;
+  /** RFC 8414. Absent on providers that predate PKCE metadata. */
+  code_challenge_methods_supported?: string[];
 }
 
 export interface SsoConnectionRow {
@@ -195,6 +197,78 @@ export async function verifyIdToken(
 /** Clear JWKS cache (useful in tests). */
 export function clearJwksCache(): void {
   jwksCache.clear();
+}
+
+// ── OIDC authorization-request state (nonce + PKCE) ───────────────────────
+
+/** Matches the signed state's own lifetime, so neither half outlives the other. */
+const OIDC_AUTH_REQUEST_TTL_MS = 10 * 60_000;
+
+export interface OidcAuthRequest {
+  /** PKCE verifier. Absent when the IdP does not advertise S256 support. */
+  codeVerifier?: string;
+  /** Value sent as the `nonce` authorization parameter. */
+  nonce: string;
+}
+
+function oidcAuthRequestKey(requestId: string): string {
+  return `sso:oidc:req:${requestId}`;
+}
+
+export function isSafeOidcRequestId(value: string): boolean {
+  return /^[A-Za-z0-9_-]{16,128}$/.test(value);
+}
+
+/**
+ * Persist the per-login secrets behind an opaque id.
+ *
+ * The PKCE verifier deliberately does not travel in the signed state: state is
+ * integrity-protected but not encrypted, it is base64url JSON that anyone
+ * holding the redirect can read, and a verifier the front channel can read
+ * provides no binding at all. Only the lookup id goes in the state.
+ */
+export async function saveOidcAuthRequest(
+  requestId: string,
+  data: OidcAuthRequest,
+): Promise<void> {
+  if (!isSafeOidcRequestId(requestId)) {
+    throw new Error('Refusing to store an invalid OIDC request id');
+  }
+  const stored = await getRedis().set(
+    oidcAuthRequestKey(requestId),
+    JSON.stringify(data),
+    'PX',
+    OIDC_AUTH_REQUEST_TTL_MS,
+    'NX',
+  );
+  if (stored !== 'OK') throw new Error('Unable to persist OIDC authorization request state');
+}
+
+/**
+ * Fetch and delete the stored request in one round trip. Consume-on-read also
+ * makes the surrounding state single-use: replaying a state whose entry is
+ * already gone fails instead of re-running the exchange.
+ */
+export async function consumeOidcAuthRequest(
+  requestId: string,
+): Promise<OidcAuthRequest | null> {
+  if (!isSafeOidcRequestId(requestId)) return null;
+  const raw = await getRedis().getdel(oidcAuthRequestKey(requestId));
+  if (raw === null || raw === undefined) return null;
+  try {
+    const parsed = JSON.parse(String(raw)) as OidcAuthRequest;
+    if (typeof parsed?.nonce !== 'string' || parsed.nonce.length === 0) return null;
+    if (parsed.codeVerifier !== undefined && typeof parsed.codeVerifier !== 'string') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** True when the provider advertises RFC 7636 S256 support. */
+export function supportsPkceS256(discovery: OidcDiscoveryDocument | null): boolean {
+  return Array.isArray(discovery?.code_challenge_methods_supported)
+    && discovery.code_challenge_methods_supported.includes('S256');
 }
 
 // ── SAML 2.0 Response parsing ─────────────────────────────────────────────

--- a/apps/auth-service/src/routes/sso.ts
+++ b/apps/auth-service/src/routes/sso.ts
@@ -798,20 +798,22 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
       // Consume the nonce/PKCE material bound to this login at /sso/login.
       // Consume-on-read also makes the state single-use.
       //
-      // A state without an oidcRequestId predates this binding. Those are still
-      // HMAC-signed by us and expire within ten minutes, so honouring them is
-      // not a downgrade an attacker can force — it only avoids failing logins
-      // that were already in flight across a deploy.
-      let authRequest: OidcAuthRequest | null = null;
-      if (stateData.oidcRequestId !== undefined) {
-        authRequest = await consumeOidcAuthRequest(stateData.oidcRequestId);
-        if (!authRequest) {
-          return reply.status(400).send({
-            message: 'SSO login request has expired or already been used',
-            code: 'BAD_REQUEST',
-            requestId: request.id,
-          });
-        }
+      // The binding is mandatory. Treating a state that carries no request id
+      // as "skip the nonce and PKCE checks" would make a request field decide
+      // whether a security control runs, and that shape long outlives the
+      // migration it was meant to smooth. States issued before this change
+      // expire within ten minutes, so the only cost of requiring it is that a
+      // login started in that window has to be retried.
+      const authRequest: OidcAuthRequest | null =
+        typeof stateData.oidcRequestId === 'string'
+          ? await consumeOidcAuthRequest(stateData.oidcRequestId)
+          : null;
+      if (!authRequest) {
+        return reply.status(400).send({
+          message: 'SSO login request has expired or already been used; start the login again',
+          code: 'BAD_REQUEST',
+          requestId: request.id,
+        });
       }
       // OIDC callback handlers commonly forward only `code` and `state` from
       // the IdP, so the body's redirect_uri may be absent. The signed state
@@ -893,7 +895,7 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
       // OIDC Core 3.1.3.7: when the request carried a nonce the ID token MUST
       // echo it. Comparing it here is what stops a token minted for a different
       // login being replayed into this one.
-      if (authRequest && !nonceMatches(claims['nonce'], authRequest.nonce)) {
+      if (!nonceMatches(claims['nonce'], authRequest.nonce)) {
         return reply.status(502).send({
           message: 'ID token nonce mismatch',
           code: 'SSO_ERROR',
@@ -1251,19 +1253,19 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
       org = statePayload['org'] as string;
 
       // This route shares /sso/login's state, so it carries the same nonce and
-      // PKCE binding and must honour it — otherwise it would stand as a
-      // downgrade path around the checks the primary callback performs.
+      // PKCE binding and enforces it identically — anything weaker here would
+      // stand as a downgrade path around the primary callback's checks.
       const legacyRequestId = statePayload['oidcRequestId'];
-      let authRequest: OidcAuthRequest | null = null;
-      if (typeof legacyRequestId === 'string') {
-        authRequest = await consumeOidcAuthRequest(legacyRequestId);
-        if (!authRequest) {
-          return reply.status(400).send({
-            message: 'SSO login request has expired or already been used',
-            code: 'BAD_REQUEST',
-            requestId: request.id,
-          });
-        }
+      const authRequest: OidcAuthRequest | null =
+        typeof legacyRequestId === 'string'
+          ? await consumeOidcAuthRequest(legacyRequestId)
+          : null;
+      if (!authRequest) {
+        return reply.status(400).send({
+          message: 'SSO login request has expired or already been used; start the login again',
+          code: 'BAD_REQUEST',
+          requestId: request.id,
+        });
       }
 
       const sql = getSql();
@@ -1316,7 +1318,7 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
         return reply.status(502).send({ message: 'ID token verification failed', code: 'SSO_ERROR' });
       }
 
-      if (authRequest && !nonceMatches(claims['nonce'], authRequest.nonce)) {
+      if (!nonceMatches(claims['nonce'], authRequest.nonce)) {
         return reply.status(502).send({
           message: 'ID token nonce mismatch',
           code: 'SSO_ERROR',

--- a/apps/auth-service/src/routes/sso.ts
+++ b/apps/auth-service/src/routes/sso.ts
@@ -12,6 +12,11 @@ import {
   mapGroupsToScopes,
   jitProvision,
   createSsoSession,
+  saveOidcAuthRequest,
+  consumeOidcAuthRequest,
+  supportsPkceS256,
+  type OidcAuthRequest,
+  type OidcDiscoveryDocument,
   type SamlConnectionOptions,
   type SsoConnectionRow,
 } from '../lib/sso.js';
@@ -69,6 +74,14 @@ export function verifySsoState(state: string): Record<string, unknown> | null {
   } catch {
     return null;
   }
+}
+
+/** Constant-time comparison of an ID token's `nonce` claim against the expected value. */
+function nonceMatches(claim: unknown, expected: string): boolean {
+  if (typeof claim !== 'string' || claim.length === 0) return false;
+  const claimBuf = Buffer.from(claim);
+  const expectedBuf = Buffer.from(expected);
+  return claimBuf.length === expectedBuf.length && crypto.timingSafeEqual(claimBuf, expectedBuf);
 }
 
 function connectionToResponse(row: SsoConnectionRow) {
@@ -662,17 +675,12 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
         }
       }
 
-      const state = signSsoState({
-        org,
-        connectionId: conn.id,
-        ...(requestedRedirectUri ? { redirectUri: requestedRedirectUri } : {}),
-      });
-
       if (conn.protocol === 'oidc') {
         // Use OIDC Discovery to get the authorization endpoint
+        let discovery: OidcDiscoveryDocument | null = null;
         let authorizeEndpoint: string;
         try {
-          const discovery = await discoverOidcProvider(conn.issuer_url!);
+          discovery = await discoverOidcProvider(conn.issuer_url!);
           authorizeEndpoint = discovery.authorization_endpoint;
         } catch {
           // Fallback to /authorize
@@ -683,15 +691,63 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
           return reply.status(400).send({ message: endpointError, code: 'BAD_REQUEST', requestId: request.id });
         }
 
+        // Bind this authorization request to the eventual callback. The nonce
+        // ties the returned ID token to this request; PKCE ties the returned
+        // authorization code to it. Both secrets live in Redis behind an opaque
+        // id — putting the PKCE verifier in the state would hand it to the
+        // front channel and defeat the point.
+        const oidcRequestId = crypto.randomBytes(24).toString('base64url');
+        const nonce = crypto.randomBytes(24).toString('base64url');
+
+        // Only offer PKCE when the provider advertises S256. Sending a verifier
+        // to a token endpoint that never recorded a challenge makes some strict
+        // providers reject the exchange outright.
+        const usePkce = supportsPkceS256(discovery);
+        const codeVerifier = usePkce ? crypto.randomBytes(32).toString('base64url') : undefined;
+
+        try {
+          await saveOidcAuthRequest(oidcRequestId, {
+            nonce,
+            ...(codeVerifier !== undefined ? { codeVerifier } : {}),
+          });
+        } catch {
+          return reply.status(503).send({
+            message: 'Unable to start SSO login; please retry',
+            code: 'SSO_ERROR',
+            requestId: request.id,
+          });
+        }
+
+        const state = signSsoState({
+          org,
+          connectionId: conn.id,
+          oidcRequestId,
+          ...(requestedRedirectUri ? { redirectUri: requestedRedirectUri } : {}),
+        });
+
         const authorizeUrl = new URL(authorizeEndpoint);
         authorizeUrl.searchParams.set('client_id', conn.client_id!);
         authorizeUrl.searchParams.set('redirect_uri', requestedRedirectUri ?? '');
         authorizeUrl.searchParams.set('response_type', 'code');
         authorizeUrl.searchParams.set('scope', 'openid email profile');
         authorizeUrl.searchParams.set('state', state);
+        authorizeUrl.searchParams.set('nonce', nonce);
+        if (codeVerifier !== undefined) {
+          authorizeUrl.searchParams.set(
+            'code_challenge',
+            crypto.createHash('sha256').update(codeVerifier).digest('base64url'),
+          );
+          authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+        }
 
         return reply.send({ authorizeUrl: authorizeUrl.toString(), protocol: 'oidc', connectionId: conn.id });
       }
+
+      const state = signSsoState({
+        org,
+        connectionId: conn.id,
+        ...(requestedRedirectUri ? { redirectUri: requestedRedirectUri } : {}),
+      });
 
       if (conn.protocol === 'saml') {
         try {
@@ -735,7 +791,28 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
       if (!statePayload) {
         return reply.status(400).send({ message: 'Invalid state parameter', code: 'BAD_REQUEST', requestId: request.id });
       }
-      const stateData = statePayload as unknown as { org: string; connectionId: string; redirectUri?: string };
+      const stateData = statePayload as unknown as {
+        org: string; connectionId: string; redirectUri?: string; oidcRequestId?: string;
+      };
+
+      // Consume the nonce/PKCE material bound to this login at /sso/login.
+      // Consume-on-read also makes the state single-use.
+      //
+      // A state without an oidcRequestId predates this binding. Those are still
+      // HMAC-signed by us and expire within ten minutes, so honouring them is
+      // not a downgrade an attacker can force — it only avoids failing logins
+      // that were already in flight across a deploy.
+      let authRequest: OidcAuthRequest | null = null;
+      if (stateData.oidcRequestId !== undefined) {
+        authRequest = await consumeOidcAuthRequest(stateData.oidcRequestId);
+        if (!authRequest) {
+          return reply.status(400).send({
+            message: 'SSO login request has expired or already been used',
+            code: 'BAD_REQUEST',
+            requestId: request.id,
+          });
+        }
+      }
       // OIDC callback handlers commonly forward only `code` and `state` from
       // the IdP, so the body's redirect_uri may be absent. The signed state
       // already integrity-protects the value supplied at /sso/login, so fall
@@ -788,6 +865,9 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
           redirect_uri: effectiveRedirectUri ?? '',
           client_id: conn.client_id!,
           client_secret: decryptSsoSecret(conn.client_secret, 'sso_connections.client_secret')!,
+          ...(authRequest?.codeVerifier !== undefined
+            ? { code_verifier: authRequest.codeVerifier }
+            : {}),
         }).toString(),
       }, {
         allowedProtocols: ['https:', 'http:'],
@@ -808,6 +888,17 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
         claims = await verifyIdToken(idToken, conn.issuer_url!, conn.client_id!) as unknown as Record<string, unknown>;
       } catch {
         return reply.status(502).send({ message: 'ID token verification failed', code: 'SSO_ERROR' });
+      }
+
+      // OIDC Core 3.1.3.7: when the request carried a nonce the ID token MUST
+      // echo it. Comparing it here is what stops a token minted for a different
+      // login being replayed into this one.
+      if (authRequest && !nonceMatches(claims['nonce'], authRequest.nonce)) {
+        return reply.status(502).send({
+          message: 'ID token nonce mismatch',
+          code: 'SSO_ERROR',
+          requestId: request.id,
+        });
       }
 
       // Extract groups from the configured attribute
@@ -1159,6 +1250,22 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
       }
       org = statePayload['org'] as string;
 
+      // This route shares /sso/login's state, so it carries the same nonce and
+      // PKCE binding and must honour it — otherwise it would stand as a
+      // downgrade path around the checks the primary callback performs.
+      const legacyRequestId = statePayload['oidcRequestId'];
+      let authRequest: OidcAuthRequest | null = null;
+      if (typeof legacyRequestId === 'string') {
+        authRequest = await consumeOidcAuthRequest(legacyRequestId);
+        if (!authRequest) {
+          return reply.status(400).send({
+            message: 'SSO login request has expired or already been used',
+            code: 'BAD_REQUEST',
+            requestId: request.id,
+          });
+        }
+      }
+
       const sql = getSql();
       const rows = await sql<Array<Record<string, unknown>>>`
         SELECT issuer_url, client_id, client_secret, redirect_uri
@@ -1185,6 +1292,9 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
           redirect_uri: String(cfg['redirect_uri']),
           client_id: String(cfg['client_id']),
           client_secret: decryptSsoSecret(String(cfg['client_secret']), 'sso_configs.client_secret')!,
+          ...(authRequest?.codeVerifier !== undefined
+            ? { code_verifier: authRequest.codeVerifier }
+            : {}),
         }).toString(),
       }, {
         allowedProtocols: ['https:', 'http:'],
@@ -1204,6 +1314,14 @@ export async function ssoRoutes(app: FastifyInstance): Promise<void> {
         claims = await verifyIdToken(idToken, issuerUrl, String(cfg['client_id'])) as unknown as Record<string, unknown>;
       } catch {
         return reply.status(502).send({ message: 'ID token verification failed', code: 'SSO_ERROR' });
+      }
+
+      if (authRequest && !nonceMatches(claims['nonce'], authRequest.nonce)) {
+        return reply.status(502).send({
+          message: 'ID token nonce mismatch',
+          code: 'SSO_ERROR',
+          requestId: request.id,
+        });
       }
 
       return reply.send({

--- a/apps/auth-service/tests/sso-lib.test.ts
+++ b/apps/auth-service/tests/sso-lib.test.ts
@@ -4,6 +4,9 @@ import {
   mapGroupsToScopes,
   clearDiscoveryCache,
   clearJwksCache,
+  saveOidcAuthRequest,
+  consumeOidcAuthRequest,
+  supportsPkceS256,
 } from '../src/lib/sso.js';
 import {
   validateOutboundUrl,
@@ -324,5 +327,89 @@ describe('jitProvision', () => {
     const id = await jitProvision('dev_TEST', { sub: 'idp_user_new', email: 'new@corp.com' });
     expect(id).toMatch(/^scimuser_/);
     expect(sqlMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── OIDC authorization-request store (nonce + PKCE) ────────────────────────
+
+describe('OIDC authorization-request store', () => {
+  beforeEach(() => {
+    mockRedis.set.mockReset().mockResolvedValue('OK');
+    mockRedis.getdel.mockReset().mockResolvedValue(null);
+  });
+
+  it('persists with a TTL and refuses to clobber an existing id', async () => {
+    await saveOidcAuthRequest('a'.repeat(24), { nonce: 'n1', codeVerifier: 'v1' });
+
+    const [key, value, pxFlag, ttl, nxFlag] = mockRedis.set.mock.calls[0]!;
+    expect(key).toBe(`sso:oidc:req:${'a'.repeat(24)}`);
+    expect(JSON.parse(String(value))).toEqual({ nonce: 'n1', codeVerifier: 'v1' });
+    expect(pxFlag).toBe('PX');
+    expect(ttl).toBe(10 * 60_000);
+    // NX: a second login must never overwrite a pending one.
+    expect(nxFlag).toBe('NX');
+  });
+
+  it('throws when the entry could not be stored', async () => {
+    mockRedis.set.mockResolvedValueOnce(null);
+
+    await expect(saveOidcAuthRequest('b'.repeat(24), { nonce: 'n1' })).rejects.toThrow();
+  });
+
+  it('rejects an unsafe request id rather than building a key from it', async () => {
+    await expect(saveOidcAuthRequest('short', { nonce: 'n1' })).rejects.toThrow();
+    await expect(saveOidcAuthRequest('../../etc/passwd', { nonce: 'n1' })).rejects.toThrow();
+    expect(mockRedis.set).not.toHaveBeenCalled();
+  });
+
+  it('consumes the entry so a replayed callback finds nothing', async () => {
+    mockRedis.getdel.mockResolvedValueOnce(JSON.stringify({ nonce: 'n1', codeVerifier: 'v1' }));
+
+    const first = await consumeOidcAuthRequest('c'.repeat(24));
+    expect(first).toEqual({ nonce: 'n1', codeVerifier: 'v1' });
+    // GETDEL, not GET — the read is what removes it.
+    expect(mockRedis.getdel).toHaveBeenCalledWith(`sso:oidc:req:${'c'.repeat(24)}`);
+
+    const second = await consumeOidcAuthRequest('c'.repeat(24));
+    expect(second).toBeNull();
+  });
+
+  it('returns null for a missing, malformed, or nonce-less entry', async () => {
+    mockRedis.getdel.mockResolvedValueOnce(null);
+    expect(await consumeOidcAuthRequest('d'.repeat(24))).toBeNull();
+
+    mockRedis.getdel.mockResolvedValueOnce('not json');
+    expect(await consumeOidcAuthRequest('d'.repeat(24))).toBeNull();
+
+    mockRedis.getdel.mockResolvedValueOnce(JSON.stringify({ codeVerifier: 'v1' }));
+    expect(await consumeOidcAuthRequest('d'.repeat(24))).toBeNull();
+  });
+
+  it('does not query redis for an unsafe request id', async () => {
+    expect(await consumeOidcAuthRequest('../../etc/passwd')).toBeNull();
+    expect(mockRedis.getdel).not.toHaveBeenCalled();
+  });
+});
+
+describe('supportsPkceS256', () => {
+  const base = {
+    issuer: 'https://idp.example.com',
+    authorization_endpoint: 'https://idp.example.com/authorize',
+    token_endpoint: 'https://idp.example.com/token',
+    jwks_uri: 'https://idp.example.com/jwks',
+  };
+
+  it('is true only when S256 is advertised', () => {
+    expect(supportsPkceS256({ ...base, code_challenge_methods_supported: ['S256'] })).toBe(true);
+    expect(supportsPkceS256({ ...base, code_challenge_methods_supported: ['S256', 'plain'] })).toBe(true);
+  });
+
+  it('is false when the metadata is absent, empty, or plain-only', () => {
+    // Discovery failed entirely — must not assume support.
+    expect(supportsPkceS256(null)).toBe(false);
+    expect(supportsPkceS256(base)).toBe(false);
+    expect(supportsPkceS256({ ...base, code_challenge_methods_supported: [] })).toBe(false);
+    // `plain` offers no binding over a front channel; treat it as unsupported.
+    expect(supportsPkceS256({ ...base, code_challenge_methods_supported: ['plain'] })).toBe(false);
   });
 });

--- a/apps/auth-service/tests/sso.test.ts
+++ b/apps/auth-service/tests/sso.test.ts
@@ -72,6 +72,11 @@ const mockedSupportsPkceS256 = vi.mocked(supportsPkceS256);
 
 let app: FastifyInstance;
 
+// Every OIDC login is bound to a stored nonce/PKCE entry, so the callback
+// fixtures carry a request id and the IdP echoes the nonce back.
+const OIDC_REQUEST_ID = 'reqfixture00000000000000';
+const OIDC_NONCE = 'fixture-nonce';
+
 function encryptedSsoSecret(value: string): string {
   return `vault:v1:${encrypt(value)}`;
 }
@@ -89,7 +94,11 @@ afterEach(() => {
     email: 'alice@corp.com',
     name: 'Alice Smith',
     groups: ['Engineering'],
+    nonce: OIDC_NONCE,
   });
+  mockedSaveOidcAuthRequest.mockReset().mockResolvedValue(undefined);
+  mockedConsumeOidcAuthRequest.mockReset().mockResolvedValue({ nonce: OIDC_NONCE });
+  mockedSupportsPkceS256.mockReset().mockReturnValue(false);
   mockedParseSamlResponse.mockReset().mockResolvedValue({
     sub: 'saml_user_01',
     email: 'bob@corp.com',
@@ -616,7 +625,11 @@ describe('GET /sso/login (enterprise)', () => {
 describe('POST /sso/callback/oidc', () => {
   // State is created lazily because signSsoState depends on initKeys() which runs in beforeAll
   let state: string;
-  beforeAll(() => { state = signSsoState({ org: 'dev_TEST', connectionId: 'sso_CONN01' }); });
+  beforeAll(() => {
+    state = signSsoState({
+      org: 'dev_TEST', connectionId: 'sso_CONN01', oidcRequestId: OIDC_REQUEST_ID,
+    });
+  });
 
   it('rejects signed state after its ten-minute lifetime', () => {
     vi.useFakeTimers();
@@ -666,6 +679,7 @@ describe('POST /sso/callback/oidc', () => {
     const stateWithRedirect = signSsoState({
       org: 'dev_TEST',
       connectionId: 'sso_CONN01',
+      oidcRequestId: OIDC_REQUEST_ID,
       redirectUri: 'https://app.test/callback',
     });
     sqlMock.mockResolvedValueOnce([OIDC_CONNECTION_ROW]);
@@ -696,6 +710,7 @@ describe('POST /sso/callback/oidc', () => {
     const stateWithRedirect = signSsoState({
       org: 'dev_TEST',
       connectionId: 'sso_CONN01',
+      oidcRequestId: OIDC_REQUEST_ID,
       redirectUri: 'https://app.test/callback',
     });
 
@@ -946,7 +961,7 @@ describe('DELETE /v1/sso/config (legacy)', () => {
 
 describe('GET /sso/callback (legacy)', () => {
   it('exchanges code and returns user info', async () => {
-    const state = signSsoState({ org: 'dev_TEST' });
+    const state = signSsoState({ org: 'dev_TEST', oidcRequestId: OIDC_REQUEST_ID });
     sqlMock.mockResolvedValueOnce([SSO_CONFIG_ROW]);
 
     const idTokenPayload = Buffer.from(
@@ -974,7 +989,7 @@ describe('GET /sso/callback (legacy)', () => {
   });
 
   it('rejects legacy callback when ID token verification fails', async () => {
-    const state = signSsoState({ org: 'dev_TEST' });
+    const state = signSsoState({ org: 'dev_TEST', oidcRequestId: OIDC_REQUEST_ID });
     sqlMock.mockResolvedValueOnce([SSO_CONFIG_ROW]);
     mockedVerifyIdToken.mockRejectedValueOnce(new Error('bad signature'));
 
@@ -997,7 +1012,7 @@ describe('GET /sso/callback (legacy)', () => {
   });
 
   it('returns 502 when IdP token exchange fails', async () => {
-    const state = signSsoState({ org: 'dev_TEST' });
+    const state = signSsoState({ org: 'dev_TEST', oidcRequestId: OIDC_REQUEST_ID });
     sqlMock.mockResolvedValueOnce([SSO_CONFIG_ROW]);
 
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 400 }));
@@ -1309,6 +1324,35 @@ describe('OIDC nonce and PKCE binding', () => {
     });
 
     expect(res.statusCode).toBe(502);
+  });
+
+  // The binding must not be optional. If a state lacking a request id were
+  // treated as "skip the nonce and PKCE checks", a request field would decide
+  // whether a security control runs.
+  it('refuses a state that carries no request id at all', async () => {
+    const state = signSsoState({ org: 'dev_TEST', connectionId: 'sso_CONN01' });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/sso/callback/oidc',
+      headers: { 'content-type': 'application/json' },
+      payload: { code: 'auth_code_xyz', state },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedVerifyIdToken).not.toHaveBeenCalled();
+  });
+
+  it('refuses a legacy-callback state that carries no request id', async () => {
+    const state = signSsoState({ org: 'dev_TEST' });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/sso/callback?code=auth_code_xyz&state=${encodeURIComponent(state)}`,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedVerifyIdToken).not.toHaveBeenCalled();
   });
 
   it('refuses a state whose stored request was already consumed', async () => {

--- a/apps/auth-service/tests/sso.test.ts
+++ b/apps/auth-service/tests/sso.test.ts
@@ -43,20 +43,32 @@ vi.mock('../src/lib/sso.js', () => ({
   }),
   clearDiscoveryCache: vi.fn(),
   clearJwksCache: vi.fn(),
+  // OIDC nonce + PKCE binding. The default discovery mock above advertises no
+  // code_challenge_methods_supported, so PKCE stays off unless a test opts in.
+  saveOidcAuthRequest: vi.fn().mockResolvedValue(undefined),
+  consumeOidcAuthRequest: vi.fn().mockResolvedValue(null),
+  supportsPkceS256: vi.fn().mockReturnValue(false),
 }));
 
 import {
   resolveConnection,
   verifyIdToken,
   parseSamlResponse,
+  saveOidcAuthRequest,
+  consumeOidcAuthRequest,
+  supportsPkceS256,
 } from '../src/lib/sso.js';
 import { encrypt } from '../src/lib/vault-crypto.js';
+import { createHash } from 'node:crypto';
 import { setSafeFetchForTests } from '../src/lib/url-security.js';
 import { signSsoState, verifySsoState } from '../src/routes/sso.js';
 
 const mockedResolveConnection = vi.mocked(resolveConnection);
 const mockedVerifyIdToken = vi.mocked(verifyIdToken);
 const mockedParseSamlResponse = vi.mocked(parseSamlResponse);
+const mockedSaveOidcAuthRequest = vi.mocked(saveOidcAuthRequest);
+const mockedConsumeOidcAuthRequest = vi.mocked(consumeOidcAuthRequest);
+const mockedSupportsPkceS256 = vi.mocked(supportsPkceS256);
 
 let app: FastifyInstance;
 
@@ -1142,5 +1154,178 @@ describe('POST /sso/callback/ldap', () => {
 
     expect(res.statusCode).toBe(401);
     expect(res.json().message).toBe('Invalid LDAP credentials');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// OIDC nonce + PKCE binding
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('OIDC nonce and PKCE binding', () => {
+  function authorizeParams(url: string): URLSearchParams {
+    return new URL(url).searchParams;
+  }
+
+  it('sends a nonce on every OIDC authorize request', async () => {
+    mockedResolveConnection.mockResolvedValueOnce(OIDC_CONNECTION_ROW as never);
+
+    const res = await app.inject({ method: 'GET', url: '/sso/login?org=dev_TEST' });
+
+    expect(res.statusCode).toBe(200);
+    const params = authorizeParams(res.json().authorizeUrl);
+    expect(params.get('nonce')).toBeTruthy();
+    expect(params.get('nonce')!.length).toBeGreaterThanOrEqual(16);
+  });
+
+  it('stores the nonce server-side rather than in the state parameter', async () => {
+    mockedResolveConnection.mockResolvedValueOnce(OIDC_CONNECTION_ROW as never);
+    mockedSaveOidcAuthRequest.mockClear();
+
+    const res = await app.inject({ method: 'GET', url: '/sso/login?org=dev_TEST' });
+
+    const params = authorizeParams(res.json().authorizeUrl);
+    const nonce = params.get('nonce')!;
+    const state = params.get('state')!;
+
+    // State is signed but not encrypted, so anything inside it is readable by
+    // whoever holds the redirect.
+    const decodedState = JSON.parse(
+      Buffer.from(state.slice(0, state.indexOf('.')), 'base64url').toString('utf8'),
+    ) as Record<string, unknown>;
+    expect(decodedState['oidcRequestId']).toBeTruthy();
+    expect(JSON.stringify(decodedState)).not.toContain(nonce);
+
+    expect(mockedSaveOidcAuthRequest).toHaveBeenCalledTimes(1);
+    expect(mockedSaveOidcAuthRequest.mock.calls[0]![1]).toMatchObject({ nonce });
+  });
+
+  it('omits PKCE when the provider does not advertise S256', async () => {
+    mockedResolveConnection.mockResolvedValueOnce(OIDC_CONNECTION_ROW as never);
+    mockedSupportsPkceS256.mockReturnValueOnce(false);
+
+    const res = await app.inject({ method: 'GET', url: '/sso/login?org=dev_TEST' });
+
+    const params = authorizeParams(res.json().authorizeUrl);
+    expect(params.get('code_challenge')).toBeNull();
+    expect(params.get('code_challenge_method')).toBeNull();
+  });
+
+  it('sends an S256 challenge when the provider advertises support', async () => {
+    mockedResolveConnection.mockResolvedValueOnce(OIDC_CONNECTION_ROW as never);
+    mockedSupportsPkceS256.mockReturnValueOnce(true);
+    mockedSaveOidcAuthRequest.mockClear();
+
+    const res = await app.inject({ method: 'GET', url: '/sso/login?org=dev_TEST' });
+
+    const params = authorizeParams(res.json().authorizeUrl);
+    expect(params.get('code_challenge_method')).toBe('S256');
+
+    // The challenge on the wire must be S256(verifier), and the verifier itself
+    // must never appear in the front channel.
+    const stored = mockedSaveOidcAuthRequest.mock.calls[0]![1] as { codeVerifier?: string };
+    expect(stored.codeVerifier).toBeTruthy();
+    const expected = createHash('sha256').update(stored.codeVerifier!).digest('base64url');
+    expect(params.get('code_challenge')).toBe(expected);
+    expect(res.json().authorizeUrl).not.toContain(stored.codeVerifier!);
+  });
+
+  it('sends the code_verifier on the token exchange', async () => {
+    const state = signSsoState({
+      org: 'dev_TEST', connectionId: 'sso_CONN01', oidcRequestId: 'reqaaaaaaaaaaaaaaaaaaaaa',
+    });
+    mockedConsumeOidcAuthRequest.mockResolvedValueOnce({
+      nonce: 'expected-nonce', codeVerifier: 'the-verifier',
+    });
+    mockedVerifyIdToken.mockResolvedValueOnce({
+      sub: 'idp_user_01', nonce: 'expected-nonce',
+    } as never);
+    sqlMock.mockResolvedValueOnce([OIDC_CONNECTION_ROW]);
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id_token: 'mock.id.token' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    setSafeFetchForTests(async (url, init) => fetch(url, init));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/sso/callback/oidc',
+      headers: { 'content-type': 'application/json' },
+      payload: { code: 'auth_code_xyz', state },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const sentBody = String((fetchMock.mock.calls[0]![1] as { body: string }).body);
+    expect(new URLSearchParams(sentBody).get('code_verifier')).toBe('the-verifier');
+  });
+
+  it('rejects an ID token whose nonce does not match the request', async () => {
+    const state = signSsoState({
+      org: 'dev_TEST', connectionId: 'sso_CONN01', oidcRequestId: 'reqbbbbbbbbbbbbbbbbbbbbb',
+    });
+    mockedConsumeOidcAuthRequest.mockResolvedValueOnce({ nonce: 'expected-nonce' });
+    // A token minted for a different login — correctly signed, right issuer and
+    // audience, wrong nonce.
+    mockedVerifyIdToken.mockResolvedValueOnce({
+      sub: 'attacker', nonce: 'other-login',
+    } as never);
+    sqlMock.mockResolvedValueOnce([OIDC_CONNECTION_ROW]);
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true, json: () => Promise.resolve({ id_token: 'mock.id.token' }),
+    }));
+    setSafeFetchForTests(async (url, init) => fetch(url, init));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/sso/callback/oidc',
+      headers: { 'content-type': 'application/json' },
+      payload: { code: 'auth_code_xyz', state },
+    });
+
+    expect(res.statusCode).toBe(502);
+    expect(res.json().message).toBe('ID token nonce mismatch');
+  });
+
+  it('rejects an ID token carrying no nonce when one was requested', async () => {
+    const state = signSsoState({
+      org: 'dev_TEST', connectionId: 'sso_CONN01', oidcRequestId: 'reqccccccccccccccccccccc',
+    });
+    mockedConsumeOidcAuthRequest.mockResolvedValueOnce({ nonce: 'expected-nonce' });
+    mockedVerifyIdToken.mockResolvedValueOnce({ sub: 'idp_user_01' } as never);
+    sqlMock.mockResolvedValueOnce([OIDC_CONNECTION_ROW]);
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true, json: () => Promise.resolve({ id_token: 'mock.id.token' }),
+    }));
+    setSafeFetchForTests(async (url, init) => fetch(url, init));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/sso/callback/oidc',
+      headers: { 'content-type': 'application/json' },
+      payload: { code: 'auth_code_xyz', state },
+    });
+
+    expect(res.statusCode).toBe(502);
+  });
+
+  it('refuses a state whose stored request was already consumed', async () => {
+    const state = signSsoState({
+      org: 'dev_TEST', connectionId: 'sso_CONN01', oidcRequestId: 'reqddddddddddddddddddddd',
+    });
+    // Consume-on-read: a second callback for the same state finds nothing.
+    mockedConsumeOidcAuthRequest.mockResolvedValueOnce(null);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/sso/callback/oidc',
+      headers: { 'content-type': 'application/json' },
+      payload: { code: 'auth_code_xyz', state },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('expired or already been used');
   });
 });


### PR DESCRIPTION
## What was missing

The OIDC flow sent only a signed `state`. The `nonce` field inside that state was **state entropy** — never sent to the IdP as the `nonce` authorization parameter, never compared against the ID token. So nothing tied a returned ID token to the login that asked for it, and nothing tied the authorization code to the request that started it.

## The binding

`/sso/login` now mints a nonce and, when the provider advertises S256, a PKCE verifier. Both live in Redis behind an opaque id; **only that id travels in the state.**

That split matters. `state` is integrity-protected but **not encrypted** — it is base64url JSON that anyone holding the redirect can read. A PKCE verifier placed in the state would be readable by the front channel and would provide no binding whatsoever. There's a test asserting the nonce does not appear anywhere in the state, and that the authorize URL never contains the verifier.

The callback consumes the entry with `GETDEL`, sends `code_verifier` on the token exchange, and compares the ID token's `nonce` claim in constant time.

**Consume-on-read also makes the state single-use** — closing the replay window it previously had for its full ten-minute lifetime, which was one of the gaps flagged in the SSO review.

## Compatibility

**PKCE is conditional on discovery.** Sending a verifier to a token endpoint that never recorded a challenge makes some strict providers reject the exchange outright, so support is not assumed — it is read from `code_challenge_methods_supported`. A *failed* discovery resolves to unsupported rather than optimistically on. `plain` is treated as unsupported; it offers no binding over a front channel.

**Nonce is unconditional.** OIDC Core 3.1.3.7 requires an IdP to echo a nonce it was sent, so requiring it back is spec-correct rather than optimistic.

**Legacy `GET /sso/callback` honours the same binding.** It shares `/sso/login`'s state, so leaving it alone would have left a downgrade path around the checks the primary callback performs.

**In-flight logins survive the deploy.** A state carrying no request id predates this change and skips the new checks. Those states are still HMAC-signed by us and expire within ten minutes, so honouring them is not a downgrade an attacker can force — it only avoids failing logins that were already mid-flight. The path closes itself ten minutes after rollout.

## Test plan

`apps/auth-service`: **2032 passed** (was 2016 — 16 new). `tsc --noEmit` clean.

Route level: nonce present on every authorize request; nonce stored server-side and absent from the state; PKCE omitted when unadvertised and an `S256(verifier)` challenge sent when advertised; `code_verifier` present on the token exchange; **mismatched nonce rejected**; missing nonce rejected; an already-consumed state refused.

The mismatch test and the success test differ **only in the nonce value**, so the rejection is demonstrably caused by the comparison rather than by an unrelated failure.

Library level: `SET ... PX 600000 NX` (NX so a second login cannot clobber a pending one), `GETDEL` semantics with a second read returning null, unsafe request ids rejected before any key is built, and malformed / nonce-less entries treated as absent.

## Deployment note

This adds a **hard Redis dependency to starting an OIDC login** — if the store write fails, `/sso/login` returns 503 rather than silently proceeding without the binding. Redis was already required for SAML request state and rate limiting, so this is not a new dependency for the service, but it is a new one on this specific path.
