### PR TITLE
docs: make Gmail primary DAAP contact

### DIFF
--- a/docs/community/ietf-draft.mdx
+++ b/docs/community/ietf-draft.mdx
@@ -8,7 +8,7 @@ description: "Delegated Agent Authorization Protocol (DAAP) — active individua
 **Prepared source candidate:** `draft-mishra-oauth-agent-grants-02`
 **Target:** IETF OAuth Working Group (`oauth@ietf.org`)
 **Status:** Active individual Internet-Draft; not IETF-endorsed and not OAuth WG-adopted
-**Author contacts:** [sanjeev@orchestrum.in](mailto:sanjeev@orchestrum.in) (primary) and [mishra.sanjeev@gmail.com](mailto:mishra.sanjeev@gmail.com) (alternate)
+**Author contacts:** [mishra.sanjeev@gmail.com](mailto:mishra.sanjeev@gmail.com) (primary) and [sanjeev@orchestrum.in](mailto:sanjeev@orchestrum.in) (alternate)
 
 The authoritative record is the [IETF Datatracker](https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/). An individual Internet-Draft is not endorsed by the IETF and has no formal standards standing unless the working group adopts it and the standards process advances it.
 

--- a/docs/ietf-draft/README.md
+++ b/docs/ietf-draft/README.md
@@ -85,7 +85,7 @@ Confirm:
 - `draft-mishra-oauth-agent-grants-02.xml` renders successfully.
 - `draft-mishra-oauth-agent-grants-02.txt` has no blocking idnits errors.
 - Datatracker metadata shows intended status as Informational after submission.
-- The formal author email is `sanjeev@orchestrum.in`; `mishra.sanjeev@gmail.com` is prominently listed as the alternate author contact in the draft body.
+- The formal author email is `mishra.sanjeev@gmail.com`; `sanjeev@orchestrum.in` is prominently listed as the alternate author contact in the draft body.
 - The implementation report still matches current package versions.
 
 ---
@@ -95,10 +95,10 @@ Confirm:
 1. Render `draft-mishra-oauth-agent-grants-02.xml`.
 2. Go to <https://datatracker.ietf.org/submit/>.
 3. Upload `draft-mishra-oauth-agent-grants-02.xml` or `.txt`.
-4. Confirm the submission from the email sent to the formal author address, `sanjeev@orchestrum.in`.
+4. Confirm the submission from the email sent to the formal author address, `mishra.sanjeev@gmail.com`.
 5. Verify that the Datatracker page shows revision `-02`.
 
-The rendered draft also identifies `mishra.sanjeev@gmail.com` as the alternate author contact. RFCXML permits one structured email address per author record, so the Orchestrum address remains the formal Datatracker contact and both addresses appear together in the draft's **Discussion Venues** section.
+The rendered draft also identifies `sanjeev@orchestrum.in` as the alternate author contact. RFCXML permits one structured email address per author record, so the Gmail address remains the formal Datatracker contact and both addresses appear together in the draft's **Discussion Venues** section.
 
 The draft will continue to appear at:
 `https://datatracker.ietf.org/doc/draft-mishra-oauth-agent-grants/`

--- a/docs/ietf-draft/draft-mishra-oauth-agent-grants-02.md
+++ b/docs/ietf-draft/draft-mishra-oauth-agent-grants-02.md
@@ -22,7 +22,7 @@ pi: [toc, sortrefs, symrefs]
 author:
   - fullname: Sanjeev Kumar
     organization: Orchestrum Technologies LLP
-    email: sanjeev@orchestrum.in
+    email: mishra.sanjeev@gmail.com
     uri: https://grantex.dev
 
 normative:
@@ -120,8 +120,8 @@ DAAP addresses these requirements as a layered profile of OAuth 2.0 concepts, re
 
 Discussion of this draft is requested on the IETF OAuth Working Group mailing list:
 
-- Author contact (primary): Sanjeev Kumar, <sanjeev@orchestrum.in>
-- Author contact (alternate): Sanjeev Kumar, <mishra.sanjeev@gmail.com>
+- Author contact (primary): Sanjeev Kumar, <mishra.sanjeev@gmail.com>
+- Author contact (alternate): Sanjeev Kumar, <sanjeev@orchestrum.in>
 - Mailing list: <oauth@ietf.org>
 - Archive: <https://mailarchive.ietf.org/arch/browse/oauth/>
 - Working group: <https://datatracker.ietf.org/wg/oauth/>

--- a/docs/ietf-draft/draft-mishra-oauth-agent-grants-02.txt
+++ b/docs/ietf-draft/draft-mishra-oauth-agent-grants-02.txt
@@ -248,11 +248,11 @@ Internet-Draft                    DAAP                       August 2026
    Discussion of this draft is requested on the IETF OAuth Working Group
    mailing list:
 
-   *  Author contact (primary): Sanjeev Kumar, sanjeev@orchestrum.in
-      (mailto:sanjeev@orchestrum.in)
+   *  Author contact (primary): Sanjeev Kumar, mishra.sanjeev@gmail.com
+      (mailto:mishra.sanjeev@gmail.com)
 
-   *  Author contact (alternate): Sanjeev Kumar,
-      mishra.sanjeev@gmail.com (mailto:mishra.sanjeev@gmail.com)
+   *  Author contact (alternate): Sanjeev Kumar, sanjeev@orchestrum.in
+      (mailto:sanjeev@orchestrum.in)
 
    *  Mailing list: oauth@ietf.org (mailto:oauth@ietf.org)
 
@@ -2592,7 +2592,7 @@ Author's Address
 
    Sanjeev Kumar
    Orchestrum Technologies LLP
-   Email: sanjeev@orchestrum.in
+   Email: mishra.sanjeev@gmail.com
    URI:   https://grantex.dev
 
 

--- a/docs/ietf-draft/draft-mishra-oauth-agent-grants-02.xml
+++ b/docs/ietf-draft/draft-mishra-oauth-agent-grants-02.xml
@@ -19,7 +19,7 @@
     <author fullname="Sanjeev Kumar">
       <organization>Orchestrum Technologies LLP</organization>
       <address>
-        <email>sanjeev@orchestrum.in</email>
+        <email>mishra.sanjeev@gmail.com</email>
         <uri>https://grantex.dev</uri>
       </address>
     </author>
@@ -79,8 +79,8 @@
 <t>Discussion of this draft is requested on the IETF OAuth Working Group mailing list:</t>
 
 <t><list style="symbols">
-  <t>Author contact (primary): Sanjeev Kumar, <eref target="mailto:sanjeev@orchestrum.in">sanjeev@orchestrum.in</eref></t>
-  <t>Author contact (alternate): Sanjeev Kumar, <eref target="mailto:mishra.sanjeev@gmail.com">mishra.sanjeev@gmail.com</eref></t>
+  <t>Author contact (primary): Sanjeev Kumar, <eref target="mailto:mishra.sanjeev@gmail.com">mishra.sanjeev@gmail.com</eref></t>
+  <t>Author contact (alternate): Sanjeev Kumar, <eref target="mailto:sanjeev@orchestrum.in">sanjeev@orchestrum.in</eref></t>
   <t>Mailing list: <eref target="mailto:oauth@ietf.org">oauth@ietf.org</eref></t>
   <t>Archive: <eref target="https://mailarchive.ietf.org/arch/browse/oauth/">https://mailarchive.ietf.org/arch/browse/oauth/</eref></t>
   <t>Working group: <eref target="https://datatracker.ietf.org/wg/oauth/">https://datatracker.ietf.org/wg/oauth/</eref></t>


### PR DESCRIPTION
Makes mishra.sanjeev@gmail.com the formal RFCXML and Datatracker primary author address for DAAP revision 02. Keeps sanjeev@orchestrum.in prominently listed as the alternate contact. Updates the source, rendered XML/TXT, submission instructions, and public IETF documentation. Validation: xml2rfc succeeds; idnits reports 0 errors and the same 3 advisory warnings; git diff --check is clean.