### PR TITLE
docs: add alternate DAAP author contact

### DIFF
--- a/docs/community/ietf-draft.mdx
+++ b/docs/community/ietf-draft.mdx
@@ -8,6 +8,7 @@ description: "Delegated Agent Authorization Protocol (DAAP) — active individua
 **Prepared source candidate:** `draft-mishra-oauth-agent-grants-02`
 **Target:** IETF OAuth Working Group (`oauth@ietf.org`)
 **Status:** Active individual Internet-Draft; not IETF-endorsed and not OAuth WG-adopted
+**Author contacts:** [sanjeev@orchestrum.in](mailto:sanjeev@orchestrum.in) (primary) and [mishra.sanjeev@gmail.com](mailto:mishra.sanjeev@gmail.com) (alternate)
 
 The authoritative record is the [IETF Datatracker](https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/). An individual Internet-Draft is not endorsed by the IETF and has no formal standards standing unless the working group adopts it and the standards process advances it.
 

--- a/docs/ietf-draft/README.md
+++ b/docs/ietf-draft/README.md
@@ -85,7 +85,7 @@ Confirm:
 - `draft-mishra-oauth-agent-grants-02.xml` renders successfully.
 - `draft-mishra-oauth-agent-grants-02.txt` has no blocking idnits errors.
 - Datatracker metadata shows intended status as Informational after submission.
-- Author email is correct and reachable for confirmation.
+- The formal author email is `sanjeev@orchestrum.in`; `mishra.sanjeev@gmail.com` is prominently listed as the alternate author contact in the draft body.
 - The implementation report still matches current package versions.
 
 ---
@@ -95,8 +95,10 @@ Confirm:
 1. Render `draft-mishra-oauth-agent-grants-02.xml`.
 2. Go to <https://datatracker.ietf.org/submit/>.
 3. Upload `draft-mishra-oauth-agent-grants-02.xml` or `.txt`.
-4. Confirm the submission from the email sent to `sanjeev@orchestrum.in`.
+4. Confirm the submission from the email sent to the formal author address, `sanjeev@orchestrum.in`.
 5. Verify that the Datatracker page shows revision `-02`.
+
+The rendered draft also identifies `mishra.sanjeev@gmail.com` as the alternate author contact. RFCXML permits one structured email address per author record, so the Orchestrum address remains the formal Datatracker contact and both addresses appear together in the draft's **Discussion Venues** section.
 
 The draft will continue to appear at:
 `https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/`

--- a/docs/ietf-draft/draft-mishra-oauth-agent-grants-02.md
+++ b/docs/ietf-draft/draft-mishra-oauth-agent-grants-02.md
@@ -120,6 +120,8 @@ DAAP addresses these requirements as a layered profile of OAuth 2.0 concepts, re
 
 Discussion of this draft is requested on the IETF OAuth Working Group mailing list:
 
+- Author contact (primary): Sanjeev Kumar, <sanjeev@orchestrum.in>
+- Author contact (alternate): Sanjeev Kumar, <mishra.sanjeev@gmail.com>
 - Mailing list: <oauth@ietf.org>
 - Archive: <https://mailarchive.ietf.org/arch/browse/oauth/>
 - Working group: <https://datatracker.ietf.org/wg/oauth/>
@@ -132,7 +134,7 @@ This is an individual Internet-Draft. Publication as an Internet-Draft does not 
 
 This revision makes the following changes:
 
-- Updates the author organization and primary contact address.
+- Updates the author organization and prominently identifies both the primary and alternate author contact addresses.
 - Clarifies that DAAP is vendor-neutral and that Grantex is a reference implementation rather than a required authority, DID method, JSON-LD context, or policy path.
 - Adds a bounded lost-response recovery rule for refresh token rotation. Authorization Servers MAY replay the immediately previous refresh token response for no more than 300 seconds and only while the Grant remains active.
 - Adds explicit alignment with the OAuth 2.0 Security Best Current Practice, PKCE, Pushed Authorization Requests, DPoP, mutual TLS, and Protected Resource Metadata.

--- a/docs/ietf-draft/draft-mishra-oauth-agent-grants-02.txt
+++ b/docs/ietf-draft/draft-mishra-oauth-agent-grants-02.txt
@@ -68,7 +68,7 @@ Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   4
      1.1.  Discussion Venues . . . . . . . . . . . . . . . . . . . .   5
-     1.2.  Changes Since -01 . . . . . . . . . . . . . . . . . . . .   5
+     1.2.  Changes Since -01 . . . . . . . . . . . . . . . . . . . .   6
      1.3.  Changes Since -00 . . . . . . . . . . . . . . . . . . . .   6
      1.4.  Requirements Language . . . . . . . . . . . . . . . . . .   7
      1.5.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   7
@@ -76,7 +76,7 @@ Table of Contents
      2.1.  DID Format  . . . . . . . . . . . . . . . . . . . . . . .   8
      2.2.  Identity Document . . . . . . . . . . . . . . . . . . . .   9
      2.3.  Key Management  . . . . . . . . . . . . . . . . . . . . .   9
-   3.  Scope Format and Registry . . . . . . . . . . . . . . . . . .   9
+   3.  Scope Format and Registry . . . . . . . . . . . . . . . . . .  10
      3.1.  Format  . . . . . . . . . . . . . . . . . . . . . . . . .  10
      3.2.  Standard Scope Registry . . . . . . . . . . . . . . . . .  10
      3.3.  Custom Scopes . . . . . . . . . . . . . . . . . . . . . .  11
@@ -248,6 +248,12 @@ Internet-Draft                    DAAP                       August 2026
    Discussion of this draft is requested on the IETF OAuth Working Group
    mailing list:
 
+   *  Author contact (primary): Sanjeev Kumar, sanjeev@orchestrum.in
+      (mailto:sanjeev@orchestrum.in)
+
+   *  Author contact (alternate): Sanjeev Kumar,
+      mishra.sanjeev@gmail.com (mailto:mishra.sanjeev@gmail.com)
+
    *  Mailing list: oauth@ietf.org (mailto:oauth@ietf.org)
 
    *  Archive: https://mailarchive.ietf.org/arch/browse/oauth/
@@ -266,12 +272,6 @@ Internet-Draft                    DAAP                       August 2026
    Draft does not imply IETF endorsement, OAuth Working Group adoption,
    or IETF consensus.
 
-1.2.  Changes Since -01
-
-   This revision makes the following changes:
-
-   *  Updates the author organization and primary contact address.
-
 
 
 
@@ -281,6 +281,13 @@ Kumar                     Expires 3 March 2027                  [Page 5]
 
 Internet-Draft                    DAAP                       August 2026
 
+
+1.2.  Changes Since -01
+
+   This revision makes the following changes:
+
+   *  Updates the author organization and prominently identifies both
+      the primary and alternate author contact addresses.
 
    *  Clarifies that DAAP is vendor-neutral and that Grantex is a
       reference implementation rather than a required authority, DID
@@ -323,13 +330,6 @@ Internet-Draft                    DAAP                       August 2026
    *  External Policy Backends (Section 13): integration with OPA and
       Cedar as policy evaluation targets.
 
-   *  Implementation Report (Appendix B): conformance results and SDK
-      coverage.
-
-   *  Updated Conformance Requirements (Section 9) with OPTIONAL
-      extensions for Budget, Events, Vault, and Policy Backends.
-
-
 
 
 
@@ -337,6 +337,12 @@ Kumar                     Expires 3 March 2027                  [Page 6]
 
 Internet-Draft                    DAAP                       August 2026
 
+
+   *  Implementation Report (Appendix B): conformance results and SDK
+      coverage.
+
+   *  Updated Conformance Requirements (Section 9) with OPTIONAL
+      extensions for Budget, Events, Vault, and Policy Backends.
 
 1.4.  Requirements Language
 
@@ -380,12 +386,6 @@ Internet-Draft                    DAAP                       August 2026
       for a specific set of Scopes.  A Grant is represented to the Agent
       as a Grant Token.
 
-   Grant Token:
-      A signed JWT [RFC7519] representing a valid, non-revoked Grant.
-      Grant Tokens are short-lived credentials carrying agent-specific
-      claims defined in Section 5.
-
-   Scope:
 
 
 
@@ -394,6 +394,12 @@ Kumar                     Expires 3 March 2027                  [Page 7]
 Internet-Draft                    DAAP                       August 2026
 
 
+   Grant Token:
+      A signed JWT [RFC7519] representing a valid, non-revoked Grant.
+      Grant Tokens are short-lived credentials carrying agent-specific
+      claims defined in Section 5.
+
+   Scope:
       A named permission string following the format
       resource:action[:constraint] as defined in Section 3.
 
@@ -437,18 +443,17 @@ Internet-Draft                    DAAP                       August 2026
 
    Example:
 
-   did:example:agent:ag_01HXYZ123abcDEF456ghi
-
-   The did:example method and identifiers in this document are
-   illustrative only.
-
-
 
 
 Kumar                     Expires 3 March 2027                  [Page 8]
 
 Internet-Draft                    DAAP                       August 2026
 
+
+   did:example:agent:ag_01HXYZ123abcDEF456ghi
+
+   The did:example method and identifiers in this document are
+   illustrative only.
 
 2.2.  Identity Document
 
@@ -494,17 +499,14 @@ Internet-Draft                    DAAP                       August 2026
       verification endpoints rather than hard-coding deployment-specific
       paths.
 
-3.  Scope Format and Registry
-
-
-
-
 
 
 Kumar                     Expires 3 March 2027                  [Page 9]
 
 Internet-Draft                    DAAP                       August 2026
 
+
+3.  Scope Format and Registry
 
 3.1.  Format
 
@@ -528,8 +530,6 @@ Internet-Draft                    DAAP                       August 2026
    The following scopes constitute the normative standard registry.
    Implementations MUST support all standard scopes that are relevant to
    the resources they expose:
-
-
 
 
 

--- a/docs/ietf-draft/draft-mishra-oauth-agent-grants-02.xml
+++ b/docs/ietf-draft/draft-mishra-oauth-agent-grants-02.xml
@@ -79,6 +79,8 @@
 <t>Discussion of this draft is requested on the IETF OAuth Working Group mailing list:</t>
 
 <t><list style="symbols">
+  <t>Author contact (primary): Sanjeev Kumar, <eref target="mailto:sanjeev@orchestrum.in">sanjeev@orchestrum.in</eref></t>
+  <t>Author contact (alternate): Sanjeev Kumar, <eref target="mailto:mishra.sanjeev@gmail.com">mishra.sanjeev@gmail.com</eref></t>
   <t>Mailing list: <eref target="mailto:oauth@ietf.org">oauth@ietf.org</eref></t>
   <t>Archive: <eref target="https://mailarchive.ietf.org/arch/browse/oauth/">https://mailarchive.ietf.org/arch/browse/oauth/</eref></t>
   <t>Working group: <eref target="https://datatracker.ietf.org/wg/oauth/">https://datatracker.ietf.org/wg/oauth/</eref></t>
@@ -94,7 +96,7 @@
 <t>This revision makes the following changes:</t>
 
 <t><list style="symbols">
-  <t>Updates the author organization and primary contact address.</t>
+  <t>Updates the author organization and prominently identifies both the primary and alternate author contact addresses.</t>
   <t>Clarifies that DAAP is vendor-neutral and that Grantex is a reference implementation rather than a required authority, DID method, JSON-LD context, or policy path.</t>
   <t>Adds a bounded lost-response recovery rule for refresh token rotation. Authorization Servers <bcp14>MAY</bcp14> replay the immediately previous refresh token response for no more than 300 seconds and only while the Grant remains active.</t>
   <t>Adds explicit alignment with the OAuth 2.0 Security Best Current Practice, PKCE, Pushed Authorization Requests, DPoP, mutual TLS, and Protected Resource Metadata.</t>


### PR DESCRIPTION
Adds mishra.sanjeev@gmail.com as the prominently labeled alternate contact for Sanjeev Kumar in the DAAP revision 02 draft, rendered XML/TXT, and IETF guidance. The formal RFCXML author email remains sanjeev@orchestrum.in because RFCXML supports one structured email per author record. Validation: xml2rfc succeeds; idnits reports 0 errors and the same 3 advisory warnings; git diff --check is clean.