### PR TITLE
fix: extend refresh token replay window

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -347,7 +347,7 @@ Response:
 | Standard agent tasks | 8 hours |
 | Long-running background agents | 24 hours (max) |
 
-Refresh tokens are single-use and rotated on every refresh. Authorization Servers MAY allow a short idempotent replay of the immediately previous refresh token solely to recover a lost refresh response; replay returns the already-rotated refresh token and MUST NOT extend the rotation chain.
+Refresh tokens are single-use and rotated on every refresh. Authorization Servers MAY allow a five-minute (300-second) idempotent replay of the immediately previous refresh token solely to recover a lost refresh response; replay returns the already-rotated refresh token and MUST NOT extend the rotation chain.
 
 Implementations caching revocation state MUST NOT cache for longer than **5 minutes**. High-stakes scopes (`payments:initiate`, `email:send`, `files:write`) SHOULD always use online verification.
 

--- a/apps/auth-service/src/routes/token.ts
+++ b/apps/auth-service/src/routes/token.ts
@@ -30,7 +30,7 @@ interface RouteError {
   code: string;
 }
 
-const REFRESH_TOKEN_REPLAY_WINDOW_SECONDS = 120;
+const REFRESH_TOKEN_REPLAY_WINDOW_SECONDS = 300;
 const REFRESH_TOKEN_ALREADY_USED = 'Refresh token already used';
 
 function routeError(statusCode: number, message: string, code = 'BAD_REQUEST'): never {
@@ -429,7 +429,7 @@ export async function tokenRoutes(app: FastifyInstance): Promise<void> {
           }
 
           // The previous refresh response may have been lost after commit.
-          // During the short replay window, return the already-rotated refresh
+          // During the five-minute replay window, return the already-rotated refresh
           // token and mint a fresh access JWT; do not rotate again.
           responseRefreshToken = rotatedToTokenId;
           refreshReplay = true;

--- a/apps/auth-service/tests/token-refresh.test.ts
+++ b/apps/auth-service/tests/token-refresh.test.ts
@@ -60,6 +60,11 @@ describe('POST /v1/token/refresh', () => {
     expect(typeof body.refreshToken).toBe('string');
     expect(body.refreshToken).not.toBe('ref_EXISTING'); // rotated
 
+    const consumeCall = sqlMock.mock.calls.find((call) =>
+      (call[0] as TemplateStringsArray).join(' ').includes('replay_expires_at = LEAST')
+    );
+    expect(consumeCall).toContain(300);
+
     // Verify JWT claims
     const claims = decodeJwt(body.grantToken);
     expect(claims.sub).toBe('user_123');

--- a/docs/guides/playground.mdx
+++ b/docs/guides/playground.mdx
@@ -24,7 +24,7 @@ The playground walks you through the complete Grantex lifecycle:
 | **2. Authorize** | `POST /v1/authorize` | Starts an authorization request. In sandbox mode, the auth code is returned directly (no consent redirect). |
 | **3. Exchange Token** | `POST /v1/token` | Exchanges the authorization code for a signed RS256 grant token JWT and a refresh token. |
 | **4. Verify Token** | `POST /v1/tokens/verify` | Verifies the grant token online — returns validity, scopes, principal, and agent info. |
-| **5. Refresh Token** | `POST /v1/token/refresh` | Uses the refresh token to get a new grant token with the same grant ID. The old refresh token is consumed, with a short replay-recovery window for lost responses. |
+| **5. Refresh Token** | `POST /v1/token/refresh` | Uses the refresh token to get a new grant token with the same grant ID. The old refresh token is consumed, with a five-minute replay-recovery window for lost responses. |
 | **6. Revoke Token** | `POST /v1/tokens/revoke` | Revokes the grant token by its JTI, making it permanently invalid. |
 | **7. Verify After Revocation** | `POST /v1/tokens/verify` | Verifies the revoked token again — confirms it now returns `valid: false`. |
 

--- a/docs/guides/token-verification.mdx
+++ b/docs/guides/token-verification.mdx
@@ -203,4 +203,4 @@ new_token = client.tokens.refresh(RefreshTokenParams(
 ```
 </CodeGroup>
 
-Refresh tokens are single-use. Each refresh returns a new refresh token, forming a rotation chain. If a refresh response is lost after the server commits, retry the same previous refresh token immediately; Grantex can return the already-rotated refresh token during a short replay-recovery window. After that window, or once the rotated child token has been used, reuse is rejected — this detects token theft without stranding callers after a lost response.
+Refresh tokens are single-use. Each refresh returns a new refresh token, forming a rotation chain. If a refresh response is lost after the server commits, retry the same previous refresh token immediately; Grantex can return the already-rotated refresh token during a five-minute (300-second) replay-recovery window. After that window, or once the rotated child token has been used, reuse is rejected — this detects token theft without stranding callers after a lost response.

--- a/docs/guides/troubleshooting.mdx
+++ b/docs/guides/troubleshooting.mdx
@@ -119,13 +119,13 @@ If `POST /v1/token/refresh` returns 400:
 
 | Error message | Cause | Fix |
 |---------------|-------|-----|
-| "Refresh token already used" | Token was already used and is outside the replay-recovery window, or its rotated child token was already used | Use the newest refresh token you stored, or re-authorize if the response containing it was lost and recovery has expired |
+| "Refresh token already used" | Token was already used and is outside the five-minute replay-recovery window, or its rotated child token was already used | Use the newest refresh token you stored, or re-authorize if the response containing it was lost and recovery has expired |
 | "Refresh token expired" | Token's 30-day TTL has elapsed | Re-authorize to get a fresh token pair |
 | "Grant has been revoked" | The underlying grant was revoked | Re-authorize the agent |
 | "Agent mismatch" | `agentId` doesn't match the grant's agent | Use the correct agent ID |
 | "Invalid refresh token" | Token ID not found | Check you're passing the correct refresh token value |
 
-If a refresh request times out or the connection drops, retry the same refresh token immediately. Grantex can recover the already-rotated refresh token for a short window without extending the rotation chain.
+If a refresh request times out or the connection drops, retry the same refresh token immediately. Grantex can recover the already-rotated refresh token for five minutes without extending the rotation chain.
 
 ## Error Codes Reference
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1189,7 +1189,7 @@ paths:
         Exchanges a refresh token for a new grant token and rotated refresh token.
         The old refresh token is marked as used after rotation (single-use rotation per SPEC §7.4).
         If the response is lost after the rotation commits, the immediately previous refresh token may be
-        retried for a short replay-recovery window; the server returns the already-rotated refresh token and
+        retried for a five-minute (300-second) replay-recovery window; the server returns the already-rotated refresh token and
         does not rotate the chain again. After that window, or once the rotated child token has been used,
         the old refresh token is rejected. Returns the same grantId with a new JWT and refresh token.
 

--- a/docs/sdks/go/tokens.mdx
+++ b/docs/sdks/go/tokens.mdx
@@ -49,7 +49,7 @@ tokenResp, err := client.Tokens.Refresh(ctx, grantex.RefreshTokenParams{
 ```
 
 <Warning>
-Always store and use the newest `RefreshToken`. If the HTTP response is lost after the server commits the rotation, retry the same previous refresh token immediately; during a short replay-recovery window, Grantex returns the already-rotated refresh token instead of rotating again. After that window, or once the rotated child token has been used, the previous refresh token is rejected.
+Always store and use the newest `RefreshToken`. If the HTTP response is lost after the server commits the rotation, retry the same previous refresh token immediately; during a five-minute (300-second) replay-recovery window, Grantex returns the already-rotated refresh token instead of rotating again. After that window, or once the rotated child token has been used, the previous refresh token is rejected.
 </Warning>
 
 ### Parameters

--- a/docs/sdks/python/tokens.mdx
+++ b/docs/sdks/python/tokens.mdx
@@ -70,7 +70,7 @@ with Grantex(api_key="gx_live_...") as client:
 
 Refresh a grant token using a refresh token. Returns a new grant token and a new refresh token. The `grant_id` stays the same.
 
-Refresh tokens are single-use and rotated on every refresh per SPEC §7.4. If the HTTP response is lost after the server commits the rotation, retry the same previous refresh token immediately. During a short replay-recovery window, Grantex returns the already-rotated refresh token instead of rotating again. After that window, or once the rotated child token has been used, the previous refresh token is rejected.
+Refresh tokens are single-use and rotated on every refresh per SPEC §7.4. If the HTTP response is lost after the server commits the rotation, retry the same previous refresh token immediately. During a five-minute (300-second) replay-recovery window, Grantex returns the already-rotated refresh token instead of rotating again. After that window, or once the rotated child token has been used, the previous refresh token is rejected.
 
 ```python
 from grantex import Grantex, RefreshTokenParams

--- a/docs/sdks/typescript/tokens.mdx
+++ b/docs/sdks/typescript/tokens.mdx
@@ -74,7 +74,7 @@ console.log(token.refreshToken); // 'rt_01HXYZ...'
 
 Refresh a grant token using a refresh token. Returns a new grant token and a new refresh token. The `grantId` stays the same.
 
-Refresh tokens are single-use and rotated on every refresh per SPEC §7.4. If the HTTP response is lost after the server commits the rotation, retry the same previous refresh token immediately. During a short replay-recovery window, Grantex returns the already-rotated refresh token instead of rotating again. After that window, or once the rotated child token has been used, the previous refresh token is rejected.
+Refresh tokens are single-use and rotated on every refresh per SPEC §7.4. If the HTTP response is lost after the server commits the rotation, retry the same previous refresh token immediately. During a five-minute (300-second) replay-recovery window, Grantex returns the already-rotated refresh token instead of rotating again. After that window, or once the rotated child token has been used, the previous refresh token is rejected.
 
 ```typescript
 const newToken = await grantex.tokens.refresh({
@@ -102,7 +102,7 @@ console.log(newToken.grantId);      // same grant ID
 Returns the same shape as `exchange()` — see above for field descriptions.
 
 <Warning>
-Always store and use the newest `refreshToken` from the response. The previous refresh token is only accepted briefly to recover a lost response and will be rejected with a `400` error after the recovery window or after the rotated token is used.
+Always store and use the newest `refreshToken` from the response. The previous refresh token is only accepted for five minutes to recover a lost response and will be rejected with a `400` error after the recovery window or after the rotated token is used.
 </Warning>
 
 ---

--- a/docs/soc2-type1/report.md
+++ b/docs/soc2-type1/report.md
@@ -343,7 +343,7 @@ The organization demonstrates a commitment to integrity and ethical values.
 
 | Control | Description | Evidence |
 |---------|-------------|----------|
-| C1.2.1 Refresh token single-use rotation | Refresh tokens are single-use. The authorization server invalidates a refresh token on first use and issues a new one; a short replay-recovery window can return the already-rotated child token if the first response was lost, but reuse is rejected after the window or after the child token is used. | `apps/auth-service/src/routes/token.ts` |
+| C1.2.1 Refresh token single-use rotation | Refresh tokens are single-use. The authorization server invalidates a refresh token on first use and issues a new one; a five-minute (300-second) replay-recovery window can return the already-rotated child token if the first response was lost, but reuse is rejected after the window or after the child token is used. | `apps/auth-service/src/routes/token.ts` |
 | C1.2.2 Redis TTL-based expiry | Redis keys for JTI tracking are set with a TTL matching the token's expiry, ensuring that revocation and replay-prevention records are automatically purged after tokens expire, limiting long-term data accumulation. | `apps/auth-service/src/routes/tokens.ts` |
 
 ---


### PR DESCRIPTION
## Summary
- extend refresh-token lost-response replay recovery from 120 seconds to 300 seconds
- document the five-minute replay-recovery contract in OpenAPI, SDK docs, troubleshooting, and SOC2 readiness evidence
- add a token-refresh unit assertion so the SQL rotation metadata keeps using the 300-second window

## Verification
- npm test -- token-refresh.test.ts
- npm run typecheck
- npm test
- node -e "const fs=require('fs'); const yaml=require('yaml'); yaml.parse(fs.readFileSync('docs/openapi.yaml','utf8')); console.log('openapi yaml ok')"
- git diff --check
