### PR TITLE
fix: route prepaid wallet e2e through production

### DIFF
--- a/.github/workflows/deploy-portal.yml
+++ b/.github/workflows/deploy-portal.yml
@@ -83,6 +83,30 @@ jobs:
           check "/v1/identity" "\"@context\""
           check "/v1/x402" "\"@context\""
 
+          echo "--- GET $BASE/v1/prepaid-wallets"
+          prepaid_list_body=$(curl -sS -L --fail-with-body --max-time 20 \
+            "$BASE/v1/prepaid-wallets" || true)
+          if ! grep -q '"code":"INVALID_TOKEN"' <<<"$prepaid_list_body"; then
+            echo "FAIL: /v1/prepaid-wallets did not reach the auth-service"
+            echo "---- response head ----"
+            head -c 500 <<<"$prepaid_list_body"
+            exit 1
+          fi
+          echo "OK"
+
+          echo "--- POST $BASE/v1/prepaid-wallets/authorizations"
+          prepaid_authorize_body=$(curl -sS -L --fail-with-body --max-time 20 \
+            -H "Content-Type: application/json" \
+            -d '{}' \
+            "$BASE/v1/prepaid-wallets/authorizations" || true)
+          if ! grep -q '"code":"INVALID_TOKEN"' <<<"$prepaid_authorize_body"; then
+            echo "FAIL: /v1/prepaid-wallets/** did not reach the auth-service"
+            echo "---- response head ----"
+            head -c 500 <<<"$prepaid_authorize_body"
+            exit 1
+          fi
+          echo "OK"
+
           echo "--- POST $BASE/v1/webauthn/assert/options"
           webauthn_body=$(curl -sS -L --fail-with-body --max-time 20 \
             -H "Content-Type: application/json" \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,12 +21,16 @@ jobs:
           cache-dependency-path: |
             package-lock.json
             packages/sdk-ts/package-lock.json
+            packages/x402/package-lock.json
 
       - name: Install and build SDK
         run: cd packages/sdk-ts && npm ci && npm run build
 
       - name: Install root dependencies
         run: npm ci
+
+      - name: Install x402 dependencies
+        run: cd packages/x402 && npm ci
 
       - name: Core auth flow
         env:

--- a/firebase.json
+++ b/firebase.json
@@ -17,6 +17,8 @@
       { "source": "/consent", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
       { "source": "/.well-known/oauth-authorization-server", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
       { "source": "/oauth/**", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
+      { "source": "/v1/prepaid-wallets", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
+      { "source": "/v1/prepaid-wallets/**", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
       { "source": "/v1/consent/**", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
       { "source": "/v1/webauthn/**", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },
       { "source": "/.well-known/jwks.json", "run": { "serviceId": "grantex-auth", "region": "us-central1" } },


### PR DESCRIPTION
## Summary
- install the x402 package dependency tree before the production E2E imports its source
- route the public prepaid-wallet OAuth resource through Firebase Hosting to Cloud Run
- smoke-test both the base and wildcard prepaid-wallet rewrites after Firebase deployment

## Verification
- local Docker health: database and Redis healthy
- prepaid-wallet, OAuth agent-profile, and principal-session E2E: 7/7 pass
- x402 typecheck: pass
- x402 package tests: 188/188 pass
- workflow YAML and firebase.json parse: pass
- git diff --check: clean

The failed main production E2E run 33321064309 first exposed the missing x402 install, then local production validation exposed the missing Firebase rewrite. No auth requirement or wallet policy is loosened.