### PR TITLE
chore(deps): bump @grantex/sdk to 0.6.0 in x402-agent-demo

### DIFF
--- a/examples/x402-agent-demo/package-lock.json
+++ b/examples/x402-agent-demo/package-lock.json
@@ -8,7 +8,7 @@
       "name": "x402-agent-demo-example",
       "version": "1.0.0",
       "dependencies": {
-        "@grantex/sdk": "^0.5.1",
+        "@grantex/sdk": "^0.6.0",
         "@grantex/x402": "^0.4.0",
         "jose": "^6.2.2",
         "tsx": "^4.21.0"
@@ -435,9 +435,9 @@
       }
     },
     "node_modules/@grantex/sdk": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@grantex/sdk/-/sdk-0.5.1.tgz",
-      "integrity": "sha512-ulrRKqx/Y3RaT6iDoCW0awmDtRRE9wASElbRu/yJGxAaP1t3xTa8olq6k9XEmPe+xSOCFd7eKIjT4jziMY9Bog==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@grantex/sdk/-/sdk-0.6.0.tgz",
+      "integrity": "sha512-qpdvgB8/U1bL1tNk+hhAb/du/lwv3CjJnl4UW6p6iBwd/1Igcq5sxFT/jqYzAs5QTV0AqE4+TWNBppb8BarGnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "jose": "^6.2.3"

--- a/examples/x402-agent-demo/package.json
+++ b/examples/x402-agent-demo/package.json
@@ -9,7 +9,7 @@
     "demo": "tsx agent.ts"
   },
   "dependencies": {
-    "@grantex/sdk": "^0.5.1",
+    "@grantex/sdk": "^0.6.0",
     "@grantex/x402": "^0.4.0",
     "jose": "^6.2.2",
     "tsx": "^4.21.0"


### PR DESCRIPTION
Supersedes #1206 after the original Dependabot branch became conflicted by the already-merged x402-agent-demo dependency updates.\n\n- updates @grantex/sdk from ^0.5.1 to ^0.6.0\n- preserves the current @grantex/x402 version and lockfile state\n- local npm ci and typecheck pass\n\nNo application source changes.