### PR TITLE
fix(sdk): align runtime version metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Published TypeScript SDK 0.3.13, Python SDK 0.3.14, and Go SDK v0.1.10 on 2026-07-11; synchronized the public release snapshot across the landing page, README, compatibility matrix, and SDK documentation.
 
 ### Fixed
+- Corrected the TypeScript SDK `User-Agent` version and tied its regression test to `package.json` so future package bumps cannot publish a stale runtime identifier.
 - Hardened live authorization so policy decisions cannot replace authenticated Principal consent; bound redirects, resources, scopes, and registered agent keys through issuance and delegation.
 - Made refresh rotation recoverable for 300 seconds only when the authenticated caller repeats the same old token and idempotency key; recovery returns the exact committed token response and survives a server restart without extending any lifetime.
 - Corrected the Go SDK source contract across Agent and Audit reads/writes: `agentId` mapping, optional registration fields, status updates, explicit scope clearing, required audit-write fields, `developerId` reads, and list envelopes.

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grantex/sdk",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "jose": "^6.2.3"

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "author": {
     "name": "Sanjeev Kumar",

--- a/packages/sdk-ts/src/http.ts
+++ b/packages/sdk-ts/src/http.ts
@@ -1,7 +1,7 @@
 import { GrantexApiError, GrantexAuthError, GrantexNetworkError } from './errors.js';
 import type { RateLimit } from './types.js';
 
-const SDK_VERSION = '0.3.13';
+const SDK_VERSION = '0.4.1';
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 500;

--- a/packages/sdk-ts/tests/client.test.ts
+++ b/packages/sdk-ts/tests/client.test.ts
@@ -1,6 +1,11 @@
+import { readFileSync } from 'node:fs';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Grantex } from '../src/client.js';
 import { GrantexApiError, GrantexAuthError, GrantexNetworkError } from '../src/errors.js';
+
+const packageVersion = (
+  JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version: string }
+).version;
 
 function makeFetch(status: number, body: unknown, headers?: Record<string, string>) {
   return vi.fn().mockResolvedValue({
@@ -310,7 +315,7 @@ describe('Grantex client', () => {
 
       const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
       const headers = init.headers as Record<string, string>;
-      expect(headers['User-Agent']).toBe('@grantex/sdk/0.3.13');
+      expect(headers['User-Agent']).toBe(`@grantex/sdk/${packageVersion}`);
     });
   });
 });


### PR DESCRIPTION
## Summary
- publish the corrective SDK source as version 0.4.1
- align the HTTP User-Agent with the package version
- derive the regression-test expectation from package.json so future bumps cannot leave stale runtime metadata

## Verification
- npm run typecheck
- npm test (450/450)
- npm run build
- npm audit --omit=dev (0 vulnerabilities)
- npm pack --dry-run

No wallet behavior or API contract changes.