### PR TITLE
fix: relay gateway bodies verbatim, drop a dead query, harden vault decrypt

### DIFF
--- a/apps/auth-service/src/lib/vault-crypto.ts
+++ b/apps/auth-service/src/lib/vault-crypto.ts
@@ -5,16 +5,29 @@ const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12;
 const TAG_LENGTH = 16;
 
+const KEY_LENGTH = 32; // AES-256
+
 function getKey(): Buffer {
   const key = config.vaultEncryptionKey;
   if (!key) {
     throw new Error('VAULT_ENCRYPTION_KEY is not configured');
   }
   // Support both hex (64 chars) and base64 (44 chars) formats
-  if (/^[0-9a-fA-F]{64}$/.test(key)) {
-    return Buffer.from(key, 'hex');
+  const decoded = /^[0-9a-fA-F]{64}$/.test(key)
+    ? Buffer.from(key, 'hex')
+    : Buffer.from(key, 'base64');
+
+  // Buffer.from silently drops characters it cannot decode, so a truncated or
+  // mistyped key yields a short buffer rather than an error. Checking the
+  // length here fails with something that names the problem, instead of
+  // createCipheriv's generic "Invalid key length".
+  if (decoded.length !== KEY_LENGTH) {
+    throw new Error(
+      `VAULT_ENCRYPTION_KEY must decode to ${KEY_LENGTH} bytes (got ${decoded.length}); `
+      + 'supply 64 hex characters or 44 base64 characters',
+    );
   }
-  return Buffer.from(key, 'base64');
+  return decoded;
 }
 
 export function encrypt(plaintext: string): string {
@@ -33,6 +46,12 @@ export function decrypt(ciphertext: string): string {
   const key = getKey();
   const data = Buffer.from(ciphertext, 'base64');
 
+  // Without this, a truncated value produces short IV/tag slices and surfaces
+  // as an opaque error from createDecipheriv or setAuthTag.
+  if (data.length < IV_LENGTH + TAG_LENGTH) {
+    throw new Error('Ciphertext is too short to contain an IV and auth tag');
+  }
+
   const iv = data.subarray(0, IV_LENGTH);
   const tag = data.subarray(IV_LENGTH, IV_LENGTH + TAG_LENGTH);
   const encrypted = data.subarray(IV_LENGTH + TAG_LENGTH);
@@ -40,5 +59,13 @@ export function decrypt(ciphertext: string): string {
   const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: TAG_LENGTH });
   decipher.setAuthTag(tag);
 
-  return decipher.update(encrypted) + decipher.final('utf8');
+  // Concatenate as bytes, then decode once.
+  //
+  // `decipher.update(buf) + decipher.final('utf8')` relied on Buffer's implicit
+  // toString() and decoded each part separately. That happens to work for GCM,
+  // which is a stream cipher and never withholds a partial block — but any
+  // mode that buffers would split a multi-byte character across the two calls
+  // and each half would decode to U+FFFD. Decoding the joined bytes has no such
+  // dependency on the cipher's internals.
+  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
 }

--- a/apps/auth-service/src/routes/token.ts
+++ b/apps/auth-service/src/routes/token.ts
@@ -158,14 +158,13 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
           )
         `;
 
-        const budgetRows = await tx`
-          SELECT remaining_budget FROM budget_allocations WHERE grant_id = ${grantId}
-        `;
-        const remainingBudget = budgetRows[0]?.['remaining_budget'];
-        const budgetAmount = remainingBudget !== undefined ? Number(remainingBudget) : undefined;
-        if (budgetAmount !== undefined && !Number.isFinite(budgetAmount)) {
-          routeError(500, 'Invalid budget allocation', 'INTERNAL_ERROR');
-        }
+        // No `bdg` claim at issuance. A budget is attached to a grant after the
+        // fact via POST /v1/budget/allocate, which requires the grant to already
+        // exist and be active — and this grant's id was generated a few lines
+        // above, inside this same transaction. Querying budget_allocations for
+        // it could therefore never return a row; it was a guaranteed-empty
+        // round trip on every token exchange. Refresh picks the budget up once
+        // one exists.
 
         // Signing is part of the transaction boundary. A key/configuration
         // failure must not consume the one-time code or persist unusable rows.
@@ -184,7 +183,6 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
           jti,
           grnt: grantId,
           ...(audience ? { aud: audience } : {}),
-          ...(budgetAmount !== undefined ? { bdg: budgetAmount } : {}),
           exp: expTimestamp,
         }));
 

--- a/apps/auth-service/tests/vault-crypto.test.ts
+++ b/apps/auth-service/tests/vault-crypto.test.ts
@@ -106,3 +106,96 @@ describe('vault-crypto', () => {
     });
   });
 });
+
+describe('vault-crypto — key and ciphertext validation', () => {
+  const HEX_KEY = 'a'.repeat(64);
+
+  it('round-trips multi-byte UTF-8 intact', async () => {
+    mockConfig.vaultEncryptionKey = HEX_KEY;
+    const { encrypt, decrypt } = await import('../src/lib/vault-crypto.js');
+
+    // Decoding the cipher output in two pieces can split a multi-byte
+    // character across the boundary and turn each half into U+FFFD. Joining
+    // the bytes before decoding removes that dependency on cipher internals.
+    for (const secret of [
+      'ключ-значение',
+      '鍵と値',
+      '🔐🗝️ emoji secret',
+      'café — naïve — €50',
+      'x'.repeat(5000) + '🔐',
+    ]) {
+      expect(decrypt(encrypt(secret))).toBe(secret);
+      expect(decrypt(encrypt(secret))).not.toContain('�');
+    }
+  });
+
+  it('round-trips an empty string', async () => {
+    mockConfig.vaultEncryptionKey = HEX_KEY;
+    const { encrypt, decrypt } = await import('../src/lib/vault-crypto.js');
+
+    expect(decrypt(encrypt(''))).toBe('');
+  });
+
+  it('accepts a base64-encoded key', async () => {
+    mockConfig.vaultEncryptionKey = Buffer.alloc(32, 7).toString('base64');
+    const { encrypt, decrypt } = await import('../src/lib/vault-crypto.js');
+
+    expect(decrypt(encrypt('hello'))).toBe('hello');
+  });
+
+  // Buffer.from silently drops undecodable characters, so a mistyped key
+  // produced a short buffer rather than an error.
+  it.each([
+    ['too short in hex', 'a'.repeat(32)],
+    ['too long in hex', 'a'.repeat(128)],
+    ['too short in base64', Buffer.alloc(16, 1).toString('base64')],
+    ['not a key at all', 'definitely-not-a-key'],
+  ])('rejects a key that is %s', async (_label, key) => {
+    mockConfig.vaultEncryptionKey = key;
+    const { encrypt } = await import('../src/lib/vault-crypto.js');
+
+    expect(() => encrypt('hello')).toThrow(/must decode to 32 bytes/);
+  });
+
+  it('rejects ciphertext too short to hold an IV and tag', async () => {
+    mockConfig.vaultEncryptionKey = HEX_KEY;
+    const { decrypt } = await import('../src/lib/vault-crypto.js');
+
+    for (const truncated of ['', Buffer.alloc(8).toString('base64'), Buffer.alloc(27).toString('base64')]) {
+      expect(() => decrypt(truncated)).toThrow(/too short/);
+    }
+  });
+
+  it('refuses ciphertext whose tag does not authenticate', async () => {
+    mockConfig.vaultEncryptionKey = HEX_KEY;
+    const { encrypt, decrypt } = await import('../src/lib/vault-crypto.js');
+
+    const raw = Buffer.from(encrypt('sensitive'), 'base64');
+    // Flip a bit in the ciphertext body, past the 12-byte IV and 16-byte tag.
+    const last = raw.length - 1;
+    raw[last] = (raw[last] ?? 0) ^ 0xff;
+
+    expect(() => decrypt(raw.toString('base64'))).toThrow();
+  });
+
+  it('refuses ciphertext encrypted under a different key', async () => {
+    mockConfig.vaultEncryptionKey = HEX_KEY;
+    const first = await import('../src/lib/vault-crypto.js');
+    const sealed = first.encrypt('sensitive');
+
+    vi.resetModules();
+    mockConfig.vaultEncryptionKey = 'b'.repeat(64);
+    const second = await import('../src/lib/vault-crypto.js');
+
+    expect(() => second.decrypt(sealed)).toThrow();
+  });
+
+  it('produces a distinct ciphertext each time', async () => {
+    mockConfig.vaultEncryptionKey = HEX_KEY;
+    const { encrypt } = await import('../src/lib/vault-crypto.js');
+
+    // A reused IV under GCM is catastrophic, so the random IV must actually vary.
+    const seen = new Set(Array.from({ length: 20 }, () => encrypt('same input')));
+    expect(seen.size).toBe(20);
+  });
+});

--- a/packages/gateway/src/proxy.ts
+++ b/packages/gateway/src/proxy.ts
@@ -12,10 +12,14 @@ export interface ProxyOptions {
  * Headers that describe *this* hop and must not be relayed to the next one
  * (RFC 9110 §7.6.1), plus the two the gateway replaces itself.
  *
- * `content-length` and `content-encoding` are dropped deliberately: the body is
- * re-serialized below, so the inbound values describe bytes that no longer
- * exist. Forwarding a stale content-length makes the upstream read a truncated
- * body or block waiting for bytes that never arrive.
+ * `content-encoding` is deliberately *not* here: the body is relayed byte for
+ * byte, so an inbound `gzip` still describes it accurately and the upstream
+ * needs it to decode.
+ *
+ * `content-length` is dropped so fetch derives it from the body it actually
+ * sends. A forwarded length can disagree with reality — a caller passing an
+ * already-parsed object gets re-serialized here — and a stale one makes the
+ * upstream read a truncated body or block waiting for bytes that never arrive.
  */
 const HOP_BY_HOP_REQUEST_HEADERS = new Set([
   'authorization',
@@ -29,7 +33,6 @@ const HOP_BY_HOP_REQUEST_HEADERS = new Set([
   'transfer-encoding',
   'upgrade',
   'content-length',
-  'content-encoding',
   'expect',
 ]);
 
@@ -49,17 +52,20 @@ const SUPPRESSED_RESPONSE_HEADERS = new Set([
 ]);
 
 /**
- * Serialize the body Fastify parsed back into something the upstream can read.
+ * Hand the upstream exactly what the client sent.
  *
- * The gateway registers a `*` parser with `parseAs: 'string'`, so anything that
- * is not JSON arrives as a raw string and must be forwarded verbatim —
- * `JSON.stringify` would wrap it in quotes and escape it, turning `a=1&b=2`
- * into `"a=1&b=2"` and breaking every form-encoded and text/plain upstream.
+ * The gateway parses every content type as a buffer, so the normal path here is
+ * the passthrough: relay those bytes untouched. Decoding them to a string first
+ * would corrupt any non-UTF-8 payload, and `JSON.stringify` would wrap a
+ * form-encoded body in quotes, turning `a=1&b=2` into `"a=1&b=2"`.
+ *
+ * Strings and plain objects are still handled so a caller that supplies an
+ * already-parsed body — as the tests do — behaves sensibly.
  */
-function serializeBody(body: unknown): string | undefined {
+function serializeBody(body: unknown): string | Buffer | undefined {
   if (body === undefined || body === null) return undefined;
+  if (Buffer.isBuffer(body)) return body;
   if (typeof body === 'string') return body;
-  if (Buffer.isBuffer(body)) return body.toString('utf-8');
   return JSON.stringify(body);
 }
 

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -9,16 +9,22 @@ import { log } from './logger.js';
 export function createGatewayServer(config: GatewayConfig): FastifyInstance {
   const app = Fastify({ logger: false });
 
-  // Capture raw body for proxying
-  app.addContentTypeParser('*', { parseAs: 'string' }, (_req, body, done) => {
+  // Capture the raw body so it can be relayed byte for byte.
+  //
+  // Parsing as a string decoded every request as UTF-8, which silently destroys
+  // any body that is not valid UTF-8 — a gzipped payload, an image, protobuf.
+  // Those bytes cannot be recovered afterwards, so the upstream received
+  // mojibake. A buffer keeps the payload intact, and the gateway never needs to
+  // look inside it: routing decisions use only the method and path.
+  //
+  // The built-in application/json and text/plain parsers are removed first;
+  // they take precedence over a '*' catch-all, so leaving them in place would
+  // let JSON be parsed and re-serialized — reordering keys, dropping the
+  // client's exact bytes, and rejecting payloads a proxy has no business
+  // validating.
+  app.removeAllContentTypeParsers();
+  app.addContentTypeParser('*', { parseAs: 'buffer' }, (_req, body, done) => {
     done(null, body);
-  });
-  app.addContentTypeParser('application/json', { parseAs: 'string' }, (_req, body, done) => {
-    try {
-      done(null, JSON.parse(body as string));
-    } catch {
-      done(null, body);
-    }
   });
 
   // Catch-all route

--- a/packages/gateway/tests/proxy.test.ts
+++ b/packages/gateway/tests/proxy.test.ts
@@ -161,7 +161,6 @@ describe('proxyRequest', () => {
       headers: {
         'content-type': 'application/json',
         'content-length': '9999',
-        'content-encoding': 'gzip',
       },
       body: { summary: 'Meeting' },
     });
@@ -170,8 +169,54 @@ describe('proxyRequest', () => {
     });
 
     const headers = vi.mocked(fetch).mock.calls[0]![1]?.headers as Record<string, string>;
+    // fetch derives the length from what it actually sends.
     expect(headers['content-length']).toBeUndefined();
-    expect(headers['content-encoding']).toBeUndefined();
+  });
+
+  it('relays a binary body byte for byte', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      headers: { entries: () => [].values() },
+      text: () => Promise.resolve(''),
+    }));
+
+    // Bytes that are not valid UTF-8. Decoding them to a string would replace
+    // each with U+FFFD and the original could never be recovered.
+    const binary = Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0xff, 0xfe, 0x00, 0x80]);
+    const req = mockReq({
+      method: 'POST',
+      headers: { 'content-type': 'application/octet-stream', 'content-encoding': 'gzip' },
+      body: binary,
+    });
+    await proxyRequest(req, mockReply(), MOCK_GRANT, {
+      upstream: 'https://api.internal.com',
+    });
+
+    const sent = vi.mocked(fetch).mock.calls[0]![1]?.body;
+    expect(Buffer.isBuffer(sent)).toBe(true);
+    expect(Buffer.compare(sent as Buffer, binary)).toBe(0);
+    expect(Buffer.from(String(sent), 'utf-8').equals(binary)).toBe(false);
+  });
+
+  it('forwards content-encoding, because the body is relayed unchanged', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      headers: { entries: () => [].values() },
+      text: () => Promise.resolve(''),
+    }));
+
+    const req = mockReq({
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'content-encoding': 'gzip' },
+      body: Buffer.from([0x1f, 0x8b, 0x08]),
+    });
+    await proxyRequest(req, mockReply(), MOCK_GRANT, {
+      upstream: 'https://api.internal.com',
+    });
+
+    const headers = vi.mocked(fetch).mock.calls[0]![1]?.headers as Record<string, string>;
+    // Dropping this would leave the upstream unable to decode the payload.
+    expect(headers['content-encoding']).toBe('gzip');
   });
 
   it('strips hop-by-hop request headers', async () => {

--- a/packages/gateway/tests/server.test.ts
+++ b/packages/gateway/tests/server.test.ts
@@ -223,3 +223,90 @@ describe('path handling', () => {
     expect(proxyRequest).toHaveBeenCalled();
   });
 });
+
+describe('request body handling', () => {
+  let server: ReturnType<typeof createGatewayServer>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    server = createGatewayServer(CONFIG);
+    vi.mocked(proxyRequest).mockResolvedValue(undefined);
+    vi.mocked(verifyGrantToken).mockResolvedValue(MOCK_GRANT);
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  function bodyGivenToProxy(): unknown {
+    return (vi.mocked(proxyRequest).mock.calls[0]![0] as { body: unknown }).body;
+  }
+
+  // The content-type parser used to decode every body as UTF-8. Bytes that are
+  // not valid UTF-8 became U+FFFD and were unrecoverable by the time the proxy
+  // saw them, so the upstream received mojibake.
+  it('preserves a non-UTF-8 body through the parser', async () => {
+    const binary = Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0xff, 0xfe, 0x00, 0x80, 0xc3, 0x28]);
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/calendar/events',
+      headers: {
+        authorization: 'Bearer token',
+        'content-type': 'application/octet-stream',
+      },
+      payload: binary,
+    });
+
+    expect(response.statusCode).not.toBe(400);
+    const received = bodyGivenToProxy();
+    expect(Buffer.isBuffer(received)).toBe(true);
+    expect(Buffer.compare(received as Buffer, binary)).toBe(0);
+  });
+
+  it('preserves a JSON body exactly as sent, without reformatting', async () => {
+    // Key order and whitespace survive, so a body the client signed still
+    // hashes to the same value downstream.
+    const raw = '{"b":2,  "a":1}';
+
+    await server.inject({
+      method: 'POST',
+      url: '/calendar/events',
+      headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+      payload: raw,
+    });
+
+    const received = bodyGivenToProxy();
+    expect(Buffer.isBuffer(received)).toBe(true);
+    expect((received as Buffer).toString('utf-8')).toBe(raw);
+  });
+
+  it('preserves a form-encoded body', async () => {
+    const raw = 'summary=Meeting&when=today';
+
+    await server.inject({
+      method: 'POST',
+      url: '/calendar/events',
+      headers: {
+        authorization: 'Bearer token',
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      payload: raw,
+    });
+
+    expect((bodyGivenToProxy() as Buffer).toString('utf-8')).toBe(raw);
+  });
+
+  it('still accepts a malformed JSON body rather than rejecting it', async () => {
+    // A proxy has no business validating the payload; that is the upstream's call.
+    const response = await server.inject({
+      method: 'POST',
+      url: '/calendar/events',
+      headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+      payload: '{not valid json',
+    });
+
+    expect(response.statusCode).not.toBe(400);
+    expect((bodyGivenToProxy() as Buffer).toString('utf-8')).toBe('{not valid json');
+  });
+});


### PR DESCRIPTION
The last three items from the review sweep.

## 1. Gateway corrupted every non-UTF-8 request body

Bodies were parsed with `parseAs: 'string'`, decoding the bytes as UTF-8. Anything that isn't valid UTF-8 — a gzipped payload, an image, protobuf — had each bad sequence replaced with U+FFFD, and the original bytes were **unrecoverable** by the time the proxy saw them.

The built-in `application/json` parser made it worse in a quieter way: JSON was parsed and re-serialized, so key order and whitespace changed. A body the client had signed no longer hashed to the same value downstream. Malformed JSON was rejected outright — by a component that has no business validating payloads.

The gateway never reads the parsed body (routing uses only method and path), so **all** parsers are removed and a single `*` buffer parser keeps the payload intact for a byte-for-byte relay.

`removeAllContentTypeParsers()` is required here: Fastify's built-in `application/json` and `text/plain` parsers take precedence over a `*` catch-all, so adding the catch-all alone would have left JSON still being reformatted. I only caught that because a test asserted on the exact bytes.

**One earlier decision reversed:** PR #887 dropped `content-encoding` because the body was being re-serialized, which made the declared encoding a lie. Now that bytes pass through unchanged the encoding is accurate again and the upstream needs it to decode — so it's forwarded, and the test asserting it was dropped is updated. `content-length` stays dropped so fetch derives it from what it actually sends.

## 2. Dead budget query on every token exchange

```js
SELECT remaining_budget FROM budget_allocations WHERE grant_id = ${grantId}
```

`grantId` is a ULID generated a few lines above and inserted in the *same transaction*. A budget is only attached via `POST /v1/budget/allocate`, which requires the grant to already exist and be active — I checked, that's the only `INSERT INTO budget_allocations` in the codebase. So this could never return a row: a guaranteed-empty round trip on every token exchange, and a `bdg` claim that was never once emitted.

Removed. The refresh path still picks a budget up once one exists, which is where it legitimately can.

## 3. vault-crypto decrypt

`decipher.update(buf) + decipher.final('utf8')` leans on `Buffer`'s implicit `toString()` and decodes the two parts **separately**. That holds for GCM, which is a stream cipher and never withholds a partial block — but any buffering mode would split a multi-byte character across the boundary and decode each half to U+FFFD. Bytes are now joined before a single decode, removing the dependency on cipher internals.

Also added: the key must decode to 32 bytes (`Buffer.from` silently drops characters it can't decode, so a mistyped key produced a short buffer and an opaque `Invalid key length` from inside `createCipheriv`), and ciphertext must be long enough to hold an IV and tag.

## Test plan

| Suite | Result |
|---|---|
| `packages/gateway` | 67 passed (+6) |
| `apps/auth-service` | 2049 passed (+11) |
| `packages/sdk-ts` | 433 passed |

`tsc --noEmit` clean on both packages.

New coverage: a non-UTF-8 body surviving the real Fastify parser end to end; JSON preserved byte-exact including key order and whitespace; form-encoded preserved; malformed JSON passed through rather than rejected; `content-encoding` forwarded; multi-byte UTF-8 round-tripping through encrypt/decrypt (Cyrillic, CJK, emoji, a 5 KB mixed string) with an explicit assertion that no U+FFFD appears; key-length rejection across four malformed shapes; short-ciphertext rejection; tampered-tag and wrong-key rejection; and 20 encryptions of identical input producing 20 distinct ciphertexts, since a reused IV under GCM is catastrophic.
