### PR TITLE
fix: recover lost refresh token responses

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -347,7 +347,7 @@ Response:
 | Standard agent tasks | 8 hours |
 | Long-running background agents | 24 hours (max) |
 
-Refresh tokens are single-use and rotated on every refresh.
+Refresh tokens are single-use and rotated on every refresh. Authorization Servers MAY allow a short idempotent replay of the immediately previous refresh token solely to recover a lost refresh response; replay returns the already-rotated refresh token and MUST NOT extend the rotation chain.
 
 Implementations caching revocation state MUST NOT cache for longer than **5 minutes**. High-stakes scopes (`payments:initiate`, `email:send`, `files:write`) SHOULD always use online verification.
 

--- a/apps/auth-service/src/db/migrations/088_refresh_token_replay_window.sql
+++ b/apps/auth-service/src/db/migrations/088_refresh_token_replay_window.sql
@@ -1,0 +1,29 @@
+-- Preserve refresh-token rotation recovery metadata for a short retry window.
+--
+-- If a refresh request commits but the HTTP response is lost, the caller only
+-- has the just-consumed refresh token. These columns let the server return the
+-- already-rotated child refresh token during a tightly bounded replay window
+-- without making refresh tokens generally reusable.
+ALTER TABLE refresh_tokens
+  ADD COLUMN IF NOT EXISTS used_at TIMESTAMPTZ;
+
+ALTER TABLE refresh_tokens
+  ADD COLUMN IF NOT EXISTS rotated_to_token_id TEXT;
+
+ALTER TABLE refresh_tokens
+  ADD COLUMN IF NOT EXISTS replay_expires_at TIMESTAMPTZ;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'refresh_tokens_rotated_to_token_id_fkey'
+  ) THEN
+    ALTER TABLE refresh_tokens
+      ADD CONSTRAINT refresh_tokens_rotated_to_token_id_fkey
+      FOREIGN KEY (rotated_to_token_id)
+      REFERENCES refresh_tokens(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;

--- a/apps/auth-service/src/lib/logger.ts
+++ b/apps/auth-service/src/lib/logger.ts
@@ -24,9 +24,13 @@ export interface AppLogger {
  * In production the output is newline-delimited JSON.
  * In development, if `pino-pretty` is installed, human-readable output is used.
  */
+export function shouldUsePrettyLogger(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.NODE_ENV === 'development' && env.LOG_PRETTY !== 'false';
+}
+
 export const logger: AppLogger = pino({
   level: process.env.LOG_LEVEL || 'info',
-  ...(process.env.NODE_ENV === 'development'
+  ...(shouldUsePrettyLogger()
     ? { transport: { target: 'pino-pretty' } }
     : {}),
 });

--- a/apps/auth-service/src/routes/token.ts
+++ b/apps/auth-service/src/routes/token.ts
@@ -30,6 +30,9 @@ interface RouteError {
   code: string;
 }
 
+const REFRESH_TOKEN_REPLAY_WINDOW_SECONDS = 120;
+const REFRESH_TOKEN_ALREADY_USED = 'Refresh token already used';
+
 function routeError(statusCode: number, message: string, code = 'BAD_REQUEST'): never {
   throw { statusCode, message, code } satisfies RouteError;
 }
@@ -319,13 +322,16 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
     let grantExpiresAt!: Date;
     let jwt!: string;
     const jti = newTokenId();
-    const newRefreshId = newRefreshTokenId();
+    let responseRefreshToken!: string;
+    let refreshReplay = false;
 
     try {
       await sql.begin(async (_tx) => {
         const tx = _tx as unknown as TxSql;
         const rows = await tx`
-          SELECT rt.id AS refresh_id, rt.grant_id, rt.is_used, rt.expires_at AS refresh_expires_at,
+          SELECT rt.id AS refresh_id, rt.grant_id, rt.is_used,
+                 rt.expires_at AS refresh_expires_at, rt.used_at,
+                 rt.rotated_to_token_id, rt.replay_expires_at,
                  g.agent_id, g.principal_id, g.developer_id, g.scopes, g.status AS grant_status,
                  g.expires_at AS grant_expires_at, g.audience,
                  g.parent_grant_id, g.delegation_depth,
@@ -347,12 +353,6 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
         if (row['agent_id'] !== agentId) {
           routeError(400, 'Agent mismatch');
         }
-        if (row['is_used']) {
-          routeError(400, 'Refresh token already used');
-        }
-        if (new Date(row['refresh_expires_at'] as string) < new Date()) {
-          routeError(400, 'Refresh token expired');
-        }
         if (row['grant_status'] === 'revoked') {
           routeError(400, 'Grant has been revoked');
         }
@@ -366,9 +366,9 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
         grantId = row['grant_id'] as string;
         scopes = row['scopes'] as string[];
         grantExpiresAt = new Date(row['grant_expires_at'] as string);
-        const now = Date.now();
+        const now = new Date();
         // Refresh tokens cannot outlive the underlying grant.
-        const refreshExpiresAt = new Date(Math.min(now + 30 * 86400 * 1000, grantExpiresAt.getTime()));
+        const refreshExpiresAt = new Date(Math.min(now.getTime() + 30 * 86400 * 1000, grantExpiresAt.getTime()));
 
         const remainingBudget = row['remaining_budget'];
         const budgetAmount = remainingBudget !== null && remainingBudget !== undefined
@@ -382,9 +382,7 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
         const parentAgt = row['parent_agent_did'] as string | null | undefined;
         const delegationDepth = Number(row['delegation_depth'] ?? 0);
 
-        // Sign before rotating the single-use refresh token. A signer failure
-        // rolls the transaction back and leaves the caller able to retry.
-        jwt = await signGrantToken({
+        const signRefreshedGrantToken = () => signGrantToken({
           sub: row['principal_id'] as string,
           agt: row['agent_did'] as string,
           dev: row['developer_id'] as string,
@@ -399,25 +397,86 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
           exp: Math.floor(grantExpiresAt.getTime() / 1000),
         });
 
+        if (row['is_used']) {
+          const replayExpiresAt = row['replay_expires_at'] !== null && row['replay_expires_at'] !== undefined
+            ? new Date(row['replay_expires_at'] as string)
+            : null;
+          const rotatedToTokenId = row['rotated_to_token_id'];
+          if (
+            typeof rotatedToTokenId !== 'string'
+            || rotatedToTokenId.length === 0
+            || replayExpiresAt === null
+            || Number.isNaN(replayExpiresAt.getTime())
+            || replayExpiresAt <= now
+          ) {
+            routeError(400, REFRESH_TOKEN_ALREADY_USED);
+          }
+
+          const rotatedRows = await tx`
+            SELECT id, grant_id, is_used, expires_at
+            FROM refresh_tokens
+            WHERE id = ${rotatedToTokenId}
+            FOR UPDATE
+          `;
+          const rotated = rotatedRows[0];
+          if (
+            !rotated
+            || rotated['grant_id'] !== grantId
+            || rotated['is_used']
+            || new Date(rotated['expires_at'] as string) <= now
+          ) {
+            routeError(400, REFRESH_TOKEN_ALREADY_USED);
+          }
+
+          // The previous refresh response may have been lost after commit.
+          // During the short replay window, return the already-rotated refresh
+          // token and mint a fresh access JWT; do not rotate again.
+          responseRefreshToken = rotatedToTokenId;
+          refreshReplay = true;
+          jwt = await signRefreshedGrantToken();
+          await tx`
+            INSERT INTO grant_tokens (jti, grant_id, expires_at)
+            VALUES (${jti}, ${grantId}, ${grantExpiresAt})
+          `;
+          return;
+        }
+
+        if (new Date(row['refresh_expires_at'] as string) < now) {
+          routeError(400, 'Refresh token expired');
+        }
+
+        const newRefreshId = newRefreshTokenId();
+        responseRefreshToken = newRefreshId;
+
+        // Sign before rotating the single-use refresh token. A signer failure
+        // rolls the transaction back and leaves the caller able to retry.
+        jwt = await signRefreshedGrantToken();
+
+        await tx`
+          INSERT INTO refresh_tokens (id, grant_id, expires_at)
+          VALUES (${newRefreshId}, ${grantId}, ${refreshExpiresAt})
+        `;
+
         const updated = await tx`
           UPDATE refresh_tokens
-          SET is_used = true
+          SET is_used = true,
+              used_at = NOW(),
+              rotated_to_token_id = ${newRefreshId},
+              replay_expires_at = LEAST(
+                NOW() + (${REFRESH_TOKEN_REPLAY_WINDOW_SECONDS} * INTERVAL '1 second'),
+                ${refreshExpiresAt}
+              )
           WHERE id = ${row['refresh_id'] as string}
             AND is_used = false
           RETURNING id
         `;
         if (!updated[0]) {
-          routeError(400, 'Refresh token already used');
+          routeError(400, REFRESH_TOKEN_ALREADY_USED);
         }
 
         await tx`
           INSERT INTO grant_tokens (jti, grant_id, expires_at)
           VALUES (${jti}, ${grantId}, ${grantExpiresAt})
-        `;
-
-        await tx`
-          INSERT INTO refresh_tokens (id, grant_id, expires_at)
-          VALUES (${newRefreshId}, ${grantId}, ${refreshExpiresAt})
         `;
       });
     } catch (err) {
@@ -439,13 +498,13 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
       scopes,
       expiresAt: grantExpiresAt.toISOString(),
     };
-    emitEvent(developerId, 'token.issued', { tokenId: jti, ...eventData }).catch(() => {});
+    emitEvent(developerId, 'token.issued', { tokenId: jti, refreshReplay, ...eventData }).catch(() => {});
 
     return reply.status(201).send({
       grantToken: jwt,
       expiresAt: grantExpiresAt.toISOString(),
       scopes,
-      refreshToken: newRefreshId,
+      refreshToken: responseRefreshToken,
       grantId,
     });
   });

--- a/apps/auth-service/tests/database-performance.test.ts
+++ b/apps/auth-service/tests/database-performance.test.ts
@@ -67,6 +67,16 @@ describe('database performance migrations', () => {
     expect(source).toContain('migrationSql.release()');
   });
 
+  it('stores refresh-token replay recovery metadata', () => {
+    const sql = readFileSync(join(migrationsDir, '088_refresh_token_replay_window.sql'), 'utf8');
+
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS used_at TIMESTAMPTZ');
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS rotated_to_token_id TEXT');
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS replay_expires_at TIMESTAMPTZ');
+    expect(sql).toContain('refresh_tokens_rotated_to_token_id_fkey');
+    expect(sql).toMatch(/REFERENCES refresh_tokens\(id\)/);
+  });
+
   it('holds the migration lock while every file runs and releases the connection', async () => {
     const migrationSql = Object.assign(vi.fn().mockResolvedValue([]), {
       unsafe: vi.fn().mockResolvedValue([]),

--- a/apps/auth-service/tests/logger.test.ts
+++ b/apps/auth-service/tests/logger.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { shouldUsePrettyLogger } from '../src/lib/logger.js';
+
+describe('standalone logger configuration', () => {
+  it('does not load pino-pretty when local Docker disables pretty logging', () => {
+    expect(shouldUsePrettyLogger({
+      NODE_ENV: 'development',
+      LOG_PRETTY: 'false',
+    })).toBe(false);
+  });
+
+  it('uses pretty logging in development by default', () => {
+    expect(shouldUsePrettyLogger({
+      NODE_ENV: 'development',
+    })).toBe(true);
+  });
+
+  it('uses JSON logging outside development', () => {
+    expect(shouldUsePrettyLogger({
+      NODE_ENV: 'production',
+    })).toBe(false);
+  });
+});

--- a/apps/auth-service/tests/metrics.test.ts
+++ b/apps/auth-service/tests/metrics.test.ts
@@ -139,6 +139,9 @@ describe('metrics instrumentation', () => {
       grant_id: 'grnt_1',
       is_used: false,
       refresh_expires_at: new Date(Date.now() + 86400_000).toISOString(),
+      used_at: null,
+      rotated_to_token_id: null,
+      replay_expires_at: null,
       agent_id: 'ag_1',
       agent_did: 'did:grantex:ag_1',
       principal_id: 'user_1',
@@ -147,11 +150,11 @@ describe('metrics instrumentation', () => {
       grant_status: 'active',
       grant_expires_at: new Date(Date.now() + 86400_000).toISOString(),
     }]);
-    // mark old used
+    // insert new refresh
+    sqlMock.mockResolvedValueOnce([]);
+    // mark old used with replay metadata
     sqlMock.mockResolvedValueOnce([{ id: 'ref_1' }]);
     // insert new token
-    sqlMock.mockResolvedValueOnce([]);
-    // insert new refresh
     sqlMock.mockResolvedValueOnce([]);
 
     const res = await app.inject({

--- a/apps/auth-service/tests/token-refresh.test.ts
+++ b/apps/auth-service/tests/token-refresh.test.ts
@@ -14,6 +14,9 @@ const validRefreshRow = {
   grant_id: 'grnt_EXISTING',
   is_used: false,
   refresh_expires_at: new Date(Date.now() + 86400_000 * 30).toISOString(),
+  used_at: null,
+  rotated_to_token_id: null,
+  replay_expires_at: null,
   agent_id: TEST_AGENT.id,
   principal_id: 'user_123',
   developer_id: TEST_DEVELOPER.id,
@@ -28,11 +31,11 @@ describe('POST /v1/token/refresh', () => {
     seedAuth();
     // Refresh token lookup (JOIN grants + agents)
     sqlMock.mockResolvedValueOnce([validRefreshRow]);
-    // UPDATE refresh_tokens SET is_used = true
+    // INSERT refresh_tokens (new)
+    sqlMock.mockResolvedValueOnce([]);
+    // UPDATE refresh_tokens SET is_used = true + rotation replay metadata
     sqlMock.mockResolvedValueOnce([{ id: 'ref_EXISTING' }]);
     // INSERT grant_tokens
-    sqlMock.mockResolvedValueOnce([]);
-    // INSERT refresh_tokens (new)
     sqlMock.mockResolvedValueOnce([]);
 
     const res = await app.inject({
@@ -76,8 +79,8 @@ describe('POST /v1/token/refresh', () => {
       parent_agent_did: 'did:grantex:ag_PARENT',
       delegation_depth: 2,
     }]);
-    sqlMock.mockResolvedValueOnce([{ id: 'ref_EXISTING' }]);
     sqlMock.mockResolvedValueOnce([]);
+    sqlMock.mockResolvedValueOnce([{ id: 'ref_EXISTING' }]);
     sqlMock.mockResolvedValueOnce([]);
 
     const res = await app.inject({
@@ -99,6 +102,10 @@ describe('POST /v1/token/refresh', () => {
   it('returns 400 when the refresh token was consumed concurrently', async () => {
     seedAuth();
     sqlMock.mockResolvedValueOnce([validRefreshRow]);
+    // INSERT refresh_tokens (new) succeeds inside the transaction but rolls
+    // back when the guarded consume UPDATE below observes concurrent use.
+    sqlMock.mockResolvedValueOnce([]);
+    // UPDATE refresh_tokens SET is_used = true ... RETURNING id
     sqlMock.mockResolvedValueOnce([]);
 
     const res = await app.inject({
@@ -110,6 +117,123 @@ describe('POST /v1/token/refresh', () => {
 
     expect(res.statusCode).toBe(400);
     expect(res.json().message).toBe('Refresh token already used');
+  });
+
+  it('recovers a lost refresh response by replaying the already-rotated refresh token inside the replay window', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{
+      ...validRefreshRow,
+      is_used: true,
+      used_at: new Date(Date.now() - 5_000).toISOString(),
+      rotated_to_token_id: 'ref_ROTATED',
+      replay_expires_at: new Date(Date.now() + 60_000).toISOString(),
+    }]);
+    // SELECT rotated child refresh token
+    sqlMock.mockResolvedValueOnce([{
+      id: 'ref_ROTATED',
+      grant_id: 'grnt_EXISTING',
+      is_used: false,
+      expires_at: new Date(Date.now() + 86400_000).toISOString(),
+    }]);
+    // INSERT grant_tokens for the fresh replayed access JWT
+    sqlMock.mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token/refresh',
+      headers: authHeader(),
+      payload: { refreshToken: 'ref_EXISTING', agentId: TEST_AGENT.id },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{
+      grantToken: string;
+      expiresAt: string;
+      scopes: string[];
+      refreshToken: string;
+      grantId: string;
+    }>();
+
+    expect(body.refreshToken).toBe('ref_ROTATED');
+    expect(body.grantId).toBe('grnt_EXISTING');
+    expect(body.scopes).toEqual(['read', 'write']);
+    const claims = decodeJwt(body.grantToken);
+    expect(claims['grnt']).toBe('grnt_EXISTING');
+
+    const sqlText = sqlMock.mock.calls.map((call) => (call[0] as TemplateStringsArray).join(' ')).join('\n');
+    expect(sqlText).toContain('FROM refresh_tokens');
+    expect(sqlText).toContain('WHERE id = ');
+    expect(sqlText).not.toContain('rotated_to_token_id =');
+  });
+
+  it('rejects a used refresh token after the replay window expires', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{
+      ...validRefreshRow,
+      is_used: true,
+      used_at: new Date(Date.now() - 180_000).toISOString(),
+      rotated_to_token_id: 'ref_ROTATED',
+      replay_expires_at: new Date(Date.now() - 1_000).toISOString(),
+    }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token/refresh',
+      headers: authHeader(),
+      payload: { refreshToken: 'ref_EXISTING', agentId: TEST_AGENT.id },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toBe('Refresh token already used');
+  });
+
+  it('rejects replay recovery once the rotated child refresh token was used', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{
+      ...validRefreshRow,
+      is_used: true,
+      used_at: new Date(Date.now() - 5_000).toISOString(),
+      rotated_to_token_id: 'ref_ROTATED',
+      replay_expires_at: new Date(Date.now() + 60_000).toISOString(),
+    }]);
+    sqlMock.mockResolvedValueOnce([{
+      id: 'ref_ROTATED',
+      grant_id: 'grnt_EXISTING',
+      is_used: true,
+      expires_at: new Date(Date.now() + 86400_000).toISOString(),
+    }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token/refresh',
+      headers: authHeader(),
+      payload: { refreshToken: 'ref_EXISTING', agentId: TEST_AGENT.id },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toBe('Refresh token already used');
+  });
+
+  it('does not recover a used refresh token if the grant was revoked after rotation', async () => {
+    seedAuth();
+    sqlMock.mockResolvedValueOnce([{
+      ...validRefreshRow,
+      is_used: true,
+      grant_status: 'revoked',
+      used_at: new Date(Date.now() - 5_000).toISOString(),
+      rotated_to_token_id: 'ref_ROTATED',
+      replay_expires_at: new Date(Date.now() + 60_000).toISOString(),
+    }]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/token/refresh',
+      headers: authHeader(),
+      payload: { refreshToken: 'ref_EXISTING', agentId: TEST_AGENT.id },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toBe('Grant has been revoked');
   });
 
   it('returns 400 for already-used refresh token', async () => {

--- a/docs/examples/token-expiry-refresh.mdx
+++ b/docs/examples/token-expiry-refresh.mdx
@@ -14,7 +14,8 @@ This example demonstrates the complete token expiry and refresh lifecycle:
 4. **Detect expiry** — local JWKS-based verification throws, online returns `valid: false`
 5. **Refresh the token** — get a new JWT with the same `grantId` and fresh expiry
 6. **Use the refreshed token** — verify it works with full scope access
-7. **Refresh token rotation** — demonstrate that old refresh tokens are single-use
+7. **Refresh response recovery** — retry the previous refresh token immediately to recover the already-rotated token
+8. **Refresh token rotation** — demonstrate that old refresh tokens cannot keep being reused
 
 ## Prerequisites
 
@@ -68,9 +69,15 @@ Token refreshed successfully!
 Offline verification: PASSED
 Online verification:  valid = true
 
+--- Refresh response recovery window ---
+Retrying the original refresh token immediately (simulates a lost HTTP response)...
+Recovered refresh token matches first rotation: true
+
 --- Refresh token rotation (single-use enforcement) ---
-Blocked! Old refresh token rejected.
-  Reason: Refresh tokens are single-use and rotate on each refresh.
+Advancing the rotation chain with the current refresh token...
+Attempting to reuse the original refresh token after the chain moved forward...
+Blocked! Original refresh token rejected.
+  Reason: Refresh tokens are single-use; recovery only works before the rotated child is used.
 
 Done! Token expiry and refresh lifecycle complete.
 ```

--- a/docs/guides/playground.mdx
+++ b/docs/guides/playground.mdx
@@ -24,7 +24,7 @@ The playground walks you through the complete Grantex lifecycle:
 | **2. Authorize** | `POST /v1/authorize` | Starts an authorization request. In sandbox mode, the auth code is returned directly (no consent redirect). |
 | **3. Exchange Token** | `POST /v1/token` | Exchanges the authorization code for a signed RS256 grant token JWT and a refresh token. |
 | **4. Verify Token** | `POST /v1/tokens/verify` | Verifies the grant token online — returns validity, scopes, principal, and agent info. |
-| **5. Refresh Token** | `POST /v1/token/refresh` | Uses the refresh token to get a new grant token with the same grant ID. The old refresh token is consumed. |
+| **5. Refresh Token** | `POST /v1/token/refresh` | Uses the refresh token to get a new grant token with the same grant ID. The old refresh token is consumed, with a short replay-recovery window for lost responses. |
 | **6. Revoke Token** | `POST /v1/tokens/revoke` | Revokes the grant token by its JTI, making it permanently invalid. |
 | **7. Verify After Revocation** | `POST /v1/tokens/verify` | Verifies the revoked token again — confirms it now returns `valid: false`. |
 

--- a/docs/guides/token-verification.mdx
+++ b/docs/guides/token-verification.mdx
@@ -203,4 +203,4 @@ new_token = client.tokens.refresh(RefreshTokenParams(
 ```
 </CodeGroup>
 
-Refresh tokens are single-use. Each refresh returns a new refresh token, forming a rotation chain. If a refresh token is used twice, the second attempt is rejected — this detects token theft.
+Refresh tokens are single-use. Each refresh returns a new refresh token, forming a rotation chain. If a refresh response is lost after the server commits, retry the same previous refresh token immediately; Grantex can return the already-rotated refresh token during a short replay-recovery window. After that window, or once the rotated child token has been used, reuse is rejected — this detects token theft without stranding callers after a lost response.

--- a/docs/guides/troubleshooting.mdx
+++ b/docs/guides/troubleshooting.mdx
@@ -119,11 +119,13 @@ If `POST /v1/token/refresh` returns 400:
 
 | Error message | Cause | Fix |
 |---------------|-------|-----|
-| "Refresh token already used" | Token was already used (single-use rotation) | Use the new refresh token from the previous refresh response |
+| "Refresh token already used" | Token was already used and is outside the replay-recovery window, or its rotated child token was already used | Use the newest refresh token you stored, or re-authorize if the response containing it was lost and recovery has expired |
 | "Refresh token expired" | Token's 30-day TTL has elapsed | Re-authorize to get a fresh token pair |
 | "Grant has been revoked" | The underlying grant was revoked | Re-authorize the agent |
 | "Agent mismatch" | `agentId` doesn't match the grant's agent | Use the correct agent ID |
 | "Invalid refresh token" | Token ID not found | Check you're passing the correct refresh token value |
+
+If a refresh request times out or the connection drops, retry the same refresh token immediately. Grantex can recover the already-rotated refresh token for a short window without extending the rotation chain.
 
 ## Error Codes Reference
 

--- a/docs/ietf-draft/draft-mishra-oauth-agent-grants-01.md
+++ b/docs/ietf-draft/draft-mishra-oauth-agent-grants-01.md
@@ -363,7 +363,7 @@ Response `200 OK`:
 }
 ~~~
 
-Refresh tokens are single-use. The Authorization Server MUST rotate the refresh token on every use. Refresh tokens MUST be invalidated when the underlying Grant is revoked.
+Refresh tokens are single-use. The Authorization Server MUST rotate the refresh token on every accepted non-replay use. To recover from a lost token response, the Authorization Server MAY allow a short idempotent replay of the immediately previous refresh token; replay MUST return the already-rotated refresh token and MUST NOT extend the rotation chain. Refresh tokens MUST be invalidated when the underlying Grant is revoked.
 
 # Grant Token Format {#grant-token-format}
 

--- a/docs/ietf-draft/draft-mishra-oauth-agent-grants-01.txt
+++ b/docs/ietf-draft/draft-mishra-oauth-agent-grants-01.txt
@@ -685,8 +685,12 @@ Internet-Draft                    DAAP                        March 2026
    }
 
    Refresh tokens are single-use.  The Authorization Server MUST rotate
-   the refresh token on every use.  Refresh tokens MUST be invalidated
-   when the underlying Grant is revoked.
+   the refresh token on every accepted non-replay use.  To recover from a
+   lost token response, the Authorization Server MAY allow a short
+   idempotent replay of the immediately previous refresh token; replay
+   MUST return the already-rotated refresh token and MUST NOT extend the
+   rotation chain.  Refresh tokens MUST be invalidated when the underlying
+   Grant is revoked.
 
 5.  Grant Token Format
 

--- a/docs/ietf-draft/draft-mishra-oauth-agent-grants-01.xml
+++ b/docs/ietf-draft/draft-mishra-oauth-agent-grants-01.xml
@@ -432,7 +432,7 @@ Content-Type: application/json
   "expiresAt": "2026-02-02T00:00:00Z"
 }
 ]]></sourcecode>
-        <t>Refresh tokens are single-use. The Authorization Server <bcp14>MUST</bcp14> rotate the refresh token on every use. Refresh tokens <bcp14>MUST</bcp14> be invalidated when the underlying Grant is revoked.</t>
+        <t>Refresh tokens are single-use. The Authorization Server <bcp14>MUST</bcp14> rotate the refresh token on every accepted non-replay use. To recover from a lost token response, the Authorization Server <bcp14>MAY</bcp14> allow a short idempotent replay of the immediately previous refresh token; replay <bcp14>MUST</bcp14> return the already-rotated refresh token and <bcp14>MUST NOT</bcp14> extend the rotation chain. Refresh tokens <bcp14>MUST</bcp14> be invalidated when the underlying Grant is revoked.</t>
       </section>
     </section>
     <section anchor="grant-token-format">

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1187,8 +1187,11 @@ paths:
       summary: Refresh a grant token
       description: |
         Exchanges a refresh token for a new grant token and rotated refresh token.
-        The old refresh token is marked as used and cannot be reused (single-use rotation per SPEC §7.4).
-        Returns the same grantId with a new JWT and new refresh token.
+        The old refresh token is marked as used after rotation (single-use rotation per SPEC §7.4).
+        If the response is lost after the rotation commits, the immediately previous refresh token may be
+        retried for a short replay-recovery window; the server returns the already-rotated refresh token and
+        does not rotate the chain again. After that window, or once the rotated child token has been used,
+        the old refresh token is rejected. Returns the same grantId with a new JWT and refresh token.
 
         **Rate limit: 20 requests/minute.**
       x-rateLimit:

--- a/docs/sdks/go/tokens.mdx
+++ b/docs/sdks/go/tokens.mdx
@@ -38,7 +38,7 @@ tokenResp, err := client.Tokens.Exchange(ctx, grantex.ExchangeTokenParams{
 
 ## Refresh
 
-Exchange a refresh token for a new grant token. Refresh tokens are single-use — each refresh returns a new refresh token.
+Exchange a refresh token for a new grant token. Refresh tokens are single-use, and each successful rotation returns a new refresh token.
 
 ```go
 tokenResp, err := client.Tokens.Refresh(ctx, grantex.RefreshTokenParams{
@@ -49,7 +49,7 @@ tokenResp, err := client.Tokens.Refresh(ctx, grantex.RefreshTokenParams{
 ```
 
 <Warning>
-Refresh tokens are single-use. Each call returns a new `RefreshToken` that you must store. The old refresh token is invalidated immediately.
+Always store and use the newest `RefreshToken`. If the HTTP response is lost after the server commits the rotation, retry the same previous refresh token immediately; during a short replay-recovery window, Grantex returns the already-rotated refresh token instead of rotating again. After that window, or once the rotated child token has been used, the previous refresh token is rejected.
 </Warning>
 
 ### Parameters

--- a/docs/sdks/python/tokens.mdx
+++ b/docs/sdks/python/tokens.mdx
@@ -68,9 +68,9 @@ with Grantex(api_key="gx_live_...") as client:
 
 ## Refresh
 
-Refresh a grant token using a refresh token. Returns a new grant token and a new refresh token (the old refresh token is invalidated). The `grant_id` stays the same.
+Refresh a grant token using a refresh token. Returns a new grant token and a new refresh token. The `grant_id` stays the same.
 
-Refresh tokens are single-use and rotated on every refresh per SPEC §7.4.
+Refresh tokens are single-use and rotated on every refresh per SPEC §7.4. If the HTTP response is lost after the server commits the rotation, retry the same previous refresh token immediately. During a short replay-recovery window, Grantex returns the already-rotated refresh token instead of rotating again. After that window, or once the rotated child token has been used, the previous refresh token is rejected.
 
 ```python
 from grantex import Grantex, RefreshTokenParams

--- a/docs/sdks/typescript/tokens.mdx
+++ b/docs/sdks/typescript/tokens.mdx
@@ -72,9 +72,9 @@ console.log(token.refreshToken); // 'rt_01HXYZ...'
 
 ## tokens.refresh()
 
-Refresh a grant token using a refresh token. Returns a new grant token and a new refresh token (the old refresh token is invalidated). The `grantId` stays the same.
+Refresh a grant token using a refresh token. Returns a new grant token and a new refresh token. The `grantId` stays the same.
 
-Refresh tokens are single-use and rotated on every refresh per SPEC §7.4.
+Refresh tokens are single-use and rotated on every refresh per SPEC §7.4. If the HTTP response is lost after the server commits the rotation, retry the same previous refresh token immediately. During a short replay-recovery window, Grantex returns the already-rotated refresh token instead of rotating again. After that window, or once the rotated child token has been used, the previous refresh token is rejected.
 
 ```typescript
 const newToken = await grantex.tokens.refresh({
@@ -83,7 +83,7 @@ const newToken = await grantex.tokens.refresh({
 });
 
 console.log(newToken.grantToken);   // new RS256 JWT
-console.log(newToken.refreshToken); // new refresh token (old one invalidated)
+console.log(newToken.refreshToken); // new refresh token; store this value
 console.log(newToken.grantId);      // same grant ID
 ```
 
@@ -102,7 +102,7 @@ console.log(newToken.grantId);      // same grant ID
 Returns the same shape as `exchange()` — see above for field descriptions.
 
 <Warning>
-Each refresh token can only be used once. If you attempt to reuse a refresh token, the request will be rejected with a `400` error. Always store and use the new `refreshToken` from the response.
+Always store and use the newest `refreshToken` from the response. The previous refresh token is only accepted briefly to recover a lost response and will be rejected with a `400` error after the recovery window or after the rotated token is used.
 </Warning>
 
 ---

--- a/docs/soc2-type1/report.md
+++ b/docs/soc2-type1/report.md
@@ -343,7 +343,7 @@ The organization demonstrates a commitment to integrity and ethical values.
 
 | Control | Description | Evidence |
 |---------|-------------|----------|
-| C1.2.1 Refresh token single-use rotation | Refresh tokens are single-use. The authorization server invalidates a refresh token on first use and issues a new one, ensuring that a captured refresh token cannot be reused. | `apps/auth-service/src/routes/token.ts` |
+| C1.2.1 Refresh token single-use rotation | Refresh tokens are single-use. The authorization server invalidates a refresh token on first use and issues a new one; a short replay-recovery window can return the already-rotated child token if the first response was lost, but reuse is rejected after the window or after the child token is used. | `apps/auth-service/src/routes/token.ts` |
 | C1.2.2 Redis TTL-based expiry | Redis keys for JTI tracking are set with a TTL matching the token's expiry, ensuring that revocation and replay-prevention records are automatically purged after tokens expire, limiting long-term data accumulation. | `apps/auth-service/src/routes/tokens.ts` |
 
 ---

--- a/docs/standards/nist-nccoe-comment.md
+++ b/docs/standards/nist-nccoe-comment.md
@@ -56,7 +56,7 @@ The Manage function allocates risk management resources. DAAP contributes throug
 | AI RMF Category | DAAP Capability | Implementation |
 |-----------------|-----------------|----------------|
 | MANAGE 1.1 — Risk treatment | Real-time grant revocation | `DELETE /v1/grants/:id` atomically revokes the grant and all descendant grants. Sub-second propagation. |
-| MANAGE 2.2 — Mechanisms to supersede | Token revocation + refresh rotation | Individual tokens revocable by JTI. Refresh tokens are single-use with automatic rotation. |
+| MANAGE 2.2 — Mechanisms to supersede | Token revocation + refresh rotation | Individual tokens revocable by JTI. Refresh tokens are single-use with automatic rotation and a bounded replay-recovery window for lost refresh responses. |
 | MANAGE 3.1 — Response plans | Event streaming + webhooks | Real-time SSE/WebSocket event streams for `grant.created`, `grant.revoked`, `token.issued`, `budget.threshold`, `budget.exhausted`. Webhooks persist delivery attempts and retry failures with a finite cap. |
 | MANAGE 4.1 — Incident response | Cascade revocation + anomaly alerts | Revoking a parent grant atomically revokes all sub-agent grants. Anomaly detection surfaces high-severity behavioral deviations. |
 

--- a/examples/token-expiry-refresh/README.md
+++ b/examples/token-expiry-refresh/README.md
@@ -10,7 +10,8 @@ Demonstrates time-bound grant tokens with automatic expiry detection and refresh
 4. **Detects expiry** — offline verification throws, online verification returns `valid: false`
 5. **Refreshes the token** — gets a new JWT with the same `grantId`
 6. **Uses the refreshed token** — verifies it works with full scope access
-7. **Refresh token rotation** — old refresh token is rejected (single-use enforcement)
+7. **Refresh response recovery** — retry the previous refresh token immediately to recover the already-rotated token
+8. **Refresh token rotation** — old refresh tokens cannot keep being reused
 
 ## Prerequisites
 
@@ -65,10 +66,15 @@ Token refreshed successfully!
 Offline verification: PASSED
 Online verification:  valid = true
 
+--- Refresh response recovery window ---
+Retrying the original refresh token immediately (simulates a lost HTTP response)...
+Recovered refresh token matches first rotation: true
+
 --- Refresh token rotation (single-use enforcement) ---
-Attempting to reuse the old refresh token...
-Blocked! Old refresh token rejected.
-  Reason: Refresh tokens are single-use and rotate on each refresh.
+Advancing the rotation chain with the current refresh token...
+Attempting to reuse the original refresh token after the chain moved forward...
+Blocked! Original refresh token rejected.
+  Reason: Refresh tokens are single-use; recovery only works before the rotated child is used.
 
 Done! Token expiry and refresh lifecycle complete.
 ```

--- a/examples/token-expiry-refresh/src/index.ts
+++ b/examples/token-expiry-refresh/src/index.ts
@@ -9,7 +9,8 @@
  *   3. Wait for the token to expire, detect expiry (offline + online)
  *   4. Refresh the expired token — get a new JWT with the same grantId
  *   5. Use the refreshed token successfully
- *   6. Demonstrate refresh token rotation (old refresh token is single-use)
+ *   6. Demonstrate refresh response recovery for a lost HTTP response
+ *   7. Demonstrate refresh token rotation (old refresh tokens cannot keep being reused)
  *
  * Prerequisites:
  *   docker compose up          # from repo root
@@ -148,20 +149,36 @@ async function main(): Promise<void> {
   const refreshedOnline = await grantex.tokens.verify(refreshed.grantToken);
   console.log('Online verification:  valid =', refreshedOnline.valid);
 
-  // ── 7. Refresh token rotation (single-use) ────────────────────
+  // ── 7. Refresh response recovery ──────────────────────────────
+  console.log('\n--- Refresh response recovery window ---');
+  console.log('Retrying the original refresh token immediately (simulates a lost HTTP response)...');
+
+  const recovered = await grantex.tokens.refresh({
+    refreshToken: savedRefreshToken,
+    agentId,
+  });
+  console.log('Recovered refresh token matches first rotation:', recovered.refreshToken === refreshed.refreshToken);
+
+  // ── 8. Refresh token rotation (single-use) ────────────────────
   console.log('\n--- Refresh token rotation (single-use enforcement) ---');
-  console.log('Attempting to reuse the old refresh token...');
+  console.log('Advancing the rotation chain with the current refresh token...');
+
+  await grantex.tokens.refresh({
+    refreshToken: recovered.refreshToken,
+    agentId,
+  });
+  console.log('Attempting to reuse the original refresh token after the chain moved forward...');
 
   try {
     await grantex.tokens.refresh({
-      refreshToken: savedRefreshToken,  // already used!
+      refreshToken: savedRefreshToken,
       agentId,
     });
     console.log('ERROR: should not reach here');
   } catch (err) {
-    console.log('Blocked! Old refresh token rejected.');
+    console.log('Blocked! Original refresh token rejected.');
     console.log('  Error:', (err as Error).message);
-    console.log('  Reason: Refresh tokens are single-use and rotate on each refresh.');
+    console.log('  Reason: Refresh tokens are single-use; recovery only works before the rotated child is used.');
   }
 
   console.log('\nDone! Token expiry and refresh lifecycle complete.');

--- a/tests/e2e-extended.mjs
+++ b/tests/e2e-extended.mjs
@@ -72,16 +72,24 @@ async function test_token_refresh() {
   const newVerify = await grantex.tokens.verify(refreshed.grantToken);
   ok(newVerify.valid === true, 'Refreshed token is valid');
 
-  // Old refresh token should be invalidated (rotated)
+  // If the refresh response is lost after commit, retrying the previous
+  // refresh token should recover the same already-rotated child token.
+  const recovered = await grantex.tokens.refresh({ refreshToken, agentId });
+  ok(recovered.refreshToken === refreshed.refreshToken, 'Previous refresh token replay recovers rotated refreshToken');
+  ok(recovered.grantId === grantId, 'Replay recovery preserves grantId');
+
+  // Once the rotated child token is used, the old token can no longer recover.
+  const advanced = await grantex.tokens.refresh({ refreshToken: recovered.refreshToken, agentId });
+  ok(!!advanced.refreshToken, 'Current refresh token advances the rotation chain');
   try {
-    await grantex.tokens.refresh({ refreshToken, agentId }); // replay old refresh token
-    ok(false, 'Old refresh token replay should fail');
+    await grantex.tokens.refresh({ refreshToken, agentId });
+    ok(false, 'Old refresh token should fail after rotated child is used');
   } catch (err) {
-    ok(err instanceof GrantexApiError, `Old refresh token rejected (${err.statusCode})`);
+    ok(err instanceof GrantexApiError, `Old refresh token rejected after child use (${err.statusCode})`);
   }
 
   // Offline verify the refreshed token
-  const offlineVerified = await verifyGrantToken(refreshed.grantToken, { jwksUri: JWKS_URI });
+  const offlineVerified = await verifyGrantToken(advanced.grantToken, { jwksUri: JWKS_URI });
   ok(offlineVerified.grantId === grantId, 'Offline verify refreshed token — same grantId');
 }
 

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -31,8 +31,8 @@ async function authorizeAndGetCode(
   const auth = await grantex.authorize({ agentId, userId, scopes });
 
   // Sandbox mode returns code directly
-  if ('code' in auth && typeof (auth as Record<string, unknown>).code === 'string') {
-    return { code: (auth as Record<string, unknown>).code as string, authRequestId: auth.authRequestId };
+  if ('code' in auth && typeof (auth as unknown as Record<string, unknown>).code === 'string') {
+    return { code: (auth as unknown as Record<string, unknown>).code as string, authRequestId: auth.authRequestId };
   }
 
   // Live mode: programmatically approve via internal endpoint
@@ -62,9 +62,21 @@ beforeAll(async () => {
 
   // Pre-register shared agents (stays within free plan limit of 200)
   const [agent1, agent2, agent3] = await Promise.all([
-    grantex.agents.register({ name: `e2e-main-${Date.now()}`, scopes: ['calendar:read', 'email:send', 'files:read'] }),
-    grantex.agents.register({ name: `e2e-parent-${Date.now()}`, scopes: ['calendar:read', 'email:send'] }),
-    grantex.agents.register({ name: `e2e-sub-${Date.now()}`, scopes: ['calendar:read'] }),
+    grantex.agents.register({
+      name: `e2e-main-${Date.now()}`,
+      description: 'Main agent for e2e auth flow tests',
+      scopes: ['calendar:read', 'email:send', 'files:read'],
+    }),
+    grantex.agents.register({
+      name: `e2e-parent-${Date.now()}`,
+      description: 'Parent agent for e2e delegation tests',
+      scopes: ['calendar:read', 'email:send'],
+    }),
+    grantex.agents.register({
+      name: `e2e-sub-${Date.now()}`,
+      description: 'Sub-agent for e2e delegation tests',
+      scopes: ['calendar:read'],
+    }),
   ]);
   mainAgent = { agentId: agent1.agentId, did: agent1.did };
   delegateAgent = { agentId: agent2.agentId, did: agent2.did };
@@ -77,6 +89,7 @@ describe('E2E: Full Auth Flow', () => {
   let grantToken: string;
   let grantId: string;
   let refreshToken: string;
+  let previousRefreshToken: string;
   let tokenId: string;
 
   it('should create an authorization request and get a code', async () => {
@@ -129,20 +142,44 @@ describe('E2E: Full Auth Flow', () => {
   });
 
   it('should refresh the grant token', async () => {
+    previousRefreshToken = refreshToken;
     const result = await grantex.tokens.refresh({ refreshToken, agentId: mainAgent.agentId });
 
     expect(result.grantToken).toBeDefined();
     expect(result.grantId).toBe(grantId);
     expect(result.refreshToken).toBeDefined();
-    expect(result.refreshToken).not.toBe(refreshToken);
+    expect(result.refreshToken).not.toBe(previousRefreshToken);
 
     grantToken = result.grantToken;
     refreshToken = result.refreshToken!;
   });
 
-  it('should fail to reuse the old refresh token', async () => {
+  it('should recover a lost refresh response by replaying the previous refresh token', async () => {
+    const result = await grantex.tokens.refresh({
+      refreshToken: previousRefreshToken,
+      agentId: mainAgent.agentId,
+    });
+
+    expect(result.grantToken).toBeDefined();
+    expect(result.grantId).toBe(grantId);
+    expect(result.refreshToken).toBe(refreshToken);
+
+    grantToken = result.grantToken;
+  });
+
+  it('should reject the old refresh token after the rotated child is used', async () => {
+    const staleRefreshToken = previousRefreshToken;
+    previousRefreshToken = refreshToken;
+
+    const result = await grantex.tokens.refresh({ refreshToken, agentId: mainAgent.agentId });
+    expect(result.refreshToken).toBeDefined();
+    expect(result.refreshToken).not.toBe(refreshToken);
+
+    grantToken = result.grantToken;
+    refreshToken = result.refreshToken!;
+
     await expect(
-      grantex.tokens.refresh({ refreshToken: 'already-used-token', agentId: mainAgent.agentId }),
+      grantex.tokens.refresh({ refreshToken: staleRefreshToken, agentId: mainAgent.agentId }),
     ).rejects.toThrow();
   });
 


### PR DESCRIPTION
## Summary
- add a bounded refresh-token replay-recovery window for lost refresh responses
- persist rotation metadata (`used_at`, `rotated_to_token_id`, `replay_expires_at`) and reject stale replay after the child token is used or the window expires
- update unit, migration, metrics, Docker-backed e2e coverage, plus OpenAPI/spec/docs/examples
- make standalone logger respect `LOG_PRETTY=false` so the local Docker image starts without dev-only `pino-pretty`

## Verification
- `apps/auth-service`: `npm run typecheck`
- `apps/auth-service`: `npm test -- logger.test.ts token-refresh.test.ts database-performance.test.ts metrics.test.ts` -> 55 passed
- `apps/auth-service`: `npm test` -> 2066 passed, 2 skipped
- `apps/auth-service`: `npm run build`
- `examples/token-expiry-refresh`: `npx tsc --noEmit`
- root: `npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --types node,vitest --skipLibCheck tests/e2e/e2e.test.ts`
- root: `node --check tests/e2e-extended.mjs`
- root: OpenAPI YAML parse ok
- root: docs nav check -> 393/393 resolve
- Docker: `docker compose up --build -d postgres redis auth-service`
- Docker health: `{"status":"healthy","database":"ok","redis":"ok"}`
- Docker DB migration check: `refresh_tokens` has `used_at`, `rotated_to_token_id`, `replay_expires_at`
- Docker e2e: `E2E_BASE_URL=http://localhost:3001 E2E_ISSUER=http://localhost:3001 npx vitest run --testTimeout=120000 tests/e2e/e2e.test.ts` -> 13 passed
- Docker extended e2e: `GRANTEX_URL=http://localhost:3001 GRANTEX_API_KEY=sandbox-api-key-local node tests/e2e-extended.mjs` -> 62 passed, 0 failed