### PR TITLE
chore: validate post-scan x402 and S3 dependency updates

### DIFF
--- a/packages/destinations/package-lock.json
+++ b/packages/destinations/package-lock.json
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1125.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1125.0.tgz",
-      "integrity": "sha512-l0npObtjYgqDfUHiifnWGFuAuMVq5r4AVf4C+jY+thJ/2iAr/eHqAjBR4clbmXxSoJ5w3+ZFGRPyci/CCkUoyg==",
+      "version": "3.1126.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1126.0.tgz",
+      "integrity": "sha512-9v+D5TOnISyWDBkY5N+lSeQ3/pPNi1bltpd7wfY2nALO7GoGq9QbRQ8KyI4j/ctnnHq40otqV5KWKYARdYI0vg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/x402/package-lock.json
+++ b/packages/x402/package-lock.json
@@ -1334,9 +1334,9 @@
       }
     },
     "node_modules/@x402/core": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.24.0.tgz",
-      "integrity": "sha512-zKFbG+RgUhBXT9RcBQZGPW1cZXL9xpiTv68XSSuO1SMoobudmVvxYgP/bhoxJuAoqJjjEceeAhT4/EcA/wolrQ==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.25.0.tgz",
+      "integrity": "sha512-5Ys0XYz3FKutxVKoXC46R/XPT/oaAbuj7ahzrlVHwQxZJPH9u6u91IOh0ztz+7G/zYGsaXR8l3ety205QtEnUw==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.24.2"
@@ -1349,6 +1349,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@x402/core": "~2.24.0"
+      }
+    },
+    "node_modules/@x402/fetch/node_modules/@x402/core": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.24.0.tgz",
+      "integrity": "sha512-zKFbG+RgUhBXT9RcBQZGPW1cZXL9xpiTv68XSSuO1SMoobudmVvxYgP/bhoxJuAoqJjjEceeAhT4/EcA/wolrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.24.2"
       }
     },
     "node_modules/accepts": {

--- a/packages/x402/package-lock.json
+++ b/packages/x402/package-lock.json
@@ -1334,21 +1334,21 @@
       }
     },
     "node_modules/@x402/core": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.24.0.tgz",
-      "integrity": "sha512-zKFbG+RgUhBXT9RcBQZGPW1cZXL9xpiTv68XSSuO1SMoobudmVvxYgP/bhoxJuAoqJjjEceeAhT4/EcA/wolrQ==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.25.0.tgz",
+      "integrity": "sha512-5Ys0XYz3FKutxVKoXC46R/XPT/oaAbuj7ahzrlVHwQxZJPH9u6u91IOh0ztz+7G/zYGsaXR8l3ety205QtEnUw==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.24.2"
       }
     },
     "node_modules/@x402/fetch": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@x402/fetch/-/fetch-2.24.0.tgz",
-      "integrity": "sha512-jhopac/aRWh3CYpDFjMxIzo/raH0ncmdDK2op6RzMoWsH3wj9/ejJylTv+Q22epReWLZ9AI35LEymN66B0MqNw==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@x402/fetch/-/fetch-2.25.0.tgz",
+      "integrity": "sha512-kpmxnMTjxZJD5r4yVhRDtCrBVfGhum+XwrUUUdffi3Y91eAm9ZiWCDNHLtahOS2kmuzTR2NPbbIoohZQJmQsxg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@x402/core": "~2.24.0"
+        "@x402/core": "~2.25.0"
       }
     },
     "node_modules/accepts": {


### PR DESCRIPTION
Includes the three updates created by the post-merge Dependabot scan: #1157, #1158 and #1159, preserving their head commits. Updates only the x402 and destinations lockfiles. Dedicated local Docker validation is running for the SDK, x402, destinations, full API E2E and Base USDC official-facilitator flow. Main merge remains gated on those results and green CI. No SDK source/API changes, version bumps, registry publishes, production security changes or funded mainnet transactions.