### PR TITLE
fix(docs): handle comma-separated live URL examples

### DIFF
--- a/scripts/check-docs-integrity.mjs
+++ b/scripts/check-docs-integrity.mjs
@@ -819,7 +819,7 @@ async function validatePublishedVersions(releaseSnapshot) {
 
 async function validateLiveUrls(publicContent) {
   const urls = new Set();
-  const pattern = /https:\/\/(?:docs\.)?grantex\.dev[^\s"'<>)]*/g;
+  const pattern = /https:\/\/(?:docs\.)?grantex\.dev[^\s"',<>)]*/g;
   for (const { text } of publicContent) {
     for (const match of text.matchAll(pattern)) {
       const url = match[0]


### PR DESCRIPTION
## Summary
- prevent the live docs integrity checker from treating comma-separated config examples as a single URL
- keeps production/live docs health checks focused on actual grantex.dev and docs.grantex.dev links

## Validation
- git diff --check
- node scripts/check-docs-integrity.mjs
- node scripts/check-docs-integrity.mjs --live