### PR TITLE
fix: bound metrics cardinality under load

### DIFF
--- a/apps/auth-service/src/plugins/metricsHook.ts
+++ b/apps/auth-service/src/plugins/metricsHook.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { Histogram } from 'prom-client';
 import { registry } from '../lib/metrics.js';
 import { config } from '../config.js';
@@ -11,6 +11,12 @@ const httpDuration = new Histogram({
   registers: [registry],
 });
 
+export function metricRouteLabel(request: Pick<FastifyRequest, 'is404' | 'routeOptions'>): string {
+  return request.is404
+    ? '__unmatched__'
+    : request.routeOptions?.url ?? '__unknown__';
+}
+
 export async function metricsHookPlugin(app: FastifyInstance): Promise<void> {
   if (!config.metricsEnabled) return;
 
@@ -22,7 +28,10 @@ export async function metricsHookPlugin(app: FastifyInstance): Promise<void> {
     }
 
     const duration = reply.elapsedTime / 1000; // ms → seconds
-    const route = request.routeOptions?.url ?? request.url;
+    // Never use the raw URL for unmatched routes. Attackers can otherwise
+    // create one Prometheus label set per random path and exhaust memory when
+    // the registry retains those time series indefinitely.
+    const route = metricRouteLabel(request);
 
     httpDuration
       .labels(request.method, route, String(reply.statusCode))

--- a/apps/auth-service/tests/metrics.test.ts
+++ b/apps/auth-service/tests/metrics.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { buildTestApp, seedAuth, authHeader, sqlMock, mockRedis } from './helpers.js';
 import type { FastifyInstance } from 'fastify';
+import { metricRouteLabel } from '../src/plugins/metricsHook.js';
 
 let app: FastifyInstance;
 
@@ -186,5 +187,12 @@ describe('metrics instrumentation', () => {
     expect(r1.statusCode).toBe(200);
     expect(r2.statusCode).toBe(200);
     expect(r3.statusCode).toBe(200);
+  });
+
+  it('bounds metric cardinality for unmatched paths', () => {
+    expect(metricRouteLabel({ is404: true, routeOptions: { url: '/random/attacker/path' } } as never))
+      .toBe('__unmatched__');
+    expect(metricRouteLabel({ is404: false, routeOptions: { url: '/v1/agents/:id' } } as never))
+      .toBe('/v1/agents/:id');
   });
 });

--- a/docker-compose.performance.yml
+++ b/docker-compose.performance.yml
@@ -1,0 +1,7 @@
+services:
+  auth-service:
+    environment:
+      # Avoid Windows/WSL localhost resolving to a competing ::1 relay while
+      # Docker publishes this service on the IPv4 loopback interface.
+      PUBLIC_BASE_URL: http://127.0.0.1:3001
+      JWT_ISSUER: http://127.0.0.1:3001

--- a/docs/internal/performance/docker-stress-performance-2026-09-01.md
+++ b/docs/internal/performance/docker-stress-performance-2026-09-01.md
@@ -1,0 +1,156 @@
+# Docker Stress and Performance Report
+
+- Date: 2026-09-01
+- Environment: Windows 11 workstation, Docker Desktop 29.7.2, Node.js 24.15.0 load runner
+- Target: one locally built Node.js 26 `apps/auth-service` container with PostgreSQL 16 and Redis 7
+- Result: PASS after remediation
+
+## Executive summary
+
+The baseline uncovered one reproducible service defect: unmatched URLs were used as raw
+Prometheus `route` labels. A caller sending unique paths could therefore create an
+unbounded number of permanently retained histogram series. In the baseline, 1,200
+unique paths created 1,200 new series, expanded the metrics response from 18,335 bytes
+to 2,492,873 bytes, and increased container memory from 107.1 MiB to 155 MiB.
+
+The metrics hook now maps every Fastify 404 to `__unmatched__`. The same 1,200-path
+workload creates one series on a fresh process and zero additional series on a repeat
+run. The first post-fix metrics response was 21,221 bytes, a 99.1% reduction from the
+affected baseline response.
+
+Two complete post-fix rounds executed 137,970 measured scenario requests. Both passed
+all latency, throughput, error, rate-limit, body-size, recovery, and cardinality checks.
+The full local Docker E2E suite then passed 255 tests across 23 files, including OAuth
+DPoP, prepaid wallets, layered spend controls, event streaming, SSO, and MPP passports.
+
+## Reproducible commands
+
+The performance override pins the local issuer to the IPv4 loopback address. This
+avoids Windows/WSL installations where `localhost` resolves to a competing `::1`
+relay before Docker's published socket.
+
+```powershell
+docker compose `
+  -f docker-compose.yml `
+  -f docker-compose.performance.yml `
+  -p grantex-stress `
+  up -d --build
+
+npm run test:stress:docker -- `
+  --container=grantex-stress-auth-service-1 `
+  --soak-seconds=30 `
+  --report=.tmp/stress-final.json
+```
+
+The runner refuses non-local targets, applies a ten-second deadline to every request,
+emits JSON evidence, and exits non-zero when a threshold or invariant fails.
+
+## Workload
+
+| Scenario | Requests | Concurrency | Expected behavior |
+| --- | ---: | ---: | --- |
+| Unmatched-route cardinality attack | 1,200 | 80 | `401`, bounded metric labels |
+| Readiness dependency pressure | 1,500 | 50 | `200`, PostgreSQL and Redis healthy |
+| Invalid API-key database pressure | 1,000 | 50 | `401`, no `5xx` or timeout |
+| JWKS burst | 5,000 | 100 | `200`, at least 1,000 req/s |
+| Authenticated DB and Redis path | 80 | 20 | `200`, below free-plan limit |
+| Authenticated plan-limit burst | 80 | 20 | `200` then protective `429` |
+| Oversized request bodies | 25 | 10 | `413` or early upload reset, no `5xx` |
+| Sustained JWKS soak | 60,000 | 75 | `200`, at least 1,000 req/s |
+| Post-pressure recovery | 100 | 10 | `200`, p95 below 150 ms |
+
+Fastify can reset an oversized upload socket after detecting a `Content-Length` above
+the 1 MiB body limit and before the client finishes transmitting. The harness accepts
+either an HTTP `413` or that early transport reset for this one adversarial scenario.
+It does not accept network errors in ordinary scenarios.
+
+## Baseline finding
+
+| Measure | Baseline |
+| --- | ---: |
+| Unmatched paths sent | 1,200 |
+| HTTP histogram series before | 2 |
+| HTTP histogram series after | 1,202 |
+| Series delta | 1,200 |
+| Metrics payload before | 18,335 bytes |
+| Metrics payload after | 2,492,873 bytes |
+| Container memory before | 107.1 MiB |
+| Container memory after | 155 MiB |
+| Unmatched-path throughput | 1,566.01 req/s |
+| Unmatched-path p95 | 143.40 ms |
+
+Root cause: `metricsHook.ts` used the raw request URL when Fastify selected its 404
+handler. Prometheus treats each distinct route label as a separate histogram family,
+including all bucket, sum, and count series.
+
+## Remediation
+
+`metricRouteLabel()` now checks Fastify's `request.is404` flag and returns the constant
+`__unmatched__`. Registered routes continue to use Fastify's normalized route pattern,
+such as `/v1/agents/:id`; the fallback for an unexpected missing route definition is
+the constant `__unknown__` rather than caller-controlled input.
+
+A unit regression test covers both unmatched and parameterized route labels. The
+Docker stress runner supplies the integration proof against the real Prometheus
+registry.
+
+## Final results
+
+First full post-fix round:
+
+| Scenario | Throughput | p95 | Status |
+| --- | ---: | ---: | --- |
+| Unmatched-route cardinality | 1,939.02 req/s | 137.15 ms | PASS |
+| Readiness dependency pressure | 1,804.97 req/s | 49.43 ms | PASS |
+| Invalid API-key DB pressure | 2,214.33 req/s | 33.55 ms | PASS |
+| JWKS burst | 1,760.17 req/s | 89.71 ms | PASS |
+| Authenticated DB and Redis path | 929.79 req/s | 28.29 ms | PASS |
+| Plan-limit burst | 1,256.43 req/s | 19.10 ms | PASS; 20 x `200`, 60 x `429` |
+| Oversized-body protection | 157.13 req/s | 80.36 ms | PASS; no `5xx` |
+| 60,000-request JWKS soak | 2,305.26 req/s | 55.15 ms | PASS |
+| Post-pressure recovery | 1,981.02 req/s | 10.95 ms | PASS |
+
+Cardinality after the fix:
+
+| Measure | First final round | Repeat round |
+| --- | ---: | ---: |
+| Series before | 2 | 7 |
+| Series after | 3 | 7 |
+| Series delta | 1 | 0 |
+| Metrics payload after | 21,221 bytes | 28,975 bytes |
+
+The repeat soak sustained 1,559.62 req/s at 83.92 ms p95 and passed every threshold.
+Container memory was 185.6 MiB before that repeat and 128.9 MiB afterward. Memory did
+not grow monotonically across the second 68,985-request round, which is consistent with
+normal V8 heap high-water and garbage-collection behavior rather than retained metric
+series.
+
+Across both final rounds there were no `5xx` responses, timeouts, or ordinary-scenario
+network errors. The post-pressure readiness probe remained healthy.
+
+## Functional verification after stress
+
+The service was rebuilt on a fresh database and Redis volume after load testing.
+
+| Verification | Result |
+| --- | --- |
+| Local Docker E2E files | 23/23 passed |
+| Local Docker E2E tests | 255/255 passed |
+| OAuth encrypted refresh replay after container restart | PASS |
+| Auth-service unit test files | 167 passed, 1 skipped |
+| Auth-service unit tests | 2,139 passed, 2 skipped |
+| Auth-service typecheck | PASS |
+| Auth-service production build | PASS |
+
+## Scope and limits
+
+This is a repeatable single-workstation, single-container stress assessment. It proves
+bounded metrics behavior and local service resilience under the documented workload;
+it is not a maximum-capacity claim for Cloud Run or a substitute for distributed load
+testing against an isolated staging environment.
+
+The run does not measure external Stripe, email, OPA, Cedar, LDAP, DNS, or third-party
+webhook latency. It also does not test multi-instance Redis coordination, Cloud SQL
+connection quotas, autoscaling, regional network latency, or production traffic. Those
+belong in an authorized staging test with explicit cost, rate, and data-isolation
+controls. The harness deliberately refuses production URLs.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "audit:supply-chain": "node scripts/check-supply-chain.mjs --audit-npm",
     "audit:python": "python scripts/audit-python-dependencies.py",
-    "test:e2e:refresh-restart": "node scripts/verify-oauth-refresh-restart.mjs"
+    "test:e2e:refresh-restart": "node scripts/verify-oauth-refresh-restart.mjs",
+    "test:stress:docker": "node scripts/docker-stress-test.mjs"
   },
   "devDependencies": {
     "@grantex/sdk": "file:packages/sdk-ts",

--- a/scripts/docker-stress-test.mjs
+++ b/scripts/docker-stress-test.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+
+function arg(name, fallback = undefined) {
+  const prefix = `${name}=`;
+  const inline = process.argv.find((value) => value.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const index = process.argv.indexOf(name);
+  if (index >= 0 && process.argv[index + 1] && !process.argv[index + 1].startsWith('--')) {
+    return process.argv[index + 1];
+  }
+  return fallback;
+}
+
+function requireLocalOrigin(value) {
+  const parsed = new URL(value);
+  const localHosts = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+  if (parsed.protocol !== 'http:' || !localHosts.has(parsed.hostname) || parsed.username || parsed.password) {
+    throw new Error('Refusing to run stress tests against a non-local HTTP endpoint');
+  }
+  return parsed.origin;
+}
+
+function percentile(values, fraction) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * fraction) - 1)];
+}
+
+function round(value) {
+  return value === null ? null : Math.round(value * 100) / 100;
+}
+
+async function timedRequest(url, options, timeoutMs = 10_000) {
+  const started = performance.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, { ...options, signal: controller.signal });
+    await response.arrayBuffer();
+    return { status: response.status, elapsedMs: performance.now() - started };
+  } catch (error) {
+    return {
+      status: controller.signal.aborted ? 'timeout' : 'network_error',
+      elapsedMs: performance.now() - started,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function runScenario(input) {
+  process.stderr.write(`[stress] ${input.name}: ${input.requests} requests at concurrency ${input.concurrency}\n`);
+  let next = 0;
+  const results = [];
+  const started = performance.now();
+  const worker = async () => {
+    while (true) {
+      const index = next;
+      next += 1;
+      if (index >= input.requests) return;
+      results.push(await timedRequest(
+        `${baseUrl}${input.path(index)}`,
+        input.options(index),
+        input.timeoutMs,
+      ));
+    }
+  };
+  await Promise.all(Array.from({ length: input.concurrency }, worker));
+  const durationMs = performance.now() - started;
+  const latencies = results.map((result) => result.elapsedMs);
+  const statusCounts = {};
+  for (const result of results) {
+    const key = String(result.status);
+    statusCounts[key] = (statusCounts[key] ?? 0) + 1;
+  }
+  const unexpected = results.filter((result) => !input.acceptedStatuses.has(result.status)).length;
+  const serverErrors = results.filter((result) => typeof result.status === 'number' && result.status >= 500).length;
+  const networkErrors = (statusCounts.network_error ?? 0) + (statusCounts.timeout ?? 0);
+  const rps = results.length / (durationMs / 1000);
+  const p95Ms = percentile(latencies, 0.95);
+  const passed = unexpected === 0
+    && serverErrors === 0
+    && (input.allowNetworkErrors === true || networkErrors === 0)
+    && (input.p95TargetMs === undefined || (p95Ms !== null && p95Ms <= input.p95TargetMs))
+    && (input.minimumRps === undefined || rps >= input.minimumRps)
+    && (input.validate === undefined || input.validate(statusCounts));
+  return {
+    name: input.name,
+    requests: results.length,
+    concurrency: input.concurrency,
+    duration_ms: round(durationMs),
+    requests_per_second: round(rps),
+    p50_ms: round(percentile(latencies, 0.5)),
+    p95_ms: round(p95Ms),
+    p99_ms: round(percentile(latencies, 0.99)),
+    max_ms: round(percentile(latencies, 1)),
+    status_counts: statusCounts,
+    unexpected_statuses: unexpected,
+    server_errors: serverErrors,
+    network_errors: networkErrors,
+    allowed_network_errors: input.allowNetworkErrors === true,
+    p95_target_ms: input.p95TargetMs ?? null,
+    minimum_rps: input.minimumRps ?? null,
+    passed,
+  };
+}
+
+async function scrapeMetrics() {
+  const headers = metricsKey ? { authorization: `Bearer ${metricsKey}` } : {};
+  const response = await fetch(`${baseUrl}/metrics`, { headers });
+  if (!response.ok) throw new Error(`Metrics scrape failed with HTTP ${response.status}`);
+  return response.text();
+}
+
+function httpHistogramSeries(metrics) {
+  return metrics.split(/\r?\n/)
+    .filter((line) => line.startsWith('grantex_http_request_duration_seconds_count{'));
+}
+
+function dockerStats(container) {
+  if (!container) return null;
+  try {
+    const output = execFileSync(
+      'docker',
+      ['stats', '--no-stream', '--format', '{{json .}}', container],
+      { encoding: 'utf8', windowsHide: true },
+    ).trim();
+    return output ? JSON.parse(output) : null;
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+// Pin the Docker-published IPv4 socket. On Windows with WSL enabled,
+// `localhost` can resolve to an unrelated ::1 relay before Docker's listener.
+const baseUrl = requireLocalOrigin(arg('--base-url', process.env.STRESS_BASE_URL ?? 'http://127.0.0.1:3001'));
+const apiKey = arg('--api-key', process.env.STRESS_API_KEY ?? 'dev-api-key-local');
+const metricsKey = arg('--metrics-key', process.env.STRESS_METRICS_API_KEY ?? 'local-metrics-api-key');
+const reportPath = arg('--report');
+const container = arg('--container');
+const soakSeconds = Number(arg('--soak-seconds', '15'));
+const allowThresholdFail = process.argv.includes('--allow-threshold-fail');
+const auth = { authorization: `Bearer ${apiKey}` };
+
+const healthProbe = await fetch(`${baseUrl}/health`);
+if (healthProbe.status !== 200) {
+  throw new Error(`Local auth-service is not healthy: HTTP ${healthProbe.status}`);
+}
+await healthProbe.arrayBuffer();
+
+// Warm pools and JIT paths before collecting latency percentiles.
+await runScenario({
+  name: 'warmup',
+  requests: 50,
+  concurrency: 10,
+  path: () => '/.well-known/jwks.json',
+  options: () => ({}),
+  acceptedStatuses: new Set([200]),
+});
+
+const resourceBefore = dockerStats(container);
+const scenarios = [];
+
+const metricsBefore = await scrapeMetrics();
+const seriesBefore = httpHistogramSeries(metricsBefore);
+scenarios.push(await runScenario({
+  name: 'unmatched_route_cardinality_attack',
+  requests: 1_200,
+  concurrency: 80,
+  path: (index) => `/stress/missing/${index}`,
+  options: () => ({}),
+  acceptedStatuses: new Set([401]),
+  p95TargetMs: 300,
+  minimumRps: 500,
+}));
+const metricsAfterCardinality = await scrapeMetrics();
+const seriesAfter = httpHistogramSeries(metricsAfterCardinality);
+const cardinality = {
+  series_before: seriesBefore.length,
+  series_after: seriesAfter.length,
+  series_delta: seriesAfter.length - seriesBefore.length,
+  metrics_bytes_before: Buffer.byteLength(metricsBefore),
+  metrics_bytes_after: Buffer.byteLength(metricsAfterCardinality),
+  passed: seriesAfter.length - seriesBefore.length <= 3,
+};
+
+scenarios.push(await runScenario({
+  name: 'readiness_dependency_pressure',
+  requests: 1_500,
+  concurrency: 50,
+  path: () => '/health',
+  options: () => ({}),
+  acceptedStatuses: new Set([200]),
+  p95TargetMs: 250,
+  minimumRps: 300,
+}));
+
+scenarios.push(await runScenario({
+  name: 'invalid_api_key_database_pressure',
+  requests: 1_000,
+  concurrency: 50,
+  path: () => '/v1/me',
+  options: (index) => ({ headers: { authorization: `Bearer invalid-stress-key-${String(index).padStart(8, '0')}` } }),
+  acceptedStatuses: new Set([401]),
+  p95TargetMs: 300,
+  minimumRps: 300,
+}));
+
+scenarios.push(await runScenario({
+  name: 'jwks_public_key_distribution',
+  requests: 5_000,
+  concurrency: 100,
+  path: () => '/.well-known/jwks.json',
+  options: () => ({}),
+  acceptedStatuses: new Set([200]),
+  p95TargetMs: 200,
+  minimumRps: 1_000,
+}));
+
+scenarios.push(await runScenario({
+  name: 'authenticated_database_and_redis_path',
+  requests: 80,
+  concurrency: 20,
+  path: () => '/v1/me',
+  options: () => ({ headers: auth }),
+  acceptedStatuses: new Set([200]),
+  p95TargetMs: 250,
+  minimumRps: 75,
+}));
+
+scenarios.push(await runScenario({
+  name: 'authenticated_plan_limit_burst',
+  requests: 80,
+  concurrency: 20,
+  path: () => '/v1/me',
+  options: () => ({ headers: auth }),
+  acceptedStatuses: new Set([200, 429]),
+  p95TargetMs: 250,
+  validate: (counts) => (counts['429'] ?? 0) > 0,
+}));
+
+const oversizedPayload = JSON.stringify({ name: 'x'.repeat(1_050_000) });
+scenarios.push(await runScenario({
+  name: 'oversized_body_protection',
+  requests: 25,
+  concurrency: 10,
+  path: () => '/v1/signup',
+  options: () => ({
+    method: 'POST',
+    headers: { 'content-type': 'application/json', connection: 'close' },
+    body: oversizedPayload,
+  }),
+  acceptedStatuses: new Set([413, 'network_error']),
+  // Fastify may reset the upload socket after detecting Content-Length above
+  // bodyLimit, before the client finishes transmitting. A 413 response or an
+  // early reset both demonstrate bounded server-side body handling.
+  allowNetworkErrors: true,
+  p95TargetMs: 500,
+  validate: (counts) => (counts['413'] ?? 0) > 0,
+}));
+
+if (!Number.isFinite(soakSeconds) || soakSeconds < 1 || soakSeconds > 300) {
+  throw new Error('--soak-seconds must be between 1 and 300');
+}
+const estimatedSoakRequests = Math.max(1_000, Math.round(soakSeconds * 2_000));
+scenarios.push(await runScenario({
+  name: 'jwks_sustained_soak',
+  requests: estimatedSoakRequests,
+  concurrency: 75,
+  path: () => '/.well-known/jwks.json',
+  options: () => ({}),
+  acceptedStatuses: new Set([200]),
+  p95TargetMs: 200,
+  minimumRps: 1_000,
+}));
+
+scenarios.push(await runScenario({
+  name: 'post_pressure_recovery',
+  requests: 100,
+  concurrency: 10,
+  path: () => '/health',
+  options: () => ({}),
+  acceptedStatuses: new Set([200]),
+  p95TargetMs: 150,
+  minimumRps: 150,
+}));
+
+const resourceAfter = dockerStats(container);
+const report = {
+  schema_version: 1,
+  generated_at: new Date().toISOString(),
+  local_only: true,
+  base_url: baseUrl,
+  runtime: { node: process.version, platform: process.platform, arch: process.arch },
+  resources: { before: resourceBefore, after: resourceAfter },
+  cardinality,
+  scenarios,
+  passed: cardinality.passed && scenarios.every((scenario) => scenario.passed),
+};
+
+const output = `${JSON.stringify(report, null, 2)}\n`;
+if (reportPath) {
+  const absolute = resolve(reportPath);
+  mkdirSync(dirname(absolute), { recursive: true });
+  writeFileSync(absolute, output, 'utf8');
+}
+process.stdout.write(output);
+if (!report.passed && !allowThresholdFail) process.exitCode = 1;


### PR DESCRIPTION
## Summary
- bound Prometheus HTTP route labels for unmatched requests to prevent unbounded cardinality under hostile or accidental unique-path load
- add a regression test for unmatched and unknown route labels
- add a local-only Docker stress harness, Compose performance override, npm entry point, and committed performance report

## Risk and production impact
- production behavior changes only for the `route` label emitted for unmatched requests (`__unmatched__` instead of attacker-controlled raw paths)
- no API, authentication, authorization, wallet, or persistence behavior changes
- the stress harness refuses non-local targets before sending traffic

## Verification
- two complete Docker stress rounds: 137,970 requests total, zero 5xx/timeouts/network errors
- 60,000-request soak exceeded 1,500 req/s in both rounds; post-pressure p95 stayed below 17 ms
- cardinality test held histogram series effectively constant instead of growing by 1,200 series
- full Docker production E2E: 23/23 files and 255/255 tests passed
- auth-service unit suite: 2,139 passed, 2 skipped; typecheck and production build passed
- encrypted refresh-token replay survived an actual auth-service container restart
- docs integrity, live-mode guard, and npm audits passed

## Report
`docs/internal/performance/docker-stress-performance-2026-09-01.md`