### PR TITLE
fix: correct wallet API examples and remote expiry E2E timing

### DIFF
--- a/docs/guides/base-usdc-custody.mdx
+++ b/docs/guides/base-usdc-custody.mdx
@@ -64,7 +64,18 @@ preserve ownership, reservation, retry and reconciliation guarantees.
 
 Using an authenticated principal-session client:
 
+The hosted principal API origin is `https://api.grantex.dev`. The OAuth issuer
+and agent wallet audience remain `https://grantex.dev` and
+`https://grantex.dev/v1/prepaid-wallets` respectively. Do not change a token's
+audience to the principal API host. Self-hosted deployments use their configured
+origins. Health and protected metrics are served by the API origin, not the
+marketing site's limited Firebase rewrites.
+
 ```ts
+const principal = new PrincipalPrepaidWalletClient({
+  baseUrl: 'https://api.grantex.dev',
+  sessionToken,
+});
 const wallet = await principal.create({
   name: 'Agent Base USDC float',
   custodyMode: 'external',

--- a/docs/integrations/x402.mdx
+++ b/docs/integrations/x402.mdx
@@ -109,7 +109,7 @@ developer API key.
 import { PrincipalPrepaidWalletClient } from '@grantex/sdk';
 
 const principal = new PrincipalPrepaidWalletClient({
-  baseUrl: 'https://grantex.dev',
+  baseUrl: 'https://api.grantex.dev',
   sessionToken,
 });
 

--- a/packages/sdk-py/README.md
+++ b/packages/sdk-py/README.md
@@ -142,7 +142,7 @@ from grantex import (
 )
 
 principal = PrincipalPrepaidWalletClient(
-    base_url="https://grantex.dev",
+    base_url="https://api.grantex.dev",
     session_token=session_token,
 )
 principal.create_spend_policy({

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -164,7 +164,7 @@ const agentWallets = new PrepaidWalletAgentClient({
 });
 
 const principalWallets = new PrincipalPrepaidWalletClient({
-  baseUrl: 'https://grantex.dev',
+  baseUrl: 'https://api.grantex.dev',
   sessionToken,
 });
 

--- a/tests/base-usdc/api-contract.test.mjs
+++ b/tests/base-usdc/api-contract.test.mjs
@@ -6,6 +6,15 @@ import { parse } from 'yaml';
 const spec = parse(readFileSync(new URL('../../docs/openapi.yaml', import.meta.url), 'utf8'));
 const routes = readFileSync(new URL('../../apps/auth-service/src/routes/prepaid-wallets.ts', import.meta.url), 'utf8');
 
+test('hosted principal-client examples use the API origin, not the marketing rewrite host', () => {
+  for (const file of ['docs/integrations/x402.mdx', 'docs/guides/base-usdc-custody.mdx',
+    'packages/sdk-ts/README.md', 'packages/sdk-py/README.md']) {
+    const text = readFileSync(new URL(`../../${file}`, import.meta.url), 'utf8');
+    assert.match(text, /base(?:Url|_url)\s*[:=]\s*['"]https:\/\/api\.grantex\.dev['"]/);
+    assert.doesNotMatch(text, /base(?:Url|_url)\s*[:=]\s*['"]https:\/\/grantex\.dev['"]/);
+  }
+});
+
 test('Base reconciliation API references resolve and match authenticated server routes', () => {
   for (const [prefix, auth] of [['/v1/prepaid-wallets', 'dpopAuth'], ['/v1/principal/prepaid-wallets', 'principalSessionAuth']]) {
     const path = `${prefix}/reservations/{reservationId}/reconcile`;

--- a/tests/e2e/prepaid-wallets.test.ts
+++ b/tests/e2e/prepaid-wallets.test.ts
@@ -490,10 +490,21 @@ describe('agent prepaid wallets and x402 v2 E2E', () => {
     }), 409, 'ASSIGNMENT_REVOKED');
     await expectApiError(principal.setAssignmentStatus(terminal.assignment.assignmentId, 'active'), 409, 'ASSIGNMENT_REVOKED');
 
-    const validity = await createWallet('Expiring assignment wallet', '1000', {
-      validUntil: new Date(Date.now() + 1_000).toISOString(),
+    const validity = await createWallet('Expiring assignment wallet', '1000');
+    // Start the short validity window after funding, not before several remote calls.
+    const expiringAssignment = await principal.assign(validity.wallet.walletId, {
+      agentId,
+      perTransactionLimit: '5000',
+      cumulativeLimit: '20000',
+      cumulativePeriodSeconds: 3600,
+      allowedRecipients: [RECIPIENT],
+      allowedScopes: [SCOPE],
+      allowedResourceOrigins: ['https://merchant.example'],
+      validUntil: new Date(Date.now() + 10_000).toISOString(),
     });
-    await new Promise((resolve) => setTimeout(resolve, 1_100));
+    expect(expiringAssignment.validUntil).toBeTruthy();
+    await new Promise((resolve) => setTimeout(resolve,
+      Math.max(0, Date.parse(expiringAssignment.validUntil!) - Date.now()) + 250));
     await expectApiError(agent.authorizePayment(authorizationRequest({
       walletId: validity.wallet.walletId,
       amount: '1',


### PR DESCRIPTION
Follow-up to deployed PR #1102. Correct hosted principal-client examples to api.grantex.dev, document the separate OAuth issuer/agent audience, and add API/documentation contract coverage. The complete production CI run passed all 23 suites. The independent workstation run found an existing one-second assignment-expiry fixture could expire during remote wallet creation/funding. Start its deadline after setup, allow 10 seconds, and wait until the returned deadline before still requiring ASSIGNMENT_NOT_CURRENT. Both complete wallet Docker E2E lifecycles pass after this test-only adjustment. No production runtime code or security control changed. Full workstation production rerun is being verified as well.