### PR TITLE
docs: publish SDK and x402 release status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## Unreleased
 
 ### Added
-- Added unreleased TypeScript SDK 0.4.0 prepaid-wallet clients and auth-service APIs for principal-owned multi-wallet assignment, per-transaction and rolling cumulative spend limits, recipient/scope allowlists, threshold reload requests with separate principal approval/funding, reservation release, activity views, and assignment/wallet/all-wallet agent stop controls.
+- Added TypeScript SDK 0.4.0 prepaid-wallet clients and auth-service APIs for principal-owned multi-wallet assignment, per-transaction and rolling cumulative spend limits, recipient/scope allowlists, threshold reload requests with separate principal approval/funding, reservation release, activity views, and assignment/wallet/all-wallet agent stop controls.
 - Added durable atomic-unit wallet balances, reservations, reload requests, and append-only ledger entries with serialized concurrent spend enforcement and agent/principal-wide idempotency.
-- Added unreleased `@grantex/x402` 0.2.0 integration with official x402 v2 headers and Foundation client packages, backed by DPoP wallet reservations and idempotent facilitator verification/settlement.
+- Added `@grantex/x402` 0.2.0 integration with official x402 v2 headers and Foundation client packages, backed by DPoP wallet reservations and idempotent facilitator verification/settlement.
 - Added profile-aware agent registration metadata, resolvable keyed agent DID documents, standard OAuth `scope` and `client_id` token claims, resource and redirect binding, signed audit checkpoints, and maintained SDK coverage for those custom API features.
 - Published `@grantex/cli` 0.3.0 on 2026-08-10 with one-command Agent Skills installation for Hermes, OpenClaw, portable `.agents/skills` workspaces, and custom skill roots.
 - Added the `use-grantex-cli` and `integrate-grantex` skills for safe JSON-first operations and service-boundary implementation guidance.
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Commerce, SCIM Bearer data-plane, admin, and other custom-auth routes remain outside these plan buckets.
 
 ### Changed
+- Published `@grantex/sdk@0.4.0`, corrective `@grantex/sdk@0.4.1`, and `@grantex/x402@0.2.0` to npm on 2026-08-30; registry-smoke-tested the prepaid-wallet exports, corrected SDK runtime identifier, x402 exports, and `grantex-x402` CLI.
 - Replaced the x402 client's simulated custom payment-proof flow with official x402 v2 `PAYMENT-REQUIRED`, `PAYMENT-SIGNATURE`, and `PAYMENT-RESPONSE` handling. The standalone GDT APIs remain available but are now documented as authorization context rather than durable cumulative spend enforcement.
 - Published TypeScript SDK 0.3.13, Python SDK 0.3.14, and Go SDK v0.1.10 on 2026-07-11; synchronized the public release snapshot across the landing page, README, compatibility matrix, and SDK documentation.
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,7 +1,7 @@
 # Grantex Compatibility Matrix
 
 Last updated: 2026-08-30
-Public release snapshot verified: 2026-08-10
+Public release snapshot verified: 2026-08-30
 
 This repository uses package-specific versions; there is no monorepo-wide SDK or package release number. The protocol specification remains v1.0 Final, while repository metadata and package registries can move independently during a release.
 
@@ -10,11 +10,10 @@ This repository uses package-specific versions; there is no monorepo-wide SDK or
 | Surface | Current value | Notes |
 | --- | --- | --- |
 | Repository changelog | v0.3.12 | Latest top-level release entry in `CHANGELOG.md`. |
-| TypeScript SDK | @grantex/sdk 0.3.13 | Published to npm on 2026-07-11. |
+| TypeScript SDK | @grantex/sdk 0.4.1 | Published to npm on 2026-08-30; corrects the runtime version identifier from 0.4.0. |
 | Python SDK | grantex 0.3.14 | Published to PyPI on 2026-07-11. |
 | Go SDK | github.com/mishrasanjeev/grantex-go v0.1.10 | Published through the Go module proxy on 2026-07-11 (requires Go 1.26.1); see known limitations below. |
-| TypeScript SDK source | @grantex/sdk 0.4.0 | Unreleased prepaid-wallet client source; public latest remains 0.3.13. |
-| x402 source | @grantex/x402 0.2.0 | Unreleased official x402 v2 prepaid-wallet integration. |
+| x402 | @grantex/x402 0.2.0 | Published to npm on 2026-08-30 with official x402 v2 prepaid-wallet support. |
 | OpenAPI | 0.4.0 | Repository API contract including prepaid wallets; independent of the deployed/public snapshot. |
 | MCP Auth | @grantex/mcp-auth 2.0.2 | Independently versioned and published to npm; single-process evaluation limitations apply. |
 | Published snapshot | [release-status.json](release-status.json) | Machine-readable source for advertised versions and live registry checks. |
@@ -25,7 +24,7 @@ The repository contains 29 packages under `packages/`. Each row maps a directory
 
 | # | Directory | Published name | Version | Status |
 | ---: | --- | --- | ---: | --- |
-| 1 | `packages/sdk-ts` | @grantex/sdk | 0.4.0 | Primary SDK (TypeScript); unreleased source, published latest is 0.3.13 |
+| 1 | `packages/sdk-ts` | @grantex/sdk | 0.4.1 | Primary SDK (TypeScript); published |
 | 2 | `packages/sdk-py` | grantex | 0.3.14 | Primary SDK (Python); published |
 | 3 | `packages/go-sdk` | github.com/mishrasanjeev/grantex-go | v0.1.10 (Go 1.26.1) | Primary SDK (Go); published |
 | 4 | `packages/cli` | @grantex/cli | 0.3.0 | Tooling; published with bundled Agent Skills |
@@ -52,7 +51,7 @@ The repository contains 29 packages under `packages/`. Each row maps a directory
 | 25 | `packages/a2a` | @grantex/a2a | 0.1.3 | A2A bridge (TS) |
 | 26 | `packages/a2a-py` | grantex-a2a | 0.1.4 | A2A bridge (Python) |
 | 27 | `packages/mpp` | @grantex/mpp | 0.1.2 | MPP support |
-| 28 | `packages/x402` | @grantex/x402 | 0.2.0 | Official x402 v2 prepaid-wallet source; unreleased |
+| 28 | `packages/x402` | @grantex/x402 | 0.2.0 | Official x402 v2 prepaid-wallet integration; published |
 | 29 | `packages/terraform-provider-grantex` | terraform-provider-grantex | Go module (Go 1.25.0) | Terraform provider |
 
 ## Known Published-Package Limitations
@@ -89,10 +88,11 @@ The repository contains 29 packages under `packages/`. Each row maps a directory
 Install the verified public releases needed by your application:
 
 ```bash
-npm install @grantex/sdk@0.3.13
+npm install @grantex/sdk@0.4.1
+npm install @grantex/x402@0.2.0 @grantex/sdk@0.4.1
 pip install grantex==0.3.14
 go get github.com/mishrasanjeev/grantex-go@v0.1.10
-npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1
 ```
 
 Unpinned install commands resolve to the registry's current release. For reproducible builds, keep the explicit versions above and review this matrix before upgrading.

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ The OAuth grant must include `wallet:spend` and the exact merchant action scope
 advertised as `extra.grantexScope`; wallet assignment policy can restrict that
 human-approved authority but cannot add to it.
 
-This API is unreleased repository source until new SDK/x402 package versions
-are published. See the [x402 integration guide](docs/integrations/x402.mdx),
+The managed clients are published as `@grantex/sdk@0.4.1` and
+`@grantex/x402@0.2.0`. See the [x402 integration guide](docs/integrations/x402.mdx),
 [wallet lifecycle](docs/features/prepaid-wallets.mdx), and
 [production-readiness guide](docs/guides/prepaid-wallet-production.mdx).
 
@@ -113,9 +113,9 @@ real-money product. Self-hosting operators must explicitly provide and test:
 - independent security, provider, reconciliation, incident-response, and
   applicable legal/regulatory review.
 
-The server deployment and npm release are separate. Registry consumers do not
-receive the repository's `@grantex/sdk@0.4.0` and `@grantex/x402@0.2.0` APIs
-until both packages are published and registry-verified. The
+The server deployment and npm release are separate. Registry consumers should
+pin the registry-verified `@grantex/sdk@0.4.1` and `@grantex/x402@0.2.0`
+releases rather than inferring availability from repository manifests. The
 [production-readiness guide](docs/guides/prepaid-wallet-production.mdx) contains
 the full hosting checklist and a maintainer-only PowerShell publication runbook.
 
@@ -138,8 +138,7 @@ Verification completed with 2,097 auth-service tests, 444 SDK tests, and 253
 tests across 21 sequential Docker E2E files. This is self-assessed evidence for
 the tested Grantex configuration, not independent interoperability
 certification, OAuth Working Group adoption, or IETF endorsement. The
-`OAuthAgentClient` API is currently repository source; verify a newer npm
-release before assuming it is present in published `@grantex/sdk@0.3.13`.
+`OAuthAgentClient` is published in `@grantex/sdk@0.4.1`.
 
 Revision `-02` remains the current Datatracker publication. Candidate `-03`
 must not be uploaded before 2026-09-09 and requires a fresh explicit approval
@@ -175,14 +174,15 @@ Start with the [OACP runtime launch closure PRD](docs/guides/oacp/runtime-launch
 
 Grantex components are independently versioned. The protocol specification remains **v1.0 Final**; SDK, MCP package, and roadmap milestone versions are separate release lines and do not represent a monorepo-wide version.
 
-Current public releases, verified 2026-08-10:
+Current public releases, verified 2026-08-30:
 
 | Component | Public version | Reproducible install |
 | --- | ---: | --- |
-| TypeScript SDK | `@grantex/sdk` `0.3.13` | `npm install @grantex/sdk@0.3.13` |
+| TypeScript SDK | `@grantex/sdk` `0.4.1` | `npm install @grantex/sdk@0.4.1` |
+| x402 Payment Protocol | `@grantex/x402` `0.2.0` | `npm install @grantex/x402@0.2.0 @grantex/sdk@0.4.1` |
 | Python SDK | `grantex` `0.3.14` | `python -m pip install grantex==0.3.14` |
 | Go SDK | `github.com/mishrasanjeev/grantex-go` `v0.1.10` (Go 1.26.1+) | `go get github.com/mishrasanjeev/grantex-go@v0.1.10` |
-| MCP Authorization Server | `@grantex/mcp-auth` `2.0.2` | `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13` |
+| MCP Authorization Server | `@grantex/mcp-auth` `2.0.2` | `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1` |
 
 > **Known published-package limits:** Go SDK `v0.1.10` has documented Agent/Audit
 > read, write, filter, query-encoding, and list-metadata limitations. MCP Auth
@@ -215,7 +215,7 @@ Omit a version pin to install the registry's current latest release. See the [re
 ## SDK quickstart
 
 ```bash
-npm install @grantex/sdk@0.3.13
+npm install @grantex/sdk@0.4.1
 ```
 
 ```typescript
@@ -253,7 +253,7 @@ if (!auth.code) {
 ```bash
 python -m pip install grantex==0.3.14               # Python SDK
 go get github.com/mishrasanjeev/grantex-go@v0.1.10 # Go SDK (Go 1.26.1+)
-npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13 # MCP endpoint evaluation
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1 # MCP endpoint evaluation
 npm install -g @grantex/cli@0.3.0                   # Optional CLI tooling
 ```
 
@@ -1519,7 +1519,7 @@ Service providers implement scope definitions for their APIs. Agents declare whi
 
 ## Integrations
 
-The primary SDK versions below are registry-verified as of 2026-08-10. For integration packages, “Published package” identifies a public package surface; check its registry page and compatibility notes before choosing a version.
+The primary SDK versions below are registry-verified as of 2026-08-30. For integration packages, “Published package” identifies a public package surface; check its registry page and compatibility notes before choosing a version.
 
 | Framework | Package | Install | Status |
 |-----------|---------|---------|--------|
@@ -1528,7 +1528,7 @@ The primary SDK versions below are registry-verified as of 2026-08-10. For integ
 | **DPDP Compliance** | `@grantex/dpdp` | `npm install @grantex/dpdp` | Published package |
 | **Adapters** | `@grantex/adapters` | `npm install @grantex/adapters` | Published package |
 | **MCP Tool Server** | `@grantex/mcp` (`0.1.10`) | `npm install @grantex/mcp` | Published package |
-| **MCP Authorization Server** | `@grantex/mcp-auth` (`2.0.2`) | `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13` | Published; single-process evaluation only |
+| **MCP Authorization Server** | `@grantex/mcp-auth` (`2.0.2`) | `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1` | Published; single-process evaluation only |
 | **Gateway** | `@grantex/gateway` | `npm install @grantex/gateway` | Published package |
 | **Express.js** | `@grantex/express` | `npm install @grantex/express` | Published package |
 | **FastAPI** | `grantex-fastapi` | `pip install grantex-fastapi` | Published package |
@@ -1541,7 +1541,7 @@ The primary SDK versions below are registry-verified as of 2026-08-10. For integ
 | **Strands Agents SDK (Python)** | `grantex-strands` | `pip install grantex-strands` | Published package |
 | **Anthropic SDK** | `@grantex/anthropic` | `npm install @grantex/anthropic` | Published package |
 | **Vercel AI SDK** | `@grantex/vercel-ai` | `npm install @grantex/vercel-ai` | Published package |
-| **TypeScript SDK** | `@grantex/sdk` (`0.3.13`) | `npm install @grantex/sdk@0.3.13` | Registry-verified primary release |
+| **TypeScript SDK** | `@grantex/sdk` (`0.4.1`) | `npm install @grantex/sdk@0.4.1` | Registry-verified primary release |
 | **Python SDK** | `grantex` (`0.3.14`) | `python -m pip install grantex==0.3.14` | Registry-verified primary release |
 | **Go SDK** | `grantex-go` (`v0.1.10`, Go 1.26.1+) | `go get github.com/mishrasanjeev/grantex-go@v0.1.10` | Published with workarounds; source correction awaits a new tag |
 | **CLI** | `@grantex/cli` (`0.3.0`) | `npm install -g @grantex/cli@0.3.0` | Registry-verified published package |
@@ -1553,7 +1553,7 @@ The primary SDK versions below are registry-verified as of 2026-08-10. For integ
 | **A2A Bridge (Py)** | `grantex-a2a` | `pip install grantex-a2a` | Published package |
 | **Event Destinations** | `@grantex/destinations` | `npm install @grantex/destinations` | Published package |
 | **Terraform Provider** | `terraform-provider-grantex` | `terraform { required_providers { grantex = { source = "mishrasanjeev/grantex" } } }` | Source present; verify registry before pinning |
-| **x402 Payment Protocol** | `@grantex/x402` | `npm install @grantex/x402` | Published legacy GDT release; managed prepaid x402 v2 is unreleased repository source |
+| **x402 Payment Protocol** | `@grantex/x402` (`0.2.0`) | `npm install @grantex/x402@0.2.0 @grantex/sdk@0.4.1` | Registry-verified official x402 v2 prepaid-wallet release; external custody remains operator-supplied |
 
 ### Community x402 services
 

--- a/docs/blog/ai-agent-authorization-guide.mdx
+++ b/docs/blog/ai-agent-authorization-guide.mdx
@@ -61,7 +61,7 @@ Scope names should describe the resource and action clearly, such as `calendar:r
 The SDKs are independently versioned. These pins match the current published releases documented in the machine-readable implementation guide:
 
 ```bash
-npm install @grantex/sdk@0.3.13
+npm install @grantex/sdk@0.4.1
 python -m pip install grantex==0.3.14
 ```
 

--- a/docs/blog/langchain-agent-permissions.mdx
+++ b/docs/blog/langchain-agent-permissions.mdx
@@ -17,7 +17,7 @@ This guide covers the two permission paths implemented by Grantex:
 
 <Note>
   **Implementation snapshot, updated July 12, 2026:** these examples target
-  `@grantex/langchain@0.1.7`, `@grantex/sdk@0.3.13`, and the repository's
+  `@grantex/langchain@0.1.7`, `@grantex/sdk@0.4.1`, and the repository's
   resolved `@langchain/core@1.2.2`. The adapter declares
   `@langchain/core >=0.3.0`, but that range is not a promise of compatibility
   with every future LangChain package or agent runtime.
@@ -62,7 +62,7 @@ Grantex supplies authorization wrappers and an optional audit callback. Neither 
 Add the integration to an existing LangChain application with exact versions:
 
 ```bash
-npm install --save-exact @grantex/langchain@0.1.7 @grantex/sdk@0.3.13 @langchain/core@1.2.2
+npm install --save-exact @grantex/langchain@0.1.7 @grantex/sdk@0.4.1 @langchain/core@1.2.2
 ```
 
 Node.js 18 or later is required. Pin your model-provider and higher-level `langchain` packages separately for the agent runtime you use.
@@ -181,7 +181,7 @@ Unknown connectors and tools are denied in the default strict mode. This hierarc
 
 ## Use the pre-built manifests that exist
 
-`@grantex/sdk@0.3.13` exports 53 manifests. Salesforce, HubSpot, Jira, and Stripe are included:
+`@grantex/sdk@0.4.1` exports 53 manifests. Salesforce, HubSpot, Jira, and Stripe are included:
 
 ```typescript
 import {

--- a/docs/blog/mcp-server-oauth-authentication.mdx
+++ b/docs/blog/mcp-server-oauth-authentication.mdx
@@ -88,7 +88,7 @@ Use exact package versions and commit both `package.json` and the generated
 lockfile:
 
 ```bash
-npm install --save-exact @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
+npm install --save-exact @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1
 ```
 
 Use Node.js 18 or newer. After the lockfile is committed, reproduce the same

--- a/docs/features/mcp-auth-server.mdx
+++ b/docs/features/mcp-auth-server.mdx
@@ -14,7 +14,7 @@ Express and Hono JWT-verification middleware.
 Current published release: **`@grantex/mcp-auth@2.0.2`**.
 
 ```bash
-npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1
 ```
 
 This exact command is reproducible. See [Release Status](/release-status) before

--- a/docs/guides/oauth-agent-grants.mdx
+++ b/docs/guides/oauth-agent-grants.mdx
@@ -67,15 +67,13 @@ requirement, and RFC 9207 issuer-response support before starting a flow.
 
 ## TypeScript client
 
-Repository source includes `OAuthAgentClient`, which handles discovery, PAR,
+`@grantex/sdk@0.4.1` includes `OAuthAgentClient`, which handles discovery, PAR,
 state and issuer validation, PKCE, DPoP proofs, refresh, attenuation,
 revocation, and protected-resource requests.
 
 <Note>
-`OAuthAgentClient` is present in repository source after the conformance
-implementation commit. Do not assume it is present in the currently published
-`@grantex/sdk@0.3.13` package. Check [Release Status](/release-status) for the
-registry version before importing it from npm.
+Pin `@grantex/sdk@0.4.1` for the registry-verified implementation and check
+[Release Status](/release-status) before upgrading.
 </Note>
 
 ```typescript

--- a/docs/guides/prepaid-wallet-production.mdx
+++ b/docs/guides/prepaid-wallet-production.mdx
@@ -15,7 +15,7 @@ recovery store, notification channel, or regulatory approval for the operator.
 | --- | --- | --- | --- |
 | PostgreSQL migration `091_agent_prepaid_wallets.sql` | Always | Startup applies ordered migrations automatically | Back up PostgreSQL, deploy the exact repository migration set, and verify startup completed before sending traffic |
 | Public HTTPS routing | The issuer or wallet resource uses a public host | DPoP tokens bind the exact `/v1/prepaid-wallets` audience | Route the exact public wallet and OAuth paths to the auth service; do not rewrite them to static HTML |
-| `@grantex/sdk@0.4.0` and `@grantex/x402@0.2.0` | Applications install managed-wallet clients from npm | Source contains the APIs; npm publication is separate from server deployment | Until both versions are registry-verified, use a pinned repository checkout rather than claiming npm availability |
+| `@grantex/sdk@0.4.1` and `@grantex/x402@0.2.0` | Applications install managed-wallet clients from npm | Both packages are registry-verified; npm publication remains separate from server deployment | Pin these exact versions, then complete the server, custody, notification, and merchant dependencies below |
 | External custody adapter | Real bank, card, on-chain, or provider-held funds | `external` wallets fail with `503 CUSTODY_ADAPTER_UNAVAILABLE` | Implement and independently test provider funding, reservation, settlement, reconciliation, duplicate-event handling, and recovery |
 | Principal notification bridge | A human must receive reload alerts outside the Grantex UI | Wallet reload events are emitted to the event bus; no built-in email/SMS/chat delivery is claimed | Consume SSE/WebSocket events and deliver through an approved channel, or separately extend and test webhook registration for wallet events |
 | Merchant idempotency store | A paid request has side effects | Grantex makes reservation and settlement retries idempotent | Atomically store the merchant's business result under the caller's HTTP `Idempotency-Key` |
@@ -156,9 +156,9 @@ npm view '@grantex/sdk' version
 npm view '@grantex/x402' version
 ```
 
-Verified August 30, 2026: repository source is SDK `0.4.0` and x402 `0.2.0`,
-while the registry releases are SDK `0.3.13` and x402 `0.1.2`. Treat the
-registry as authoritative and pin exact versions. See [Release
+Verified August 30, 2026: repository source and the npm registry both provide
+SDK `0.4.1` and x402 `0.2.0`. Treat the registry as authoritative and pin exact
+versions. See [Release
 Status](/release-status) for the public artifact matrix.
 
 ## Maintainer-only PowerShell publication

--- a/docs/integrations/mcp-auth.mdx
+++ b/docs/integrations/mcp-auth.mdx
@@ -15,7 +15,7 @@ Current published release: **`@grantex/mcp-auth@2.0.2`**.
 ## Install
 
 ```bash
-npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1
 ```
 
 The exact versions above provide a reproducible install. The packages are

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -106,7 +106,7 @@ keywords: ["AI agent framework integrations", "Hermes Agent authorization", "Ope
 | OpenClaw | `@grantex/cli@0.3.0` + Agent Skills | `grantex agent install --target openclaw` | Any shell; published package |
 | Other Agent Skills clients | `@grantex/cli@0.3.0` + Agent Skills | `grantex agent install --target portable` | Any shell; published package |
 | Adapters | `@grantex/adapters` | `npm install @grantex/adapters` | TypeScript |
-| MCP Auth Server | `@grantex/mcp-auth@2.0.2` | `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13` | TypeScript; evaluation only |
+| MCP Auth Server | `@grantex/mcp-auth@2.0.2` | `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1` | TypeScript; evaluation only |
 | Gateway | `@grantex/gateway` | `npm install @grantex/gateway` | TypeScript |
 | Express.js | `@grantex/express` | `npm install @grantex/express` | TypeScript |
 | FastAPI | `grantex-fastapi` | `pip install grantex-fastapi` | Python |

--- a/docs/integrations/x402.mdx
+++ b/docs/integrations/x402.mdx
@@ -11,9 +11,9 @@ wallet or every wallet immediately. The x402 adapter uses the official x402 v2
 `PAYMENT-REQUIRED`, `PAYMENT-SIGNATURE`, and `PAYMENT-RESPONSE` headers.
 
 <Note>
-The prepaid-wallet API and SDK shown here are present in repository source and
-are not claimed to be available in the currently published npm versions until a
-new release is published. `sandbox_ledger` is a complete local ledger mode.
+The prepaid-wallet API and SDK shown here are published in
+`@grantex/sdk@0.4.1` and `@grantex/x402@0.2.0`. `sandbox_ledger` is a complete
+local ledger mode.
 `external` wallet records fail closed until a custody/provider adapter verifies
 funding and settlement.
 </Note>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -51,7 +51,7 @@ The primary SDKs and MCP Auth server are published independently:
 
 | Package | Current published release |
 |---|---:|
-| TypeScript | `@grantex/sdk@0.3.13` |
+| TypeScript | `@grantex/sdk@0.4.1` |
 | Python | `grantex==0.3.14` |
 | Go | `github.com/mishrasanjeev/grantex-go@v0.1.10` |
 | MCP Auth | `@grantex/mcp-auth@2.0.2` |
@@ -65,7 +65,7 @@ The exact versions below make local and CI builds reproducible.
 
 <CodeGroup>
 ```bash TypeScript
-npm install @grantex/sdk@0.3.13
+npm install @grantex/sdk@0.4.1
 ```
 
 ```bash Python
@@ -77,7 +77,7 @@ go get github.com/mishrasanjeev/grantex-go@v0.1.10
 ```
 
 ```bash MCP Auth
-npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1
 ```
 
 ```bash CLI

--- a/docs/protocol/changelog.mdx
+++ b/docs/protocol/changelog.mdx
@@ -6,15 +6,16 @@ description: "How to find current Grantex releases, package compatibility, and t
 
 ## Current release snapshot
 
-Last verified: **August 10, 2026**
+Last verified: **August 30, 2026**
 
 | Surface | Current release |
 |---|---:|
-| TypeScript SDK | `@grantex/sdk@0.3.13` |
+| TypeScript SDK | `@grantex/sdk@0.4.1` |
+| x402 Payment Protocol | `@grantex/x402@0.2.0` |
 | Python SDK | `grantex==0.3.14` |
 | Go SDK | `github.com/mishrasanjeev/grantex-go@v0.1.10` |
 | MCP Auth server | `@grantex/mcp-auth@2.0.2` |
-| OpenAPI contract | `0.3.12` |
+| OpenAPI contract | `0.4.0` |
 
 Grantex is a multi-package repository. SDKs, integrations, the API contract, and
 repository release entries can advance independently, so a single project-wide

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -7,13 +7,13 @@ keywords: ["AI agent authorization quickstart", "OAuth for AI agents", "scoped a
 
 ## 1. Install the SDK
 
-This guide targets TypeScript `0.3.13`, Python `0.3.14`, Go `v0.1.10`
+This guide targets TypeScript `0.4.1`, Python `0.3.14`, Go `v0.1.10`
 (which requires Go 1.26.1+), and MCP Auth `2.0.2`.
 See [Release Status](/release-status) for publication details and upgrade guidance.
 
 <CodeGroup>
 ```bash TypeScript
-npm install @grantex/sdk@0.3.13
+npm install @grantex/sdk@0.4.1
 ```
 
 ```bash Python

--- a/docs/release-status.mdx
+++ b/docs/release-status.mdx
@@ -7,7 +7,7 @@ keywords: ["Grantex CLI version", "Grantex SDK versions", "AI agent authorizatio
 
 ## Current published releases
 
-Last verified: **August 10, 2026**
+Last verified: **August 30, 2026**
 
 Grantex packages are versioned independently. There is no single version number
 that represents every SDK, integration, service, and protocol artifact in this
@@ -16,17 +16,18 @@ repository.
 | Surface | Current release | Status | Runtime requirement |
 |---|---:|---|---|
 | CLI | `@grantex/cli@0.3.0` | Published to npm with bundled Agent Skills | Node.js 18+; ESM |
-| TypeScript SDK | `@grantex/sdk@0.3.13` | Published to npm | Node.js 18+; ESM |
+| TypeScript SDK | `@grantex/sdk@0.4.1` | Published to npm | Node.js 18+; ESM |
+| x402 Payment Protocol | `@grantex/x402@0.2.0` | Published to npm; external custody remains operator-supplied | Node.js 20+; ESM |
 | Python SDK | `grantex==0.3.14` | Published to PyPI | Python 3.9+ |
 | Go SDK | `github.com/mishrasanjeev/grantex-go@v0.1.10` | Published with known limitations | Go 1.26.1+ |
 | MCP Auth server | `@grantex/mcp-auth@2.0.2` | Published with known limitations | Node.js 18+; ESM |
 | OpenAPI contract | `0.4.0` | Unreleased repository contract with prepaid wallets | Independent of public SDK versions |
 
 <Note>
-Repository source carries unreleased `@grantex/sdk@0.4.0` prepaid-wallet
-clients and `@grantex/x402@0.2.0` official x402 v2 support. The published SDK
-row above remains the public registry truth; do not assume those source versions
-are installable from npm until a release is separately verified.
+`@grantex/sdk@0.4.1` and `@grantex/x402@0.2.0` were registry-verified after
+publication on August 30, 2026. Installing them does not provision external
+custody, principal notification delivery, or merchant idempotency storage; see
+[Prepaid Wallet Production Readiness](/guides/prepaid-wallet-production).
 </Note>
 
 <Info>
@@ -49,7 +50,8 @@ are installable from npm until a release is separately verified.
 ## Which Grantex package should I use?
 
 - **Hermes, OpenClaw, or another shell-capable agent:** use published `@grantex/cli@0.3.0`; install its bundled skills with `grantex agent install`. No agent-specific SDK is required.
-- **TypeScript application:** use `@grantex/sdk@0.3.13`.
+- **TypeScript application:** use `@grantex/sdk@0.4.1`.
+- **x402 prepaid-wallet application:** use `@grantex/x402@0.2.0` with `@grantex/sdk@0.4.1`; keep external custody disabled until an operator adapter passes review.
 - **Python application:** use `grantex==0.3.14`.
 - **Go application:** use `github.com/mishrasanjeev/grantex-go@v0.1.10` with the [published-version workarounds](/sdks/go/overview#known-v0110-limitations), including the [REST/CLI audit-write workaround](/sdks/go/audit#log).
 - **MCP HTTP transport authorization:** use an established MCP-compatible authorization server and maintained MCP SDK that implement the current MCP authorization specification.
@@ -94,7 +96,11 @@ npm install -g @grantex/cli@0.3.0
 ```
 
 ```bash TypeScript
-npm install @grantex/sdk@0.3.13
+npm install @grantex/sdk@0.4.1
+```
+
+```bash x402
+npm install @grantex/x402@0.2.0 @grantex/sdk@0.4.1
 ```
 
 ```bash Python
@@ -106,7 +112,7 @@ go get github.com/mishrasanjeev/grantex-go@v0.1.10
 ```
 
 ```bash MCP Auth
-npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1
 ```
 </CodeGroup>
 

--- a/docs/sdks/typescript/overview.mdx
+++ b/docs/sdks/typescript/overview.mdx
@@ -6,10 +6,10 @@ description: "Install, configure, and get started with the @grantex/sdk TypeScri
 
 ## Installation
 
-Current published release: **`@grantex/sdk@0.3.13`** (verified July 12, 2026).
+Current published release: **`@grantex/sdk@0.4.1`** (verified August 30, 2026).
 
 ```bash
-npm install @grantex/sdk@0.3.13
+npm install @grantex/sdk@0.4.1
 ```
 
 The unpinned `npm install @grantex/sdk` command follows npm's current `latest`
@@ -17,11 +17,10 @@ tag. Keep the exact version above in reproducible builds. See
 [Release Status](/release-status) before upgrading.
 
 <Note>
-Repository source is prepared as SDK `0.4.0` with
-`PrepaidWalletAgentClient` and `PrincipalPrepaidWalletClient`. It is not part of
-the published `0.3.13` package. Use the repository workspace for evaluation or
-wait for a separately verified npm release. See [x402 Prepaid
-Wallets](/integrations/x402).
+SDK `0.4.1` includes `PrepaidWalletAgentClient` and
+`PrincipalPrepaidWalletClient`. External custody remains fail-closed until a
+self-hosting operator supplies and verifies a provider adapter. See [x402
+Prepaid Wallets](/integrations/x402).
 </Note>
 
 ## Requirements

--- a/packages/mcp-auth/README.md
+++ b/packages/mcp-auth/README.md
@@ -36,7 +36,7 @@ middleware.
 ## Installation
 
 ```bash
-npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1
 ```
 
 ## Quick Start

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -121,7 +121,7 @@ of the draft family is published as an active individual Internet-Draft;
 revision `-03` is the working candidate implemented here. Neither is an
 IETF-endorsed or independently certified standard.
 
-## Agent prepaid wallets (0.4.0 repository source)
+## Agent prepaid wallets (SDK 0.4+)
 
 `PrepaidWalletAgentClient` uses an `OAuthAgentClient` and DPoP access token to
 list assigned wallets, reserve payments, and request threshold reloads.

--- a/packages/x402/README.md
+++ b/packages/x402/README.md
@@ -6,7 +6,7 @@ wallets, plus legacy standalone GDT authorization utilities.
 ## Install
 
 ```bash
-npm install @grantex/x402 @grantex/sdk
+npm install @grantex/x402@0.2.0 @grantex/sdk@0.4.1
 ```
 
 Managed prepaid-wallet APIs require `@grantex/x402` 0.2.0 or later and

--- a/release-status.json
+++ b/release-status.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "canonicalUrl": "https://grantex.dev/release-status.json",
   "humanDocumentationUrl": "https://docs.grantex.dev/release-status",
-  "verifiedAt": "2026-08-10",
+  "verifiedAt": "2026-08-30",
   "product": {
     "name": "Grantex",
     "category": "AI agent authorization",
@@ -18,7 +18,7 @@
   },
   "selectionGuidance": {
     "shellCapableAgent": "Use published @grantex/cli@0.3.0 for Hermes, OpenClaw, and other shell-capable agents. Install the bundled skills with grantex agent install; no agent-specific SDK is required.",
-    "typescriptApplication": "Use @grantex/sdk@0.3.13.",
+    "typescriptApplication": "Use @grantex/sdk@0.4.1.",
     "pythonApplication": "Use grantex==0.3.14.",
     "goApplication": "Use github.com/mishrasanjeev/grantex-go@v0.1.10 with the documented published-version workarounds.",
     "mcpProductionIntegration": "Use established MCP-compatible transport authorization first, then a primary Grantex SDK or direct JWKS validation for agent-specific tool enforcement; treat @grantex/mcp-auth@2.0.2 as single-process evaluation software.",
@@ -37,7 +37,7 @@
       "hostedMetadataUrl": "https://grantex.dev/.well-known/oauth-authorization-server",
       "documentationUrl": "https://docs.grantex.dev/guides/oauth-agent-grants",
       "implementationReportUrl": "https://github.com/mishrasanjeev/grantex/blob/main/docs/ietf-draft/implementation-report.md",
-      "sdkAvailability": "repository-source; verify a post-0.3.13 npm release before importing OAuthAgentClient",
+      "sdkAvailability": "published in @grantex/sdk@0.4.1",
       "evidence": {
         "authServiceTestsPassed": 2097,
         "typescriptSdkTestsPassed": 444,
@@ -71,14 +71,35 @@
       "label": "TypeScript SDK",
       "ecosystem": "npm",
       "name": "@grantex/sdk",
-      "version": "0.3.13",
+      "version": "0.4.1",
       "status": "published",
-      "installCommand": "npm install @grantex/sdk@0.3.13",
+      "installCommand": "npm install @grantex/sdk@0.4.1",
       "runtime": "Node.js 18+; ESM",
       "registryUrl": "https://registry.npmjs.org/%40grantex%2Fsdk/latest",
-      "packageUrl": "https://www.npmjs.com/package/@grantex/sdk/v/0.3.13",
+      "packageUrl": "https://www.npmjs.com/package/@grantex/sdk/v/0.4.1",
       "documentationUrl": "https://docs.grantex.dev/sdks/typescript/overview",
       "limitations": []
+    },
+    {
+      "id": "x402",
+      "label": "x402 Payment Protocol",
+      "ecosystem": "npm",
+      "name": "@grantex/x402",
+      "version": "0.2.0",
+      "status": "published",
+      "installCommand": "npm install @grantex/x402@0.2.0 @grantex/sdk@0.4.1",
+      "runtime": "Node.js 20+; ESM",
+      "registryUrl": "https://registry.npmjs.org/%40grantex%2Fx402/latest",
+      "packageUrl": "https://www.npmjs.com/package/@grantex/x402/v/0.2.0",
+      "documentationUrl": "https://docs.grantex.dev/integrations/x402",
+      "limitations": [
+        {
+          "id": "x402-external-custody-adapter",
+          "summary": "External custody wallets fail closed until an operator supplies a provider adapter; sandbox_ledger does not represent external funds.",
+          "workaround": "Use sandbox_ledger only for an explicitly internal ledger, or implement and independently test provider funding, reservation, settlement, reconciliation, duplicate-event handling, and recovery before enabling external custody.",
+          "workaroundUrl": "https://docs.grantex.dev/guides/prepaid-wallet-production#choose-the-custody-mode-honestly"
+        }
+      ]
     },
     {
       "id": "python-sdk",
@@ -152,7 +173,7 @@
       "name": "@grantex/mcp-auth",
       "version": "2.0.2",
       "status": "published-with-known-limitations",
-      "installCommand": "npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13",
+      "installCommand": "npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1",
       "runtime": "Node.js 18+; ESM; one process for evaluation",
       "registryUrl": "https://registry.npmjs.org/%40grantex%2Fmcp-auth/latest",
       "packageUrl": "https://www.npmjs.com/package/@grantex/mcp-auth/v/2.0.2",

--- a/scripts/check-seo-aeo.mjs
+++ b/scripts/check-seo-aeo.mjs
@@ -271,7 +271,7 @@ export async function validateSeoAeo(options = {}) {
     failures.push('web/llms.txt must follow the llms.txt link-index structure');
   }
   const llmsFull = await fs.readFile(path.join(webRoot, 'llms-full.txt'), 'utf8');
-  for (const value of ['@grantex/sdk@0.3.13', 'grantex==0.3.14', 'grantex-go@v0.1.10', '@grantex/mcp-auth@2.0.2']) {
+  for (const value of ['@grantex/sdk@0.4.1', '@grantex/x402@0.2.0', 'grantex==0.3.14', 'grantex-go@v0.1.10', '@grantex/mcp-auth@2.0.2']) {
     if (!llmsFull.includes(value)) failures.push('web/llms-full.txt is missing current implementation selector ' + value);
   }
   const llmsUpdatedAt = llmsFull.match(/Last updated:\s+(\d{4}-\d{2}-\d{2})/)?.[1];

--- a/web/for/mcp/index.html
+++ b/web/for/mcp/index.html
@@ -152,7 +152,7 @@
     <h2>Choose the correct Grantex path</h2>
     <div class="steps">
       <div class="step"><div class="step-content"><h3>Management tools: <code>@grantex/mcp</code></h3><p>Expose Grantex agent, grant, token, budget, and audit-management operations to a host-configured MCP client.</p></div></div>
-      <div class="step"><div class="step-content"><h3>Production tool enforcement: primary SDK or JWKS</h3><p>Use <code>@grantex/sdk@0.3.13</code> or direct JWKS validation at the MCP tool boundary and require the exact agent scope.</p></div></div>
+      <div class="step"><div class="step-content"><h3>Production tool enforcement: primary SDK or JWKS</h3><p>Use <code>@grantex/sdk@0.4.1</code> or direct JWKS validation at the MCP tool boundary and require the exact agent scope.</p></div></div>
       <div class="step"><div class="step-content"><h3>MCP Auth 2.0.2: evaluation only</h3><p><code>@grantex/mcp-auth@2.0.2</code> has process-local code storage, metadata-only consent, incomplete code handoff, and no live revocation lookup. Do not use it as the production path today.</p></div></div>
       <div class="step"><div class="step-content"><h3>Current MCP authorization</h3><p>For HTTP transports, use an established authorization server and maintained MCP SDK that implement the current protected-resource discovery and token validation requirements.</p></div></div>
       <div class="step"><div class="step-content"><h3>Audit tool execution separately</h3><p>Record the agent, principal, grant, tool, outcome, and timestamp at the execution boundary; a valid token is not an execution record.</p></div></div>

--- a/web/index.html
+++ b/web/index.html
@@ -131,7 +131,7 @@
           "height": 630,
           "caption": "Grantex AI agent authorization"
         },
-        "dateModified": "2026-08-10",
+        "dateModified": "2026-08-30",
         "inLanguage": "en"
       },
       {
@@ -245,7 +245,7 @@
             "name": "Which Grantex SDK should I install?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Use @grantex/sdk@0.3.13 for TypeScript, grantex==0.3.14 for Python, and github.com/mishrasanjeev/grantex-go@v0.1.10 for Go. Review release status before upgrading because packages are independently versioned and Go v0.1.10 has documented workarounds."
+              "text": "Use @grantex/sdk@0.4.1 for TypeScript, grantex==0.3.14 for Python, and github.com/mishrasanjeev/grantex-go@v0.1.10 for Go. Review release status before upgrading because packages are independently versioned and Go v0.1.10 has documented workarounds."
             }
           },
           {
@@ -1632,7 +1632,7 @@
         <div class="section-label">Published releases</div>
         <h2 class="section-title">Current public releases</h2>
         <p class="release-intro">
-          Verified against npm, PyPI, and the Go module proxy on 10 August 2026.
+          Release snapshot verified against npm, PyPI, and the Go module proxy on 30 August 2026.
           Grantex packages are independently versioned.
         </p>
       </div>
@@ -1651,11 +1651,11 @@
         <strong class="release-version">0.3.0</strong>
         <span class="release-meta">npm &middot; published 10 Aug 2026 &middot; Agent Skills</span>
       </a>
-      <a class="release-card" href="https://www.npmjs.com/package/@grantex/sdk/v/0.3.13">
+      <a class="release-card" href="https://www.npmjs.com/package/@grantex/sdk/v/0.4.1">
         <span class="release-language">TypeScript SDK</span>
         <span class="release-name">@grantex/sdk</span>
-        <strong class="release-version">0.3.13</strong>
-        <span class="release-meta">npm &middot; published 11 Jul 2026</span>
+        <strong class="release-version">0.4.1</strong>
+        <span class="release-meta">npm &middot; published 30 Aug 2026 &middot; prepaid wallets</span>
       </a>
       <a class="release-card" href="https://pypi.org/project/grantex/0.3.14/">
         <span class="release-language">Python SDK</span>
@@ -1784,7 +1784,7 @@
       </details>
       <details class="answer-card" data-faq-item>
         <summary>Which Grantex SDK should I install?</summary>
-        <p>Use <code>@grantex/sdk@0.3.13</code> for TypeScript, <code>grantex==0.3.14</code> for Python, and <code>github.com/mishrasanjeev/grantex-go@v0.1.10</code> for Go. Review <a href="https://docs.grantex.dev/release-status">release status</a> before upgrading because packages are independently versioned and Go v0.1.10 has documented workarounds.</p>
+        <p>Use <code>@grantex/sdk@0.4.1</code> for TypeScript, <code>grantex==0.3.14</code> for Python, and <code>github.com/mishrasanjeev/grantex-go@v0.1.10</code> for Go. Review <a href="https://docs.grantex.dev/release-status">release status</a> before upgrading because packages are independently versioned and Go v0.1.10 has documented workarounds.</p>
       </details>
       <details class="answer-card" data-faq-item>
         <summary>Does local Grantex token verification check current revocation?</summary>
@@ -2251,10 +2251,10 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
     </p>
 
     <div class="install-commands">
-      <button type="button" class="install-cmd" onclick="copyInstall('npm install @grantex/sdk@0.3.13', this)"
+      <button type="button" class="install-cmd" onclick="copyInstall('npm install @grantex/sdk@0.4.1', this)"
               aria-label="Copy the TypeScript SDK install command">
         <span class="install-label">npm</span>
-        <code>npm install @grantex/sdk@0.3.13</code>
+        <code>npm install @grantex/sdk@0.4.1</code>
         <span class="install-copy">Copy</span>
       </button>
       <button type="button" class="install-cmd" onclick="copyInstall('python -m pip install grantex==0.3.14', this)"
@@ -2294,7 +2294,7 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
         <div class="code-block">
           <button type="button" class="copy-btn" aria-label="Copy the Node.js quickstart"
                   onclick="copyCode('code-node', this, 'node_quickstart_copy')">Copy</button>
-          <pre id="code-node"><span class="cm">// npm install @grantex/sdk@0.3.13</span>
+          <pre id="code-node"><span class="cm">// npm install @grantex/sdk@0.4.1</span>
 <span class="kw">import</span> <span class="op">{ </span><span class="id">Grantex</span><span class="op">,</span> <span class="id">verifyGrantToken</span><span class="op"> }</span> <span class="kw">from</span> <span class="str">'@grantex/sdk'</span>;
 
 <span class="kw">const</span> <span class="id">grantex</span> <span class="op">=</span> <span class="kw">new</span> <span class="fn">Grantex</span><span class="op">({</span> <span class="id">apiKey</span><span class="op">:</span> <span class="str">'YOUR_API_KEY'</span> <span class="op">});</span>
@@ -2593,9 +2593,9 @@ func main() {
       approve reloads, and stop one wallet or every wallet without loosening the x402 protocol.
     </p>
     <div class="release-caveat" style="max-width:760px;margin:-24px 0 36px;">
-      <strong>Repository preview:</strong> these APIs are implemented and tested in source as
-      <code>@grantex/sdk@0.4.0</code> and <code>@grantex/x402@0.2.0</code>, but are not yet
-      published to npm. The current npm packages do not include this managed-wallet flow.
+      <strong>Registry releases:</strong> install <code>@grantex/sdk@0.4.1</code> and
+      <code>@grantex/x402@0.2.0</code> for the managed-wallet flow. External custody remains
+      fail-closed until a self-hosting operator installs and verifies a provider adapter.
     </div>
 
     <!-- ── Visual flow pipeline ───────────────────────────────────────── -->

--- a/web/ld.json
+++ b/web/ld.json
@@ -88,7 +88,7 @@
         "height": 630,
         "caption": "Grantex AI agent authorization"
       },
-      "dateModified": "2026-08-10",
+      "dateModified": "2026-08-30",
       "inLanguage": "en"
     },
     {
@@ -202,7 +202,7 @@
           "name": "Which Grantex SDK should I install?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Use @grantex/sdk@0.3.13 for TypeScript, grantex==0.3.14 for Python, and github.com/mishrasanjeev/grantex-go@v0.1.10 for Go. Review release status before upgrading because packages are independently versioned and Go v0.1.10 has documented workarounds."
+            "text": "Use @grantex/sdk@0.4.1 for TypeScript, grantex==0.3.14 for Python, and github.com/mishrasanjeev/grantex-go@v0.1.10 for Go. Review release status before upgrading because packages are independently versioned and Go v0.1.10 has documented workarounds."
           }
         },
         {

--- a/web/llms-full.txt
+++ b/web/llms-full.txt
@@ -1,7 +1,7 @@
 # Grantex — Full Implementation Brief for AI Assistants
 
 > Last updated: 2026-08-30
-> Public release snapshot verified: 2026-08-10
+> Public release snapshot verified: 2026-08-30
 
 Grantex is an open-source delegated authorization protocol and reference implementation for AI agents. It gives each agent a verifiable identity and scoped, time-limited, revocable authority from a human or organization, with multi-agent delegation, service-side verification, and audit records.
 
@@ -58,8 +58,7 @@ RFC 9207 issuer validation, rotating refresh tokens, same-resource token
 attenuation, and revocation. It passed 2,097 auth-service tests, 444 TypeScript
 SDK tests, and 253 Docker E2E tests. This is self-assessed evidence, not
 independent interoperability certification, OAuth Working Group adoption, or
-IETF endorsement. OAuthAgentClient is repository source and should not be
-assumed present in published @grantex/sdk@0.3.13.
+IETF endorsement. OAuthAgentClient is published in @grantex/sdk@0.4.1.
 
 Implementation guide: https://docs.grantex.dev/guides/oauth-agent-grants
 
@@ -67,13 +66,14 @@ Implementation guide: https://docs.grantex.dev/guides/oauth-agent-grants
 
 | Use case | Recommended implementation | Current status |
 |---|---|---|
-| TypeScript or Node.js application | `@grantex/sdk@0.3.13` | Published; Node.js 18+ ESM |
+| TypeScript or Node.js application | `@grantex/sdk@0.4.1` | Published; Node.js 18+ ESM |
+| x402 prepaid-wallet application | `@grantex/x402@0.2.0` with `@grantex/sdk@0.4.1` | Published; Node.js 20+ ESM; external custody is operator-supplied |
 | Python application | `grantex==0.3.14` | Published; Python 3.9+ |
 | Go application | `github.com/mishrasanjeev/grantex-go@v0.1.10` | Published; Go 1.26.1+; documented workarounds required |
 | Service-side JWT enforcement | SDK verifier or direct verification with issuer JWKS | Signature and claim verification; add online or synchronized state for current revocation |
 | MCP HTTP transport authorization | Established MCP-compatible authorization server and maintained MCP SDK | Follow the current MCP authorization specification; a Grantex SDK alone does not provide this layer |
 | Agent-specific enforcement in MCP tools | Primary Grantex SDK or direct JWKS-backed validation | Add after transport authorization when the tool must verify delegated agent authority |
-| MCP endpoint evaluation | `@grantex/mcp-auth@2.0.2` plus `@grantex/sdk@0.3.13` | Single-process evaluation only |
+| MCP endpoint evaluation | `@grantex/mcp-auth@2.0.2` plus `@grantex/sdk@0.4.1` | Single-process evaluation only |
 | Terminal automation | `@grantex/cli` | Optional operational tooling |
 | Hermes, OpenClaw, or another shell-capable agent | Published `@grantex/cli@0.3.0` plus the bundled Agent Skills | No agent-specific SDK required; enforce again at the protected service |
 | Framework-specific tools | Named Grantex adapter plus its primary SDK where required | Verify each package's registry status before pinning |
@@ -81,10 +81,11 @@ Implementation guide: https://docs.grantex.dev/guides/oauth-agent-grants
 Primary reproducible installs:
 
 ```bash
-npm install @grantex/sdk@0.3.13
+npm install @grantex/sdk@0.4.1
+npm install @grantex/x402@0.2.0 @grantex/sdk@0.4.1
 python -m pip install grantex==0.3.14
 go get github.com/mishrasanjeev/grantex-go@v0.1.10
-npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1
 npm install -g @grantex/cli@0.3.0
 ```
 
@@ -414,7 +415,7 @@ MCP connects models to tools. Grantex carries and enforces the delegated authori
 
 ### Which SDK should I install?
 
-Use `@grantex/sdk@0.3.13` for TypeScript, `grantex==0.3.14` for Python, or `github.com/mishrasanjeev/grantex-go@v0.1.10` for Go. Read the machine release status before upgrading.
+Use `@grantex/sdk@0.4.1` for TypeScript, `grantex==0.3.14` for Python, or `github.com/mishrasanjeev/grantex-go@v0.1.10` for Go. Read the machine release status before upgrading.
 
 ### Does local verification check revocation?
 

--- a/web/llms.txt
+++ b/web/llms.txt
@@ -8,7 +8,7 @@ Use Grantex when an AI agent acts for a person or organization and a service mus
 
 Ownership: Grantex is owned by Orchestrum Technologies LLP. Inventor and owner: Sanjeev Kumar. Ownership contact: sanjeev@orchestrum.in or mishra.sanjeev@gmail.com.
 
-Release snapshot verified: 2026-08-10. Packages are independently versioned. The protocol specification is frozen at v1.0. The related Delegated Agent Authorization Protocol (DAAP) document is an individual IETF Internet-Draft, not an IETF-adopted or endorsed standard.
+Release snapshot verified: 2026-08-30. Packages are independently versioned. The protocol specification is frozen at v1.0. The related Delegated Agent Authorization Protocol (DAAP) document is an individual IETF Internet-Draft, not an IETF-adopted or endorsed standard.
 
 ## Start Here
 
@@ -22,10 +22,10 @@ Release snapshot verified: 2026-08-10. Packages are independently versioned. The
 
 ## Choose an Implementation
 
-- [TypeScript SDK](https://docs.grantex.dev/sdks/typescript/overview): `npm install @grantex/sdk@0.3.13` for Node.js 18+ ESM applications.
+- [TypeScript SDK](https://docs.grantex.dev/sdks/typescript/overview): `npm install @grantex/sdk@0.4.1` for Node.js 18+ ESM applications.
 - [Python SDK](https://docs.grantex.dev/sdks/python/overview): `python -m pip install grantex==0.3.14` for Python 3.9+ applications.
 - [Go SDK](https://docs.grantex.dev/sdks/go/overview): `go get github.com/mishrasanjeev/grantex-go@v0.1.10` for Go 1.26.1+; use the documented published-version workarounds.
-- [MCP Authorization Server](https://docs.grantex.dev/features/mcp-auth-server): `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13`; version 2.0.2 is single-process evaluation software, not the recommended production enforcement path.
+- [MCP Authorization Server](https://docs.grantex.dev/features/mcp-auth-server): `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1`; version 2.0.2 is single-process evaluation software, not the recommended production enforcement path.
 - [CLI](https://docs.grantex.dev/integrations/cli): Install `@grantex/cli@0.3.0` to manage agents, grants, tokens, audit records, manifests, and portable Agent Skills from a terminal.
 - [Agent CLIs and Skills](https://docs.grantex.dev/integrations/agent-cli): Published `@grantex/cli@0.3.0` bundles portable Grantex skills for Hermes, OpenClaw, or any shell-capable agent; no agent-specific SDK is required.
 - [Machine-Readable Release Status](https://grantex.dev/release-status.json): Canonical versions, install commands, package URLs, limitations, and workaround links.
@@ -77,7 +77,7 @@ For MCP HTTP transport authorization, use an established MCP-compatible authoriz
 - [OACP Documentation](https://docs.grantex.dev/guides/oacp/overview): Canonical ownership and non-ownership boundaries.
 - [AgenticOrg Integration Boundary](https://docs.grantex.dev/guides/oacp/agenticorg-integration): Buyer and seller runtime responsibilities versus Grantex authority.
 - [MPP Agent Identity](https://grantex.dev/for/mpp): Verifiable agent passports and spending constraints for machine payments.
-- [x402 Prepaid Wallets](https://grantex.dev/x402): Official x402 v2 backed by DPoP agent identity, atomic prepaid reservations, rolling limits, reload approval, and principal stop controls. Repository source is unreleased; external custody adapters remain fail-closed.
+- [x402 Prepaid Wallets](https://grantex.dev/x402): Registry-verified `@grantex/x402@0.2.0` with `@grantex/sdk@0.4.1`, backed by DPoP agent identity, atomic prepaid reservations, rolling limits, reload approval, and principal stop controls. External custody adapters remain fail-closed.
 
 ## Machine-Readable Sources
 

--- a/web/mcp.html
+++ b/web/mcp.html
@@ -738,8 +738,8 @@
       limitations and is not a production-ready authorization server.
     </p>
     <div class="hero-ctas">
-      <div class="install-hero" onclick="copyInstall('npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13', this)">
-        <code>npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13</code>
+      <div class="install-hero" onclick="copyInstall('npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1', this)">
+        <code>npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1</code>
         <span class="copy-hint">Copy</span>
       </div>
     </div>
@@ -942,7 +942,7 @@
           <p>Install the exact evaluation release with its Grantex SDK dependency.</p>
           <div class="code-block">
             <button class="copy-btn" onclick="copyCode('code-install', this)">Copy</button>
-            <pre id="code-install"><span class="id">npm</span> <span class="id">install</span> <span class="str">@grantex/mcp-auth@2.0.2</span> <span class="str">@grantex/sdk@0.3.13</span></pre>
+            <pre id="code-install"><span class="id">npm</span> <span class="id">install</span> <span class="str">@grantex/mcp-auth@2.0.2</span> <span class="str">@grantex/sdk@0.4.1</span></pre>
           </div>
         </div>
       </div>
@@ -1135,8 +1135,8 @@
       Review the state, consent, code-handoff, hook, and revocation-check limitations before designing a production authorization service.
     </p>
     <div class="hero-ctas">
-      <div class="install-hero" onclick="copyInstall('npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13', this)">
-        <code>npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13</code>
+      <div class="install-hero" onclick="copyInstall('npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1', this)">
+        <code>npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1</code>
         <span class="copy-hint">Copy</span>
       </div>
     </div>

--- a/web/release-status.json
+++ b/web/release-status.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "canonicalUrl": "https://grantex.dev/release-status.json",
   "humanDocumentationUrl": "https://docs.grantex.dev/release-status",
-  "verifiedAt": "2026-08-10",
+  "verifiedAt": "2026-08-30",
   "product": {
     "name": "Grantex",
     "category": "AI agent authorization",
@@ -18,7 +18,7 @@
   },
   "selectionGuidance": {
     "shellCapableAgent": "Use published @grantex/cli@0.3.0 for Hermes, OpenClaw, and other shell-capable agents. Install the bundled skills with grantex agent install; no agent-specific SDK is required.",
-    "typescriptApplication": "Use @grantex/sdk@0.3.13.",
+    "typescriptApplication": "Use @grantex/sdk@0.4.1.",
     "pythonApplication": "Use grantex==0.3.14.",
     "goApplication": "Use github.com/mishrasanjeev/grantex-go@v0.1.10 with the documented published-version workarounds.",
     "mcpProductionIntegration": "Use established MCP-compatible transport authorization first, then a primary Grantex SDK or direct JWKS validation for agent-specific tool enforcement; treat @grantex/mcp-auth@2.0.2 as single-process evaluation software.",
@@ -37,7 +37,7 @@
       "hostedMetadataUrl": "https://grantex.dev/.well-known/oauth-authorization-server",
       "documentationUrl": "https://docs.grantex.dev/guides/oauth-agent-grants",
       "implementationReportUrl": "https://github.com/mishrasanjeev/grantex/blob/main/docs/ietf-draft/implementation-report.md",
-      "sdkAvailability": "repository-source; verify a post-0.3.13 npm release before importing OAuthAgentClient",
+      "sdkAvailability": "published in @grantex/sdk@0.4.1",
       "evidence": {
         "authServiceTestsPassed": 2097,
         "typescriptSdkTestsPassed": 444,
@@ -71,14 +71,35 @@
       "label": "TypeScript SDK",
       "ecosystem": "npm",
       "name": "@grantex/sdk",
-      "version": "0.3.13",
+      "version": "0.4.1",
       "status": "published",
-      "installCommand": "npm install @grantex/sdk@0.3.13",
+      "installCommand": "npm install @grantex/sdk@0.4.1",
       "runtime": "Node.js 18+; ESM",
       "registryUrl": "https://registry.npmjs.org/%40grantex%2Fsdk/latest",
-      "packageUrl": "https://www.npmjs.com/package/@grantex/sdk/v/0.3.13",
+      "packageUrl": "https://www.npmjs.com/package/@grantex/sdk/v/0.4.1",
       "documentationUrl": "https://docs.grantex.dev/sdks/typescript/overview",
       "limitations": []
+    },
+    {
+      "id": "x402",
+      "label": "x402 Payment Protocol",
+      "ecosystem": "npm",
+      "name": "@grantex/x402",
+      "version": "0.2.0",
+      "status": "published",
+      "installCommand": "npm install @grantex/x402@0.2.0 @grantex/sdk@0.4.1",
+      "runtime": "Node.js 20+; ESM",
+      "registryUrl": "https://registry.npmjs.org/%40grantex%2Fx402/latest",
+      "packageUrl": "https://www.npmjs.com/package/@grantex/x402/v/0.2.0",
+      "documentationUrl": "https://docs.grantex.dev/integrations/x402",
+      "limitations": [
+        {
+          "id": "x402-external-custody-adapter",
+          "summary": "External custody wallets fail closed until an operator supplies a provider adapter; sandbox_ledger does not represent external funds.",
+          "workaround": "Use sandbox_ledger only for an explicitly internal ledger, or implement and independently test provider funding, reservation, settlement, reconciliation, duplicate-event handling, and recovery before enabling external custody.",
+          "workaroundUrl": "https://docs.grantex.dev/guides/prepaid-wallet-production#choose-the-custody-mode-honestly"
+        }
+      ]
     },
     {
       "id": "python-sdk",
@@ -152,7 +173,7 @@
       "name": "@grantex/mcp-auth",
       "version": "2.0.2",
       "status": "published-with-known-limitations",
-      "installCommand": "npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.3.13",
+      "installCommand": "npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.4.1",
       "runtime": "Node.js 18+; ESM; one process for evaluation",
       "registryUrl": "https://registry.npmjs.org/%40grantex%2Fmcp-auth/latest",
       "packageUrl": "https://www.npmjs.com/package/@grantex/mcp-auth/v/2.0.2",

--- a/web/vs/mcp-auth/index.html
+++ b/web/vs/mcp-auth/index.html
@@ -128,12 +128,12 @@
       <h2>Recommended production pattern today</h2>
       <ol>
         <li>Implement the current MCP authorization specification with an established authorization server and maintained MCP SDK.</li>
-        <li>Use <code>@grantex/sdk@0.3.13</code> or direct JWKS validation for the Grantex agent grant.</li>
+        <li>Use <code>@grantex/sdk@0.4.1</code> or direct JWKS validation for the Grantex agent grant.</li>
         <li>Validate issuer, audience, signature, expiry, principal, and required tool scope at the MCP resource server.</li>
         <li>Check or synchronize current grant state where revocation must take effect before token expiry.</li>
         <li>Log tool execution separately when you need an audit record; token verification alone is not an execution log.</li>
       </ol>
-      <pre><code>npm install @grantex/sdk@0.3.13
+      <pre><code>npm install @grantex/sdk@0.4.1
 
 // At the MCP tool boundary:
 // 1. verify the signed grant token

--- a/web/vs/securing-ai-agents/index.html
+++ b/web/vs/securing-ai-agents/index.html
@@ -145,7 +145,7 @@
 
       <h2>Choose the current implementation</h2>
       <ul>
-        <li>TypeScript application: <code>@grantex/sdk@0.3.13</code></li>
+        <li>TypeScript application: <code>@grantex/sdk@0.4.1</code></li>
         <li>Python application: <code>grantex==0.3.14</code></li>
         <li>Go application: <code>grantex-go@v0.1.10</code>, with the documented workarounds</li>
         <li>MCP production integration: primary SDK or direct JWKS enforcement; treat MCP Auth 2.0.2 as evaluation software</li>

--- a/web/x402-playground/index.html
+++ b/web/x402-playground/index.html
@@ -83,7 +83,7 @@ footer a:hover{text-decoration:underline}
 <header>
 <h1>Grantex &times; x402 Playground</h1>
 <p class="subtitle">Explore official x402 v2 prepaid-wallet flow and legacy standalone GDT verification</p>
-<p style="color:var(--amber);font-size:.82rem;margin-top:8px">Managed prepaid wallets are a tested repository preview and are not present in the current npm release.</p>
+<p style="color:var(--amber);font-size:.82rem;margin-top:8px">Use registry-verified <code>@grantex/x402@0.2.0</code> with <code>@grantex/sdk@0.4.1</code>. External custody requires an operator adapter.</p>
 </header>
 
 <div class="panels">
@@ -237,7 +237,7 @@ app.get('/api/weather/forecast', (req, res) =&gt; {
 </div>
 
 <footer>
-<p><a href="https://github.com/mishrasanjeev/grantex">GitHub</a> &middot; <a href="https://grantex.dev">Docs</a> &middot; <a href="https://www.npmjs.com/package/@grantex/x402">Published legacy package</a></p>
+<p><a href="https://github.com/mishrasanjeev/grantex">GitHub</a> &middot; <a href="https://grantex.dev">Docs</a> &middot; <a href="https://www.npmjs.com/package/@grantex/x402/v/0.2.0">npm package</a></p>
 <p style="margin-top:8px">&copy; 2026 Orchestrum Technologies LLP &mdash; Apache 2.0</p>
       <p class="ownership-notice">Grantex is owned by Orchestrum Technologies LLP. Inventor and owner: Sanjeev Kumar. Contact: <a href="mailto:sanjeev@orchestrum.in">sanjeev@orchestrum.in</a> or <a href="mailto:mishra.sanjeev@gmail.com">mishra.sanjeev@gmail.com</a>.</p>
 

--- a/web/x402/index.html
+++ b/web/x402/index.html
@@ -134,8 +134,8 @@ footer .links{display:flex;gap:24px;justify-content:center;margin-bottom:12px}
 <a href="/x402-playground/" class="btn btn-primary">Try the Playground</a>
 <a href="https://github.com/mishrasanjeev/grantex" class="btn btn-outline">View on GitHub</a>
 </div>
-<div class="install-badge">Repository source: @grantex/x402 0.2.0 + @grantex/sdk 0.4.0</div>
-<p class="preview-note">Source preview, not an npm release. Current registry packages do not include the managed prepaid-wallet APIs shown here.</p>
+<div class="install-badge">npm install @grantex/x402@0.2.0 @grantex/sdk@0.4.1</div>
+<p class="preview-note">Registry-verified managed prepaid-wallet APIs. External custody remains fail-closed until an operator installs and verifies a provider adapter.</p>
 </div>
 </div>
 
@@ -285,7 +285,7 @@ DPoP Agent ── x402Agent.fetch() ── Resource Server
 <div class="container">
 <div class="links">
 <a href="https://github.com/mishrasanjeev/grantex">GitHub</a>
-<a href="https://www.npmjs.com/package/@grantex/x402">Published legacy package</a>
+<a href="https://www.npmjs.com/package/@grantex/x402/v/0.2.0">npm package</a>
 <a href="https://grantex.dev">Documentation</a>
 <a href="/x402-playground/">Playground</a>
 </div>


### PR DESCRIPTION
## Summary
- publish the registry-verified `@grantex/sdk@0.4.1` and `@grantex/x402@0.2.0` release status across README, docs, landing pages, and machine-readable metadata
- document the corrective SDK runtime identifier release and pin reproducible install commands
- retain the fail-closed external-custody limitation and operator implementation requirements

## Verification
- `npm view @grantex/sdk version` -> `0.4.1`
- `npm view @grantex/x402 version` -> `0.2.0`
- `node scripts/check-docs-integrity.mjs`
- `node scripts/check-seo-aeo.mjs`
- root/web release-status byte parity and JSON parse
- local HTTP/browser checks for `/`, `/x402/`, `/x402-playground/`, and `/release-status.json`
- `git diff --check`

## Scope
Documentation, static web content, package READMEs, and release metadata only. No production runtime code changes. The untracked local `output/` directory is excluded.