### PR TITLE
docs: clarify refresh token recovery boundary

### DIFF
--- a/docs/guides/security-hardening.mdx
+++ b/docs/guides/security-hardening.mdx
@@ -109,11 +109,11 @@ Default token lifetimes:
 | Token type | Default TTL |
 |------------|-------------|
 | Grant token | Matches the `expiresIn` parameter on authorization (e.g., `24h`) |
-| Refresh token | 30 days, single-use |
+| Refresh token | Up to 30 days, capped by grant expiration, single-use |
 | Principal session token | Matches `expiresIn` from `POST /v1/principal-sessions` |
 
 <Tip>
-Use short-lived grant tokens (1-4 hours) combined with refresh tokens for long-running workflows. This limits the blast radius of a compromised token.
+Use grant lifetimes that match the authorized workflow. Refresh tokens rotate credentials while the grant remains active; they do not extend an expired grant.
 </Tip>
 
 ## Scope Format Validation

--- a/docs/guides/token-verification.mdx
+++ b/docs/guides/token-verification.mdx
@@ -175,7 +175,7 @@ rotation refresh explicitly.
 
 ## Token Refresh
 
-When a grant token expires, use the refresh token to obtain a new one without re-prompting the user:
+Before a grant expires, use the refresh token to rotate credentials and obtain a fresh JWT for the same active grant:
 
 <CodeGroup>
 ```typescript TypeScript
@@ -187,6 +187,7 @@ const newToken = await grantex.tokens.refresh({
 // newToken.grantToken — new JWT
 // newToken.refreshToken — new refresh token (old one is invalidated)
 // newToken.grantId — same grant, new token
+// newToken.expiresAt — same underlying grant expiration
 ```
 
 ```python Python
@@ -200,7 +201,8 @@ new_token = client.tokens.refresh(RefreshTokenParams(
 # new_token.grant_token — new JWT
 # new_token.refresh_token — new refresh token (old one is invalidated)
 # new_token.grant_id — same grant, new token
+# new_token.expires_at — same underlying grant expiration
 ```
 </CodeGroup>
 
-Refresh tokens are single-use. Each refresh returns a new refresh token, forming a rotation chain. If a refresh response is lost after the server commits, retry the same previous refresh token immediately; Grantex can return the already-rotated refresh token during a five-minute (300-second) replay-recovery window. After that window, or once the rotated child token has been used, reuse is rejected — this detects token theft without stranding callers after a lost response.
+Refresh tokens are single-use. Each refresh returns a new refresh token, forming a rotation chain. Refresh does not extend the underlying grant's `expiresAt`; after the grant expires, the caller must re-authorize. If a refresh response is lost after the server commits, retry the same previous refresh token immediately; Grantex can return the already-rotated refresh token during a five-minute (300-second) replay-recovery window while the grant remains active. After that window, or once the rotated child token has been used, reuse is rejected — this detects token theft without stranding callers after a lost response.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1186,12 +1186,13 @@ paths:
       tags: [Tokens]
       summary: Refresh a grant token
       description: |
-        Exchanges a refresh token for a new grant token and rotated refresh token.
+        Exchanges a refresh token for a new grant token and rotated refresh token while the underlying grant remains active.
+        Refresh does not extend the grant expiration; after the grant expires, the caller must re-authorize.
         The old refresh token is marked as used after rotation (single-use rotation per SPEC §7.4).
         If the response is lost after the rotation commits, the immediately previous refresh token may be
         retried for a five-minute (300-second) replay-recovery window; the server returns the already-rotated refresh token and
         does not rotate the chain again. After that window, or once the rotated child token has been used,
-        the old refresh token is rejected. Returns the same grantId with a new JWT and refresh token.
+        the old refresh token is rejected. Returns the same grantId and expiresAt with a new JWT and refresh token.
 
         **Rate limit: 20 requests/minute.**
       x-rateLimit:

--- a/docs/sdks/typescript/tokens.mdx
+++ b/docs/sdks/typescript/tokens.mdx
@@ -61,20 +61,20 @@ console.log(token.refreshToken); // 'rt_01HXYZ...'
 </ResponseField>
 
 <ResponseField name="expiresAt" type="string">
-  ISO 8601 timestamp when the grant token expires.
+  ISO 8601 timestamp when the underlying grant expires.
 </ResponseField>
 
 <ResponseField name="refreshToken" type="string">
-  A refresh token for obtaining new grant tokens without re-authorization.
+  A refresh token for rotating credentials while the grant remains active.
 </ResponseField>
 
 ---
 
 ## tokens.refresh()
 
-Refresh a grant token using a refresh token. Returns a new grant token and a new refresh token. The `grantId` stays the same.
+Refresh a grant token using a refresh token while the underlying grant remains active. Returns a new grant token and a new refresh token. The `grantId` and `expiresAt` stay the same.
 
-Refresh tokens are single-use and rotated on every refresh per SPEC §7.4. If the HTTP response is lost after the server commits the rotation, retry the same previous refresh token immediately. During a five-minute (300-second) replay-recovery window, Grantex returns the already-rotated refresh token instead of rotating again. After that window, or once the rotated child token has been used, the previous refresh token is rejected.
+Refresh tokens are single-use and rotated on every refresh per SPEC §7.4. Refresh does not extend the grant lifetime; after `expiresAt`, the caller must re-authorize. If the HTTP response is lost after the server commits the rotation, retry the same previous refresh token immediately. During a five-minute (300-second) replay-recovery window, Grantex returns the already-rotated refresh token instead of rotating again. After that window, or once the rotated child token has been used, the previous refresh token is rejected.
 
 ```typescript
 const newToken = await grantex.tokens.refresh({
@@ -85,6 +85,7 @@ const newToken = await grantex.tokens.refresh({
 console.log(newToken.grantToken);   // new RS256 JWT
 console.log(newToken.refreshToken); // new refresh token; store this value
 console.log(newToken.grantId);      // same grant ID
+console.log(newToken.expiresAt);    // same grant expiration
 ```
 
 ### Parameters
@@ -102,7 +103,7 @@ console.log(newToken.grantId);      // same grant ID
 Returns the same shape as `exchange()` — see above for field descriptions.
 
 <Warning>
-Always store and use the newest `refreshToken` from the response. The previous refresh token is only accepted for five minutes to recover a lost response and will be rejected with a `400` error after the recovery window or after the rotated token is used.
+Always store and use the newest `refreshToken` from the response. The previous refresh token is only accepted for five minutes to recover a lost response while the grant remains active, and will be rejected with a `400` error after the recovery window, after the rotated token is used, or after the grant expires.
 </Warning>
 
 ---

--- a/examples/token-expiry-refresh/README.md
+++ b/examples/token-expiry-refresh/README.md
@@ -1,17 +1,16 @@
-# Token Expiry & Refresh
+# Token Refresh & Rotation
 
-Demonstrates time-bound grant tokens with automatic expiry detection and refresh token rotation.
+Demonstrates time-bound grants, refresh token rotation, lost-response recovery, and the re-authorization boundary after a grant expires.
 
 ## What it does
 
-1. **Registers an agent** and authorizes with a short-lived token (10 seconds)
-2. **Uses the token** successfully before expiry (offline + online verification)
-3. **Waits for expiry** with a visible countdown
-4. **Detects expiry** — offline verification throws, online verification returns `valid: false`
-5. **Refreshes the token** — gets a new JWT with the same `grantId`
-6. **Uses the refreshed token** — verifies it works with full scope access
-7. **Refresh response recovery** — retry the previous refresh token immediately to recover the already-rotated token
-8. **Refresh token rotation** — old refresh tokens cannot keep being reused
+1. **Registers an agent** and authorizes an active grant
+2. **Uses the token** successfully while the grant is active (offline + online verification)
+3. **Refreshes the token** — gets a new JWT and rotated refresh token for the same `grantId`
+4. **Uses the refreshed token** — verifies it works with full scope access
+5. **Refresh response recovery** — retry the previous refresh token immediately to recover the already-rotated token
+6. **Refresh token rotation** — old refresh tokens cannot keep being reused
+7. **Expired grant boundary** — proves that an expired grant must be re-authorized rather than refreshed
 
 ## Prerequisites
 
@@ -33,34 +32,26 @@ npm start
 ## Expected output
 
 ```
-=== Token Expiry & Refresh Demo ===
+=== Token Refresh & Rotation Demo ===
 
 Agent registered: ag_01...
 
---- Authorizing with 10s TTL ---
+--- Authorizing an active grant (5m) ---
 Grant token received:
   grantId:      grnt_01...
   scopes:       calendar:read, email:send
-  expiresAt:    2026-03-30T12:00:10.000Z
+  expiresAt:    2026-03-30T12:05:00.000Z
   refreshToken: ref_01HXYZ...
 
 --- Using token before expiry ---
 Offline verification: PASSED
 Online verification:  valid = true
 
---- Waiting 12s for token to expire ---
-  Token should now be expired.
-
---- Detecting expiry ---
-Offline verification: EXPIRED
-  Error: "exp" claim timestamp check failed
-Online verification:  valid = false (expected: false)
-
 --- Refreshing token ---
 Token refreshed successfully!
-  grantId:       grnt_01... (same as original)
-  new expiresAt: 2026-03-30T12:00:22.000Z
-  scopes:        calendar:read, email:send
+  grantId:   grnt_01... (same as original)
+  expiresAt: 2026-03-30T12:05:00.000Z (grant lifetime unchanged)
+  scopes:    calendar:read, email:send
 
 --- Using refreshed token ---
 Offline verification: PASSED
@@ -76,7 +67,14 @@ Attempting to reuse the original refresh token after the chain moved forward...
 Blocked! Original refresh token rejected.
   Reason: Refresh tokens are single-use; recovery only works before the rotated child is used.
 
-Done! Token expiry and refresh lifecycle complete.
+--- Expired grant boundary ---
+Creating a short-lived grant (3s) to show the re-authorization boundary...
+Waiting 5s for the grant to expire...
+Online verification after expiry: valid = false (expected: false)
+Refresh after grant expiry blocked.
+  Reason: Refresh rotates credentials for an active grant; expired grants require re-authorization.
+
+Done! Token refresh lifecycle complete.
 ```
 
 ## Environment variables
@@ -85,4 +83,10 @@ Done! Token expiry and refresh lifecycle complete.
 |----------|---------|-------------|
 | `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
 | `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |
-| `TOKEN_TTL` | `10s` | Grant token time-to-live (e.g. `10s`, `1m`, `1h`) |
+| `GRANT_TTL` | `5m` | Active grant lifetime used for refresh rotation |
+| `EXPIRED_GRANT_TTL` | `3s` | Short grant lifetime used only for the expired-grant boundary check |
+| `TOKEN_TTL` | unset | Backward-compatible alias for `EXPIRED_GRANT_TTL` |
+
+## Refresh boundary
+
+`expiresIn` controls the underlying grant lifetime. Refresh rotates credentials for that active grant and does not extend the grant's `expiresAt`. If the refresh response is lost after the server commits rotation, retry the previous refresh token immediately; Grantex can return the already-rotated refresh token during the five-minute recovery window. After the grant expires, the caller must re-authorize.

--- a/examples/token-expiry-refresh/src/index.ts
+++ b/examples/token-expiry-refresh/src/index.ts
@@ -1,16 +1,15 @@
 /**
- * Grantex Token Expiry & Refresh — Time-Bound Grants
+ * Grantex Token Refresh & Rotation - Time-Bound Grants
  *
- * Demonstrates how to work with short-lived grant tokens and the
- * refresh token rotation pattern:
+ * Demonstrates how to work with time-bound grants and the refresh token
+ * rotation pattern:
  *
- *   1. Register an agent and authorize with a short-lived token (10s)
- *   2. Use the token successfully before it expires
- *   3. Wait for the token to expire, detect expiry (offline + online)
- *   4. Refresh the expired token — get a new JWT with the same grantId
- *   5. Use the refreshed token successfully
- *   6. Demonstrate refresh response recovery for a lost HTTP response
- *   7. Demonstrate refresh token rotation (old refresh tokens cannot keep being reused)
+ *   1. Register an agent and authorize a grant
+ *   2. Verify the token while the grant is active
+ *   3. Refresh the active grant - get a new JWT with the same grantId
+ *   4. Demonstrate refresh response recovery for a lost HTTP response
+ *   5. Demonstrate refresh token rotation (old refresh tokens cannot keep being reused)
+ *   6. Demonstrate that an expired grant must be re-authorized, not refreshed
  *
  * Prerequisites:
  *   docker compose up          # from repo root
@@ -24,7 +23,8 @@ const BASE_URL = process.env['GRANTEX_URL'] ?? 'http://localhost:3001';
 const API_KEY = process.env['GRANTEX_API_KEY'] ?? 'sandbox-api-key-local';
 const JWKS_URI = `${BASE_URL}/.well-known/jwks.json`;
 
-const TOKEN_TTL = process.env['TOKEN_TTL'] ?? '10s';
+const GRANT_TTL = process.env['GRANT_TTL'] ?? '5m';
+const EXPIRED_GRANT_TTL = process.env['EXPIRED_GRANT_TTL'] ?? process.env['TOKEN_TTL'] ?? '3s';
 
 /** Handle agent.id vs agentId API response gotcha */
 function getAgentId(agent: Record<string, unknown>): string {
@@ -50,7 +50,7 @@ async function main(): Promise<void> {
   const grantex = new Grantex({ apiKey: API_KEY, baseUrl: BASE_URL });
 
   // ── 1. Register agent ──────────────────────────────────────────
-  console.log('=== Token Expiry & Refresh Demo ===\n');
+  console.log('=== Token Refresh & Rotation Demo ===\n');
 
   const agentRaw = await grantex.agents.register({
     name: 'time-sensitive-agent',
@@ -60,14 +60,14 @@ async function main(): Promise<void> {
   const agentId = getAgentId(agentRaw as unknown as Record<string, unknown>);
   console.log('Agent registered:', agentId);
 
-  // ── 2. Authorize with short-lived token ────────────────────────
-  console.log(`\n--- Authorizing with ${TOKEN_TTL} TTL ---`);
+  // ── 2. Authorize a grant ───────────────────────────────────────
+  console.log(`\n--- Authorizing an active grant (${GRANT_TTL}) ---`);
 
   const authRequest = await grantex.authorize({
     agentId,
     userId: 'user-alice',
     scopes: ['calendar:read', 'email:send'],
-    expiresIn: TOKEN_TTL,
+    expiresIn: GRANT_TTL,
   });
 
   const code = (authRequest as unknown as Record<string, unknown>)['code'] as string;
@@ -98,32 +98,11 @@ async function main(): Promise<void> {
 
   const onlineCheck = await grantex.tokens.verify(tokenResponse.grantToken);
   console.log('Online verification:  valid =', onlineCheck.valid);
-
-  // ── 4. Wait for expiry ─────────────────────────────────────────
-  const ttlSeconds = parseDurationSeconds(TOKEN_TTL);
-
-  console.log(`\n--- Waiting ${ttlSeconds + 2}s for token to expire ---`);
-  for (let i = ttlSeconds + 2; i > 0; i--) {
-    process.stdout.write(`  ${i}s remaining...\r`);
-    await sleep(1000);
-  }
-  console.log('  Token should now be expired.       ');
-
-  // Detect expiry offline
-  console.log('\n--- Detecting expiry ---');
-  try {
-    await verifyGrantToken(tokenResponse.grantToken, { jwksUri: JWKS_URI });
-    console.log('ERROR: should not reach here');
-  } catch (err) {
-    console.log('Offline verification: EXPIRED');
-    console.log('  Error:', (err as Error).message);
+  if (!onlineCheck.valid) {
+    throw new Error('Expected the initial grant token to verify while the grant is active');
   }
 
-  // Detect expiry online
-  const expiredCheck = await grantex.tokens.verify(tokenResponse.grantToken);
-  console.log('Online verification:  valid =', expiredCheck.valid, '(expected: false)');
-
-  // ── 5. Refresh the token ───────────────────────────────────────
+  // ── 4. Refresh while the grant is active ───────────────────────
   console.log('\n--- Refreshing token ---');
 
   const refreshed = await grantex.tokens.refresh({
@@ -131,11 +110,11 @@ async function main(): Promise<void> {
     agentId,
   });
   console.log('Token refreshed successfully!');
-  console.log('  grantId:      ', refreshed.grantId, '(same as original)');
-  console.log('  new expiresAt:', refreshed.expiresAt);
-  console.log('  scopes:       ', refreshed.scopes.join(', '));
+  console.log('  grantId:  ', refreshed.grantId, '(same as original)');
+  console.log('  expiresAt:', refreshed.expiresAt, '(grant lifetime unchanged)');
+  console.log('  scopes:   ', refreshed.scopes.join(', '));
 
-  // ── 6. Use refreshed token ─────────────────────────────────────
+  // ── 5. Use refreshed token ─────────────────────────────────────
   console.log('\n--- Using refreshed token ---');
 
   const refreshedVerified = await verifyGrantToken(refreshed.grantToken, {
@@ -148,8 +127,11 @@ async function main(): Promise<void> {
 
   const refreshedOnline = await grantex.tokens.verify(refreshed.grantToken);
   console.log('Online verification:  valid =', refreshedOnline.valid);
+  if (!refreshedOnline.valid) {
+    throw new Error('Expected the refreshed grant token to verify while the grant is active');
+  }
 
-  // ── 7. Refresh response recovery ──────────────────────────────
+  // ── 6. Refresh response recovery ──────────────────────────────
   console.log('\n--- Refresh response recovery window ---');
   console.log('Retrying the original refresh token immediately (simulates a lost HTTP response)...');
 
@@ -158,8 +140,11 @@ async function main(): Promise<void> {
     agentId,
   });
   console.log('Recovered refresh token matches first rotation:', recovered.refreshToken === refreshed.refreshToken);
+  if (recovered.refreshToken !== refreshed.refreshToken) {
+    throw new Error('Expected replay recovery to return the already-rotated refresh token');
+  }
 
-  // ── 8. Refresh token rotation (single-use) ────────────────────
+  // ── 7. Refresh token rotation (single-use) ────────────────────
   console.log('\n--- Refresh token rotation (single-use enforcement) ---');
   console.log('Advancing the rotation chain with the current refresh token...');
 
@@ -169,19 +154,67 @@ async function main(): Promise<void> {
   });
   console.log('Attempting to reuse the original refresh token after the chain moved forward...');
 
+  let originalRefreshTokenRejected = false;
   try {
     await grantex.tokens.refresh({
       refreshToken: savedRefreshToken,
       agentId,
     });
-    console.log('ERROR: should not reach here');
   } catch (err) {
+    originalRefreshTokenRejected = true;
     console.log('Blocked! Original refresh token rejected.');
     console.log('  Error:', (err as Error).message);
     console.log('  Reason: Refresh tokens are single-use; recovery only works before the rotated child is used.');
   }
+  if (!originalRefreshTokenRejected) {
+    throw new Error('Original refresh token was unexpectedly accepted after the rotated child was used');
+  }
 
-  console.log('\nDone! Token expiry and refresh lifecycle complete.');
+  // ── 8. Expired grant boundary ──────────────────────────────────
+  console.log('\n--- Expired grant boundary ---');
+  console.log(`Creating a short-lived grant (${EXPIRED_GRANT_TTL}) to show the re-authorization boundary...`);
+
+  const expiringAuthRequest = await grantex.authorize({
+    agentId,
+    userId: `user-expired-${Date.now()}`,
+    scopes: ['calendar:read'],
+    expiresIn: EXPIRED_GRANT_TTL,
+  });
+
+  const expiringCode = (expiringAuthRequest as unknown as Record<string, unknown>)['code'] as string;
+  if (!expiringCode) {
+    console.error('No code returned for expiring grant - are you using the sandbox API key?');
+    process.exit(1);
+  }
+
+  const expiringToken = await grantex.tokens.exchange({ code: expiringCode, agentId });
+  const expiringTtlSeconds = parseDurationSeconds(EXPIRED_GRANT_TTL);
+  console.log(`Waiting ${expiringTtlSeconds + 2}s for the grant to expire...`);
+  await sleep((expiringTtlSeconds + 2) * 1000);
+
+  const expiredCheck = await grantex.tokens.verify(expiringToken.grantToken);
+  console.log('Online verification after expiry: valid =', expiredCheck.valid, '(expected: false)');
+  if (expiredCheck.valid) {
+    throw new Error('Expected the short-lived grant token to be expired');
+  }
+
+  let expiredGrantRefreshRejected = false;
+  try {
+    await grantex.tokens.refresh({
+      refreshToken: expiringToken.refreshToken,
+      agentId,
+    });
+  } catch (err) {
+    expiredGrantRefreshRejected = true;
+    console.log('Refresh after grant expiry blocked.');
+    console.log('  Error:', (err as Error).message);
+    console.log('  Reason: Refresh rotates credentials for an active grant; expired grants require re-authorization.');
+  }
+  if (!expiredGrantRefreshRejected) {
+    throw new Error('Expired grant refresh was unexpectedly accepted');
+  }
+
+  console.log('\nDone! Token refresh lifecycle complete.');
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- clarify that refresh token rotation works only while the underlying grant remains active
- update the token refresh example to demonstrate active-grant rotation, 300-second lost-response recovery, single-use enforcement, and expired-grant re-authorization boundary
- align TypeScript SDK docs, token verification guide, security hardening guide, and OpenAPI description with the server contract

## Validation
- full local Docker e2e suite: 19/19 files, 253/253 tests passed
- token refresh unit suite: 14/14 passed
- Docker auth e2e refresh flow: 13/13 passed
- token-expiry-refresh example passed against http://localhost:3001
- docs integrity passed
- live-mode guard passed

No SDK package/source update is required; the existing SDK refresh API already matches the server behavior.