### PR TITLE
fix: align Python integrations with hardened runtime

### DIFF
--- a/examples/crewai-agent/README.md
+++ b/examples/crewai-agent/README.md
@@ -26,6 +26,7 @@ docker compose up -d
 # Run the example
 cd examples/crewai-agent
 pip install -r requirements.txt
+pip install "grantex-crewai[crewai]"
 python main.py
 ```
 

--- a/examples/crewai-agent/main.py
+++ b/examples/crewai-agent/main.py
@@ -23,11 +23,12 @@ import os
 
 import httpx
 
-from grantex import ExchangeTokenParams, Grantex
+from grantex import ExchangeTokenParams, Grantex, ListAuditParams
 from grantex_crewai import create_grantex_tool, with_audit_logging
 
 BASE_URL = os.environ.get("GRANTEX_URL", "http://localhost:3001")
 API_KEY = os.environ.get("GRANTEX_API_KEY", "sandbox-api-key-local")
+JWKS_URI = f"{BASE_URL}/.well-known/jwks.json"
 
 
 def get_grant_token(
@@ -74,6 +75,8 @@ def main() -> None:
         name="read_calendar",
         description="Read the user's upcoming calendar events",
         grant_token=grant_token,
+        jwks_uri=JWKS_URI,
+        issuer=BASE_URL,
         required_scope="calendar:read",
         func=lambda query="today": json.dumps({
             "events": [
@@ -87,6 +90,8 @@ def main() -> None:
         name="send_email",
         description="Send an email on behalf of the user",
         grant_token=grant_token,
+        jwks_uri=JWKS_URI,
+        issuer=BASE_URL,
         required_scope="email:send",
         func=lambda message="": f'Email sent successfully: "{message}"',
     )
@@ -123,6 +128,8 @@ def main() -> None:
             name="delete_account",
             description="Delete the user account",
             grant_token=grant_token,
+            jwks_uri=JWKS_URI,
+            issuer=BASE_URL,
             required_scope="account:delete",  # not in our grant!
             func=lambda: "deleted",
         )
@@ -132,7 +139,9 @@ def main() -> None:
 
     # ── 6. Inspect audit trail ─────────────────────────────────────────
     print("\n--- Audit trail ---")
-    audit_log = client.audit.list(agent_id=agent.id, grant_id=grant_id)
+    audit_log = client.audit.list(
+        ListAuditParams(agent_id=agent.id, grant_id=grant_id)
+    )
     for entry in audit_log.entries:
         print(f"  [{entry.status}] {entry.action} — {entry.timestamp}")
 

--- a/examples/google-adk/README.md
+++ b/examples/google-adk/README.md
@@ -25,6 +25,7 @@ docker compose up -d
 # Run the example
 cd examples/google-adk
 pip install -r requirements.txt
+pip install "grantex-adk[adk]"
 python main.py
 ```
 

--- a/examples/google-adk/main.py
+++ b/examples/google-adk/main.py
@@ -22,11 +22,12 @@ import os
 
 import httpx
 
-from grantex import ExchangeTokenParams, Grantex
+from grantex import ExchangeTokenParams, Grantex, ListAuditParams
 from grantex_adk import create_grantex_tool
 
 BASE_URL = os.environ.get("GRANTEX_URL", "http://localhost:3001")
 API_KEY = os.environ.get("GRANTEX_API_KEY", "sandbox-api-key-local")
+JWKS_URI = f"{BASE_URL}/.well-known/jwks.json"
 
 
 def get_grant_token(
@@ -71,6 +72,8 @@ def main() -> None:
         name="read_calendar",
         description="Read the user's upcoming calendar events",
         grant_token=grant_token,
+        jwks_uri=JWKS_URI,
+        issuer=BASE_URL,
         required_scope="calendar:read",
         func=lambda query="today": json.dumps({
             "events": [
@@ -84,6 +87,8 @@ def main() -> None:
         name="send_email",
         description="Send an email on behalf of the user",
         grant_token=grant_token,
+        jwks_uri=JWKS_URI,
+        issuer=BASE_URL,
         required_scope="email:send",
         func=lambda message="": f'Email sent successfully: "{message}"',
     )
@@ -111,6 +116,8 @@ def main() -> None:
             name="delete_account",
             description="Delete the user account",
             grant_token=grant_token,
+            jwks_uri=JWKS_URI,
+            issuer=BASE_URL,
             required_scope="account:delete",  # not in our grant!
             func=lambda: "deleted",
         )
@@ -120,7 +127,9 @@ def main() -> None:
 
     # ── 5. Inspect audit trail ─────────────────────────────────────────
     print("\n--- Audit trail ---")
-    audit_log = client.audit.list(agent_id=agent.id, grant_id=grant_id)
+    audit_log = client.audit.list(
+        ListAuditParams(agent_id=agent.id, grant_id=grant_id)
+    )
     for entry in audit_log.entries:
         print(f"  [{entry.status}] {entry.action} — {entry.timestamp}")
 

--- a/examples/openai-agents/README.md
+++ b/examples/openai-agents/README.md
@@ -25,6 +25,7 @@ docker compose up -d
 # Run the example
 cd examples/openai-agents
 pip install -r requirements.txt
+pip install "grantex-openai-agents[openai-agents]"
 python main.py
 ```
 

--- a/examples/openai-agents/main.py
+++ b/examples/openai-agents/main.py
@@ -17,16 +17,46 @@ Prerequisites:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 
 import httpx
 
-from grantex import ExchangeTokenParams, Grantex
+from agents.tool_context import ToolContext
+from grantex import ExchangeTokenParams, Grantex, ListAuditParams
 from grantex_openai_agents import create_grantex_tool
 
 BASE_URL = os.environ.get("GRANTEX_URL", "http://localhost:3001")
 API_KEY = os.environ.get("GRANTEX_API_KEY", "sandbox-api-key-local")
+JWKS_URI = f"{BASE_URL}/.well-known/jwks.json"
+
+
+def read_calendar(query: str = "today") -> str:
+    return json.dumps(
+        {
+            "events": [
+                {"title": "Team standup", "time": "9:00 AM", "query": query},
+                {"title": "Design review", "time": "2:00 PM", "query": query},
+            ]
+        }
+    )
+
+
+def send_email(message: str = "") -> str:
+    return f'Email sent successfully: "{message}"'
+
+
+async def invoke_tool(tool: object, arguments: dict[str, str]) -> object:
+    """Invoke a FunctionTool without starting an LLM-backed agent run."""
+    payload = json.dumps(arguments)
+    context = ToolContext(
+        context=None,
+        tool_name=tool.name,  # type: ignore[attr-defined]
+        tool_call_id="local-example-call",
+        tool_arguments=payload,
+    )
+    return await tool.on_invoke_tool(context, payload)  # type: ignore[attr-defined]
 
 
 def get_grant_token(
@@ -71,21 +101,20 @@ def main() -> None:
         name="read_calendar",
         description="Read the user's upcoming calendar events",
         grant_token=grant_token,
+        jwks_uri=JWKS_URI,
+        issuer=BASE_URL,
         required_scope="calendar:read",
-        func=lambda query="today": json.dumps({
-            "events": [
-                {"title": "Team standup", "time": "9:00 AM", "query": query},
-                {"title": "Design review", "time": "2:00 PM", "query": query},
-            ]
-        }),
+        func=read_calendar,
     )
 
     email_tool = create_grantex_tool(
         name="send_email",
         description="Send an email on behalf of the user",
         grant_token=grant_token,
+        jwks_uri=JWKS_URI,
+        issuer=BASE_URL,
         required_scope="email:send",
-        func=lambda message="": f'Email sent successfully: "{message}"',
+        func=send_email,
     )
 
     print("Tools created: read_calendar, send_email")
@@ -95,12 +124,15 @@ def main() -> None:
     # Here we invoke them directly to show the Grantex integration.
 
     print("\n--- Invoking read_calendar ---")
-    calendar_result = calendar_tool.run(query="today")
+    calendar_result = asyncio.run(invoke_tool(calendar_tool, {"query": "today"}))
     print(f"Result: {calendar_result}")
 
     print("\n--- Invoking send_email ---")
-    email_result = email_tool.run(
-        message="Meeting summary: standup at 9 AM, design review at 2 PM"
+    email_result = asyncio.run(
+        invoke_tool(
+            email_tool,
+            {"message": "Meeting summary: standup at 9 AM, design review at 2 PM"},
+        )
     )
     print(f"Result: {email_result}")
 
@@ -111,6 +143,8 @@ def main() -> None:
             name="delete_account",
             description="Delete the user account",
             grant_token=grant_token,
+            jwks_uri=JWKS_URI,
+            issuer=BASE_URL,
             required_scope="account:delete",  # not in our grant!
             func=lambda: "deleted",
         )
@@ -120,7 +154,9 @@ def main() -> None:
 
     # ── 5. Inspect audit trail ─────────────────────────────────────────
     print("\n--- Audit trail ---")
-    audit_log = client.audit.list(agent_id=agent.id, grant_id=grant_id)
+    audit_log = client.audit.list(
+        ListAuditParams(agent_id=agent.id, grant_id=grant_id)
+    )
     for entry in audit_log.entries:
         print(f"  [{entry.status}] {entry.action} — {entry.timestamp}")
 

--- a/examples/quickstart-py/main.py
+++ b/examples/quickstart-py/main.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import os
 
 from grantex import (
+    AuthorizeParams,
     ExchangeTokenParams,
     Grantex,
     verify_grant_token,
@@ -44,30 +45,16 @@ def main() -> None:
 
     # ── 2. Authorize (sandbox mode — auto-approved) ────────────────────
     auth_request = client.authorize(
-        agent_id=agent.id,
-        user_id="test-user-001",
-        scopes=["calendar:read", "email:send"],
+        AuthorizeParams(
+            agent_id=agent.id,
+            user_id="test-user-001",
+            scopes=["calendar:read", "email:send"],
+        )
     )
     print(f"Auth request: {auth_request.request_id}")
 
-    # In sandbox mode the response includes a `code` we can exchange immediately.
-    # The SDK types don't include sandbox-only fields, so we access the raw dict.
-    code: str | None = getattr(auth_request, "_raw_code", None)
-    # The sandbox code is returned as part of the response — get it from the raw
-    # authorize response. Since the Python SDK parses into a dataclass, we need to
-    # reach into the HTTP layer. For simplicity, re-fetch via the raw response.
-    import httpx
-
-    raw = httpx.post(
-        f"{BASE_URL}/v1/authorize",
-        headers={"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"},
-        json={
-            "agentId": agent.id,
-            "principalId": "test-user-001",
-            "scopes": ["calendar:read", "email:send"],
-        },
-    )
-    code = raw.json().get("code")
+    # Sandbox authorization responses include an immediately exchangeable code.
+    code = auth_request.code
     if not code:
         print("No code returned — are you using the sandbox API key?")
         raise SystemExit(1)
@@ -96,7 +83,9 @@ def main() -> None:
     # ── 5. Log an audit entry ──────────────────────────────────────────
     entry = client.audit.log(
         agent_id=agent.id,
+        agent_did=agent.did,
         grant_id=token.grant_id,
+        principal_id=verified.principal_id,
         action="calendar.read",
         status="success",
         metadata={"query": "today", "results": 3},

--- a/packages/crewai/README.md
+++ b/packages/crewai/README.md
@@ -129,7 +129,9 @@ with_audit_logging(
 ) -> BaseTool
 ```
 
-Patches the tool's `_run` method to log audit entries via the Grantex client.
+Fetches the grant and agent once to validate their relationship and resolve the
+immutable agent DID and principal ID, then patches the tool's `_run` method to
+log complete audit entries via the Grantex client.
 
 | Parameter | Description |
 |---|---|

--- a/packages/crewai/pyproject.toml
+++ b/packages/crewai/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "pytest>=8.3,<9; python_version < '3.10'",
     "pytest>=9.0.3; python_version >= '3.10'",
     "pytest-mock>=3.12",
+    "pydantic>=2,<3",
 ]
 
 

--- a/packages/crewai/src/grantex_crewai/_audit.py
+++ b/packages/crewai/src/grantex_crewai/_audit.py
@@ -31,6 +31,14 @@ def with_audit_logging(
         tool = with_audit_logging(tool, grantex_client,
                                   agent_id="ag_01...", grant_id="grnt_01...")
     """
+    grant = client.grants.get(grant_id)
+    if grant.agent_id != agent_id:
+        raise ValueError(
+            f"Grant {grant_id!r} belongs to agent {grant.agent_id!r}, "
+            f"not {agent_id!r}"
+        )
+    agent = client.agents.get(agent_id)
+
     original_run = tool._run  # noqa: SLF001
 
     def _audited_run(**kwargs: Any) -> str:
@@ -39,7 +47,9 @@ def with_audit_logging(
             result: str = original_run(**kwargs)
             client.audit.log(
                 agent_id=agent_id,
+                agent_did=agent.did,
                 grant_id=grant_id,
+                principal_id=grant.principal_id,
                 action=action,
                 metadata={"kwargs": kwargs},
                 status="success",
@@ -48,7 +58,9 @@ def with_audit_logging(
         except Exception as exc:
             client.audit.log(
                 agent_id=agent_id,
+                agent_did=agent.did,
                 grant_id=grant_id,
+                principal_id=grant.principal_id,
                 action=action,
                 metadata={"kwargs": kwargs, "error": str(exc)},
                 status="failure",

--- a/packages/crewai/tests/conftest.py
+++ b/packages/crewai/tests/conftest.py
@@ -99,5 +99,13 @@ def _mock_verify_grant_token(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture()
 def mock_grantex() -> MagicMock:
     client = MagicMock()
+    client.grants.get.return_value = SimpleNamespace(
+        agent_id="ag_01",
+        principal_id="user_01",
+    )
+    client.agents.get.return_value = SimpleNamespace(
+        id="ag_01",
+        did="did:grantex:ag_01",
+    )
     client.audit.log = MagicMock(return_value=None)
     return client

--- a/packages/crewai/tests/test_audit.py
+++ b/packages/crewai/tests/test_audit.py
@@ -32,9 +32,13 @@ def test_audit_logs_success(mock_grantex: MagicMock) -> None:
     result = tool._run(item="widget")
 
     assert result == "processed:widget"
+    mock_grantex.grants.get.assert_called_once_with("grnt_01")
+    mock_grantex.agents.get.assert_called_once_with("ag_01")
     mock_grantex.audit.log.assert_called_once_with(
         agent_id="ag_01",
+        agent_did="did:grantex:ag_01",
         grant_id="grnt_01",
+        principal_id="user_01",
         action="tool.run:test_tool",
         metadata={"kwargs": {"item": "widget"}},
         status="success",
@@ -55,7 +59,9 @@ def test_audit_logs_failure_and_reraises(mock_grantex: MagicMock) -> None:
 
     mock_grantex.audit.log.assert_called_once_with(
         agent_id="ag_01",
+        agent_did="did:grantex:ag_01",
         grant_id="grnt_01",
+        principal_id="user_01",
         action="tool.run:test_tool",
         metadata={"kwargs": {"item": "widget"}, "error": "something went wrong"},
         status="failure",
@@ -69,6 +75,18 @@ def test_audit_returns_same_tool_instance(mock_grantex: MagicMock) -> None:
         tool, mock_grantex, agent_id="ag_01", grant_id="grnt_01"
     )
     assert id(returned) == original_id
+
+
+def test_audit_rejects_grant_for_another_agent(mock_grantex: MagicMock) -> None:
+    tool = _make_tool(lambda: "ok")
+    mock_grantex.grants.get.return_value.agent_id = "ag_other"
+
+    with pytest.raises(ValueError, match="belongs to agent 'ag_other'"):
+        with_audit_logging(
+            tool, mock_grantex, agent_id="ag_01", grant_id="grnt_01"
+        )
+
+    mock_grantex.audit.log.assert_not_called()
 
 
 def test_audit_does_not_log_on_scope_error() -> None:

--- a/packages/openai-agents/src/grantex_openai_agents/_tools.py
+++ b/packages/openai-agents/src/grantex_openai_agents/_tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import wraps
 from typing import Any, Callable
 
 from grantex import GrantexTokenError, VerifyGrantTokenOptions, verify_grant_token
@@ -59,10 +60,12 @@ def create_grantex_tool(
 
     _verify_required_scope()
 
-    # Wrap func so the decorator sees a proper function with name/docstring
-    def _wrapper(**kwargs: Any) -> str:
+    # Preserve the callable's signature so the Agents SDK can build a strict
+    # JSON schema instead of treating the tool as an unbounded **kwargs object.
+    @wraps(func)
+    def _wrapper(*args: Any, **kwargs: Any) -> str:
         _verify_required_scope()
-        return func(**kwargs)
+        return func(*args, **kwargs)
 
     _wrapper.__name__ = name
     _wrapper.__doc__ = description

--- a/packages/openai-agents/tests/test_tools.py
+++ b/packages/openai-agents/tests/test_tools.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
 from grantex_openai_agents import create_grantex_tool, get_tool_scopes
@@ -64,6 +66,24 @@ def test_tool_run_delegates_to_func() -> None:
     result = tool.run(url="https://example.com")
     assert result == "fetched:https://example.com"
     assert calls == [{"url": "https://example.com"}]
+
+
+def test_tool_preserves_wrapped_function_signature() -> None:
+    def fetch(url: str, timeout: int = 10) -> str:
+        return f"{url}:{timeout}"
+
+    tool = create_grantex_tool(
+        name="fetch",
+        description="Fetch a URL.",
+        grant_token=TOKEN_WITH_SCOPES,
+        required_scope="data:read",
+        func=fetch,
+    )
+
+    assert (
+        str(inspect.signature(tool._func))
+        == "(url: 'str', timeout: 'int' = 10) -> 'str'"
+    )
 
 
 def test_get_tool_scopes_returns_scp_list() -> None:

--- a/tests/e2e-extended.mjs
+++ b/tests/e2e-extended.mjs
@@ -19,6 +19,7 @@ import {
   verifyWebhookSignature,
   GrantexApiError,
 } from '@grantex/sdk';
+import { randomUUID } from 'node:crypto';
 
 const BASE_URL = process.env['GRANTEX_URL'] ?? 'https://grantex-auth-dd4mtrt2gq-uc.a.run.app';
 const API_KEY = process.env['GRANTEX_API_KEY'] ?? 'gx_test_playground_demo_2026';
@@ -62,7 +63,12 @@ async function test_token_refresh() {
   ok(original.valid === true, 'Original token is valid');
 
   // Refresh
-  const refreshed = await grantex.tokens.refresh({ refreshToken, agentId });
+  const refreshRecoveryKey = randomUUID();
+  const refreshed = await grantex.tokens.refresh({
+    refreshToken,
+    agentId,
+    idempotencyKey: refreshRecoveryKey,
+  });
   ok(!!refreshed.grantToken, 'Refresh returns new grantToken');
   ok(!!refreshed.refreshToken, 'Refresh returns new refreshToken');
   ok(refreshed.grantId === grantId, 'Refresh preserves grantId');
@@ -74,7 +80,11 @@ async function test_token_refresh() {
 
   // If the refresh response is lost after commit, retrying the previous
   // refresh token should recover the same already-rotated child token.
-  const recovered = await grantex.tokens.refresh({ refreshToken, agentId });
+  const recovered = await grantex.tokens.refresh({
+    refreshToken,
+    agentId,
+    idempotencyKey: refreshRecoveryKey,
+  });
   ok(recovered.refreshToken === refreshed.refreshToken, 'Previous refresh token replay recovers rotated refreshToken');
   ok(recovered.grantId === grantId, 'Replay recovery preserves grantId');
 

--- a/tests/e2e-negative.mjs
+++ b/tests/e2e-negative.mjs
@@ -225,6 +225,7 @@ async function test_scope_enforcement() {
     description: 'Admin',
     inputSchema: { type: 'object' },
     grantToken,
+    jwksUri: JWKS_URI,
     requiredScope: 'admin:all',
     execute: async () => 'should-not-run',
   });
@@ -246,6 +247,7 @@ async function test_scope_enforcement() {
     description: 'Write',
     inputSchema: { type: 'object' },
     grantToken: emptyAgent.grantToken,
+    jwksUri: JWKS_URI,
     requiredScope: 'file:write', // not granted
     execute: async () => 'should-not-run',
   });
@@ -262,6 +264,7 @@ async function test_scope_enforcement() {
     description: 'Read',
     inputSchema: { type: 'object', properties: { x: { type: 'string' } } },
     grantToken,
+    jwksUri: JWKS_URI,
     requiredScope: 'file:read',
     execute: async () => 'ok',
   });
@@ -487,6 +490,7 @@ async function test_integration_edge_cases() {
     description: 'Read',
     inputSchema: { type: 'object' },
     grantToken,
+    jwksUri: JWKS_URI,
     requiredScope: 'file:read',
     execute: async () => ({ data: 'sensitive' }),
   });
@@ -499,6 +503,7 @@ async function test_integration_edge_cases() {
     description: 'Case',
     inputSchema: { type: 'object' },
     grantToken,
+    jwksUri: JWKS_URI,
     requiredScope: 'FILE:READ', // wrong case
     execute: async () => 'bad',
   });
@@ -510,8 +515,8 @@ async function test_integration_edge_cases() {
   }
 
   // Multiple tools in registry, execute wrong one
-  const toolA = createGrantexTool({ name: 'a', description: 'A', inputSchema: { type: 'object' }, grantToken, requiredScope: 'file:read', execute: async () => 'A' });
-  const toolB = createGrantexTool({ name: 'b', description: 'B', inputSchema: { type: 'object' }, grantToken, requiredScope: 'file:write', execute: async () => 'B' });
+  const toolA = createGrantexTool({ name: 'a', description: 'A', inputSchema: { type: 'object' }, grantToken, jwksUri: JWKS_URI, requiredScope: 'file:read', execute: async () => 'A' });
+  const toolB = createGrantexTool({ name: 'b', description: 'B', inputSchema: { type: 'object' }, grantToken, jwksUri: JWKS_URI, requiredScope: 'file:write', execute: async () => 'B' });
   const reg = new GrantexToolRegistry();
   reg.register(toolA).register(toolB);
 
@@ -526,6 +531,7 @@ async function test_integration_edge_cases() {
     description: 'Crash',
     inputSchema: { type: 'object' },
     grantToken,
+    jwksUri: JWKS_URI,
     requiredScope: 'file:read',
     execute: async () => { throw new Error('intentional crash'); },
   });

--- a/tests/e2e-python.py
+++ b/tests/e2e-python.py
@@ -7,11 +7,11 @@ Run:
   python tests/e2e-python.py
 """
 
+import asyncio
+import json
 import os
 import sys
 import time
-import json
-import base64
 import traceback
 
 # Fix Windows console encoding
@@ -20,6 +20,7 @@ sys.stderr.reconfigure(encoding='utf-8', errors='replace')
 
 BASE_URL = os.environ.get("GRANTEX_URL", "https://grantex-auth-dd4mtrt2gq-uc.a.run.app")
 API_KEY = os.environ.get("GRANTEX_API_KEY", "gx_test_playground_demo_2026")
+ISSUER = os.environ.get("GRANTEX_ISSUER", "https://grantex.dev")
 
 passed = 0
 failed = 0
@@ -40,20 +41,6 @@ def skip(msg):
     global skipped
     skipped += 1
     print(f"  [SKIP] {msg}")
-
-
-def make_token(scopes):
-    """Create a fake JWT for offline scope testing."""
-    header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).decode().rstrip("=")
-    payload = base64.urlsafe_b64encode(json.dumps({
-        "iss": "https://grantex.dev",
-        "sub": "user_01",
-        "scp": scopes,
-        "jti": "tok_01",
-        "grnt": "grnt_01",
-        "exp": 9999999999,
-    }).encode()).decode().rstrip("=")
-    return f"{header}.{payload}.fakesig"
 
 
 def getval(obj, *keys):
@@ -186,30 +173,35 @@ def test_crewai():
         skip("grantex-crewai or crewai not installed (requires heavy framework deps)")
         return
 
-    token = make_token(["file:read", "file:write"])
+    from grantex import Grantex
+    client = Grantex(api_key=API_KEY, base_url=BASE_URL)
+    _, token, _, _, _ = setup_agent(client, "crewai", ["file:read", "file:write"])
 
     tool = create_grantex_tool(
         name="read_file",
         description="Read a file",
         grant_token=token,
+        jwks_uri=f"{BASE_URL}/.well-known/jwks.json",
+        issuer=ISSUER,
         required_scope="file:read",
         func=lambda path: f"contents of {path}",
     )
     ok(tool.name == "read_file", "CrewAI tool created")
 
-    result = tool.run("test.txt")
+    result = tool.run(path="test.txt")
     ok("contents" in result, f"Tool executed: {result}")
 
-    bad_tool = create_grantex_tool(
-        name="admin_tool",
-        description="Admin",
-        grant_token=token,
-        required_scope="admin:all",
-        func=lambda: "bad",
-    )
     try:
-        bad_tool.run("")
-        ok(False, "Missing scope should throw")
+        create_grantex_tool(
+            name="admin_tool",
+            description="Admin",
+            grant_token=token,
+            jwks_uri=f"{BASE_URL}/.well-known/jwks.json",
+            issuer=ISSUER,
+            required_scope="admin:all",
+            func=lambda: "bad",
+        )
+        ok(False, "Missing scope should throw at creation")
     except Exception as e:
         ok("admin:all" in str(e), f"Scope error: {e}")
 
@@ -227,16 +219,45 @@ def test_openai_agents():
         skip("grantex-openai-agents or OpenAI Agents SDK not installed (requires heavy framework deps)")
         return
 
-    token = make_token(["data:read"])
+    from grantex import Grantex
+    client = Grantex(api_key=API_KEY, base_url=BASE_URL)
+    _, token, _, _, _ = setup_agent(client, "openai-agents", ["data:read"])
 
     tool = create_grantex_tool(
         name="query_data",
         description="Query data",
         grant_token=token,
+        jwks_uri=f"{BASE_URL}/.well-known/jwks.json",
+        issuer=ISSUER,
         required_scope="data:read",
         func=lambda q: f"results for {q}",
     )
     ok(tool.name == "query_data", "OpenAI Agents tool created")
+
+    from agents.tool_context import ToolContext
+    arguments = json.dumps({"q": "revenue"})
+    context = ToolContext(
+        context=None,
+        tool_name=tool.name,
+        tool_call_id="python-e2e-call",
+        tool_arguments=arguments,
+    )
+    result = asyncio.run(tool.on_invoke_tool(context, arguments))
+    ok("results for revenue" in result, f"Tool executed: {result}")
+
+    try:
+        create_grantex_tool(
+            name="admin_tool",
+            description="Admin",
+            grant_token=token,
+            jwks_uri=f"{BASE_URL}/.well-known/jwks.json",
+            issuer=ISSUER,
+            required_scope="admin:all",
+            func=lambda: "bad",
+        )
+        ok(False, "Missing scope should throw at creation")
+    except Exception as e:
+        ok("admin:all" in str(e), f"Scope error: {e}")
 
 
 # ================================================================
@@ -251,13 +272,17 @@ def test_google_adk():
         skip("grantex-adk not installed")
         return
 
-    token = make_token(["calendar:read"])
+    from grantex import Grantex
+    client = Grantex(api_key=API_KEY, base_url=BASE_URL)
+    _, token, _, _, _ = setup_agent(client, "google-adk", ["calendar:read"])
 
     # Valid scope — ADK tools use **kwargs
     tool = create_grantex_tool(
         name="read_calendar",
         description="Read calendar",
         grant_token=token,
+        jwks_uri=f"{BASE_URL}/.well-known/jwks.json",
+        issuer=ISSUER,
         required_scope="calendar:read",
         func=lambda date="today": f"events for {date}",
     )
@@ -272,6 +297,8 @@ def test_google_adk():
             name="admin",
             description="Admin",
             grant_token=token,
+            jwks_uri=f"{BASE_URL}/.well-known/jwks.json",
+            issuer=ISSUER,
             required_scope="admin:all",
             func=lambda: "bad",
         )


### PR DESCRIPTION
## Summary
- make local/production integration E2E use real signed grants, explicit JWKS/issuer configuration, and refresh idempotency keys
- align Python examples with the current typed SDK, OpenAI Agents strict schemas, and complete audit identities
- validate CrewAI grant/agent ownership before audit logging and make its CI development dependency complete

## Local verification
- combined tree matched the post-merge candidate tree exactly
- Docker build and canonical suite: 255/255 tests
- extended/negative Docker suites: 62/62 and 58/58
- Python real-framework Docker E2E: 30/30, no skips
- quickstart, CrewAI, OpenAI Agents 0.22, and Google ADK examples executed against Docker
- Python adapter unit tests: 24/24; strict mypy clean
- refresh replay survived an auth-service container restart
- Docker stress suite passed all 9 scenarios; 113,078-request JWKS soak at 3,769 req/s and 29 ms p95
- npm supply-chain audit: 36 lockfiles / 4,285 entries clean
- Python vulnerability/license audit: 14/14 surfaces clean
- documentation integrity and git diff checks clean