### PR TITLE
docs: record production verification and Terraform availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## Unreleased
 
 ### Dependency integration (2026-09-07)
-- Integrated the 49 pending dependency PRs as a single validation candidate,
+- Merged the 49 pending dependency PRs through integration PR #1156,
   including Vitest 5, SimpleWebAuthn 14, solc 0.8.36 and framework/type patches.
 - Paired Vitest and coverage upgrades, regenerated overlapping lockfiles and
   grouped future Dependabot updates. CI source tooling uses Node.js 24.
@@ -15,6 +15,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   generation and malformed-evidence rejection tests. Security policy is unchanged.
 - Updated contributor, README, deployment and release-status guidance. Published
   SDK versions are unchanged; deployment/test evidence is recorded separately.
+- Revalidated and merged three post-scan lockfile updates through PR #1160:
+  x402 core/fetch 2.25.0 and destinations S3 3.1126.0. A fresh public npm consumer
+  passed the local Docker payment suite and all 255 local API E2E tests.
+- Cloud Run and Firebase deployments passed. The final production E2E run passed
+  255/255 tests across 23 files, with zero skips. Full local SDK/app, Python,
+  Go, security and deployment evidence is in the
+  [validation report](docs/internal/dependency-batch-2026-09-07.md).
+- Corrected Terraform availability guidance: its public provider registry lookup
+  returns 404. Source builds pass, but publication and live provider acceptance
+  remain separate work; ordinary registry installation is not available.
 
 ### Verified SDK publications (2026-09-07)
 - Published `@grantex/sdk@0.6.0` and `@grantex/x402@0.4.0` to npm after the

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -52,7 +52,7 @@ The repository contains 29 packages under `packages/`. Each row maps a directory
 | 26 | `packages/a2a-py` | grantex-a2a | 0.1.4 | A2A bridge (Python) |
 | 27 | `packages/mpp` | @grantex/mpp | 0.1.2 | MPP support |
 | 28 | `packages/x402` | @grantex/x402 | 0.4.0 | Official x402 v2 layered-wallet integration with opt-in Base USDC |
-| 29 | `packages/terraform-provider-grantex` | terraform-provider-grantex | Go module (Go 1.25.0) | Terraform provider |
+| 29 | `packages/terraform-provider-grantex` | terraform-provider-grantex | Go module (Go 1.25.0) | Source-only Terraform provider; public registry returned 404 on 2026-09-07 |
 
 ## Known Published-Package Limitations
 

--- a/README.md
+++ b/README.md
@@ -1605,7 +1605,7 @@ check its registry page and compatibility notes before choosing a version.
 | **A2A Bridge (TS)** | `@grantex/a2a` | `npm install @grantex/a2a` | Published package |
 | **A2A Bridge (Py)** | `grantex-a2a` | `pip install grantex-a2a` | Published package |
 | **Event Destinations** | `@grantex/destinations` | `npm install @grantex/destinations` | Published package |
-| **Terraform Provider** | `terraform-provider-grantex` | `terraform { required_providers { grantex = { source = "mishrasanjeev/grantex" } } }` | Source present; verify registry before pinning |
+| **Terraform Provider** | `terraform-provider-grantex` | [Source-build evaluation](https://docs.grantex.dev/guides/terraform) | Source only; public registry lookup returned 404 on September 7, 2026 |
 | **x402 Payment Protocol** | `@grantex/x402` (`0.4.0`) | `npm install @grantex/x402@0.4.0 @grantex/sdk@0.6.0` | Registry-verified layered x402 v2 release; external custody remains operator-supplied |
 
 The guarded `publish-primary-sdks.yml` workflow builds and tests each prepared

--- a/docs/guides/terraform.mdx
+++ b/docs/guides/terraform.mdx
@@ -7,7 +7,26 @@ description: "Manage Grantex resources as infrastructure with the official Terra
 
 The Grantex Terraform provider lets you manage agents, policies, webhooks, SSO configuration, and budget allocations as code.
 
-## Installation
+## Availability and Installation
+
+<Warning>
+The provider is currently source-only. On September 7, 2026, the public
+Terraform Registry lookup for `mishrasanjeev/grantex` returned HTTP 404.
+The configuration below is not an available registry install, and ordinary
+`terraform init` cannot download it. Registry publication and live acceptance
+testing remain separate release work; the repository build passing is not
+evidence that this provider is published or production-certified.
+</Warning>
+
+For local evaluation, build `packages/terraform-provider-grantex` with its
+declared Go toolchain and configure a local provider binary using HashiCorp's
+[development override instructions](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers).
+Use a disposable sandbox account. Development overrides are not a production
+installation method and do not make registry-based initialization succeed.
+
+The following is a provider configuration template for that local evaluation
+or a future verified registry release. The version constraint is illustrative,
+not a claim that version `0.1` is available:
 
 ```hcl
 terraform {

--- a/docs/internal/dependency-batch-2026-09-07.md
+++ b/docs/internal/dependency-batch-2026-09-07.md
@@ -4,10 +4,16 @@
 
 - Integration PR: https://github.com/mishrasanjeev/grantex/pull/1156
 - Baseline main: `32b85f0cb8b5bc55578f138fb93f8aa0206c5fe3`.
-- Reviewed integration code/test commit: `d1823c42f9b126e5e3351c95535347b8df7fa6bd`.
+- Final integration PR head: `ac3afc1db0f209f957cd52ceaa53804ec5e7b0f5`.
+- Integration merge: `884f30ca368e15aec9757cb9a06f51c48c9afe7d`.
 - Scope: all 49 open dependency PRs captured before the integration PR was opened.
   Nine had failing checks. All 49 captured heads are ancestors of the integration
   candidate; all 40 explicitly requested manifest changes were verified present.
+- A post-merge Dependabot scan opened three additional lockfile PRs, #1157-#1159.
+  They were tested separately and merged through
+  https://github.com/mishrasanjeev/grantex/pull/1160 at
+  `c000c41908fcf598807f859741d665d289f9e79c`.
+  GitHub confirmed all 52 original dependency PRs as merged, not merely closed.
 - No force pushes, admin merges, production security relaxation, registry publishes
   or funded mainnet payments are part of this batch.
 - Local work used an isolated checkout outside OneDrive. The original checkout's
@@ -85,24 +91,90 @@ execution, exact finalized funding, pre-signing denials, malformed challenges,
 tampering, replay, concurrent retry, restart recovery, block/exposure accounting,
 settlement and RPC-outage/expiry behavior.
 
-## CI Evidence
+## Post-Scan Local Revalidation
 
-All 36 active checks passed at `d1823c42`; the two expected skips were
-Mintlify's PR deployment and the scheduled/manual OWASP full scan.
-The exact final PR head must be green again after any report-only commit.
+The three additional PRs updated only two lockfiles: x402 core/fetch to 2.25.0
+and the destinations S3 development dependency to 3.1126.0. No production
+service source, package manifest, security control or SDK version changed.
 
-- CI: https://github.com/mishrasanjeev/grantex/actions/runs/34081914817
-- Base Docker compatibility: https://github.com/mishrasanjeev/grantex/actions/runs/34081914859
-- Security scan: https://github.com/mishrasanjeev/grantex/actions/runs/34081914968
-- CodeQL: https://github.com/mishrasanjeev/grantex/actions/runs/34081914959
-- Dependency review: https://github.com/mishrasanjeev/grantex/actions/runs/34081914840
+- A fresh two-CPU Linux Docker container passed SDK 457/457, x402 206/206 and
+  destinations 15/15 tests, plus clean installs, typechecks and builds.
+- A fresh public npm consumer installed `@grantex/sdk@0.6.0` and
+  `@grantex/x402@0.4.0`, resolving both `@x402/core` and `@x402/fetch` to 2.25.0.
+- That public consumer passed 12/12 Base Docker test results (11 scenarios),
+  zero skips, 50.55 seconds, and the full local API E2E suite: 255/255 tests in
+  23 files, zero skips, 92.37 seconds.
+- The final supply-chain audit passed: 37 lockfiles and 4,203 package entries,
+  with clean npm audits. The public package dependency ranges already accept
+  the updates; no registry republish was required or performed.
 
-## Deployment Gate
+## CI and Deployment Evidence
 
-At report preparation, main merge and production validation have not occurred.
-Local validation is complete; merge remains gated on the final PR-head checks. Record the
-merge SHA, Cloud Run revision, Firebase deployment and production E2E results
-after completion; do not infer deployment from a successful local test.
+Both integration PRs passed all 36 active checks at their exact final heads;
+the two expected skips were Mintlify's PR deployment and the scheduled/manual
+OWASP full scan. Merges used ordinary merge commits, not admin bypasses.
+
+Main `884f30ca` completed successfully:
+
+- CI: https://github.com/mishrasanjeev/grantex/actions/runs/34083153292
+- CodeQL: https://github.com/mishrasanjeev/grantex/actions/runs/34083153306
+- Security scan: https://github.com/mishrasanjeev/grantex/actions/runs/34083153311
+- Cloud Run deploy: https://github.com/mishrasanjeev/grantex/actions/runs/34083153298
+- Firebase portal/web deploy: https://github.com/mishrasanjeev/grantex/actions/runs/34083153345
+- Post-deploy MPP lifecycle/JWKS E2E: https://github.com/mishrasanjeev/grantex/actions/runs/34083264233
+
+Follow-up main `c000c419` also completed successfully:
+
+- CI: https://github.com/mishrasanjeev/grantex/actions/runs/34084189997
+- CodeQL: https://github.com/mishrasanjeev/grantex/actions/runs/34084189998
+- Security scan: https://github.com/mishrasanjeev/grantex/actions/runs/34084190001
+
+Cloud Run inspection confirmed revision `grantex-auth-00276-t4q` serving 100%
+of traffic from the image tagged `884f30ca368e15aec9757cb9a06f51c48c9afe7d`.
+There is no diff between that deployed source and `c000c419` in auth-service,
+portal, web, Firebase configuration or either deployment workflow. The
+client-lockfile-only follow-up correctly did not trigger another service deploy.
+Landing page, dashboard, API health and public JWKS returned HTTP 200.
+The new dependency guide was published by Mintlify and the live documentation
+integrity check passed after deployment.
+
+## Final Production E2E
+
+The workstation ran every E2E file listed in `.github/workflows/e2e.yml`
+against production after the follow-up main CI passed. Results:
+
+| Field | Verified value |
+| --- | --- |
+| API/test source | `c000c41908fcf598807f859741d665d289f9e79c` |
+| Start / finish (UTC) | 2026-09-07 04:47:34 / 04:52:26 |
+| Tests | 255 passed, 0 failed, 0 skipped |
+| Files / elapsed | 23 / 291.78 seconds |
+| API target | `https://grantex-auth-dd4mtrt2gq-uc.a.run.app` |
+| Public host / issuer | `https://grantex.dev` |
+| Client artifacts | Fresh public npm SDK 0.6.0 and x402 0.4.0, core/fetch 2.25.0 |
+| Live revision | `grantex-auth-00276-t4q`, 100% traffic |
+
+This is a new post-merge run, not a reused result from the earlier SDK release.
+The metrics credential was read from the deployed Secret Manager binding,
+passed only in the test process environment and never printed or committed.
+The JSON runner report was inspected for its success, pass, fail and skip fields;
+the process exit code alone was not used as proof. The later documentation-only
+changes do not alter the tested API, SDK or portal artifacts.
+
+All owned Grantex Docker validation containers and their isolated test stack
+were removed after local tests. Other workstation projects and the original
+checkout's untracked `output/` were left alone.
+
+## External Registry Limitation
+
+Dependabot's Terraform example update job failed with `dependency_not_found`:
+https://github.com/mishrasanjeev/grantex/actions/runs/34083220440.
+A direct registry check confirmed HTTP 404 for `mishrasanjeev/grantex` on
+September 7, 2026. This is not a failing PR or application deployment, but it
+means Terraform registry installation and automatic version discovery do not
+work for this source-only provider. README, compatibility/release status and
+both provider guides now state the limitation. The updater was not disabled
+to conceal it; publication and provider live acceptance tests remain separate work.
 
 ## Limits
 
@@ -168,6 +240,9 @@ after completion; do not infer deployment from a successful local test.
 | #1150 | `2135ea18f964` | chore(deps-dev): bump @types/node from 26.4.0 to 26.4.1 in /examples/x402-agent-demo |
 | #1151 | `c7025309ec3c` | chore(deps): bump ai from 7.0.87 to 7.0.92 in /examples/vercel-ai-chatbot |
 | #1152 | `da43bb8bae90` | chore(deps-dev): bump solc from 0.8.35 to 0.8.36 in /tests/base-usdc |
+| #1157 | `42719a393f01` | x402 core 2.24.0 to 2.25.0; post-scan revalidation |
+| #1158 | `2b7386065759` | x402 fetch 2.24.0 to 2.25.0; post-scan revalidation |
+| #1159 | `b5ca48ad49b9` | destinations S3 development dependency 3.1125.0 to 3.1126.0; post-scan revalidation |
 
 ## Upstream References
 

--- a/docs/release-status.mdx
+++ b/docs/release-status.mdx
@@ -22,6 +22,7 @@ repository.
 | Go SDK | `github.com/mishrasanjeev/grantex-go@v0.3.0` | - | Tagged, public Go-proxy verified, and fresh-install verified | Go 1.26.1+ |
 | MCP Auth server | `@grantex/mcp-auth@2.0.2` | - | Published with known limitations | Node.js 18+; ESM |
 | OpenAPI contract | `0.5.0` | - | Repository contract with layered prepaid-wallet governance | Independent of public SDK versions |
+| Terraform provider | Not available in the public registry at verification | Source only | Registry lookup returned 404 on September 7, 2026; [local evaluation](/guides/terraform) only | Go toolchain declared by the provider module |
 
 <Note>
 TypeScript `0.6.0`, Python `0.5.0`, Go `v0.3.0`, and x402 `0.4.0` are

--- a/packages/terraform-provider-grantex/docs/index.md
+++ b/packages/terraform-provider-grantex/docs/index.md
@@ -2,6 +2,16 @@
 
 The Grantex provider is used to manage [Grantex](https://grantex.dev) resources for delegated authorization of AI agents. It provides infrastructure-as-code management for agents, policies, webhooks, SSO configurations, and budget allocations.
 
+## Availability
+
+This provider is source-only. The public Terraform Registry lookup for
+`mishrasanjeev/grantex` returned HTTP 404 on September 7, 2026, so ordinary
+`terraform init` cannot install it from that registry. Local builds passed,
+but provider live acceptance tests and registry publication are separate work.
+Use the [source-build evaluation guide](https://docs.grantex.dev/guides/terraform)
+with a disposable sandbox account. The configuration and version constraint
+below are templates, not evidence of a published provider release.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Documentation-only completion of #1156 and #1160. Records all 52 merged dependency PRs, 5117 Node tests, 613 Python tests, Go race/build verification, local Docker API/payment results, actual Cloud Run/Firebase deployment evidence and the new post-merge production E2E result: 255 passed, zero failures or skips across 23 files in 291.78 seconds. Corrects Terraform installation guidance after a direct registry 404 and the matching Dependabot updater failure; does not disable the updater or claim the provider is published. README, compatibility/release status, changelog and both provider guides are consistent. Local docs integrity and API documentation contract tests pass. No runtime source changes, secrets, SDK version changes or registry publishes.