### PR TITLE
docs: align refresh recovery public copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,14 @@ const token = await grantex.tokens.exchange({
 console.log(token.grantToken);  // RS256 JWT — pass this to your agent
 console.log(token.scopes);      // ['calendar:read', 'payments:initiate:max_500']
 console.log(token.grantId);     // 'grnt_01HXYZ...'
+console.log(token.refreshToken); // store securely for active-grant rotation
 ```
+
+Refresh tokens are single-use and rotate on every accepted refresh. If the
+refresh HTTP response is lost after the server commits, retry the same previous
+refresh token immediately; Grantex can recover the already-rotated token pair
+for five minutes (300 seconds). Refresh does not extend `token.expiresAt`; after
+the grant expires, start a new authorization request.
 
 ### 4. Verify the token and use it
 
@@ -1654,7 +1661,7 @@ Walk through all 7 steps of the protocol: register an agent, authorize, exchange
 | [`quickstart-go`](examples/quickstart-go) | Core authorization lifecycle using the Go SDK | `go run .` |
 | [`multi-agent-email-flow`](examples/multi-agent-email-flow) | Multi-agent email automation with delegation, enforcement, and cascade revocation | `npm start` |
 | [`audit-dashboard`](examples/audit-dashboard) | Audit trail querying, filtering, and hash chain integrity verification | `npm start` |
-| [`token-expiry-refresh`](examples/token-expiry-refresh) | Time-bound grant tokens with automatic expiry detection and refresh rotation | `npm start` |
+| [`token-expiry-refresh`](examples/token-expiry-refresh) | Active-grant refresh rotation, 300-second lost-response recovery, and expired-grant re-authorization | `npm start` |
 | [`x402-agent-demo`](examples/x402-agent-demo) | AI agent using Grantex Delegation Token + x402 payments | `npm start` |
 | [`x402-weather-api`](examples/x402-weather-api) | Express server with x402 payment flow + GDT enforcement | `npm start` |
 

--- a/docs/examples/token-expiry-refresh.mdx
+++ b/docs/examples/token-expiry-refresh.mdx
@@ -1,21 +1,20 @@
 ---
-title: "Token Expiry & Refresh"
-sidebarTitle: "Token Expiry"
-description: "Time-bound grants with expiry detection and refresh token rotation."
+title: "Token Refresh & Rotation"
+sidebarTitle: "Token Refresh"
+description: "Active-grant refresh rotation, lost-response recovery, and the expired-grant re-authorization boundary."
 ---
 
 ## What it does
 
-This example demonstrates the complete token expiry and refresh lifecycle:
+This example demonstrates the complete token refresh lifecycle:
 
-1. **Authorize with a short-lived token** (10 seconds) using the `expiresIn` parameter
-2. **Use the token** successfully before it expires (local JWKS-based + online verification)
-3. **Wait for expiry** — observe the token becoming invalid
-4. **Detect expiry** — local JWKS-based verification throws, online returns `valid: false`
-5. **Refresh the token** — get a new JWT with the same `grantId` and fresh expiry
-6. **Use the refreshed token** — verify it works with full scope access
-7. **Refresh response recovery** — retry the previous refresh token immediately to recover the already-rotated token
-8. **Refresh token rotation** — demonstrate that old refresh tokens cannot keep being reused
+1. **Authorize an active grant** using the `expiresIn` parameter
+2. **Use the token** successfully while the grant remains active (local JWKS-based + online verification)
+3. **Refresh the token** — get a new JWT and rotated refresh token with the same `grantId` and `expiresAt`
+4. **Use the refreshed token** — verify it works with full scope access
+5. **Refresh response recovery** — retry the previous refresh token immediately to recover the already-rotated token
+6. **Refresh token rotation** — demonstrate that old refresh tokens cannot keep being reused
+7. **Expired grant boundary** — demonstrate that an expired grant must be re-authorized rather than refreshed
 
 ## Prerequisites
 
@@ -41,29 +40,26 @@ npm start
 ## Expected output
 
 ```text
-=== Token Expiry & Refresh Demo ===
+=== Token Refresh & Rotation Demo ===
 
 Agent registered: ag_01HXYZ...
 
---- Authorizing with 10s TTL ---
+--- Authorizing an active grant (5m) ---
 Grant token received:
-  expiresAt: 2026-03-30T12:00:10.000Z
+  grantId:      grnt_01...
+  scopes:       calendar:read, email:send
+  expiresAt:    2026-03-30T12:05:00.000Z
   refreshToken: ref_01HXYZ...
 
 --- Using token before expiry ---
 Offline verification: PASSED
 Online verification:  valid = true
 
---- Waiting 12s for token to expire ---
-  Token should now be expired.
-
---- Detecting expiry ---
-Offline verification: EXPIRED
-Online verification:  valid = false (expected: false)
-
 --- Refreshing token ---
 Token refreshed successfully!
-  grantId: grnt_01... (same as original)
+  grantId:   grnt_01... (same as original)
+  expiresAt: 2026-03-30T12:05:00.000Z (grant lifetime unchanged)
+  scopes:    calendar:read, email:send
 
 --- Using refreshed token ---
 Offline verification: PASSED
@@ -79,7 +75,14 @@ Attempting to reuse the original refresh token after the chain moved forward...
 Blocked! Original refresh token rejected.
   Reason: Refresh tokens are single-use; recovery only works before the rotated child is used.
 
-Done! Token expiry and refresh lifecycle complete.
+--- Expired grant boundary ---
+Creating a short-lived grant (3s) to show the re-authorization boundary...
+Waiting 5s for the grant to expire...
+Online verification after expiry: valid = false (expected: false)
+Refresh after grant expiry blocked.
+  Reason: Refresh rotates credentials for an active grant; expired grants require re-authorization.
+
+Done! Token refresh lifecycle complete.
 ```
 
 ## Environment variables
@@ -88,7 +91,13 @@ Done! Token expiry and refresh lifecycle complete.
 |----------|---------|-------------|
 | `GRANTEX_URL` | `http://localhost:3001` | Base URL of the Grantex auth service |
 | `GRANTEX_API_KEY` | `sandbox-api-key-local` | API key. Use a sandbox key for auto-approval |
-| `TOKEN_TTL` | `10s` | Grant token time-to-live (e.g. `10s`, `1m`, `1h`) |
+| `GRANT_TTL` | `5m` | Active grant lifetime used for refresh rotation |
+| `EXPIRED_GRANT_TTL` | `3s` | Short grant lifetime used only for the expired-grant boundary check |
+| `TOKEN_TTL` | unset | Backward-compatible alias for `EXPIRED_GRANT_TTL` |
+
+## Refresh boundary
+
+`expiresIn` controls the underlying grant lifetime. Refresh rotates credentials for that active grant and does not extend the grant's `expiresAt`. If the refresh response is lost after the server commits rotation, retry the previous refresh token immediately; Grantex can return the already-rotated refresh token during the five-minute recovery window. After the grant expires, the caller must re-authorize.
 
 ## Source code
 

--- a/docs/guides/playground.mdx
+++ b/docs/guides/playground.mdx
@@ -24,7 +24,7 @@ The playground walks you through the complete Grantex lifecycle:
 | **2. Authorize** | `POST /v1/authorize` | Starts an authorization request. In sandbox mode, the auth code is returned directly (no consent redirect). |
 | **3. Exchange Token** | `POST /v1/token` | Exchanges the authorization code for a signed RS256 grant token JWT and a refresh token. |
 | **4. Verify Token** | `POST /v1/tokens/verify` | Verifies the grant token online — returns validity, scopes, principal, and agent info. |
-| **5. Refresh Token** | `POST /v1/token/refresh` | Uses the refresh token to get a new grant token with the same grant ID. The old refresh token is consumed, with a five-minute replay-recovery window for lost responses. |
+| **5. Refresh Token** | `POST /v1/token/refresh` | Uses the refresh token to rotate credentials while the grant remains active. The same previous refresh token can recover a lost response for five minutes, and refresh does not extend grant expiry. |
 | **6. Revoke Token** | `POST /v1/tokens/revoke` | Revokes the grant token by its JTI, making it permanently invalid. |
 | **7. Verify After Revocation** | `POST /v1/tokens/verify` | Verifies the revoked token again — confirms it now returns `valid: false`. |
 

--- a/docs/guides/rate-limits.mdx
+++ b/docs/guides/rate-limits.mdx
@@ -20,7 +20,7 @@ Grantex applies one-minute fixed-window limits. Fastify applies one pre-auth pol
 | **Standard API-key - Enterprise plan** | 2,000 req/min | Per developer, across routes and source IPs |
 | `POST /v1/authorize` | 10 req/min | Additional Redis-backed per-developer authorization bucket; the Fastify default and plan budget also apply |
 | `POST /v1/token` | 20 req/min | Stricter — exchanges codes for tokens |
-| `POST /v1/token/refresh` | 20 req/min | Stricter — refreshes grant tokens |
+| `POST /v1/token/refresh` | 20 req/min | Stricter — refreshes active grant tokens |
 | `GET /.well-known/jwks.json` | **Exempt** | Public key distribution is never throttled |
 
 A route-specific Fastify `config.rateLimit` replaces the 5,000 requests/minute Fastify default for that route; those two Fastify policies are not stacked. The Redis-backed standard developer plan budget remains an additional policy when standard API-key authentication applies.

--- a/docs/guides/security-best-practices.mdx
+++ b/docs/guides/security-best-practices.mdx
@@ -22,11 +22,14 @@ Never store grant tokens in browser `localStorage`, cookies, or client-side stor
 
 ### Refresh Token Storage
 
-Refresh tokens have a 30-day TTL and are single-use. Store them with the same care as API keys:
+Refresh tokens are single-use and last up to 30 days, capped by the underlying grant expiration. Store them with the same care as API keys:
 
 - Encrypt at rest (e.g., envelope encryption with a KMS)
 - Restrict access to the service that performs token refresh
 - Never log refresh tokens — redact them in your logging pipeline
+- Always store the newest refresh token returned by the server
+- If a refresh response is lost, retry the same previous refresh token immediately; recovery is bounded to five minutes while the grant remains active
+- Do not use refresh as a grant extension mechanism; after the grant expires, start a new authorization request
 
 ## Scope Design
 

--- a/docs/guides/troubleshooting.mdx
+++ b/docs/guides/troubleshooting.mdx
@@ -119,13 +119,13 @@ If `POST /v1/token/refresh` returns 400:
 
 | Error message | Cause | Fix |
 |---------------|-------|-----|
-| "Refresh token already used" | Token was already used and is outside the five-minute replay-recovery window, or its rotated child token was already used | Use the newest refresh token you stored, or re-authorize if the response containing it was lost and recovery has expired |
-| "Refresh token expired" | Token's 30-day TTL has elapsed | Re-authorize to get a fresh token pair |
+| "Refresh token already used" | Token was already used and is outside the five-minute replay-recovery window, its rotated child token was already used, or the grant has expired | Use the newest refresh token you stored, or re-authorize if the response containing it was lost and recovery has expired |
+| "Refresh token expired" | The refresh token's own expiry elapsed; refresh tokens last up to 30 days and are capped by grant expiration | Re-authorize to get a fresh token pair |
 | "Grant has been revoked" | The underlying grant was revoked | Re-authorize the agent |
 | "Agent mismatch" | `agentId` doesn't match the grant's agent | Use the correct agent ID |
 | "Invalid refresh token" | Token ID not found | Check you're passing the correct refresh token value |
 
-If a refresh request times out or the connection drops, retry the same refresh token immediately. Grantex can recover the already-rotated refresh token for five minutes without extending the rotation chain.
+If a refresh request times out or the connection drops, retry the same refresh token immediately. Grantex can recover the already-rotated refresh token for five minutes while the grant remains active, without extending the rotation chain or grant lifetime.
 
 ## Error Codes Reference
 

--- a/docs/ietf-draft/draft-mishra-oauth-agent-grants-01.md
+++ b/docs/ietf-draft/draft-mishra-oauth-agent-grants-01.md
@@ -363,7 +363,7 @@ Response `200 OK`:
 }
 ~~~
 
-Refresh tokens are single-use. The Authorization Server MUST rotate the refresh token on every accepted non-replay use. To recover from a lost token response, the Authorization Server MAY allow a short idempotent replay of the immediately previous refresh token; replay MUST return the already-rotated refresh token and MUST NOT extend the rotation chain. Refresh tokens MUST be invalidated when the underlying Grant is revoked.
+Refresh tokens are single-use and MUST NOT outlive the underlying Grant. The Authorization Server MUST rotate the refresh token on every accepted non-replay use. To recover from a lost token response, the Authorization Server MAY allow a short idempotent replay of the immediately previous refresh token while the Grant remains active; replay MUST return the already-rotated refresh token and MUST NOT extend the rotation chain or the Grant lifetime. Refresh tokens MUST be invalidated when the underlying Grant is expired or revoked.
 
 # Grant Token Format {#grant-token-format}
 

--- a/docs/ietf-draft/implementation-report.md
+++ b/docs/ietf-draft/implementation-report.md
@@ -22,7 +22,7 @@ This document reports on the conformance status of the Grantex reference impleme
 | `/v1/agents` | POST | Yes | ULID-based agent IDs, DID generation |
 | `/v1/authorize` | POST | Yes | PKCE S256 supported |
 | `/v1/token` | POST | Yes | RS256 JWT, refresh token rotation |
-| `/v1/token/refresh` | POST | Yes | Single-use rotation per SPEC §7.4 |
+| `/v1/token/refresh` | POST | Yes | Active-grant single-use rotation with bounded lost-response recovery |
 | `/v1/tokens/verify` | POST | Yes | Online verification with revocation check |
 | `/v1/tokens/revoke` | POST | Yes | JTI-based revocation, 204 response |
 | `/v1/grants` | GET | Yes | Filtered by developer |
@@ -147,7 +147,7 @@ The `@grantex/conformance` package (v0.1.4) provides an automated test suite tha
 - Cascade revocation (3-level delegation tree)
 - Hash chain verification
 - RS256 algorithm enforcement (rejects `none`, `HS256`)
-- Refresh token single-use rotation
+- Refresh token single-use rotation, capped by grant expiration
 - Rate limiting behavior
 - Budget atomic debit concurrency
 - Event streaming connectivity

--- a/docs/sdks/go/tokens.mdx
+++ b/docs/sdks/go/tokens.mdx
@@ -31,14 +31,14 @@ tokenResp, err := client.Tokens.Exchange(ctx, grantex.ExchangeTokenParams{
 | Field | Type | Description |
 |-------|------|-------------|
 | `GrantToken` | `string` | JWT grant token |
-| `ExpiresAt` | `string` | ISO 8601 token expiry |
+| `ExpiresAt` | `string` | ISO 8601 grant expiry |
 | `Scopes` | `[]string` | Granted scopes |
-| `RefreshToken` | `string` | Refresh token for rotation |
+| `RefreshToken` | `string` | Refresh token for active-grant rotation |
 | `GrantID` | `string` | Grant record ID |
 
 ## Refresh
 
-Exchange a refresh token for a new grant token. Refresh tokens are single-use, and each successful rotation returns a new refresh token.
+Exchange a refresh token for a new grant token while the underlying grant remains active. Refresh tokens are single-use, and each successful rotation returns a new refresh token without extending `ExpiresAt`.
 
 ```go
 tokenResp, err := client.Tokens.Refresh(ctx, grantex.RefreshTokenParams{
@@ -46,10 +46,11 @@ tokenResp, err := client.Tokens.Refresh(ctx, grantex.RefreshTokenParams{
     AgentID:      "agent-id",
 })
 // tokenResp.RefreshToken is a NEW refresh token — store it
+// tokenResp.ExpiresAt is the same grant expiration
 ```
 
 <Warning>
-Always store and use the newest `RefreshToken`. If the HTTP response is lost after the server commits the rotation, retry the same previous refresh token immediately; during a five-minute (300-second) replay-recovery window, Grantex returns the already-rotated refresh token instead of rotating again. After that window, or once the rotated child token has been used, the previous refresh token is rejected.
+Always store and use the newest `RefreshToken`. If the HTTP response is lost after the server commits the rotation, retry the same previous refresh token immediately; during a five-minute (300-second) replay-recovery window, Grantex returns the already-rotated refresh token instead of rotating again while the grant remains active. After that window, once the rotated child token has been used, or after grant expiration, the previous refresh token is rejected.
 </Warning>
 
 ### Parameters
@@ -61,7 +62,7 @@ Always store and use the newest `RefreshToken`. If the HTTP response is lost aft
 
 ### Response
 
-Same `ExchangeTokenResponse` as Exchange — includes a new `GrantToken` and `RefreshToken`.
+Same `ExchangeTokenResponse` as Exchange — includes a new `GrantToken` and `RefreshToken` with the same `GrantID` and `ExpiresAt`.
 
 ## Verify
 

--- a/docs/sdks/python/tokens.mdx
+++ b/docs/sdks/python/tokens.mdx
@@ -50,8 +50,8 @@ with Grantex(api_key="gx_live_...") as client:
 | `grant_token`   | `str`             | The JWT grant token.                             |
 | `grant_id`      | `str`             | The unique grant identifier.                     |
 | `scopes`        | `tuple[str, ...]` | The approved scopes.                             |
-| `expires_at`    | `str`             | ISO 8601 timestamp when the token expires.       |
-| `refresh_token` | `str`             | A refresh token for obtaining new grant tokens.  |
+| `expires_at`    | `str`             | ISO 8601 timestamp when the underlying grant expires. |
+| `refresh_token` | `str`             | A refresh token for rotating credentials while the grant remains active. |
 
 ### Exchange with PKCE
 
@@ -68,9 +68,9 @@ with Grantex(api_key="gx_live_...") as client:
 
 ## Refresh
 
-Refresh a grant token using a refresh token. Returns a new grant token and a new refresh token. The `grant_id` stays the same.
+Refresh a grant token using a refresh token while the underlying grant remains active. Returns a new grant token and a new refresh token. The `grant_id` and `expires_at` stay the same.
 
-Refresh tokens are single-use and rotated on every refresh per SPEC §7.4. If the HTTP response is lost after the server commits the rotation, retry the same previous refresh token immediately. During a five-minute (300-second) replay-recovery window, Grantex returns the already-rotated refresh token instead of rotating again. After that window, or once the rotated child token has been used, the previous refresh token is rejected.
+Refresh tokens are single-use and rotated on every refresh per SPEC §7.4. Refresh does not extend the grant lifetime; after `expires_at`, the caller must re-authorize. If the HTTP response is lost after the server commits the rotation, retry the same previous refresh token immediately. During a five-minute (300-second) replay-recovery window, Grantex returns the already-rotated refresh token instead of rotating again while the grant remains active. After that window, or once the rotated child token has been used, the previous refresh token is rejected.
 
 ```python
 from grantex import Grantex, RefreshTokenParams
@@ -84,6 +84,7 @@ with Grantex(api_key="gx_live_...") as client:
     print(f"New grant token: {new_token.grant_token}")
     print(f"New refresh token: {new_token.refresh_token}")
     print(f"Same grant ID: {new_token.grant_id}")
+    print(f"Same grant expiration: {new_token.expires_at}")
 ```
 
 ### RefreshTokenParams
@@ -98,7 +99,7 @@ with Grantex(api_key="gx_live_...") as client:
 Returns an `ExchangeTokenResponse` — same shape as `exchange()`. See above for field descriptions.
 
 <Warning>
-Each refresh token can only be used once. If you attempt to reuse a refresh token, the request will be rejected with a `400` error. Always store and use the new `refresh_token` from the response.
+Each refresh token can only be used once. Always store and use the new `refresh_token` from the response. The previous token is accepted only for lost-response recovery during the five-minute window while the grant remains active; after the window, after the rotated child token is used, or after grant expiration, reuse is rejected with a `400` error.
 </Warning>
 
 ## Verify

--- a/docs/soc2-type1/report.md
+++ b/docs/soc2-type1/report.md
@@ -343,7 +343,7 @@ The organization demonstrates a commitment to integrity and ethical values.
 
 | Control | Description | Evidence |
 |---------|-------------|----------|
-| C1.2.1 Refresh token single-use rotation | Refresh tokens are single-use. The authorization server invalidates a refresh token on first use and issues a new one; a five-minute (300-second) replay-recovery window can return the already-rotated child token if the first response was lost, but reuse is rejected after the window or after the child token is used. | `apps/auth-service/src/routes/token.ts` |
+| C1.2.1 Refresh token single-use rotation | Refresh tokens are single-use and capped by the underlying grant expiration. The authorization server invalidates a refresh token on first accepted non-replay use and issues a new one; a five-minute (300-second) replay-recovery window can return the already-rotated child token if the first response was lost while the grant remains active, but reuse is rejected after the window, after the child token is used, or after grant expiration. | `apps/auth-service/src/routes/token.ts` |
 | C1.2.2 Redis TTL-based expiry | Redis keys for JTI tracking are set with a TTL matching the token's expiry, ensuring that revocation and replay-prevention records are automatically purged after tokens expire, limiting long-term data accumulation. | `apps/auth-service/src/routes/tokens.ts` |
 
 ---

--- a/docs/standards/nist-nccoe-comment.md
+++ b/docs/standards/nist-nccoe-comment.md
@@ -56,7 +56,7 @@ The Manage function allocates risk management resources. DAAP contributes throug
 | AI RMF Category | DAAP Capability | Implementation |
 |-----------------|-----------------|----------------|
 | MANAGE 1.1 — Risk treatment | Real-time grant revocation | `DELETE /v1/grants/:id` atomically revokes the grant and all descendant grants. Sub-second propagation. |
-| MANAGE 2.2 — Mechanisms to supersede | Token revocation + refresh rotation | Individual tokens revocable by JTI. Refresh tokens are single-use with automatic rotation and a bounded replay-recovery window for lost refresh responses. |
+| MANAGE 2.2 — Mechanisms to supersede | Token revocation + refresh rotation | Individual tokens are revocable by JTI. Refresh tokens are single-use, capped by grant expiration, and include a bounded replay-recovery window for lost refresh responses without extending the grant lifetime. |
 | MANAGE 3.1 — Response plans | Event streaming + webhooks | Real-time SSE/WebSocket event streams for `grant.created`, `grant.revoked`, `token.issued`, `budget.threshold`, `budget.exhausted`. Webhooks persist delivery attempts and retry failures with a finite cap. |
 | MANAGE 4.1 — Incident response | Cascade revocation + anomaly alerts | Revoking a parent grant atomically revokes all sub-agent grants. Anomaly detection surfaces high-severity behavioral deviations. |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,7 +37,7 @@ All examples use the sandbox key by default.
 | [`nextjs-starter`](./nextjs-starter/) | Next.js interactive consent flow with callback handling | `@grantex/sdk` |
 | [`openai-agents`](./openai-agents/) | OpenAI Agents SDK with scope enforcement | `grantex`, `grantex-openai-agents` |
 | [`google-adk`](./google-adk/) | Google ADK with scoped function tools | `grantex`, `grantex-adk` |
-| [`token-expiry-refresh`](./token-expiry-refresh/) | Time-bound grants with expiry detection and refresh token rotation | `@grantex/sdk` |
+| [`token-expiry-refresh`](./token-expiry-refresh/) | Active-grant refresh rotation, 300-second lost-response recovery, and expired-grant re-authorization | `@grantex/sdk` |
 | [`audit-dashboard`](./audit-dashboard/) | Audit trail querying, filtering, metrics, and hash chain verification | `@grantex/sdk` |
 | [`multi-agent-email-flow`](./multi-agent-email-flow/) | Multi-agent delegation with failure handling and audit trail | `@grantex/sdk` |
 | [`gemma-raspberry-pi`](./gemma-raspberry-pi/) | Gemma 4 smart home agent on Raspberry Pi with offline auth | `grantex-gemma` |

--- a/examples/token-expiry-refresh/README.md
+++ b/examples/token-expiry-refresh/README.md
@@ -1,6 +1,6 @@
 # Token Refresh & Rotation
 
-Demonstrates time-bound grants, refresh token rotation, lost-response recovery, and the re-authorization boundary after a grant expires.
+Demonstrates active-grant refresh rotation, lost-response recovery, and the re-authorization boundary after a grant expires.
 
 ## What it does
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -91,7 +91,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 |---|---|
 | `grantex_token_exchange` | Exchange authorization code for a signed grant token (RS256 JWT) |
 | `grantex_token_verify` | Verify a grant token — check scopes, expiry, and revocation status |
-| `grantex_token_refresh` | Refresh a grant token using a refresh token |
+| `grantex_token_refresh` | Rotate credentials for an active grant using a refresh token |
 | `grantex_token_revoke` | Revoke a grant token by JTI |
 
 ### Grant Management (4)

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -342,8 +342,10 @@ console.log(token.refreshToken); // for token refresh
 | `grantToken` | `string` | Signed RS256 JWT — the agent's bearer credential |
 | `grantId` | `string` | Grant record ID |
 | `scopes` | `string[]` | Scopes the user approved |
-| `expiresAt` | `string` | Token expiry (ISO 8601) |
-| `refreshToken` | `string` | Refresh token for obtaining new grant tokens |
+| `expiresAt` | `string` | Underlying grant expiry (ISO 8601) |
+| `refreshToken` | `string` | Refresh token for rotating credentials while the grant remains active |
+
+Refresh tokens are single-use and rotate on every accepted refresh. If a refresh response is lost after the server commits rotation, retry the same previous refresh token immediately; Grantex can return the already-rotated token pair for five minutes (300 seconds) while the grant remains active. Refresh does not extend `expiresAt`; after the grant expires, re-authorize.
 
 ---
 

--- a/web/index.html
+++ b/web/index.html
@@ -2953,10 +2953,10 @@ grantex agent install --dir /path/to/skills</pre>
       <a href="https://github.com/mishrasanjeev/grantex/tree/main/examples/token-expiry-refresh"
          class="example-card" style="text-decoration:none;">
         <div class="example-lang">TypeScript</div>
-        <h3>Token Expiry &amp; Refresh</h3>
+        <h3>Token Refresh &amp; Rotation</h3>
         <p>
-          Time-bound grant tokens with automatic expiry detection, refresh token
-          rotation, and single-use refresh enforcement.
+          Active-grant refresh rotation, 300-second lost-response recovery,
+          single-use enforcement, and the expired-grant re-authorization boundary.
         </p>
         <div class="example-packages">
           <span class="example-pkg">@grantex/sdk</span>
@@ -3262,7 +3262,7 @@ grantex agent install --dir /path/to/skills</pre>
             <span class="check">&#x2713;</span>
             <div>
               <h4><a href="https://docs.grantex.dev/guides/security-hardening" style="color:inherit;text-decoration:none;">Security Hardening</a></h4>
-              <p>Fastify per-IP defaults or route overrides, plus additional standard-auth plan budgets (with JWKS exempt), HTTP security headers (HSTS, CSP, X-Frame-Options), HMAC-signed SSO state, timing-safe auth, scope validation, and 1MB body limits.</p>
+              <p>Fastify per-IP defaults or route overrides, plus additional standard-auth plan budgets (with JWKS exempt), HTTP security headers, HMAC-signed SSO state, timing-safe auth, scope validation, bounded refresh-token recovery, and 1MB body limits.</p>
             </div>
           </div>
           <div class="enterprise-feature">

--- a/web/playground.html
+++ b/web/playground.html
@@ -368,7 +368,7 @@
         <span class="step-badge badge-pending" id="badge5">Pending</span>
       </div>
       <div class="step-body">
-        <div class="step-desc">Exchange the single-use refresh token for a new grant token. The old refresh token is invalidated (rotation).</div>
+        <div class="step-desc">Exchange the single-use refresh token for a new grant token while the grant is active. A lost response can be recovered for 300 seconds; refresh does not extend grant expiry.</div>
         <div class="panel">
           <div class="panel-label"><span class="method method-post">POST</span> /v1/token/refresh</div>
           <pre id="req5"></pre>


### PR DESCRIPTION
## Summary
- update the landing page and playground copy for refresh-token recovery
- align README, SDK docs, package READMEs, and example docs with the active-grant refresh boundary
- clarify that lost refresh responses are recoverable for five minutes / 300 seconds, refresh does not extend grant expiry, and expired grants require re-authorization

## Validation
- git diff --check
- git diff --cached --check
- node scripts/check-docs-integrity.mjs
- node scripts/check-seo-aeo.mjs
- stale refresh-copy scan for old 120-second / token-expiry wording