### PR TITLE
test: allow decreasing refresh replay lifetime

### DIFF
--- a/tests/e2e/oauth-agent-profile.test.ts
+++ b/tests/e2e/oauth-agent-profile.test.ts
@@ -147,7 +147,15 @@ describe('OAuth agent-grants profile E2E', () => {
     const recoveryKey = 'oauth-profile-recovery-attempt-0001';
     const replayChild = await client.refresh(replayFamily.refresh_token!, { idempotencyKey: recoveryKey });
     const recovered = await client.refresh(replayFamily.refresh_token!, { idempotencyKey: recoveryKey });
-    expect(recovered).toEqual({ ...replayChild, refresh_replay: true });
+    expect(recovered).toMatchObject({
+      access_token: replayChild.access_token,
+      refresh_token: replayChild.refresh_token,
+      token_type: replayChild.token_type,
+      scope: replayChild.scope,
+      refresh_replay: true,
+    });
+    expect(recovered.expires_in).toBeGreaterThan(0);
+    expect(recovered.expires_in).toBeLessThanOrEqual(replayChild.expires_in);
     expect((await client.fetch(RESOURCE, replayChild.access_token)).status).toBe(200);
 
     const { tokens: replayMisuseFamily } = await authorization(client);


### PR DESCRIPTION
Preserves exact replay-token assertions while allowing the intentionally recalculated expires_in value to decrease. The test requires a positive TTL that never exceeds the original child-token TTL. Verified against the production OAuth Agent Grants endpoint; production code is unchanged.