### PR TITLE
release: publish governed Base USDC SDKs

### DIFF
--- a/.github/workflows/publish-primary-sdks.yml
+++ b/.github/workflows/publish-primary-sdks.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       publish_npm:
-        description: 'Publish the prepared @grantex/sdk patch through npm trusted publishing'
+        description: 'Publish @grantex/sdk 0.6.0 and @grantex/x402 0.4.0 through trusted publishing'
         required: true
         default: false
         type: boolean
@@ -18,7 +18,7 @@ on:
         default: false
         type: boolean
       publish_go:
-        description: 'Sync packages/go-sdk to mishrasanjeev/grantex-go and tag v0.2.1'
+        description: 'Sync packages/go-sdk to mishrasanjeev/grantex-go and tag v0.3.0'
         required: true
         default: false
         type: boolean
@@ -38,7 +38,12 @@ jobs:
       - name: Validate confirmation
         env:
           CONFIRMATION: ${{ inputs.confirmation }}
-        run: test "$CONFIRMATION" = 'RELEASE_PRIMARY_SDKS'
+          PUBLISH: ${{ inputs.publish_npm || inputs.publish_pypi || inputs.publish_go }}
+        run: |
+          test "$CONFIRMATION" = 'RELEASE_PRIMARY_SDKS'
+          if [ "$PUBLISH" = 'true' ]; then
+            test "$GITHUB_REF" = 'refs/heads/main'
+          fi
 
   verify:
     name: Verify all primary SDKs
@@ -57,10 +62,10 @@ jobs:
           go-version: '1.26.1'
           cache-dependency-path: packages/go-sdk/go.sum
 
-      - name: Verify TypeScript SDK 0.5.1
+      - name: Verify TypeScript SDK 0.6.0
         working-directory: packages/sdk-ts
         run: |
-          test "$(node -p "require('./package.json').version")" = "0.5.1"
+          test "$(node -p "require('./package.json').version")" = "0.6.0"
           npm ci
           npm run typecheck
           npm test
@@ -68,32 +73,40 @@ jobs:
           mkdir -p ../../release-artifacts/npm
           npm pack --pack-destination ../../release-artifacts/npm
 
-      - name: Verify x402 SDK 0.3.0
+      - name: Verify x402 SDK 0.4.0
         working-directory: packages/x402
         run: |
-          test "$(node -p "require('./package.json').version")" = "0.3.0"
+          test "$(node -p "require('./package.json').version")" = "0.4.0"
           npm ci
           npm run typecheck
           npm test
           npm run build
           npm pack --pack-destination ../../release-artifacts/npm
 
-      - name: Verify Python SDK 0.4.1
+      - name: Verify packed npm clients
+        run: |
+          mkdir -p "$RUNNER_TEMP/grantex-sdk-consumer"
+          npm install --prefix "$RUNNER_TEMP/grantex-sdk-consumer" --ignore-scripts \
+            "$PWD/release-artifacts/npm/grantex-sdk-0.6.0.tgz" \
+            "$PWD/release-artifacts/npm/grantex-x402-0.4.0.tgz"
+          node scripts/verify-sdk-artifacts.mjs "$RUNNER_TEMP/grantex-sdk-consumer"
+
+      - name: Verify Python SDK 0.5.0
         working-directory: packages/sdk-py
         run: |
           python -m pip install --upgrade pip build 'twine>=7,<8'
           python -m pip install -e '.[dev]'
-          test "$(python -c 'import grantex; print(grantex.__version__)')" = "0.4.1"
+          test "$(python -c 'import grantex; print(grantex.__version__)')" = "0.5.0"
           python -m ruff check src
           python -m mypy src/grantex
           python -m pytest
           python -m build --outdir ../../release-artifacts/pypi
           python -m twine check ../../release-artifacts/pypi/*
 
-      - name: Verify Go SDK v0.2.1
+      - name: Verify Go SDK v0.3.0
         working-directory: packages/go-sdk
         run: |
-          test "$(grep -Eo 'sdkVersion = "[^"]+"' http.go | cut -d'"' -f2)" = "0.2.1"
+          test "$(grep -Eo 'sdkVersion = "[^"]+"' http.go | cut -d'"' -f2)" = "0.3.0"
           go test ./...
 
       - name: Upload immutable release candidates
@@ -128,9 +141,10 @@ jobs:
           npm install --global npm@11.19.1
           node -e "const [major, minor] = process.versions.node.split('.').map(Number); if (major < 22 || (major === 22 && minor < 14)) process.exit(1)"
           node -e "const { execFileSync } = require('node:child_process'); const [major, minor, patch] = execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim().split('.').map(Number); if (major < 11 || (major === 11 && (minor < 5 || (minor === 5 && patch < 1)))) process.exit(1)"
-      - name: Publish TypeScript SDK patch
+      - name: Publish TypeScript and x402 SDKs
         run: |
-          npm publish release-artifacts/npm/grantex-sdk-0.5.1.tgz --access public
+          npm publish release-artifacts/npm/grantex-sdk-0.6.0.tgz --access public
+          npm publish release-artifacts/npm/grantex-x402-0.4.0.tgz --access public
 
   pypi:
     name: Publish Python SDK
@@ -170,12 +184,12 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: '1.26.1'
-      - name: Sync, test, commit, and tag v0.2.1
+      - name: Sync, test, commit, and tag v0.3.0
         shell: bash
         run: |
           set -euo pipefail
-          if git -C grantex-go ls-remote --exit-code --tags origin refs/tags/v0.2.1; then
-            echo 'v0.2.1 already exists' >&2
+          if git -C grantex-go ls-remote --exit-code --tags origin refs/tags/v0.3.0; then
+            echo 'v0.3.0 already exists' >&2
             exit 1
           fi
           rsync -a --delete --exclude='.git' grantex/packages/go-sdk/ grantex-go/
@@ -187,6 +201,6 @@ jobs:
             echo 'No Go SDK source change to publish' >&2
             exit 1
           }
-          git -C grantex-go commit -m 'release: v0.2.1'
-          git -C grantex-go tag -a v0.2.1 -m 'Grantex Go SDK v0.2.1'
-          git -C grantex-go push --atomic origin HEAD:main v0.2.1
+          git -C grantex-go commit -m 'release: v0.3.0'
+          git -C grantex-go tag -a v0.3.0 -m 'Grantex Go SDK v0.3.0'
+          git -C grantex-go push --atomic origin HEAD:main v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### SDK release candidates (2026-09-07)
+- Prepared TypeScript SDK 0.6.0, x402 0.4.0, Python SDK 0.5.0 and Go SDK
+  v0.3.0 for the governed Base USDC release. These versions add EVM payment
+  responses and authenticated finalized-chain reconciliation. The x402 adapter
+  provides opt-in request-bound Base 402/sign/retry; Python and Go do not add
+  automatic HTTP payment wrappers. Existing prepaid behavior remains the default.
+- Updated package runtime identifiers and the guarded primary-SDK publication
+  workflow. The public release snapshot remains on verified registry versions
+  until each new artifact is published and clean-install tested.
+
 ### Added
 - Added opt-in governed Base native USDC x402 v2 EIP-3009 payments, verified
   finalized funding, encrypted restart-safe signature recovery, and finalized

--- a/package-lock.json
+++ b/package-lock.json
@@ -1922,7 +1922,7 @@
     },
     "packages/sdk-ts": {
       "name": "@grantex/sdk",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/go-sdk/LICENSE
+++ b/packages/go-sdk/LICENSE
@@ -1,0 +1,185 @@
+Copyright 2026 Orchestrum Technologies LLP.
+Grantex inventor and owner: Sanjeev Kumar <sanjeev@orchestrum.in> or <mishra.sanjeev@gmail.com>.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as defined by the copyright owner or by an
+      individual or Legal Entity authorized to submit on behalf of the
+      copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and subsequently
+      incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any
+      Contribution embodied within the Work constitutes direct or contributory
+      patent infringement, then any patent licenses granted to You under
+      this License for that Work shall terminate as of the date such
+      litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Contribution, either on an inclusive or exclusive basis.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or all other
+      commercial damages or losses), even if such Contributor has been
+      advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may offer such
+      conditions only on Your own behalf and on Your sole responsibility,
+      not on behalf of any other Contributor, and only if You agree to
+      indemnify, defend, and hold each Contributor harmless for any
+      liability incurred by, or claims asserted against, such Contributor
+      by reason of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Grantex Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/go-sdk/NOTICE
+++ b/packages/go-sdk/NOTICE
@@ -12,4 +12,5 @@ states otherwise. The open-source license does not remove or transfer the
 product ownership notice above.
 
 Third-party dependencies retain their own licenses. See
-THIRD_PARTY_NOTICES.md for reviewed distribution notices and obligations.
+https://github.com/mishrasanjeev/grantex/blob/main/THIRD_PARTY_NOTICES.md
+for reviewed distribution notices and obligations.

--- a/packages/go-sdk/NOTICE
+++ b/packages/go-sdk/NOTICE
@@ -1,0 +1,15 @@
+Grantex Ownership Notice
+
+Grantex is owned by Orchestrum Technologies LLP.
+
+Inventor and owner: Sanjeev Kumar.
+
+Ownership contact: sanjeev@orchestrum.in or mishra.sanjeev@gmail.com
+
+The Grantex protocol specification, source code, SDKs, examples, and
+documentation are made available under the Apache License 2.0 unless a file
+states otherwise. The open-source license does not remove or transfer the
+product ownership notice above.
+
+Third-party dependencies retain their own licenses. See
+THIRD_PARTY_NOTICES.md for reviewed distribution notices and obligations.

--- a/packages/go-sdk/README.md
+++ b/packages/go-sdk/README.md
@@ -1,16 +1,16 @@
 # Grantex Go SDK
 
-**Source update (not yet published):** wallet responses include typed
+**New in v0.3.0:** wallet responses include typed
 `EVMPayment`/`EVMAuthorization` fields and agent/principal clients expose
 `ReconcileReservation`. Automatic x402 HTTP retries are currently provided by
-the TypeScript adapter. See [Base custody setup](../../docs/guides/base-usdc-custody.mdx).
+the TypeScript adapter. See [Base custody setup](https://docs.grantex.dev/guides/base-usdc-custody).
 
 Official Go SDK for the [Grantex](https://grantex.dev) delegated authorization protocol — OAuth 2.0 for AI agents.
 
 ## Installation
 
 ```bash
-go get github.com/mishrasanjeev/grantex-go@v0.2.1
+go get github.com/mishrasanjeev/grantex-go@v0.3.0
 ```
 
 Requires Go 1.26.1 or newer, matching the module's `go.mod` directive.

--- a/packages/go-sdk/http.go
+++ b/packages/go-sdk/http.go
@@ -17,7 +17,7 @@ import (
 	"time"
 )
 
-const sdkVersion = "0.2.1"
+const sdkVersion = "0.3.0"
 
 func parseRateLimitHeaders(header http.Header) *RateLimit {
 	limitStr := header.Get("X-RateLimit-Limit")

--- a/packages/go-sdk/http_test.go
+++ b/packages/go-sdk/http_test.go
@@ -18,7 +18,7 @@ func TestHTTPClientGet(t *testing.T) {
 		if r.Header.Get("Authorization") != "Bearer test-key" {
 			t.Errorf("expected Bearer test-key, got %s", r.Header.Get("Authorization"))
 		}
-		if r.Header.Get("User-Agent") != "grantex-go/0.2.1" {
+		if r.Header.Get("User-Agent") != "grantex-go/"+sdkVersion {
 			t.Errorf("unexpected User-Agent: %s", r.Header.Get("User-Agent"))
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/packages/sdk-py/LICENSE
+++ b/packages/sdk-py/LICENSE
@@ -1,0 +1,185 @@
+Copyright 2026 Orchestrum Technologies LLP.
+Grantex inventor and owner: Sanjeev Kumar <sanjeev@orchestrum.in> or <mishra.sanjeev@gmail.com>.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as defined by the copyright owner or by an
+      individual or Legal Entity authorized to submit on behalf of the
+      copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and subsequently
+      incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any
+      Contribution embodied within the Work constitutes direct or contributory
+      patent infringement, then any patent licenses granted to You under
+      this License for that Work shall terminate as of the date such
+      litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Contribution, either on an inclusive or exclusive basis.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or all other
+      commercial damages or losses), even if such Contributor has been
+      advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may offer such
+      conditions only on Your own behalf and on Your sole responsibility,
+      not on behalf of any other Contributor, and only if You agree to
+      indemnify, defend, and hold each Contributor harmless for any
+      liability incurred by, or claims asserted against, such Contributor
+      by reason of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Grantex Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/sdk-py/NOTICE
+++ b/packages/sdk-py/NOTICE
@@ -12,4 +12,5 @@ states otherwise. The open-source license does not remove or transfer the
 product ownership notice above.
 
 Third-party dependencies retain their own licenses. See
-THIRD_PARTY_NOTICES.md for reviewed distribution notices and obligations.
+https://github.com/mishrasanjeev/grantex/blob/main/THIRD_PARTY_NOTICES.md
+for reviewed distribution notices and obligations.

--- a/packages/sdk-py/NOTICE
+++ b/packages/sdk-py/NOTICE
@@ -1,0 +1,15 @@
+Grantex Ownership Notice
+
+Grantex is owned by Orchestrum Technologies LLP.
+
+Inventor and owner: Sanjeev Kumar.
+
+Ownership contact: sanjeev@orchestrum.in or mishra.sanjeev@gmail.com
+
+The Grantex protocol specification, source code, SDKs, examples, and
+documentation are made available under the Apache License 2.0 unless a file
+states otherwise. The open-source license does not remove or transfer the
+product ownership notice above.
+
+Third-party dependencies retain their own licenses. See
+THIRD_PARTY_NOTICES.md for reviewed distribution notices and obligations.

--- a/packages/sdk-py/README.md
+++ b/packages/sdk-py/README.md
@@ -1,9 +1,9 @@
 # grantex
 
-**Source update (not yet published):** agent and principal wallet clients expose
+**New in 0.5.0:** agent and principal wallet clients expose
 `reconcile_reservation()`. Authorization dictionaries preserve the server's
 additive `evmPayment` payload. Automatic x402 HTTP retries are currently provided
-by the TypeScript adapter, not this SDK. See [Base custody setup](../../docs/guides/base-usdc-custody.mdx).
+by the TypeScript adapter, not this SDK. See [Base custody setup](https://docs.grantex.dev/guides/base-usdc-custody).
 
 Python SDK for the [Grantex](https://grantex.dev) delegated authorization protocol — OAuth 2.0 for AI agents.
 
@@ -18,7 +18,7 @@ Grantex lets humans authorize AI agents with **verifiable, revocable, audited gr
 ## Install
 
 ```bash
-pip install grantex
+pip install grantex==0.5.0
 ```
 
 ## Quick start

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -61,3 +61,7 @@ testpaths = ["tests"]
 [tool.ruff]
 line-length = 88
 target-version = "py39"
+
+[tool.ruff.lint]
+# Preserve the release gate used before Ruff 0.16 expanded its implicit defaults.
+select = ["E4", "E7", "E9", "F"]

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grantex"
-version = "0.4.1"
+version = "0.5.0"
 description = "Python SDK for the Grantex delegated authorization protocol — OAuth 2.0 for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk-py/src/grantex/__init__.py
+++ b/packages/sdk-py/src/grantex/__init__.py
@@ -166,7 +166,7 @@ from .prepaid_wallets import (
 SsoConnectionListResponse = ListSsoConnectionsResponse
 SsoSessionListResponse = ListSsoSessionsResponse
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 
 __all__ = [
     # Main client

--- a/packages/sdk-py/src/grantex/_http.py
+++ b/packages/sdk-py/src/grantex/_http.py
@@ -9,7 +9,7 @@ import httpx
 from ._errors import GrantexApiError, GrantexAuthError, GrantexNetworkError
 from ._types import RateLimit
 
-_SDK_VERSION = "0.4.1"
+_SDK_VERSION = "0.5.0"
 _DEFAULT_TIMEOUT = 30.0
 _DEFAULT_MAX_RETRIES = 3
 _RETRY_BASE_DELAY = 0.5  # seconds

--- a/packages/sdk-py/tests/test_client.py
+++ b/packages/sdk-py/tests/test_client.py
@@ -94,7 +94,9 @@ def test_user_agent_header_sent() -> None:
         AuthorizeParams(agent_id="ag_01", user_id="u_01", scopes=[])
     )
     request = respx.calls[0].request
-    assert request.headers["user-agent"] == "grantex-python/0.4.1"
+    from grantex import __version__
+
+    assert request.headers["user-agent"] == f"grantex-python/{__version__}"
 
 
 @respx.mock

--- a/packages/sdk-ts/LICENSE
+++ b/packages/sdk-ts/LICENSE
@@ -1,0 +1,185 @@
+Copyright 2026 Orchestrum Technologies LLP.
+Grantex inventor and owner: Sanjeev Kumar <sanjeev@orchestrum.in> or <mishra.sanjeev@gmail.com>.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as defined by the copyright owner or by an
+      individual or Legal Entity authorized to submit on behalf of the
+      copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and subsequently
+      incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any
+      Contribution embodied within the Work constitutes direct or contributory
+      patent infringement, then any patent licenses granted to You under
+      this License for that Work shall terminate as of the date such
+      litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Contribution, either on an inclusive or exclusive basis.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or all other
+      commercial damages or losses), even if such Contributor has been
+      advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may offer such
+      conditions only on Your own behalf and on Your sole responsibility,
+      not on behalf of any other Contributor, and only if You agree to
+      indemnify, defend, and hold each Contributor harmless for any
+      liability incurred by, or claims asserted against, such Contributor
+      by reason of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Grantex Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/sdk-ts/NOTICE
+++ b/packages/sdk-ts/NOTICE
@@ -12,4 +12,5 @@ states otherwise. The open-source license does not remove or transfer the
 product ownership notice above.
 
 Third-party dependencies retain their own licenses. See
-THIRD_PARTY_NOTICES.md for reviewed distribution notices and obligations.
+https://github.com/mishrasanjeev/grantex/blob/main/THIRD_PARTY_NOTICES.md
+for reviewed distribution notices and obligations.

--- a/packages/sdk-ts/NOTICE
+++ b/packages/sdk-ts/NOTICE
@@ -1,0 +1,15 @@
+Grantex Ownership Notice
+
+Grantex is owned by Orchestrum Technologies LLP.
+
+Inventor and owner: Sanjeev Kumar.
+
+Ownership contact: sanjeev@orchestrum.in or mishra.sanjeev@gmail.com
+
+The Grantex protocol specification, source code, SDKs, examples, and
+documentation are made available under the Apache License 2.0 unless a file
+states otherwise. The open-source license does not remove or transfer the
+product ownership notice above.
+
+Third-party dependencies retain their own licenses. See
+THIRD_PARTY_NOTICES.md for reviewed distribution notices and obligations.

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -9,13 +9,13 @@ TypeScript SDK for the [Grantex](https://grantex.dev) delegated authorization pr
 
 ## Installation
 
-**Source update (not yet published):** the wallet clients now preserve the
+**New in 0.6.0:** the wallet clients preserve the
 server's Base USDC `evmPayment` payload and expose `reconcileReservation()` for
-finalized settlement/expiry. Use the updated `@grantex/x402` source adapter for
-the automatic 402/payment/retry flow. See [Base custody setup](../../docs/guides/base-usdc-custody.mdx).
+finalized settlement/expiry. Use `@grantex/x402@0.4.0` or later for
+the automatic 402/payment/retry flow. See [Base custody setup](https://docs.grantex.dev/guides/base-usdc-custody).
 
 ```bash
-npm install @grantex/sdk
+npm install @grantex/sdk@0.6.0
 ```
 
 ## Quick Start

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grantex/sdk",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jose": "^6.2.3"

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/sdk",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "TypeScript SDK for the Grantex delegated authorization protocol",
   "author": {
     "name": "Sanjeev Kumar",

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -30,7 +30,8 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "NOTICE"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/packages/sdk-ts/src/http.ts
+++ b/packages/sdk-ts/src/http.ts
@@ -1,7 +1,7 @@
 import { GrantexApiError, GrantexAuthError, GrantexNetworkError } from './errors.js';
 import type { RateLimit } from './types.js';
 
-const SDK_VERSION = '0.5.1';
+const SDK_VERSION = '0.6.0';
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 500;

--- a/packages/x402/LICENSE
+++ b/packages/x402/LICENSE
@@ -1,0 +1,185 @@
+Copyright 2026 Orchestrum Technologies LLP.
+Grantex inventor and owner: Sanjeev Kumar <sanjeev@orchestrum.in> or <mishra.sanjeev@gmail.com>.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as defined by the copyright owner or by an
+      individual or Legal Entity authorized to submit on behalf of the
+      copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and subsequently
+      incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any
+      Contribution embodied within the Work constitutes direct or contributory
+      patent infringement, then any patent licenses granted to You under
+      this License for that Work shall terminate as of the date such
+      litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Contribution, either on an inclusive or exclusive basis.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or all other
+      commercial damages or losses), even if such Contributor has been
+      advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may offer such
+      conditions only on Your own behalf and on Your sole responsibility,
+      not on behalf of any other Contributor, and only if You agree to
+      indemnify, defend, and hold each Contributor harmless for any
+      liability incurred by, or claims asserted against, such Contributor
+      by reason of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Grantex Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/x402/NOTICE
+++ b/packages/x402/NOTICE
@@ -12,4 +12,5 @@ states otherwise. The open-source license does not remove or transfer the
 product ownership notice above.
 
 Third-party dependencies retain their own licenses. See
-THIRD_PARTY_NOTICES.md for reviewed distribution notices and obligations.
+https://github.com/mishrasanjeev/grantex/blob/main/THIRD_PARTY_NOTICES.md
+for reviewed distribution notices and obligations.

--- a/packages/x402/NOTICE
+++ b/packages/x402/NOTICE
@@ -1,0 +1,15 @@
+Grantex Ownership Notice
+
+Grantex is owned by Orchestrum Technologies LLP.
+
+Inventor and owner: Sanjeev Kumar.
+
+Ownership contact: sanjeev@orchestrum.in or mishra.sanjeev@gmail.com
+
+The Grantex protocol specification, source code, SDKs, examples, and
+documentation are made available under the Apache License 2.0 unless a file
+states otherwise. The open-source license does not remove or transfer the
+product ownership notice above.
+
+Third-party dependencies retain their own licenses. See
+THIRD_PARTY_NOTICES.md for reviewed distribution notices and obligations.

--- a/packages/x402/README.md
+++ b/packages/x402/README.md
@@ -6,7 +6,7 @@ wallets, plus legacy standalone GDT authorization utilities.
 ## Install
 
 ```bash
-npm install @grantex/x402@0.3.0 @grantex/sdk@0.5.1
+npm install @grantex/x402@0.4.0 @grantex/sdk@0.6.0
 ```
 
 Layered policy, semantic payment context, and exact approval retry require
@@ -14,10 +14,10 @@ Layered policy, semantic payment context, and exact approval retry require
 
 ## Payment network compatibility
 
-The default client supports `exact` on `grantex:prepaid`. This source checkout
-also supports opt-in Base native USDC EIP-3009 through Grantex's `base_usdc`
-custody adapter. **This addition is not in the published 0.3.0 package.**
-Build the checkout until a tested release containing it is published.
+The default client supports `exact` on `grantex:prepaid`. Version 0.4.0
+adds opt-in Base native USDC EIP-3009 through Grantex's `base_usdc`
+custody adapter. Version 0.3.0 does not include Base support. Provision a funded
+wallet and trusted RPC as described in the [Base custody guide](https://docs.grantex.dev/guides/base-usdc-custody).
 
 ```ts
 const paid = createX402Agent({

--- a/packages/x402/package-lock.json
+++ b/packages/x402/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grantex/x402",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grantex/x402",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^3.1.0",

--- a/packages/x402/package.json
+++ b/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grantex/x402",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Official x402 v2 integration backed by principal-controlled Grantex prepaid wallets",
   "author": {
     "name": "Sanjeev Kumar",

--- a/packages/x402/package.json
+++ b/packages/x402/package.json
@@ -25,7 +25,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "NOTICE"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/scripts/verify-sdk-artifacts.mjs
+++ b/scripts/verify-sdk-artifacts.mjs
@@ -18,7 +18,7 @@ for (const name of ['Grantex', 'OAuthAgentClient', 'generateOAuthAgentKey', 'Pri
 assert.equal(typeof x402.createX402Agent, 'function');
 assert.throws(() => x402.createX402Agent({ walletId: 'wal_test', authorizePayment: async () => ({}), baseUsdc: { scope: '' } }), /scope/);
 const guarded = x402.createX402Agent({ walletId: 'wal_test', authorizePayment: async () => ({}), baseUsdc: { scope: 'licensing:preflight' } });
-await assert.rejects(() => guarded.fetch('https://merchant.example/test'), /idempotencyKey/);
+assert.throws(() => guarded.fetch('https://merchant.example/test'), /idempotencyKey/);
 
 const seen = [];
 const result = { reservationId: 'wres_artifact', status: 'reserved', transaction: null };

--- a/scripts/verify-sdk-artifacts.mjs
+++ b/scripts/verify-sdk-artifacts.mjs
@@ -22,7 +22,13 @@ await assert.rejects(() => guarded.fetch('https://merchant.example/test'), /idem
 
 const seen = [];
 const result = { reservationId: 'wres_artifact', status: 'reserved', transaction: null };
+let metadata;
 const server = createServer((req, res) => {
+  if (req.url === '/.well-known/oauth-authorization-server') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(metadata));
+    return;
+  }
   seen.push({ method: req.method, url: req.url, authorization: req.headers.authorization, dpop: req.headers.dpop });
   res.writeHead(200, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify(result));
@@ -30,11 +36,21 @@ const server = createServer((req, res) => {
 await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
 try {
   const baseUrl = `http://127.0.0.1:${server.address().port}`;
+  metadata = {
+    issuer: baseUrl, authorization_endpoint: `${baseUrl}/oauth/authorize`, token_endpoint: `${baseUrl}/oauth/token`,
+    jwks_uri: `${baseUrl}/.well-known/jwks.json`, revocation_endpoint: `${baseUrl}/oauth/revoke`,
+    pushed_authorization_request_endpoint: `${baseUrl}/oauth/par`, require_pushed_authorization_requests: true,
+    response_types_supported: ['code'], grant_types_supported: ['authorization_code', 'refresh_token', 'urn:ietf:params:oauth:grant-type:token-exchange'],
+    code_challenge_methods_supported: ['S256'], authorization_response_iss_parameter_supported: true,
+    dpop_signing_alg_values_supported: ['ES256'], token_endpoint_auth_methods_supported: ['none'], revocation_endpoint_auth_methods_supported: ['none'],
+  };
   const principal = new sdk.PrincipalPrepaidWalletClient({ baseUrl, sessionToken: 'artifact-test-only' });
   assert.deepEqual(await principal.reconcileReservation('wres_artifact'), result);
   const key = await sdk.generateOAuthAgentKey();
-  const agent = new sdk.PrepaidWalletAgentClient({ accessToken: 'artifact-test-only', privateKey: key.privateKey,
-    publicJwk: key.publicJwk, resourceUrl: `${baseUrl}/v1/prepaid-wallets` });
+  const oauthClient = await sdk.OAuthAgentClient.create({ issuer: baseUrl, clientId: 'ag_artifact',
+    redirectUri: `${baseUrl}/callback`, resource: `${baseUrl}/v1/prepaid-wallets`,
+    privateKey: key.privateKey, publicJwk: key.publicJwk, allowInsecureLoopback: true });
+  const agent = new sdk.PrepaidWalletAgentClient({ accessToken: 'artifact-test-only', oauthClient });
   assert.deepEqual(await agent.reconcileReservation('wres_artifact'), result);
   assert.equal(seen.length, 2);
   assert.equal(seen[0].method, 'POST');

--- a/scripts/verify-sdk-artifacts.mjs
+++ b/scripts/verify-sdk-artifacts.mjs
@@ -8,6 +8,10 @@ assert.ok(process.argv[2], 'Pass the clean consumer directory containing install
 const root = resolve(process.argv[2]);
 const pkg = name => resolve(root, 'node_modules', ...name.split('/'));
 const read = name => JSON.parse(readFileSync(resolve(pkg(name), 'package.json'), 'utf8'));
+for (const name of ['@grantex/sdk', '@grantex/x402']) {
+  assert.match(readFileSync(resolve(pkg(name), 'LICENSE'), 'utf8'), /Apache License/);
+  assert.match(readFileSync(resolve(pkg(name), 'NOTICE'), 'utf8'), /Orchestrum Technologies LLP/);
+}
 assert.equal(read('@grantex/sdk').version, '0.6.0');
 assert.equal(read('@grantex/x402').version, '0.4.0');
 const sdk = await import(pathToFileURL(resolve(pkg('@grantex/sdk'), 'dist/index.js')).href);

--- a/scripts/verify-sdk-artifacts.mjs
+++ b/scripts/verify-sdk-artifacts.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+assert.ok(process.argv[2], 'Pass the clean consumer directory containing installed SDK packages');
+const root = resolve(process.argv[2]);
+const pkg = name => resolve(root, 'node_modules', ...name.split('/'));
+const read = name => JSON.parse(readFileSync(resolve(pkg(name), 'package.json'), 'utf8'));
+assert.equal(read('@grantex/sdk').version, '0.6.0');
+assert.equal(read('@grantex/x402').version, '0.4.0');
+const sdk = await import(pathToFileURL(resolve(pkg('@grantex/sdk'), 'dist/index.js')).href);
+const x402 = await import(pathToFileURL(resolve(pkg('@grantex/x402'), 'dist/index.js')).href);
+for (const name of ['Grantex', 'OAuthAgentClient', 'generateOAuthAgentKey', 'PrincipalPrepaidWalletClient', 'PrepaidWalletAgentClient']) {
+  assert.equal(typeof sdk[name], 'function', `Missing packaged SDK export ${name}`);
+}
+assert.equal(typeof x402.createX402Agent, 'function');
+assert.throws(() => x402.createX402Agent({ walletId: 'wal_test', authorizePayment: async () => ({}), baseUsdc: { scope: '' } }), /scope/);
+const guarded = x402.createX402Agent({ walletId: 'wal_test', authorizePayment: async () => ({}), baseUsdc: { scope: 'licensing:preflight' } });
+await assert.rejects(() => guarded.fetch('https://merchant.example/test'), /idempotencyKey/);
+
+const seen = [];
+const result = { reservationId: 'wres_artifact', status: 'reserved', transaction: null };
+const server = createServer((req, res) => {
+  seen.push({ method: req.method, url: req.url, authorization: req.headers.authorization, dpop: req.headers.dpop });
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(result));
+});
+await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+try {
+  const baseUrl = `http://127.0.0.1:${server.address().port}`;
+  const principal = new sdk.PrincipalPrepaidWalletClient({ baseUrl, sessionToken: 'artifact-test-only' });
+  assert.deepEqual(await principal.reconcileReservation('wres_artifact'), result);
+  const key = await sdk.generateOAuthAgentKey();
+  const agent = new sdk.PrepaidWalletAgentClient({ accessToken: 'artifact-test-only', privateKey: key.privateKey,
+    publicJwk: key.publicJwk, resourceUrl: `${baseUrl}/v1/prepaid-wallets` });
+  assert.deepEqual(await agent.reconcileReservation('wres_artifact'), result);
+  assert.equal(seen.length, 2);
+  assert.equal(seen[0].method, 'POST');
+  assert.equal(seen[0].url, '/v1/principal/prepaid-wallets/reservations/wres_artifact/reconcile');
+  assert.equal(seen[0].authorization, 'Bearer artifact-test-only');
+  assert.equal(seen[1].method, 'POST');
+  assert.equal(seen[1].url, '/v1/prepaid-wallets/reservations/wres_artifact/reconcile');
+  assert.equal(seen[1].authorization, 'DPoP artifact-test-only');
+  assert.equal(seen[1].dpop.split('.').length, 3);
+} finally {
+  await new Promise(resolve => server.close(resolve));
+}
+console.log('SDK artifact verification passed: exact versions, exports, Base safety gates and authenticated reconciliation wire contracts.');

--- a/tests/base-usdc/README.md
+++ b/tests/base-usdc/README.md
@@ -48,6 +48,9 @@ The test then imports both clients from that directory's `node_modules`.
 Run `node scripts/verify-sdk-artifacts.mjs <consumer-directory>` for the
 packaged export, wire-contract and version checks. Unset the environment
 variable after verification; all chain operations still target local Anvil.
+The root Vitest configuration also honors this variable for the existing
+production/local E2E suites, including the x402 import in the prepaid lifecycle.
+Missing installed artifacts fail immediately instead of falling back to source.
 
 The test compiler's `memorystream@0.3.1` tarball includes the MIT license
 (Copyright 2011 Dmitry Nizovtsev) but omits current lockfile license metadata.

--- a/tests/base-usdc/README.md
+++ b/tests/base-usdc/README.md
@@ -41,6 +41,14 @@ This does not prove that a third-party production merchant or PayAI will accept
 a funded mainnet payment. The captured UK taxi challenge is a wire fixture; the
 local test substitutes only the local resource URL and test recipient.
 
+To verify release tarballs or published packages instead of checkout builds,
+install the exact SDK and x402 artifacts in a clean directory and set
+`GRANTEX_SDK_TEST_ROOT` to its absolute path before running the same suite.
+The test then imports both clients from that directory's `node_modules`.
+Run `node scripts/verify-sdk-artifacts.mjs <consumer-directory>` for the
+packaged export, wire-contract and version checks. Unset the environment
+variable after verification; all chain operations still target local Anvil.
+
 The test compiler's `memorystream@0.3.1` tarball includes the MIT license
 (Copyright 2011 Dmitry Nizovtsev) but omits current lockfile license metadata.
 The supply-chain checker records that exact reviewed version, not a blanket

--- a/tests/base-usdc/base-usdc.test.mjs
+++ b/tests/base-usdc/base-usdc.test.mjs
@@ -5,10 +5,16 @@ import { createRequire } from 'node:module';
 import { execFileSync } from 'node:child_process';
 import { randomUUID, generateKeyPairSync } from 'node:crypto';
 import { createServer } from 'node:http';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
 import solc from 'solc';
-import { OAuthAgentClient, generateOAuthAgentKey, PrincipalPrepaidWalletClient, PrepaidWalletAgentClient } from '../../packages/sdk-ts/dist/index.js';
-import { createX402Agent } from '../../packages/x402/dist/agent.js';
+const consumer = process.env.GRANTEX_SDK_TEST_ROOT;
+const sdkModule = consumer ? pathToFileURL(resolve(consumer, 'node_modules/@grantex/sdk/dist/index.js'))
+  : new URL('../../packages/sdk-ts/dist/index.js', import.meta.url);
+const x402Module = consumer ? pathToFileURL(resolve(consumer, 'node_modules/@grantex/x402/dist/index.js'))
+  : new URL('../../packages/x402/dist/index.js', import.meta.url);
+const { OAuthAgentClient, generateOAuthAgentKey, PrincipalPrepaidWalletClient, PrepaidWalletAgentClient } = await import(sdkModule.href);
+const { createX402Agent } = await import(x402Module.href);
 
 const require = createRequire(new URL('../../apps/auth-service/package.json', import.meta.url));
 const { createPublicClient, createWalletClient, http, parseSignature } = require('viem');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,22 @@
 import { defineConfig } from 'vitest/config';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const consumer = process.env['GRANTEX_SDK_TEST_ROOT'];
+const sdk = consumer ? resolve(consumer, 'node_modules/@grantex/sdk/dist/index.js') : undefined;
+const x402 = consumer ? resolve(consumer, 'node_modules/@grantex/x402/dist/index.js') : undefined;
+if (consumer && (!existsSync(sdk!) || !existsSync(x402!))) {
+  throw new Error('GRANTEX_SDK_TEST_ROOT must contain installed SDK and x402 distributions');
+}
 
 export default defineConfig({
+  resolve: {
+    alias: consumer ? [
+      { find: '@grantex/sdk', replacement: sdk! },
+      { find: '@grantex/x402', replacement: x402! },
+      { find: /^\.\.\/\.\.\/packages\/x402\/src\/agent\.js$/, replacement: x402! },
+    ] : [],
+  },
   test: {
     include: ['tests/e2e/**/*.test.ts'],
     // Run E2E tests sequentially to avoid production rate limits


### PR DESCRIPTION
Prepare TypeScript 0.6.0, x402 0.4.0, Python 0.5.0 and Go v0.3.0. Update runtime identifiers and package READMEs, extend the guarded release workflow to publish both npm packages, add clean-consumer artifact checks and enable the Base Docker suite to consume installed tarballs/registry packages. Publication is allowed only from main. Preserve the existing pre-Ruff-0.16 lint gate explicitly instead of accepting newly expanded implicit defaults. Source suites passed: TS 457, x402 206, Python 613; packaged Docker and Go verification are being completed before merge/publication. Published release metadata remains on verified prior versions until new registry artifacts are verified. No funded production wallet is provisioned and no real-money merchant payment is claimed.