### PR TITLE
fix(auth): preserve audit hash verification across metadata encodings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,22 @@ jobs:
   auth-service:
     name: Auth Service
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: grantex_test
+          POSTGRES_PASSWORD: grantex_test
+          POSTGRES_DB: grantex_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U grantex_test -d grantex_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      AUDIT_INTEGRATION_DATABASE_URL: postgres://grantex_test:grantex_test@127.0.0.1:5432/grantex_test
     defaults:
       run:
         working-directory: apps/auth-service

--- a/apps/auth-service/scripts/audit-chain-forensics.mjs
+++ b/apps/auth-service/scripts/audit-chain-forensics.mjs
@@ -1,0 +1,630 @@
+#!/usr/bin/env node
+/**
+ * Audit-chain forensics — explain WHY a stored audit hash no longer verifies,
+ * and distinguish a benign format/encoding artifact from genuine tampering.
+ *
+ * STRICTLY READ-ONLY. One SELECT inside `SET TRANSACTION READ ONLY`. It never
+ * writes, never migrates, and never recomputes-and-stores a hash. Rewriting
+ * historical hashes on a tamper-evident log destroys the only property the log
+ * exists to provide, so this tool deliberately cannot do it.
+ *
+ * ── Root cause this tool was built to characterize ───────────────────────────
+ * routes/audit.ts:101 passes `${JSON.stringify(metadata)}` into a JSONB column.
+ * That double-encodes. postgres.js sets `describeFirst` when a query has
+ * parameters (connection.js:238), asks the server to resolve parameter types,
+ * then applies that type's serializer (connection.js:959). The jsonb serializer
+ * is `JSON.stringify` (types.js:19). So the already-stringified value is
+ * stringified a second time and the column holds a JSONB *string*:
+ *
+ *     jsonb_typeof(metadata) = 'string'
+ *     metadata::text         = "{\"amount\":10}"      <- note the quoting
+ *
+ * Verified empirically against real Postgres 16 — see jsonb-writeback-probe.mjs.
+ * `sql.json(metadata)` and passing the raw object both store a proper object.
+ *
+ * Consequence: `computeAuditHash` receives an object at write time and a STRING
+ * at read time, so verifyChain (compliance.ts) fails on the very first entry,
+ * for every row ever written, including rows written seconds ago. This is an
+ * encoding defect, not evidence of tampering.
+ *
+ * ── Why the stored string is good news ───────────────────────────────────────
+ * Because audit.ts:101 has stored `JSON.stringify(metadata)` since the service's
+ * first commit (813ee176) and was never changed, the stored text preserves the
+ * ORIGINAL JS insertion order — the exact bytes that went into the hash. Legacy
+ * rows are therefore verifiable EXACTLY, with no guessing: splice the stored
+ * string back in. No permutation search is needed for string-encoded rows.
+ *
+ * ── Hash format history (independent of the encoding defect) ────────────────
+ *   Era A  813ee176 .. ede8b7ca^   (.. 2026-02-26)
+ *          JSON.stringify({ …, metadata, timestamp, previousHash })
+ *          Key is `previousHash`. No `status` field at all.
+ *   Era B  ede8b7ca .. 903f0aee^   (2026-02-26 .. 2026-08-12)
+ *          `prevHash` replaces `previousHash`; `status` appended.
+ *          Metadata serialized in JS insertion order.
+ *   Era C  903f0aee .. HEAD        (2026-08-12 ..)
+ *          Field-by-field concatenation with canonically key-sorted metadata.
+ *          Byte-identical to Era B when metadata is empty, single-key, or was
+ *          already written in sorted order.
+ *
+ * Eras A and B hash metadata in insertion order; Era C canonicalizes it. Given
+ * the stored string, both are checkable exactly — verbatim for A/B, parse-then-
+ * canonicalize for C.
+ *
+ * ── Usage ────────────────────────────────────────────────────────────────────
+ *   node apps/auth-service/scripts/audit-chain-forensics.mjs \
+ *     --url "$DATABASE_URL" --developer dev_abc123 --limit 20
+ *
+ *   node apps/auth-service/scripts/audit-chain-forensics.mjs --file rows.json
+ *
+ * Cloud SQL private instances need the Auth Proxy first:
+ *   cloud-sql-proxy --port 5433 grantex-prod:us-central1:<instance>
+ *   ... then --url "postgres://user:pw@127.0.0.1:5433/dbname"
+ *
+ * Flags:
+ *   --url <conn>       Postgres connection string (default: $DATABASE_URL)
+ *   --file <path>      Read rows from a JSON array instead of a database
+ *   --developer <id>   Restrict to one developer. Chains are per-developer, so
+ *                      without this, linkage across tenants is NOT checked.
+ *   --limit <n>        Rows to examine, oldest first (default 20, 0 = all)
+ *   --budget <n>       Cap on the permutation fallback, used only for rows whose
+ *                      metadata is stored as an object (default 200000)
+ *   --show-metadata    Print metadata values. Off by default — audit metadata is
+ *                      customer data and this output tends to land in logs.
+ *   --json             Machine-readable output
+ *
+ * Exit codes: 0 = ran successfully (regardless of findings), 1 = usage or
+ * connection error. Findings are never an error exit; this is a diagnostic.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+// ─── args ─────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const out = {
+    url: process.env['DATABASE_URL'] ?? null,
+    file: null,
+    developer: null,
+    limit: 20,
+    budget: 200000,
+    showMetadata: false,
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case '--url': out.url = argv[++i]; break;
+      case '--file': out.file = argv[++i]; break;
+      case '--developer': out.developer = argv[++i]; break;
+      case '--limit': out.limit = Number(argv[++i]); break;
+      case '--budget': out.budget = Number(argv[++i]); break;
+      case '--show-metadata': out.showMetadata = true; break;
+      case '--json': out.json = true; break;
+      case '--help': case '-h': out.help = true; break;
+      default: throw new Error(`unknown flag: ${a}`);
+    }
+  }
+  if (!Number.isSafeInteger(out.limit) || out.limit < 0) throw new Error('--limit must be a non-negative integer');
+  if (!Number.isSafeInteger(out.budget) || out.budget < 1) throw new Error('--budget must be a positive integer');
+  return out;
+}
+
+// ─── the three historical hash formats ────────────────────────────────────────
+// Each takes an already-serialized metadata string, so the caller controls which
+// candidate serialization is being tested.
+
+const sha256hex = (input) => createHash('sha256').update(input).digest('hex');
+const S = JSON.stringify;
+
+function prefix(f) {
+  return '{'
+    + `"id":${S(f.id)},`
+    + `"agentId":${S(f.agentId)},`
+    + `"agentDid":${S(f.agentDid)},`
+    + `"grantId":${S(f.grantId)},`
+    + `"principalId":${S(f.principalId)},`
+    + `"developerId":${S(f.developerId)},`
+    + `"action":${S(f.action)},`;
+}
+
+/** Era A — `previousHash`, no `status`. */
+const hashEraA = (f, metaJson) => sha256hex(prefix(f)
+  + `"metadata":${metaJson},"timestamp":${S(f.timestamp)},"previousHash":${S(f.prevHash ?? null)}}`);
+
+/** Era B — `prevHash` + `status`. */
+const hashEraB = (f, metaJson) => sha256hex(prefix(f)
+  + `"metadata":${metaJson},"timestamp":${S(f.timestamp)},"prevHash":${S(f.prevHash ?? null)},"status":${S(f.status)}}`);
+
+/** Era C — current production format (src/lib/hash.ts). Same shape as B; the
+ *  difference lives entirely in which metadata serialization is supplied. */
+const hashEraC = hashEraB;
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== 'object') return S(value) ?? 'null';
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  const entries = Object.entries(value)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([k, v]) => `${S(k)}:${canonicalJson(v)}`).join(',')}}`;
+}
+
+/**
+ * dist/ is consulted only as a drift check. It is never used for verdicts: if
+ * that build predates PR #887 it *is* an Era B implementation, and deferring to
+ * it would report legacy rows as verifying — the exact false negative this tool
+ * exists to prevent.
+ */
+async function distDriftCheck() {
+  const probe = {
+    id: 'alog_probe', agentId: 'ag', agentDid: 'did:grantex:ag', grantId: 'g',
+    principalId: 'p', developerId: 'd', action: 'a',
+    timestamp: '2026-01-01T00:00:00.000Z', prevHash: null, status: 'success',
+  };
+  const meta = { zebra: 1, alpha: { yankee: true, bravo: [3, 2] } };
+  try {
+    const mod = await import('../dist/lib/hash.js');
+    if (typeof mod.computeAuditHash !== 'function') throw new Error('no export');
+    const distHash = mod.computeAuditHash({ ...probe, metadata: meta });
+    return distHash === hashEraC(probe, canonicalJson(meta))
+      ? 'dist/lib/hash.js agrees'
+      : 'DRIFT: dist/lib/hash.js is stale (pre-#887). Not used; rebuild to clear.';
+  } catch {
+    return 'dist/ absent — drift check skipped';
+  }
+}
+
+// ─── metadata: encoding + candidate serializations ────────────────────────────
+
+/**
+ * Rows may hold metadata as a JSONB string (every row written by audit.ts:101)
+ * or as a proper object (rows written via sql.json, i.e. after the fix). Both
+ * must be handled, and the string form must be PARSED before canonical hashing —
+ * treating it as an opaque string is what produces false "tampered" verdicts.
+ */
+function classifyMetadata(raw) {
+  if (typeof raw === 'string') {
+    try {
+      return { encoding: 'string', parsed: JSON.parse(raw), storedText: raw, parseError: false };
+    } catch {
+      // JSON.parse error messages include a snippet of the input on current
+      // Node versions. Store only a boolean so default output cannot leak data.
+      return { encoding: 'string', parsed: null, storedText: raw, parseError: true };
+    }
+  }
+  if (raw === null || raw === undefined) return { encoding: 'object', parsed: {}, storedText: null, parseError: false };
+  if (typeof raw === 'object') return { encoding: Array.isArray(raw) ? 'array' : 'object', parsed: raw, storedText: null, parseError: false };
+  return { encoding: typeof raw, parsed: raw, storedText: null, parseError: false };
+}
+
+const ORDERINGS = {
+  'as-stored order': null,
+  'lexicographic': (a, b) => (a < b ? -1 : a > b ? 1 : 0),
+  'reverse-lexicographic': (a, b) => (a < b ? 1 : a > b ? -1 : 0),
+  'length-then-bytes': (a, b) => a.length - b.length || (a < b ? -1 : a > b ? 1 : 0),
+};
+
+function serializeWithOrder(value, cmp) {
+  if (value === null || typeof value !== 'object') return S(value) ?? 'null';
+  if (Array.isArray(value)) return `[${value.map((v) => serializeWithOrder(v, cmp)).join(',')}]`;
+  let keys = Object.keys(value).filter((k) => value[k] !== undefined);
+  if (cmp) keys = keys.slice().sort(cmp);
+  return `{${keys.map((k) => `${S(k)}:${serializeWithOrder(value[k], cmp)}`).join(',')}}`;
+}
+
+/**
+ * Ordered candidate serializations, best-evidence first.
+ *
+ * For a string-encoded row the FIRST candidate is the stored text verbatim.
+ * That is not a guess: audit.ts:101 wrote exactly `JSON.stringify(metadata)`,
+ * the same call whose output Eras A and B embedded in the hash, so the bytes
+ * are identical and the match is exact.
+ */
+function metadataCandidates(meta) {
+  const out = [];
+  const seen = new Set();
+  const add = (label, json) => {
+    if (json === null || seen.has(json)) return;
+    seen.add(json);
+    out.push({ label, json });
+  };
+  if (meta.encoding === 'string' && meta.storedText !== null) {
+    add('stored string verbatim (exact — original insertion order)', meta.storedText);
+  }
+  if (meta.parsed !== null && typeof meta.parsed === 'object') {
+    add('parsed + canonicalized', canonicalJson(meta.parsed));
+    for (const [name, cmp] of Object.entries(ORDERINGS)) add(`parsed, ${name}`, serializeWithOrder(meta.parsed, cmp));
+  } else if (meta.parsed !== null) {
+    add('scalar', S(meta.parsed));
+  }
+  // Only meaningful if metadata was somehow stored as a raw string that is not
+  // valid JSON; kept so such a row still gets an exact check rather than a guess.
+  if (meta.encoding === 'string' && meta.parseError) add('stored string as opaque scalar', S(meta.storedText));
+  return out;
+}
+
+// ─── bounded permutation fallback (object-encoded rows only) ─────────────────
+
+class BudgetExceeded extends Error {}
+const makeBudget = (cap) => { let n = 0; return { spend() { if (++n > cap) throw new BudgetExceeded(); }, used: () => n }; };
+
+function* permute(arr) {
+  if (arr.length <= 1) { yield arr.slice(); return; }
+  for (let i = 0; i < arr.length; i++) {
+    for (const p of permute(arr.slice(0, i).concat(arr.slice(i + 1)))) yield [arr[i], ...p];
+  }
+}
+
+function* crossProduct(lists) {
+  if (lists.length === 0) { yield []; return; }
+  const [first, ...rest] = lists;
+  for (const item of first) for (const combo of crossProduct(rest)) yield [item, ...combo];
+}
+
+function* serializations(value, budget) {
+  if (value === null || typeof value !== 'object') { yield S(value) ?? 'null'; return; }
+  if (Array.isArray(value)) {
+    const lists = value.map((v) => Array.from(serializations(v, budget)));
+    for (const combo of crossProduct(lists)) { budget.spend(); yield `[${combo.join(',')}]`; }
+    return;
+  }
+  const keys = Object.keys(value).filter((k) => value[k] !== undefined);
+  if (keys.length === 0) { yield '{}'; return; }
+  const perKey = new Map(keys.map((k) => [k, Array.from(serializations(value[k], budget))]));
+  for (const perm of permute(keys)) {
+    const lists = perm.map((k) => perKey.get(k).map((s) => `${S(k)}:${s}`));
+    for (const combo of crossProduct(lists)) { budget.spend(); yield `{${combo.join(',')}}`; }
+  }
+}
+
+// ─── timestamp candidates ─────────────────────────────────────────────────────
+
+function timestampCandidates(row) {
+  const raw = row.ts_raw ?? null;
+  const value = row.timestamp;
+  const date = value instanceof Date ? value : new Date(String(value));
+  const out = new Set();
+  if (!Number.isNaN(date.getTime())) {
+    const iso = date.toISOString();
+    out.add(iso);
+    if (iso.endsWith('.000Z')) out.add(iso.replace('.000Z', 'Z'));
+  }
+  if (typeof value === 'string') out.add(value);
+  if (raw) out.add(raw);
+  return { candidates: [...out], subMillisecond: typeof raw === 'string' && /\.\d{4,}/.test(raw) };
+}
+
+// ─── row loading ──────────────────────────────────────────────────────────────
+
+async function loadFromDatabase(opts) {
+  let postgres;
+  try { ({ default: postgres } = await import('postgres')); }
+  catch { throw new Error('cannot resolve the `postgres` package — run with apps/auth-service dependencies installed'); }
+  const sql = postgres(opts.url, { max: 1, idle_timeout: 5, connect_timeout: 10 });
+  try {
+    return await sql.begin(async (tx) => {
+      // Belt and braces: even a bug in this script cannot write to production.
+      await tx`SET TRANSACTION READ ONLY`;
+      const dev = opts.developer;
+      const lim = opts.limit === 0 ? 2147483647 : opts.limit;
+      return await tx`
+        SELECT id, agent_id, agent_did, grant_id, principal_id, developer_id,
+               action, metadata, hash, previous_hash, timestamp, status,
+               timestamp::text        AS ts_raw,
+               jsonb_typeof(metadata) AS meta_type
+        FROM audit_entries
+        WHERE (${dev}::text IS NULL OR developer_id = ${dev ?? ''})
+        -- Mirrors the export endpoint's chain order exactly (compliance.ts:375).
+        ORDER BY timestamp ASC, id ASC
+        LIMIT ${lim}
+      `;
+    });
+  } finally {
+    await sql.end();
+  }
+}
+
+/**
+ * File mode applies the same developer filter, ordering and limit as the SQL
+ * path, so a dump and a live query produce the same analysis for the same input.
+ */
+function loadFromFile(path, opts) {
+  const parsed = JSON.parse(readFileSync(path, 'utf8'));
+  if (!Array.isArray(parsed)) throw new Error('--file must contain a JSON array of audit_entries rows');
+  let rows = parsed;
+  if (opts.developer) rows = rows.filter((r) => r.developer_id === opts.developer);
+  rows = rows.slice().sort((a, b) => {
+    const av = a.timestamp instanceof Date ? a.timestamp.getTime() : Date.parse(String(a.timestamp));
+    const bv = b.timestamp instanceof Date ? b.timestamp.getTime() : Date.parse(String(b.timestamp));
+    const byTime = Number.isFinite(av) && Number.isFinite(bv)
+      ? av - bv
+      : String(a.ts_raw ?? a.timestamp).localeCompare(String(b.ts_raw ?? b.timestamp));
+    return byTime || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
+  });
+  return opts.limit === 0 ? rows : rows.slice(0, opts.limit);
+}
+
+const toFields = (row, timestamp) => ({
+  id: row.id,
+  agentId: row.agent_id,
+  agentDid: row.agent_did,
+  grantId: row.grant_id,
+  principalId: row.principal_id,
+  developerId: row.developer_id,
+  action: row.action,
+  timestamp,
+  prevHash: row.previous_hash ?? null,
+  status: row.status ?? 'success',
+});
+
+// ─── analysis ─────────────────────────────────────────────────────────────────
+
+/**
+ * Era B and Era C share one hash function — the ONLY difference between them is
+ * whether metadata went in as insertion-order or canonically sorted bytes. So
+ * the era cannot be read off which function matched; it must be derived from
+ * which candidate serialization matched. When the two coincide (empty,
+ * single-key, or already-sorted metadata) the row is genuinely ambiguous and is
+ * reported as such rather than guessed.
+ */
+function deriveBCEra(matchedJson, meta) {
+  const canonical = meta.parsed !== null && typeof meta.parsed === 'object' ? canonicalJson(meta.parsed) : null;
+  if (matchedJson === canonical) {
+    // A JSONB object has already lost its original insertion order, so a
+    // canonical-byte match could have been written by either B or C. A legacy
+    // string is the only representation that preserves enough evidence to
+    // distinguish them when its bytes differ from canonical.
+    if (meta.encoding !== 'string') return 'B/C';
+    return matchedJson === meta.storedText ? 'B/C' : 'C';
+  }
+  return 'B';
+}
+
+function analyzeRow(row, budgetCap) {
+  const { candidates: timestamps, subMillisecond } = timestampCandidates(row);
+  const meta = classifyMetadata(row.metadata);
+  const metaCandidates = metadataCandidates(meta);
+
+  const result = {
+    id: row.id,
+    developerId: row.developer_id,
+    timestamp: row.ts_raw ?? String(row.timestamp),
+    metaEncoding: row.meta_type ?? meta.encoding,
+    metaKeys: meta.parsed && typeof meta.parsed === 'object' && !Array.isArray(meta.parsed) ? Object.keys(meta.parsed) : [],
+    metadata: meta.parsed,
+    metaParseError: meta.parseError ? 'invalid_json' : null,
+    storedHash: row.hash,
+    previousHash: row.previous_hash ?? null,
+    subMillisecond,
+    era: null,
+    via: null,
+    timestampUsed: null,
+    truncated: false,
+  };
+
+  // Exact candidates first — for string-encoded rows these are not guesses.
+  // Era A is a distinct field layout (previousHash, no status) so it is tested
+  // on its own; B and C share a layout and are separated by deriveBCEra.
+  for (const ts of timestamps) {
+    const fields = toFields(row, ts);
+    for (const cand of metaCandidates) {
+      if (hashEraA(fields, cand.json) === row.hash) {
+        return { ...result, era: 'A', via: cand.label, timestampUsed: ts };
+      }
+    }
+    for (const cand of metaCandidates) {
+      if (hashEraB(fields, cand.json) === row.hash) {
+        return { ...result, era: deriveBCEra(cand.json, meta), via: cand.label, timestampUsed: ts };
+      }
+    }
+  }
+
+  // Fallback: only object-encoded rows can have lost their original key order,
+  // so only they justify a search. String-encoded rows are already exact above.
+  if (meta.encoding !== 'string' && meta.parsed && typeof meta.parsed === 'object') {
+    for (const ts of timestamps) {
+      const fields = toFields(row, ts);
+      for (const [era, fn] of [['A', hashEraA], ['BC', hashEraB]]) {
+        const budget = makeBudget(budgetCap);
+        try {
+          for (const metaJson of serializations(meta.parsed, budget)) {
+            if (fn(fields, metaJson) === row.hash) {
+              return {
+                ...result,
+                era: era === 'A' ? 'A' : deriveBCEra(metaJson, meta),
+                via: 'recovered by permutation search',
+                timestampUsed: ts,
+              };
+            }
+          }
+        } catch (err) {
+          if (err instanceof BudgetExceeded) { result.truncated = true; continue; }
+          throw err;
+        }
+      }
+    }
+  }
+
+  return result; // era stays null
+}
+
+/** Chains are per-developer. Verifying across tenants invents false breaks. */
+function linkageByDeveloper(rows) {
+  const groups = new Map();
+  for (const row of rows) {
+    if (!groups.has(row.developer_id)) groups.set(row.developer_id, []);
+    groups.get(row.developer_id).push(row);
+  }
+  const out = [];
+  for (const [dev, list] of groups) {
+    let prev = null, broken = null;
+    for (const row of list) {
+      const entryPrev = row.previous_hash ?? null;
+      if (prev !== null && entryPrev !== prev) { broken = row.id; break; }
+      prev = row.hash;
+    }
+    out.push({ developerId: dev, rows: list.length, broken });
+  }
+  return out;
+}
+
+// ─── report ───────────────────────────────────────────────────────────────────
+
+const ERA_LABEL = {
+  A: 'Era A  (pre-2026-02-26: previousHash, no status)',
+  B: 'Era B  (2026-02-26..2026-08-12: prevHash + status, insertion-order metadata)',
+  C: 'Era C  (current: canonical metadata)',
+  'B/C': 'Era B or C (indistinguishable — insertion order already equals canonical)',
+};
+
+function report(rows, results, drift, opts) {
+  const line = '─'.repeat(78);
+  console.log(`\n${line}\nAUDIT CHAIN FORENSICS\n${line}`);
+  console.log(`Rows examined : ${results.length}${opts.developer ? `  (developer ${opts.developer})` : '  (ALL developers)'}`);
+  console.log(`Era C source  : inline transcription of src/lib/hash.ts — ${drift}`);
+
+  // ── 1. storage encoding ──
+  const encCounts = results.reduce((a, r) => { a[r.metaEncoding] = (a[r.metaEncoding] ?? 0) + 1; return a; }, {});
+  console.log(`\n${line}\n1. How is metadata stored?  (the audit.ts:101 double-encoding defect)\n${line}`);
+  for (const [t, n] of Object.entries(encCounts)) console.log(`  jsonb_typeof = ${String(t).padEnd(8)} ${n} row(s)`);
+  const strings = encCounts['string'] ?? 0;
+  if (strings > 0) {
+    console.log(`\n  => CONFIRMED: ${strings} row(s) hold a double-encoded JSON STRING.`);
+    console.log('     audit.ts:101 passes JSON.stringify(metadata) into a JSONB parameter;');
+    console.log('     postgres.js then applies the jsonb serializer (JSON.stringify) again.');
+    console.log('     computeAuditHash sees an object on write and a string on read, so');
+    console.log('     verifyChain fails on the first entry for EVERY row ever written.');
+    console.log('     Fix the write path with sql.json(metadata) and decode on read.');
+  } else {
+    console.log('\n  => No double-encoded rows in this sample; metadata is stored as JSONB objects.');
+  }
+  const badParse = results.filter((r) => r.metaParseError);
+  if (badParse.length) {
+    console.log(`\n  !! ${badParse.length} row(s) hold a string that is not valid JSON:`);
+    for (const r of badParse.slice(0, 5)) console.log(`     - ${r.id}`);
+  }
+
+  // ── 2. era attribution ──
+  const eraCounts = results.reduce((a, r) => { const k = r.era ?? 'unmatched'; a[k] = (a[k] ?? 0) + 1; return a; }, {});
+  console.log(`\n${line}\n2. Which hash format wrote each row?\n${line}`);
+  for (const era of ['A', 'B', 'C', 'B/C']) if (eraCounts[era]) console.log(`  ${String(eraCounts[era]).padStart(4)}  ${ERA_LABEL[era]}`);
+  if (eraCounts['unmatched']) console.log(`  ${String(eraCounts['unmatched']).padStart(4)}  UNMATCHED — no historical format reproduces the stored hash`);
+  console.log('\n  Note: Eras B and C share a field layout and differ only in metadata byte');
+  console.log('  order, so rows whose insertion order already equals canonical order cannot');
+  console.log('  be attributed to one or the other and are reported as "B/C".');
+
+  // ── 3. per-row ──
+  console.log(`\n${line}\n3. Per-row detail (oldest first)\n${line}`);
+  for (const r of results) {
+    const verdict = r.era
+      ? `EXPLAINED — Era ${r.era}`
+      : r.truncated ? 'INCONCLUSIVE (search budget exhausted)' : 'UNEXPLAINED';
+    console.log(`\n  ${r.id}   ${r.timestamp}   [${r.developerId}]`);
+    console.log(`    verdict     : ${verdict}`);
+    console.log(`    metadata    : ${r.metaEncoding}${r.metaKeys.length ? ` — ${r.metaKeys.length} key(s): ${r.metaKeys.join(', ')}` : ' — empty'}`);
+    if (r.era) console.log(`    matched via : ${r.via}`);
+    if (r.subMillisecond) {
+      console.log('    NOTE        : sub-millisecond timestamp (column DEFAULT NOW()); a JS Date');
+      console.log('                  cannot represent it, so the hashed string is unrecoverable.');
+    }
+    if (opts.showMetadata) console.log(`    value       : ${S(r.metadata)}`);
+  }
+
+  // ── 4. linkage ──
+  console.log(`\n${line}\n4. Linkage (previous_hash chaining, per developer)\n${line}`);
+  if (!opts.developer) {
+    console.log('  Chains are per-developer; each is checked separately below. Pass --developer');
+    console.log('  to scope the whole report to the tenant whose export failed.\n');
+  }
+  const linkage = linkageByDeveloper(rows);
+  for (const g of linkage) {
+    console.log(g.broken
+      ? `  ${g.developerId}: BROKEN at ${g.broken} (${g.rows} row(s)) — not explained by a format change.`
+      : `  ${g.developerId}: INTACT (${g.rows} row(s))`);
+  }
+  const anyLinkBreak = linkage.some((g) => g.broken);
+
+  // ── 5. conclusion ──
+  console.log(`\n${line}\n5. Conclusion\n${line}`);
+  const unexplained = results.filter((r) => r.era === null && !r.truncated);
+  const inconclusive = results.filter((r) => r.truncated);
+
+  if (unexplained.length) {
+    console.log(`  ${unexplained.length} row(s) match NO historical format under any candidate`);
+    console.log('  serialization. That is not explained by the encoding defect or the format');
+    console.log('  history, and warrants investigation:');
+    for (const r of unexplained.slice(0, 10)) console.log(`    - ${r.id}  ${r.timestamp}  [${r.developerId}]`);
+  } else if (inconclusive.length) {
+    console.log(`  ${inconclusive.length} row(s) exhausted the search budget and are INCONCLUSIVE,`);
+    console.log('  not negative. Re-run with a larger --budget before drawing any conclusion.');
+  } else if (strings > 0) {
+    console.log('  Every row is explained. The verification failure is the audit.ts:101');
+    console.log('  double-encoding defect, not tampering.');
+    console.log('');
+    console.log('  Because the stored string preserves the original insertion order, these');
+    console.log('  hashes remain checkable EXACTLY. The remediation is therefore:');
+    console.log('    1. Write new metadata with sql.json(metadata).');
+    console.log('    2. Decode string-encoded metadata on read and in verifyChain.');
+    console.log('    3. Verify mixed chains era-aware (A/B verbatim, C parse-then-canonical).');
+    console.log('');
+    console.log('  Do NOT migrate stored metadata from string to object. Converting it lets');
+    console.log('  Postgres normalize key order, destroying the insertion order that Era A/B');
+    console.log('  hashes are taken over, and permanently breaking rows that verify today.');
+  } else {
+    console.log('  Every row examined verifies under a known format with no encoding defect');
+    console.log('  present. The production failure is not reproduced by this sample — widen');
+    console.log('  --limit, or confirm the export ran against this same developer_id.');
+  }
+  if (anyLinkBreak) {
+    console.log('\n  Linkage is broken for at least one developer. Linkage is independent of');
+    console.log('  content hashing and is NOT affected by the encoding defect — treat it as a');
+    console.log('  genuine integrity finding (tampering or row deletion) until shown otherwise.');
+  }
+  console.log('');
+}
+
+// ─── main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  let opts;
+  try { opts = parseArgs(process.argv.slice(2)); }
+  catch (err) {
+    console.error(`error: ${err.message}\n`);
+    console.error('usage: audit-chain-forensics.mjs [--url <conn> | --file <path>] [--developer <id>] [--limit <n>]');
+    process.exit(1);
+  }
+  if (opts.help) {
+    console.log(readFileSync(new URL(import.meta.url), 'utf8').split('*/')[0].replace(/^#!.*\n/, ''));
+    return;
+  }
+
+  let rows;
+  try {
+    if (opts.file) rows = loadFromFile(opts.file, opts);
+    else if (opts.url) rows = await loadFromDatabase(opts);
+    else throw new Error('no data source — pass --url, --file, or set DATABASE_URL');
+  } catch (err) {
+    console.error(`error: ${err.message}`);
+    process.exit(1);
+  }
+
+  if (rows.length === 0) { console.log('No audit entries matched. Nothing to analyze.'); return; }
+
+  const drift = await distDriftCheck();
+  const results = rows.map((row) => analyzeRow(row, opts.budget));
+
+  if (opts.json) {
+    // Metadata values are customer data; withheld unless explicitly requested,
+    // since this output is the kind that gets piped to a file.
+    const emitted = opts.showMetadata ? results : results.map(({ metadata, ...rest }) => rest);
+    console.log(JSON.stringify({
+      eraCSource: `inline (${drift})`,
+      rows: emitted,
+      linkage: linkageByDeveloper(rows),
+    }, null, 2));
+    return;
+  }
+  report(rows, results, drift, opts);
+}
+
+await main();

--- a/apps/auth-service/scripts/jsonb-writeback-probe.mjs
+++ b/apps/auth-service/scripts/jsonb-writeback-probe.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Settles one question with a real Postgres: what does audit.ts:101 actually
+ * store in the JSONB `metadata` column?
+ *
+ * The competing claims are (a) postgres.js sends a JS string with type OID 0,
+ * Postgres resolves it against the JSONB column and parses it into an object;
+ * (b) postgres.js JSON-serializes the already-stringified value again, storing
+ * a JSON string. Both predict identical API output once you parse, so only the
+ * stored jsonb_typeof discriminates.
+ *
+ * Reproduces the exact statement shape from routes/audit.ts — same column list,
+ * same VALUES ordering, same parameter position — because parameter type
+ * inference depends on that context.
+ *
+ * Uses a transaction-scoped TEMP table that is dropped automatically at
+ * commit. It never drops, replaces, or updates an existing table.
+ *
+ * Usage: node jsonb-writeback-probe.mjs "postgres://user:pw@host:port/db"
+ */
+
+import postgres from 'postgres';
+
+const url = process.argv[2];
+if (!url) { console.error('usage: jsonb-writeback-probe.mjs <connection-string>'); process.exit(1); }
+
+const sql = postgres(url, { max: 1, idle_timeout: 5, connect_timeout: 10 });
+
+const metadata = { zebra: 1, alpha: { yankee: true, bravo: [3, 2] }, mike: 'x' };
+
+try {
+  const results = await sql.begin(async (tx) => {
+    // Verbatim columns from migrations 001_initial.sql + 002_spec_compliance.sql.
+    // pg_temp shadows any permanent table with the same name for this session.
+    await tx`
+      CREATE TEMP TABLE audit_entries (
+        id            TEXT PRIMARY KEY,
+        agent_id      TEXT NOT NULL,
+        agent_did     TEXT NOT NULL,
+        grant_id      TEXT NOT NULL,
+        principal_id  TEXT NOT NULL,
+        developer_id  TEXT NOT NULL,
+        action        TEXT NOT NULL,
+        metadata      JSONB NOT NULL DEFAULT '{}',
+        hash          TEXT NOT NULL,
+        previous_hash TEXT,
+        timestamp     TIMESTAMPTZ DEFAULT NOW(),
+        status        TEXT NOT NULL DEFAULT 'success'
+      ) ON COMMIT DROP`;
+
+    const variants = [
+      ['A: JSON.stringify(metadata)  <- historical audit.ts:101', JSON.stringify(metadata)],
+      ['B: metadata (raw object)', metadata],
+      ['C: sql.json(metadata)  <- fixed write path', tx.json(metadata)],
+    ];
+
+    const rows = [];
+    for (const [label, param] of variants) {
+      const id = `alog_${rows.length}`;
+      // Same column list and ordering as routes/audit.ts.
+      await tx`
+        INSERT INTO audit_entries (id, agent_id, agent_did, grant_id, principal_id, developer_id, action, metadata, hash, previous_hash, timestamp, status)
+        VALUES (
+          ${id}, ${'ag_01'}, ${'did:grantex:ag_01'}, ${'grnt_01'}, ${'user_01'},
+          ${'dev_TEST'}, ${'tool.run'}, ${param}, ${'deadbeef'},
+          ${null}, ${'2026-01-01T00:00:00.000Z'}, ${'success'}
+        )`;
+      const [row] = await tx`
+        SELECT jsonb_typeof(metadata) AS jtype, metadata, metadata::text AS raw
+        FROM audit_entries WHERE id = ${id}`;
+      rows.push({ label, jtype: row.jtype, driverType: typeof row.metadata, raw: row.raw });
+    }
+    return rows;
+  });
+
+  console.log('\nWhat each write style stores in a JSONB column\n' + '─'.repeat(72));
+  for (const r of results) {
+    console.log(`\n${r.label}`);
+    console.log(`  jsonb_typeof(metadata) : ${r.jtype}`);
+    console.log(`  driver read-back type  : ${r.driverType}`);
+    console.log(`  stored text            : ${r.raw.length > 90 ? r.raw.slice(0, 90) + '…' : r.raw}`);
+  }
+
+  const asWritten = results[0];
+  console.log('\n' + '─'.repeat(72));
+  console.log(asWritten.jtype === 'object'
+    ? 'VERDICT: audit.ts:101 stores a JSONB OBJECT. Double-encoding does not occur.'
+    : `VERDICT: audit.ts:101 stores a JSONB ${asWritten.jtype.toUpperCase()} — the value is double-encoded.`);
+  console.log('');
+} finally {
+  await sql.end();
+}

--- a/apps/auth-service/src/lib/audit-entry.ts
+++ b/apps/auth-service/src/lib/audit-entry.ts
@@ -1,0 +1,19 @@
+import { auditMetadataForResponse } from './hash.js';
+
+/** Map a database audit row to the public API shape, decoding legacy metadata in memory. */
+export function toAuditEntryResponse(row: Record<string, unknown>) {
+  return {
+    entryId: row['id'],
+    agentId: row['agent_id'],
+    agentDid: row['agent_did'],
+    grantId: row['grant_id'],
+    principalId: row['principal_id'],
+    developerId: row['developer_id'],
+    action: row['action'],
+    metadata: auditMetadataForResponse(row['metadata']),
+    hash: row['hash'],
+    prevHash: row['previous_hash'] ?? null,
+    timestamp: row['timestamp'],
+    status: row['status'] ?? 'success',
+  };
+}

--- a/apps/auth-service/src/lib/hash.ts
+++ b/apps/auth-service/src/lib/hash.ts
@@ -27,6 +27,49 @@ export interface AuditHashFields {
   status: string;
 }
 
+export type StoredAuditHashFields = Omit<AuditHashFields, 'metadata'> & {
+  metadata: unknown;
+};
+
+export type AuditHashFormat = 'A' | 'B' | 'C' | 'B/C';
+
+interface DecodedAuditMetadata {
+  value: Record<string, unknown>;
+  /** Exact JSON.stringify(metadata) bytes retained by the legacy JSONB string. */
+  legacyJson: string | null;
+}
+
+function isMetadataObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Decode the historical JSONB-string representation without mutating storage.
+ *
+ * audit.ts passed JSON.stringify(metadata) to a JSONB parameter from the first
+ * release through the Era-C canonicalization change. postgres.js serialized
+ * that string again, so the column contains a JSONB string whose value is the
+ * original JSON text. Keeping `legacyJson` lets Eras A/B be verified byte for
+ * byte while `value` supplies the logical object needed by Era C and API reads.
+ */
+function decodeAuditMetadata(value: unknown): DecodedAuditMetadata | null {
+  if (value === null || value === undefined) return { value: {}, legacyJson: null };
+  if (isMetadataObject(value)) return { value, legacyJson: null };
+  if (typeof value !== 'string') return null;
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isMetadataObject(parsed) ? { value: parsed, legacyJson: value } : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Return the logical metadata object for API responses, preserving corrupt data verbatim. */
+export function auditMetadataForResponse(value: unknown): unknown {
+  return decodeAuditMetadata(value)?.value ?? value;
+}
+
 /**
  * Deterministic JSON with object keys sorted.
  *
@@ -48,24 +91,78 @@ function canonicalJson(value: unknown): string {
   return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalJson(v)}`).join(',')}}`;
 }
 
-export function computeAuditHash(fields: AuditHashFields): string {
-  // Built field-by-field rather than via JSON.stringify on a literal so that
-  // only `metadata` gains canonical ordering. The scalar fields keep their
-  // existing serialization, so hashes of entries with empty, single-key, or
-  // already-sorted metadata are byte-identical to those written before this
-  // change and continue to verify.
-  const canonical = '{'
+function auditPrefix(fields: Omit<AuditHashFields, 'metadata'>): string {
+  return '{'
     + `"id":${JSON.stringify(fields.id)},`
     + `"agentId":${JSON.stringify(fields.agentId)},`
     + `"agentDid":${JSON.stringify(fields.agentDid)},`
     + `"grantId":${JSON.stringify(fields.grantId)},`
     + `"principalId":${JSON.stringify(fields.principalId)},`
     + `"developerId":${JSON.stringify(fields.developerId)},`
-    + `"action":${JSON.stringify(fields.action)},`
-    + `"metadata":${canonicalJson(fields.metadata ?? {})},`
+    + `"action":${JSON.stringify(fields.action)},`;
+}
+
+function computeAuditHashWithMetadataJson(
+  fields: Omit<AuditHashFields, 'metadata'>,
+  metadataJson: string,
+): string {
+  return sha256hex(auditPrefix(fields)
+    + `"metadata":${metadataJson},`
     + `"timestamp":${JSON.stringify(fields.timestamp)},`
     + `"prevHash":${JSON.stringify(fields.prevHash)},`
     + `"status":${JSON.stringify(fields.status)}`
-    + '}';
-  return sha256hex(canonical);
+    + '}');
+}
+
+function computeEraAAuditHash(
+  fields: Omit<AuditHashFields, 'metadata'>,
+  metadataJson: string,
+): string {
+  return sha256hex(auditPrefix(fields)
+    + `"metadata":${metadataJson},`
+    + `"timestamp":${JSON.stringify(fields.timestamp)},`
+    + `"previousHash":${JSON.stringify(fields.prevHash)}`
+    + '}');
+}
+
+export function computeAuditHash(fields: AuditHashFields): string {
+  // Built field-by-field rather than via JSON.stringify on a literal so that
+  // only `metadata` gains canonical ordering. The scalar fields keep their
+  // existing serialization, so hashes of entries with empty, single-key, or
+  // already-sorted metadata are byte-identical to those written before this
+  // change and continue to verify.
+  const { metadata, ...scalars } = fields;
+  return computeAuditHashWithMetadataJson(scalars, canonicalJson(metadata ?? {}));
+}
+
+/**
+ * Match a stored row against every hash layout the service has emitted.
+ *
+ * This is deliberately read-only compatibility logic. It never rewrites
+ * metadata or hashes. Eras A/B are attempted only when the exact historical
+ * JSON text survived in the legacy JSONB string; object-encoded rows are
+ * checked canonically as Era C without an unbounded permutation search.
+ */
+export function matchStoredAuditHash(
+  fields: StoredAuditHashFields,
+  storedHash: string,
+): AuditHashFormat | null {
+  const decoded = decodeAuditMetadata(fields.metadata);
+  if (!decoded) return null;
+
+  const { metadata: _metadata, ...scalars } = fields;
+  const currentMatches = computeAuditHash({ ...scalars, metadata: decoded.value }) === storedHash;
+
+  let eraBMatches = false;
+  let eraAMatches = false;
+  if (decoded.legacyJson !== null) {
+    eraBMatches = computeAuditHashWithMetadataJson(scalars, decoded.legacyJson) === storedHash;
+    eraAMatches = computeEraAAuditHash(scalars, decoded.legacyJson) === storedHash;
+  }
+
+  if (eraAMatches) return 'A';
+  if (eraBMatches && currentMatches) return 'B/C';
+  if (currentMatches) return 'C';
+  if (eraBMatches) return 'B';
+  return null;
 }

--- a/apps/auth-service/src/routes/audit.ts
+++ b/apps/auth-service/src/routes/audit.ts
@@ -1,5 +1,7 @@
 import type { FastifyInstance } from 'fastify';
+import type postgres from 'postgres';
 import { getSql, type TxSql } from '../db/client.js';
+import { toAuditEntryResponse } from '../lib/audit-entry.js';
 import { newAuditEntryId } from '../lib/ids.js';
 import { computeAuditHash } from '../lib/hash.js';
 import { isPlanName, PLAN_LIMITS } from '../lib/plans.js';
@@ -98,7 +100,7 @@ export async function auditRoutes(app: FastifyInstance): Promise<void> {
         INSERT INTO audit_entries (id, agent_id, agent_did, grant_id, principal_id, developer_id, action, metadata, hash, previous_hash, timestamp, status)
         VALUES (
           ${id}, ${agentId}, ${agentDid}, ${grantId}, ${principalId},
-          ${developerId}, ${action}, ${JSON.stringify(metadata)}, ${hash},
+          ${developerId}, ${action}, ${tx.json(metadata as postgres.JSONValue)}, ${hash},
           ${prevHash}, ${timestamp}, ${status}
         )
         RETURNING id, agent_id, agent_did, grant_id, principal_id, developer_id, action, metadata, hash, previous_hash, timestamp, status
@@ -114,7 +116,7 @@ export async function auditRoutes(app: FastifyInstance): Promise<void> {
       });
     }
     if (!createdRow) throw new Error('Audit entry insert returned no row');
-    return reply.status(201).send(toAuditResponse(createdRow));
+    return reply.status(201).send(toAuditEntryResponse(createdRow));
   });
 
   // GET /v1/audit/entries
@@ -152,7 +154,7 @@ export async function auditRoutes(app: FastifyInstance): Promise<void> {
       ORDER BY timestamp ASC, id ASC
     `, parameters);
 
-    return reply.send({ entries: rows.map(toAuditResponse) });
+    return reply.send({ entries: rows.map(toAuditEntryResponse) });
   });
 
   // GET /v1/audit/:id
@@ -167,23 +169,6 @@ export async function auditRoutes(app: FastifyInstance): Promise<void> {
     if (!entry) {
       return reply.status(404).send({ message: 'Audit entry not found', code: 'NOT_FOUND', requestId: request.id });
     }
-    return reply.send(toAuditResponse(entry));
+    return reply.send(toAuditEntryResponse(entry));
   });
-}
-
-function toAuditResponse(row: Record<string, unknown>) {
-  return {
-    entryId: row['id'],
-    agentId: row['agent_id'],
-    agentDid: row['agent_did'],
-    grantId: row['grant_id'],
-    principalId: row['principal_id'],
-    developerId: row['developer_id'],
-    action: row['action'],
-    metadata: row['metadata'],
-    hash: row['hash'],
-    prevHash: row['previous_hash'],
-    timestamp: row['timestamp'],
-    status: row['status'] ?? 'success',
-  };
 }

--- a/apps/auth-service/src/routes/compliance.ts
+++ b/apps/auth-service/src/routes/compliance.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { getSql } from '../db/client.js';
-import { computeAuditHash } from '../lib/hash.js';
+import { toAuditEntryResponse } from '../lib/audit-entry.js';
+import { matchStoredAuditHash } from '../lib/hash.js';
 
 type Framework = 'soc2' | 'gdpr' | 'all';
 
@@ -41,7 +42,7 @@ function verifyChain(entries: Array<Record<string, unknown>>): ChainIntegrity {
     }
 
     const timestamp = entry['timestamp'];
-    const recomputed = computeAuditHash({
+    const matchedFormat = matchStoredAuditHash({
       id: entry['id'] as string,
       agentId: entry['agent_id'] as string,
       agentDid: entry['agent_did'] as string,
@@ -49,13 +50,13 @@ function verifyChain(entries: Array<Record<string, unknown>>): ChainIntegrity {
       principalId: entry['principal_id'] as string,
       developerId: entry['developer_id'] as string,
       action: entry['action'] as string,
-      metadata: (entry['metadata'] ?? {}) as Record<string, unknown>,
+      metadata: entry['metadata'],
       timestamp: timestamp instanceof Date ? timestamp.toISOString() : String(timestamp),
       prevHash: entryPrevHash,
       status: (entry['status'] as string | null) ?? 'success',
-    });
+    }, entry['hash'] as string);
 
-    if (recomputed !== entry['hash']) {
+    if (matchedFormat === null) {
       return {
         valid: false,
         checkedEntries: i,
@@ -285,20 +286,7 @@ export async function complianceRoutes(app: FastifyInstance): Promise<void> {
       delegationDepth: r['delegation_depth'] ?? 0,
     }));
 
-    const entries = (auditRows as Array<Record<string, unknown>>).map((r) => ({
-      entryId: r['id'],
-      agentId: r['agent_id'],
-      agentDid: r['agent_did'],
-      grantId: r['grant_id'],
-      principalId: r['principal_id'],
-      developerId: r['developer_id'],
-      action: r['action'],
-      metadata: r['metadata'],
-      hash: r['hash'],
-      prevHash: r['previous_hash'] ?? null,
-      timestamp: r['timestamp'],
-      status: r['status'] ?? 'success',
-    }));
+    const entries = (auditRows as Array<Record<string, unknown>>).map(toAuditEntryResponse);
 
     const policyList = (policyRows as Array<Record<string, unknown>>).map((r) => ({
       id: r['id'],
@@ -375,20 +363,7 @@ export async function complianceRoutes(app: FastifyInstance): Promise<void> {
       ORDER BY timestamp ASC, id ASC
     `;
 
-    const entries = rows.map((r) => ({
-      entryId: r['id'],
-      agentId: r['agent_id'],
-      agentDid: r['agent_did'],
-      grantId: r['grant_id'],
-      principalId: r['principal_id'],
-      developerId: r['developer_id'],
-      action: r['action'],
-      metadata: r['metadata'],
-      hash: r['hash'],
-      prevHash: r['previous_hash'] ?? null,
-      timestamp: r['timestamp'],
-      status: r['status'] ?? 'success',
-    }));
+    const entries = rows.map(toAuditEntryResponse);
 
     return reply.send({
       generatedAt: new Date().toISOString(),

--- a/apps/auth-service/tests/audit-forensics-script.test.ts
+++ b/apps/auth-service/tests/audit-forensics-script.test.ts
@@ -1,0 +1,164 @@
+import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+
+const S = JSON.stringify;
+const sha = (value: string) => createHash('sha256').update(value).digest('hex');
+const canonical = (value: unknown): string => {
+  if (value === null || typeof value !== 'object') return S(value) ?? 'null';
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([key, nested]) => `${S(key)}:${canonical(nested)}`)
+    .join(',')}}`;
+};
+
+type FixtureRow = Record<string, unknown> & {
+  id: string;
+  developer_id: string;
+  timestamp: string;
+  previous_hash: string | null;
+  hash?: string;
+};
+
+const prefix = (row: FixtureRow) => '{'
+  + `"id":${S(row.id)},"agentId":${S(row['agent_id'])},"agentDid":${S(row['agent_did'])},`
+  + `"grantId":${S(row['grant_id'])},"principalId":${S(row['principal_id'])},`
+  + `"developerId":${S(row.developer_id)},"action":${S(row['action'])},`;
+const hashA = (row: FixtureRow, metadataJson: string) => sha(prefix(row)
+  + `"metadata":${metadataJson},"timestamp":${S(row.timestamp)},`
+  + `"previousHash":${S(row.previous_hash)}}`);
+const hashBC = (row: FixtureRow, metadataJson: string) => sha(prefix(row)
+  + `"metadata":${metadataJson},"timestamp":${S(row.timestamp)},`
+  + `"prevHash":${S(row.previous_hash)},"status":${S(row['status'])}}`);
+
+function row(
+  id: string,
+  developerId: string,
+  timestamp: string,
+  previousHash: string | null,
+  metadata: unknown,
+  action = 'tool.run',
+): FixtureRow {
+  return {
+    id,
+    agent_id: `ag_${developerId}`,
+    agent_did: `did:grantex:ag_${developerId}`,
+    grant_id: `grnt_${developerId}`,
+    principal_id: `user_${developerId}`,
+    developer_id: developerId,
+    action,
+    metadata,
+    previous_hash: previousHash,
+    timestamp,
+    ts_raw: timestamp,
+    status: 'success',
+    meta_type: typeof metadata === 'string' ? 'string' : 'object',
+  };
+}
+
+function runForensics(fixture: string, ...args: string[]) {
+  return spawnSync(process.execPath, [
+    'scripts/audit-chain-forensics.mjs', '--file', fixture, ...args,
+  ], { cwd: process.cwd(), encoding: 'utf8' });
+}
+
+describe('audit-chain-forensics.mjs', () => {
+  it('classifies historical formats, tampering, filtering, and tenant linkage', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'grantex-forensics-test-'));
+    try {
+      const raw = '{"zebra":1,"alpha":{"yankee":true,"bravo":[3,2]}}';
+      const rows: FixtureRow[] = [];
+      let current = row('alog_A', 'dev_A', '2026-02-25T00:00:00.000Z', null, raw);
+      current.hash = hashA(current, raw);
+      rows.push(current);
+
+      current = row('alog_B', 'dev_A', '2026-03-01T00:00:00.000Z', current.hash!, raw);
+      current.hash = hashBC(current, raw);
+      rows.push(current);
+
+      current = row('alog_C', 'dev_A', '2026-08-13T00:00:00.000Z', current.hash!, raw);
+      current.hash = hashBC(current, canonical(JSON.parse(raw)));
+      rows.push(current);
+
+      current = row('alog_TAMPER', 'dev_A', '2026-08-14T00:00:00.000Z', current.hash!, raw, 'tool.delete');
+      current.hash = hashBC({ ...current, action: 'tool.run' }, canonical(JSON.parse(raw)));
+      rows.push(current);
+
+      const sorted = '{"alpha":1,"zebra":2}';
+      current = row('alog_BC', 'dev_B', '2026-08-01T00:00:00.000Z', null, sorted);
+      current.hash = hashBC(current, sorted);
+      rows.push(current);
+
+      // JSONB object read-back order differs from the original canonical bytes;
+      // without preserved insertion order the only defensible result is B/C.
+      current = row('alog_OBJECT_AMBIG', 'dev_C', '2026-08-01T00:00:01.000Z', null, { b: 2, aa: 1 });
+      current.hash = hashBC(current, '{"aa":1,"b":2}');
+      rows.push(current);
+
+      const fixture = join(dir, 'rows.json');
+      writeFileSync(fixture, JSON.stringify(rows), 'utf8');
+      const result = runForensics(fixture, '--limit', '0', '--json');
+      expect(result.status, result.stderr).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        rows: Array<{ id: string; era: string | null }>;
+        linkage: Array<{ developerId: string; broken: string | null }>;
+      };
+      expect(Object.fromEntries(parsed.rows.map((item) => [item.id, item.era ?? 'UNEXPLAINED'])))
+        .toMatchObject({
+          alog_A: 'A',
+          alog_B: 'B',
+          alog_C: 'C',
+          alog_TAMPER: 'UNEXPLAINED',
+          alog_BC: 'B/C',
+          alog_OBJECT_AMBIG: 'B/C',
+        });
+      expect(parsed.linkage).toEqual(expect.arrayContaining([
+        expect.objectContaining({ developerId: 'dev_A', broken: null }),
+        expect.objectContaining({ developerId: 'dev_B', broken: null }),
+        expect.objectContaining({ developerId: 'dev_C', broken: null }),
+      ]));
+
+      const filtered = runForensics(fixture, '--developer', 'dev_B', '--limit', '1', '--json');
+      expect(filtered.status, filtered.stderr).toBe(0);
+      expect((JSON.parse(filtered.stdout) as { rows: Array<{ id: string }> }).rows)
+        .toEqual([expect.objectContaining({ id: 'alog_BC' })]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps exhausted searches inconclusive and withholds invalid metadata text', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'grantex-forensics-safety-'));
+    try {
+      const validRaw = '{"zebra":1,"alpha":2}';
+      const valid = row('alog_VALID', 'dev_A', '2026-08-13T00:00:00.000Z', null, validRaw);
+      valid.hash = hashBC(valid, canonical(JSON.parse(validRaw)));
+      const unknown = row('alog_UNKNOWN', 'dev_B', '2026-08-14T00:00:00.000Z', null, {
+        delta: 4, charlie: 3, bravo: 2, alpha: 1,
+      });
+      unknown.hash = '0'.repeat(64);
+      const invalid = row('alog_INVALID', 'dev_C', '2026-08-15T00:00:00.000Z', null, 'customer-secret-value');
+      invalid.hash = '1'.repeat(64);
+
+      const fixture = join(dir, 'rows.json');
+      writeFileSync(fixture, JSON.stringify([valid, unknown, invalid]), 'utf8');
+      const text = runForensics(fixture, '--limit', '0', '--budget', '1');
+      expect(text.status, text.stderr).toBe(0);
+      expect(text.stdout).toContain('INCONCLUSIVE');
+      expect(text.stdout).not.toContain('Every row is explained');
+      expect(text.stdout).not.toContain('customer-secret');
+
+      const json = runForensics(fixture, '--limit', '0', '--budget', '1', '--json');
+      expect(json.status, json.stderr).toBe(0);
+      expect(json.stdout).not.toContain('customer-secret');
+      expect((JSON.parse(json.stdout) as { rows: Array<{ id: string; metaParseError: string | null }> }).rows)
+        .toContainEqual(expect.objectContaining({ id: 'alog_INVALID', metaParseError: 'invalid_json' }));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/auth-service/tests/audit-postgres.integration.test.ts
+++ b/apps/auth-service/tests/audit-postgres.integration.test.ts
@@ -1,0 +1,141 @@
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import postgres from 'postgres';
+import { describe, expect, it } from 'vitest';
+import { computeAuditHash, matchStoredAuditHash } from '../src/lib/hash.js';
+
+const databaseUrl = process.env['AUDIT_INTEGRATION_DATABASE_URL'];
+const describePostgres = databaseUrl ? describe : describe.skip;
+
+describePostgres('audit metadata write/read integration (Postgres)', () => {
+  it('stores sql.json as an object and verifies both new and legacy rows', async () => {
+    const sql = postgres(databaseUrl!, { max: 1, idle_timeout: 5, connect_timeout: 10 });
+    try {
+      await sql.begin(async (tx) => {
+        await tx`
+          CREATE TEMP TABLE audit_entries_probe (
+            id            TEXT PRIMARY KEY,
+            agent_id      TEXT NOT NULL,
+            agent_did     TEXT NOT NULL,
+            grant_id      TEXT NOT NULL,
+            principal_id  TEXT NOT NULL,
+            developer_id  TEXT NOT NULL,
+            action        TEXT NOT NULL,
+            metadata      JSONB NOT NULL,
+            hash          TEXT NOT NULL,
+            previous_hash TEXT,
+            timestamp     TIMESTAMPTZ NOT NULL,
+            status        TEXT NOT NULL
+          ) ON COMMIT DROP`;
+
+        const metadata = { zebra: 1, alpha: { yankee: true, bravo: [3, 2] } };
+        const base = {
+          agentId: 'ag_01',
+          agentDid: 'did:grantex:ag_01',
+          grantId: 'grnt_01',
+          principalId: 'user_01',
+          developerId: 'dev_TEST',
+          action: 'tool.run',
+          timestamp: '2026-08-14T00:00:00.000Z',
+          prevHash: null as string | null,
+          status: 'success',
+        };
+
+        const currentFields = { ...base, id: 'alog_current', metadata };
+        const currentHash = computeAuditHash(currentFields);
+        await tx`
+          INSERT INTO audit_entries_probe
+            (id, agent_id, agent_did, grant_id, principal_id, developer_id,
+             action, metadata, hash, previous_hash, timestamp, status)
+          VALUES
+            (${currentFields.id}, ${base.agentId}, ${base.agentDid}, ${base.grantId},
+             ${base.principalId}, ${base.developerId}, ${base.action}, ${tx.json(metadata)},
+             ${currentHash}, ${base.prevHash}, ${base.timestamp}, ${base.status})`;
+
+        const [currentRow] = await tx`
+          SELECT *, jsonb_typeof(metadata) AS metadata_type
+          FROM audit_entries_probe WHERE id = ${currentFields.id}`;
+        expect(currentRow!['metadata_type']).toBe('object');
+        expect(currentRow!['metadata']).toEqual(metadata);
+        expect(matchStoredAuditHash({
+          ...currentFields,
+          timestamp: (currentRow!['timestamp'] as Date).toISOString(),
+          metadata: currentRow!['metadata'],
+        }, currentHash)).toBe('C');
+
+        // Reproduce the historical `${JSON.stringify(metadata)}` write exactly.
+        const encodedFields = { ...base, id: 'alog_encoded_c', metadata };
+        const encodedHash = computeAuditHash(encodedFields);
+        await tx`
+          INSERT INTO audit_entries_probe
+            (id, agent_id, agent_did, grant_id, principal_id, developer_id,
+             action, metadata, hash, previous_hash, timestamp, status)
+          VALUES
+            (${encodedFields.id}, ${base.agentId}, ${base.agentDid}, ${base.grantId},
+             ${base.principalId}, ${base.developerId}, ${base.action}, ${JSON.stringify(metadata)},
+             ${encodedHash}, ${base.prevHash}, ${base.timestamp}, ${base.status})`;
+
+        const [encodedRow] = await tx`
+          SELECT *, jsonb_typeof(metadata) AS metadata_type
+          FROM audit_entries_probe WHERE id = ${encodedFields.id}`;
+        expect(encodedRow!['metadata_type']).toBe('string');
+        expect(encodedRow!['metadata']).toBe(JSON.stringify(metadata));
+        expect(matchStoredAuditHash({
+          ...encodedFields,
+          timestamp: (encodedRow!['timestamp'] as Date).toISOString(),
+          metadata: encodedRow!['metadata'],
+        }, encodedHash)).toBe('C');
+
+        const eraBFields = {
+          ...base,
+          id: 'alog_era_b',
+          metadata,
+          timestamp: '2026-03-01T00:00:00.000Z',
+        };
+        const eraBHash = createHash('sha256').update(JSON.stringify({
+          id: eraBFields.id,
+          agentId: eraBFields.agentId,
+          agentDid: eraBFields.agentDid,
+          grantId: eraBFields.grantId,
+          principalId: eraBFields.principalId,
+          developerId: eraBFields.developerId,
+          action: eraBFields.action,
+          metadata,
+          timestamp: eraBFields.timestamp,
+          prevHash: eraBFields.prevHash,
+          status: eraBFields.status,
+        })).digest('hex');
+        await tx`
+          INSERT INTO audit_entries_probe
+            (id, agent_id, agent_did, grant_id, principal_id, developer_id,
+             action, metadata, hash, previous_hash, timestamp, status)
+          VALUES
+            (${eraBFields.id}, ${base.agentId}, ${base.agentDid}, ${base.grantId},
+             ${base.principalId}, ${base.developerId}, ${base.action}, ${JSON.stringify(metadata)},
+             ${eraBHash}, ${base.prevHash}, ${eraBFields.timestamp}, ${base.status})`;
+
+        const [eraBRow] = await tx`
+          SELECT * FROM audit_entries_probe WHERE id = ${eraBFields.id}`;
+        expect(matchStoredAuditHash({
+          ...eraBFields,
+          timestamp: (eraBRow!['timestamp'] as Date).toISOString(),
+          metadata: eraBRow!['metadata'],
+        }, eraBHash)).toBe('B');
+      });
+    } finally {
+      await sql.end();
+    }
+  });
+
+  it('runs the writeback probe without touching permanent tables', () => {
+    const result = spawnSync(process.execPath, [
+      'scripts/jsonb-writeback-probe.mjs',
+      databaseUrl!,
+    ], { cwd: process.cwd(), encoding: 'utf8' });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('jsonb_typeof(metadata) : string');
+    expect(result.stdout.match(/jsonb_typeof\(metadata\) : object/g)).toHaveLength(2);
+    expect(result.stdout).toContain('the value is double-encoded');
+  });
+});

--- a/apps/auth-service/tests/audit.test.ts
+++ b/apps/auth-service/tests/audit.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { buildTestApp, authHeader, seedAuth, sqlMock, TEST_AGENT, TEST_GRANT, TEST_DEVELOPER } from './helpers.js';
 import type { FastifyInstance } from 'fastify';
-import { computeAuditHash } from '../src/lib/hash.js';
+import {
+  auditMetadataForResponse,
+  computeAuditHash,
+  matchStoredAuditHash,
+} from '../src/lib/hash.js';
 import { createHash } from 'node:crypto';
 
 let app: FastifyInstance;
@@ -64,6 +68,7 @@ describe('POST /v1/audit/log', () => {
     expect(body.status).toBe('success');
     expect(body.entryId).toBe(auditEntry.id);
     expect(sqlMock.begin).toHaveBeenCalledTimes(1);
+    expect(sqlMock.json).toHaveBeenCalledWith({ tool: 'search' });
     const allSql = sqlMock.mock.calls.map((call) => (call[0] as TemplateStringsArray).join(' ')).join('\n');
     expect(allSql).toContain('pg_advisory_xact_lock');
   });
@@ -148,6 +153,24 @@ describe('GET /v1/audit/entries', () => {
     const body = res.json<{ entries: Array<{ entryId: string }> }>();
     expect(body.entries).toHaveLength(1);
     expect(body.entries[0]!.entryId).toBe(auditEntry.id);
+  });
+
+  it('decodes legacy string-encoded metadata in responses', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{
+      ...auditEntry,
+      metadata: JSON.stringify({ zebra: 1, alpha: { bravo: true } }),
+    }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/audit/entries',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ entries: Array<{ metadata: unknown }> }>().entries[0]!.metadata)
+      .toEqual({ zebra: 1, alpha: { bravo: true } });
   });
 
   it('accepts filter query params', async () => {
@@ -295,5 +318,113 @@ describe('computeAuditHash', () => {
         status: 'success',
       })).digest('hex'),
     );
+  });
+
+  it('matches current hashes after decoding legacy string storage', () => {
+    const fields = {
+      id: 'alog_C',
+      agentId: 'ag_001',
+      agentDid: 'did:grantex:ag_001',
+      grantId: 'grnt_001',
+      principalId: 'user_001',
+      developerId: 'dev_001',
+      action: 'invoke',
+      metadata: { zebra: 1, alpha: { yankee: true, bravo: [3, 2] } },
+      timestamp: '2026-08-13T00:00:00.000Z',
+      prevHash: null,
+      status: 'success',
+    };
+    const storedHash = computeAuditHash(fields);
+
+    expect(matchStoredAuditHash({
+      ...fields,
+      metadata: JSON.stringify(fields.metadata),
+    }, storedHash)).toBe('C');
+  });
+
+  it('matches exact Era A and Era B hashes without rewriting metadata', () => {
+    const metadata = { zebra: 1, alpha: { yankee: true, bravo: [3, 2] } };
+    const base = {
+      id: 'alog_legacy',
+      agentId: 'ag_001',
+      agentDid: 'did:grantex:ag_001',
+      grantId: 'grnt_001',
+      principalId: 'user_001',
+      developerId: 'dev_001',
+      action: 'invoke',
+      metadata,
+      timestamp: '2026-03-01T00:00:00.000Z',
+      prevHash: 'previous',
+      status: 'success',
+    };
+    const eraAHash = createHash('sha256').update(JSON.stringify({
+      id: base.id,
+      agentId: base.agentId,
+      agentDid: base.agentDid,
+      grantId: base.grantId,
+      principalId: base.principalId,
+      developerId: base.developerId,
+      action: base.action,
+      metadata,
+      timestamp: base.timestamp,
+      previousHash: base.prevHash,
+    })).digest('hex');
+    const eraBHash = createHash('sha256').update(JSON.stringify({
+      id: base.id,
+      agentId: base.agentId,
+      agentDid: base.agentDid,
+      grantId: base.grantId,
+      principalId: base.principalId,
+      developerId: base.developerId,
+      action: base.action,
+      metadata,
+      timestamp: base.timestamp,
+      prevHash: base.prevHash,
+      status: base.status,
+    })).digest('hex');
+    const stored = { ...base, metadata: JSON.stringify(metadata) };
+
+    expect(matchStoredAuditHash(stored, eraAHash)).toBe('A');
+    expect(matchStoredAuditHash(stored, eraBHash)).toBe('B');
+  });
+
+  it('reports B/C when insertion-order and canonical bytes are identical', () => {
+    const fields = {
+      id: 'alog_ambiguous',
+      agentId: 'ag_001',
+      agentDid: 'did:grantex:ag_001',
+      grantId: 'grnt_001',
+      principalId: 'user_001',
+      developerId: 'dev_001',
+      action: 'invoke',
+      metadata: { alpha: 1, zebra: 2 },
+      timestamp: '2026-08-13T00:00:00.000Z',
+      prevHash: null,
+      status: 'success',
+    };
+
+    expect(matchStoredAuditHash(
+      { ...fields, metadata: JSON.stringify(fields.metadata) },
+      computeAuditHash(fields),
+    )).toBe('B/C');
+  });
+
+  it('does not normalize malformed legacy metadata into a valid hash', () => {
+    const fields = {
+      id: 'alog_bad',
+      agentId: 'ag_001',
+      agentDid: 'did:grantex:ag_001',
+      grantId: 'grnt_001',
+      principalId: 'user_001',
+      developerId: 'dev_001',
+      action: 'invoke',
+      metadata: 'customer-secret-value',
+      timestamp: '2026-08-13T00:00:00.000Z',
+      prevHash: null,
+      status: 'success',
+    };
+
+    expect(matchStoredAuditHash(fields, '0'.repeat(64))).toBeNull();
+    expect(auditMetadataForResponse(fields.metadata)).toBe(fields.metadata);
   });
 });

--- a/apps/auth-service/tests/compliance.test.ts
+++ b/apps/auth-service/tests/compliance.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { buildTestApp, authHeader, seedAuth, sqlMock } from './helpers.js';
 import { computeAuditHash } from '../src/lib/hash.js';
 import type { FastifyInstance } from 'fastify';
+import { createHash } from 'node:crypto';
 
 let app: FastifyInstance;
 
@@ -259,7 +260,7 @@ describe('GET /v1/compliance/evidence-pack', () => {
   };
 
   /** Primes 9 mock slots: 1 auth + 8 concurrent SQL calls in Promise.all order. */
-  function seedEvidencePack() {
+  function seedEvidencePack(auditFixture: Array<Record<string, unknown>> = [MOCK_AUDIT_ROW]) {
     seedAuth();
     // Promise.all order: agentStats, grantStats, auditStats, policyStats, sub,
     //                    full grants, full audit, full policies
@@ -269,7 +270,7 @@ describe('GET /v1/compliance/evidence-pack', () => {
     sqlMock.mockResolvedValueOnce([POLICY_STATS]);
     sqlMock.mockResolvedValueOnce([SUB]);
     sqlMock.mockResolvedValueOnce([MOCK_GRANT_ROW]);
-    sqlMock.mockResolvedValueOnce([MOCK_AUDIT_ROW]);
+    sqlMock.mockResolvedValueOnce(auditFixture);
     sqlMock.mockResolvedValueOnce([MOCK_POLICY_ROW]);
   }
 
@@ -320,6 +321,62 @@ describe('GET /v1/compliance/evidence-pack', () => {
     expect(body.meta.since).toBe('2026-01-01T00:00:00Z');
     expect(body.meta.until).toBe('2026-12-31T00:00:00Z');
     expect(body.meta.framework).toBe('soc2');
+  });
+
+  it('decodes and verifies current hashes stored with legacy string encoding', async () => {
+    const metadata = { zebra: 1, alpha: { yankee: true, bravo: [3, 2] } };
+    const current = auditRow({ id: 'alog_encoded', metadata });
+    seedEvidencePack([{ ...current, metadata: JSON.stringify(metadata) }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/compliance/evidence-pack',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      auditEntries: Array<{ metadata: unknown }>;
+      chainIntegrity: { valid: boolean; checkedEntries: number };
+    }>();
+    expect(body.auditEntries[0]!.metadata).toEqual(metadata);
+    expect(body.chainIntegrity).toMatchObject({ valid: true, checkedEntries: 1 });
+  });
+
+  it('verifies an exact Era B row from its preserved metadata string', async () => {
+    const metadata = { zebra: 1, alpha: { yankee: true, bravo: [3, 2] } };
+    const row = auditRow({
+      id: 'alog_era_b',
+      metadata,
+      timestamp: '2026-03-01T00:00:00.000Z',
+    });
+    const legacyHash = createHash('sha256').update(JSON.stringify({
+      id: row.id,
+      agentId: row.agent_id,
+      agentDid: row.agent_did,
+      grantId: row.grant_id,
+      principalId: row.principal_id,
+      developerId: row.developer_id,
+      action: row.action,
+      metadata,
+      timestamp: row.timestamp,
+      prevHash: row.previous_hash,
+      status: row.status,
+    })).digest('hex');
+    seedEvidencePack([{
+      ...row,
+      metadata: JSON.stringify(metadata),
+      hash: legacyHash,
+    }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/compliance/evidence-pack',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ chainIntegrity: { valid: boolean } }>().chainIntegrity.valid).toBe(true);
   });
 
   it('reports chain integrity broken when hash chain is invalid', async () => {


### PR DESCRIPTION
## Summary

- store new audit metadata as a proper JSONB object with `tx.json`
- decode historical string-encoded metadata only in memory
- verify mixed Era A/B/C hashes from preserved legacy bytes without rewriting rows
- harden the read-only forensic tool and make the writeback probe temp-table-only
- add PostgreSQL 16 integration coverage to CI

## Safety

- no migration
- no `UPDATE` of historical audit metadata or hashes
- no recompute-and-store path
- invalid metadata remains an integrity failure

## Verification

- `npm run typecheck`
- `npm run build`
- `npm test` (2,058 passed; PostgreSQL integration skipped locally)
- focused forensic regression tests (32 passed)
- CI provisions PostgreSQL 16 for the two real-database tests

Fixes the audit-chain failure from E2E run 31807302639.
