### PR TITLE
docs: confirm published npm Base wallet SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## Unreleased
 
 ### Verified SDK publications (2026-09-07)
+- Published `@grantex/sdk@0.6.0` and `@grantex/x402@0.4.0` to npm after the
+  workstation publishing approval completed. Both registry integrity hashes
+  exactly match the tested tarballs. A new consumer installed both exact versions
+  from npm and passed public-export, license/notice, Base safety, authenticated
+  reconciliation, and zero-vulnerability audit checks. The public registry
+  packages also passed the isolated Docker Base and existing wallet lifecycles,
+  then all 255 production E2E tests across 23 files in 281.80 seconds.
 - Published Python `grantex==0.5.0` to PyPI and Go SDK `v0.3.0` to the standalone
   module. Verified distribution hashes, clean public-registry installs, all
   613 Python tests, the Go race suite, and production reconciliation authentication
   boundaries. Both expose EVM payment responses and principal/agent reconciliation;
   neither adds an automatic x402 HTTP payment wrapper.
 - Included Apache-2.0 LICENSE and NOTICE files in the four primary release
-  artifacts. TypeScript `0.6.0` and x402 `0.4.0` remain prepared candidates
-  pending npm publishing approval; the public snapshot retains their prior
-  verified versions. Local EVM tests do not prove a funded mainnet payment.
+  artifacts. The public snapshot now reflects all four verified versions.
+  Local EVM tests do not prove a funded mainnet payment.
 
 ### SDK release candidates (2026-09-07)
 - Prepared TypeScript SDK 0.6.0, x402 0.4.0, Python SDK 0.5.0 and Go SDK
@@ -24,8 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   provides opt-in request-bound Base 402/sign/retry; Python and Go do not add
   automatic HTTP payment wrappers. Existing prepaid behavior remains the default.
 - Updated package runtime identifiers and the guarded primary-SDK publication
-  workflow. The public release snapshot remains on verified registry versions
-  until each new artifact is published and clean-install tested.
+  workflow. Publication and clean-install verification subsequently completed
+  for all four versions as recorded above.
 
 ### Added
 - Added opt-in governed Base native USDC x402 v2 EIP-3009 payments, verified
@@ -33,8 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   settlement/expiry reconciliation. Signed exposure survives blocks and timeouts.
   Migration `094` and explicit custody/RPC provisioning are required. Added
   TypeScript/Python/Go reconciliation methods, API documentation and isolated
-  Docker tests with official x402 facilitator execution. These additive client
-  APIs are source additions, not a claim of new registry publication.
+  Docker tests with official x402 facilitator execution. Published client versions
+  are recorded separately in the verified SDK publications above.
 - Added layered prepaid-wallet spend governance across assignment, wallet,
   agent, shared budget-group, principal, and developer scopes. Policies support
   deny, exact principal approval, amount/count limits, reservation-aware rolling

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -10,10 +10,10 @@ This repository uses package-specific versions; there is no monorepo-wide SDK or
 | Surface | Current value | Notes |
 | --- | --- | --- |
 | Repository changelog | v0.3.12 | Latest top-level release entry in `CHANGELOG.md`. |
-| TypeScript SDK | @grantex/sdk 0.5.1 published | Adds bounded refresh recovery to the layered wallet and OAuth clients; npm integrity and clean-install verified. |
+| TypeScript SDK | @grantex/sdk 0.6.0 published | Adds EVM payment responses and authenticated reconciliation, retaining bounded refresh recovery; npm integrity and clean-install verified. |
 | Python SDK | grantex 0.5.0 published | Adds EVM payment responses and principal/agent reconciliation, retaining bounded refresh recovery; PyPI clean-install and full-suite verified. No automatic x402 HTTP wrapper. |
 | Go SDK | github.com/mishrasanjeev/grantex-go v0.3.0 published | Adds typed EVM payment responses and principal/agent reconciliation, retaining bounded refresh recovery; public proxy and race-suite verified; Go 1.26.1 is required. No automatic x402 HTTP wrapper. |
-| x402 | @grantex/x402 0.3.0 published | Official x402 v2, semantic policy context, structured exact-approval challenge, and approved retry; npm and fresh-install verified; external custody remains operator-supplied. |
+| x402 | @grantex/x402 0.4.0 published | Adds opt-in request-bound Base USDC 402/sign/retry to official x402 v2 and layered wallet governance; npm and fresh-install verified; custody and trusted RPC remain operator-provisioned. |
 | OpenAPI | 0.5.0 | Repository API contract including layered prepaid-wallet governance; independent of the deployed/public snapshot. |
 | MCP Auth | @grantex/mcp-auth 2.0.2 | Independently versioned and published to npm; single-process evaluation limitations apply. |
 | Published snapshot | [release-status.json](release-status.json) | Machine-readable source for advertised versions and live registry checks. |
@@ -24,7 +24,7 @@ The repository contains 29 packages under `packages/`. Each row maps a directory
 
 | # | Directory | Published name | Version | Status |
 | ---: | --- | --- | ---: | --- |
-| 1 | `packages/sdk-ts` | @grantex/sdk | 0.5.1 | Primary SDK (TypeScript); published and registry verified |
+| 1 | `packages/sdk-ts` | @grantex/sdk | 0.6.0 | Primary SDK (TypeScript); published and registry verified |
 | 2 | `packages/sdk-py` | grantex | 0.5.0 | Primary SDK (Python); published and registry verified |
 | 3 | `packages/go-sdk` | github.com/mishrasanjeev/grantex-go | v0.3.0 (Go 1.26.1) | Primary SDK (Go); tag and public proxy verified |
 | 4 | `packages/cli` | @grantex/cli | 0.3.0 | Tooling; published with bundled Agent Skills |
@@ -51,7 +51,7 @@ The repository contains 29 packages under `packages/`. Each row maps a directory
 | 25 | `packages/a2a` | @grantex/a2a | 0.1.3 | A2A bridge (TS) |
 | 26 | `packages/a2a-py` | grantex-a2a | 0.1.4 | A2A bridge (Python) |
 | 27 | `packages/mpp` | @grantex/mpp | 0.1.2 | MPP support |
-| 28 | `packages/x402` | @grantex/x402 | 0.3.0 | Official x402 v2 layered-wallet integration |
+| 28 | `packages/x402` | @grantex/x402 | 0.4.0 | Official x402 v2 layered-wallet integration with opt-in Base USDC |
 | 29 | `packages/terraform-provider-grantex` | terraform-provider-grantex | Go module (Go 1.25.0) | Terraform provider |
 
 ## Known Published-Package Limitations
@@ -75,11 +75,11 @@ The repository contains 29 packages under `packages/`. Each row maps a directory
 Install the verified public releases needed by your application:
 
 ```bash
-npm install @grantex/sdk@0.5.1
-npm install @grantex/x402@0.3.0 @grantex/sdk@0.5.1
+npm install @grantex/sdk@0.6.0
+npm install @grantex/x402@0.4.0 @grantex/sdk@0.6.0
 pip install grantex==0.5.0
 go get github.com/mishrasanjeev/grantex-go@v0.3.0
-npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0
 ```
 
 Unpinned install commands resolve to the registry's current release. For reproducible builds, keep the explicit versions above and review this matrix before upgrading.

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ can verify funding and settlement. The source checkout now includes opt-in
 Base native USDC EIP-3009 payments with policy-gated signing, verified funding,
 durable signature retries and finalized-chain reconciliation. Python `0.5.0`
 and Go `v0.3.0` publish the EVM response and reconciliation APIs; neither adds
-an automatic HTTP payment wrapper. The TypeScript `0.6.0` and x402 `0.4.0`
-candidates, including automatic Base 402/sign/retry, await npm publication. See the
+an automatic HTTP payment wrapper. Published TypeScript `0.6.0` and x402 `0.4.0`
+include the opt-in automatic Base 402/sign/retry flow. All four releases are
+registry verified. See the
 [Base USDC custody guide](docs/guides/base-usdc-custody.mdx), including the limit
 that blocking cannot recall an already issued on-chain signature.
 
@@ -111,8 +112,8 @@ See [Agent Wallet Governance](docs/guides/agent-wallet-governance.mdx) for the
 complete responsibility matrix, policy composition, exact approval protocol,
 and honest residual gap list.
 
-The managed clients are implemented in registry-verified `@grantex/sdk@0.5.1`,
-`@grantex/x402@0.3.0`, Python `grantex==0.5.0`, and Go `v0.3.0`. External
+The managed clients are implemented in registry-verified `@grantex/sdk@0.6.0`,
+`@grantex/x402@0.4.0`, Python `grantex==0.5.0`, and Go `v0.3.0`. External
 custody, principal notification delivery, and
 merchant result idempotency remain operator responsibilities.
 See the [x402 integration
@@ -187,7 +188,7 @@ and 255 tests across 23 sequential Docker E2E files. This is self-assessed evide
 the tested Grantex configuration, not independent interoperability
 certification, OAuth Working Group adoption, or IETF endorsement. The
 updated `OAuthAgentClient` is published in registry-verified
-`@grantex/sdk@0.5.1`.
+`@grantex/sdk@0.6.0`.
 
 Revision `-02` remains the current Datatracker publication. Candidate `-03`
 must not be uploaded before 2026-09-09 and requires a fresh explicit approval
@@ -227,11 +228,11 @@ Current public releases and repository versions, verified 2026-09-07:
 
 | Component | Published version | Repository version | Reproducible install |
 | --- | ---: | ---: | --- |
-| TypeScript SDK | `@grantex/sdk` `0.5.1` | `0.6.0` (unpublished candidate) | `npm install @grantex/sdk@0.5.1` |
-| x402 Payment Protocol | `@grantex/x402` `0.3.0` | `0.4.0` (unpublished candidate) | `npm install @grantex/x402@0.3.0 @grantex/sdk@0.5.1` |
+| TypeScript SDK | `@grantex/sdk` `0.6.0` | `0.6.0` | `npm install @grantex/sdk@0.6.0` |
+| x402 Payment Protocol | `@grantex/x402` `0.4.0` | `0.4.0` | `npm install @grantex/x402@0.4.0 @grantex/sdk@0.6.0` |
 | Python SDK | `grantex` `0.5.0` | - | `python -m pip install grantex==0.5.0` |
 | Go SDK | `github.com/mishrasanjeev/grantex-go` `v0.3.0` (Go 1.26.1+) | - | `go get github.com/mishrasanjeev/grantex-go@v0.3.0` |
-| MCP Authorization Server | `@grantex/mcp-auth` `2.0.2` | - | `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1` |
+| MCP Authorization Server | `@grantex/mcp-auth` `2.0.2` | - | `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0` |
 
 > **Known published-package limits:** MCP Auth `2.0.2` keeps authorization codes
 > in process memory, does not render consent,
@@ -260,7 +261,7 @@ Omit a version pin to install the registry's current latest release. See the [re
 ## SDK quickstart
 
 ```bash
-npm install @grantex/sdk@0.5.1
+npm install @grantex/sdk@0.6.0
 ```
 
 ```typescript
@@ -298,7 +299,7 @@ if (!auth.code) {
 ```bash
 python -m pip install grantex==0.5.0               # Python SDK
 go get github.com/mishrasanjeev/grantex-go@v0.3.0 # Go SDK (Go 1.26.1+)
-npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1 # MCP endpoint evaluation
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0 # MCP endpoint evaluation
 npm install -g @grantex/cli@0.3.0                   # Optional CLI tooling
 ```
 
@@ -1575,7 +1576,7 @@ check its registry page and compatibility notes before choosing a version.
 | **DPDP Compliance** | `@grantex/dpdp` | `npm install @grantex/dpdp` | Published package |
 | **Adapters** | `@grantex/adapters` | `npm install @grantex/adapters` | Published package |
 | **MCP Tool Server** | `@grantex/mcp` (`0.1.10`) | `npm install @grantex/mcp` | Published package |
-| **MCP Authorization Server** | `@grantex/mcp-auth` (`2.0.2`) | `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1` | Published; single-process evaluation only |
+| **MCP Authorization Server** | `@grantex/mcp-auth` (`2.0.2`) | `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0` | Published; single-process evaluation only |
 | **Gateway** | `@grantex/gateway` | `npm install @grantex/gateway` | Published package |
 | **Express.js** | `@grantex/express` | `npm install @grantex/express` | Published package |
 | **FastAPI** | `grantex-fastapi` | `pip install grantex-fastapi` | Published package |
@@ -1588,7 +1589,7 @@ check its registry page and compatibility notes before choosing a version.
 | **Strands Agents SDK (Python)** | `grantex-strands` | `pip install grantex-strands` | Published package |
 | **Anthropic SDK** | `@grantex/anthropic` | `npm install @grantex/anthropic` | Published package |
 | **Vercel AI SDK** | `@grantex/vercel-ai` | `npm install @grantex/vercel-ai` | Published package |
-| **TypeScript SDK** | `@grantex/sdk` (`0.5.1`) | `npm install @grantex/sdk@0.5.1` | Registry-verified published package |
+| **TypeScript SDK** | `@grantex/sdk` (`0.6.0`) | `npm install @grantex/sdk@0.6.0` | Registry-verified published package |
 | **Python SDK** | `grantex` (`0.5.0`) | `python -m pip install grantex==0.5.0` | Registry-verified published package |
 | **Go SDK** | `grantex-go` (`v0.3.0`, Go 1.26.1+) | `go get github.com/mishrasanjeev/grantex-go@v0.3.0` | Tag and public Go-proxy verified |
 | **CLI** | `@grantex/cli` (`0.3.0`) | `npm install -g @grantex/cli@0.3.0` | Registry-verified published package |
@@ -1600,7 +1601,7 @@ check its registry page and compatibility notes before choosing a version.
 | **A2A Bridge (Py)** | `grantex-a2a` | `pip install grantex-a2a` | Published package |
 | **Event Destinations** | `@grantex/destinations` | `npm install @grantex/destinations` | Published package |
 | **Terraform Provider** | `terraform-provider-grantex` | `terraform { required_providers { grantex = { source = "mishrasanjeev/grantex" } } }` | Source present; verify registry before pinning |
-| **x402 Payment Protocol** | `@grantex/x402` (`0.3.0`) | `npm install @grantex/x402@0.3.0 @grantex/sdk@0.5.1` | Registry-verified layered x402 v2 release; external custody remains operator-supplied |
+| **x402 Payment Protocol** | `@grantex/x402` (`0.4.0`) | `npm install @grantex/x402@0.4.0 @grantex/sdk@0.6.0` | Registry-verified layered x402 v2 release; external custody remains operator-supplied |
 
 The guarded `publish-primary-sdks.yml` workflow builds and tests each prepared
 version once, then publishes those immutable artifacts. Before it can publish, a

--- a/docs/guides/base-usdc-custody.mdx
+++ b/docs/guides/base-usdc-custody.mdx
@@ -6,8 +6,9 @@ description: "Governed x402 EIP-3009 signing, verified funding, safe retries and
 <Warning>
 This adapter requires explicit custody/RPC provisioning even after the server
 code is deployed. Python `0.5.0` and Go `v0.3.0` publish the response and
-reconciliation APIs, not automatic HTTP payment wrappers. The TypeScript `0.6.0`
-and x402 `0.4.0` candidates await npm publication. Local tests prove local EVM
+reconciliation APIs, not automatic HTTP payment wrappers. Published TypeScript
+`0.6.0` and x402 `0.4.0` provide the opt-in Base 402/sign/retry flow. All four
+versions are registry verified. Local tests prove local EVM
 execution, not a real-money third-party payment. Server
 deployment, SDK publication and a funded production compatibility call are
 separate milestones; none implies the others.

--- a/docs/guides/oauth-agent-grants.mdx
+++ b/docs/guides/oauth-agent-grants.mdx
@@ -71,12 +71,12 @@ requirement, and RFC 9207 issuer-response support before starting a flow.
 
 ## TypeScript client
 
-`@grantex/sdk@0.5.1` includes `OAuthAgentClient`, which handles discovery, PAR,
+`@grantex/sdk@0.6.0` includes `OAuthAgentClient`, which handles discovery, PAR,
 state and issuer validation, PKCE, DPoP proofs, refresh, attenuation,
 revocation, and protected-resource requests.
 
 <Note>
-`@grantex/sdk@0.5.1` is published and clean-install verified for this profile.
+`@grantex/sdk@0.6.0` is published and clean-install verified for this profile.
 See [Release Status](/release-status) for the registry evidence and current
 limitations.
 </Note>

--- a/docs/guides/prepaid-wallet-production.mdx
+++ b/docs/guides/prepaid-wallet-production.mdx
@@ -14,8 +14,8 @@ recovery store, notification channel, or regulatory approval for the operator.
 The source checkout includes a specific [Base USDC adapter](/guides/base-usdc-custody).
 It requires migration `094`, operator-provisioned keys, a trusted Base RPC,
 verified funding and reconciliation monitoring. Python `0.5.0` and Go `v0.3.0`
-publish the response and reconciliation APIs; the TypeScript `0.6.0` and x402
-`0.4.0` automatic Base payment candidates await npm publication. Other external
+publish the response and reconciliation APIs; published TypeScript `0.6.0` and
+x402 `0.4.0` support opt-in automatic Base payment retries. Other external
 providers still need their own adapter.
 Signed EVM holds are not released on a wallet block or a local timeout alone.
 
@@ -23,7 +23,7 @@ Signed EVM holds are not released on a wallet block or a local timeout alone.
 | --- | --- | --- | --- |
 | PostgreSQL migrations `091_agent_prepaid_wallets.sql` and `092_layered_wallet_spend_controls.sql` | Always | Startup applies ordered migrations automatically | Back up PostgreSQL, deploy the exact repository migration set, and verify startup completed before sending traffic |
 | Public HTTPS routing | The issuer or wallet resource uses a public host | DPoP tokens bind the exact `/v1/prepaid-wallets` audience | Route the exact public wallet and OAuth paths to the auth service; do not rewrite them to static HTML |
-| `@grantex/sdk@0.5.1` and `@grantex/x402@0.3.0` | Applications install managed-wallet clients from npm | Both exact versions are published and clean-install verified | Pin these exact versions and complete the dependencies below |
+| `@grantex/sdk@0.6.0` and `@grantex/x402@0.4.0` | Applications install managed-wallet clients from npm | Both exact versions are published and clean-install verified | Pin these exact versions and complete the dependencies below |
 | External custody adapter | Real bank, card, on-chain, or provider-held funds | Configured `base_usdc` supports native Base USDC; other/unconfigured providers fail closed | Follow the Base custody guide or implement and independently test the selected provider's funding, reservation, settlement, reconciliation and recovery |
 | Principal notification bridge | A human must receive reload alerts outside the Grantex UI | Wallet reload events are emitted to the event bus; no built-in email/SMS/chat delivery is claimed | Consume SSE/WebSocket events and deliver through an approved channel, or separately extend and test webhook registration for wallet events |
 | Merchant idempotency store | A paid request has side effects | Grantex makes reservation and settlement retries idempotent | Atomically store the merchant's business result under the caller's HTTP `Idempotency-Key` |
@@ -175,8 +175,8 @@ npm view '@grantex/sdk' version
 npm view '@grantex/x402' version
 ```
 
-Published and clean-install verified: SDK `0.5.1` on September 7, 2026 and
-x402 `0.3.0` on August 31, 2026. Registry publication is not inferred from the source tree, so treat
+Published and clean-install verified: SDK `0.6.0` and x402 `0.4.0` on
+September 7, 2026. Registry publication is not inferred from the source tree, so treat
 the registry as authoritative and verify exact versions before each deployment.
 See [Release
 Status](/release-status) for the public artifact matrix.
@@ -349,8 +349,8 @@ After publication, verify from empty temporary projects rather than importing
 the monorepo checkout:
 
 ```powershell
-npm view '@grantex/sdk@0.5.1' version dist.integrity --json
-npm view '@grantex/x402@0.3.0' version dist.integrity --json
+npm view '@grantex/sdk@0.6.0' version dist.integrity --json
+npm view '@grantex/x402@0.4.0' version dist.integrity --json
 python -m pip download --no-deps --dest $env:TEMP 'grantex==0.5.0'
 go list -m -json 'github.com/mishrasanjeev/grantex-go@v0.3.0'
 ```

--- a/docs/integrations/mcp-auth.mdx
+++ b/docs/integrations/mcp-auth.mdx
@@ -15,7 +15,7 @@ Current published release: **`@grantex/mcp-auth@2.0.2`**.
 ## Install
 
 ```bash
-npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0
 ```
 
 The exact versions above provide a reproducible install. The packages are

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -106,7 +106,7 @@ keywords: ["AI agent framework integrations", "Hermes Agent authorization", "Ope
 | OpenClaw | `@grantex/cli@0.3.0` + Agent Skills | `grantex agent install --target openclaw` | Any shell; published package |
 | Other Agent Skills clients | `@grantex/cli@0.3.0` + Agent Skills | `grantex agent install --target portable` | Any shell; published package |
 | Adapters | `@grantex/adapters` | `npm install @grantex/adapters` | TypeScript |
-| MCP Auth Server | `@grantex/mcp-auth@2.0.2` | `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1` | TypeScript; evaluation only |
+| MCP Auth Server | `@grantex/mcp-auth@2.0.2` | `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0` | TypeScript; evaluation only |
 | Gateway | `@grantex/gateway` | `npm install @grantex/gateway` | TypeScript |
 | Express.js | `@grantex/express` | `npm install @grantex/express` | TypeScript |
 | FastAPI | `grantex-fastapi` | `pip install grantex-fastapi` | Python |

--- a/docs/integrations/x402.mdx
+++ b/docs/integrations/x402.mdx
@@ -13,8 +13,8 @@ wallet immediately. The x402 adapter uses the official x402 v2
 
 <Note>
 The prepaid-wallet API and SDK shown here are available in the published
-`@grantex/sdk@0.5.1`, `@grantex/x402@0.3.0`, Python `grantex==0.5.0`, and Go
-`v0.3.0`. All four versions are registry verified. TypeScript `0.5.1`, Python
+`@grantex/sdk@0.6.0`, `@grantex/x402@0.4.0`, Python `grantex==0.5.0`, and Go
+`v0.3.0`. All four versions are registry verified. TypeScript `0.6.0`, Python
 `0.5.0`, and Go `v0.3.0` include bounded refresh recovery and retry hardening.
 `sandbox_ledger` is a complete local ledger mode.
 `external` wallet records fail closed until a custody/provider adapter verifies
@@ -25,8 +25,8 @@ funding and settlement.
 
 The default remains `exact` on `grantex:prepaid`. The source checkout now also
 supports opt-in Base native USDC EIP-3009. Automatic Base 402/sign/retry requires
-the prepared TypeScript `0.6.0` and x402 `0.4.0` candidates, which await npm
-publication. Published Python `0.5.0` and Go `v0.3.0` include EVM payment responses
+published TypeScript `0.6.0` and x402 `0.4.0`, both verified from clean npm
+installs. Published Python `0.5.0` and Go `v0.3.0` include EVM payment responses
 and authenticated reconciliation, but no automatic HTTP payment wrapper. Server
 deployment and funded custody/RPC provisioning remain separate requirements.
 

--- a/docs/internal/base-usdc-sdk-release-2026-09-07.md
+++ b/docs/internal/base-usdc-sdk-release-2026-09-07.md
@@ -14,13 +14,15 @@ passed with all publication flags disabled.
 | --- | --- |
 | Python `grantex==0.5.0` | Published to PyPI; wheel and sdist SHA-256 values match the local tested artifacts; clean public-index install verified |
 | Go `github.com/mishrasanjeev/grantex-go@v0.3.0` | Published tag at `1f6806670e908cb5470379c5e370eaff260bb829`; public proxy download and module checksums verified |
-| TypeScript `@grantex/sdk@0.6.0` | Prepared and tested; not registry verified or published at the time of this report; npm requires a separate publishing approval |
-| x402 `@grantex/x402@0.4.0` | Prepared and tested; not registry verified or published at the time of this report; npm requires a separate publishing approval |
+| TypeScript `@grantex/sdk@0.6.0` | Published to npm on 2026-09-07; registry integrity matches the tested tarball; exact-version clean registry install verified |
+| x402 `@grantex/x402@0.4.0` | Published to npm on 2026-09-07; registry integrity matches the tested tarball; exact-version clean registry install verified |
 
-The npm login succeeded. Earlier publish approvals expired, and exact-version
-registry requests still returned 404. The public release snapshot therefore
-retains TypeScript `0.5.1` and x402 `0.3.0`. Do not infer publication from a
-package manifest or from a successful local tarball installation.
+Earlier npm publish approvals expired and exact-version registry requests
+returned 404. A fresh approval completed on 2026-09-07, and both packages were
+published successfully. A new consumer directory installed the exact versions
+with npm registry tarball URLs in its lockfile and matching integrity values.
+The public release snapshot now advertises TypeScript `0.6.0` and x402 `0.4.0`.
+Do not infer publication from a manifest or local tarball installation alone.
 
 ## Verification
 
@@ -33,18 +35,21 @@ package manifest or from a successful local tarball installation.
 | Python installed artifacts | 613 tests passed against the local wheel and again against the clean public PyPI wheel |
 | Go source and publication | Full source tests, standalone race tests, and public-module race tests passed; `go mod verify` passed |
 | npm artifact consumer | Exact candidate versions, public exports, LICENSE/NOTICE, synchronous Base safety gates, and principal/DPoP-agent reconciliation wire contracts passed |
+| Public npm consumer | A separate clean directory installed exact registry versions; all artifact checks passed and npm audit reported zero vulnerabilities |
 | Local Docker Base | 11 scenarios plus the parent result passed (12 Node test results), using the final npm tarballs against the isolated PostgreSQL/Redis/auth-service/Anvil stack |
 | Local Docker existing wallets | Complete prepaid-wallet lifecycle and layered spend-control lifecycle passed using installed npm candidates |
+| Public npm Docker retest | 11 Base scenarios plus the parent result passed (12 Node results, 42.81s); existing prepaid-wallet and layered-policy lifecycle tests both passed (30.25s), using public registry packages |
 | API contract | Both Base API contract tests passed |
 | Public Python/Go production boundary | Principal and agent reconciliation requests with deliberately invalid credentials returned 401 in both installed SDKs |
 | Full production candidate E2E | 255 tests passed across all 23 files in 282.88 seconds, with `GRANTEX_SDK_TEST_ROOT` selecting installed TypeScript/x402 candidate tarballs; this was not an npm registry install |
+| Full production public-registry E2E | 255 tests passed across all 23 files in 281.80 seconds after publication, with `GRANTEX_SDK_TEST_ROOT` selecting the new clean npm registry consumer |
 | Documentation | Local integrity, mirrored metadata, links, navigation, JSON-LD, and live registry checks passed |
 | Supply chain | 37 lockfiles and 4,308 entries passed repository checks; tested npm dependency installations and consumer audit reported zero vulnerabilities |
 
 These are repeated suites, not additive distinct-test totals. Python and Go
 production 401 probes verify routing and authentication boundaries, not successful
-funded settlement. npm registry-install verification remains outstanding even
-though the full production candidate E2E suite passed.
+funded settlement. The public npm install is distinct from the earlier candidate
+installation; both use the same verified immutable artifact bytes.
 
 Final prepared npm artifact integrity values:
 
@@ -68,7 +73,7 @@ sha512-REjrrQFEnhEJDCuEgl3JDJqA82G3ENLaDobG2e5Xc6jv0x12sM+E9sg78j5LI0h+C97yKiORw
   its existing `E4`, `E7`, `E9`, and `F` gate. This does not claim that all of
   Ruff's additional opt-in findings were remediated.
 
-Local authenticated publication was used for Python and Go. This is not evidence
+Local authenticated publication was used for npm, Python and Go. This is not evidence
 that npm/PyPI trusted publishing is configured, nor an artifact-provenance claim.
 The standalone Go repository accepted an ordinary owner push of main and the
 annotated tag, while reporting a bypass of its pull-request rule. No force push
@@ -76,12 +81,12 @@ was used; future Go releases should follow a separate PR-gated publication path.
 
 ## Remaining boundaries
 
-- TypeScript/x402 npm publication and clean public-registry verification remain
-  open until fresh publishing approval succeeds. Never commit credentials,
-  disable two-factor authentication, or treat login as publish approval.
+- Publication and clean registry verification are complete for all four SDKs.
+  Future releases still require publishing approval or configured trusted
+  publishing. Never commit credentials or disable two-factor authentication.
 - Python and Go expose EVM payment responses and authenticated reconciliation,
   not an automatic HTTP 402/sign/retry wrapper. That wrapper belongs to the
-  prepared x402 adapter.
+  published x402 adapter.
 - The Base server implementation was deployed previously. This SDK release
   does not enable or fund custody; production Base RPC and wallet bindings are
   not configured by this release.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -51,7 +51,7 @@ The primary SDKs and MCP Auth server are published independently:
 
 | Package | Current published release |
 |---|---:|
-| TypeScript | `@grantex/sdk@0.5.1` |
+| TypeScript | `@grantex/sdk@0.6.0` |
 | Python | `grantex==0.5.0` |
 | Go | `github.com/mishrasanjeev/grantex-go@v0.3.0` |
 | MCP Auth | `@grantex/mcp-auth@2.0.2` |
@@ -65,7 +65,7 @@ The exact versions below make local and CI builds reproducible.
 
 <CodeGroup>
 ```bash TypeScript
-npm install @grantex/sdk@0.5.1
+npm install @grantex/sdk@0.6.0
 ```
 
 ```bash Python
@@ -77,7 +77,7 @@ go get github.com/mishrasanjeev/grantex-go@v0.3.0
 ```
 
 ```bash MCP Auth
-npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0
 ```
 
 ```bash CLI

--- a/docs/protocol/changelog.mdx
+++ b/docs/protocol/changelog.mdx
@@ -10,8 +10,8 @@ Release snapshot verified: **September 7, 2026**
 
 | Surface | Current release |
 |---|---:|
-| TypeScript SDK | `@grantex/sdk@0.5.1` |
-| x402 Payment Protocol | `@grantex/x402@0.3.0` |
+| TypeScript SDK | `@grantex/sdk@0.6.0` |
+| x402 Payment Protocol | `@grantex/x402@0.4.0` |
 | Python SDK | `grantex==0.5.0` |
 | Go SDK | `github.com/mishrasanjeev/grantex-go@v0.3.0` |
 | MCP Auth server | `@grantex/mcp-auth@2.0.2` |
@@ -21,7 +21,7 @@ Grantex is a multi-package repository. SDKs, integrations, the API contract, and
 repository release entries can advance independently, so a single project-wide
 version number would be misleading.
 
-TypeScript `@grantex/sdk@0.5.1`, Python `0.5.0`, and Go `v0.3.0` are published
+TypeScript `@grantex/sdk@0.6.0`, Python `0.5.0`, and Go `v0.3.0` are published
 and verified from clean public-registry installs.
 
 ## Canonical sources

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -7,14 +7,14 @@ keywords: ["AI agent authorization quickstart", "OAuth for AI agents", "scoped a
 
 ## 1. Install the SDK
 
-This guide installs the current registry-verified TypeScript `0.5.1`, Python
+This guide installs the current registry-verified TypeScript `0.6.0`, Python
 `0.5.0`, Go `v0.3.0` (which requires Go 1.26.1+), and MCP Auth `2.0.2`.
 See [Release Status](/release-status) for exact package status and
 upgrade guidance.
 
 <CodeGroup>
 ```bash TypeScript
-npm install @grantex/sdk@0.5.1
+npm install @grantex/sdk@0.6.0
 ```
 
 ```bash Python

--- a/docs/release-status.mdx
+++ b/docs/release-status.mdx
@@ -16,15 +16,15 @@ repository.
 | Surface | Published baseline | Prepared candidate | Status | Runtime requirement |
 |---|---:|---:|---|---|
 | CLI | `@grantex/cli@0.3.0` | - | Published to npm with bundled Agent Skills | Node.js 18+; ESM |
-| TypeScript SDK | `@grantex/sdk@0.5.1` | `0.6.0` | Baseline verified; candidate awaits npm publishing approval | Node.js 18+; ESM |
-| x402 Payment Protocol | `@grantex/x402@0.3.0` | `0.4.0` | Baseline verified; Base 402/sign/retry candidate awaits npm publishing approval | Node.js 20+; ESM |
+| TypeScript SDK | `@grantex/sdk@0.6.0` | - | Published; npm integrity and clean-install verified | Node.js 18+; ESM |
+| x402 Payment Protocol | `@grantex/x402@0.4.0` | - | Published; opt-in Base 402/sign/retry; npm integrity and clean-install verified | Node.js 20+; ESM |
 | Python SDK | `grantex==0.5.0` | - | Published to PyPI and fresh-install verified | Python 3.9+ |
 | Go SDK | `github.com/mishrasanjeev/grantex-go@v0.3.0` | - | Tagged, public Go-proxy verified, and fresh-install verified | Go 1.26.1+ |
 | MCP Auth server | `@grantex/mcp-auth@2.0.2` | - | Published with known limitations | Node.js 18+; ESM |
 | OpenAPI contract | `0.5.0` | - | Repository contract with layered prepaid-wallet governance | Independent of public SDK versions |
 
 <Note>
-TypeScript `0.5.1`, Python `0.5.0`, Go `v0.3.0`, and x402 `0.3.0` are
+TypeScript `0.6.0`, Python `0.5.0`, Go `v0.3.0`, and x402 `0.4.0` are
 published and registry verified. Installing any SDK does not provision external
 custody, principal notification delivery, or merchant idempotency storage; see
 [Prepaid Wallet Production Readiness](/guides/prepaid-wallet-production).
@@ -44,17 +44,18 @@ retain bounded refresh recovery. Full tests passed against a clean PyPI wheel
 and the public Go module, including Go race tests. Neither language adds an
 automatic x402 HTTP payment-and-retry wrapper.
 
-TypeScript `0.6.0` and x402 `0.4.0` are built and tested candidates, not public
-npm releases yet. Their prepared tarballs include the license and notice files
-and pass installed-package tests and isolated Docker Base execution. Publication
-requires a separate npm approval after login. See [Base USDC
+TypeScript `0.6.0` and x402 `0.4.0` were published on September 7, 2026.
+Both registry integrity hashes match the tested tarballs. A clean npm install
+passed public-export, license/notice, Base safety, and authenticated reconciliation
+checks with zero reported consumer vulnerabilities. The x402 adapter provides
+opt-in request-bound Base USDC 402/sign/retry. See [Base USDC
 Custody](/guides/base-usdc-custody) for the custody and RPC prerequisites.
 
 <Info>
   As of August 10, 2026, published `@grantex/cli@0.3.0` includes the Hermes,
   OpenClaw, and portable Agent Skills installer. Repository source on `main`
   includes corrected Go Agent/Audit read/write contracts and layered prepaid
-  wallet clients across TypeScript, Python, and Go. TypeScript `0.5.1`, Python
+  wallet clients across TypeScript, Python, and Go. TypeScript `0.6.0`, Python
   `0.5.0`, and Go `v0.3.0` include matching bounded refresh-recovery behavior.
   Standard developer API-key plan throughput and custom-auth quotas
   remain separate from SDK publication.
@@ -63,8 +64,8 @@ Custody](/guides/base-usdc-custody) for the custody and RPC prerequisites.
 ## Which Grantex package should I use?
 
 - **Hermes, OpenClaw, or another shell-capable agent:** use published `@grantex/cli@0.3.0`; install its bundled skills with `grantex agent install`. No agent-specific SDK is required.
-- **TypeScript application:** use npm-verified `@grantex/sdk@0.5.1` for bounded refresh recovery, layered prepaid-wallet governance, and OAuth Agent Grants.
-- **x402 prepaid-wallet application:** use published `@grantex/x402@0.3.0` with published `@grantex/sdk@0.5.1`; keep external custody disabled until an operator adapter passes review.
+- **TypeScript application:** use npm-verified `@grantex/sdk@0.6.0` for bounded refresh recovery, layered prepaid-wallet governance, and OAuth Agent Grants.
+- **x402 prepaid-wallet application:** use published `@grantex/x402@0.4.0` with published `@grantex/sdk@0.6.0`; keep external custody disabled until an operator adapter passes review.
 - **Python application:** use PyPI-verified `grantex==0.5.0` for bounded refresh recovery and layered prepaid-wallet governance.
 - **Go application:** use public-proxy-verified `github.com/mishrasanjeev/grantex-go@v0.3.0` for bounded refresh recovery, corrected Agent/Audit contracts, and layered prepaid-wallet governance.
 - **MCP HTTP transport authorization:** use an established MCP-compatible authorization server and maintained MCP SDK that implement the current MCP authorization specification.
@@ -92,11 +93,11 @@ npm install -g @grantex/cli@0.3.0
 ```
 
 ```bash TypeScript
-npm install @grantex/sdk@0.5.1
+npm install @grantex/sdk@0.6.0
 ```
 
 ```bash x402
-npm install @grantex/x402@0.3.0 @grantex/sdk@0.5.1
+npm install @grantex/x402@0.4.0 @grantex/sdk@0.6.0
 ```
 
 ```bash Python
@@ -108,7 +109,7 @@ go get github.com/mishrasanjeev/grantex-go@v0.3.0
 ```
 
 ```bash MCP Auth
-npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0
 ```
 </CodeGroup>
 

--- a/docs/sdks/typescript/overview.mdx
+++ b/docs/sdks/typescript/overview.mdx
@@ -6,12 +6,12 @@ description: "Install, configure, and get started with the @grantex/sdk TypeScri
 
 ## Installation
 
-Published release: **`@grantex/sdk@0.5.1`**. npm integrity, exact-version
+Published release: **`@grantex/sdk@0.6.0`**. npm integrity, exact-version
 clean installation, public exports, and a zero-vulnerability consumer audit
 were verified on 7 September 2026.
 
 ```bash
-npm install @grantex/sdk@0.5.1
+npm install @grantex/sdk@0.6.0
 ```
 
 The unpinned `npm install @grantex/sdk` command follows npm's current `latest`
@@ -19,11 +19,14 @@ tag. Keep the exact version above in reproducible builds. See
 [Release Status](/release-status) before upgrading.
 
 <Note>
-SDK `0.5.1` includes `PrepaidWalletAgentClient`,
+SDK `0.6.0` includes `PrepaidWalletAgentClient`,
 `PrincipalPrepaidWalletClient`, and `DeveloperPrepaidWalletPolicyClient` with
 safe assignment defaults, layered policy, exact approval, semantic context, and
-reload governance. External custody remains fail-closed until a
-self-hosting operator supplies and verifies a provider adapter. See [x402
+reload governance. Version `0.6.0` also adds EVM payment responses and
+`reconcileReservation()` to principal and agent wallet clients. Pair it with
+`@grantex/x402@0.4.0` for opt-in Base USDC 402/sign/retry. External custody
+remains fail-closed until the operator configures the Base custody/RPC adapter
+or supplies another verified provider. See [x402
 Prepaid Wallets](/integrations/x402) and [Agent Wallet
 Governance](/guides/agent-wallet-governance).
 </Note>

--- a/release-status.json
+++ b/release-status.json
@@ -18,7 +18,7 @@
   },
   "selectionGuidance": {
     "shellCapableAgent": "Use published @grantex/cli@0.3.0 for Hermes, OpenClaw, and other shell-capable agents. Install the bundled skills with grantex agent install; no agent-specific SDK is required.",
-    "typescriptApplication": "Use npm-verified @grantex/sdk@0.5.1 for Node.js 18+ TypeScript applications that need bounded refresh recovery, layered prepaid-wallet governance, and OAuth Agent Grants.",
+    "typescriptApplication": "Use npm-verified @grantex/sdk@0.6.0 for Node.js 18+ TypeScript applications that need bounded refresh recovery, layered prepaid-wallet governance, and OAuth Agent Grants.",
     "pythonApplication": "Use PyPI-verified grantex==0.5.0 for Python 3.9+ applications that need EVM payment responses, principal/agent reconciliation, bounded refresh recovery, and layered prepaid-wallet governance. No automatic x402 HTTP payment wrapper is included.",
     "goApplication": "Use public-proxy-verified github.com/mishrasanjeev/grantex-go@v0.3.0 for Go 1.26.1+ applications that need typed EVM payment responses, principal/agent reconciliation, bounded refresh recovery, and layered prepaid-wallet governance. No automatic x402 HTTP payment wrapper is included.",
     "mcpProductionIntegration": "Use established MCP-compatible transport authorization first, then a primary Grantex SDK or direct JWKS validation for agent-specific tool enforcement; treat @grantex/mcp-auth@2.0.2 as single-process evaluation software.",
@@ -37,7 +37,7 @@
       "hostedMetadataUrl": "https://grantex.dev/.well-known/oauth-authorization-server",
       "documentationUrl": "https://docs.grantex.dev/guides/oauth-agent-grants",
       "implementationReportUrl": "https://github.com/mishrasanjeev/grantex/blob/main/docs/ietf-draft/implementation-report.md",
-      "sdkAvailability": "published in @grantex/sdk@0.5.1; npm integrity, exact-version clean install, and public exports verified",
+      "sdkAvailability": "published in @grantex/sdk@0.6.0; npm integrity, exact-version clean install, and public exports verified",
       "evidence": {
         "authServiceTestsPassed": 2138,
         "typescriptSdkTestsPassed": 456,
@@ -71,12 +71,12 @@
       "label": "TypeScript SDK",
       "ecosystem": "npm",
       "name": "@grantex/sdk",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "status": "published",
-      "installCommand": "npm install @grantex/sdk@0.5.1",
+      "installCommand": "npm install @grantex/sdk@0.6.0",
       "runtime": "Node.js 18+; ESM",
       "registryUrl": "https://registry.npmjs.org/%40grantex%2Fsdk/latest",
-      "packageUrl": "https://www.npmjs.com/package/@grantex/sdk/v/0.5.1",
+      "packageUrl": "https://www.npmjs.com/package/@grantex/sdk/v/0.6.0",
       "documentationUrl": "https://docs.grantex.dev/sdks/typescript/overview",
       "limitations": []
     },
@@ -85,19 +85,19 @@
       "label": "x402 Payment Protocol",
       "ecosystem": "npm",
       "name": "@grantex/x402",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "status": "published-with-known-limitations",
-      "installCommand": "npm install @grantex/x402@0.3.0 @grantex/sdk@0.5.1",
+      "installCommand": "npm install @grantex/x402@0.4.0 @grantex/sdk@0.6.0",
       "runtime": "Node.js 20+; ESM",
       "registryUrl": "https://registry.npmjs.org/%40grantex%2Fx402/latest",
-      "packageUrl": "https://www.npmjs.com/package/@grantex/x402/v/0.3.0",
+      "packageUrl": "https://www.npmjs.com/package/@grantex/x402/v/0.4.0",
       "documentationUrl": "https://docs.grantex.dev/integrations/x402",
       "limitations": [
         {
           "id": "x402-external-custody-adapter",
-          "summary": "External custody wallets fail closed until an operator supplies a provider adapter; sandbox_ledger does not represent external funds.",
-          "workaround": "Use sandbox_ledger only for an explicitly internal ledger, or implement and independently test provider funding, reservation, settlement, reconciliation, duplicate-event handling, and recovery before enabling external custody.",
-          "workaroundUrl": "https://docs.grantex.dev/guides/prepaid-wallet-production#choose-the-custody-mode-honestly"
+          "summary": "Opt-in Base USDC requires operator-provisioned custody, verified funding and trusted RPC. The initial signer is in-process, not HSM/MPC; unconfigured or unsupported external providers fail closed.",
+          "workaround": "Follow the Base custody provisioning and incident runbook. Retain signed exposure until finalized reconciliation; blocking cannot recall issued signatures. Independently validate funded production merchant compatibility before enabling real-money traffic.",
+          "workaroundUrl": "https://docs.grantex.dev/guides/base-usdc-custody"
         }
       ]
     },
@@ -136,7 +136,7 @@
       "name": "@grantex/mcp-auth",
       "version": "2.0.2",
       "status": "published-with-known-limitations",
-      "installCommand": "npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1",
+      "installCommand": "npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0",
       "runtime": "Node.js 18+; ESM; one process for evaluation",
       "registryUrl": "https://registry.npmjs.org/%40grantex%2Fmcp-auth/latest",
       "packageUrl": "https://www.npmjs.com/package/@grantex/mcp-auth/v/2.0.2",

--- a/web/for/mcp/index.html
+++ b/web/for/mcp/index.html
@@ -152,7 +152,7 @@
     <h2>Choose the correct Grantex path</h2>
     <div class="steps">
       <div class="step"><div class="step-content"><h3>Management tools: <code>@grantex/mcp</code></h3><p>Expose Grantex agent, grant, token, budget, and audit-management operations to a host-configured MCP client.</p></div></div>
-      <div class="step"><div class="step-content"><h3>Production tool enforcement: primary SDK or JWKS</h3><p>Use <code>@grantex/sdk@0.5.1</code> or direct JWKS validation at the MCP tool boundary and require the exact agent scope.</p></div></div>
+      <div class="step"><div class="step-content"><h3>Production tool enforcement: primary SDK or JWKS</h3><p>Use <code>@grantex/sdk@0.6.0</code> or direct JWKS validation at the MCP tool boundary and require the exact agent scope.</p></div></div>
       <div class="step"><div class="step-content"><h3>MCP Auth 2.0.2: evaluation only</h3><p><code>@grantex/mcp-auth@2.0.2</code> has process-local code storage, metadata-only consent, incomplete code handoff, and no live revocation lookup. Do not use it as the production path today.</p></div></div>
       <div class="step"><div class="step-content"><h3>Current MCP authorization</h3><p>For HTTP transports, use an established authorization server and maintained MCP SDK that implement the current protected-resource discovery and token validation requirements.</p></div></div>
       <div class="step"><div class="step-content"><h3>Audit tool execution separately</h3><p>Record the agent, principal, grant, tool, outcome, and timestamp at the execution boundary; a valid token is not an execution record.</p></div></div>

--- a/web/index.html
+++ b/web/index.html
@@ -245,7 +245,7 @@
             "name": "Which Grantex SDK should I install?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Use the registry-verified @grantex/sdk@0.5.1 for TypeScript, grantex==0.5.0 for Python, and github.com/mishrasanjeev/grantex-go@v0.3.0 for Go. See release status for exact evidence and limitations."
+              "text": "Use the registry-verified @grantex/sdk@0.6.0 for TypeScript, grantex==0.5.0 for Python, and github.com/mishrasanjeev/grantex-go@v0.3.0 for Go. See release status for exact evidence and limitations."
             }
           },
           {
@@ -1632,8 +1632,8 @@
         <div class="section-label">Release state</div>
         <h2 class="section-title">Primary SDK release state</h2>
         <p class="release-intro">
-          Release snapshot verified on 7 September 2026. TypeScript 0.5.1,
-          Python 0.5.0, Go v0.3.0, and x402 0.3.0 are registry-verified.
+          Release snapshot verified on 7 September 2026. TypeScript 0.6.0,
+          Python 0.5.0, Go v0.3.0, and x402 0.4.0 are registry-verified.
           External custody remains operator-supplied.
         </p>
       </div>
@@ -1652,16 +1652,16 @@
         <strong class="release-version">0.3.0</strong>
         <span class="release-meta">npm &middot; published 10 Aug 2026 &middot; Agent Skills</span>
       </a>
-      <a class="release-card" href="https://www.npmjs.com/package/@grantex/sdk/v/0.5.1">
+      <a class="release-card" href="https://www.npmjs.com/package/@grantex/sdk/v/0.6.0">
         <span class="release-language">TypeScript SDK</span>
         <span class="release-name">@grantex/sdk</span>
-        <strong class="release-version">0.5.1</strong>
+        <strong class="release-version">0.6.0</strong>
         <span class="release-meta">npm &middot; current published release</span>
       </a>
-      <a class="release-card" href="https://www.npmjs.com/package/@grantex/x402/v/0.3.0">
+      <a class="release-card" href="https://www.npmjs.com/package/@grantex/x402/v/0.4.0">
         <span class="release-language">x402 Payment Protocol</span>
         <span class="release-name">@grantex/x402</span>
-        <strong class="release-version">0.3.0</strong>
+        <strong class="release-version">0.4.0</strong>
         <span class="release-meta">npm &middot; published; external custody is operator-supplied</span>
       </a>
       <a class="release-card" href="https://pypi.org/project/grantex/0.5.0/">
@@ -1786,7 +1786,7 @@
       </details>
       <details class="answer-card" data-faq-item>
         <summary>Which Grantex SDK should I install?</summary>
-        <p>Use the registry-verified <code>@grantex/sdk@0.5.1</code> for TypeScript, <code>grantex==0.5.0</code> for Python, and <code>github.com/mishrasanjeev/grantex-go@v0.3.0</code> for Go. See <a href="https://docs.grantex.dev/release-status">release status</a> for exact evidence and limitations.</p>
+        <p>Use the registry-verified <code>@grantex/sdk@0.6.0</code> for TypeScript, <code>grantex==0.5.0</code> for Python, and <code>github.com/mishrasanjeev/grantex-go@v0.3.0</code> for Go. See <a href="https://docs.grantex.dev/release-status">release status</a> for exact evidence and limitations.</p>
       </details>
       <details class="answer-card" data-faq-item>
         <summary>Does local Grantex token verification check current revocation?</summary>
@@ -2253,10 +2253,10 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
     </p>
 
     <div class="install-commands">
-      <button type="button" class="install-cmd" onclick="copyInstall('npm install @grantex/sdk@0.5.1', this)"
+      <button type="button" class="install-cmd" onclick="copyInstall('npm install @grantex/sdk@0.6.0', this)"
               aria-label="Copy the TypeScript SDK install command">
         <span class="install-label">npm</span>
-        <code>npm install @grantex/sdk@0.5.1</code>
+        <code>npm install @grantex/sdk@0.6.0</code>
         <span class="install-copy">Copy</span>
       </button>
       <button type="button" class="install-cmd" onclick="copyInstall('python -m pip install grantex==0.5.0', this)"
@@ -2296,7 +2296,7 @@ grantex.enforce(token, <span style="color:#c3e88d;">"my-crm"</span>, <span style
         <div class="code-block">
           <button type="button" class="copy-btn" aria-label="Copy the Node.js quickstart"
                   onclick="copyCode('code-node', this, 'node_quickstart_copy')">Copy</button>
-          <pre id="code-node"><span class="cm">// npm install @grantex/sdk@0.5.1</span>
+          <pre id="code-node"><span class="cm">// npm install @grantex/sdk@0.6.0</span>
 <span class="kw">import</span> <span class="op">{ </span><span class="id">Grantex</span><span class="op">,</span> <span class="id">verifyGrantToken</span><span class="op"> }</span> <span class="kw">from</span> <span class="str">'@grantex/sdk'</span>;
 
 <span class="kw">const</span> <span class="id">grantex</span> <span class="op">=</span> <span class="kw">new</span> <span class="fn">Grantex</span><span class="op">({</span> <span class="id">apiKey</span><span class="op">:</span> <span class="str">'YOUR_API_KEY'</span> <span class="op">});</span>
@@ -2596,8 +2596,8 @@ func main() {
       and stop one wallet or every wallet without loosening the x402 protocol.
     </p>
     <div class="release-caveat" style="max-width:760px;margin:-24px 0 36px;">
-      <strong>Registry releases:</strong> install <code>@grantex/sdk@0.5.1</code> and
-      <code>@grantex/x402@0.3.0</code> for the managed-wallet flow. External custody remains
+      <strong>Registry releases:</strong> install <code>@grantex/sdk@0.6.0</code> and
+      <code>@grantex/x402@0.4.0</code> for the managed-wallet flow. External custody remains
       fail-closed until a self-hosting operator installs and verifies a provider adapter.
       Grantex governs delegated agent authority and reservation; the issuer or custodian still owns
       KYC/KYB, sanctions, custody, network controls, clearing, settlement, disputes, and reconciliation.

--- a/web/ld.json
+++ b/web/ld.json
@@ -202,7 +202,7 @@
           "name": "Which Grantex SDK should I install?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Use the registry-verified @grantex/sdk@0.5.1 for TypeScript, grantex==0.5.0 for Python, and github.com/mishrasanjeev/grantex-go@v0.3.0 for Go. See release status for exact evidence and limitations."
+            "text": "Use the registry-verified @grantex/sdk@0.6.0 for TypeScript, grantex==0.5.0 for Python, and github.com/mishrasanjeev/grantex-go@v0.3.0 for Go. See release status for exact evidence and limitations."
           }
         },
         {

--- a/web/llms-full.txt
+++ b/web/llms-full.txt
@@ -60,7 +60,7 @@ SDK tests, and 255 Docker E2E tests, plus an encrypted refresh-recovery restart
 test. This is self-assessed evidence, not
 independent interoperability certification, OAuth Working Group adoption, or
 IETF endorsement. OAuthAgentClient is included in registry-verified
-@grantex/sdk@0.5.1.
+@grantex/sdk@0.6.0.
 
 Implementation guide: https://docs.grantex.dev/guides/oauth-agent-grants
 
@@ -68,14 +68,14 @@ Implementation guide: https://docs.grantex.dev/guides/oauth-agent-grants
 
 | Use case | Recommended implementation | Current status |
 |---|---|---|
-| TypeScript or Node.js application | `@grantex/sdk@0.5.1` | Published; npm and clean-install verified; Node.js 18+ ESM |
-| x402 prepaid-wallet application | `@grantex/x402@0.3.0` with `@grantex/sdk@0.5.1` | Both packages are published and registry verified; Node.js 20+ ESM; external custody is operator-supplied |
+| TypeScript or Node.js application | `@grantex/sdk@0.6.0` | Published; npm and clean-install verified; Node.js 18+ ESM |
+| x402 prepaid-wallet application | `@grantex/x402@0.4.0` with `@grantex/sdk@0.6.0` | Both packages are published and registry verified; Node.js 20+ ESM; external custody is operator-supplied |
 | Python application | `grantex==0.5.0` | Published; PyPI and clean-install verified; Python 3.9+ |
 | Go application | `github.com/mishrasanjeev/grantex-go@v0.3.0` | Published; tag, public Go proxy, and clean-install verified; Go 1.26.1+ |
 | Service-side JWT enforcement | SDK verifier or direct verification with issuer JWKS | Signature and claim verification; add online or synchronized state for current revocation |
 | MCP HTTP transport authorization | Established MCP-compatible authorization server and maintained MCP SDK | Follow the current MCP authorization specification; a Grantex SDK alone does not provide this layer |
 | Agent-specific enforcement in MCP tools | Primary Grantex SDK or direct JWKS-backed validation | Add after transport authorization when the tool must verify delegated agent authority |
-| MCP endpoint evaluation | `@grantex/mcp-auth@2.0.2` plus `@grantex/sdk@0.5.1` | Single-process evaluation only; both packages are published |
+| MCP endpoint evaluation | `@grantex/mcp-auth@2.0.2` plus `@grantex/sdk@0.6.0` | Single-process evaluation only; both packages are published |
 | Terminal automation | `@grantex/cli` | Optional operational tooling |
 | Hermes, OpenClaw, or another shell-capable agent | Published `@grantex/cli@0.3.0` plus the bundled Agent Skills | No agent-specific SDK required; enforce again at the protected service |
 | Framework-specific tools | Named Grantex adapter plus its primary SDK where required | Verify each package's registry status before pinning |
@@ -83,11 +83,11 @@ Implementation guide: https://docs.grantex.dev/guides/oauth-agent-grants
 Primary reproducible installs:
 
 ```bash
-npm install @grantex/sdk@0.5.1
-npm install @grantex/x402@0.3.0 @grantex/sdk@0.5.1
+npm install @grantex/sdk@0.6.0
+npm install @grantex/x402@0.4.0 @grantex/sdk@0.6.0
 python -m pip install grantex==0.5.0
 go get github.com/mishrasanjeev/grantex-go@v0.3.0
-npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1
+npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0
 npm install -g @grantex/cli@0.3.0
 ```
 
@@ -126,7 +126,8 @@ The newer source checkout includes an opt-in native Base USDC EIP-3009 adapter
 with policy-gated signing, verified finalized funding and chain reconciliation.
 It requires operator-provisioned custody and trusted RPC. Python 0.5.0 and Go
 v0.3.0 publish EVM response and reconciliation APIs, not automatic HTTP payment
-wrappers. TypeScript 0.6.0 and x402 0.4.0 await npm publication. Server deployment
+wrappers. Published TypeScript 0.6.0 and x402 0.4.0 support the opt-in automatic
+Base 402/sign/retry flow. All four versions are registry verified. Server deployment
 alone does not activate real
 wallets. Blocks stop new signatures; existing signed exposure stays reserved
 until finalized settlement or unused expiry. This is not an HSM/MPC custody
@@ -414,7 +415,7 @@ MCP connects models to tools. Grantex carries and enforces the delegated authori
 
 ### Which SDK should I install?
 
-Use npm-verified `@grantex/sdk@0.5.1` for TypeScript, published `grantex==0.5.0` for Python, or public-proxy-verified `github.com/mishrasanjeev/grantex-go@v0.3.0` for Go. Read the machine release status before upgrading.
+Use npm-verified `@grantex/sdk@0.6.0` for TypeScript, published `grantex==0.5.0` for Python, or public-proxy-verified `github.com/mishrasanjeev/grantex-go@v0.3.0` for Go. Read the machine release status before upgrading.
 
 ### Does local verification check revocation?
 

--- a/web/llms.txt
+++ b/web/llms.txt
@@ -8,7 +8,7 @@ Use Grantex when an AI agent acts for a person or organization and a service mus
 
 Ownership: Grantex is owned by Orchestrum Technologies LLP. Inventor and owner: Sanjeev Kumar. Ownership contact: sanjeev@orchestrum.in or mishra.sanjeev@gmail.com.
 
-Release snapshot verified: 2026-09-07. Packages are independently versioned. TypeScript @grantex/sdk 0.5.1, Python grantex 0.5.0, Go v0.3.0, and x402 0.3.0 are published and registry verified. The protocol specification is frozen at v1.0. The related Delegated Agent Authorization Protocol (DAAP) document is an individual IETF Internet-Draft, not an IETF-adopted or endorsed standard.
+Release snapshot verified: 2026-09-07. Packages are independently versioned. TypeScript @grantex/sdk 0.6.0, Python grantex 0.5.0, Go v0.3.0, and x402 0.4.0 are published and registry verified. The protocol specification is frozen at v1.0. The related Delegated Agent Authorization Protocol (DAAP) document is an individual IETF Internet-Draft, not an IETF-adopted or endorsed standard.
 
 ## Start Here
 
@@ -22,10 +22,10 @@ Release snapshot verified: 2026-09-07. Packages are independently versioned. Typ
 
 ## Choose an Implementation
 
-- [TypeScript SDK](https://docs.grantex.dev/sdks/typescript/overview): `npm install @grantex/sdk@0.5.1` for Node.js 18+ ESM applications; npm and clean-install verified.
+- [TypeScript SDK](https://docs.grantex.dev/sdks/typescript/overview): `npm install @grantex/sdk@0.6.0` for Node.js 18+ ESM applications; npm and clean-install verified.
 - [Python SDK](https://docs.grantex.dev/sdks/python/overview): `python -m pip install grantex==0.5.0` for Python 3.9+ applications; PyPI and clean-install verified.
 - [Go SDK](https://docs.grantex.dev/sdks/go/overview): `go get github.com/mishrasanjeev/grantex-go@v0.3.0` for Go 1.26.1+; tag, public proxy, and clean-install verified.
-- [MCP Authorization Server](https://docs.grantex.dev/features/mcp-auth-server): `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1`; version 2.0.2 is single-process evaluation software, not the recommended production enforcement path.
+- [MCP Authorization Server](https://docs.grantex.dev/features/mcp-auth-server): `npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0`; version 2.0.2 is single-process evaluation software, not the recommended production enforcement path.
 - [CLI](https://docs.grantex.dev/integrations/cli): Install `@grantex/cli@0.3.0` to manage agents, grants, tokens, audit records, manifests, and portable Agent Skills from a terminal.
 - [Agent CLIs and Skills](https://docs.grantex.dev/integrations/agent-cli): Published `@grantex/cli@0.3.0` bundles portable Grantex skills for Hermes, OpenClaw, or any shell-capable agent; no agent-specific SDK is required.
 - [Machine-Readable Release Status](https://grantex.dev/release-status.json): Canonical versions, install commands, package URLs, limitations, and workaround links.
@@ -77,7 +77,7 @@ For MCP HTTP transport authorization, use an established MCP-compatible authoriz
 - [OACP Documentation](https://docs.grantex.dev/guides/oacp/overview): Canonical ownership and non-ownership boundaries.
 - [AgenticOrg Integration Boundary](https://docs.grantex.dev/guides/oacp/agenticorg-integration): Buyer and seller runtime responsibilities versus Grantex authority.
 - [MPP Agent Identity](https://grantex.dev/for/mpp): Verifiable agent passports and spending constraints for machine payments.
-- [x402 Prepaid Wallets](https://grantex.dev/x402): Published `@grantex/x402@0.3.0` with registry-verified `@grantex/sdk@0.5.1` adds DPoP agent identity, layered cross-wallet policy, exact principal approvals, reload governance, atomic reservations, and stop controls. Opt-in Base USDC support is a newer source addition, not part of these registry releases.
+- [x402 Prepaid Wallets](https://grantex.dev/x402): Published `@grantex/x402@0.4.0` with registry-verified `@grantex/sdk@0.6.0` adds DPoP agent identity, layered cross-wallet policy, exact principal approvals, reload governance, atomic reservations, stop controls, and opt-in Base USDC 402/sign/retry. Base custody, funding and trusted RPC must be provisioned separately.
 - [Base USDC Custody](https://docs.grantex.dev/guides/base-usdc-custody): Operator-provisioned native Base USDC EIP-3009 signing with finalized funding and reconciliation. Blocks stop new signatures but cannot recall issued ones. Requires dedicated custody, trusted RPC and updated source clients; no funded third-party production payment is claimed.
 
 ## Machine-Readable Sources

--- a/web/mcp.html
+++ b/web/mcp.html
@@ -738,8 +738,8 @@
       limitations and is not a production-ready authorization server.
     </p>
     <div class="hero-ctas">
-      <div class="install-hero" onclick="copyInstall('npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1', this)">
-        <code>npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1</code>
+      <div class="install-hero" onclick="copyInstall('npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0', this)">
+        <code>npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0</code>
         <span class="copy-hint">Copy</span>
       </div>
     </div>
@@ -942,7 +942,7 @@
           <p>Install the exact evaluation release with its Grantex SDK dependency.</p>
           <div class="code-block">
             <button class="copy-btn" onclick="copyCode('code-install', this)">Copy</button>
-            <pre id="code-install"><span class="id">npm</span> <span class="id">install</span> <span class="str">@grantex/mcp-auth@2.0.2</span> <span class="str">@grantex/sdk@0.5.1</span></pre>
+            <pre id="code-install"><span class="id">npm</span> <span class="id">install</span> <span class="str">@grantex/mcp-auth@2.0.2</span> <span class="str">@grantex/sdk@0.6.0</span></pre>
           </div>
         </div>
       </div>
@@ -1135,8 +1135,8 @@
       Review the state, consent, code-handoff, hook, and revocation-check limitations before designing a production authorization service.
     </p>
     <div class="hero-ctas">
-      <div class="install-hero" onclick="copyInstall('npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1', this)">
-        <code>npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1</code>
+      <div class="install-hero" onclick="copyInstall('npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0', this)">
+        <code>npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0</code>
         <span class="copy-hint">Copy</span>
       </div>
     </div>

--- a/web/release-status.json
+++ b/web/release-status.json
@@ -18,7 +18,7 @@
   },
   "selectionGuidance": {
     "shellCapableAgent": "Use published @grantex/cli@0.3.0 for Hermes, OpenClaw, and other shell-capable agents. Install the bundled skills with grantex agent install; no agent-specific SDK is required.",
-    "typescriptApplication": "Use npm-verified @grantex/sdk@0.5.1 for Node.js 18+ TypeScript applications that need bounded refresh recovery, layered prepaid-wallet governance, and OAuth Agent Grants.",
+    "typescriptApplication": "Use npm-verified @grantex/sdk@0.6.0 for Node.js 18+ TypeScript applications that need bounded refresh recovery, layered prepaid-wallet governance, and OAuth Agent Grants.",
     "pythonApplication": "Use PyPI-verified grantex==0.5.0 for Python 3.9+ applications that need EVM payment responses, principal/agent reconciliation, bounded refresh recovery, and layered prepaid-wallet governance. No automatic x402 HTTP payment wrapper is included.",
     "goApplication": "Use public-proxy-verified github.com/mishrasanjeev/grantex-go@v0.3.0 for Go 1.26.1+ applications that need typed EVM payment responses, principal/agent reconciliation, bounded refresh recovery, and layered prepaid-wallet governance. No automatic x402 HTTP payment wrapper is included.",
     "mcpProductionIntegration": "Use established MCP-compatible transport authorization first, then a primary Grantex SDK or direct JWKS validation for agent-specific tool enforcement; treat @grantex/mcp-auth@2.0.2 as single-process evaluation software.",
@@ -37,7 +37,7 @@
       "hostedMetadataUrl": "https://grantex.dev/.well-known/oauth-authorization-server",
       "documentationUrl": "https://docs.grantex.dev/guides/oauth-agent-grants",
       "implementationReportUrl": "https://github.com/mishrasanjeev/grantex/blob/main/docs/ietf-draft/implementation-report.md",
-      "sdkAvailability": "published in @grantex/sdk@0.5.1; npm integrity, exact-version clean install, and public exports verified",
+      "sdkAvailability": "published in @grantex/sdk@0.6.0; npm integrity, exact-version clean install, and public exports verified",
       "evidence": {
         "authServiceTestsPassed": 2138,
         "typescriptSdkTestsPassed": 456,
@@ -71,12 +71,12 @@
       "label": "TypeScript SDK",
       "ecosystem": "npm",
       "name": "@grantex/sdk",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "status": "published",
-      "installCommand": "npm install @grantex/sdk@0.5.1",
+      "installCommand": "npm install @grantex/sdk@0.6.0",
       "runtime": "Node.js 18+; ESM",
       "registryUrl": "https://registry.npmjs.org/%40grantex%2Fsdk/latest",
-      "packageUrl": "https://www.npmjs.com/package/@grantex/sdk/v/0.5.1",
+      "packageUrl": "https://www.npmjs.com/package/@grantex/sdk/v/0.6.0",
       "documentationUrl": "https://docs.grantex.dev/sdks/typescript/overview",
       "limitations": []
     },
@@ -85,19 +85,19 @@
       "label": "x402 Payment Protocol",
       "ecosystem": "npm",
       "name": "@grantex/x402",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "status": "published-with-known-limitations",
-      "installCommand": "npm install @grantex/x402@0.3.0 @grantex/sdk@0.5.1",
+      "installCommand": "npm install @grantex/x402@0.4.0 @grantex/sdk@0.6.0",
       "runtime": "Node.js 20+; ESM",
       "registryUrl": "https://registry.npmjs.org/%40grantex%2Fx402/latest",
-      "packageUrl": "https://www.npmjs.com/package/@grantex/x402/v/0.3.0",
+      "packageUrl": "https://www.npmjs.com/package/@grantex/x402/v/0.4.0",
       "documentationUrl": "https://docs.grantex.dev/integrations/x402",
       "limitations": [
         {
           "id": "x402-external-custody-adapter",
-          "summary": "External custody wallets fail closed until an operator supplies a provider adapter; sandbox_ledger does not represent external funds.",
-          "workaround": "Use sandbox_ledger only for an explicitly internal ledger, or implement and independently test provider funding, reservation, settlement, reconciliation, duplicate-event handling, and recovery before enabling external custody.",
-          "workaroundUrl": "https://docs.grantex.dev/guides/prepaid-wallet-production#choose-the-custody-mode-honestly"
+          "summary": "Opt-in Base USDC requires operator-provisioned custody, verified funding and trusted RPC. The initial signer is in-process, not HSM/MPC; unconfigured or unsupported external providers fail closed.",
+          "workaround": "Follow the Base custody provisioning and incident runbook. Retain signed exposure until finalized reconciliation; blocking cannot recall issued signatures. Independently validate funded production merchant compatibility before enabling real-money traffic.",
+          "workaroundUrl": "https://docs.grantex.dev/guides/base-usdc-custody"
         }
       ]
     },
@@ -136,7 +136,7 @@
       "name": "@grantex/mcp-auth",
       "version": "2.0.2",
       "status": "published-with-known-limitations",
-      "installCommand": "npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.5.1",
+      "installCommand": "npm install @grantex/mcp-auth@2.0.2 @grantex/sdk@0.6.0",
       "runtime": "Node.js 18+; ESM; one process for evaluation",
       "registryUrl": "https://registry.npmjs.org/%40grantex%2Fmcp-auth/latest",
       "packageUrl": "https://www.npmjs.com/package/@grantex/mcp-auth/v/2.0.2",

--- a/web/vs/mcp-auth/index.html
+++ b/web/vs/mcp-auth/index.html
@@ -128,12 +128,12 @@
       <h2>Recommended production pattern today</h2>
       <ol>
         <li>Implement the current MCP authorization specification with an established authorization server and maintained MCP SDK.</li>
-        <li>Use <code>@grantex/sdk@0.5.1</code> or direct JWKS validation for the Grantex agent grant.</li>
+        <li>Use <code>@grantex/sdk@0.6.0</code> or direct JWKS validation for the Grantex agent grant.</li>
         <li>Validate issuer, audience, signature, expiry, principal, and required tool scope at the MCP resource server.</li>
         <li>Check or synchronize current grant state where revocation must take effect before token expiry.</li>
         <li>Log tool execution separately when you need an audit record; token verification alone is not an execution log.</li>
       </ol>
-      <pre><code>npm install @grantex/sdk@0.5.1
+      <pre><code>npm install @grantex/sdk@0.6.0
 
 // At the MCP tool boundary:
 // 1. verify the signed grant token

--- a/web/vs/securing-ai-agents/index.html
+++ b/web/vs/securing-ai-agents/index.html
@@ -145,7 +145,7 @@
 
       <h2>Choose the current implementation</h2>
       <ul>
-        <li>TypeScript application: <code>@grantex/sdk@0.5.1</code></li>
+        <li>TypeScript application: <code>@grantex/sdk@0.6.0</code></li>
         <li>Python application: <code>grantex==0.3.14</code></li>
         <li>Go application: <code>grantex-go@v0.1.10</code>, with the documented workarounds</li>
         <li>MCP production integration: primary SDK or direct JWKS enforcement; treat MCP Auth 2.0.2 as evaluation software</li>

--- a/web/x402-playground/index.html
+++ b/web/x402-playground/index.html
@@ -83,7 +83,7 @@ footer a:hover{text-decoration:underline}
 <header>
 <h1>Grantex &times; x402 Playground</h1>
 <p class="subtitle">Explore official x402 v2 prepaid-wallet flow and legacy standalone GDT verification</p>
-<p style="color:var(--amber);font-size:.82rem;margin-top:8px"><code>@grantex/x402@0.3.0</code> and <code>@grantex/sdk@0.5.1</code> are published and registry verified. External custody requires an operator adapter.</p>
+<p style="color:var(--amber);font-size:.82rem;margin-top:8px"><code>@grantex/x402@0.4.0</code> and <code>@grantex/sdk@0.6.0</code> are published and registry verified. External custody requires an operator adapter.</p>
 </header>
 
 <div class="panels">
@@ -237,7 +237,7 @@ app.get('/api/weather/forecast', (req, res) =&gt; {
 </div>
 
 <footer>
-<p><a href="https://github.com/mishrasanjeev/grantex">GitHub</a> &middot; <a href="https://grantex.dev">Docs</a> &middot; <a href="https://www.npmjs.com/package/@grantex/x402/v/0.3.0">npm package</a></p>
+<p><a href="https://github.com/mishrasanjeev/grantex">GitHub</a> &middot; <a href="https://grantex.dev">Docs</a> &middot; <a href="https://www.npmjs.com/package/@grantex/x402/v/0.4.0">npm package</a></p>
 <p style="margin-top:8px">&copy; 2026 Orchestrum Technologies LLP &mdash; Apache 2.0</p>
       <p class="ownership-notice">Grantex is owned by Orchestrum Technologies LLP. Inventor and owner: Sanjeev Kumar. Contact: <a href="mailto:sanjeev@orchestrum.in">sanjeev@orchestrum.in</a> or <a href="mailto:mishra.sanjeev@gmail.com">mishra.sanjeev@gmail.com</a>.</p>
 

--- a/web/x402/index.html
+++ b/web/x402/index.html
@@ -134,7 +134,7 @@ footer .links{display:flex;gap:24px;justify-content:center;margin-bottom:12px}
 <a href="/x402-playground/" class="btn btn-primary">Try the Playground</a>
 <a href="https://github.com/mishrasanjeev/grantex" class="btn btn-outline">View on GitHub</a>
 </div>
-<div class="install-badge">npm install @grantex/x402@0.3.0 @grantex/sdk@0.5.1</div>
+<div class="install-badge">npm install @grantex/x402@0.4.0 @grantex/sdk@0.6.0</div>
 <p class="preview-note">Registry-verified managed prepaid-wallet APIs. External custody remains fail-closed until an operator installs and verifies a provider adapter.</p>
 </div>
 </div>
@@ -285,7 +285,7 @@ DPoP Agent ── x402Agent.fetch() ── Resource Server
 <div class="container">
 <div class="links">
 <a href="https://github.com/mishrasanjeev/grantex">GitHub</a>
-<a href="https://www.npmjs.com/package/@grantex/x402/v/0.3.0">npm package</a>
+<a href="https://www.npmjs.com/package/@grantex/x402/v/0.4.0">npm package</a>
 <a href="https://grantex.dev">Documentation</a>
 <a href="/x402-playground/">Playground</a>
 </div>


### PR DESCRIPTION
## Summary
- Confirm npm publication of @grantex/sdk@0.6.0 and @grantex/x402@0.4.0.
- Update README, SDK/integration/hosting docs, landing pages, JSON-LD and mirrored release metadata to the verified versions.
- Remove pending npm publication notices and record final public-registry evidence in the committed release report.
- Retain explicit custody/RPC, in-process signing, and funded-mainnet compatibility limitations; Python/Go still do not claim automatic x402 HTTP wrappers.

## Verification
- Both npm dist.integrity values exactly match the previously tested immutable tarballs.
- Brand-new consumer installed both exact versions from registry.npmjs.org; no local file dependency or repository-source fallback.
- Public exports, LICENSE/NOTICE, Base safety gates, authenticated reconciliation wire contracts: passed.
- npm consumer audit: 0 vulnerabilities.
- Docker Base: 11 scenarios plus parent result passed (12 Node results).
- Docker existing prepaid-wallet and layered-policy lifecycle tests: both passed.
- Production against registry-installed SDKs: 255/255 tests across 23 files passed in 281.80s.
- Documentation integrity including live registries and supply-chain policy: passed.

No runtime source changes. No funded external Base-mainnet merchant payment is claimed.