### PR TITLE
fix(webhooks): bind delivery signatures to a timestamp

### DIFF
--- a/apps/auth-service/src/lib/webhook.ts
+++ b/apps/auth-service/src/lib/webhook.ts
@@ -2,8 +2,33 @@ import { createHmac } from 'node:crypto';
 import { ulid } from 'ulid';
 import { getSql } from '../db/client.js';
 
+/**
+ * Legacy signature: HMAC over the payload alone.
+ *
+ * A signature that commits to nothing but the body stays valid forever, so a
+ * captured delivery can be replayed at any point. Kept only so receivers that
+ * have not yet moved to {@link signTimestampedWebhookPayload} keep working.
+ *
+ * @deprecated Use the timestamped scheme; this one carries no replay bound.
+ */
 export function signWebhookPayload(secret: string, payload: string): string {
   return 'sha256=' + createHmac('sha256', secret).update(payload).digest('hex');
+}
+
+/**
+ * Signature over `<unix-seconds>.<payload>`, sent alongside an
+ * `X-Grantex-Timestamp` header so the receiver can bound how old a delivery
+ * may be. Binding the timestamp into the signed material is what makes the
+ * bound meaningful — an unsigned timestamp header could simply be rewritten.
+ */
+export function signTimestampedWebhookPayload(
+  secret: string,
+  timestamp: string,
+  payload: string,
+): string {
+  return 'sha256=' + createHmac('sha256', secret)
+    .update(`${timestamp}.${payload}`)
+    .digest('hex');
 }
 
 /**

--- a/apps/auth-service/src/workers/webhookDelivery.ts
+++ b/apps/auth-service/src/workers/webhookDelivery.ts
@@ -2,12 +2,14 @@ import type postgres from 'postgres';
 import { webhookDeliveriesTotal } from '../lib/metrics.js';
 import { config } from '../config.js';
 import { safeFetch } from '../lib/url-security.js';
+import { signTimestampedWebhookPayload } from '../lib/webhook.js';
 
 interface PendingDelivery {
   id: string;
   url: string;
   payload: string;
   signature: string;
+  secret: string | null;
   attempts: number;
   max_attempts: number;
 }
@@ -32,7 +34,7 @@ async function processDeliveries(sql: ReturnType<typeof postgres>): Promise<void
   // the two-minute lease (20 rows / 5 workers * 10-second request timeout).
   const rows = await sql<PendingDelivery[]>`
     WITH due AS (
-      SELECT id
+      SELECT id, webhook_id
       FROM webhook_deliveries
       WHERE status = 'pending'
         AND next_retry_at <= NOW()
@@ -43,9 +45,10 @@ async function processDeliveries(sql: ReturnType<typeof postgres>): Promise<void
     UPDATE webhook_deliveries AS delivery
     SET next_retry_at = NOW() + INTERVAL '2 minutes'
     FROM due
+    LEFT JOIN webhooks ON webhooks.id = due.webhook_id
     WHERE delivery.id = due.id
     RETURNING delivery.id, delivery.url, delivery.payload, delivery.signature,
-              delivery.attempts, delivery.max_attempts
+              webhooks.secret, delivery.attempts, delivery.max_attempts
   `;
 
   let nextRowIndex = 0;
@@ -65,11 +68,33 @@ async function processDelivery(
   const nextAttempt = row.attempts + 1;
 
   try {
+    // The timestamped signature is computed per attempt, not once at enqueue.
+    // Signing it alongside the payload at enqueue time would make the timestamp
+    // describe when the event was queued, and a retry arriving after the
+    // exponential backoff (up to eight minutes) would then fall outside any
+    // sensible replay window and be rejected as stale.
+    //
+    // Inside the try so a failure here is recorded against this delivery rather
+    // than rejecting out of the batch and stalling every other row in it.
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const timestampedSignature = row.secret
+      ? signTimestampedWebhookPayload(row.secret, timestamp, row.payload)
+      : null;
+
     const res = await safeFetch(row.url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        // Legacy, payload-only and therefore replayable indefinitely. Retained
+        // so existing receivers keep working; remove once they have moved to
+        // the timestamped header.
         'X-Grantex-Signature': row.signature,
+        ...(timestampedSignature !== null
+          ? {
+              'X-Grantex-Timestamp': timestamp,
+              'X-Grantex-Signature-V2': timestampedSignature,
+            }
+          : {}),
         'User-Agent': 'Grantex-Webhooks/0.1',
       },
       body: row.payload,

--- a/apps/auth-service/tests/setup.ts
+++ b/apps/auth-service/tests/setup.ts
@@ -118,10 +118,14 @@ vi.mock('../src/lib/events.js', () => ({
 
 // Mock webhook delivery — keeps signWebhookPayload and enqueueWebhookDeliveries
 // available for webhook-specific tests.
-vi.mock('../src/lib/webhook.js', () => ({
-  enqueueWebhookDeliveries: vi.fn().mockResolvedValue(undefined),
-  signWebhookPayload: vi.fn().mockReturnValue('sha256=mock'),
-}));
+vi.mock('../src/lib/webhook.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/lib/webhook.js')>();
+  return {
+    ...actual,
+    enqueueWebhookDeliveries: vi.fn().mockResolvedValue(undefined),
+    signWebhookPayload: vi.fn().mockReturnValue('sha256=mock'),
+  };
+});
 
 // Mock OpenTelemetry — prevent real tracing in tests
 vi.mock('@opentelemetry/api', () => {

--- a/apps/auth-service/tests/webhookDelivery.test.ts
+++ b/apps/auth-service/tests/webhookDelivery.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { startWebhookDeliveryWorker } from '../src/workers/webhookDelivery.js';
+import { createHmac } from 'node:crypto';
+import { startWebhookDeliveryWorker, stopWebhookDeliveryWorker } from '../src/workers/webhookDelivery.js';
 import { sqlMock } from './setup.js';
 import { setSafeFetchForTests } from '../src/lib/url-security.js';
 
@@ -195,5 +196,105 @@ describe('startWebhookDeliveryWorker', () => {
     expect(sqlMock).toHaveBeenCalledTimes(3);
 
     clearInterval(timer);
+  });
+});
+
+// ── Timestamped signature headers ──────────────────────────────────────────
+
+describe('webhook delivery signature headers', () => {
+  const SECRET = 'whsec_worker';
+  const PAYLOAD = '{"type":"grant.created"}';
+
+  const signedDelivery = {
+    id: 'whd_SIGN01',
+    url: 'https://example.com/webhook',
+    payload: PAYLOAD,
+    signature: 'sha256=legacyvalue',
+    secret: SECRET,
+    attempts: 0,
+    max_attempts: 5,
+  };
+
+  function sentHeaders(): Record<string, string> {
+    return (mockSafeFetch.mock.calls[0]![1] as { headers: Record<string, string> }).headers;
+  }
+
+  it('sends a timestamped signature alongside the legacy header', async () => {
+    sqlMock.mockResolvedValueOnce([signedDelivery]);
+    mockSafeFetch.mockResolvedValueOnce(new Response('', { status: 200 }));
+    sqlMock.mockResolvedValueOnce([]);
+
+    startWebhookDeliveryWorker(sqlMock as never, 60_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const headers = sentHeaders();
+    // Legacy header preserved so existing receivers keep working.
+    expect(headers['X-Grantex-Signature']).toBe('sha256=legacyvalue');
+
+    const timestamp = headers['X-Grantex-Timestamp']!;
+    expect(timestamp).toMatch(/^\d+$/);
+
+    const expected = 'sha256=' + createHmac('sha256', SECRET)
+      .update(`${timestamp}.${PAYLOAD}`)
+      .digest('hex');
+    expect(headers['X-Grantex-Signature-V2']).toBe(expected);
+  });
+
+  // Signing at enqueue time would date the signature to when the event was
+  // queued; a retry arriving after the backoff would then read as stale.
+  it('stamps each attempt with the time it is actually sent', async () => {
+    vi.setSystemTime(new Date('2026-08-13T00:00:00Z'));
+    sqlMock.mockResolvedValueOnce([signedDelivery]);
+    mockSafeFetch.mockResolvedValueOnce(new Response('', { status: 200 }));
+    sqlMock.mockResolvedValueOnce([]);
+
+    startWebhookDeliveryWorker(sqlMock as never, 60_000);
+    await vi.advanceTimersByTimeAsync(0);
+    const first = sentHeaders()['X-Grantex-Timestamp'];
+
+    stopWebhookDeliveryWorker();
+    mockSafeFetch.mockReset();
+    sqlMock.mockReset();
+
+    // Same row redelivered ten minutes later — well past any replay window.
+    vi.setSystemTime(new Date('2026-08-13T00:10:00Z'));
+    sqlMock.mockResolvedValueOnce([signedDelivery]);
+    mockSafeFetch.mockResolvedValueOnce(new Response('', { status: 200 }));
+    sqlMock.mockResolvedValueOnce([]);
+
+    startWebhookDeliveryWorker(sqlMock as never, 60_000);
+    await vi.advanceTimersByTimeAsync(0);
+    const second = sentHeaders()['X-Grantex-Timestamp'];
+
+    expect(Number(second) - Number(first!)).toBe(600);
+  });
+
+  it('omits the timestamped header when the endpoint secret is unavailable', async () => {
+    // LEFT JOIN: a delivery whose webhook row has since been deleted still
+    // goes out on the legacy header rather than failing outright.
+    sqlMock.mockResolvedValueOnce([{ ...signedDelivery, secret: null }]);
+    mockSafeFetch.mockResolvedValueOnce(new Response('', { status: 200 }));
+    sqlMock.mockResolvedValueOnce([]);
+
+    startWebhookDeliveryWorker(sqlMock as never, 60_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const headers = sentHeaders();
+    expect(headers['X-Grantex-Signature']).toBe('sha256=legacyvalue');
+    expect(headers['X-Grantex-Timestamp']).toBeUndefined();
+    expect(headers['X-Grantex-Signature-V2']).toBeUndefined();
+  });
+
+  it('leases the endpoint secret in the same statement as the delivery', async () => {
+    sqlMock.mockResolvedValueOnce([signedDelivery]);
+    mockSafeFetch.mockResolvedValueOnce(new Response('', { status: 200 }));
+    sqlMock.mockResolvedValueOnce([]);
+
+    startWebhookDeliveryWorker(sqlMock as never, 60_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const claimSql = (sqlMock.mock.calls[0]?.[0] as TemplateStringsArray).join(' ');
+    expect(claimSql).toContain('webhooks.secret');
+    expect(claimSql).toContain('LEFT JOIN webhooks');
   });
 });

--- a/docs/guides/webhooks.mdx
+++ b/docs/guides/webhooks.mdx
@@ -93,23 +93,41 @@ Every webhook POST has the same envelope:
 
 ## Verifying Signatures
 
-Every request includes an `X-Grantex-Signature` header with a hex-encoded HMAC-SHA256 signature of the raw request body:
+Every request carries a timestamped signature over `<timestamp>.<raw body>`:
 
 ```
-X-Grantex-Signature: sha256=<hex>
+X-Grantex-Timestamp: <unix seconds>
+X-Grantex-Signature-V2: sha256=<hex>
+X-Grantex-Signature: sha256=<hex>      # legacy, see below
 ```
 
-<CodeGroup>
-```typescript TypeScript
-import { verifyWebhookSignature } from '@grantex/sdk';
+Verify against `X-Grantex-Signature-V2` and reject deliveries older than your
+tolerance (300 seconds by default). Both halves matter: the timestamp is inside
+the signed material, so it cannot be rewritten, and without it a captured
+delivery would stay valid forever.
+
+Each delivery attempt is signed at the moment it is sent, so a retry arriving
+after backoff carries a fresh timestamp rather than the time the event was
+queued.
+
+Always verify against the **raw** request body. A body that has been parsed and
+re-serialized will not hash to the same value.
+
+**TypeScript:**
+
+```typescript
+import { verifyWebhook } from '@grantex/sdk';
 
 app.post('/webhooks/grantex', (req, res) => {
-  const sig = req.headers['x-grantex-signature'] as string;
-  const rawBody = req.rawBody;
+  const rawBody = req.rawBody; // raw string/Buffer, not parsed JSON
 
-  if (!verifyWebhookSignature(rawBody, sig, process.env.GRANTEX_WEBHOOK_SECRET!)) {
-    return res.status(401).send('Invalid signature');
-  }
+  const ok = verifyWebhook({
+    payload: rawBody,
+    signature: req.headers['x-grantex-signature-v2'] as string,
+    timestamp: req.headers['x-grantex-timestamp'] as string,
+    secret: process.env.GRANTEX_WEBHOOK_SECRET!,
+  });
+  if (!ok) return res.status(401).send('Invalid signature');
 
   const event = JSON.parse(rawBody);
   console.log('Received event:', event.type);
@@ -117,28 +135,54 @@ app.post('/webhooks/grantex', (req, res) => {
 });
 ```
 
-```python Python
-from grantex import verify_webhook_signature
+**Python:**
+
+```python
+from grantex import verify_webhook
 import os
 
 @app.route('/webhooks/grantex', methods=['POST'])
 def handle_webhook():
-    sig = request.headers.get('X-Grantex-Signature', '')
     raw_body = request.get_data(as_text=True)
 
-    if not verify_webhook_signature(raw_body, sig, os.environ['GRANTEX_WEBHOOK_SECRET']):
+    ok = verify_webhook(
+        raw_body,
+        request.headers.get('X-Grantex-Signature-V2', ''),
+        request.headers.get('X-Grantex-Timestamp', ''),
+        os.environ['GRANTEX_WEBHOOK_SECRET'],
+    )
+    if not ok:
         return 'Invalid signature', 401
 
     event = request.get_json()
     print('Received event:', event['type'])
     return '', 200
 ```
-</CodeGroup>
 
-<Note>
-Always verify signatures before trusting the payload. Use the raw request body — not the parsed JSON.
-</Note>
+**Go:**
 
+```go
+ok := grantex.VerifyWebhook(
+    rawBody,
+    r.Header.Get("X-Grantex-Signature-V2"),
+    r.Header.Get("X-Grantex-Timestamp"),
+    os.Getenv("GRANTEX_WEBHOOK_SECRET"),
+    grantex.DefaultWebhookToleranceSeconds,
+)
+if !ok {
+    http.Error(w, "Invalid signature", http.StatusUnauthorized)
+    return
+}
+```
+
+### Legacy `X-Grantex-Signature`
+
+The original header signs the body alone. Because it commits to nothing
+time-bound, a delivery captured once stays valid forever and can be replayed at
+any time. It is still sent so existing receivers keep working, and
+`verifyWebhookSignature` / `verify_webhook_signature` /
+`VerifyWebhookSignature` still verify it — but they are deprecated. Move to the
+timestamped header; the legacy one will be withdrawn.
 ## SDK Usage
 
 <CodeGroup>

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -95,24 +95,41 @@ Every webhook POST has the same envelope:
 
 ## Verifying Signatures
 
-Every request includes an `X-Grantex-Signature` header with a hex-encoded HMAC-SHA256 signature of the raw request body:
+Every request carries a timestamped signature over `<timestamp>.<raw body>`:
 
 ```
-X-Grantex-Signature: sha256=<hex>
+X-Grantex-Timestamp: <unix seconds>
+X-Grantex-Signature-V2: sha256=<hex>
+X-Grantex-Signature: sha256=<hex>      # legacy, see below
 ```
+
+Verify against `X-Grantex-Signature-V2` and reject deliveries older than your
+tolerance (300 seconds by default). Both halves matter: the timestamp is inside
+the signed material, so it cannot be rewritten, and without it a captured
+delivery would stay valid forever.
+
+Each delivery attempt is signed at the moment it is sent, so a retry arriving
+after backoff carries a fresh timestamp rather than the time the event was
+queued.
+
+Always verify against the **raw** request body. A body that has been parsed and
+re-serialized will not hash to the same value.
 
 **TypeScript:**
 
 ```typescript
-import { verifyWebhookSignature } from '@grantex/sdk';
+import { verifyWebhook } from '@grantex/sdk';
 
 app.post('/webhooks/grantex', (req, res) => {
-  const sig = req.headers['x-grantex-signature'] as string;
-  const rawBody = req.rawBody; // must be the raw string/Buffer, not parsed JSON
+  const rawBody = req.rawBody; // raw string/Buffer, not parsed JSON
 
-  if (!verifyWebhookSignature(rawBody, sig, process.env.GRANTEX_WEBHOOK_SECRET!)) {
-    return res.status(401).send('Invalid signature');
-  }
+  const ok = verifyWebhook({
+    payload: rawBody,
+    signature: req.headers['x-grantex-signature-v2'] as string,
+    timestamp: req.headers['x-grantex-timestamp'] as string,
+    secret: process.env.GRANTEX_WEBHOOK_SECRET!,
+  });
+  if (!ok) return res.status(401).send('Invalid signature');
 
   const event = JSON.parse(rawBody);
   console.log('Received event:', event.type);
@@ -123,15 +140,20 @@ app.post('/webhooks/grantex', (req, res) => {
 **Python:**
 
 ```python
-from grantex import verify_webhook_signature
+from grantex import verify_webhook
 import os
 
 @app.route('/webhooks/grantex', methods=['POST'])
 def handle_webhook():
-    sig = request.headers.get('X-Grantex-Signature', '')
     raw_body = request.get_data(as_text=True)
 
-    if not verify_webhook_signature(raw_body, sig, os.environ['GRANTEX_WEBHOOK_SECRET']):
+    ok = verify_webhook(
+        raw_body,
+        request.headers.get('X-Grantex-Signature-V2', ''),
+        request.headers.get('X-Grantex-Timestamp', ''),
+        os.environ['GRANTEX_WEBHOOK_SECRET'],
+    )
+    if not ok:
         return 'Invalid signature', 401
 
     event = request.get_json()
@@ -139,8 +161,30 @@ def handle_webhook():
     return '', 200
 ```
 
-> Always verify signatures before trusting the payload. Use the raw request body — not the parsed JSON.
+**Go:**
 
+```go
+ok := grantex.VerifyWebhook(
+    rawBody,
+    r.Header.Get("X-Grantex-Signature-V2"),
+    r.Header.Get("X-Grantex-Timestamp"),
+    os.Getenv("GRANTEX_WEBHOOK_SECRET"),
+    grantex.DefaultWebhookToleranceSeconds,
+)
+if !ok {
+    http.Error(w, "Invalid signature", http.StatusUnauthorized)
+    return
+}
+```
+
+### Legacy `X-Grantex-Signature`
+
+The original header signs the body alone. Because it commits to nothing
+time-bound, a delivery captured once stays valid forever and can be replayed at
+any time. It is still sent so existing receivers keep working, and
+`verifyWebhookSignature` / `verify_webhook_signature` /
+`VerifyWebhookSignature` still verify it — but they are deprecated. Move to the
+timestamped header; the legacy one will be withdrawn.
 ---
 
 ## Managing Endpoints

--- a/packages/go-sdk/webhooks.go
+++ b/packages/go-sdk/webhooks.go
@@ -6,6 +6,8 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
+	"strconv"
+	"time"
 )
 
 // WebhooksService handles webhook endpoint management.
@@ -29,8 +31,16 @@ func (s *WebhooksService) Delete(ctx context.Context, webhookID string) error {
 	return err
 }
 
+// DefaultWebhookToleranceSeconds bounds how old a delivery may be.
+const DefaultWebhookToleranceSeconds = 300
+
 // VerifyWebhookSignature verifies an HMAC-SHA256 webhook signature.
 // The signature should be in "sha256=<hex>" format.
+//
+// Deprecated: this checks only that the body was signed with your secret. It
+// commits to nothing time-bound, so a delivery captured once stays valid
+// forever and can be replayed at will. Prefer VerifyWebhook, which binds the
+// signature to a timestamp and rejects stale deliveries.
 func VerifyWebhookSignature(payload []byte, signature string, secret string) bool {
 	if len(signature) < 8 || signature[:7] != "sha256=" {
 		return false
@@ -41,6 +51,51 @@ func VerifyWebhookSignature(payload []byte, signature string, secret string) boo
 	}
 
 	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	expected := mac.Sum(nil)
+
+	return subtle.ConstantTimeCompare(sigBytes, expected) == 1
+}
+
+// VerifyWebhook verifies a timestamped webhook delivery.
+//
+// It checks that the signature covers "<timestamp>.<payload>" and that the
+// timestamp is recent. Both halves matter: without the signature the timestamp
+// could be rewritten, and without the timestamp the signature never expires.
+//
+// signature is the X-Grantex-Signature-V2 header and timestamp the
+// X-Grantex-Timestamp header. Pass the untouched request body; a body that has
+// been parsed and re-serialized will not hash to the same value.
+//
+// toleranceSeconds bounds the delivery's age; pass
+// DefaultWebhookToleranceSeconds for the standard window. Deliveries dated
+// that far into the future are refused too, so a forged clock cannot buy an
+// unbounded window.
+func VerifyWebhook(payload []byte, signature, timestamp, secret string, toleranceSeconds int64) bool {
+	if len(signature) < 8 || signature[:7] != "sha256=" {
+		return false
+	}
+	sentAt, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil || sentAt < 0 {
+		return false
+	}
+
+	age := time.Now().Unix() - sentAt
+	if age < 0 {
+		age = -age
+	}
+	if age > toleranceSeconds {
+		return false
+	}
+
+	sigBytes, err := hex.DecodeString(signature[7:])
+	if err != nil {
+		return false
+	}
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(timestamp))
+	mac.Write([]byte("."))
 	mac.Write(payload)
 	expected := mac.Sum(nil)
 

--- a/packages/go-sdk/webhooks_test.go
+++ b/packages/go-sdk/webhooks_test.go
@@ -8,7 +8,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestWebhooksCreate(t *testing.T) {
@@ -115,5 +118,109 @@ func TestVerifyWebhookSignatureShort(t *testing.T) {
 func TestVerifyWebhookSignatureBadHex(t *testing.T) {
 	if VerifyWebhookSignature([]byte("payload"), "sha256=not-hex-at-all!!!", "secret") {
 		t.Error("expected false for bad hex")
+	}
+}
+
+// ── Timestamped verification (replay-bounded) ──────────────────────────────
+
+const tsSecret = "whsec_test"
+const tsPayload = `{"id":"evt_1","type":"grant.created"}`
+
+func signTimestamped(timestamp, payload, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(timestamp))
+	mac.Write([]byte("."))
+	mac.Write([]byte(payload))
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func nowUnix() int64 { return time.Now().Unix() }
+
+func TestVerifyWebhookAcceptsFreshDelivery(t *testing.T) {
+	ts := strconv.FormatInt(nowUnix(), 10)
+	if !VerifyWebhook([]byte(tsPayload), signTimestamped(ts, tsPayload, tsSecret), ts, tsSecret, DefaultWebhookToleranceSeconds) {
+		t.Fatal("expected a fresh, correctly signed delivery to verify")
+	}
+}
+
+// The whole point of the scheme: a delivery captured today must not still
+// verify tomorrow, which is exactly what the payload-only signature allowed.
+func TestVerifyWebhookRejectsReplayAfterWindow(t *testing.T) {
+	ts := strconv.FormatInt(nowUnix()-301, 10)
+	if VerifyWebhook([]byte(tsPayload), signTimestamped(ts, tsPayload, tsSecret), ts, tsSecret, DefaultWebhookToleranceSeconds) {
+		t.Fatal("expected a delivery past the tolerance window to be rejected")
+	}
+}
+
+func TestVerifyWebhookAcceptsInsideWindow(t *testing.T) {
+	ts := strconv.FormatInt(nowUnix()-299, 10)
+	if !VerifyWebhook([]byte(tsPayload), signTimestamped(ts, tsPayload, tsSecret), ts, tsSecret, DefaultWebhookToleranceSeconds) {
+		t.Fatal("expected a delivery inside the window to verify")
+	}
+}
+
+func TestVerifyWebhookRejectsFutureDatedDelivery(t *testing.T) {
+	ts := strconv.FormatInt(nowUnix()+3600, 10)
+	if VerifyWebhook([]byte(tsPayload), signTimestamped(ts, tsPayload, tsSecret), ts, tsSecret, DefaultWebhookToleranceSeconds) {
+		t.Fatal("expected a future-dated delivery to be rejected")
+	}
+}
+
+// The signature covers the timestamp, so refreshing the header alone fails.
+func TestVerifyWebhookRejectsRewrittenTimestamp(t *testing.T) {
+	signedAt := strconv.FormatInt(nowUnix()-3600, 10)
+	sig := signTimestamped(signedAt, tsPayload, tsSecret)
+	fresh := strconv.FormatInt(nowUnix(), 10)
+	if VerifyWebhook([]byte(tsPayload), sig, fresh, tsSecret, DefaultWebhookToleranceSeconds) {
+		t.Fatal("expected a rewritten timestamp to be rejected")
+	}
+}
+
+func TestVerifyWebhookRejectsTamperedBody(t *testing.T) {
+	ts := strconv.FormatInt(nowUnix(), 10)
+	sig := signTimestamped(ts, tsPayload, tsSecret)
+	if VerifyWebhook([]byte(`{"id":"evt_1","type":"grant.deleted"}`), sig, ts, tsSecret, DefaultWebhookToleranceSeconds) {
+		t.Fatal("expected a tampered body to be rejected")
+	}
+}
+
+func TestVerifyWebhookRejectsWrongSecret(t *testing.T) {
+	ts := strconv.FormatInt(nowUnix(), 10)
+	sig := signTimestamped(ts, tsPayload, "whsec_other")
+	if VerifyWebhook([]byte(tsPayload), sig, ts, tsSecret, DefaultWebhookToleranceSeconds) {
+		t.Fatal("expected a signature from another secret to be rejected")
+	}
+}
+
+func TestVerifyWebhookRejectsLegacyPayloadOnlySignature(t *testing.T) {
+	ts := strconv.FormatInt(nowUnix(), 10)
+	mac := hmac.New(sha256.New, []byte(tsSecret))
+	mac.Write([]byte(tsPayload))
+	legacy := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if VerifyWebhook([]byte(tsPayload), legacy, ts, tsSecret, DefaultWebhookToleranceSeconds) {
+		t.Fatal("expected a legacy payload-only signature to be rejected")
+	}
+}
+
+func TestVerifyWebhookRejectsMalformedInputs(t *testing.T) {
+	ts := strconv.FormatInt(nowUnix(), 10)
+	valid := signTimestamped(ts, tsPayload, tsSecret)
+
+	for _, timestamp := range []string{"", "not-a-time", "-100", strings.Repeat("9", 40)} {
+		sig := signTimestamped(timestamp, tsPayload, tsSecret)
+		if VerifyWebhook([]byte(tsPayload), sig, timestamp, tsSecret, DefaultWebhookToleranceSeconds) {
+			t.Fatalf("expected timestamp %q to be rejected", timestamp)
+		}
+	}
+
+	for _, sig := range []string{"", "garbage", "sha256=", "sha256=zz"} {
+		if VerifyWebhook([]byte(tsPayload), sig, ts, tsSecret, DefaultWebhookToleranceSeconds) {
+			t.Fatalf("expected signature %q to be rejected", sig)
+		}
+	}
+
+	// Sanity: the valid case still passes, so the loop above is not vacuous.
+	if !VerifyWebhook([]byte(tsPayload), valid, ts, tsSecret, DefaultWebhookToleranceSeconds) {
+		t.Fatal("expected the control case to verify")
 	}
 }

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -156,7 +156,7 @@ SsoSessionListResponse = ListSsoSessionsResponse
 
 from ._pkce import PkceChallenge, generate_pkce
 from ._verify import verify_grant_token
-from ._webhook import verify_webhook_signature
+from ._webhook import verify_webhook, verify_webhook_signature
 from .manifest import ToolManifest, Permission, EnforceResult
 from ._fastapi import GrantexEnforcer
 
@@ -175,6 +175,7 @@ __all__ = [
     # Standalone verify
     "verify_grant_token",
     # Webhook signature verification
+    "verify_webhook",
     "verify_webhook_signature",
     # Errors
     "GrantexError",

--- a/packages/sdk-py/src/grantex/_webhook.py
+++ b/packages/sdk-py/src/grantex/_webhook.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import re
+import time
+
+_DEFAULT_TOLERANCE_SECONDS = 300
+_TIMESTAMP_RE = re.compile(r"^\d{1,15}$")
 
 
 def verify_webhook_signature(
@@ -10,6 +15,12 @@ def verify_webhook_signature(
     secret: str,
 ) -> bool:
     """Verify that a webhook payload was sent by Grantex.
+
+    .. deprecated::
+        This checks only that the body was signed with your secret. It commits
+        to nothing time-bound, so a delivery captured once stays valid forever
+        and can be replayed at will. Prefer :func:`verify_webhook`, which binds
+        the signature to a timestamp and rejects stale deliveries.
 
     Args:
         payload:   The raw request body received from Grantex.
@@ -22,4 +33,50 @@ def verify_webhook_signature(
     if isinstance(payload, str):
         payload = payload.encode()
     expected = "sha256=" + hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(signature, expected)
+
+
+def verify_webhook(
+    payload: str | bytes,
+    signature: str,
+    timestamp: str,
+    secret: str,
+    tolerance_seconds: int = _DEFAULT_TOLERANCE_SECONDS,
+) -> bool:
+    """Verify a timestamped webhook delivery.
+
+    Checks that the signature covers ``<timestamp>.<payload>`` and that the
+    timestamp is recent. Both halves matter: without the signature the
+    timestamp could be rewritten, and without the timestamp the signature never
+    expires.
+
+    Pass the untouched request body. A body that has been parsed and
+    re-serialized will not hash to the same value.
+
+    Args:
+        payload:           The raw request body received from Grantex.
+        signature:         The value of the X-Grantex-Signature-V2 header.
+        timestamp:         The value of the X-Grantex-Timestamp header.
+        secret:            The webhook secret returned when the endpoint was created.
+        tolerance_seconds: How old a delivery may be. Deliveries dated this far
+                           into the future are refused too, so a forged clock
+                           cannot buy an unbounded window.
+
+    Returns:
+        True if the signature is valid and the delivery is fresh, else False.
+    """
+    if not isinstance(signature, str) or not signature:
+        return False
+    if not isinstance(timestamp, str) or not _TIMESTAMP_RE.match(timestamp):
+        return False
+
+    age_seconds = int(time.time()) - int(timestamp)
+    if abs(age_seconds) > tolerance_seconds:
+        return False
+
+    if isinstance(payload, str):
+        payload = payload.encode()
+
+    signed = timestamp.encode() + b"." + payload
+    expected = "sha256=" + hmac.new(secret.encode(), signed, hashlib.sha256).hexdigest()
     return hmac.compare_digest(signature, expected)

--- a/packages/sdk-py/tests/test_webhooks.py
+++ b/packages/sdk-py/tests/test_webhooks.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import time
 
 import httpx
+import pytest
 import respx
 
 from grantex import Grantex
-from grantex._webhook import verify_webhook_signature
+from grantex._webhook import verify_webhook, verify_webhook_signature
 
 BASE_URL = "http://test.local"
 
@@ -84,3 +86,93 @@ def test_verify_signature_bytes_payload() -> None:
     secret = "my-secret"
     sig = _make_sig(payload, secret)
     assert verify_webhook_signature(payload, sig, secret) is True
+
+
+# ── Timestamped verification (replay-bounded) ──────────────────────────────
+
+_TS_SECRET = "whsec_test"
+_TS_PAYLOAD = '{"id":"evt_1","type":"grant.created"}'
+
+
+def _sign(timestamp: str, payload: str, secret: str = _TS_SECRET) -> str:
+    signed = timestamp.encode() + b"." + payload.encode()
+    return "sha256=" + hmac.new(secret.encode(), signed, hashlib.sha256).hexdigest()
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def test_verify_webhook_accepts_fresh_delivery():
+    ts = str(_now())
+    assert verify_webhook(_TS_PAYLOAD, _sign(ts, _TS_PAYLOAD), ts, _TS_SECRET) is True
+
+
+def test_verify_webhook_accepts_bytes_body():
+    ts = str(_now())
+    assert verify_webhook(
+        _TS_PAYLOAD.encode(), _sign(ts, _TS_PAYLOAD), ts, _TS_SECRET
+    ) is True
+
+
+def test_verify_webhook_rejects_replay_after_window():
+    # The whole point: a delivery captured today must not verify tomorrow.
+    ts = str(_now() - 301)
+    assert verify_webhook(_TS_PAYLOAD, _sign(ts, _TS_PAYLOAD), ts, _TS_SECRET) is False
+
+
+def test_verify_webhook_accepts_inside_window():
+    ts = str(_now() - 299)
+    assert verify_webhook(_TS_PAYLOAD, _sign(ts, _TS_PAYLOAD), ts, _TS_SECRET) is True
+
+
+def test_verify_webhook_honours_custom_tolerance():
+    ts = str(_now() - 60)
+    sig = _sign(ts, _TS_PAYLOAD)
+    assert verify_webhook(_TS_PAYLOAD, sig, ts, _TS_SECRET, tolerance_seconds=30) is False
+    assert verify_webhook(_TS_PAYLOAD, sig, ts, _TS_SECRET, tolerance_seconds=120) is True
+
+
+def test_verify_webhook_rejects_future_dated_delivery():
+    ts = str(_now() + 3600)
+    assert verify_webhook(_TS_PAYLOAD, _sign(ts, _TS_PAYLOAD), ts, _TS_SECRET) is False
+
+
+def test_verify_webhook_rejects_rewritten_timestamp():
+    # The signature covers the timestamp, so refreshing the header alone fails.
+    signed_at = str(_now() - 3600)
+    sig = _sign(signed_at, _TS_PAYLOAD)
+    assert verify_webhook(_TS_PAYLOAD, sig, str(_now()), _TS_SECRET) is False
+
+
+def test_verify_webhook_rejects_tampered_body():
+    ts = str(_now())
+    sig = _sign(ts, _TS_PAYLOAD)
+    assert verify_webhook('{"id":"evt_1","type":"grant.deleted"}', sig, ts, _TS_SECRET) is False
+
+
+def test_verify_webhook_rejects_wrong_secret():
+    ts = str(_now())
+    sig = _sign(ts, _TS_PAYLOAD, "whsec_other")
+    assert verify_webhook(_TS_PAYLOAD, sig, ts, _TS_SECRET) is False
+
+
+def test_verify_webhook_rejects_legacy_payload_only_signature():
+    ts = str(_now())
+    legacy = "sha256=" + hmac.new(
+        _TS_SECRET.encode(), _TS_PAYLOAD.encode(), hashlib.sha256
+    ).hexdigest()
+    assert verify_webhook(_TS_PAYLOAD, legacy, ts, _TS_SECRET) is False
+
+
+@pytest.mark.parametrize("timestamp", ["", "not-a-time", "-100", "9" * 40])
+def test_verify_webhook_rejects_bad_timestamps(timestamp):
+    assert verify_webhook(
+        _TS_PAYLOAD, _sign(timestamp, _TS_PAYLOAD), timestamp, _TS_SECRET
+    ) is False
+
+
+@pytest.mark.parametrize("signature", ["", "garbage", "sha256=", "sha256=zz"])
+def test_verify_webhook_rejects_bad_signatures(signature):
+    ts = str(_now())
+    assert verify_webhook(_TS_PAYLOAD, signature, ts, _TS_SECRET) is False

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -5,7 +5,7 @@ export { Grantex } from './client.js';
 export { verifyGrantToken } from './verify.js';
 
 // Webhook signature verification
-export { verifyWebhookSignature } from './webhook.js';
+export { verifyWebhookSignature, verifyWebhook, type VerifyWebhookOptions } from './webhook.js';
 
 // PKCE helper
 export { generatePkce, type PkceChallenge } from './pkce.js';

--- a/packages/sdk-ts/src/webhook.ts
+++ b/packages/sdk-ts/src/webhook.ts
@@ -1,7 +1,24 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 
+/** Default age limit for a delivery, matching the sender's retry envelope. */
+const DEFAULT_TOLERANCE_SECONDS = 300;
+
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  // timingSafeEqual throws on a length mismatch, so compare lengths first —
+  // length is not the secret here, the digest is.
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(left, right);
+}
+
 /**
  * Verify that a webhook payload was sent by Grantex.
+ *
+ * @deprecated This checks only that the body was signed with your secret. It
+ * commits to nothing time-bound, so a delivery captured once stays valid
+ * forever and can be replayed at will. Prefer {@link verifyWebhook}, which
+ * binds the signature to a timestamp and rejects stale deliveries.
  *
  * @param payload   - The raw request body string (or Buffer) received from Grantex.
  * @param signature - The value of the `X-Grantex-Signature` header.
@@ -20,4 +37,61 @@ export function verifyWebhookSignature(
   } catch {
     return false;
   }
+}
+
+export interface VerifyWebhookOptions {
+  /** The raw request body, exactly as received — do not re-serialize it. */
+  payload: string | Buffer;
+  /** The value of the `X-Grantex-Signature-V2` header. */
+  signature: string;
+  /** The value of the `X-Grantex-Timestamp` header (unix seconds). */
+  timestamp: string;
+  /** The webhook secret returned when the endpoint was created. */
+  secret: string;
+  /**
+   * How old a delivery may be, in seconds. Defaults to 300. Deliveries dated
+   * in the future by more than this are also refused, so a forged clock cannot
+   * buy an attacker an unbounded window.
+   */
+  toleranceSeconds?: number;
+}
+
+/**
+ * Verify a timestamped webhook delivery.
+ *
+ * Checks that the signature covers `<timestamp>.<payload>` and that the
+ * timestamp is recent. Both halves matter: without the signature the timestamp
+ * could be rewritten, and without the timestamp the signature never expires.
+ *
+ * ```ts
+ * const ok = verifyWebhook({
+ *   payload: rawBody,
+ *   signature: req.headers['x-grantex-signature-v2'],
+ *   timestamp: req.headers['x-grantex-timestamp'],
+ *   secret: process.env.GRANTEX_WEBHOOK_SECRET,
+ * });
+ * ```
+ *
+ * Pass the untouched request body. A body that has been parsed and
+ * re-serialized will not hash to the same value.
+ */
+export function verifyWebhook(options: VerifyWebhookOptions): boolean {
+  const { payload, signature, timestamp, secret } = options;
+  const tolerance = options.toleranceSeconds ?? DEFAULT_TOLERANCE_SECONDS;
+
+  if (typeof signature !== 'string' || signature.length === 0) return false;
+  if (typeof timestamp !== 'string' || !/^\d{1,15}$/.test(timestamp)) return false;
+
+  const sentAt = Number(timestamp);
+  if (!Number.isSafeInteger(sentAt)) return false;
+
+  const ageSeconds = Math.floor(Date.now() / 1000) - sentAt;
+  if (Math.abs(ageSeconds) > tolerance) return false;
+
+  const expected = 'sha256=' + createHmac('sha256', secret)
+    .update(`${timestamp}.`)
+    .update(payload)
+    .digest('hex');
+
+  return timingSafeStringEqual(signature, expected);
 }

--- a/packages/sdk-ts/tests/webhooks.test.ts
+++ b/packages/sdk-ts/tests/webhooks.test.ts
@@ -1,7 +1,7 @@
 import { createHmac } from 'node:crypto';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Grantex } from '../src/client.js';
-import { verifyWebhookSignature } from '../src/webhook.js';
+import { verifyWebhookSignature, verifyWebhook } from '../src/webhook.js';
 
 function makeFetch(status: number, body: unknown) {
   return vi.fn().mockResolvedValue({
@@ -96,5 +96,129 @@ describe('verifyWebhookSignature', () => {
     const buf = Buffer.from(payload);
     const sig = makeSignature(payload, secret);
     expect(verifyWebhookSignature(buf, sig, secret)).toBe(true);
+  });
+});
+
+// ── Timestamped verification (replay-bounded) ──────────────────────────────
+
+describe('verifyWebhook', () => {
+  const SECRET = 'whsec_test';
+  const PAYLOAD = '{"id":"evt_1","type":"grant.created"}';
+
+  function sign(timestamp: string, payload: string | Buffer, secret = SECRET): string {
+    return 'sha256=' + createHmac('sha256', secret)
+      .update(`${timestamp}.`)
+      .update(payload)
+      .digest('hex');
+  }
+
+  function nowSeconds(): number {
+    return Math.floor(Date.now() / 1000);
+  }
+
+  it('accepts a fresh, correctly signed delivery', () => {
+    const ts = String(nowSeconds());
+    expect(verifyWebhook({
+      payload: PAYLOAD, signature: sign(ts, PAYLOAD), timestamp: ts, secret: SECRET,
+    })).toBe(true);
+  });
+
+  it('accepts a Buffer body identical to the string body', () => {
+    const ts = String(nowSeconds());
+    expect(verifyWebhook({
+      payload: Buffer.from(PAYLOAD),
+      signature: sign(ts, PAYLOAD),
+      timestamp: ts,
+      secret: SECRET,
+    })).toBe(true);
+  });
+
+  // The point of the scheme: a delivery captured today must not still verify
+  // tomorrow, which is exactly what the payload-only signature allowed.
+  it('rejects a delivery replayed after the tolerance window', () => {
+    const ts = String(nowSeconds() - 301);
+    expect(verifyWebhook({
+      payload: PAYLOAD, signature: sign(ts, PAYLOAD), timestamp: ts, secret: SECRET,
+    })).toBe(false);
+  });
+
+  it('accepts a delivery still inside the window', () => {
+    const ts = String(nowSeconds() - 299);
+    expect(verifyWebhook({
+      payload: PAYLOAD, signature: sign(ts, PAYLOAD), timestamp: ts, secret: SECRET,
+    })).toBe(true);
+  });
+
+  it('honours a custom tolerance', () => {
+    const ts = String(nowSeconds() - 60);
+    expect(verifyWebhook({
+      payload: PAYLOAD, signature: sign(ts, PAYLOAD), timestamp: ts, secret: SECRET,
+      toleranceSeconds: 30,
+    })).toBe(false);
+    expect(verifyWebhook({
+      payload: PAYLOAD, signature: sign(ts, PAYLOAD), timestamp: ts, secret: SECRET,
+      toleranceSeconds: 120,
+    })).toBe(true);
+  });
+
+  // A future-dated delivery would otherwise stay valid for as long as the
+  // attacker cared to postdate it.
+  it('rejects a delivery dated far in the future', () => {
+    const ts = String(nowSeconds() + 3600);
+    expect(verifyWebhook({
+      payload: PAYLOAD, signature: sign(ts, PAYLOAD), timestamp: ts, secret: SECRET,
+    })).toBe(false);
+  });
+
+  it('rejects a rewritten timestamp, because the signature covers it', () => {
+    const signedAt = String(nowSeconds() - 3600);
+    const signature = sign(signedAt, PAYLOAD);
+    // Attacker refreshes the header to look current but cannot re-sign it.
+    expect(verifyWebhook({
+      payload: PAYLOAD, signature, timestamp: String(nowSeconds()), secret: SECRET,
+    })).toBe(false);
+  });
+
+  it('rejects a tampered body', () => {
+    const ts = String(nowSeconds());
+    expect(verifyWebhook({
+      payload: '{"id":"evt_1","type":"grant.deleted"}',
+      signature: sign(ts, PAYLOAD),
+      timestamp: ts,
+      secret: SECRET,
+    })).toBe(false);
+  });
+
+  it('rejects a signature made with a different secret', () => {
+    const ts = String(nowSeconds());
+    expect(verifyWebhook({
+      payload: PAYLOAD, signature: sign(ts, PAYLOAD, 'whsec_other'), timestamp: ts, secret: SECRET,
+    })).toBe(false);
+  });
+
+  it('rejects a legacy payload-only signature', () => {
+    const ts = String(nowSeconds());
+    const legacy = 'sha256=' + createHmac('sha256', SECRET).update(PAYLOAD).digest('hex');
+    expect(verifyWebhook({
+      payload: PAYLOAD, signature: legacy, timestamp: ts, secret: SECRET,
+    })).toBe(false);
+  });
+
+  it.each([
+    ['empty', ''],
+    ['non-numeric', 'not-a-time'],
+    ['negative', '-100'],
+    ['absurdly long', '9'.repeat(40)],
+  ])('rejects a %s timestamp', (_label, timestamp) => {
+    expect(verifyWebhook({
+      payload: PAYLOAD, signature: sign(timestamp, PAYLOAD), timestamp, secret: SECRET,
+    })).toBe(false);
+  });
+
+  it('rejects an empty or malformed signature without throwing', () => {
+    const ts = String(nowSeconds());
+    for (const signature of ['', 'garbage', 'sha256=', 'sha256=zz']) {
+      expect(verifyWebhook({ payload: PAYLOAD, signature, timestamp: ts, secret: SECRET })).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## The problem

`X-Grantex-Signature` covers the request body **and nothing else**, so it never goes stale. A delivery captured once — from a log, a proxy, a compromised receiver — verifies just as well a month later, and a receiver following the documented verification had no way to distinguish a replay from a fresh event.

Commerce webhooks already solved this (timestamp in the signed payload, replay window, timing-safe compare). The core delivery path had not.

## The fix

Deliveries now also carry:

```
X-Grantex-Timestamp: <unix seconds>
X-Grantex-Signature-V2: sha256=HMAC(secret, "<timestamp>.<payload>")
```

The timestamp is **inside the signed material**, so it cannot be rewritten to refresh a stale capture — there's a test for exactly that.

### Signing moved to delivery time

The signature was computed once at enqueue and stored on the row. A timestamp fixed at that moment would describe when the event was *queued*, so a retry arriving after the exponential backoff (up to eight minutes) would read as stale and be rejected.

Each attempt is now signed as it's sent. The worker leases the endpoint secret in the same statement that claims the row, so this costs no extra query. The signing call sits **inside** the per-delivery `try` so a failure is recorded against that delivery rather than rejecting out of the batch and stalling every other row in it.

## All three SDKs

| SDK | New | Legacy |
|---|---|---|
| TypeScript | `verifyWebhook({ payload, signature, timestamp, secret, toleranceSeconds? })` | `verifyWebhookSignature` — deprecated |
| Python | `verify_webhook(payload, signature, timestamp, secret, tolerance_seconds=300)` | `verify_webhook_signature` — deprecated |
| Go | `VerifyWebhook(payload, signature, timestamp, secret, toleranceSeconds)` | `VerifyWebhookSignature` — deprecated |

Each rejects: stale deliveries, future-dated ones (a forged clock would otherwise buy an unbounded window), rewritten timestamps, tampered bodies, wrong secrets, legacy payload-only signatures, and malformed input. Default tolerance 300s.

## This does not close the hole by itself — read this

**The legacy header is still sent and the old verifiers still accept it**, so nothing breaks on deploy. But that also means **the replay window stays open until receivers stop honouring the legacy header.** This change *enables* the fix; it doesn't complete it.

Completing it needs a deprecation window, then removing `X-Grantex-Signature` from the sender and the legacy verifiers from the SDKs. I'd suggest tracking that as a follow-up with a date attached rather than leaving it implicit.

## Test plan

| Suite | Result |
|---|---|
| `apps/auth-service` | 2038 passed (+4) |
| `packages/sdk-ts` | 433 passed (+15) |
| `packages/sdk-py` | 25 passed (+13) |
| `packages/go-sdk` | pass (+8) |

`tsc --noEmit` clean on auth-service and sdk-ts; `go build ./...` and `go test ./...` clean; `check-docs-integrity.mjs` passes.

Worker coverage asserts the exact HMAC on the wire, that two attempts ten minutes apart carry timestamps 600s apart, that the secret is leased in the claim statement, and that a delivery whose webhook row was deleted still goes out on the legacy header rather than failing.

## One thing worth flagging separately

`tests/setup.ts` factory-mocked the whole of `lib/webhook.js`, so a newly exported **pure** helper was `undefined` inside the worker and the delivery failed silently — the cycle's `.catch` swallowed it and no test noticed. Switched to a partial mock via `importOriginal`. Worth knowing that pattern exists elsewhere in the suite: a factory mock that omits an export turns into a silent runtime hole rather than a compile error.
